### PR TITLE
feat(agentic): layered LLM request timeouts (ADR-024)

### DIFF
--- a/agentic/types.go
+++ b/agentic/types.go
@@ -41,6 +41,10 @@ type AgentRequest struct {
 	Temperature float64          `json:"temperature,omitempty"`
 	Tools       []ToolDefinition `json:"tools,omitempty"`
 	ToolChoice  *ToolChoice      `json:"tool_choice,omitempty"`
+	// Timeout caps this specific request. Go duration string (e.g. "30s").
+	// Empty means fall through to endpoint, capability, or component-level
+	// timeout. Takes precedence over all other timeout sources when set.
+	Timeout string `json:"timeout,omitempty"`
 }
 
 // Validate checks if the AgentRequest is valid

--- a/agentic/user_types.go
+++ b/agentic/user_types.go
@@ -279,6 +279,11 @@ type TaskMessage struct {
 
 	// Domain context propagated to all tool calls in this loop
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// Timeout caps LLM calls issued for this task. Go duration string
+	// (e.g. "30s"). Empty means fall through to endpoint, capability, or
+	// component-level timeout. Highest precedence when set.
+	Timeout string `json:"timeout,omitempty"`
 }
 
 // ConstructedContext is an alias for types.ConstructedContext.

--- a/docs/adr/024-layered-llm-timeouts.md
+++ b/docs/adr/024-layered-llm-timeouts.md
@@ -1,0 +1,136 @@
+# ADR-024: Layered LLM Request Timeouts
+
+## Status
+
+Proposed
+
+## Context
+
+The `agentic-model` component wraps every LLM call in a single
+`context.WithTimeout` driven by one component-level config field
+(`config.Timeout`, default `120s`). This is wrong in both directions for any
+real deployment:
+
+- **Fast calls wait too long to fail.** A classification call that should
+  return in under a second still burns 120 seconds before cancellation when the
+  endpoint stalls.
+- **Heavy calls die mid-plan.** A multi-step planning call that legitimately
+  needs 180 seconds is cancelled at 120.
+
+Three gaps surfaced from upstream users (in particular semspec):
+
+1. **No per-capability timeouts.** Capabilities (`fast`, `general`, `heavy`,
+   `summarization`, etc.) are the natural axis along which response-time
+   budgets differ, but today there is one global value across all of them.
+2. **Per-endpoint `request_timeout` ignored.** semspec already configures a
+   `request_timeout` field per endpoint in its model registry. semstreams
+   didn't read it.
+3. **No per-task override.** A plan-reviewer task (short-lived) has no way to
+   ask for a tighter budget than a DAG-node implementation task routed to the
+   same capability.
+
+The registry already owns the axes along which operators reason about model
+behavior (capabilities, endpoints). That's where timeout configuration belongs
+— not sprawled across every `TaskMessage` producer.
+
+## Decision
+
+Introduce a four-layer precedence chain for the per-call timeout applied in
+`agentic-model.executeRequest`. The first layer with a non-empty, parseable
+duration wins:
+
+| Precedence | Source | Storage |
+|------------|--------|---------|
+| 1 (highest) | `TaskMessage.Timeout` → `AgentRequest.Timeout` | Per-message field; cached by `LoopManager` for continuation iterations |
+| 2 | `EndpointConfig.RequestTimeout` | `model_registry.endpoints.<name>.request_timeout` |
+| 3 | `CapabilityConfig.Timeout` | `model_registry.capabilities.<name>.timeout` |
+| 4 (lowest) | `agentic-model.config.Timeout` | Component config (unchanged default `120s`) |
+
+A hardcoded `120s` remains as the final safety fallback when every other layer
+is empty or zero.
+
+### Resolution site
+
+All resolution happens in one place: a new `(*Component).resolveTimeout`
+helper called from `executeRequest`. `getClientForRequest` is extended to
+return the resolved `*EndpointConfig` and (when `req.Model` was a capability
+name) the capability name, so the resolver has everything it needs without a
+second registry walk. This keeps the precedence chain testable in isolation
+and observable via one structured log line per request carrying a
+`timeout_source` field with values `task`, `endpoint`, `capability`,
+`component`, or `default`.
+
+### Validation posture
+
+- **Config-level timeouts** (endpoint, capability, component) validate as
+  parseable durations at the configured layer. Today they are read lazily in
+  `resolveTimeout` — a malformed value logs a warning and falls through, so
+  one bad registry entry never poisons every request.
+- **Message-level timeouts** (task, request) also fall through on parse
+  failure rather than returning an error. A misconfigured producer should not
+  be able to block a task; the next layer down still applies.
+
+### Loop continuity
+
+`TaskMessage.Timeout` is cached in `LoopManager` keyed by `loopID`
+(`CacheRequestTimeout` / `GetCachedRequestTimeout`) following the same pattern
+as cached tools, tool choice, and metadata. Continuation iterations rebuild
+`AgentRequest` from `LoopEntity`, so without the cache the task-level timeout
+would only apply to the first LLM call of a loop. The cache is cleaned up
+alongside the other per-loop caches on loop termination.
+
+## Consequences
+
+### Positive
+
+- semspec's existing `request_timeout` per endpoint is honored without config
+  migration on its side.
+- Operators tune response-time budgets once per capability in the model
+  registry, rather than threading a timeout through every TaskMessage
+  producer.
+- The `timeout_source` log field makes timeout behavior directly observable
+  from logs, which helps debug "why did this call time out?" questions that
+  today require grepping config files.
+- The `messageTimeout` field parsed in `NewComponent` — dead code before this
+  change — is now the canonical component-level default, so the config value
+  is parsed once rather than on every request.
+
+### Negative
+
+- Four precedence layers are more surface area than one. The observability
+  mitigation (`timeout_source` log field) matters.
+- `getClientForRequest` now returns four values instead of two. Acceptable
+  locally; the capability/endpoint are genuinely needed for resolution.
+- New fields on `EndpointConfig`, `CapabilityConfig`, `AgentRequest`, and
+  `TaskMessage` — but each is `omitempty` and existing configs/messages
+  continue to work unchanged.
+
+### Neutral
+
+- The four timeout fields are all Go duration strings (`"45s"`, `"5m"`), matching
+  the existing `agentic-model.timeout` pattern rather than introducing
+  numeric-seconds or duration-object alternatives.
+- Provider-side request timeout hints (`x-request-timeout` and similar
+  headers) are out of scope. `context.WithTimeout` at the call site remains
+  authoritative; provider-hint plumbing can be a follow-up if needed.
+
+## Alternatives Considered
+
+### A. Component config as a map `{"default": "120s", "fast": "30s"}`
+
+Would put capability timeouts on the agentic-model component instead of the
+registry. Rejected: splits timeout configuration across two places (component
+for capabilities, registry endpoints for per-endpoint timeout), and makes it
+unclear which layer is the source of truth. The registry already owns the
+capability concept.
+
+### B. Single new field, replacing the existing global timeout
+
+Would force every deployment to re-tune on upgrade. Rejected in favor of
+additive layers that preserve today's default behavior when no new fields are
+set.
+
+### C. Retry/hedging policy keyed off timeout class
+
+Interesting but orthogonal to the structural gap semspec hit. Tracked as
+post-beta follow-up work.

--- a/docs/advanced/08-agentic-components.md
+++ b/docs/advanced/08-agentic-components.md
@@ -215,7 +215,7 @@ in the component config.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `timeout` | string | 120s | Request timeout |
+| `timeout` | string | 120s | Component-level default LLM request timeout. See [Timeout Resolution](#timeout-resolution) for the full precedence chain. |
 | `retry.max_attempts` | int | 3 | Maximum retry attempts |
 | `retry.initial_delay` | string | 1s | Initial delay before first retry |
 | `retry.max_delay` | string | 60s | Maximum delay between retries |
@@ -232,12 +232,51 @@ in the component config.
 | `api_key_env` | string | no | Environment variable containing API key |
 | `requests_per_minute` | int | no | Token bucket rate limit (0 = unlimited) |
 | `max_concurrent` | int | no | Maximum simultaneous in-flight requests (0 = unlimited) |
+| `request_timeout` | string | no | Per-endpoint LLM request timeout (e.g. `"45s"`). Overrides capability and component defaults. See [Timeout Resolution](#timeout-resolution). |
+
+**Capability Configuration** (in `model_registry.capabilities`):
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `preferred` | []string | yes | Endpoint names in order of preference |
+| `fallback` | []string | no | Backup endpoint names |
+| `requires_tools` | bool | no | Filter the chain to tool-capable endpoints only |
+| `timeout` | string | no | Per-capability LLM request timeout (e.g. `"30s"`). Overrides component default; overridden by endpoint and task timeouts. See [Timeout Resolution](#timeout-resolution). |
 
 **Endpoint Resolution**:
 
 1. Exact match on `model` field in request
 2. Fall back to `default` endpoint if present
 3. Return error if no match
+
+#### Timeout Resolution
+
+agentic-model wraps every LLM call in a `context.WithTimeout`. The timeout is
+resolved at the call site from four layers, highest precedence first:
+
+| Precedence | Source | Where it's set |
+|------------|--------|----------------|
+| 1 (highest) | `TaskMessage.timeout` → `AgentRequest.timeout` | Producer of the TaskMessage; persists across continuation iterations of the same loop |
+| 2 | `endpoint.request_timeout` | `model_registry.endpoints.<name>.request_timeout` |
+| 3 | `capability.timeout` | `model_registry.capabilities.<name>.timeout` |
+| 4 (lowest) | `agentic-model.timeout` | Component config (default `120s`) |
+
+The first layer with a non-empty, parseable duration wins. A malformed duration
+at any layer logs a warning and falls through to the next. The selected source
+is emitted on every request as a structured log field `timeout_source` with
+values `task`, `endpoint`, `capability`, `component`, or `default`.
+
+**Worked example**: with `TaskMessage.Timeout="30s"`, endpoint
+`request_timeout="60s"`, capability `timeout="90s"`, and component `timeout="120s"`,
+the effective request timeout is **30 seconds** (`timeout_source=task`). Omit
+`TaskMessage.Timeout` and it becomes 60 seconds (`timeout_source=endpoint`), and so on.
+
+**When to use which layer**:
+
+- **Component** — sets the baseline for any request that doesn't match a more specific rule. Keep this as the safety ceiling.
+- **Capability** — the natural place to express "fast classification calls should fail faster than heavy planning calls." Lets operators tune budgets without touching every TaskMessage producer.
+- **Endpoint** — use when a specific endpoint has known latency characteristics (e.g. a local quantized model with predictable response times).
+- **Task** — use sparingly for one-off overrides (e.g. a plan-reviewer task that should time out quickly even when routed to the default capability).
 
 **Compatible Providers**:
 
@@ -466,16 +505,36 @@ Sent from agentic-tools to agentic-loop:
 
 ### Timeout Tuning
 
-Different workloads require different timeouts:
+Different workloads require different timeouts. The agentic-model component
+resolves each LLM call's timeout from four layers (see [Timeout Resolution](#timeout-resolution)):
+task → endpoint → capability → component default. The **capability** layer is
+usually the right place to express workload-shape tuning, because capabilities
+already partition model traffic by intent (fast classification, heavy planning,
+summarization, etc.) and a single registry block covers all callers.
 
-| Workload | Loop Timeout | Model Timeout | Tool Timeout |
-|----------|--------------|---------------|--------------|
-| Simple Q&A | 30s | 30s | 10s |
-| Code review | 120s | 60s | 30s |
-| Research tasks | 300s | 120s | 60s |
-| Complex analysis | 600s | 180s | 120s |
+**Capability-level recommendations** (`model_registry.capabilities.<name>.timeout`):
 
-**Rule of thumb**: Loop timeout should be > (max_iterations × model_timeout) + tool_overhead
+| Capability | Typical Timeout | Workload |
+|------------|----------------|----------|
+| `fast` | 15–30s | Classification, routing, short answers |
+| `general` | 60s | Default Q&A, summaries, simple tool use |
+| `heavy` | 120–180s | Planning, multi-step reasoning, long context |
+| `summarization` | 180–300s | Full-context compaction across large histories |
+
+**Endpoint-level** (`model_registry.endpoints.<name>.request_timeout`): set
+when a specific endpoint has known latency quirks (e.g. a local quantized model
+with slower TTFT) independent of what capability is routing to it.
+
+**Task-level** (`TaskMessage.timeout`): reserve for one-off overrides, e.g. a
+short-lived plan-reviewer task that should time out quickly even when routed
+to a `heavy`-capability endpoint.
+
+**Component default** (`agentic-model.timeout`): keep this as the safety
+ceiling — the last-resort cap when no more specific rule applies.
+
+**Loop and tool timeouts** remain separate concerns (see agentic-loop and
+agentic-tools configs above). Rule of thumb: loop timeout should be >
+(`max_iterations` × longest expected model timeout) + tool overhead.
 
 ### Max Iterations
 
@@ -872,7 +931,10 @@ Use secret management systems in production:
 Protect against runaway loops and costs:
 
 1. **Iteration limits**: Always set `max_iterations`
-2. **Timeout guards**: Always set `timeout` at loop and tool levels
+2. **Layered timeout guards**: Set `timeout` at loop and tool levels, and tune
+   LLM call timeouts per capability or endpoint in the model registry
+   (see [Timeout Resolution](#timeout-resolution)). The component-level
+   `agentic-model.timeout` remains the safety ceiling.
 3. **Endpoint throttling**: Configure `requests_per_minute` and `max_concurrent` on each endpoint in
    the model registry. The throttle is shared across all agents targeting that endpoint, preventing
    agent teams from collectively saturating a provider's rate limit.

--- a/docs/basics/07-agentic-quickstart.md
+++ b/docs/basics/07-agentic-quickstart.md
@@ -125,6 +125,11 @@ The agentic configuration (`configs/agentic.json`) defines the component pipelin
 }
 ```
 
+> Need different LLM timeouts for fast vs heavy workloads? You can set
+> `request_timeout` per endpoint and `timeout` per capability in the model
+> registry — see
+> [agentic-components → Timeout Resolution](../advanced/08-agentic-components.md#timeout-resolution).
+
 **agentic-tools** - Tool executor:
 
 ```json

--- a/docs/concepts/13-agentic-systems.md
+++ b/docs/concepts/13-agentic-systems.md
@@ -521,6 +521,11 @@ Long-running loops can consume resources. Timeouts apply at multiple levels:
 
 - **Loop timeout** (default 120s): Maximum total execution time
 - **Tool timeout** (default 60s): Maximum time per tool execution
+- **LLM request timeout**: Per-call budget resolved from a four-layer precedence
+  chain — task → endpoint → capability → component default. Lets operators
+  give fast classification calls a shorter leash than heavy planning calls
+  without editing every producer. See
+  [agentic-components → Timeout Resolution](../advanced/08-agentic-components.md#timeout-resolution).
 - **Context cancellation**: Propagates through all operations for clean shutdown
 
 ### Tool Allowlists

--- a/model/registry.go
+++ b/model/registry.go
@@ -102,6 +102,11 @@ type EndpointConfig struct {
 	// MaxConcurrent limits concurrent in-flight requests to this endpoint.
 	// 0 means no concurrency limit.
 	MaxConcurrent int `json:"max_concurrent,omitempty"`
+	// RequestTimeout caps a single LLM request to this endpoint.
+	// Go duration string (e.g. "45s", "5m"). Empty means no per-endpoint cap;
+	// the capability or component-level timeout applies. See agentic-model
+	// Timeout Resolution for the full precedence chain.
+	RequestTimeout string `json:"request_timeout,omitempty"`
 }
 
 // CapabilityConfig defines model preferences for a capability.
@@ -114,6 +119,12 @@ type CapabilityConfig struct {
 	Fallback []string `json:"fallback,omitempty"`
 	// RequiresTools filters the chain to only tool-capable endpoints.
 	RequiresTools bool `json:"requires_tools,omitempty"`
+	// Timeout caps a single LLM request routed via this capability.
+	// Go duration string (e.g. "45s", "5m"). Empty means no per-capability
+	// cap; the component-level timeout applies. Endpoint and task timeouts
+	// take precedence over this value. See agentic-model Timeout Resolution
+	// for the full precedence chain.
+	Timeout string `json:"timeout,omitempty"`
 }
 
 // DefaultsConfig holds default model settings.
@@ -147,6 +158,11 @@ type RegistryReader interface {
 	// GetEndpoint returns the full endpoint configuration for an endpoint name.
 	// Returns nil if the endpoint is not configured.
 	GetEndpoint(name string) *EndpointConfig
+
+	// GetCapability returns the full capability configuration for a capability
+	// name. Returns nil if the name is not a configured capability (e.g. when
+	// the caller passed an endpoint name instead).
+	GetCapability(name string) *CapabilityConfig
 
 	// GetMaxTokens returns the context window size for an endpoint name.
 	// Returns 0 if the endpoint is not configured.
@@ -311,6 +327,16 @@ func (r *Registry) GetEndpoint(name string) *EndpointConfig {
 		return nil
 	}
 	return ep
+}
+
+// GetCapability returns the capability configuration for a name, or nil if not
+// a configured capability.
+func (r *Registry) GetCapability(name string) *CapabilityConfig {
+	capCfg, ok := r.Capabilities[name]
+	if !ok {
+		return nil
+	}
+	return capCfg
 }
 
 // GetMaxTokens returns the context window size for an endpoint name.

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -424,6 +424,11 @@ func (h *MessageHandler) HandleTask(ctx context.Context, task TaskMessage) (Hand
 		h.loopManager.CacheMetadata(loopID, task.Metadata)
 	}
 
+	// Cache per-task request timeout so continuation iterations reuse it.
+	if task.Timeout != "" {
+		h.loopManager.CacheRequestTimeout(loopID, task.Timeout)
+	}
+
 	return h.buildTaskRequest(loopID, task, entity, messages, tools)
 }
 
@@ -438,6 +443,7 @@ func (h *MessageHandler) buildTaskRequest(loopID string, task TaskMessage, entit
 		Messages:   messages,
 		Tools:      tools,
 		ToolChoice: task.ToolChoice,
+		Timeout:    task.Timeout,
 	}
 
 	h.loopManager.TrackRequest(request.RequestID, loopID)
@@ -993,6 +999,7 @@ func (h *MessageHandler) handleToolsComplete(
 		Messages:   messages,
 		Tools:      tools,
 		ToolChoice: toolChoice,
+		Timeout:    h.loopManager.GetCachedRequestTimeout(loopID),
 	}
 
 	// Track request ID to loop ID mapping (cache for fast lookup)

--- a/processor/agentic-loop/handlers_test.go
+++ b/processor/agentic-loop/handlers_test.go
@@ -1576,6 +1576,47 @@ func TestHandleTask_MetadataCachedAndPropagated(t *testing.T) {
 	t.Error("Should publish tool.execute with metadata")
 }
 
+func TestHandleTask_PropagatesTimeoutToAgentRequest(t *testing.T) {
+	handler := agenticloop.NewMessageHandler(createTestConfig())
+
+	task := agenticloop.TaskMessage{
+		TaskID:  "task-timeout",
+		Role:    "general",
+		Model:   "test-model",
+		Prompt:  "Test with timeout",
+		Timeout: "30s",
+	}
+
+	ctx := context.Background()
+	result, err := handler.HandleTask(ctx, task)
+	if err != nil {
+		t.Fatalf("HandleTask() error = %v", err)
+	}
+
+	for _, msg := range result.PublishedMessages {
+		if !containsIgnoreCase(msg.Subject, "agent.request") {
+			continue
+		}
+		var envelope map[string]any
+		if err := json.Unmarshal(msg.Data, &envelope); err != nil {
+			t.Fatalf("Failed to unmarshal envelope: %v", err)
+		}
+		payload, ok := envelope["payload"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected payload in BaseMessage envelope")
+		}
+		got, ok := payload["timeout"].(string)
+		if !ok {
+			t.Fatalf("AgentRequest.timeout missing or wrong type: %T", payload["timeout"])
+		}
+		if got != "30s" {
+			t.Errorf("AgentRequest.timeout = %q, want %q", got, "30s")
+		}
+		return
+	}
+	t.Error("HandleTask() should publish agent.request message")
+}
+
 // --- ToolCallFilter tests ---
 
 // mockFilter implements agentic.ToolCallFilter for testing

--- a/processor/agentic-loop/state.go
+++ b/processor/agentic-loop/state.go
@@ -16,24 +16,25 @@ import (
 
 // LoopManager manages loop entity lifecycle and state
 type LoopManager struct {
-	loops             map[string]*agentic.LoopEntity
-	contextManagers   map[string]*ContextManager          // loopID -> ContextManager
-	pendingTools      map[string]map[string]bool          // loopID -> map[callID]bool
-	queuedToolCalls   map[string][]agentic.ToolCall       // loopID -> remaining calls to dispatch serially
-	cachedTools       map[string][]agentic.ToolDefinition // loopID -> tools (runtime cache, not persisted)
-	cachedToolChoice  map[string]*agentic.ToolChoice      // loopID -> tool choice (runtime cache, not persisted)
-	cachedMetadata    map[string]map[string]any           // loopID -> metadata (domain context, not persisted)
-	taskPrompts       map[string]string                   // loopID -> original task prompt (for context recovery)
-	requestToLoop     map[string]string                   // requestID -> loopID
-	toolCallToLoop    map[string]string                   // callID -> loopID
-	callIDToName      map[string]string                   // callID -> function name (for Gemini tool result name field)
-	callIDToArguments map[string]map[string]any           // callID -> tool arguments (for trajectory audit)
-	requestStartTimes map[string]time.Time                // requestID -> start time (for duration measurement)
-	toolStartTimes    map[string]time.Time                // callID -> start time (for duration measurement)
-	contextConfig     ContextConfig                       // shared context config
-	modelRegistry     model.RegistryReader                // model registry for context managers
-	logger            *slog.Logger                        // logger for context managers
-	mu                sync.RWMutex
+	loops                map[string]*agentic.LoopEntity
+	contextManagers      map[string]*ContextManager          // loopID -> ContextManager
+	pendingTools         map[string]map[string]bool          // loopID -> map[callID]bool
+	queuedToolCalls      map[string][]agentic.ToolCall       // loopID -> remaining calls to dispatch serially
+	cachedTools          map[string][]agentic.ToolDefinition // loopID -> tools (runtime cache, not persisted)
+	cachedToolChoice     map[string]*agentic.ToolChoice      // loopID -> tool choice (runtime cache, not persisted)
+	cachedMetadata       map[string]map[string]any           // loopID -> metadata (domain context, not persisted)
+	cachedRequestTimeout map[string]string                   // loopID -> request timeout (from TaskMessage.Timeout, not persisted)
+	taskPrompts          map[string]string                   // loopID -> original task prompt (for context recovery)
+	requestToLoop        map[string]string                   // requestID -> loopID
+	toolCallToLoop       map[string]string                   // callID -> loopID
+	callIDToName         map[string]string                   // callID -> function name (for Gemini tool result name field)
+	callIDToArguments    map[string]map[string]any           // callID -> tool arguments (for trajectory audit)
+	requestStartTimes    map[string]time.Time                // requestID -> start time (for duration measurement)
+	toolStartTimes       map[string]time.Time                // callID -> start time (for duration measurement)
+	contextConfig        ContextConfig                       // shared context config
+	modelRegistry        model.RegistryReader                // model registry for context managers
+	logger               *slog.Logger                        // logger for context managers
+	mu                   sync.RWMutex
 }
 
 // LoopManagerOption is a functional option for configuring LoopManager
@@ -56,22 +57,23 @@ func WithLoopManagerModelRegistry(reg model.RegistryReader) LoopManagerOption {
 // NewLoopManager creates a new LoopManager
 func NewLoopManager(opts ...LoopManagerOption) *LoopManager {
 	lm := &LoopManager{
-		loops:             make(map[string]*agentic.LoopEntity),
-		contextManagers:   make(map[string]*ContextManager),
-		pendingTools:      make(map[string]map[string]bool),
-		queuedToolCalls:   make(map[string][]agentic.ToolCall),
-		cachedTools:       make(map[string][]agentic.ToolDefinition),
-		cachedToolChoice:  make(map[string]*agentic.ToolChoice),
-		cachedMetadata:    make(map[string]map[string]any),
-		taskPrompts:       make(map[string]string),
-		requestToLoop:     make(map[string]string),
-		toolCallToLoop:    make(map[string]string),
-		callIDToName:      make(map[string]string),
-		callIDToArguments: make(map[string]map[string]any),
-		requestStartTimes: make(map[string]time.Time),
-		toolStartTimes:    make(map[string]time.Time),
-		contextConfig:     DefaultContextConfig(),
-		logger:            slog.Default(),
+		loops:                make(map[string]*agentic.LoopEntity),
+		contextManagers:      make(map[string]*ContextManager),
+		pendingTools:         make(map[string]map[string]bool),
+		queuedToolCalls:      make(map[string][]agentic.ToolCall),
+		cachedTools:          make(map[string][]agentic.ToolDefinition),
+		cachedToolChoice:     make(map[string]*agentic.ToolChoice),
+		cachedMetadata:       make(map[string]map[string]any),
+		cachedRequestTimeout: make(map[string]string),
+		taskPrompts:          make(map[string]string),
+		requestToLoop:        make(map[string]string),
+		toolCallToLoop:       make(map[string]string),
+		callIDToName:         make(map[string]string),
+		callIDToArguments:    make(map[string]map[string]any),
+		requestStartTimes:    make(map[string]time.Time),
+		toolStartTimes:       make(map[string]time.Time),
+		contextConfig:        DefaultContextConfig(),
+		logger:               slog.Default(),
 	}
 	for _, opt := range opts {
 		opt(lm)
@@ -82,22 +84,23 @@ func NewLoopManager(opts ...LoopManagerOption) *LoopManager {
 // NewLoopManagerWithConfig creates a new LoopManager with custom context config
 func NewLoopManagerWithConfig(contextConfig ContextConfig, opts ...LoopManagerOption) *LoopManager {
 	lm := &LoopManager{
-		loops:             make(map[string]*agentic.LoopEntity),
-		contextManagers:   make(map[string]*ContextManager),
-		pendingTools:      make(map[string]map[string]bool),
-		queuedToolCalls:   make(map[string][]agentic.ToolCall),
-		cachedTools:       make(map[string][]agentic.ToolDefinition),
-		cachedToolChoice:  make(map[string]*agentic.ToolChoice),
-		cachedMetadata:    make(map[string]map[string]any),
-		taskPrompts:       make(map[string]string),
-		requestToLoop:     make(map[string]string),
-		toolCallToLoop:    make(map[string]string),
-		callIDToName:      make(map[string]string),
-		callIDToArguments: make(map[string]map[string]any),
-		requestStartTimes: make(map[string]time.Time),
-		toolStartTimes:    make(map[string]time.Time),
-		contextConfig:     contextConfig,
-		logger:            slog.Default(),
+		loops:                make(map[string]*agentic.LoopEntity),
+		contextManagers:      make(map[string]*ContextManager),
+		pendingTools:         make(map[string]map[string]bool),
+		queuedToolCalls:      make(map[string][]agentic.ToolCall),
+		cachedTools:          make(map[string][]agentic.ToolDefinition),
+		cachedToolChoice:     make(map[string]*agentic.ToolChoice),
+		cachedMetadata:       make(map[string]map[string]any),
+		cachedRequestTimeout: make(map[string]string),
+		taskPrompts:          make(map[string]string),
+		requestToLoop:        make(map[string]string),
+		toolCallToLoop:       make(map[string]string),
+		callIDToName:         make(map[string]string),
+		callIDToArguments:    make(map[string]map[string]any),
+		requestStartTimes:    make(map[string]time.Time),
+		toolStartTimes:       make(map[string]time.Time),
+		contextConfig:        contextConfig,
+		logger:               slog.Default(),
 	}
 	for _, opt := range opts {
 		opt(lm)
@@ -195,6 +198,7 @@ func (m *LoopManager) DeleteLoop(loopID string) error {
 	delete(m.cachedTools, loopID)
 	delete(m.cachedToolChoice, loopID)
 	delete(m.cachedMetadata, loopID)
+	delete(m.cachedRequestTimeout, loopID)
 	delete(m.taskPrompts, loopID)
 
 	// Clean up maps keyed by requestID/callID that embed the loopID prefix.
@@ -269,6 +273,23 @@ func (m *LoopManager) GetCachedMetadata(loopID string) map[string]any {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.cachedMetadata[loopID]
+}
+
+// CacheRequestTimeout stores the per-request timeout for a loop (from
+// TaskMessage.Timeout). Reused for all continuation iterations so the
+// task-level budget persists across LLM calls in the same loop.
+func (m *LoopManager) CacheRequestTimeout(loopID, timeout string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cachedRequestTimeout[loopID] = timeout
+}
+
+// GetCachedRequestTimeout retrieves the cached per-request timeout for a loop.
+// Returns empty string when no task-level timeout was set.
+func (m *LoopManager) GetCachedRequestTimeout(loopID string) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.cachedRequestTimeout[loopID]
 }
 
 // CacheTaskPrompt stores the original task prompt for context recovery.

--- a/processor/agentic-model/component.go
+++ b/processor/agentic-model/component.go
@@ -341,7 +341,7 @@ func (c *Component) handleRequest(ctx context.Context, data []byte) {
 		slog.String("model", req.Model),
 		slog.String("role", req.Role))
 
-	client, err := c.getClientForRequest(req)
+	client, endpoint, capability, err := c.getClientForRequest(req)
 	if err != nil {
 		c.logger.Error("Failed to resolve endpoint", "error", err, "model", req.Model)
 		c.publishErrorResponse(ctx, req.RequestID, err.Error())
@@ -354,7 +354,7 @@ func (c *Component) handleRequest(ctx context.Context, data []byte) {
 		c.metrics.recordRequestStart(req.Model)
 	}
 
-	resp, err := c.executeRequest(ctx, client, req)
+	resp, err := c.executeRequest(ctx, client, req, endpoint, capability)
 	duration := time.Since(startTime).Seconds()
 
 	if err != nil || resp.Status == "error" {
@@ -462,11 +462,19 @@ func (c *Component) handleModelSuccess(ctx context.Context, req agentic.AgentReq
 //
 // This allows callers to set req.Model to either a capability name (e.g. "fast")
 // or a concrete endpoint name (e.g. "ollama-qwen32b") and get the right client.
-func (c *Component) getClientForRequest(req agentic.AgentRequest) (*Client, error) {
+//
+// Returns the resolved client, the endpoint config, and the capability name (empty
+// when req.Model was a concrete endpoint name). Callers use the capability name to
+// look up per-capability timeouts.
+func (c *Component) getClientForRequest(req agentic.AgentRequest) (*Client, *model.EndpointConfig, string, error) {
 	var ep *model.EndpointConfig
+	var capability string
 
 	// 1. Try capability-based resolution
 	chain := c.modelRegistry.GetFallbackChain(req.Model)
+	if len(chain) > 0 {
+		capability = req.Model
+	}
 	for _, name := range chain {
 		if candidate := c.modelRegistry.GetEndpoint(name); candidate != nil {
 			ep = candidate
@@ -488,7 +496,7 @@ func (c *Component) getClientForRequest(req agentic.AgentRequest) (*Client, erro
 	}
 
 	if ep == nil {
-		return nil, errs.WrapInvalid(
+		return nil, nil, "", errs.WrapInvalid(
 			fmt.Errorf("no endpoint found for model %q in registry", req.Model),
 			"Component", "getClientForRequest", "resolve endpoint",
 		)
@@ -501,12 +509,12 @@ func (c *Component) getClientForRequest(req agentic.AgentRequest) (*Client, erro
 	defer c.clientMu.Unlock()
 
 	if client, ok := c.clientCache[cacheKey]; ok {
-		return client, nil
+		return client, ep, capability, nil
 	}
 
 	client, err := NewClient(ep)
 	if err != nil {
-		return nil, errs.Wrap(err, "Component", "getClientForRequest", fmt.Sprintf("create client for model %q", req.Model))
+		return nil, nil, "", errs.Wrap(err, "Component", "getClientForRequest", fmt.Sprintf("create client for model %q", req.Model))
 	}
 
 	// Wire provider adapter for request/response normalization.
@@ -530,7 +538,7 @@ func (c *Component) getClientForRequest(req agentic.AgentRequest) (*Client, erro
 	}
 
 	c.clientCache[cacheKey] = client
-	return client, nil
+	return client, ep, capability, nil
 }
 
 // makeChunkHandler returns a ChunkHandler that publishes chunks to core NATS.
@@ -551,19 +559,84 @@ func (c *Component) makeChunkHandler() ChunkHandler {
 	}
 }
 
-// executeRequest executes the chat completion with timeout
-func (c *Component) executeRequest(ctx context.Context, client *Client, req agentic.AgentRequest) (agentic.AgentResponse, error) {
-	timeout := 120 * time.Second
-	if c.config.Timeout != "" {
-		if d, err := time.ParseDuration(c.config.Timeout); err == nil {
-			timeout = d
-		}
-	}
+// executeRequest executes the chat completion with a resolved timeout.
+// Timeout precedence is applied by resolveTimeout.
+func (c *Component) executeRequest(
+	ctx context.Context,
+	client *Client,
+	req agentic.AgentRequest,
+	endpoint *model.EndpointConfig,
+	capability string,
+) (agentic.AgentResponse, error) {
+	timeout := c.resolveTimeout(req, endpoint, capability)
 
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	return client.ChatCompletion(reqCtx, req)
+}
+
+// resolveTimeout picks the effective request timeout using precedence:
+//  1. req.Timeout (per-task override; propagated from TaskMessage.Timeout)
+//  2. endpoint.RequestTimeout
+//  3. capability.Timeout (looked up via registry when capability is non-empty)
+//  4. component messageTimeout (cached from config.Timeout at construction)
+//  5. hardcoded 120s safety default
+//
+// Invalid duration strings at levels 1-3 log a warning and fall through to the
+// next level, so a malformed per-message override never blocks a task. The
+// selected source is logged at debug level as timeout_source.
+func (c *Component) resolveTimeout(req agentic.AgentRequest, endpoint *model.EndpointConfig, capability string) time.Duration {
+	const fallback = 120 * time.Second
+
+	tryParse := func(value, source string) (time.Duration, bool) {
+		if value == "" {
+			return 0, false
+		}
+		d, err := time.ParseDuration(value)
+		if err != nil {
+			c.logger.Warn("Invalid timeout value; falling through",
+				"source", source,
+				"value", value,
+				"error", err,
+				"request_id", req.RequestID)
+			return 0, false
+		}
+		return d, true
+	}
+
+	if d, ok := tryParse(req.Timeout, "task"); ok {
+		c.logger.Debug("Resolved request timeout", "timeout_source", "task", "timeout", d, "request_id", req.RequestID)
+		return d
+	}
+
+	if endpoint != nil {
+		if d, ok := tryParse(endpoint.RequestTimeout, "endpoint"); ok {
+			c.logger.Debug("Resolved request timeout", "timeout_source", "endpoint", "timeout", d, "request_id", req.RequestID)
+			return d
+		}
+	}
+
+	if capability != "" && c.modelRegistry != nil {
+		if capCfg := c.modelRegistry.GetCapability(capability); capCfg != nil {
+			if d, ok := tryParse(capCfg.Timeout, "capability"); ok {
+				c.logger.Debug("Resolved request timeout",
+					"timeout_source", "capability",
+					"capability", capability,
+					"timeout", d,
+					"request_id", req.RequestID)
+				return d
+			}
+		}
+	}
+
+	if c.messageTimeout > 0 {
+		c.logger.Debug("Resolved request timeout", "timeout_source", "component", "timeout", c.messageTimeout, "request_id", req.RequestID)
+		return c.messageTimeout
+	}
+
+	c.logger.Debug("Resolved request timeout", "timeout_source", "default", "timeout", fallback, "request_id", req.RequestID)
+	return fallback
 }
 
 // incrementErrors safely increments the error counter

--- a/processor/agentic-model/resolve_timeout_test.go
+++ b/processor/agentic-model/resolve_timeout_test.go
@@ -1,0 +1,140 @@
+package agenticmodel
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model"
+)
+
+func newTimeoutTestComponent(t *testing.T, componentTimeout time.Duration, registry *model.Registry) *Component {
+	t.Helper()
+	return &Component{
+		logger:         slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+		messageTimeout: componentTimeout,
+		modelRegistry:  registry,
+	}
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) { return len(p), nil }
+
+func TestResolveTimeout_PrecedenceChain(t *testing.T) {
+	registry := &model.Registry{
+		Capabilities: map[string]*model.CapabilityConfig{
+			"fast":       {Timeout: "15s", Preferred: []string{"ep"}},
+			"bad-parse":  {Timeout: "not-a-duration", Preferred: []string{"ep"}},
+			"no-timeout": {Preferred: []string{"ep"}},
+		},
+		Endpoints: map[string]*model.EndpointConfig{
+			"ep": {URL: "http://x", Model: "m"},
+		},
+	}
+
+	endpointWithTimeout := &model.EndpointConfig{URL: "http://x", Model: "m", RequestTimeout: "45s"}
+	endpointNoTimeout := &model.EndpointConfig{URL: "http://x", Model: "m"}
+	endpointBadTimeout := &model.EndpointConfig{URL: "http://x", Model: "m", RequestTimeout: "bogus"}
+
+	tests := []struct {
+		name       string
+		req        agentic.AgentRequest
+		endpoint   *model.EndpointConfig
+		capability string
+		componentT time.Duration
+		want       time.Duration
+	}{
+		{
+			name:       "task wins over everything",
+			req:        agentic.AgentRequest{Timeout: "5s"},
+			endpoint:   endpointWithTimeout,
+			capability: "fast",
+			componentT: 120 * time.Second,
+			want:       5 * time.Second,
+		},
+		{
+			name:       "endpoint wins when task empty",
+			req:        agentic.AgentRequest{},
+			endpoint:   endpointWithTimeout,
+			capability: "fast",
+			componentT: 120 * time.Second,
+			want:       45 * time.Second,
+		},
+		{
+			name:       "capability wins when task and endpoint empty",
+			req:        agentic.AgentRequest{},
+			endpoint:   endpointNoTimeout,
+			capability: "fast",
+			componentT: 120 * time.Second,
+			want:       15 * time.Second,
+		},
+		{
+			name:       "component default wins when task/endpoint/capability empty",
+			req:        agentic.AgentRequest{},
+			endpoint:   endpointNoTimeout,
+			capability: "no-timeout",
+			componentT: 90 * time.Second,
+			want:       90 * time.Second,
+		},
+		{
+			name:       "hardcoded fallback when component timeout is zero",
+			req:        agentic.AgentRequest{},
+			endpoint:   endpointNoTimeout,
+			capability: "",
+			componentT: 0,
+			want:       120 * time.Second,
+		},
+		{
+			name:       "invalid task timeout falls through to endpoint",
+			req:        agentic.AgentRequest{Timeout: "garbage"},
+			endpoint:   endpointWithTimeout,
+			capability: "fast",
+			componentT: 120 * time.Second,
+			want:       45 * time.Second,
+		},
+		{
+			name:       "invalid endpoint timeout falls through to capability",
+			req:        agentic.AgentRequest{},
+			endpoint:   endpointBadTimeout,
+			capability: "fast",
+			componentT: 120 * time.Second,
+			want:       15 * time.Second,
+		},
+		{
+			name:       "invalid capability timeout falls through to component",
+			req:        agentic.AgentRequest{},
+			endpoint:   endpointNoTimeout,
+			capability: "bad-parse",
+			componentT: 77 * time.Second,
+			want:       77 * time.Second,
+		},
+		{
+			name:       "nil endpoint skipped cleanly",
+			req:        agentic.AgentRequest{},
+			endpoint:   nil,
+			capability: "fast",
+			componentT: 120 * time.Second,
+			want:       15 * time.Second,
+		},
+		{
+			name:       "empty capability skipped cleanly",
+			req:        agentic.AgentRequest{},
+			endpoint:   endpointNoTimeout,
+			capability: "",
+			componentT: 42 * time.Second,
+			want:       42 * time.Second,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTimeoutTestComponent(t, tc.componentT, registry)
+			got := c.resolveTimeout(tc.req, tc.endpoint, tc.capability)
+			if got != tc.want {
+				t.Errorf("resolveTimeout = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Four-layer timeout precedence on agentic-model (task → endpoint → capability → component)
- New fields: `TaskMessage.Timeout`, `AgentRequest.Timeout`, `EndpointConfig.RequestTimeout`, `CapabilityConfig.Timeout`
- `timeout_source` structured log field for observability
- `LoopManager` caches the task timeout so continuation iterations reuse it

## Why
Today the agentic-model component wraps every LLM call in a single component-level 120s timeout. That's wrong in both directions: fast calls wait too long to fail, heavy calls die mid-plan. This ADR introduces the natural axes operators already reason about — capabilities, endpoints, and per-task overrides — and resolves them in one place (`(*Component).resolveTimeout`). Addresses upstream requests from semspec (per-endpoint `request_timeout`, per-capability budgets, per-task overrides for plan-reviewer vs implementation workloads routed through the same capability).

## Test plan
- [x] `go test -race ./processor/agentic-model/...` (incl. new `resolve_timeout_test.go`)
- [x] `go test -race ./processor/agentic-loop/...` (incl. new `TestHandleTask_PropagatesTimeoutToAgentRequest`)
- [x] `go test -race ./...` (full suite)
- [x] `task lint`
- [x] `task schema:generate` — no schema drift (internal types)
- [ ] E2E: exercise a task with an explicit `timeout` and confirm log line shows `timeout_source=task`

🤖 Generated with [Claude Code](https://claude.com/claude-code)