### PR TITLE
fix(agentic): replace hardcoded NATS subjects with port-resolved subjects

### DIFF
--- a/component/ports.go
+++ b/component/ports.go
@@ -1,6 +1,31 @@
 // Package component provides port configuration and management for component connections.
 package component
 
+import "strings"
+
+// ResolveSubject returns the configured subject for the named port,
+// replacing the trailing wildcard (`*` or `>`) with suffix. This lets
+// components publish/subscribe using port-configured subjects instead
+// of hardcoding subject prefixes.
+//
+// Falls back to portName + "." + suffix when no matching port is found,
+// preserving backward compatibility for configs that omit the port.
+func ResolveSubject(ports []PortDefinition, portName, suffix string) string {
+	for _, p := range ports {
+		if p.Name == portName {
+			switch {
+			case strings.HasSuffix(p.Subject, ".*"):
+				return strings.TrimSuffix(p.Subject, "*") + suffix
+			case strings.HasSuffix(p.Subject, ".>"):
+				return strings.TrimSuffix(p.Subject, ">") + suffix
+			default:
+				return p.Subject + "." + suffix
+			}
+		}
+	}
+	return portName + "." + suffix
+}
+
 // PortDefinition represents a port configuration from JSON
 type PortDefinition struct {
 	Name        string `json:"name"                  schema:"readonly,type:string,description:Port identifier"`

--- a/processor/agentic-dispatch/commands.go
+++ b/processor/agentic-dispatch/commands.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/google/uuid"
 )
@@ -123,7 +124,7 @@ func (c *Component) handleCancelCommand(ctx context.Context, msg agentic.UserMes
 		return agentic.UserResponse{}, errs.Wrap(err, "Component", "handleCancelCommand", "marshal signal")
 	}
 
-	subject := fmt.Sprintf("agent.signal.%s", targetLoopID)
+	subject := component.ResolveSubject(c.outputPortDefs(), "agent.signal", targetLoopID)
 	if err := c.natsClient.Publish(ctx, subject, signalData); err != nil {
 		return agentic.UserResponse{}, errs.WrapTransient(err, "Component", "handleCancelCommand", "publish signal")
 	}

--- a/processor/agentic-dispatch/component.go
+++ b/processor/agentic-dispatch/component.go
@@ -307,7 +307,7 @@ func (c *Component) setupSubscriptions(ctx context.Context) error {
 	agentCreatedCfg := natsclient.StreamConsumerConfig{
 		StreamName:    "AGENT",
 		ConsumerName:  "agentic-dispatch-agent-created",
-		FilterSubject: "agent.created.*",
+		FilterSubject: c.inputPortSubject("agent.created", "agent.created.*"),
 		DeliverPolicy: "new",
 		AckPolicy:     "explicit",
 		MaxDeliver:    3,
@@ -331,7 +331,7 @@ func (c *Component) setupSubscriptions(ctx context.Context) error {
 	agentFailedCfg := natsclient.StreamConsumerConfig{
 		StreamName:    "AGENT",
 		ConsumerName:  "agentic-dispatch-agent-failed",
-		FilterSubject: "agent.failed.*",
+		FilterSubject: c.inputPortSubject("agent.failed", "agent.failed.*"),
 		DeliverPolicy: "new",
 		AckPolicy:     "explicit",
 		MaxDeliver:    3,
@@ -568,7 +568,7 @@ func (c *Component) handleTaskSubmission(ctx context.Context, msg agentic.UserMe
 		return
 	}
 
-	subject := fmt.Sprintf("agent.task.%s", taskID)
+	subject := component.ResolveSubject(c.outputPortDefs(), "agent.task", taskID)
 	if err := c.natsClient.PublishToStream(ctx, subject, taskData); err != nil {
 		c.logger.Error("Failed to publish task", slog.String("error", err.Error()))
 		c.sendResponse(ctx, agentic.UserResponse{
@@ -848,6 +848,28 @@ func (c *Component) CommandRegistry() *CommandRegistry {
 // LoopTracker returns the loop tracker
 func (c *Component) LoopTracker() *LoopTracker {
 	return c.loopTracker
+}
+
+// inputPortSubject returns the configured subject for the named input port,
+// falling back to the provided default when no matching port is found.
+func (c *Component) inputPortSubject(portName, fallback string) string {
+	if c.config.Ports != nil {
+		for _, p := range c.config.Ports.Inputs {
+			if p.Name == portName {
+				return p.Subject
+			}
+		}
+	}
+	return fallback
+}
+
+// outputPortDefs returns the output port definitions slice, or nil when Ports is unset.
+// This lets ResolveSubject fall back gracefully to portName + "." + suffix.
+func (c *Component) outputPortDefs() []component.PortDefinition {
+	if c.config.Ports == nil {
+		return nil
+	}
+	return c.config.Ports.Outputs
 }
 
 // loadGlobalCommands loads globally registered commands into the component

--- a/processor/agentic-dispatch/config.go
+++ b/processor/agentic-dispatch/config.go
@@ -67,6 +67,22 @@ func DefaultConfig() Config {
 					Required:    true,
 					Description: "Agent task completions",
 				},
+				{
+					Name:        "agent.created",
+					Type:        "jetstream",
+					Subject:     "agent.created.*",
+					StreamName:  "AGENT",
+					Required:    false,
+					Description: "Loop creation events",
+				},
+				{
+					Name:        "agent.failed",
+					Type:        "jetstream",
+					Subject:     "agent.failed.*",
+					StreamName:  "AGENT",
+					Required:    false,
+					Description: "Loop failure events",
+				},
 			},
 			Outputs: []component.PortDefinition{
 				{

--- a/processor/agentic-dispatch/config_test.go
+++ b/processor/agentic-dispatch/config_test.go
@@ -22,7 +22,7 @@ func TestDefaultConfig(t *testing.T) {
 
 	// Check ports
 	require.NotNil(t, config.Ports)
-	assert.Len(t, config.Ports.Inputs, 2)
+	assert.Len(t, config.Ports.Inputs, 4)
 	assert.Len(t, config.Ports.Outputs, 3)
 }
 

--- a/processor/agentic-dispatch/http.go
+++ b/processor/agentic-dispatch/http.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/service"
 	"github.com/google/uuid"
@@ -335,7 +336,7 @@ func (c *Component) processTaskSubmissionSync(ctx context.Context, msg agentic.U
 		}
 	}
 
-	subject := fmt.Sprintf("agent.task.%s", taskID)
+	subject := component.ResolveSubject(c.outputPortDefs(), "agent.task", taskID)
 	if err := c.natsClient.PublishToStream(ctx, subject, taskData); err != nil {
 		c.logger.Error("Failed to publish task", slog.String("error", err.Error()))
 		return agentic.UserResponse{

--- a/processor/agentic-governance/component.go
+++ b/processor/agentic-governance/component.go
@@ -156,25 +156,25 @@ func (c *Component) setupInputConsumers(ctx context.Context) error {
 		}
 
 		var msgType MessageType
-		var outputSubjectPrefix string
+		var outputPortName string
 
 		// Route to appropriate handler based on port name
 		switch port.Name {
 		case "task_validation":
 			msgType = MessageTypeTask
-			outputSubjectPrefix = "agent.task.validated"
+			outputPortName = "agent.task.validated"
 		case "request_validation":
 			msgType = MessageTypeRequest
-			outputSubjectPrefix = "agent.request.validated"
+			outputPortName = "agent.request.validated"
 		case "response_validation":
 			msgType = MessageTypeResponse
-			outputSubjectPrefix = "agent.response.validated"
+			outputPortName = "agent.response.validated"
 		default:
 			c.logger.Debug("Skipping unknown input port", "port", port.Name)
 			continue
 		}
 
-		handler := c.createHandler(msgType, outputSubjectPrefix)
+		handler := c.createHandler(msgType, outputPortName)
 		if err := c.setupConsumer(ctx, port, handler); err != nil {
 			return errs.Wrap(err, "Component", "setupInputConsumers", fmt.Sprintf("setup consumer for %s", port.Name))
 		}
@@ -183,15 +183,17 @@ func (c *Component) setupInputConsumers(ctx context.Context) error {
 	return nil
 }
 
-// createHandler creates a message handler for a specific message type
-func (c *Component) createHandler(msgType MessageType, outputSubjectPrefix string) func(context.Context, []byte) {
+// createHandler creates a message handler for a specific message type.
+// outputPortName is the output port name used to resolve the publish subject via port config.
+func (c *Component) createHandler(msgType MessageType, outputPortName string) func(context.Context, []byte) {
 	return func(ctx context.Context, data []byte) {
-		c.handleMessage(ctx, data, msgType, outputSubjectPrefix)
+		c.handleMessage(ctx, data, msgType, outputPortName)
 	}
 }
 
-// handleMessage processes a message through the filter chain
-func (c *Component) handleMessage(ctx context.Context, data []byte, msgType MessageType, outputSubjectPrefix string) {
+// handleMessage processes a message through the filter chain.
+// outputPortName identifies the output port in config whose subject pattern is used to publish validated messages.
+func (c *Component) handleMessage(ctx context.Context, data []byte, msgType MessageType, outputPortName string) {
 	// Parse the incoming message
 	var msg Message
 	if err := json.Unmarshal(data, &msg); err != nil {
@@ -263,8 +265,8 @@ func (c *Component) handleMessage(ctx context.Context, data []byte, msgType Mess
 			outputMsg = &msg
 		}
 
-		// Build output subject
-		outputSubject := fmt.Sprintf("%s.%s", outputSubjectPrefix, msg.ID)
+		// Build output subject from port config, falling back to portName + "." + msg.ID
+		outputSubject := component.ResolveSubject(c.outputPortDefs(), outputPortName, msg.ID)
 
 		outputData, err := json.Marshal(outputMsg)
 		if err != nil {
@@ -533,6 +535,15 @@ func (c *Component) DataFlow() component.FlowMetrics {
 		ErrorRate:         errorRate,
 		LastActivity:      lastActivity,
 	}
+}
+
+// outputPortDefs returns the output port definitions slice, or nil when Ports is unset.
+// This lets ResolveSubject fall back gracefully to portName + "." + suffix.
+func (c *Component) outputPortDefs() []component.PortDefinition {
+	if c.config.Ports == nil {
+		return nil
+	}
+	return c.config.Ports.Outputs
 }
 
 // ProcessMessage is a convenience method for testing filter chain processing

--- a/processor/agentic-governance/component_test.go
+++ b/processor/agentic-governance/component_test.go
@@ -93,9 +93,9 @@ func TestComponent_OutputPorts(t *testing.T) {
 	for i, p := range ports {
 		portNames[i] = p.Name
 	}
-	assert.Contains(t, portNames, "validated_tasks")
-	assert.Contains(t, portNames, "validated_requests")
-	assert.Contains(t, portNames, "validated_responses")
+	assert.Contains(t, portNames, "agent.task.validated")
+	assert.Contains(t, portNames, "agent.request.validated")
+	assert.Contains(t, portNames, "agent.response.validated")
 	assert.Contains(t, portNames, "violations")
 	assert.Contains(t, portNames, "user_errors")
 }

--- a/processor/agentic-governance/config.go
+++ b/processor/agentic-governance/config.go
@@ -177,28 +177,28 @@ func DefaultConfig() Config {
 
 	outputDefs := []component.PortDefinition{
 		{
-			Name:        "validated_tasks",
+			Name:        "agent.task.validated",
 			Type:        "jetstream",
 			Subject:     "agent.task.validated.*",
 			StreamName:  "AGENT",
 			Required:    true,
-			Description: "Approved task requests (JetStream)",
+			Description: "Validated task messages",
 		},
 		{
-			Name:        "validated_requests",
+			Name:        "agent.request.validated",
 			Type:        "jetstream",
 			Subject:     "agent.request.validated.*",
 			StreamName:  "AGENT",
 			Required:    true,
-			Description: "Approved model requests (JetStream)",
+			Description: "Validated agent requests",
 		},
 		{
-			Name:        "validated_responses",
+			Name:        "agent.response.validated",
 			Type:        "jetstream",
 			Subject:     "agent.response.validated.*",
 			StreamName:  "AGENT",
 			Required:    true,
-			Description: "Approved model responses (JetStream)",
+			Description: "Validated agent responses",
 		},
 		{
 			Name:        "violations",

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -983,7 +983,7 @@ func (c *Component) publishContextEvent(ctx context.Context, event agentic.Conte
 		return
 	}
 
-	subject := fmt.Sprintf("agent.context.compaction.%s", event.LoopID)
+	subject := component.ResolveSubject(c.config.Ports.Outputs, "agent.context.compaction", event.LoopID)
 	if err := c.natsClient.PublishToStream(ctx, subject, data); err != nil {
 		c.logger.Error("Failed to publish context event", "error", err, "subject", subject)
 	}
@@ -1281,7 +1281,7 @@ func (c *Component) handleCancelSignal(ctx context.Context, signal agentic.UserS
 		return
 	}
 
-	subject := fmt.Sprintf("agent.complete.%s", loopID)
+	subject := component.ResolveSubject(c.config.Ports.Outputs, "agent.complete", loopID)
 	if err := c.natsClient.PublishToStream(ctx, subject, completionData); err != nil {
 		c.logger.Error("Failed to publish completion",
 			slog.String("error", err.Error()),

--- a/processor/agentic-memory/component.go
+++ b/processor/agentic-memory/component.go
@@ -421,3 +421,12 @@ func (c *Component) DataFlow() component.FlowMetrics {
 		LastActivity:      lastActivity,
 	}
 }
+
+// outputPortDefs returns the output port definitions slice, or nil when Ports is unset.
+// This lets ResolveSubject fall back gracefully to portName + "." + suffix.
+func (c *Component) outputPortDefs() []component.PortDefinition {
+	if c.config.Ports == nil {
+		return nil
+	}
+	return c.config.Ports.Outputs
+}

--- a/processor/agentic-memory/publisher.go
+++ b/processor/agentic-memory/publisher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/pkg/errs"
 )
@@ -80,8 +81,8 @@ func (c *Component) publishInjectedContext(ctx context.Context, loopID, source s
 		return errs.Wrap(err, "Component", "publishInjectedContext", "marshal injected context message")
 	}
 
-	// Build subject: agent.context.injected.{loopID}
-	subject := fmt.Sprintf("agent.context.injected.%s", loopID)
+	// Build subject from output port config, falling back to default pattern
+	subject := component.ResolveSubject(c.outputPortDefs(), "injected_context", loopID)
 
 	// Publish if NATS client available
 	if c.natsClient != nil {


### PR DESCRIPTION
## Summary
7 cross-component NATS subjects were hardcoded via `fmt.Sprintf`, bypassing the port configuration system. semteams can't remap subjects via config because the code ignores port definitions and constructs subjects from string literals.

## Fix
New `component.ResolveSubject(ports, portName, suffix)` helper resolves subjects from port config instead of hardcoding. Falls back to `portName.suffix` for backward compat.

**4 packages fixed:**
- **agentic-loop** (2 sites): `agent.complete.*`, `agent.context.compaction.*`
- **agentic-dispatch** (4 sites): `agent.task.*`, `agent.signal.*`, `agent.created.*` (new input port), `agent.failed.*` (new input port)
- **agentic-memory** (1 site): `agent.context.injected.*`
- **agentic-governance** (3 sites): `agent.{task,request,response}.validated.*`

Post-fix: `grep -rn 'fmt.Sprintf("agent\.\|fmt.Sprintf("tool\.'` returns zero hits across all agentic components.

## Backward compat
- Existing configs work unchanged — `DefaultConfig` provides the same default subjects
- `ResolveSubject` falls back to `portName + "." + suffix` if port not found
- New input ports in agentic-dispatch are `required: false`

## Test plan
- [x] `go build ./...`
- [x] `task lint` — clean (1 pre-existing function-length warning)
- [x] `go test -race ./processor/agentic-{loop,dispatch,memory,governance}/...` — all pass
- [x] `go test -race ./...` — full suite passes
- [x] `task schema:generate` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)