### PR TITLE
feat(agentic): token usage metrics + tool result truncation

### DIFF
--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -836,6 +836,7 @@ func (c *Component) recordResponseMetrics(response *agentic.AgentResponse, resul
 
 	c.metrics.recordIteration()
 	c.metrics.recordTrajectoryStep("model_call")
+	c.metrics.recordRequestTokens(response.TokenUsage.PromptTokens, response.TokenUsage.CompletionTokens)
 
 	// Record dispatched tool calls
 	if response.Status == "tool_call" {

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -929,6 +929,9 @@ func (c *Component) handleToolResultMessage(ctx context.Context, data []byte) {
 	if c.metrics != nil {
 		c.metrics.recordToolResultReceived(hasError)
 		c.metrics.recordTrajectoryStep("tool_call")
+		if c.config.ToolResultMaxBytes > 0 && len(toolResult.Content) > c.config.ToolResultMaxBytes {
+			c.metrics.recordToolResultTruncated()
+		}
 	}
 
 	// Apply accumulated Boid steering signals before handler processes result

--- a/processor/agentic-loop/config.go
+++ b/processor/agentic-loop/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	PositionsBucket      string                `json:"positions_bucket,omitempty" schema:"type:string,description:NATS KV bucket name for boid agent positions,default:AGENT_POSITIONS,category:advanced"`
 	BoidEnabled          bool                  `json:"boid_enabled,omitempty" schema:"type:bool,description:Enable Boid-style agent coordination (position tracking and steering signals),default:false,category:advanced"`
 	BoidSignalTTL        string                `json:"boid_signal_ttl,omitempty" schema:"type:string,description:TTL for Boid steering signals before expiration (e.g. 30s or 1m),default:30s,category:advanced"`
+	ToolResultMaxBytes   int                   `json:"tool_result_max_bytes,omitempty" schema:"type:int,description:Maximum bytes for tool result content before truncation. 0 means no limit,default:32768,category:advanced"`
 	TrajectoryDetail     string                `json:"trajectory_detail,omitempty" schema:"type:string,description:Trajectory detail level: summary (default) or full,default:summary,category:advanced"`
 	ContentBucket        string                `json:"content_bucket,omitempty" schema:"type:string,description:NATS ObjectStore bucket for trajectory step content (tool results and model responses),default:AGENT_CONTENT,category:advanced"`
 	TrajectoryCacheTTL   string                `json:"trajectory_cache_ttl,omitempty" schema:"type:string,description:TTL for trajectory cache (e.g. 4h or 30m). Trajectories older than this are only available via graph queries,default:4h,category:advanced"`
@@ -206,17 +207,18 @@ func DefaultContextConfig() ContextConfig {
 // DefaultConfig returns the default configuration
 func DefaultConfig() Config {
 	return Config{
-		MaxIterations:    20,
-		Timeout:          "120s",
-		StreamName:       "AGENT",
-		LoopsBucket:      "AGENT_LOOPS",
-		PositionsBucket:  "AGENT_POSITIONS",
-		BoidEnabled:      false,
-		BoidSignalTTL:    "30s",
-		ContentBucket:    "AGENT_CONTENT",
-		TrajectoryDetail: "summary",
-		Consumer:         DefaultConsumerConfig(),
-		Context:          DefaultContextConfig(),
+		MaxIterations:      20,
+		Timeout:            "120s",
+		StreamName:         "AGENT",
+		LoopsBucket:        "AGENT_LOOPS",
+		PositionsBucket:    "AGENT_POSITIONS",
+		BoidEnabled:        false,
+		BoidSignalTTL:      "30s",
+		ContentBucket:      "AGENT_CONTENT",
+		ToolResultMaxBytes: 32768,
+		TrajectoryDetail:   "summary",
+		Consumer:           DefaultConsumerConfig(),
+		Context:            DefaultContextConfig(),
 		Ports: &component.PortConfig{
 			Inputs: []component.PortDefinition{
 				{

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"time"
+	"unicode/utf8"
 
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/message"
@@ -73,6 +74,21 @@ func NewMessageHandler(config Config, loopManagerOpts ...LoopManagerOption) *Mes
 		compactor:         NewCompactor(config.Context),
 		logger:            slog.Default(),
 	}
+}
+
+// truncateToolResult caps a tool result string at maxBytes, preserving UTF-8
+// validity and appending a marker showing the original size.
+func truncateToolResult(s string, maxBytes int) string {
+	marker := fmt.Sprintf("\n…[truncated: %d bytes → %d]", len(s), maxBytes)
+	budget := maxBytes - len(marker)
+	if budget <= 0 {
+		return marker
+	}
+	cut := budget
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + marker
 }
 
 // resolveProvider looks up the LLM provider for a model endpoint name.
@@ -831,6 +847,17 @@ func (h *MessageHandler) HandleToolResult(ctx context.Context, loopID string, to
 			result.FailureState = failure
 		}
 		return result, errs.WrapFatal(fmt.Errorf("loop timeout exceeded"), "agentic-loop", "HandleToolResult", "check timeout")
+	}
+
+	// Truncate oversized tool results before they enter the context window.
+	if h.config.ToolResultMaxBytes > 0 && len(toolResult.Content) > h.config.ToolResultMaxBytes {
+		original := len(toolResult.Content)
+		toolResult.Content = truncateToolResult(toolResult.Content, h.config.ToolResultMaxBytes)
+		h.logger.Warn("tool result truncated",
+			slog.String("loop_id", loopID),
+			slog.String("tool", toolResult.Name),
+			slog.Int("original_bytes", original),
+			slog.Int("max_bytes", h.config.ToolResultMaxBytes))
 	}
 
 	entity, err := h.loopManager.GetLoop(loopID)

--- a/processor/agentic-loop/metrics.go
+++ b/processor/agentic-loop/metrics.go
@@ -31,6 +31,10 @@ type loopMetrics struct {
 	toolCallsDispatched *prometheus.CounterVec
 	toolResultsReceived *prometheus.CounterVec
 
+	// Token usage per LLM request
+	requestTokensIn  prometheus.Histogram
+	requestTokensOut prometheus.Histogram
+
 	// Context management
 	contextUtilization           prometheus.Gauge
 	contextCompactionsTotal      prometheus.Counter
@@ -146,6 +150,22 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 				Help:      "Total Boid position updates in KV store",
 			}),
 
+			requestTokensIn: prometheus.NewHistogram(prometheus.HistogramOpts{
+				Namespace: "semstreams",
+				Subsystem: "agentic_loop",
+				Name:      "request_tokens_in",
+				Help:      "Prompt tokens per LLM request",
+				Buckets:   prometheus.ExponentialBuckets(100, 2, 12), // 100 to ~400k
+			}),
+
+			requestTokensOut: prometheus.NewHistogram(prometheus.HistogramOpts{
+				Namespace: "semstreams",
+				Subsystem: "agentic_loop",
+				Name:      "request_tokens_out",
+				Help:      "Completion tokens per LLM request",
+				Buckets:   prometheus.ExponentialBuckets(10, 2, 12), // 10 to ~40k
+			}),
+
 			contextUtilization: prometheus.NewGauge(prometheus.GaugeOpts{
 				Namespace: "semstreams",
 				Subsystem: "agentic_loop",
@@ -199,6 +219,8 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 			_ = registry.RegisterCounterVec("agentic-loop", "boid_signals_received_total", metrics.boidSignalsReceived)
 			_ = registry.RegisterCounter("agentic-loop", "boid_position_updates_total", metrics.boidPositionUpdates)
 			_ = registry.RegisterCounter("agentic-loop", "boid_entities_filtered_total", metrics.boidEntitiesFiltered)
+			_ = registry.RegisterHistogram("agentic-loop", "request_tokens_in", metrics.requestTokensIn)
+			_ = registry.RegisterHistogram("agentic-loop", "request_tokens_out", metrics.requestTokensOut)
 			_ = registry.RegisterGauge("agentic-loop", "context_utilization", metrics.contextUtilization)
 			_ = registry.RegisterCounter("agentic-loop", "context_compactions_total", metrics.contextCompactionsTotal)
 			_ = registry.RegisterHistogram("agentic-loop", "context_compaction_tokens_saved", metrics.contextCompactionTokensSaved)
@@ -219,6 +241,8 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 			_ = prometheus.DefaultRegisterer.Register(metrics.boidSignalsReceived)
 			_ = prometheus.DefaultRegisterer.Register(metrics.boidPositionUpdates)
 			_ = prometheus.DefaultRegisterer.Register(metrics.boidEntitiesFiltered)
+			_ = prometheus.DefaultRegisterer.Register(metrics.requestTokensIn)
+			_ = prometheus.DefaultRegisterer.Register(metrics.requestTokensOut)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextUtilization)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextCompactionsTotal)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextCompactionTokensSaved)
@@ -295,6 +319,16 @@ func (m *loopMetrics) recordBoidPositionUpdate() {
 // recordBoidEntitiesFiltered records entity filtering by Boid steering.
 func (m *loopMetrics) recordBoidEntitiesFiltered() {
 	m.boidEntitiesFiltered.Inc()
+}
+
+// recordRequestTokens records prompt and completion token counts for an LLM request.
+func (m *loopMetrics) recordRequestTokens(tokensIn, tokensOut int) {
+	if tokensIn > 0 {
+		m.requestTokensIn.Observe(float64(tokensIn))
+	}
+	if tokensOut > 0 {
+		m.requestTokensOut.Observe(float64(tokensOut))
+	}
 }
 
 // recordContextUtilization updates the current context utilization gauge.

--- a/processor/agentic-loop/metrics.go
+++ b/processor/agentic-loop/metrics.go
@@ -35,6 +35,9 @@ type loopMetrics struct {
 	requestTokensIn  prometheus.Histogram
 	requestTokensOut prometheus.Histogram
 
+	// Tool result truncation
+	toolResultsTruncated prometheus.Counter
+
 	// Context management
 	contextUtilization           prometheus.Gauge
 	contextCompactionsTotal      prometheus.Counter
@@ -166,6 +169,13 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 				Buckets:   prometheus.ExponentialBuckets(10, 2, 12), // 10 to ~40k
 			}),
 
+			toolResultsTruncated: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "agentic_loop",
+				Name:      "tool_results_truncated_total",
+				Help:      "Total tool results truncated because they exceeded tool_result_max_bytes",
+			}),
+
 			contextUtilization: prometheus.NewGauge(prometheus.GaugeOpts{
 				Namespace: "semstreams",
 				Subsystem: "agentic_loop",
@@ -221,6 +231,7 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 			_ = registry.RegisterCounter("agentic-loop", "boid_entities_filtered_total", metrics.boidEntitiesFiltered)
 			_ = registry.RegisterHistogram("agentic-loop", "request_tokens_in", metrics.requestTokensIn)
 			_ = registry.RegisterHistogram("agentic-loop", "request_tokens_out", metrics.requestTokensOut)
+			_ = registry.RegisterCounter("agentic-loop", "tool_results_truncated_total", metrics.toolResultsTruncated)
 			_ = registry.RegisterGauge("agentic-loop", "context_utilization", metrics.contextUtilization)
 			_ = registry.RegisterCounter("agentic-loop", "context_compactions_total", metrics.contextCompactionsTotal)
 			_ = registry.RegisterHistogram("agentic-loop", "context_compaction_tokens_saved", metrics.contextCompactionTokensSaved)
@@ -243,6 +254,7 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 			_ = prometheus.DefaultRegisterer.Register(metrics.boidEntitiesFiltered)
 			_ = prometheus.DefaultRegisterer.Register(metrics.requestTokensIn)
 			_ = prometheus.DefaultRegisterer.Register(metrics.requestTokensOut)
+			_ = prometheus.DefaultRegisterer.Register(metrics.toolResultsTruncated)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextUtilization)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextCompactionsTotal)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextCompactionTokensSaved)
@@ -329,6 +341,11 @@ func (m *loopMetrics) recordRequestTokens(tokensIn, tokensOut int) {
 	if tokensOut > 0 {
 		m.requestTokensOut.Observe(float64(tokensOut))
 	}
+}
+
+// recordToolResultTruncated increments the truncation counter.
+func (m *loopMetrics) recordToolResultTruncated() {
+	m.toolResultsTruncated.Inc()
 }
 
 // recordContextUtilization updates the current context utilization gauge.

--- a/schemas/agentic-loop.v1.json
+++ b/schemas/agentic-loop.v1.json
@@ -140,6 +140,12 @@
       "default": "120s",
       "category": "basic"
     },
+    "tool_result_max_bytes": {
+      "type": "number",
+      "description": "Maximum bytes for tool result content before truncation. 0 means no limit",
+      "default": 32768,
+      "category": "advanced"
+    },
     "trajectory_cache_ttl": {
       "type": "string",
       "description": "TTL for trajectory cache (e.g. 4h or 30m). Trajectories older than this are only available via graph queries",


### PR DESCRIPTION
## Summary
Two features for semspec operators monitoring context size during agent runs:

**Per-request token histograms** — new Prometheus metrics `request_tokens_in` and `request_tokens_out` track prompt and completion token counts per LLM request. Data was already in trajectories but not exposed as time-series. Enables Grafana dashboards for context growth over iterations.

**Configurable tool result truncation** — new `tool_result_max_bytes` config (default 32KB) caps oversized tool results before they enter the context window. UTF-8 safe, appends a marker showing original vs truncated size. New `tool_results_truncated_total` counter tracks how often it fires.

## Why
semspec team needs visibility into prompt sizes during runs. Today they have `context_utilization` (0-1 ratio) and `context_compaction_tokens_saved` but no per-request token breakdown. And there's no guard against a single tool result blowing the context budget — a graph query returning thousands of entities goes straight into the prompt uncapped.

## Changes
- `processor/agentic-loop/metrics.go` — 3 new Prometheus collectors (request_tokens_in histogram, request_tokens_out histogram, tool_results_truncated_total counter)
- `processor/agentic-loop/component.go` — wire metrics in recordResponseMetrics + tool result handler
- `processor/agentic-loop/config.go` — `tool_result_max_bytes` field (default 32768, 0 disables)
- `processor/agentic-loop/handlers.go` — `truncateToolResult` helper (UTF-8 safe), truncation in HandleToolResult before content enters context
- `schemas/agentic-loop.v1.json` — regenerated

## Test plan
- [x] `task lint` — clean (1 pre-existing function-length warning on HandleToolResult)
- [x] `go test -race ./processor/agentic-loop/...` — passes
- [x] `go test -race ./...` — full suite passes
- [x] `task schema:generate` — no drift after regen

## New Prometheus metrics for semspec

```
semstreams_agentic_loop_request_tokens_in{quantile="0.5"}     — median prompt tokens per request
semstreams_agentic_loop_request_tokens_out{quantile="0.99"}   — p99 completion tokens
semstreams_agentic_loop_tool_results_truncated_total           — count of truncated tool results
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)