### PR TITLE
fix(graph-ingest): set Version=1 on referential-integrity stubs

### DIFF
--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -1031,10 +1031,15 @@ func (c *Component) ensureReferencedEntityExists(ctx context.Context, entityID, 
 		return nil // Entity exists, nothing to do
 	}
 
-	// Entity doesn't exist - create a stub
+	// Entity doesn't exist - create a stub.
+	// Version is set to 1 to match the invariant held by every other
+	// EntityState write path (see component.go:872, messagemanager/
+	// processor.go:276, datamanager/manager.go:792). When the real entity
+	// later arrives, the merge path increments Version to 2.
 	now := time.Now()
 	stub := &graph.EntityState{
 		ID:        entityID,
+		Version:   1,
 		UpdatedAt: now,
 		Triples: []message.Triple{
 			{

--- a/processor/graph-ingest/component_test.go
+++ b/processor/graph-ingest/component_test.go
@@ -884,6 +884,64 @@ func TestComponent_RespectsContext_Timeout(t *testing.T) {
 	}
 }
 
+// TestComponent_CreateEntity_ReferentialIntegrityStubHasVersion1 verifies that
+// stub entities created for referential integrity (when a relationship triple
+// references an entity that doesn't yet exist) are written with Version=1.
+//
+// Historical bug: stubs were written without Version, defaulting to 0, which
+// violated the invariant held by every other EntityState write path. Downstream
+// consumers that check Version > 0 (notably the e2e entity-structure validator)
+// would silently reject these stubs as invalid.
+func TestComponent_CreateEntity_ReferentialIntegrityStubHasVersion1(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	sourceID := "c360.platform.robotics.mav1.drone.001"
+	targetID := "c360.platform.robotics.mav1.operator.alice"
+
+	// Entity with a relationship triple whose object is a valid entity ID
+	// referencing a target that does NOT yet exist in the bucket. This
+	// triggers ensureReferencedEntityExists → stub creation.
+	entity := &graph.EntityState{
+		ID: sourceID,
+		Triples: []message.Triple{
+			{
+				Subject:    sourceID,
+				Predicate:  "robotics.assignment.operator",
+				Object:     targetID,
+				Source:     "test",
+				Timestamp:  time.Now(),
+				Confidence: 1.0,
+			},
+		},
+		Version:   1,
+		UpdatedAt: time.Now(),
+	}
+
+	require.NoError(t, comp.CreateEntity(ctx, entity))
+
+	// Read the stub back from the mock bucket and verify Version == 1.
+	entry, err := comp.entityBucket.Get(ctx, targetID)
+	require.NoError(t, err, "stub for referenced target should have been created")
+
+	var stub graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &stub))
+
+	assert.Equal(t, uint64(1), stub.Version,
+		"stub entity must be written with Version=1 to match the invariant held by all other write paths")
+	assert.Equal(t, targetID, stub.ID)
+
+	// Sanity: the stub triples include the referential-integrity markers.
+	foundStubMarker := false
+	for _, tr := range stub.Triples {
+		if tr.Predicate == "core.identity.stub" {
+			foundStubMarker = true
+			break
+		}
+	}
+	assert.True(t, foundStubMarker, "stub should carry core.identity.stub predicate")
+}
+
 // ====================================================================================
 // Helper Functions
 // ====================================================================================

--- a/test/e2e/scenarios/validate_entity.go
+++ b/test/e2e/scenarios/validate_entity.go
@@ -417,8 +417,13 @@ func (s *TieredScenario) executeValidateEntityStructure(ctx context.Context, res
 	}
 
 	if len(validationErrors) > 0 {
-		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("Entity structure validation issues: %v", validationErrors))
+		// Fail loudly instead of warning. Pre-fix, this check silently
+		// logged ~3 errors per run for 6+ weeks because stub entities
+		// were written with Version=0 (see graph-ingest stub creation
+		// fix). Now that the invariant holds, any validation failure is
+		// a genuine regression and should block merge.
+		return fmt.Errorf("entity structure validation failed for %d of %d sampled entities: %v",
+			len(validationErrors), len(entities), validationErrors)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
Stub entities created for referential integrity at `processor/graph-ingest/component.go:1036` were written without `Version`, defaulting to `0`. Every other `EntityState` write path sets `Version: 1` on create. The missing field violated the invariant and caused the statistical e2e tier to silently log ~3 \`validation_errors\` per run for six weeks.

## Why
Discovered while reviewing the statistical e2e output from the ops-agent PR investigation (#6). `executeValidateEntityStructure` samples 5 entities and checks \`Version > 0\`. `entities_validated` was stuck at 1–2 even when all 5 retrieved cleanly — tracing that back revealed the stub path was the only \`EntityState\` write site without \`Version: 1\`.

## Changes
- **`processor/graph-ingest/component.go`** — set \`Version: 1\` on stub creation with a comment pointing at the invariant (peers: \`component.go:872\`, \`messagemanager/processor.go:276\`, \`datamanager/manager.go:792\`).
- **`processor/graph-ingest/component_test.go`** — new \`TestComponent_CreateEntity_ReferentialIntegrityStubHasVersion1\` that creates an entity with a relationship triple pointing to a non-existent target, reads the resulting stub, and asserts \`Version==1\`. Verified it fails on the pre-fix code (temporary stash test: \`expected: 0x1, actual: 0x0\`).
- **`test/e2e/scenarios/validate_entity.go`** — promote the warning path to a scenario failure. Non-zero \`validation_errors\` now blocks the run so future regressions of this invariant are caught immediately.

## Blast radius
Low but real. The stub is overwritten when the real entity arrives — \`messagemanager/processor.go:292\` sets \`Version = existing.Version + 1\`, which still works (1 → 2). During the window between stub and real write, or permanently if the real entity never arrives, consumers saw \`Version=0\`.

Nothing else in the repo checks \`Version == 0\` as a sentinel (\`grep -rn "\\.Version\\s*==\\s*0" --include='*.go' | grep -v _test\` returns only the triple-add init path, which immediately increments).

## Test plan
- [x] \`go test -race ./processor/graph-ingest/...\` — new regression passes; fails correctly on pre-fix code
- [x] \`task lint\` — clean
- [x] \`task test:integration\` — passes (flaky \`TestIntegration_ClusteringMinSize\` cleared on re-run; unrelated)
- [x] \`task e2e:statistical\` — \`entities_validated\` **2 → 5**, \`validation_errors\` **3 → 0**, 41/41 stages pass
- [ ] \`task e2e:agentic\` — should be neutral; stubs are less common in the agentic tier but the fix applies to any referential-integrity write

## Follow-up (separate issue)
Pre-existing flakiness in \`executeVerifyEntityRetrieval\` (hardcoded fixture IDs, \`missing_count\` fluctuates 0–3 across runs) is a timing/ingestion race not addressed here. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)