### PR TITLE
beta.27: cron rule type (#15) — ADR-031 Option A implementation

### DIFF
--- a/configs/grafana/dashboards/cron-scheduler.json
+++ b/configs/grafana/dashboards/cron-scheduler.json
@@ -1,0 +1,291 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "description": "Cron rule fire rate by outcome. Spikes in {status=\"error\"} indicate downstream action failures (NATS, KV, publish_agent). Any value on {status=\"panic\"} is a programming-bug signal — page someone. {status=\"cooldown_skipped\"} means the cron expression ticks faster than actions complete on average; tune cooldown or schedule.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "expr": "sum by (status) (rate(semstreams_cron_rule_fires_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cron Rule Fire Rate (by status)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Action-dispatch latency per cron rule. p99 climbing past the rule's cooldown is the early warning that the next tick will be cooldown-skipped or inflight-blocked.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, rule_id) (rate(semstreams_cron_rule_fire_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{rule_id}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, rule_id) (rate(semstreams_cron_rule_fire_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{rule_id}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, rule_id) (rate(semstreams_cron_rule_fire_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{rule_id}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Fire Duration (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Missed fires detected on scheduler restart. Per ADR-031 missed fires are log-only (not auto-replayed). Sustained non-zero rate means the binary is restarting frequently across cron-fire boundaries.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "expr": "sum by (rule_id) (increase(semstreams_cron_rule_missed_fires_total[1h]))",
+          "legendFormat": "missed/h {{rule_id}}",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (rule_id) (increase(semstreams_cron_rule_missed_fires_capped_total[1h]))",
+          "legendFormat": "capped/h {{rule_id}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Missed Fires (per hour)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Number of cron rules currently registered with the scheduler. Drops on hot-reload removals. Useful for confirming a config change took effect.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 16 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "expr": "semstreams_cron_rule_registered",
+          "refId": "A"
+        }
+      ],
+      "title": "Registered Cron Rules",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "1 = scheduler is started and ticking. 0 = stopped. Alert on this dropping while the processor is otherwise healthy — catches the 'scheduler crashed but processor still alive' pathology.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "text": "STOPPED" } }, "type": "value" },
+            { "options": { "1": { "color": "green", "text": "RUNNING" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 16 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "expr": "semstreams_cron_scheduler_running",
+          "refId": "A"
+        }
+      ],
+      "title": "Scheduler Running",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Panic-status fire rate (last 5m). Any non-zero value is a programming bug. Alert: rate(semstreams_cron_rule_fires_total{status=\"panic\"}[5m]) > 0 → page someone. The recover keeps the scheduler alive but a panic means a downstream action threw an unrecoverable error — fix the code, do not tune the alert.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.000001 }
+            ]
+          },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 16 },
+      "id": 7,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "expr": "sum(rate(semstreams_cron_rule_fires_total{status=\"panic\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Panic Fire Rate (page on > 0)",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "description": "Time until each rule's next scheduled fire, derived from next_fire_timestamp_seconds - time(). Negative values mean the rule should have fired but hasn't — investigate the scheduler. Useful as the operational answer to 'when does this thing fire next?'",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": true
+          },
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 22 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": ["mean", "min"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "expr": "semstreams_cron_rule_next_fire_timestamp_seconds - time()",
+          "legendFormat": "{{rule_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Time Until Next Fire (per rule)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": ["semstreams", "cron", "scheduler"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Cron Scheduler",
+  "uid": "semstreams-cron",
+  "version": 1
+}

--- a/configs/rules/cron/governance-example.json
+++ b/configs/rules/cron/governance-example.json
@@ -1,0 +1,24 @@
+{
+  "id": "governance_kill_switch_sweep",
+  "type": "cron",
+  "name": "Daily kill-switch sweep",
+  "description": "Worked starting point for the cron → publish_agent → ops-role coordinator pattern (ADR-028). The cron rule is just the clock; the spawned governance coordinator does the actual scan over flagged entities and emits structured ops.diagnosis.* triples via emit_diagnosis. A downstream expression rule can match those triples and react. See docs/concepts/18-rule-driven-artifacts.md → 'When to combine cron + ops-role coordinator'.",
+  "enabled": true,
+  "schedule": "@daily",
+  "cooldown": "20h",
+  "actions": [
+    {
+      "type": "publish_agent",
+      "subject": "agent.task.governance.kill_switch_sweep.$schedule.id",
+      "role": "governance",
+      "model": "default",
+      "prompt": "Daily kill-switch sweep — fired by cron rule $schedule.id at $now. Previous sweep: $schedule.last_fired_at. Walk the kill-switch markers, identify entities that should be disabled, and emit ops.diagnosis.kill_switch.* findings via emit_diagnosis for human review. Per ADR-028 ops-role Phase 1: read-only — do not mutate.",
+      "tools": ["read_entity", "graph_query", "emit_diagnosis"]
+    }
+  ],
+  "metadata": {
+    "ops_pattern": "cron-coordinator",
+    "phase": "1-read-only",
+    "adr": "028"
+  }
+}

--- a/configs/rules/cron/heartbeat-example.json
+++ b/configs/rules/cron/heartbeat-example.json
@@ -1,0 +1,20 @@
+{
+  "id": "system_cron_heartbeat",
+  "type": "cron",
+  "name": "System Heartbeat",
+  "description": "Publishes a heartbeat envelope on system.cron.heartbeat once per minute. Smallest worked example of the cron rule kind: useful as a liveness probe target for ops dashboards and as a copy-paste starting point for authoring new cron rules.",
+  "enabled": true,
+  "schedule": "* * * * *",
+  "actions": [
+    {
+      "type": "publish",
+      "subject": "system.cron.heartbeat",
+      "payload": {
+        "rule_id": "$schedule.id",
+        "spec": "$schedule.spec",
+        "fired_at": "$now",
+        "previous_fire": "$schedule.last_fired_at"
+      }
+    }
+  ]
+}

--- a/docs/adr/031-time-trigger-primitive.md
+++ b/docs/adr/031-time-trigger-primitive.md
@@ -2,9 +2,20 @@
 
 ## Status
 
-**Proposed (2026-04-29).** No tag is committed. This ADR captures the
-design space for a future framework primitive so the discussion has a
-target before implementation pressure forces a quick choice.
+**Accepted — Option A (2026-04-30).** Implementation pending; tracked
+in [issue #15](https://github.com/c360studio/semstreams/issues/15).
+
+The semteams onboarding flow captures cadence and trigger fields per
+operating-model entry (`om.entry.cadence`, `om.entry.trigger`) and has
+no way to act on them. That's the internal forcing function the
+"Implementation-pressure triggers" section below anticipated. Building
+Option A — a `"type": "cron"` rule kind layered into the existing
+rule processor — is small enough to ship without locking in surface
+that a future Option B couldn't extract from underneath.
+
+Originally proposed 2026-04-29 with a lean toward Option A but no
+implementation commitment. That posture lasted one day before the
+internal need surfaced.
 
 ## Context
 

--- a/docs/adr/031-time-trigger-primitive.md
+++ b/docs/adr/031-time-trigger-primitive.md
@@ -2,20 +2,25 @@
 
 ## Status
 
-**Accepted — Option A (2026-04-30).** Implementation pending; tracked
-in [issue #15](https://github.com/c360studio/semstreams/issues/15).
+**Accepted — Option A. Shipped in beta.27 (2026-04-30).**
+Implementation in commits `8ca3cc2..6a4c7a1` on issue
+[#15](https://github.com/c360studio/semstreams/issues/15);
+migration guide:
+[migration-beta26-to-beta27.md](../operations/migration-beta26-to-beta27.md).
 
 The semteams onboarding flow captures cadence and trigger fields per
 operating-model entry (`om.entry.cadence`, `om.entry.trigger`) and has
 no way to act on them. That's the internal forcing function the
 "Implementation-pressure triggers" section below anticipated. Building
 Option A — a `"type": "cron"` rule kind layered into the existing
-rule processor — is small enough to ship without locking in surface
+rule processor — was small enough to ship without locking in surface
 that a future Option B couldn't extract from underneath.
 
 Originally proposed 2026-04-29 with a lean toward Option A but no
 implementation commitment. That posture lasted one day before the
-internal need surfaced.
+internal need surfaced. Implementation landed across seven reviewable
+chunks in a single PR; see [Implementation notes](#implementation-notes)
+below.
 
 ## Context
 
@@ -187,12 +192,13 @@ CronJob, GCP Cloud Scheduler) to POST to existing HTTP entry points
 
 ## Decision
 
-**Defer commitment.** Adopt no implementation today. The decision the
-ADR records is: when scheduling pressure forces the build, **prefer
-Option A first** unless concrete operator-friction reasons emerge that
-make the dedicated scheduler component worth the surface cost.
+**Adopt Option A.** Originally drafted as "defer commitment, prefer
+Option A first when forced," the decision was promoted to "implement
+Option A now" on 2026-04-30 when semteams' onboarding-driven cadence
+need surfaced. Shipped in beta.27 across seven reviewable chunks; see
+[Implementation notes](#implementation-notes) below.
 
-### Rationale for the lean toward Option A
+### Rationale for Option A
 
 - The rule processor already owns "condition → action" — adding a
   time-source-of-truth condition stays inside its job description.
@@ -257,6 +263,65 @@ Until one of those, defer. Cadence-driven dispatch is a real gap, but
 shipping the wrong primitive locks the surface for every product
 downstream of it.
 
+## Implementation notes
+
+Shipped in beta.27 in seven reviewable chunks. Each chunk landed on
+the `feat/cron-rule-type` branch with a pre-commit go-reviewer pass
+per [feedback memory](../../) on review cadence:
+
+| Chunk | Commit | Surface |
+|---|---|---|
+| 1 | `8ca3cc2` | `CronRule` type, factory, `Definition` extensions (`Schedule`, `Actions` fields). `robfig/cron/v3` pulled (zero transitive deps). |
+| 2 | `339773a` | `CronScheduler` core + lifecycle wiring (`Register`/`Deregister`/`Start`/`Stop`, FireEveryN gate, cooldown gate, inflight CAS, panic backstop). |
+| 3 | `b0902de` | `RULE_SCHEDULES` KV bucket + `ScheduleTracker` + missed-fire detection on startup. |
+| 4 | `49b08a4` | `$schedule.*` substitution context + cross-restart `lastFiredNanos` hydration. |
+| 5 | `65a56f2` | Seven Prometheus metrics under `semstreams_cron_*` + Grafana dashboard. |
+| 6 | `6a4c7a1` | testcontainer-NATS integration tests + two latent bug fixes (null-conditions panic in `definitionFromMap`, seed-then-reconcile cooldown reset). |
+| 7 | (this commit) | Migration guide, ADR final-status update, concept-doc paragraphs, governance-shaped example. |
+
+Three retrofit-safe seams thread through the implementation per the
+"single-user MVP, multi-tenant-ready" design constraint:
+
+1. `RULE_SCHEDULES` keyed by bare `{ruleID}` for MVP; `scheduleKey()`
+   in `schedule_tracker.go` is the single chokepoint a future
+   `.{entityID}` suffix would extend without rewriting call sites.
+2. `$schedule.*` is cron-context-only and disjoint from `$entity.*`;
+   future `for_each` per-entity fan-out populates `$entity.*` per
+   iteration alongside `$schedule.*` with no shim changes.
+3. `Definition.Schedule` is global today; `Definition.ForEach`
+   would be additive — rules that don't set it keep current
+   single-fire semantics.
+
+### Settled implementation-pass questions
+
+The "What this ADR does NOT decide" section above listed four
+implementation-pass concerns. They settled as follows:
+
+- **Cron expression flavour**: POSIX 5-field + descriptors
+  (`@hourly`/`@daily`/`@weekly`/`@monthly`/`@yearly`/`@every Ns`).
+  Quartz seconds-precision and "first Tuesday of month" deferred.
+- **Per-tenant scoping**: deferred. MVP is single-user; the three
+  retrofit seams above keep the future per-tenant pass purely
+  additive.
+- **Concurrent-fire semantics**: each registered rule has its own
+  inflight CAS guard; cron rules within a tick fire concurrently
+  (robfig/cron's default). Per-rule `cooldown` and `fire_every_n_events`
+  control fire rate; no cross-rule ordering guarantees.
+- **Exposure surface**: config-only for MVP. HTTP API to register/
+  cancel schedules at runtime is deferred.
+
+### Deferred extensions
+
+Tracked in [issue #15](https://github.com/c360studio/semstreams/issues/15)
+as the ADR-031 implementation tracking issue:
+
+- Per-entity fan-out via `Definition.ForEach`
+- Per-tenant scoping (KV key suffix, action substitution scope)
+- Trigger-text parsing (freeform → cron, with confirmation step)
+- Runtime register/cancel HTTP API
+- Quartz syntax extensions (seconds-precision, "first Tuesday")
+- Cron rules with workflow-style multi-step actions
+
 ## Related
 
 - [ADR-028: Orchestration Architecture](028-orchestration-architecture.md)
@@ -265,7 +330,8 @@ downstream of it.
 - [Concept: Orchestration Layers](../concepts/14-orchestration-layers.md)
   — the two-layer rule/component model.
 - [Concept: Rule-Driven Artifacts](../concepts/18-rule-driven-artifacts.md)
-  — the event-driven version of the pattern this ADR proposes a
-  time-driven sibling for.
-- GitHub: c360studio/semstreams#15 — the issue that motivated this
-  ADR.
+  — the event-driven version of the pattern this ADR's primitive
+  enables a time-driven sibling for.
+- [Migration: beta.26 → beta.27](../operations/migration-beta26-to-beta27.md)
+  — the upgrade guide for the shipped implementation.
+- GitHub: c360studio/semstreams#15 — the tracking issue.

--- a/docs/concepts/14-orchestration-layers.md
+++ b/docs/concepts/14-orchestration-layers.md
@@ -46,7 +46,26 @@ essential for building maintainable, scalable systems.
 
 ## Reactive Patterns
 
-The reactive engine supports two patterns through the same unified infrastructure:
+The reactive engine fires rules in response to three signal kinds:
+
+| Signal | Rule kind | Triggered by |
+|---|---|---|
+| KV state change | expression rule (`type: "expression"`) | A bucket key transitioning to a state where the rule's `When` predicates match |
+| NATS subject match | expression rule (`type: "expression"`) | A message landing on a subject the rule subscribes to |
+| Wallclock | **cron rule (`type: "cron"`)** | A cron expression's `Next()` time elapsing |
+
+Cron rules ship in beta.27
+([ADR-031](../adr/031-time-trigger-primitive.md),
+[migration guide](../operations/migration-beta26-to-beta27.md)). They
+share every existing rule action (`publish`, `publish_agent`,
+`update_kv`, etc.) but bypass condition evaluation — there is no
+"state" for a clock to be in. A `"type": "cron"` rule accepts
+`schedule`, `actions`, `cooldown`, `fire_every_n_events`, `name`,
+`description`, `enabled`, `metadata` and nothing else; condition-side
+fields (`conditions`, `logic`, `on_enter`, `on_exit`, etc.) are
+rejected at config-load time.
+
+The reactive engine supports two coordination patterns through the same unified infrastructure:
 
 ### Single-Trigger Pattern (Rules-style)
 

--- a/docs/concepts/18-rule-driven-artifacts.md
+++ b/docs/concepts/18-rule-driven-artifacts.md
@@ -161,6 +161,75 @@ component is structurally cheaper than spawning a renderer agent.
   [#13](https://github.com/c360studio/semstreams/issues/13) closed
   out-of-scope on this principle.
 
+## Time-driven artifacts (cron rules)
+
+The patterns above all watch graph or NATS state. Beta.27 added the
+[time-driven sibling](../adr/031-time-trigger-primitive.md): a
+`"type": "cron"` rule fires on a wallclock schedule and uses the same
+`publish` / `publish_agent` actions to emit an artifact. The shape:
+
+```text
+┌──────────────┐  schedule    ┌────────────────┐ publish ┌──────────────────┐
+│ Wallclock    ├─────────────►│  Cron rule     ├────────►│ Output component │
+│ (cron tick)  │  matches     │  (rule         │ subject │ (file / httppost │
+│              │  expression  │   processor)   │         │  / etc.)         │
+└──────────────┘              └────────────────┘         └──────────┬───────┘
+                                                                    │
+                                                                    ▼
+                                                         ┌────────────────────┐
+                                                         │ Disk / HTTP / Obj  │
+                                                         │ Storage            │
+                                                         └────────────────────┘
+```
+
+Use a cron rule when the artifact emission is **cadence-driven** rather
+than state-driven — periodic snapshots, scheduled exports, daily roll-
+ups. State-driven emission (snapshot-on-profile-change) stays on the
+expression rule path described above.
+
+### Worked example: hourly status snapshot
+
+```json
+{
+  "id": "hourly-status-snapshot",
+  "type": "cron",
+  "name": "Hourly status snapshot",
+  "enabled": true,
+  "schedule": "@hourly",
+  "actions": [
+    {
+      "type": "publish",
+      "subject": "output.status-snapshot.hourly",
+      "payload": {
+        "rule_id": "$schedule.id",
+        "fired_at": "$now",
+        "previous_fire": "$schedule.last_fired_at"
+      }
+    }
+  ]
+}
+```
+
+An `output/file` component subscribes to `output.status-snapshot.hourly`
+and writes each message to a timestamped JSON file. The `$schedule.*`
+substitution tokens (`$schedule.id`, `$schedule.spec`,
+`$schedule.last_fired_at`) and the always-available `$now` give the
+output component everything it needs to name files and detect missed
+intervals.
+
+### When to combine cron + ops-role coordinator
+
+For artifacts that require *iteration over graph state* — a
+kill-switch sweep that disables flagged entities, a chain-hash audit
+that walks a chain looking for breaks — use the
+**cron → `publish_agent` → ops-role coordinator** pattern from
+[ADR-028](../adr/028-orchestration-architecture.md). The cron rule is
+just the clock; the spawned coordinator does the iteration / chain
+walk and emits structured `ops.diagnosis.*` triples that downstream
+expression rules can match on. See
+`configs/rules/cron/governance-example.json` for a worked starting
+point.
+
 ## Operational notes
 
 - **Subject naming.** Use the standard `output.<purpose>.<routing>`
@@ -186,5 +255,8 @@ component is structurally cheaper than spawning a renderer agent.
   right substrate when designing the watch side of the rule.
 - [ADR-028](../adr/028-orchestration-architecture.md) — why rules
   carry references, not content.
-- [ADR-031](../adr/031-time-trigger-primitive.md) — proposed time-
-  driven version of this pattern (cadence-based emission).
+- [ADR-031](../adr/031-time-trigger-primitive.md) — the time-driven
+  primitive that powers the cron-rule section above. Shipped in
+  beta.27.
+- [Migration: beta.26 → beta.27](../operations/migration-beta26-to-beta27.md)
+  — upgrade path for the cron rule kind.

--- a/docs/operations/migration-beta26-to-beta27.md
+++ b/docs/operations/migration-beta26-to-beta27.md
@@ -1,0 +1,270 @@
+# Migration Guide: beta.26 → beta.27
+
+## Summary
+
+Beta.27 is the **time-trigger primitive** tag. It implements
+[ADR-031](../adr/031-time-trigger-primitive.md) Option A: a new
+`"type": "cron"` rule kind layered into the existing rule processor,
+with no changes to existing expression rules and no payload-registry
+additions.
+
+| Surface | Status |
+|---|---|
+| New rule kind: `"type": "cron"` | **Additive** — opt-in per rule |
+| New KV bucket: `RULE_SCHEDULES` | **Additive** — created on demand |
+| New substitution namespace: `$schedule.*` | **Additive** — cron rules only |
+| New Prometheus metrics: `semstreams_cron_*` | **Additive** — 7 collectors |
+| New Grafana dashboard: `cron-scheduler.json` | **Additive** — opt-in import |
+| Existing expression rules | **Unchanged** — no behavioural delta |
+| Public API | **No breakage** |
+
+**The simplest beta.26 → beta.27 upgrade is to do nothing.** Existing
+deployments without cron rules see no behaviour change. Activation
+requires authoring a `"type": "cron"` rule.
+
+Two latent bugs in the hot-reload parser were also fixed; see
+[Drive-by fixes](#drive-by-fixes) below. Neither was reachable from
+beta.26 production state because both required cron rules to trigger.
+
+## What ships
+
+### The cron rule kind
+
+```json
+{
+  "id": "weekly-planning-prompt",
+  "type": "cron",
+  "name": "Weekly planning prompt",
+  "enabled": true,
+  "schedule": "0 9 * * MON",
+  "actions": [
+    {
+      "type": "publish_agent",
+      "role": "planning-coach",
+      "model": "default",
+      "prompt": "It's $now — your weekly planning block."
+    }
+  ]
+}
+```
+
+Cron rules accept **only**: `schedule`, `actions`, `cooldown`,
+`fire_every_n_events`, `name`, `description`, `enabled`, `metadata`.
+Forbidden fields (`conditions`, `logic`, `on_enter`, `on_exit`,
+`on_recovery`, `while_true`, `rerun_on_recovery`, `max_iterations`,
+`entity.*`, `related_patterns`) cause `NewCronRule` to return a typed
+error at config-load time. Failing loud at config-load beats silently
+ignoring fields the author thought were doing something.
+
+### Cron expression flavour
+
+POSIX 5-field plus descriptors: `@hourly`, `@daily`, `@weekly`,
+`@monthly`, `@yearly`, plus `@every <duration>` for fast-cycling
+schedules (`@every 1m`, `@every 30s`). Quartz seconds-precision and
+"first Tuesday of month" are deferred per ADR-031.
+
+### `$schedule.*` substitution namespace
+
+| Token | Value | First-fire behaviour |
+|---|---|---|
+| `$schedule.id` | The firing rule's ID | (always populated) |
+| `$schedule.spec` | The cron expression | (always populated) |
+| `$schedule.last_fired_at` | Prior fire's wallclock, RFC3339 UTC | empty string |
+| `$now` | Current wallclock, RFC3339 UTC | (always populated) |
+
+`$schedule.last_fired_at` renders as the **empty string** on the
+first fire (not the Go zero-time literal `0001-01-01T00:00:00Z`).
+Authors detect first-fire by branching on emptiness; rendering an
+empty token in a NATS subject path produces a consecutive-dot
+fail-fast at publish rather than a silently-accepted bad timestamp.
+
+The `$schedule.*` namespace is intentionally disjoint from
+`$entity.*` / `$related.*` / `$state.*`. A cron-only `$schedule.*`
+token reaching an expression-rule path (or vice versa) survives
+substitution and trips the warn-on-unresolved-token logger — same
+posture as a missing `$entity.triple.*` field.
+
+### `RULE_SCHEDULES` KV bucket
+
+Per-rule last-fired timestamps persist in a new bucket created on
+demand. JSON shape:
+
+```json
+{
+  "rule_id": "weekly-planning-prompt",
+  "schedule_spec": "0 9 * * MON",
+  "last_fired_at": "2026-04-27T09:00:00Z"
+}
+```
+
+Two access patterns are supported:
+
+1. **In-process callers** hold a `*ScheduleTracker` reference (e.g.
+   from a custom processor wrapper) and call `LastFiredAt(ctx, ruleID)`.
+   `ScheduleTracker.Bucket()` exposes the raw `jetstream.KeyValue`
+   handle so callers can use `Watch` for live updates or `ListKeys`
+   for filtered scans.
+2. **Out-of-process callers** read the bucket directly using the
+   exported `rule.ScheduleBucketName` constant + `rule.LastFireRecord`
+   JSON shape. Both are part of the framework's public contract;
+   renames require a migration. Useful for governance startup hooks
+   that need to issue catch-up sweeps after long downtime.
+
+### Missed-fire policy: log-only
+
+Per ADR-031 product direction, missed fires across scheduler downtime
+are **logged at Warn**, not auto-replayed. A missed Monday planning
+prompt isn't worth a Tuesday catch-up. The next regularly scheduled
+fire happens on its normal cadence.
+
+The missed-fire detector runs once at `Start()`, walks the rule's
+schedule from the persisted `last_fired_at` forward, counts expected
+fires up to a cap of 100, and emits a single Warn per rule. The
+companion metric `semstreams_cron_rule_missed_fires_total{rule_id}`
+increments by the detected count; `semstreams_cron_rule_missed_fires_capped_total{rule_id}`
+increments when a rule hits the cap (long-downtime indicator).
+
+### Cross-restart cooldown semantics
+
+The cooldown gate respects the persisted last-fired timestamp. A rule
+with a 1h cooldown that fired one minute before process restart will
+skip its next post-restart fire on the cooldown gate. Implementation:
+`restoreFromTracker` hydrates `entry.lastFiredNanos` from the
+persisted record before `cron.Start()` ticks. Same code path that
+emits missed-fire warnings.
+
+### Prometheus metrics + Grafana dashboard
+
+Seven new collectors under `semstreams_cron_*`:
+
+| Metric | Type | Labels |
+|---|---|---|
+| `rule_fires_total` | Counter | `rule_id`, `status` |
+| `rule_fire_duration_seconds` | Histogram | `rule_id` |
+| `rule_registered` | Gauge | (none) |
+| `rule_missed_fires_total` | Counter | `rule_id` |
+| `rule_missed_fires_capped_total` | Counter | `rule_id` |
+| `rule_next_fire_timestamp_seconds` | Gauge | `rule_id` |
+| `scheduler_running` | Gauge | (none) |
+
+Status taxonomy: `success` / `error` / `panic` / `cooldown_skipped`
+/ `inflight_skipped`.
+
+- **`status="error"`**: a downstream action returned an error
+  (NATS unreachable, validation failed). Aggregate "expected failures."
+- **`status="panic"`**: an action panicked. The recover keeps the
+  scheduler goroutine alive but **this is a programming-bug signal**.
+  Page on `rate(semstreams_cron_rule_fires_total{status="panic"}[5m]) > 0`;
+  fix the code, don't tune the alert. Cron-side code does not panic
+  deliberately — the recover exists because action dispatch crosses
+  uncontrolled boundaries (NATS, KV, HTTP/LLM via `publish_agent`)
+  and robfig/cron does not recover from panics in jobs.
+- **`status="cooldown_skipped"`**: the configured cooldown gate
+  blocked a tick. Operator-by-design.
+- **`status="inflight_skipped"`**: a previous fire was still running
+  when this tick arrived (CAS rejection). Operator-error indicator —
+  actions are slower than schedule, configure a cooldown explicitly
+  or speed up the actions.
+
+A Grafana dashboard `configs/grafana/dashboards/cron-scheduler.json`
+ships with seven panels including a dedicated panic-rate stat (red
+threshold above zero, paging-friendly).
+
+## Retrofit-safe seams
+
+The MVP is single-user but three explicit seams keep the future
+per-tenant fan-out path purely additive:
+
+1. **KV key shape.** `RULE_SCHEDULES` is keyed by bare `{ruleID}` for
+   MVP. Future per-entity fan-out adds `.{entityID}` suffix; existing
+   single-fire records remain valid. The `scheduleKey()` chokepoint
+   in `schedule_tracker.go` is the only edit-site needed when the
+   suffix lands.
+2. **Substitution namespace.** `$schedule.*` is cron-context-only;
+   `$entity.*` is populated only when an entity is in scope (today:
+   never for cron; tomorrow: per `for_each` iteration). The future
+   `$trigger.*` namespace for richer tick metadata (e.g.
+   `$trigger.attempt`, `$trigger.scheduled_for`) lands as a sibling
+   shim, not as overload.
+3. **Schedule scope.** `Definition.Schedule` is a global cron
+   expression today. Adding `Definition.ForEach` later is opt-in and
+   orthogonal — rules that don't set it stay at the current
+   single-fire semantics.
+
+The MVP does not implement any per-tenant scoping. It simply does
+not paint corners that a future per-tenant pass would have to back
+out of.
+
+## Worked examples
+
+### Heartbeat (smallest)
+
+`configs/rules/cron/heartbeat-example.json`. Every-minute heartbeat on
+`system.cron.heartbeat`, exercising every `$schedule.*` token. Useful
+as a liveness probe target and as a copy-paste starting point.
+
+### Governance ops-role coordinator
+
+`configs/rules/cron/governance-example.json`. Daily kill-switch sweep
+that uses cron → `publish_agent` → governance ops-role coordinator
+(per ADR-028). The cron rule is a clock; the coordinator does the
+actual scan + emits structured triples. Worked starting point for
+kill-switch sweeps and chain-hash audit windows.
+
+## Drive-by fixes
+
+Two latent bugs were uncovered by the integration test suite. Both
+required cron rules to trigger; neither was reachable from beta.26
+production state.
+
+### `definitionFromMap` panicked on null `conditions` field
+
+`Definition.Conditions` has no `omitempty` JSON tag, so a Definition
+with no conditions JSON-marshals as `"conditions": null`. The
+hot-reload parser's `conditionsVal.([]any)` type assertion panicked
+on nil. Pre-beta.27 the panic was only reachable via cron rules (the
+only Type that legitimately has no conditions); cron rules are new,
+so no production deployments were affected.
+
+Fixed with explicit nil-guard plus defensive type assertions
+throughout `definitionFromMap` (`type`, `description`,
+`entity.watch_buckets[i]`). Malformed KV records now return a typed
+error rather than panicking the watcher reconcile goroutine.
+
+### Seed-then-reconcile reset cron rule cooldown state
+
+Hot-reload's startup path seeds `InlineRules` to KV, then the watcher's
+reconcile pass reads them back and re-applies them. Pre-beta.27 the
+re-apply unconditionally Deregister+Register-ed every cron rule, which
+reset `entry.lastFiredNanos` to 0 — producing a transient "ignored
+cooldown" window right at process startup.
+
+Fixed with a `reflect.DeepEqual` idempotency check in
+`applyCronRuleChange`. `loadRules` now also populates
+`rp.ruleConfigs[def.ID]` at load time so the check sees a populated
+entry on the first reconcile.
+
+## Upgrade procedure
+
+For deployments without cron rules: **no action required.** Existing
+expression rules continue to behave identically.
+
+For deployments adding cron rules:
+
+1. Author one or more `"type": "cron"` rules in your flow's
+   `inline_rules`, `rules_files`, or hot-reload KV bucket.
+2. (Optional) Import `configs/grafana/dashboards/cron-scheduler.json`
+   into Grafana for the operator dashboard.
+3. (Optional) Configure an alert on
+   `rate(semstreams_cron_rule_fires_total{status="panic"}[5m]) > 0`
+   to page on programming bugs in cron-fired action paths.
+4. Restart the rule processor. The `RULE_SCHEDULES` KV bucket is
+   created on first start; missed-fire detection runs once on each
+   subsequent start.
+
+## Related
+
+- [ADR-031: Time-Trigger Primitive for Reactive Rules](../adr/031-time-trigger-primitive.md)
+- [Concept: Orchestration Layers](../concepts/14-orchestration-layers.md)
+- [Concept: Rule-Driven Artifacts](../concepts/18-rule-driven-artifacts.md)
+- GitHub: c360studio/semstreams#15 — the tracking issue.

--- a/go.mod
+++ b/go.mod
@@ -11,10 +11,10 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.66.1
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
-	github.com/vektah/gqlparser/v2 v2.5.11
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/net v0.46.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -24,7 +24,6 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,12 +6,6 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
-github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
-github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883 h1:bvNMNQO63//z+xNgfBlViaCIJKLlCJ6/fmUseuG0wVQ=
-github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
-github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -34,8 +28,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
-github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/docker v28.5.1+incompatible h1:Bm8DchhSD2J6PsFzxC35TZo4TLGR2PdW/E69rU45NhM=
@@ -139,12 +131,12 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/sashabaranov/go-openai v1.41.2 h1:vfPRBZNMpnqu8ELsclWcAvF19lDNgh1t6TVfFFOPiSM=
 github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
-github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
-github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=
 github.com/shirou/gopsutil/v4 v4.25.6 h1:kLysI2JsKorfaFPcYmcJqbzROzsBWEOAtw6A7dIfqXs=
 github.com/shirou/gopsutil/v4 v4.25.6/go.mod h1:PfybzyydfZcN+JMMjkF6Zb8Mq1A/VcogFFg7hj50W9c=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
@@ -162,8 +154,6 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
-github.com/vektah/gqlparser/v2 v2.5.11 h1:JJxLtXIoN7+3x6MBdtIP59TP1RANnY7pXOaDnADQSf8=
-github.com/vektah/gqlparser/v2 v2.5.11/go.mod h1:1rCcfwB2ekJofmluGWXMSEnPMZgbxzwj6FaZ/4OT8Cc=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
@@ -233,8 +223,6 @@ google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -1445,6 +1445,27 @@ func TestExecutionContext_SubstituteVariables_WarnsOnUnresolved(t *testing.T) {
 			template:      "a=$entity.triple.missing.one b=$related.id c=$state.iteration",
 			wantLeftovers: []string{"$entity.triple.missing.one", "$state.iteration"},
 		},
+		{
+			// Cron-only $schedule.* token in an expression-rule path
+			// (Schedule == nil). Locks the regex extension that added
+			// "schedule" to the alternation so a future refactor can't
+			// silently drop the namespace.
+			name:          "schedule token without schedule context",
+			ec:            &ExecutionContext{EntityID: "entity.001"},
+			template:      "key=$schedule.unknown_field",
+			wantLeftovers: []string{"$schedule.unknown_field"},
+		},
+		{
+			// Unknown $schedule.* field on a populated cron context —
+			// the schedule shim only handles id/spec/last_fired_at, so
+			// any other token survives and warns.
+			name: "unknown schedule field on populated context",
+			ec: &ExecutionContext{
+				Schedule: &ScheduleContext{ID: "r1", Spec: "@hourly"},
+			},
+			template:      "missing=$schedule.attempt",
+			wantLeftovers: []string{"$schedule.attempt"},
+		},
 	}
 
 	for _, tc := range tests {

--- a/processor/rule/config_validation.go
+++ b/processor/rule/config_validation.go
@@ -221,46 +221,48 @@ func ValidateDefinition(def Definition) error {
 // loadRules performs when reading from JSON files so that hot-reloaded rules
 // carry the same gate and stateful-action metadata as file-loaded rules.
 func definitionFromMap(ruleID string, ruleMap map[string]any) (Definition, error) {
+	// Defensive type assertion on Type: validateSingleRuleConfig gates
+	// on a string Type before reaching here, but the watcher path can
+	// also reach definitionFromMap from places that pre-date that
+	// validator. Failing with a typed error rather than a panic keeps
+	// the reconcile goroutine alive.
+	typeStr, ok := ruleMap["type"].(string)
+	if !ok {
+		return Definition{}, fmt.Errorf("rule %s: type must be a string, got %T", ruleID, ruleMap["type"])
+	}
 	def := Definition{
 		ID:      ruleID,
-		Type:    ruleMap["type"].(string),
+		Type:    typeStr,
 		Name:    getStringWithDefault(ruleMap, "name", ruleID),
 		Enabled: getBoolWithDefault(ruleMap, "enabled", true),
 		Logic:   getStringWithDefault(ruleMap, "logic", "and"),
 	}
 
-	// Parse description if present
-	if desc, ok := ruleMap["description"]; ok {
-		def.Description = desc.(string)
-	}
+	// Parse description if present. Defensive type assertion: a
+	// malformed KV record with a non-string description must not
+	// panic the watcher's reconcile goroutine.
+	def.Description = getStringWithDefault(ruleMap, "description", "")
 
-	// Parse conditions
-	if conditionsVal, ok := ruleMap["conditions"]; ok {
-		conditionsSlice := conditionsVal.([]any)
-		def.Conditions = make([]expression.ConditionExpression, len(conditionsSlice))
-		for i, condVal := range conditionsSlice {
-			condMap := condVal.(map[string]any)
-			cond := expression.ConditionExpression{
-				Field:    condMap["field"].(string),
-				Operator: condMap["operator"].(string),
-				Value:    condMap["value"],
-				Required: getBoolWithDefault(condMap, "required", true),
-			}
-			if from, ok := condMap["from"]; ok {
-				cond.From = from
-			}
-			def.Conditions[i] = cond
-		}
+	conds, err := parseConditionsFromMap(ruleID, ruleMap)
+	if err != nil {
+		return Definition{}, err
 	}
+	def.Conditions = conds
 
-	// Parse entity configuration if present
+	// Parse entity configuration if present. Defensive type assertions
+	// throughout — a malformed KV record must not panic the watcher's
+	// reconcile goroutine.
 	if entityVal, ok := ruleMap["entity"]; ok {
 		if entityMap, ok := entityVal.(map[string]any); ok {
 			def.Entity.Pattern = getStringWithDefault(entityMap, "pattern", "")
 			if buckets, ok := entityMap["watch_buckets"].([]any); ok {
-				def.Entity.WatchBuckets = make([]string, len(buckets))
+				def.Entity.WatchBuckets = make([]string, 0, len(buckets))
 				for i, b := range buckets {
-					def.Entity.WatchBuckets[i] = b.(string)
+					s, ok := b.(string)
+					if !ok {
+						return Definition{}, fmt.Errorf("rule %s: entity.watch_buckets[%d] must be string, got %T", ruleID, i, b)
+					}
+					def.Entity.WatchBuckets = append(def.Entity.WatchBuckets, s)
 				}
 			}
 		}
@@ -350,6 +352,42 @@ func (rp *Processor) createRuleFromConfig(ruleID string, ruleMap map[string]any)
 		return nil, Definition{}, err
 	}
 	return r, def, nil
+}
+
+// parseConditionsFromMap extracts the conditions array from a ruleMap
+// (the hot-reload wire format). The map-key check is not enough — a
+// rule with no conditions (e.g. cron rules) JSON-marshals as
+// `"conditions": null` because Definition.Conditions has no `omitempty`
+// tag. Unmarshaling into map[string]any then yields a nil-but-present
+// entry; type-asserting nil to []any panics. Guarded explicitly so
+// cron rules round-trip cleanly through the hot-reload KV bucket.
+func parseConditionsFromMap(ruleID string, ruleMap map[string]any) ([]expression.ConditionExpression, error) {
+	conditionsVal, ok := ruleMap["conditions"]
+	if !ok || conditionsVal == nil {
+		return nil, nil
+	}
+	conditionsSlice, ok := conditionsVal.([]any)
+	if !ok {
+		return nil, fmt.Errorf("rule %s: conditions must be an array, got %T", ruleID, conditionsVal)
+	}
+	conds := make([]expression.ConditionExpression, len(conditionsSlice))
+	for i, condVal := range conditionsSlice {
+		condMap, ok := condVal.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("rule %s: condition[%d] must be an object", ruleID, i)
+		}
+		cond := expression.ConditionExpression{
+			Field:    getStringWithDefault(condMap, "field", ""),
+			Operator: getStringWithDefault(condMap, "operator", ""),
+			Value:    condMap["value"],
+			Required: getBoolWithDefault(condMap, "required", true),
+		}
+		if from, ok := condMap["from"]; ok {
+			cond.From = from
+		}
+		conds[i] = cond
+	}
+	return conds, nil
 }
 
 // getStringWithDefault safely gets a string value with default

--- a/processor/rule/config_validation.go
+++ b/processor/rule/config_validation.go
@@ -92,6 +92,24 @@ func (rp *Processor) validateSingleRuleConfig(ruleID string, ruleConfig any) err
 			"RuleProcessor", "validateSingleRuleConfig", "check rule type")
 	}
 
+	// Cron rules carry a different shape — schedule + actions, no
+	// conditions, no logic. Build the Definition and round-trip it through
+	// NewCronRule so the same validation surface (forbidden fields,
+	// schedule parse, cooldown parse, action type non-empty) catches both
+	// file-loaded and hot-reloaded rules.
+	if ruleTypeStr == CronRuleType {
+		def, err := definitionFromMap(ruleID, ruleMap)
+		if err != nil {
+			return errs.Wrap(err, "RuleProcessor", "validateSingleRuleConfig",
+				fmt.Sprintf("parse cron rule %s", ruleID))
+		}
+		if _, err := NewCronRule(def); err != nil {
+			return errs.WrapInvalid(err, "RuleProcessor", "validateSingleRuleConfig",
+				fmt.Sprintf("validate cron rule %s", ruleID))
+		}
+		return nil
+	}
+
 	// Validate expression-based rules if conditions are present
 	if _, hasConditions := ruleMap["conditions"]; hasConditions {
 		if err := rp.validateExpressionRule(ruleID, ruleMap); err != nil {
@@ -170,8 +188,13 @@ func (rp *Processor) validateExpressionRule(ruleID string, ruleMap map[string]an
 	return nil
 }
 
-// isKnownRuleType checks if a rule type is supported
+// isKnownRuleType checks if a rule type is supported. Cron is a built-in
+// type that does not go through the factory registry (CronRule does not
+// implement the Rule interface), so it is recognised here directly.
 func (rp *Processor) isKnownRuleType(ruleType string) bool {
+	if ruleType == CronRuleType {
+		return true
+	}
 	_, exists := GetRuleFactory(ruleType)
 	return exists
 }
@@ -279,6 +302,22 @@ func definitionFromMap(ruleID string, ruleMap map[string]any) (Definition, error
 	def.OnExit = parseActions("on_exit")
 	def.WhileTrue = parseActions("while_true")
 	def.OnRecovery = parseActions("on_recovery")
+
+	// Cron-specific fields. These are populated regardless of Type so the
+	// round-trip (Definition → ruleMap → Definition) is lossless and so
+	// validation in NewCronRule has the full surface available. NewCronRule
+	// rejects them when Type != "cron" via its forbidden-field check.
+	def.Actions = parseActions("actions")
+	def.Schedule = getStringWithDefault(ruleMap, "schedule", "")
+	def.Cooldown = getStringWithDefault(ruleMap, "cooldown", "")
+
+	// Parse metadata if present — provenance carried through to action
+	// substitution (e.g., om_entry_id from semteams onboarding).
+	if metaVal, ok := ruleMap["metadata"]; ok {
+		if metaMap, ok := metaVal.(map[string]any); ok {
+			def.Metadata = metaMap
+		}
+	}
 
 	// Parse RerunOnRecovery flag if present
 	def.RerunOnRecovery = getBoolWithDefault(ruleMap, "rerun_on_recovery", false)

--- a/processor/rule/config_validation_test.go
+++ b/processor/rule/config_validation_test.go
@@ -1,0 +1,98 @@
+package rule
+
+import (
+	"testing"
+)
+
+// definitionFromMap is the hot-reload wire-format → Definition decoder.
+// The tests here lock the field-level parsing contract so a future
+// refactor cannot silently drop a previously-supported field.
+
+// Regression: pre-Chunk-2 the hot-reload path silently dropped the
+// `cooldown` field — definitionFromMap forgot to read it, so a rule
+// re-applied via ApplyConfigUpdate would lose its cooldown gating
+// even though the on-disk config still set it. Chunk 2's fix added
+// the parse line; this test pins it. See
+// project_cron_rule_implementation.md → "Two deferred SHOULD-FIX items
+// from Chunk 2 reviewer".
+func TestDefinitionFromMap_PreservesCooldownOnHotReload(t *testing.T) {
+	t.Parallel()
+
+	ruleMap := map[string]any{
+		"id":       "battery-low",
+		"type":     "expression",
+		"name":     "Battery low",
+		"enabled":  true,
+		"cooldown": "5m",
+	}
+
+	def, err := definitionFromMap("battery-low", ruleMap)
+	if err != nil {
+		t.Fatalf("definitionFromMap = %v, want nil", err)
+	}
+	if def.Cooldown != "5m" {
+		t.Errorf("Cooldown = %q, want %q (hot-reload must not drop cooldown)", def.Cooldown, "5m")
+	}
+}
+
+// Sibling regressions: the cron-side fields (schedule, actions,
+// metadata) were added in the same commit that fixed cooldown. Pin
+// them too so a future round-trip refactor can't drop them silently.
+func TestDefinitionFromMap_PreservesCronFields(t *testing.T) {
+	t.Parallel()
+
+	ruleMap := map[string]any{
+		"id":       "weekly-planning",
+		"type":     "cron",
+		"name":     "Weekly planning prompt",
+		"enabled":  true,
+		"schedule": "0 9 * * MON",
+		"actions": []any{
+			map[string]any{
+				"type":    "publish",
+				"subject": "system.cron.heartbeat",
+			},
+		},
+		"metadata": map[string]any{
+			"om_entry_id": "weekly-planning-block",
+		},
+	}
+
+	def, err := definitionFromMap("weekly-planning", ruleMap)
+	if err != nil {
+		t.Fatalf("definitionFromMap = %v, want nil", err)
+	}
+	if def.Schedule != "0 9 * * MON" {
+		t.Errorf("Schedule = %q, want %q", def.Schedule, "0 9 * * MON")
+	}
+	if len(def.Actions) != 1 {
+		t.Fatalf("len(Actions) = %d, want 1", len(def.Actions))
+	}
+	if def.Actions[0].Type != "publish" || def.Actions[0].Subject != "system.cron.heartbeat" {
+		t.Errorf("Action = %+v, want type=publish subject=system.cron.heartbeat", def.Actions[0])
+	}
+	if got := def.Metadata["om_entry_id"]; got != "weekly-planning-block" {
+		t.Errorf("Metadata[om_entry_id] = %v, want %q", got, "weekly-planning-block")
+	}
+}
+
+// Empty-cooldown remains the empty string (not the zero-time literal
+// or some other sentinel) so the downstream parse step (cron_rule.go
+// for cron rules, expression-factory for expression rules) can branch
+// on len() == 0.
+func TestDefinitionFromMap_AbsentCooldownIsEmptyString(t *testing.T) {
+	t.Parallel()
+
+	ruleMap := map[string]any{
+		"id":      "no-cooldown",
+		"type":    "expression",
+		"enabled": true,
+	}
+	def, err := definitionFromMap("no-cooldown", ruleMap)
+	if err != nil {
+		t.Fatalf("definitionFromMap = %v, want nil", err)
+	}
+	if def.Cooldown != "" {
+		t.Errorf("Cooldown = %q, want empty string for absent field", def.Cooldown)
+	}
+}

--- a/processor/rule/cron_metrics.go
+++ b/processor/rule/cron_metrics.go
@@ -1,0 +1,284 @@
+// Package rule - Prometheus metrics for the cron scheduler.
+//
+// The cron scheduler exposes seven metrics under the
+// `semstreams_cron_*` namespace. They mirror what an operator typically
+// wants to see for a periodically-firing component:
+//
+//   - fires_total{rule_id, status} — counter; status is success / error
+//     / panic / cooldown_skipped. Lets ops see fire rates per rule and
+//     spot rules whose cron expression ticks faster than actions
+//     complete (cooldown_skipped grows).
+//   - fire_duration_seconds{rule_id} — histogram of action-dispatch
+//     latency. Surfaces slow `publish_agent` rules that risk
+//     overlapping with the next tick before the cooldown gate triggers.
+//   - registered — gauge; total registered cron rules. Flips on
+//     hot-reload; useful for confirming a config change took effect.
+//   - missed_fires_total{rule_id} — counter; incremented once per
+//     missed fire detected on Start. Per ADR-031 the policy is log-only,
+//     so the metric tracks cumulative missed fires rather than
+//     auto-replay attempts.
+//   - missed_fires_capped_total{rule_id} — counter; incremented when
+//     a rule's missed-fire count hits the detection cap (currently 100).
+//     Lets operators alert on long downtimes without grepping logs.
+//   - next_fire_timestamp_seconds{rule_id} — gauge; Unix epoch seconds
+//     of the rule's next scheduled fire. Enables alerts like "no fire
+//     in last 2× period" by comparing scrape time against the gauge.
+//   - scheduler_running — gauge; 1 when Start has been called and Stop
+//     hasn't, 0 otherwise. Catches the "processor still alive but
+//     scheduler crashed" pathology.
+//
+// The constructor follows the routerMetrics pattern in
+// agentic-dispatch: per-registry instances cached so multiple
+// processors sharing a registry get the same collectors, plus a
+// nil-registry singleton fallback for production deployments using
+// the default Prometheus registerer. Both paths support nil-tolerant
+// recordX helpers so callers don't have to nil-check before every
+// observation.
+package rule
+
+import (
+	"sync"
+
+	"github.com/c360studio/semstreams/metric"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Cron fire status labels — exported as constants so call sites and
+// downstream alerting rules use the same strings. Adding a new status
+// here MUST be paired with a dashboard panel update; otherwise the new
+// label silently increases cardinality without operator visibility.
+const (
+	cronFireStatusSuccess         = "success"
+	cronFireStatusError           = "error"
+	cronFireStatusPanic           = "panic"
+	cronFireStatusCooldownSkipped = "cooldown_skipped"
+	// cronFireStatusInflightSkipped distinguishes the operator-error
+	// case "actions are slower than schedule, no cooldown configured"
+	// from the configured-and-working cooldown_skipped path. Operators
+	// alerting on inflight_skipped > 0 know to either tune the schedule,
+	// configure a cooldown explicitly, or speed up the actions.
+	cronFireStatusInflightSkipped = "inflight_skipped"
+)
+
+// cronMetrics holds the Prometheus collectors for cron-scheduler
+// observability. All recordX methods are safe to call on a nil
+// receiver — production paths can take the nil-metrics branch on
+// startup misconfiguration without crashing.
+type cronMetrics struct {
+	firesTotal             *prometheus.CounterVec
+	fireDurationSeconds    *prometheus.HistogramVec
+	registered             prometheus.Gauge
+	missedFiresTotal       *prometheus.CounterVec
+	missedFiresCappedTotal *prometheus.CounterVec
+	nextFireTimestampSecs  *prometheus.GaugeVec
+	schedulerRunning       prometheus.Gauge
+}
+
+// Per-registry caching mirrors routerMetrics in agentic-dispatch.
+// Tests pass a fresh MetricsRegistry per test for isolation; production
+// uses nil and gets a process-singleton.
+var (
+	cronMetricsMu    sync.Mutex
+	cronMetricsCache = make(map[*metric.MetricsRegistry]*cronMetrics)
+	cronNilMetrics   *cronMetrics
+	cronNilOnce      sync.Once
+)
+
+// getCronMetrics returns a *cronMetrics bound to registry, constructing
+// and registering the collectors on first use. A nil registry returns a
+// process-singleton bound to the default Prometheus registerer.
+func getCronMetrics(registry *metric.MetricsRegistry) *cronMetrics {
+	if registry == nil {
+		cronNilOnce.Do(func() {
+			cronNilMetrics = createAndRegisterCronMetrics(nil)
+		})
+		return cronNilMetrics
+	}
+	cronMetricsMu.Lock()
+	defer cronMetricsMu.Unlock()
+	if m, ok := cronMetricsCache[registry]; ok {
+		return m
+	}
+	m := createAndRegisterCronMetrics(registry)
+	cronMetricsCache[registry] = m
+	return m
+}
+
+func createAndRegisterCronMetrics(registry *metric.MetricsRegistry) *cronMetrics {
+	const (
+		namespace = "semstreams"
+		subsystem = "cron"
+	)
+	m := &cronMetrics{
+		firesTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "rule_fires_total",
+			Help:      "Cron rule fire attempts by rule and outcome (success/error/panic/cooldown_skipped)",
+		}, []string{"rule_id", "status"}),
+
+		fireDurationSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "rule_fire_duration_seconds",
+			Help:      "Action-dispatch latency per cron rule fire",
+			// 1ms to ~16s — covers fast publish actions through slow
+			// publish_agent dispatches that include LLM round-trips.
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 14),
+		}, []string{"rule_id"}),
+
+		registered: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "rule_registered",
+			Help:      "Number of cron rules currently registered with the scheduler",
+		}),
+
+		missedFiresTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "rule_missed_fires_total",
+			Help:      "Cron rule missed fires detected on scheduler restart (log-only policy; not replayed)",
+		}, []string{"rule_id"}),
+
+		missedFiresCappedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "rule_missed_fires_capped_total",
+			Help:      "Cron rules whose missed-fire detection hit the bounded cap (100) at restart — long downtime indicator",
+		}, []string{"rule_id"}),
+
+		nextFireTimestampSecs: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "rule_next_fire_timestamp_seconds",
+			Help:      "Unix epoch (seconds) of the next scheduled fire per cron rule",
+		}, []string{"rule_id"}),
+
+		schedulerRunning: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "scheduler_running",
+			Help:      "1 when the cron scheduler is started and ticking, 0 otherwise",
+		}),
+	}
+
+	if registry != nil {
+		_ = registry.RegisterCounterVec(subsystem, "rule_fires_total", m.firesTotal)
+		_ = registry.RegisterHistogramVec(subsystem, "rule_fire_duration_seconds", m.fireDurationSeconds)
+		_ = registry.RegisterGauge(subsystem, "rule_registered", m.registered)
+		_ = registry.RegisterCounterVec(subsystem, "rule_missed_fires_total", m.missedFiresTotal)
+		_ = registry.RegisterCounterVec(subsystem, "rule_missed_fires_capped_total", m.missedFiresCappedTotal)
+		_ = registry.RegisterGaugeVec(subsystem, "rule_next_fire_timestamp_seconds", m.nextFireTimestampSecs)
+		_ = registry.RegisterGauge(subsystem, "scheduler_running", m.schedulerRunning)
+	} else {
+		_ = prometheus.DefaultRegisterer.Register(m.firesTotal)
+		_ = prometheus.DefaultRegisterer.Register(m.fireDurationSeconds)
+		_ = prometheus.DefaultRegisterer.Register(m.registered)
+		_ = prometheus.DefaultRegisterer.Register(m.missedFiresTotal)
+		_ = prometheus.DefaultRegisterer.Register(m.missedFiresCappedTotal)
+		_ = prometheus.DefaultRegisterer.Register(m.nextFireTimestampSecs)
+		_ = prometheus.DefaultRegisterer.Register(m.schedulerRunning)
+	}
+	return m
+}
+
+// recordFire is the single chokepoint for fires_total + fire_duration.
+// It increments fires_total{rule_id, status} unconditionally and
+// observes the duration histogram only for statuses that represent a
+// completed dispatch (success / error). Skipped statuses (cooldown,
+// inflight) and the panic backstop intentionally skip the histogram:
+//
+//   - cooldown / inflight skipped fires never dispatched; their
+//     "duration" is just the gate-check time and would pull the
+//     histogram artificially low.
+//   - panic IS a dispatch outcome but its duration measures partial
+//     work + recovery overhead, which would distort success/error
+//     percentiles. Panics are paged on via the counter, not the
+//     histogram.
+//
+// Callers always go through this method — there is no sibling helper
+// per status — so this is the only place a future contributor needs to
+// edit when the status taxonomy changes.
+func (m *cronMetrics) recordFire(ruleID, status string, durationSeconds float64) {
+	if m == nil {
+		return
+	}
+	m.firesTotal.WithLabelValues(ruleID, status).Inc()
+	if status == cronFireStatusSuccess || status == cronFireStatusError {
+		m.fireDurationSeconds.WithLabelValues(ruleID).Observe(durationSeconds)
+	}
+}
+
+// recordRuleRegistered increments the registered gauge. Called from
+// CronScheduler.Register on a successful (re-)registration.
+func (m *cronMetrics) recordRuleRegistered() {
+	if m == nil {
+		return
+	}
+	m.registered.Inc()
+}
+
+// recordRuleDeregistered decrements the registered gauge. Called from
+// CronScheduler.Deregister on a successful removal.
+func (m *cronMetrics) recordRuleDeregistered() {
+	if m == nil {
+		return
+	}
+	m.registered.Dec()
+}
+
+// recordMissedFire increments missed_fires_total by the given count for
+// a single rule. The detector reports the total in one call rather than
+// invoking N times so consumers see the increment as one logical event.
+func (m *cronMetrics) recordMissedFire(ruleID string, count int) {
+	if m == nil || count <= 0 {
+		return
+	}
+	m.missedFiresTotal.WithLabelValues(ruleID).Add(float64(count))
+}
+
+// recordMissedFireCapped increments missed_fires_capped_total when a
+// rule's restart-detection hit the bounded cap. One call per rule per
+// restart.
+func (m *cronMetrics) recordMissedFireCapped(ruleID string) {
+	if m == nil {
+		return
+	}
+	m.missedFiresCappedTotal.WithLabelValues(ruleID).Inc()
+}
+
+// recordNextFire updates the next-fire-timestamp gauge for a rule.
+// Called after Register and after each successful fire so the gauge
+// always reflects the freshest schedule.Next() value.
+func (m *cronMetrics) recordNextFire(ruleID string, unixSeconds float64) {
+	if m == nil {
+		return
+	}
+	m.nextFireTimestampSecs.WithLabelValues(ruleID).Set(unixSeconds)
+}
+
+// clearNextFire removes the next-fire gauge for a rule. Called on
+// Deregister so a removed rule's gauge doesn't go stale and produce
+// false-positive alerts.
+func (m *cronMetrics) clearNextFire(ruleID string) {
+	if m == nil {
+		return
+	}
+	m.nextFireTimestampSecs.DeleteLabelValues(ruleID)
+}
+
+// recordSchedulerRunning sets the running gauge. running=true on
+// Start, false on Stop. The gauge surfaces the "scheduler crashed but
+// processor still alive" pathology that a process-level liveness check
+// would miss.
+func (m *cronMetrics) recordSchedulerRunning(running bool) {
+	if m == nil {
+		return
+	}
+	if running {
+		m.schedulerRunning.Set(1)
+	} else {
+		m.schedulerRunning.Set(0)
+	}
+}

--- a/processor/rule/cron_metrics_test.go
+++ b/processor/rule/cron_metrics_test.go
@@ -1,0 +1,184 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/metric"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func newCronMetricsForTest(t *testing.T) *cronMetrics {
+	t.Helper()
+	// Per-test registry guarantees isolation: getCronMetrics caches by
+	// pointer, so a fresh registry yields fresh collectors with no
+	// accumulated counts from sibling tests.
+	return getCronMetrics(metric.NewMetricsRegistry())
+}
+
+func TestGetCronMetrics_NilRegistryReturnsSingleton(t *testing.T) {
+	t.Parallel()
+	a := getCronMetrics(nil)
+	b := getCronMetrics(nil)
+	if a != b {
+		t.Errorf("getCronMetrics(nil) returned distinct singletons; want shared instance")
+	}
+}
+
+func TestGetCronMetrics_PerRegistryIsolation(t *testing.T) {
+	t.Parallel()
+	r1 := metric.NewMetricsRegistry()
+	r2 := metric.NewMetricsRegistry()
+	m1 := getCronMetrics(r1)
+	m2 := getCronMetrics(r2)
+	if m1 == m2 {
+		t.Error("distinct registries returned shared metrics; want per-registry isolation")
+	}
+}
+
+func TestCronMetrics_RecordFireSuccessAndError(t *testing.T) {
+	t.Parallel()
+	m := newCronMetricsForTest(t)
+
+	m.recordFire("rule-A", cronFireStatusSuccess, 0.05)
+	m.recordFire("rule-A", cronFireStatusError, 0.10)
+	m.recordFire("rule-B", cronFireStatusSuccess, 0.02)
+
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues("rule-A", cronFireStatusSuccess)); got != 1 {
+		t.Errorf("rule-A success = %f, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues("rule-A", cronFireStatusError)); got != 1 {
+		t.Errorf("rule-A error = %f, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues("rule-B", cronFireStatusSuccess)); got != 1 {
+		t.Errorf("rule-B success = %f, want 1", got)
+	}
+
+	// Histogram observed for both success and error (= actual dispatches).
+	if got := testutil.CollectAndCount(m.fireDurationSeconds); got == 0 {
+		t.Errorf("fire duration histogram has no observations after recordFire(success/error)")
+	}
+}
+
+// Skipped statuses (cooldown_skipped, inflight_skipped) and the panic
+// backstop status all skip the histogram observation. Skipped fires
+// never dispatched; panic duration represents partial work + recovery
+// overhead and would distort success/error percentiles. Panics are
+// paged on via the counter, not the histogram. This test locks the
+// chokepoint contract documented on recordFire.
+func TestCronMetrics_RecordFireSkippedStatusesOmitDuration(t *testing.T) {
+	t.Parallel()
+	m := newCronMetricsForTest(t)
+
+	// Seed one valid observation so we can detect any extra additions
+	// from the skipped/panic calls below.
+	m.recordFire("rule", cronFireStatusSuccess, 0.05)
+	baseline := testutil.CollectAndCount(m.fireDurationSeconds)
+
+	m.recordFire("rule", cronFireStatusCooldownSkipped, 0.001)
+	m.recordFire("rule", cronFireStatusInflightSkipped, 0.001)
+	m.recordFire("rule", cronFireStatusPanic, 0.001)
+
+	// Counters must increment for each call.
+	for _, status := range []string{cronFireStatusCooldownSkipped, cronFireStatusInflightSkipped, cronFireStatusPanic} {
+		if got := testutil.ToFloat64(m.firesTotal.WithLabelValues("rule", status)); got != 1 {
+			t.Errorf("fires{status=%s} = %f, want 1", status, got)
+		}
+	}
+	// Histogram MUST NOT have grown past the baseline — none of the
+	// three statuses observe duration.
+	if got := testutil.CollectAndCount(m.fireDurationSeconds); got != baseline {
+		t.Errorf("fire_duration histogram count = %d, want %d (skipped/panic statuses must not observe duration)", got, baseline)
+	}
+}
+
+func TestCronMetrics_RegisteredGaugeFlips(t *testing.T) {
+	t.Parallel()
+	m := newCronMetricsForTest(t)
+
+	m.recordRuleRegistered()
+	m.recordRuleRegistered()
+	if got := testutil.ToFloat64(m.registered); got != 2 {
+		t.Errorf("registered = %f, want 2", got)
+	}
+	m.recordRuleDeregistered()
+	if got := testutil.ToFloat64(m.registered); got != 1 {
+		t.Errorf("registered after deregister = %f, want 1", got)
+	}
+}
+
+func TestCronMetrics_MissedFiresAdditive(t *testing.T) {
+	t.Parallel()
+	m := newCronMetricsForTest(t)
+
+	m.recordMissedFire("rule", 5)
+	m.recordMissedFire("rule", 3)
+	if got := testutil.ToFloat64(m.missedFiresTotal.WithLabelValues("rule")); got != 8 {
+		t.Errorf("missed fires = %f, want 8", got)
+	}
+
+	// Zero / negative counts are no-ops.
+	m.recordMissedFire("rule", 0)
+	m.recordMissedFire("rule", -1)
+	if got := testutil.ToFloat64(m.missedFiresTotal.WithLabelValues("rule")); got != 8 {
+		t.Errorf("missed fires after zero/negative = %f, want 8 (unchanged)", got)
+	}
+}
+
+func TestCronMetrics_MissedFireCappedCounter(t *testing.T) {
+	t.Parallel()
+	m := newCronMetricsForTest(t)
+	m.recordMissedFireCapped("rule")
+	if got := testutil.ToFloat64(m.missedFiresCappedTotal.WithLabelValues("rule")); got != 1 {
+		t.Errorf("capped = %f, want 1", got)
+	}
+}
+
+func TestCronMetrics_NextFireGaugeSetAndClear(t *testing.T) {
+	t.Parallel()
+	m := newCronMetricsForTest(t)
+
+	m.recordNextFire("rule", 1735689600) // 2025-01-01T00:00:00Z
+	if got := testutil.ToFloat64(m.nextFireTimestampSecs.WithLabelValues("rule")); got != 1735689600 {
+		t.Errorf("next_fire = %f, want 1735689600", got)
+	}
+
+	m.clearNextFire("rule")
+	// After delete, ToFloat64 on the WithLabelValues handle re-creates
+	// the gauge at 0; instead, count vector entries via CollectAndCount.
+	if got := testutil.CollectAndCount(m.nextFireTimestampSecs); got != 0 {
+		t.Errorf("next_fire vector count after clear = %d, want 0", got)
+	}
+}
+
+func TestCronMetrics_SchedulerRunningGauge(t *testing.T) {
+	t.Parallel()
+	m := newCronMetricsForTest(t)
+
+	m.recordSchedulerRunning(true)
+	if got := testutil.ToFloat64(m.schedulerRunning); got != 1 {
+		t.Errorf("running=true gauge = %f, want 1", got)
+	}
+	m.recordSchedulerRunning(false)
+	if got := testutil.ToFloat64(m.schedulerRunning); got != 0 {
+		t.Errorf("running=false gauge = %f, want 0", got)
+	}
+}
+
+// All recordX methods must be safe on a nil receiver. Production paths
+// initialize cronMetrics from a registry; degraded mode (nil registry +
+// production singleton race in tests) historically left some fields nil.
+// This test guards against any future field that forgets the nil guard.
+func TestCronMetrics_NilReceiverSafe(t *testing.T) {
+	t.Parallel()
+	var m *cronMetrics
+	m.recordFire("r", cronFireStatusSuccess, 0.1)
+	m.recordFire("r", cronFireStatusCooldownSkipped, 0)
+	m.recordRuleRegistered()
+	m.recordRuleDeregistered()
+	m.recordMissedFire("r", 5)
+	m.recordMissedFireCapped("r")
+	m.recordNextFire("r", 0)
+	m.clearNextFire("r")
+	m.recordSchedulerRunning(true)
+	// Reaching here without panic is the assertion.
+}

--- a/processor/rule/cron_rule.go
+++ b/processor/rule/cron_rule.go
@@ -1,0 +1,199 @@
+// Package rule - Cron rule type for time-driven actions.
+//
+// Cron rules are a third firing path alongside KV-watch and message-path
+// rules. Unlike expression rules, cron rules have no condition — they fire
+// on a clock tick alone, dispatched by CronScheduler against the same
+// ActionExecutor that expression rules use.
+//
+// CronRule is intentionally NOT an implementation of the Rule interface.
+// Subscribe / Evaluate / ExecuteEvents are message-driven concepts that
+// don't fit time-driven firing. Keeping cron rules outside the Rule
+// registry means they don't accidentally appear in evaluateRulesForMessage
+// dispatch and don't need no-op stubs cluttering the type.
+package rule
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	cronlib "github.com/robfig/cron/v3"
+)
+
+// CronRuleType is the string used as Definition.Type for cron rules.
+const CronRuleType = "cron"
+
+// cronParser is the package-shared parser. POSIX 5-field plus descriptors
+// (@hourly, @daily, @weekly, @monthly, @yearly). Deliberately excludes
+// quartz seconds-precision and "first Tuesday of month" — those are
+// tracked as deferred items per ADR-031.
+var cronParser = cronlib.NewParser(
+	cronlib.Minute | cronlib.Hour | cronlib.Dom | cronlib.Month | cronlib.Dow | cronlib.Descriptor,
+)
+
+// CronRule holds a parsed cron-rule definition ready for the scheduler to
+// register and fire. It carries everything the scheduler needs at fire
+// time without re-reading the source Definition.
+//
+// Fields are unexported behind accessor methods so the scheduler and
+// metrics layer can hold a CronRule reference without coupling to its
+// internals — important for the future per-tenant fan-out path which
+// will need to build per-iteration Actions copies without mutating the
+// shared CronRule.
+type CronRule struct {
+	id          string
+	name        string
+	description string
+	enabled     bool
+	scheduleStr string
+	schedule    cronlib.Schedule
+	actions     []Action
+	cooldown    time.Duration
+	fireEveryN  int
+	metadata    map[string]any
+}
+
+// NewCronRule builds a CronRule from a Definition. Returns an error if
+// any cron-specific validation fails: wrong Type, missing schedule,
+// schedule fails to parse, cooldown unparseable, forbidden field
+// present, or any action with an empty Type.
+func NewCronRule(def Definition) (*CronRule, error) {
+	if err := validateCronDefinition(def); err != nil {
+		return nil, err
+	}
+
+	schedule, err := cronParser.Parse(def.Schedule)
+	if err != nil {
+		return nil, fmt.Errorf("rule %s schedule %q: %w", def.ID, def.Schedule, err)
+	}
+
+	var cooldown time.Duration
+	if def.Cooldown != "" {
+		cooldown, err = time.ParseDuration(def.Cooldown)
+		if err != nil {
+			return nil, fmt.Errorf("rule %s cooldown %q: %w", def.ID, def.Cooldown, err)
+		}
+	}
+
+	return &CronRule{
+		id:          def.ID,
+		name:        def.Name,
+		description: def.Description,
+		enabled:     def.Enabled,
+		scheduleStr: def.Schedule,
+		schedule:    schedule,
+		actions:     slices.Clone(def.Actions),
+		cooldown:    cooldown,
+		fireEveryN:  def.FireEveryNEvents,
+		metadata:    def.Metadata,
+	}, nil
+}
+
+// ID returns the rule's stable identifier.
+func (r *CronRule) ID() string { return r.id }
+
+// Name returns the human-readable rule name.
+func (r *CronRule) Name() string { return r.name }
+
+// Description returns the rule's description string.
+func (r *CronRule) Description() string { return r.description }
+
+// Enabled reports whether the rule should be registered with the scheduler.
+func (r *CronRule) Enabled() bool { return r.enabled }
+
+// ScheduleString returns the original cron expression, useful for metrics
+// labels and substitution variables.
+func (r *CronRule) ScheduleString() string { return r.scheduleStr }
+
+// Schedule returns the parsed cron schedule. Used by the scheduler to
+// compute next-fire times and by the missed-fire detector to compute
+// expected fire intervals.
+func (r *CronRule) Schedule() cronlib.Schedule { return r.schedule }
+
+// Actions returns a clone of the action list to execute on each fire.
+// The clone protects callers (per-iteration fan-out, in particular) from
+// accidentally mutating the shared CronRule's slice across fires.
+func (r *CronRule) Actions() []Action { return slices.Clone(r.actions) }
+
+// Metadata returns the rule's metadata map, or nil if none was supplied.
+// Useful for carrying provenance (e.g. operating-model entry IDs) from
+// the source Definition through to action substitution.
+func (r *CronRule) Metadata() map[string]any { return r.metadata }
+
+// Cooldown returns the duration after which a fire may run again. Zero
+// means no cooldown.
+func (r *CronRule) Cooldown() time.Duration { return r.cooldown }
+
+// FireEveryN returns the action-gating factor (every Nth tick fires
+// actions). Zero or one means "fire every tick."
+func (r *CronRule) FireEveryN() int { return r.fireEveryN }
+
+// validateCronDefinition rejects cron-rule definitions that carry fields
+// only meaningful for expression rules. Errors surface at config-load
+// time so authors see them before any rule fires.
+func validateCronDefinition(def Definition) error {
+	if def.ID == "" {
+		return fmt.Errorf("cron rule: id is required")
+	}
+	if def.Type != CronRuleType {
+		return fmt.Errorf("cron rule %s: type %q, want %q", def.ID, def.Type, CronRuleType)
+	}
+	if strings.TrimSpace(def.Schedule) == "" {
+		return fmt.Errorf("cron rule %s: schedule is required", def.ID)
+	}
+	if len(def.Actions) == 0 {
+		return fmt.Errorf("cron rule %s: at least one action is required", def.ID)
+	}
+	for i, a := range def.Actions {
+		if strings.TrimSpace(a.Type) == "" {
+			return fmt.Errorf("cron rule %s: action[%d] missing type", def.ID, i)
+		}
+	}
+
+	// Reject expression-rule fields that have no meaning under a clock-only
+	// firing model. Failing loud at config-load beats silently ignoring
+	// fields the author thought were doing something.
+	var rejected []string
+	if len(def.Conditions) > 0 {
+		rejected = append(rejected, "conditions")
+	}
+	if def.Logic != "" {
+		rejected = append(rejected, "logic")
+	}
+	if len(def.OnEnter) > 0 {
+		rejected = append(rejected, "on_enter")
+	}
+	if len(def.OnExit) > 0 {
+		rejected = append(rejected, "on_exit")
+	}
+	if len(def.OnRecovery) > 0 {
+		rejected = append(rejected, "on_recovery")
+	}
+	if len(def.WhileTrue) > 0 {
+		rejected = append(rejected, "while_true")
+	}
+	if def.RerunOnRecovery {
+		rejected = append(rejected, "rerun_on_recovery")
+	}
+	if def.MaxIterations > 0 {
+		rejected = append(rejected, "max_iterations")
+	}
+	if def.Entity.Pattern != "" {
+		rejected = append(rejected, "entity.pattern")
+	}
+	if len(def.Entity.WatchBuckets) > 0 {
+		rejected = append(rejected, "entity.watch_buckets")
+	}
+	if len(def.RelatedPatterns) > 0 {
+		rejected = append(rejected, "related_patterns")
+	}
+	if len(rejected) > 0 {
+		return fmt.Errorf("cron rule %s: forbidden fields present: %s "+
+			"(cron rules accept only: schedule, actions, cooldown, fire_every_n_events, "+
+			"name, description, enabled, metadata)",
+			def.ID, strings.Join(rejected, ", "))
+	}
+
+	return nil
+}

--- a/processor/rule/cron_rule_test.go
+++ b/processor/rule/cron_rule_test.go
@@ -1,0 +1,238 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/processor/rule/expression"
+)
+
+func validCronDef() Definition {
+	return Definition{
+		ID:       "weekly-planning",
+		Type:     CronRuleType,
+		Name:     "Weekly planning prompt",
+		Enabled:  true,
+		Schedule: "0 9 * * MON",
+		Actions: []Action{
+			{Type: ActionTypePublish, Subject: "system.cron.heartbeat"},
+		},
+	}
+}
+
+func TestNewCronRule_HappyPath(t *testing.T) {
+	r, err := NewCronRule(validCronDef())
+	if err != nil {
+		t.Fatalf("NewCronRule = %v, want nil", err)
+	}
+	if r.ID() != "weekly-planning" {
+		t.Errorf("ID = %q, want weekly-planning", r.ID())
+	}
+	if r.ScheduleString() != "0 9 * * MON" {
+		t.Errorf("ScheduleString = %q, want %q", r.ScheduleString(), "0 9 * * MON")
+	}
+	if !r.Enabled() {
+		t.Errorf("Enabled = false, want true")
+	}
+	if len(r.Actions()) != 1 {
+		t.Errorf("Actions = %d, want 1", len(r.Actions()))
+	}
+	if r.Cooldown() != 0 {
+		t.Errorf("Cooldown = %v, want 0", r.Cooldown())
+	}
+	// Schedule must produce a future fire time.
+	next := r.Schedule().Next(time.Now())
+	if !next.After(time.Now()) {
+		t.Errorf("Schedule.Next(now) = %v, want a future time", next)
+	}
+}
+
+func TestNewCronRule_DescriptorSchedules(t *testing.T) {
+	for _, spec := range []string{"@hourly", "@daily", "@weekly", "@monthly", "@yearly"} {
+		t.Run(spec, func(t *testing.T) {
+			def := validCronDef()
+			def.Schedule = spec
+			r, err := NewCronRule(def)
+			if err != nil {
+				t.Fatalf("NewCronRule(%q) = %v, want nil", spec, err)
+			}
+			if r.ScheduleString() != spec {
+				t.Errorf("ScheduleString = %q, want %q", r.ScheduleString(), spec)
+			}
+		})
+	}
+}
+
+func TestNewCronRule_CooldownParsed(t *testing.T) {
+	def := validCronDef()
+	def.Cooldown = "30s"
+	r, err := NewCronRule(def)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if r.Cooldown() != 30*time.Second {
+		t.Errorf("Cooldown = %v, want 30s", r.Cooldown())
+	}
+}
+
+func TestNewCronRule_RejectsBadSchedule(t *testing.T) {
+	def := validCronDef()
+	def.Schedule = "this is not cron"
+	_, err := NewCronRule(def)
+	if err == nil {
+		t.Fatal("err = nil, want parse error")
+	}
+	if !strings.Contains(err.Error(), "schedule") {
+		t.Errorf("error message %q should mention 'schedule'", err.Error())
+	}
+}
+
+func TestNewCronRule_RejectsBadCooldown(t *testing.T) {
+	def := validCronDef()
+	def.Cooldown = "not a duration"
+	_, err := NewCronRule(def)
+	if err == nil {
+		t.Fatal("err = nil, want cooldown parse error")
+	}
+}
+
+func TestNewCronRule_RequiresID(t *testing.T) {
+	def := validCronDef()
+	def.ID = ""
+	_, err := NewCronRule(def)
+	if err == nil || !strings.Contains(err.Error(), "id is required") {
+		t.Errorf("err = %v, want id-required error", err)
+	}
+}
+
+func TestNewCronRule_RequiresSchedule(t *testing.T) {
+	def := validCronDef()
+	def.Schedule = ""
+	_, err := NewCronRule(def)
+	if err == nil || !strings.Contains(err.Error(), "schedule is required") {
+		t.Errorf("err = %v, want schedule-required error", err)
+	}
+}
+
+func TestNewCronRule_RequiresAtLeastOneAction(t *testing.T) {
+	def := validCronDef()
+	def.Actions = nil
+	_, err := NewCronRule(def)
+	if err == nil || !strings.Contains(err.Error(), "action is required") {
+		t.Errorf("err = %v, want action-required error", err)
+	}
+}
+
+func TestNewCronRule_RejectsForbiddenFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Definition)
+		field  string
+	}{
+		{"conditions", func(d *Definition) {
+			d.Conditions = []expression.ConditionExpression{{Field: "x", Operator: "eq", Value: 1}}
+		}, "conditions"},
+		{"logic", func(d *Definition) { d.Logic = "and" }, "logic"},
+		{"on_enter", func(d *Definition) { d.OnEnter = []Action{{Type: ActionTypePublish}} }, "on_enter"},
+		{"on_exit", func(d *Definition) { d.OnExit = []Action{{Type: ActionTypePublish}} }, "on_exit"},
+		{"on_recovery", func(d *Definition) { d.OnRecovery = []Action{{Type: ActionTypePublish}} }, "on_recovery"},
+		{"while_true", func(d *Definition) { d.WhileTrue = []Action{{Type: ActionTypePublish}} }, "while_true"},
+		{"rerun_on_recovery", func(d *Definition) { d.RerunOnRecovery = true }, "rerun_on_recovery"},
+		{"max_iterations", func(d *Definition) { d.MaxIterations = 5 }, "max_iterations"},
+		{"entity.pattern", func(d *Definition) { d.Entity.Pattern = "*.foo.*" }, "entity.pattern"},
+		{"entity.watch_buckets", func(d *Definition) { d.Entity.WatchBuckets = []string{"X"} }, "entity.watch_buckets"},
+		{"related_patterns", func(d *Definition) { d.RelatedPatterns = []string{"*"} }, "related_patterns"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			def := validCronDef()
+			tc.mutate(&def)
+			_, err := NewCronRule(def)
+			if err == nil {
+				t.Fatalf("err = nil, want forbidden-field error mentioning %q", tc.field)
+			}
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Errorf("err = %q, want it to mention %q", err.Error(), tc.field)
+			}
+			if !strings.Contains(err.Error(), "forbidden fields present") {
+				t.Errorf("err = %q, want it to mention 'forbidden fields present'", err.Error())
+			}
+		})
+	}
+}
+
+func TestNewCronRule_AllowsCooldownAndFireEveryN(t *testing.T) {
+	// Cooldown and fire_every_n_events are deliberately allowed on cron
+	// rules because they're orthogonal to scheduling: cooldown suppresses
+	// overlapping fires, fire_every_n_events gates the action counter.
+	def := validCronDef()
+	def.Cooldown = "5s"
+	def.FireEveryNEvents = 3
+	r, err := NewCronRule(def)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if r.FireEveryN() != 3 {
+		t.Errorf("FireEveryN = %d, want 3", r.FireEveryN())
+	}
+	if r.Cooldown() != 5*time.Second {
+		t.Errorf("Cooldown = %v, want 5s", r.Cooldown())
+	}
+}
+
+func TestNewCronRule_RejectsWrongType(t *testing.T) {
+	def := validCronDef()
+	def.Type = "expression"
+	_, err := NewCronRule(def)
+	if err == nil || !strings.Contains(err.Error(), `type "expression"`) {
+		t.Errorf("err = %v, want type-mismatch error", err)
+	}
+}
+
+func TestNewCronRule_RejectsActionWithEmptyType(t *testing.T) {
+	def := validCronDef()
+	def.Actions = []Action{{Subject: "x"}} // Type empty — would bomb in executor
+	_, err := NewCronRule(def)
+	if err == nil || !strings.Contains(err.Error(), "missing type") {
+		t.Errorf("err = %v, want missing-type error", err)
+	}
+}
+
+func TestNewCronRule_PreservesMetadata(t *testing.T) {
+	def := validCronDef()
+	def.Metadata = map[string]any{"om_entry_id": "om-rhythms-abc123", "source": "onboarding"}
+	r, err := NewCronRule(def)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	got := r.Metadata()
+	if got["om_entry_id"] != "om-rhythms-abc123" || got["source"] != "onboarding" {
+		t.Errorf("Metadata = %+v, want provenance preserved", got)
+	}
+}
+
+func TestNewCronRule_ActionsAccessorReturnsClone(t *testing.T) {
+	// Mutating the returned slice must not affect the rule's internal state.
+	// Important for the future per-tenant fan-out path which will build
+	// per-iteration Action copies.
+	def := validCronDef()
+	def.Actions = []Action{{Type: ActionTypePublish, Subject: "first"}}
+	r, err := NewCronRule(def)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	a := r.Actions()
+	a[0].Subject = "MUTATED"
+	if r.Actions()[0].Subject != "first" {
+		t.Errorf("Actions() returned the live slice; mutation leaked into the rule (%q)", r.Actions()[0].Subject)
+	}
+}
+
+func TestCronRuleType_Constant(t *testing.T) {
+	// The const value is part of the public config surface — pinning it
+	// here so nobody renames "cron" without realizing it's a config break.
+	if CronRuleType != "cron" {
+		t.Errorf("CronRuleType = %q, want %q", CronRuleType, "cron")
+	}
+}

--- a/processor/rule/cron_scheduler.go
+++ b/processor/rule/cron_scheduler.go
@@ -41,6 +41,7 @@ import (
 type CronScheduler struct {
 	cron     *cronlib.Cron
 	executor ActionExecutorInterface
+	tracker  *ScheduleTracker
 	logger   *slog.Logger
 
 	mu      sync.Mutex
@@ -88,7 +89,13 @@ type cronEntry struct {
 // the given executor. The logger is required (use slog.Default() if no
 // component logger is available); a nil executor is rejected because every
 // fire would silently no-op, hiding misconfiguration.
-func NewCronScheduler(executor ActionExecutorInterface, logger *slog.Logger) (*CronScheduler, error) {
+//
+// The tracker is optional: pass nil and the scheduler runs without
+// persistence (no missed-fire detection on restart, no cross-process
+// readability of last-fired timestamps). Tests typically pass nil; the
+// production processor wires in a tracker bound to the RULE_SCHEDULES
+// bucket.
+func NewCronScheduler(executor ActionExecutorInterface, tracker *ScheduleTracker, logger *slog.Logger) (*CronScheduler, error) {
 	if executor == nil {
 		return nil, errors.New("cron scheduler: executor is required")
 	}
@@ -103,6 +110,7 @@ func NewCronScheduler(executor ActionExecutorInterface, logger *slog.Logger) (*C
 		// parser is therefore unused.
 		cron:     cronlib.New(),
 		executor: executor,
+		tracker:  tracker,
 		logger:   logger,
 		entries:  make(map[string]*cronEntry),
 	}, nil
@@ -164,6 +172,13 @@ func (s *CronScheduler) Deregister(ruleID string) {
 // and passed to every subsequent fire callback so action dispatches
 // inherit the processor's cancellation. Calling Start twice is an error;
 // the scheduler is single-shot per Start/Stop cycle.
+//
+// Before the ticker starts, Start runs a one-shot missed-fire detection
+// pass against the persisted last-fired records (when a tracker is
+// configured). Detected missed fires are logged at Warn — log-only per
+// ADR-031 product direction. Detection failures are logged but do not
+// block startup; a clean cron tick is more important than a perfect
+// audit log.
 func (s *CronScheduler) Start(ctx context.Context) error {
 	if ctx == nil {
 		return errors.New("cron scheduler: Start requires a non-nil context")
@@ -177,9 +192,86 @@ func (s *CronScheduler) Start(ctx context.Context) error {
 	s.started = true
 	s.mu.Unlock()
 
+	s.detectMissedFires(ctx)
+
 	s.cron.Start()
 	s.logger.Info("Cron scheduler started", "registered_rules", s.RegisteredCount())
 	return nil
+}
+
+// detectMissedFires walks the registered rules, looks up each rule's
+// last-fired record, and logs a Warn for any rule whose schedule expected
+// at least one fire between LastFiredAt and now. Per ADR-031 the policy
+// is log-only: the next regular tick still happens on its normal cadence.
+//
+// Rules with no persisted record are skipped — there's nothing to compare
+// against, and treating "first deploy" as "infinitely many missed fires"
+// would generate misleading noise.
+func (s *CronScheduler) detectMissedFires(ctx context.Context) {
+	if s.tracker == nil {
+		return
+	}
+
+	// Snapshot under lock, then release before per-rule KV reads. A
+	// concurrent Deregister between snapshot and iteration is benign:
+	// we'd emit at most one Warn line for a rule no longer registered,
+	// no dispatch happens. Concurrent Register can't race in practice
+	// because Start sets s.started before this runs and hot-reload
+	// goes through rp.mu.Lock — but even if it did, the new rule has
+	// no last-fired record yet and is treated as "first deploy".
+	s.mu.Lock()
+	rules := make([]*CronRule, 0, len(s.entries))
+	for _, entry := range s.entries {
+		rules = append(rules, entry.rule)
+	}
+	s.mu.Unlock()
+
+	// Capture now once: the audit horizon is a single instant, not
+	// per-rule. Calling time.Now() per iteration would let the horizon
+	// drift across the loop and slightly under-count missed fires for
+	// rules processed late in a slow startup.
+	now := time.Now()
+	for _, rule := range rules {
+		rec, err := s.tracker.LastFiredAt(ctx, rule.ID())
+		if err != nil {
+			if errors.Is(err, ErrScheduleRecordNotFound) {
+				continue
+			}
+			s.logger.Warn("Failed to read last-fired record for missed-fire detection",
+				"rule_id", rule.ID(),
+				"error", err)
+			continue
+		}
+
+		// Count expected fires between rec.LastFiredAt and now by walking
+		// the rule's schedule. A bounded loop prevents pathological log
+		// floods if a rule has been disabled across years of downtime —
+		// after the cap we report "many" rather than the true count.
+		const missedCap = 100
+		missed := 0
+		next := rule.Schedule().Next(rec.LastFiredAt)
+		var lastExpected time.Time
+		for !next.After(now) {
+			missed++
+			lastExpected = next
+			if missed >= missedCap {
+				break
+			}
+			next = rule.Schedule().Next(next)
+		}
+
+		if missed == 0 {
+			continue
+		}
+
+		s.logger.Warn("Cron rule missed fires while scheduler was offline",
+			"rule_id", rule.ID(),
+			"schedule", rule.ScheduleString(),
+			"last_fired_at", rec.LastFiredAt,
+			"missed_fires", missed,
+			"last_expected_fire", lastExpected,
+			"capped", missed >= missedCap)
+	}
 }
 
 // Stop signals the scheduler to halt. It returns the context returned by
@@ -313,10 +405,26 @@ func (s *CronScheduler) fire(ruleID string) {
 		}
 	}
 
-	// Record last-fired timestamp only after dispatch — Chunk 3 will
-	// also persist this to RULE_SCHEDULES KV for cross-restart
-	// missed-fire detection.
-	entry.lastFiredNanos.Store(time.Now().UnixNano())
+	// Record last-fired timestamp only after dispatch — both in-memory
+	// (cooldown gate) and persisted to RULE_SCHEDULES KV (cross-restart
+	// missed-fire detection). Persistence failures are logged but do
+	// not affect dispatch correctness; the next successful fire will
+	// overwrite the record.
+	firedAt := time.Now()
+	entry.lastFiredNanos.Store(firedAt.UnixNano())
+
+	if s.tracker != nil {
+		// Best-effort persistence: the cooldown gate uses entry.lastFiredNanos
+		// (in-memory), so KV unavailability is purely an observability
+		// concern. Worst case across a restart: missed-fire detection thinks
+		// the rule fired one tick earlier than it did → at most one stray
+		// Warn log on next startup, no dispatch impact.
+		if err := s.tracker.RecordFire(parentCtx, ruleID, rule.ScheduleString(), firedAt); err != nil {
+			s.logger.Warn("Failed to persist cron rule fire timestamp",
+				"rule_id", ruleID,
+				"error", err)
+		}
+	}
 
 	if dispatchedOK {
 		s.logger.Debug("Cron rule fired",

--- a/processor/rule/cron_scheduler.go
+++ b/processor/rule/cron_scheduler.go
@@ -42,6 +42,7 @@ type CronScheduler struct {
 	cron     *cronlib.Cron
 	executor ActionExecutorInterface
 	tracker  *ScheduleTracker
+	metrics  *cronMetrics
 	logger   *slog.Logger
 
 	mu      sync.Mutex
@@ -85,20 +86,42 @@ type cronEntry struct {
 	inflight atomic.Bool
 }
 
+// CronSchedulerConfig groups the collaborators NewCronScheduler needs.
+// Constructed by initializeCronScheduler in production; tests build it
+// inline with whichever fields they exercise. Following the team's
+// "4+ args → request struct" convention so future additions (timeouts,
+// custom parsers, observers) don't grow a positional arg list.
+type CronSchedulerConfig struct {
+	// Executor is required. A nil executor is rejected because every
+	// fire would silently no-op, hiding misconfiguration.
+	Executor ActionExecutorInterface
+
+	// Tracker is optional. Pass nil to run without persistence — no
+	// cross-restart missed-fire detection, no cooldown hydration on
+	// startup. Tests typically pass nil; the production processor
+	// wires in a tracker bound to the RULE_SCHEDULES bucket.
+	Tracker *ScheduleTracker
+
+	// Metrics is optional. Pass nil to run without Prometheus
+	// observability — every recordX call short-circuits on the nil
+	// receiver. Tests that don't assert on metrics pass nil; the
+	// production processor wires in metrics scoped to its registry.
+	Metrics *cronMetrics
+
+	// Logger is optional. Defaults to slog.Default() when nil so the
+	// scheduler always has something to log to.
+	Logger *slog.Logger
+}
+
 // NewCronScheduler builds a scheduler that will dispatch actions through
-// the given executor. The logger is required (use slog.Default() if no
-// component logger is available); a nil executor is rejected because every
-// fire would silently no-op, hiding misconfiguration.
-//
-// The tracker is optional: pass nil and the scheduler runs without
-// persistence (no missed-fire detection on restart, no cross-process
-// readability of last-fired timestamps). Tests typically pass nil; the
-// production processor wires in a tracker bound to the RULE_SCHEDULES
-// bucket.
-func NewCronScheduler(executor ActionExecutorInterface, tracker *ScheduleTracker, logger *slog.Logger) (*CronScheduler, error) {
-	if executor == nil {
+// cfg.Executor. Returns an error only when cfg.Executor is nil — the
+// other fields are all optional with documented degraded-mode
+// behaviour.
+func NewCronScheduler(cfg CronSchedulerConfig) (*CronScheduler, error) {
+	if cfg.Executor == nil {
 		return nil, errors.New("cron scheduler: executor is required")
 	}
+	logger := cfg.Logger
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -109,8 +132,9 @@ func NewCronScheduler(executor ActionExecutorInterface, tracker *ScheduleTracker
 		// to satisfy our own cronParser (cron_rule.go). The Cron's own
 		// parser is therefore unused.
 		cron:     cronlib.New(),
-		executor: executor,
-		tracker:  tracker,
+		executor: cfg.Executor,
+		tracker:  cfg.Tracker,
+		metrics:  cfg.Metrics,
 		logger:   logger,
 		entries:  make(map[string]*cronEntry),
 	}, nil
@@ -146,6 +170,9 @@ func (s *CronScheduler) Register(rule *CronRule) error {
 	entry.entryID = s.cron.Schedule(rule.Schedule(), job)
 	s.entries[ruleID] = entry
 
+	s.metrics.recordRuleRegistered()
+	s.metrics.recordNextFire(ruleID, float64(rule.Schedule().Next(time.Now()).Unix()))
+
 	s.logger.Info("Cron rule registered",
 		"rule_id", ruleID,
 		"schedule", rule.ScheduleString(),
@@ -165,6 +192,8 @@ func (s *CronScheduler) Deregister(ruleID string) {
 	}
 	s.cron.Remove(entry.entryID)
 	delete(s.entries, ruleID)
+	s.metrics.recordRuleDeregistered()
+	s.metrics.clearNextFire(ruleID)
 	s.logger.Info("Cron rule deregistered", "rule_id", ruleID)
 }
 
@@ -198,6 +227,7 @@ func (s *CronScheduler) Start(ctx context.Context) error {
 	s.restoreFromTracker(ctx)
 
 	s.cron.Start()
+	s.metrics.recordSchedulerRunning(true)
 	s.logger.Info("Cron scheduler started", "registered_rules", s.RegisteredCount())
 	return nil
 }
@@ -286,13 +316,19 @@ func (s *CronScheduler) restoreFromTracker(ctx context.Context) {
 			continue
 		}
 
+		capped := missed >= missedCap
+		s.metrics.recordMissedFire(rule.ID(), missed)
+		if capped {
+			s.metrics.recordMissedFireCapped(rule.ID())
+		}
+
 		s.logger.Warn("Cron rule missed fires while scheduler was offline",
 			"rule_id", rule.ID(),
 			"schedule", rule.ScheduleString(),
 			"last_fired_at", rec.LastFiredAt,
 			"missed_fires", missed,
 			"last_expected_fire", lastExpected,
-			"capped", missed >= missedCap)
+			"capped", capped)
 	}
 }
 
@@ -313,6 +349,7 @@ func (s *CronScheduler) Stop() context.Context {
 	}
 	s.started = false
 	stopCtx := s.cron.Stop()
+	s.metrics.recordSchedulerRunning(false)
 	s.logger.Info("Cron scheduler stopping")
 	return stopCtx
 }
@@ -375,6 +412,7 @@ func (s *CronScheduler) fire(ruleID string) {
 	// that ticks faster than actions complete on average.
 	if cooldown := entry.rule.Cooldown(); cooldown > 0 {
 		if previousFiredNanos > 0 && time.Since(time.Unix(0, previousFiredNanos)) < cooldown {
+			s.metrics.recordFire(ruleID, cronFireStatusCooldownSkipped, 0)
 			s.logger.Debug("Cron rule fire skipped (cooldown)",
 				"rule_id", ruleID,
 				"cooldown", cooldown)
@@ -386,27 +424,53 @@ func (s *CronScheduler) fire(ruleID string) {
 	// is the source of truth for "currently dispatching"; cooldown above
 	// is wallclock-based and orthogonal. Both are needed: cooldown handles
 	// fast-cycling slow rules, inflight handles a fire that exceeded its
-	// own period.
+	// own period. Distinct status from cooldown_skipped because the
+	// operator action is different: cooldown_skipped means "configured
+	// throttling worked", inflight_skipped means "actions are slower
+	// than the schedule, configure a cooldown or speed them up".
 	if !entry.inflight.CompareAndSwap(false, true) {
+		s.metrics.recordFire(ruleID, cronFireStatusInflightSkipped, 0)
 		s.logger.Warn("Cron rule fire skipped (previous fire still running)",
 			"rule_id", ruleID)
 		return
 	}
 	defer entry.inflight.Store(false)
 
-	// Defer panic-recover before any action dispatch so a panicking
-	// action surfaces as a logged error instead of crashing robfig's
-	// internal goroutine. A panic mid-loop intentionally drops the
-	// remaining sibling actions in this tick — the next scheduled tick
-	// will retry from the top. The deferred inflight reset above runs
-	// after this recover (LIFO) so the next tick is not gated by the
-	// panicker.
+	s.dispatchAndRecord(parentCtx, ruleID, entry, previousFiredNanos)
+}
+
+// dispatchAndRecord is the post-gates portion of fire(). Extracted from
+// fire() so the gate-heavy entry path stays under the function-length
+// lint cap; behaviour is unchanged. Holds the deferred panic-recover
+// (backstop only — cron-side code does not panic deliberately) and the
+// metric / persistence side-effects that a fire produces regardless of
+// whether the dispatch loop succeeded, errored, or panicked.
+//
+// status=panic on fires_total is a programming-bug signal distinct
+// from status=error (expected downstream failures). An operator alert
+// on rate(cron_rule_fires_total{status="panic"}[5m]) should page
+// someone — if you see panics, fix the code, don't tune the alert.
+//
+// A panic mid-loop intentionally drops the remaining sibling actions
+// in this tick — the next scheduled tick will retry from the top. The
+// caller's deferred inflight reset runs after this recover (LIFO) so
+// the next tick is not gated by the panicker.
+func (s *CronScheduler) dispatchAndRecord(parentCtx context.Context, ruleID string, entry *cronEntry, previousFiredNanos int64) {
+	dispatchStart := time.Now()
+	status := cronFireStatusSuccess
+
 	defer func() {
 		if r := recover(); r != nil {
+			status = cronFireStatusPanic
 			s.logger.Error("Cron rule fire panicked",
 				"rule_id", ruleID,
 				"panic", r)
 		}
+		// Single source of truth for fires_total + fire_duration: the
+		// deferred block runs whether we exited normally or via panic,
+		// so the counter and histogram always reflect the actual
+		// outcome.
+		s.metrics.recordFire(ruleID, status, time.Since(dispatchStart).Seconds())
 	}()
 
 	rule := entry.rule
@@ -444,6 +508,9 @@ func (s *CronScheduler) fire(ruleID string) {
 			// publish doesn't block sibling triple writes etc.
 		}
 	}
+	if !dispatchedOK {
+		status = cronFireStatusError
+	}
 
 	// Record last-fired timestamp only after dispatch — both in-memory
 	// (cooldown gate) and persisted to RULE_SCHEDULES KV (cross-restart
@@ -452,6 +519,7 @@ func (s *CronScheduler) fire(ruleID string) {
 	// overwrite the record.
 	firedAt := time.Now()
 	entry.lastFiredNanos.Store(firedAt.UnixNano())
+	s.metrics.recordNextFire(ruleID, float64(rule.Schedule().Next(firedAt).Unix()))
 
 	if s.tracker != nil {
 		// Best-effort persistence: the cooldown gate uses entry.lastFiredNanos

--- a/processor/rule/cron_scheduler.go
+++ b/processor/rule/cron_scheduler.go
@@ -173,12 +173,15 @@ func (s *CronScheduler) Deregister(ruleID string) {
 // inherit the processor's cancellation. Calling Start twice is an error;
 // the scheduler is single-shot per Start/Stop cycle.
 //
-// Before the ticker starts, Start runs a one-shot missed-fire detection
+// Before the ticker starts, Start runs a one-shot restoreFromTracker
 // pass against the persisted last-fired records (when a tracker is
-// configured). Detected missed fires are logged at Warn — log-only per
-// ADR-031 product direction. Detection failures are logged but do not
-// block startup; a clean cron tick is more important than a perfect
-// audit log.
+// configured). It seeds each entry's in-memory lastFiredNanos cache so
+// the cooldown gate and `$schedule.last_fired_at` substitution behave
+// correctly across restarts, and it logs a Warn for any rule whose
+// schedule expected at least one fire between the persisted timestamp
+// and now (log-only per ADR-031 product direction). Tracker failures
+// are logged but do not block startup; a clean cron tick is more
+// important than a perfect audit log.
 func (s *CronScheduler) Start(ctx context.Context) error {
 	if ctx == nil {
 		return errors.New("cron scheduler: Start requires a non-nil context")
@@ -192,37 +195,48 @@ func (s *CronScheduler) Start(ctx context.Context) error {
 	s.started = true
 	s.mu.Unlock()
 
-	s.detectMissedFires(ctx)
+	s.restoreFromTracker(ctx)
 
 	s.cron.Start()
 	s.logger.Info("Cron scheduler started", "registered_rules", s.RegisteredCount())
 	return nil
 }
 
-// detectMissedFires walks the registered rules, looks up each rule's
-// last-fired record, and logs a Warn for any rule whose schedule expected
-// at least one fire between LastFiredAt and now. Per ADR-031 the policy
-// is log-only: the next regular tick still happens on its normal cadence.
+// restoreFromTracker walks the registered rules, looks up each rule's
+// last-fired record, and does two things:
+//
+//  1. Seeds entry.lastFiredNanos so the cooldown gate and the
+//     $schedule.last_fired_at substitution see the persisted timestamp
+//     immediately after restart, instead of treating the first
+//     post-restart fire as "never fired".
+//  2. Logs a Warn for any rule whose schedule expected at least one
+//     fire between the persisted timestamp and now. Per ADR-031 the
+//     policy is log-only: the next regular tick still happens on its
+//     normal cadence.
 //
 // Rules with no persisted record are skipped — there's nothing to compare
 // against, and treating "first deploy" as "infinitely many missed fires"
 // would generate misleading noise.
-func (s *CronScheduler) detectMissedFires(ctx context.Context) {
+func (s *CronScheduler) restoreFromTracker(ctx context.Context) {
 	if s.tracker == nil {
 		return
 	}
 
-	// Snapshot under lock, then release before per-rule KV reads. A
-	// concurrent Deregister between snapshot and iteration is benign:
-	// we'd emit at most one Warn line for a rule no longer registered,
-	// no dispatch happens. Concurrent Register can't race in practice
-	// because Start sets s.started before this runs and hot-reload
-	// goes through rp.mu.Lock — but even if it did, the new rule has
-	// no last-fired record yet and is treated as "first deploy".
+	// Snapshot entries (not just rules) under lock so the hydration
+	// step can write entry.lastFiredNanos without holding mu — the
+	// atomic.Int64 is its own synchronisation. A concurrent Register/
+	// Deregister between snapshot and iteration is benign: hydrating a
+	// removed entry's atomic is a no-op from the cron ticker's
+	// perspective (no callbacks fire for it), and Warn lines for a
+	// removed rule are at worst a single confusing log entry per
+	// restart. The benign-write argument is what matters; the call
+	// chain is not actually serialised because cronScheduler.Start
+	// runs on the processor's run() goroutine after rp.Start releases
+	// rp.mu, so an ApplyConfigUpdate could race the snapshot.
 	s.mu.Lock()
-	rules := make([]*CronRule, 0, len(s.entries))
+	entries := make([]*cronEntry, 0, len(s.entries))
 	for _, entry := range s.entries {
-		rules = append(rules, entry.rule)
+		entries = append(entries, entry)
 	}
 	s.mu.Unlock()
 
@@ -231,17 +245,25 @@ func (s *CronScheduler) detectMissedFires(ctx context.Context) {
 	// drift across the loop and slightly under-count missed fires for
 	// rules processed late in a slow startup.
 	now := time.Now()
-	for _, rule := range rules {
+	for _, entry := range entries {
+		rule := entry.rule
 		rec, err := s.tracker.LastFiredAt(ctx, rule.ID())
 		if err != nil {
 			if errors.Is(err, ErrScheduleRecordNotFound) {
 				continue
 			}
-			s.logger.Warn("Failed to read last-fired record for missed-fire detection",
+			s.logger.Warn("Failed to read last-fired record on startup",
 				"rule_id", rule.ID(),
 				"error", err)
 			continue
 		}
+
+		// Hydrate the in-memory cache. Done unconditionally on a
+		// successful tracker read so the cooldown gate immediately
+		// reflects pre-restart state and the $schedule.last_fired_at
+		// substitution renders the persisted timestamp on the first
+		// post-restart fire.
+		entry.lastFiredNanos.Store(rec.LastFiredAt.UnixNano())
 
 		// Count expected fires between rec.LastFiredAt and now by walking
 		// the rule's schedule. A bounded loop prevents pathological log
@@ -340,12 +362,19 @@ func (s *CronScheduler) fire(ruleID string) {
 		}
 	}
 
+	// Capture the previous fire timestamp once: the cooldown gate
+	// reads it for its check, and the ScheduleContext built for
+	// substitution below uses it as `$schedule.last_fired_at`. Reading
+	// once keeps both views consistent with each other (no mid-fire
+	// race where cooldown sees the prior timestamp but substitution
+	// sees `time.Now()` because another fire snuck in).
+	previousFiredNanos := entry.lastFiredNanos.Load()
+
 	// Cooldown gate — skip if the previous fire's wallclock is too
 	// recent. Defends against the operator-error case of a cron expression
 	// that ticks faster than actions complete on average.
 	if cooldown := entry.rule.Cooldown(); cooldown > 0 {
-		last := entry.lastFiredNanos.Load()
-		if last > 0 && time.Since(time.Unix(0, last)) < cooldown {
+		if previousFiredNanos > 0 && time.Since(time.Unix(0, previousFiredNanos)) < cooldown {
 			s.logger.Debug("Cron rule fire skipped (cooldown)",
 				"rule_id", ruleID,
 				"cooldown", cooldown)
@@ -384,12 +413,23 @@ func (s *CronScheduler) fire(ruleID string) {
 	actions := rule.Actions() // already a clone — safe to iterate
 
 	// ExecutionContext is intentionally sparse for cron fires: no entity,
-	// no related entity, no MatchState. SubstituteVariables in
-	// execution_context.go handles `$now` natively; Chunk 4 adds the
-	// `$schedule.*` namespace via a cron-specific shim. Until then,
-	// authors should restrict cron action templates to `$now` plus
-	// literal strings.
-	ec := &ExecutionContext{}
+	// no related entity, no MatchState. The Schedule shim supplies the
+	// cron-specific `$schedule.*` namespace; SubstituteVariables in
+	// execution_context.go also handles `$now` natively. The future
+	// per-entity fan-out extension (Definition.ForEach) populates
+	// EntityID / Entity / State per iteration alongside Schedule —
+	// neither shim leaks into the other.
+	var lastFired time.Time
+	if previousFiredNanos > 0 {
+		lastFired = time.Unix(0, previousFiredNanos).UTC()
+	}
+	ec := &ExecutionContext{
+		Schedule: &ScheduleContext{
+			ID:          ruleID,
+			Spec:        rule.ScheduleString(),
+			LastFiredAt: lastFired,
+		},
+	}
 
 	dispatchedOK := true
 	for i, action := range actions {

--- a/processor/rule/cron_scheduler.go
+++ b/processor/rule/cron_scheduler.go
@@ -1,0 +1,326 @@
+// Package rule - Cron scheduler for time-driven rule firing.
+//
+// CronScheduler is the third firing path of the rule processor, parallel to
+// message-driven and KV-watch-driven evaluation. It wraps robfig/cron/v3.Cron
+// and dispatches each registered CronRule's actions through the shared
+// ActionExecutor at the times described by the rule's cron expression.
+//
+// Lifecycle is owned by the rule processor:
+//
+//  1. Processor.Start (via initializeCronScheduler) constructs the scheduler
+//     and registers the cron rules loaded by Initialize.
+//  2. Processor.run launches the scheduler with Start(ctx); robfig spawns
+//     its own internal goroutine that walks the schedule and dispatches
+//     each fire callback on its own goroutine.
+//  3. Processor.run defers Stop on shutdown, draining in-flight fires up
+//     to the shutdown grace period.
+//  4. Hot reload (applyRuleChanges) calls Register / Deregister under the
+//     processor's mu.Lock; robfig supports live add/remove without a
+//     scheduler restart.
+//
+// The fire path is best-effort: per-rule panic-recover keeps one bad action
+// from crashing the scheduler goroutine, action errors are logged and do
+// not stop sibling actions in the same tick. This matches StatefulEvaluator
+// behaviour so the operator's mental model is consistent across rule kinds.
+package rule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	cronlib "github.com/robfig/cron/v3"
+)
+
+// CronScheduler dispatches CronRule actions on a cron schedule. Methods are
+// safe for concurrent use; the entries map is guarded by mu.
+type CronScheduler struct {
+	cron     *cronlib.Cron
+	executor ActionExecutorInterface
+	logger   *slog.Logger
+
+	mu      sync.Mutex
+	entries map[string]*cronEntry
+
+	// parentCtx is captured by Start and used by every fire callback so
+	// long-running actions inherit the processor's lifecycle context.
+	// Nil before Start; nil-checked in fire so Register-then-fire-before-Start
+	// (impossible in current usage but cheap to defend) cannot panic.
+	//
+	// Single-shot per scheduler instance: a Stop+Start sequence is
+	// rejected by the started guard, so parentCtx never needs to be
+	// replaced mid-lifetime. A processor restart constructs a fresh
+	// CronScheduler in initializeCronScheduler, which gets its own ctx.
+	parentCtx context.Context
+	started   bool
+}
+
+// cronEntry is the per-registered-rule state held by the scheduler.
+//
+// tickCount, lastFiredNanos, and inflight are read/written from the fire
+// callback without holding mu so that a long-running fire on one rule
+// doesn't serialise scheduling decisions for sibling rules.
+type cronEntry struct {
+	rule    *CronRule
+	entryID cronlib.EntryID
+
+	// tickCount counts every clock-tick delivered by robfig (before the
+	// FireEveryN gate). Used to compute the every-Nth-tick cadence.
+	tickCount atomic.Int64
+
+	// lastFiredNanos records the wallclock of the last successful action
+	// dispatch. Read by the cooldown gate and updated only after action
+	// dispatch returns. Zero means "never fired."
+	lastFiredNanos atomic.Int64
+
+	// inflight is true while a fire callback is between the inflight-CAS
+	// and the deferred reset. Skipping when already inflight prevents a
+	// long-running publish_agent from queuing a second fire on the next
+	// tick.
+	inflight atomic.Bool
+}
+
+// NewCronScheduler builds a scheduler that will dispatch actions through
+// the given executor. The logger is required (use slog.Default() if no
+// component logger is available); a nil executor is rejected because every
+// fire would silently no-op, hiding misconfiguration.
+func NewCronScheduler(executor ActionExecutorInterface, logger *slog.Logger) (*CronScheduler, error) {
+	if executor == nil {
+		return nil, errors.New("cron scheduler: executor is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &CronScheduler{
+		// cronlib.New uses the default parser (POSIX 5-field + descriptors)
+		// internally for AddFunc/AddJob, but we register via Schedule(),
+		// passing the rule's pre-parsed Schedule so spec strings only need
+		// to satisfy our own cronParser (cron_rule.go). The Cron's own
+		// parser is therefore unused.
+		cron:     cronlib.New(),
+		executor: executor,
+		logger:   logger,
+		entries:  make(map[string]*cronEntry),
+	}, nil
+}
+
+// Register schedules a CronRule for periodic firing. Disabled rules are
+// skipped silently (logged at Debug). Returns an error if the rule is
+// already registered — callers performing hot-reload should call
+// Deregister first.
+func (s *CronScheduler) Register(rule *CronRule) error {
+	if rule == nil {
+		return errors.New("cron scheduler: nil rule")
+	}
+	if !rule.Enabled() {
+		s.logger.Debug("Skipping disabled cron rule", "rule_id", rule.ID())
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.entries[rule.ID()]; exists {
+		return fmt.Errorf("cron rule %s already registered", rule.ID())
+	}
+
+	entry := &cronEntry{rule: rule}
+	ruleID := rule.ID() // captured by closure; rule is stable for the entry's lifetime
+
+	job := cronlib.FuncJob(func() {
+		s.fire(ruleID)
+	})
+
+	entry.entryID = s.cron.Schedule(rule.Schedule(), job)
+	s.entries[ruleID] = entry
+
+	s.logger.Info("Cron rule registered",
+		"rule_id", ruleID,
+		"schedule", rule.ScheduleString(),
+		"action_count", len(rule.Actions()))
+	return nil
+}
+
+// Deregister removes a cron rule from the scheduler. It is a no-op when
+// the rule isn't registered, so hot-reload can call it unconditionally.
+func (s *CronScheduler) Deregister(ruleID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entry, ok := s.entries[ruleID]
+	if !ok {
+		return
+	}
+	s.cron.Remove(entry.entryID)
+	delete(s.entries, ruleID)
+	s.logger.Info("Cron rule deregistered", "rule_id", ruleID)
+}
+
+// Start kicks off the scheduler ticker. The supplied context is captured
+// and passed to every subsequent fire callback so action dispatches
+// inherit the processor's cancellation. Calling Start twice is an error;
+// the scheduler is single-shot per Start/Stop cycle.
+func (s *CronScheduler) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("cron scheduler: Start requires a non-nil context")
+	}
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return errors.New("cron scheduler: already started")
+	}
+	s.parentCtx = ctx
+	s.started = true
+	s.mu.Unlock()
+
+	s.cron.Start()
+	s.logger.Info("Cron scheduler started", "registered_rules", s.RegisteredCount())
+	return nil
+}
+
+// Stop signals the scheduler to halt. It returns the context returned by
+// robfig's Cron.Stop, which closes when all in-flight fires have
+// completed. Callers should select on the returned context with their
+// shutdown deadline. Calling Stop on a never-started scheduler is safe.
+func (s *CronScheduler) Stop() context.Context {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.started {
+		// Return a closed context so callers can wait safely without
+		// special-casing the never-started branch.
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+	s.started = false
+	stopCtx := s.cron.Stop()
+	s.logger.Info("Cron scheduler stopping")
+	return stopCtx
+}
+
+// RegisteredCount returns the number of rules currently registered. Used
+// by the processor for logging and (Chunk 5) the registered-rules gauge.
+func (s *CronScheduler) RegisteredCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.entries)
+}
+
+// fire is the per-tick callback installed for every rule. The four gates
+// (existence, FireEveryN, cooldown, inflight) keep dispatch correct under
+// hot-reload, slow actions, and overlapping ticks; the deferred recover
+// keeps a panicking action from killing the scheduler goroutine.
+func (s *CronScheduler) fire(ruleID string) {
+	s.mu.Lock()
+	entry, ok := s.entries[ruleID]
+	parentCtx := s.parentCtx
+	s.mu.Unlock()
+	if !ok {
+		// Rule was deregistered between the tick scheduling and now;
+		// dropping silently is correct — robfig will not deliver future
+		// ticks for the removed entry.
+		return
+	}
+	if parentCtx == nil {
+		// Defensive: should be impossible because Start sets parentCtx
+		// before Cron starts walking the schedule. Falling back to
+		// Background keeps a misordered call from panicking.
+		parentCtx = context.Background()
+	}
+
+	tick := entry.tickCount.Add(1)
+
+	// FireEveryN gate — every Nth tick fires actions; intermediate ticks
+	// are noop'd. N=0 and N=1 both mean "fire every tick" (matches
+	// FireEveryNEvents semantics on expression rules).
+	if n := entry.rule.FireEveryN(); n > 1 {
+		if tick%int64(n) != 0 {
+			s.logger.Debug("Cron rule tick skipped (every-N gate)",
+				"rule_id", ruleID,
+				"tick", tick,
+				"every", n)
+			return
+		}
+	}
+
+	// Cooldown gate — skip if the previous fire's wallclock is too
+	// recent. Defends against the operator-error case of a cron expression
+	// that ticks faster than actions complete on average.
+	if cooldown := entry.rule.Cooldown(); cooldown > 0 {
+		last := entry.lastFiredNanos.Load()
+		if last > 0 && time.Since(time.Unix(0, last)) < cooldown {
+			s.logger.Debug("Cron rule fire skipped (cooldown)",
+				"rule_id", ruleID,
+				"cooldown", cooldown)
+			return
+		}
+	}
+
+	// Inflight guard — skip if a previous fire is still running. The CAS
+	// is the source of truth for "currently dispatching"; cooldown above
+	// is wallclock-based and orthogonal. Both are needed: cooldown handles
+	// fast-cycling slow rules, inflight handles a fire that exceeded its
+	// own period.
+	if !entry.inflight.CompareAndSwap(false, true) {
+		s.logger.Warn("Cron rule fire skipped (previous fire still running)",
+			"rule_id", ruleID)
+		return
+	}
+	defer entry.inflight.Store(false)
+
+	// Defer panic-recover before any action dispatch so a panicking
+	// action surfaces as a logged error instead of crashing robfig's
+	// internal goroutine. A panic mid-loop intentionally drops the
+	// remaining sibling actions in this tick — the next scheduled tick
+	// will retry from the top. The deferred inflight reset above runs
+	// after this recover (LIFO) so the next tick is not gated by the
+	// panicker.
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Error("Cron rule fire panicked",
+				"rule_id", ruleID,
+				"panic", r)
+		}
+	}()
+
+	rule := entry.rule
+	actions := rule.Actions() // already a clone — safe to iterate
+
+	// ExecutionContext is intentionally sparse for cron fires: no entity,
+	// no related entity, no MatchState. SubstituteVariables in
+	// execution_context.go handles `$now` natively; Chunk 4 adds the
+	// `$schedule.*` namespace via a cron-specific shim. Until then,
+	// authors should restrict cron action templates to `$now` plus
+	// literal strings.
+	ec := &ExecutionContext{}
+
+	dispatchedOK := true
+	for i, action := range actions {
+		if err := s.executor.Execute(parentCtx, action, ec); err != nil {
+			dispatchedOK = false
+			s.logger.Warn("Cron rule action failed",
+				"rule_id", ruleID,
+				"action_index", i,
+				"action_type", action.Type,
+				"error", err)
+			// Best-effort: continue to subsequent actions so one bad
+			// publish doesn't block sibling triple writes etc.
+		}
+	}
+
+	// Record last-fired timestamp only after dispatch — Chunk 3 will
+	// also persist this to RULE_SCHEDULES KV for cross-restart
+	// missed-fire detection.
+	entry.lastFiredNanos.Store(time.Now().UnixNano())
+
+	if dispatchedOK {
+		s.logger.Debug("Cron rule fired",
+			"rule_id", ruleID,
+			"actions", len(actions))
+	}
+}

--- a/processor/rule/cron_scheduler_integration_test.go
+++ b/processor/rule/cron_scheduler_integration_test.go
@@ -1,0 +1,334 @@
+//go:build integration
+
+// Cron-scheduler end-to-end tests. Build-tagged `integration` so they
+// only run when Docker + testcontainers is available — they spin up a
+// real NATS JetStream, register cron rules through the Processor's
+// public API, and assert on observable side-effects (NATS messages
+// landing, RULE_SCHEDULES KV records persisting, missed-fire metrics
+// incrementing across restart).
+//
+// Schedules use `@every 1s` so the test wallclock stays small. The
+// `@every Ns` descriptor was added by robfig/cron specifically for
+// fast-cycling smoke tests; it is not a recommended production
+// schedule.
+//
+// Lives in `package rule` (not rule_test) so the cron metrics
+// internals are reachable for direct counter inspection — matches the
+// kv_hot_reload_integration_test.go pattern.
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/metric"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// getIntegrationNATSClient creates a NATS client for cron integration
+// tests. Mirrors getTestNATSClient in rule_integration_test.go but
+// scoped to this package's test file (which is `package rule` rather
+// than `package rule_test`).
+func getIntegrationNATSClient(t *testing.T) *natsclient.Client {
+	t.Helper()
+	testClient, err := natsclient.NewSharedTestClient(
+		natsclient.WithJetStream(),
+		natsclient.WithKV(),
+		natsclient.WithTestTimeout(5*time.Second),
+		natsclient.WithStartTimeout(30*time.Second),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create test client: %v", err)
+	}
+	t.Cleanup(func() { testClient.Terminate() })
+	return testClient.Client
+}
+
+// startCronProcessorForTest builds a rule.Processor wired with the
+// supplied inline rules and brings it through Initialize → Start. The
+// caller can stop the processor explicitly (cross-restart tests need
+// that control); a t.Cleanup handler also Stops it as a backstop.
+func startCronProcessorForTest(t *testing.T, natsClient *natsclient.Client, rules []Definition) (*Processor, *metric.MetricsRegistry) {
+	t.Helper()
+
+	cfg := DefaultConfig()
+	cfg.Ports = &component.PortConfig{
+		Inputs: []component.PortDefinition{
+			{Name: "entity_events", Type: "nats", Subject: "events.graph.entity.>", Interface: "core.entity.v1", Required: false},
+		},
+		Outputs: []component.PortDefinition{
+			{Name: "rule_events", Type: "nats", Subject: "events.rule.triggered", Interface: "core.rule.v1", Required: false},
+		},
+	}
+	cfg.InlineRules = rules
+	cfg.EnableGraphIntegration = false
+
+	registry := metric.NewMetricsRegistry()
+	proc, err := NewProcessorWithMetrics(natsClient, &cfg, registry)
+	require.NoError(t, err)
+	// No SetDecoder call: cron rules fire on a clock, not on incoming
+	// messages, so the decoder path is unused. Same posture as
+	// kv_hot_reload_integration_test.go.
+	require.NoError(t, proc.Initialize())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, proc.Start(ctx))
+	t.Cleanup(func() { _ = proc.Stop(5 * time.Second) })
+
+	return proc, registry
+}
+
+// TestIntegration_CronRule_FiresOnSchedule registers an @every 1s
+// rule, subscribes to the publish subject, and asserts at least one
+// message arrives within 3 seconds. Smoke test for the full path:
+// scheduler tick → fire → ActionExecutor → NATS publish.
+func TestIntegration_CronRule_FiresOnSchedule(t *testing.T) {
+	natsClient := getIntegrationNATSClient(t)
+	subject := fmt.Sprintf("test.cron.heartbeat.%s", t.Name())
+
+	received := make(chan *nats.Msg, 4)
+	sub, err := natsClient.Subscribe(context.Background(), subject, func(_ context.Context, msg *nats.Msg) {
+		select {
+		case received <- msg:
+		default:
+		}
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	rules := []Definition{{
+		ID:       "every-second-heartbeat-" + t.Name(),
+		Type:     CronRuleType,
+		Name:     "every-second heartbeat",
+		Enabled:  true,
+		Schedule: "@every 1s",
+		Actions: []Action{{
+			Type:    ActionTypePublish,
+			Subject: subject,
+		}},
+	}}
+	startCronProcessorForTest(t, natsClient, rules)
+
+	select {
+	case msg := <-received:
+		// actions.go injects subject + timestamp into the published
+		// JSON. Confirms the publish path executed end-to-end.
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(msg.Data, &body))
+		require.Equal(t, subject, body["subject"])
+	case <-time.After(3 * time.Second):
+		t.Fatal("cron rule did not fire within 3s for @every 1s schedule")
+	}
+}
+
+// TestIntegration_CronRule_PersistsLastFiredToKV waits for one fire,
+// then reads RULE_SCHEDULES directly to confirm the persistence path
+// landed. Closes the loop on Chunk 3's KV-write semantics through
+// real JetStream (not the mock bucket the unit tests use).
+func TestIntegration_CronRule_PersistsLastFiredToKV(t *testing.T) {
+	natsClient := getIntegrationNATSClient(t)
+	subject := fmt.Sprintf("test.cron.persist.%s", t.Name())
+	ruleID := "persist-test-" + t.Name()
+
+	received := make(chan struct{}, 1)
+	sub, err := natsClient.Subscribe(context.Background(), subject, func(_ context.Context, _ *nats.Msg) {
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+
+	rules := []Definition{{
+		ID:       ruleID,
+		Type:     CronRuleType,
+		Name:     "persist-fire test",
+		Enabled:  true,
+		Schedule: "@every 1s",
+		Actions: []Action{{
+			Type:    ActionTypePublish,
+			Subject: subject,
+		}},
+	}}
+	startCronProcessorForTest(t, natsClient, rules)
+
+	select {
+	case <-received:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first fire did not arrive")
+	}
+
+	// Poll RULE_SCHEDULES — the RecordFire call is async with the
+	// publish (both fire from inside the dispatch loop), so a brief
+	// retry loop avoids flakes on slow CI.
+	js, err := natsClient.JetStream()
+	require.NoError(t, err)
+	bucket, err := js.KeyValue(context.Background(), ScheduleBucketName)
+	require.NoError(t, err)
+
+	var rec LastFireRecord
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		entry, err := bucket.Get(context.Background(), ruleID)
+		if err == nil {
+			require.NoError(t, json.Unmarshal(entry.Value(), &rec))
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	require.NotZero(t, rec.LastFiredAt, "RULE_SCHEDULES has no persisted record after fire")
+	require.Equal(t, ruleID, rec.RuleID)
+	require.Equal(t, "@every 1s", rec.ScheduleSpec)
+}
+
+// TestIntegration_CronRule_DetectsMissedFiresAcrossRestart proves the
+// restart-recovery path end-to-end: a fire on the first processor
+// persists to RULE_SCHEDULES; we Stop, seed a stale timestamp to
+// avoid waiting wallclock, then Start a second processor against the
+// same NATS instance and assert restoreFromTracker increments the
+// missed_fires_total counter on the second registry.
+func TestIntegration_CronRule_DetectsMissedFiresAcrossRestart(t *testing.T) {
+	natsClient := getIntegrationNATSClient(t)
+	ruleID := "missed-fire-test-" + t.Name()
+	subject := fmt.Sprintf("test.cron.missed.%s", t.Name())
+
+	rules := []Definition{{
+		ID:       ruleID,
+		Type:     CronRuleType,
+		Name:     "missed-fire test",
+		Enabled:  true,
+		Schedule: "@every 1s",
+		Actions: []Action{{
+			Type:    ActionTypePublish,
+			Subject: subject,
+		}},
+	}}
+
+	received := make(chan struct{}, 1)
+	sub, err := natsClient.Subscribe(context.Background(), subject, func(_ context.Context, _ *nats.Msg) {
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	proc1, _ := startCronProcessorForTest(t, natsClient, rules)
+	select {
+	case <-received:
+	case <-time.After(3 * time.Second):
+		t.Fatal("first run did not fire")
+	}
+	require.NoError(t, proc1.Stop(5*time.Second))
+
+	// Seed a stale timestamp so missed-fire detection sees several
+	// expected fires without us waiting real seconds. Six seconds of
+	// "downtime" against an @every 1s schedule yields >= 5 expected
+	// fires — well above the cap and well above any flake threshold.
+	js, err := natsClient.JetStream()
+	require.NoError(t, err)
+	bucket, err := js.KeyValue(context.Background(), ScheduleBucketName)
+	require.NoError(t, err)
+
+	stale := LastFireRecord{
+		RuleID:       ruleID,
+		ScheduleSpec: "@every 1s",
+		LastFiredAt:  time.Now().Add(-6 * time.Second),
+	}
+	staleData, err := json.Marshal(stale)
+	require.NoError(t, err)
+	_, err = bucket.Put(context.Background(), ruleID, staleData)
+	require.NoError(t, err)
+
+	// Second run: fresh processor against the same NATS. The new
+	// metrics registry sees missed_fires_total > 0 only if
+	// restoreFromTracker walked the stale record + emitted to the
+	// counter.
+	_, registry2 := startCronProcessorForTest(t, natsClient, rules)
+
+	cronM := getCronMetrics(registry2)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if testutil.ToFloat64(cronM.missedFiresTotal.WithLabelValues(ruleID)) > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	missed := testutil.ToFloat64(cronM.missedFiresTotal.WithLabelValues(ruleID))
+	require.Greater(t, missed, float64(0), "missed_fires_total = 0; restoreFromTracker did not increment the counter for the seeded stale record")
+}
+
+// TestIntegration_CronRule_CooldownAcrossRestart proves the cross-
+// restart cooldown fix from Chunk 4: a rule with a 1h cooldown that
+// fired moments before "restart" must skip its first post-restart
+// fire on the cooldown gate. Without lastFiredNanos hydration in
+// restoreFromTracker, the gauge would treat the first post-restart
+// fire as "never fired" and double-dispatch.
+func TestIntegration_CronRule_CooldownAcrossRestart(t *testing.T) {
+	natsClient := getIntegrationNATSClient(t)
+	ruleID := "cooldown-restart-" + t.Name()
+	subject := fmt.Sprintf("test.cron.cooldown.%s", t.Name())
+
+	rules := []Definition{{
+		ID:       ruleID,
+		Type:     CronRuleType,
+		Name:     "cooldown across restart",
+		Enabled:  true,
+		Schedule: "@every 1s",
+		Cooldown: "1h",
+		Actions: []Action{{
+			Type:    ActionTypePublish,
+			Subject: subject,
+		}},
+	}}
+
+	var (
+		mu       sync.Mutex
+		received int
+	)
+	sub, err := natsClient.Subscribe(context.Background(), subject, func(_ context.Context, _ *nats.Msg) {
+		mu.Lock()
+		received++
+		mu.Unlock()
+	})
+	require.NoError(t, err)
+	defer func() { _ = sub.Unsubscribe() }()
+
+	// First run: expect one fire (cooldown=1h, so subsequent ticks
+	// within the same run are cooldown-skipped).
+	proc1, _ := startCronProcessorForTest(t, natsClient, rules)
+	time.Sleep(2500 * time.Millisecond)
+	require.NoError(t, proc1.Stop(5*time.Second))
+
+	mu.Lock()
+	firstRunCount := received
+	mu.Unlock()
+	require.Equal(t, 1, firstRunCount, "first run should fire exactly once (1h cooldown after first tick)")
+
+	// Second run: same NATS, same rule, no further @every 1s ticks
+	// should dispatch because the persisted last-fired is < 1h old.
+	// Hydration in restoreFromTracker is what makes this work — without
+	// it, the post-restart cooldown gate would treat the rule as "never
+	// fired" and dispatch immediately.
+	proc2, _ := startCronProcessorForTest(t, natsClient, rules)
+	time.Sleep(2500 * time.Millisecond)
+	require.NoError(t, proc2.Stop(5*time.Second))
+
+	mu.Lock()
+	totalCount := received
+	mu.Unlock()
+	require.Equal(t, 1, totalCount, "post-restart fires within cooldown window: got %d, want 1 (= unchanged from first run)", totalCount)
+}

--- a/processor/rule/cron_scheduler_test.go
+++ b/processor/rule/cron_scheduler_test.go
@@ -46,7 +46,7 @@ func (r *recordingExecutor) callCount() int {
 
 func newSchedulerForTest(t *testing.T, exec ActionExecutorInterface) *CronScheduler {
 	t.Helper()
-	s, err := NewCronScheduler(exec, slog.Default())
+	s, err := NewCronScheduler(exec, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("NewCronScheduler = %v, want nil", err)
 	}
@@ -68,7 +68,7 @@ func cronRuleForTest(t *testing.T, mutate func(*Definition)) *CronRule {
 }
 
 func TestNewCronScheduler_RejectsNilExecutor(t *testing.T) {
-	_, err := NewCronScheduler(nil, slog.Default())
+	_, err := NewCronScheduler(nil, nil, slog.Default())
 	if err == nil {
 		t.Fatal("err = nil, want non-nil for nil executor")
 	}
@@ -407,5 +407,160 @@ func TestCronEntry_AtomicCountersAreSafe(t *testing.T) {
 	}
 	if entry.lastFiredNanos.Load() == 0 {
 		t.Error("lastFiredNanos = 0, want non-zero after 100 stores")
+	}
+}
+
+// newSchedulerWithTrackerForTest builds a scheduler wired to a real
+// ScheduleTracker backed by an in-memory bucket, so persistence behaviour
+// can be asserted without testcontainers.
+func newSchedulerWithTrackerForTest(t *testing.T, exec ActionExecutorInterface) (*CronScheduler, *ScheduleTracker) {
+	t.Helper()
+	bucket := newMockKVBucket()
+	tracker := NewScheduleTracker(bucket, slog.Default())
+	s, err := NewCronScheduler(exec, tracker, slog.Default())
+	if err != nil {
+		t.Fatalf("NewCronScheduler = %v", err)
+	}
+	return s, tracker
+}
+
+// fire() must persist a last-fired record when a tracker is wired in.
+// Skipped fires (cooldown/inflight/everyN) must not persist.
+func TestCronScheduler_FirePersistsLastFiredRecord(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, tracker := newSchedulerWithTrackerForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	before := time.Now()
+	s.fire(rule.ID())
+
+	rec, err := tracker.LastFiredAt(context.Background(), rule.ID())
+	if err != nil {
+		t.Fatalf("LastFiredAt = %v, want nil", err)
+	}
+	if rec.RuleID != rule.ID() {
+		t.Errorf("RuleID = %q, want %q", rec.RuleID, rule.ID())
+	}
+	if rec.ScheduleSpec != rule.ScheduleString() {
+		t.Errorf("ScheduleSpec = %q, want %q", rec.ScheduleSpec, rule.ScheduleString())
+	}
+	if rec.LastFiredAt.Before(before.Add(-time.Second)) {
+		t.Errorf("LastFiredAt = %v, want >= %v", rec.LastFiredAt, before)
+	}
+}
+
+// fire() with no tracker must remain a clean no-op rather than panicking
+// — the scheduler degrades gracefully when the bucket couldn't be
+// created at startup.
+func TestCronScheduler_FireWithNilTrackerNoops(t *testing.T) {
+	exec := &recordingExecutor{}
+	s := newSchedulerForTest(t, exec) // tracker is nil
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+	s.fire(rule.ID()) // must not panic
+	if exec.callCount() != 1 {
+		t.Errorf("Execute calls = %d, want 1", exec.callCount())
+	}
+}
+
+// fire() must persist EVERY successful dispatch, overwriting prior
+// records. Verifies the timestamp advances across consecutive fires.
+func TestCronScheduler_FireOverwritesPriorRecord(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, tracker := newSchedulerWithTrackerForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID())
+	first, err := tracker.LastFiredAt(context.Background(), rule.ID())
+	if err != nil {
+		t.Fatalf("LastFiredAt after first = %v", err)
+	}
+
+	// Sleep past clock resolution so the second timestamp is definitively
+	// newer. 2ms is comfortably > nanosecond clock granularity on every
+	// supported OS without slowing CI.
+	time.Sleep(2 * time.Millisecond)
+	s.fire(rule.ID())
+	second, err := tracker.LastFiredAt(context.Background(), rule.ID())
+	if err != nil {
+		t.Fatalf("LastFiredAt after second = %v", err)
+	}
+	if !second.LastFiredAt.After(first.LastFiredAt) {
+		t.Errorf("second.LastFiredAt = %v, want after %v", second.LastFiredAt, first.LastFiredAt)
+	}
+}
+
+// detectMissedFires must skip rules with no persisted record — first
+// deploy is "fresh start", not "infinitely many missed fires".
+func TestCronScheduler_DetectMissedFires_NoRecordSkips(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, _ := newSchedulerWithTrackerForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	// detectMissedFires must not error or panic; it simply has nothing
+	// to report.
+	s.detectMissedFires(context.Background())
+}
+
+// detectMissedFires with a tracker but no rules registered must be a
+// clean no-op; mirrors the bare-startup path before any cron rules
+// are loaded.
+func TestCronScheduler_DetectMissedFires_NoRulesNoop(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, _ := newSchedulerWithTrackerForTest(t, exec)
+	s.detectMissedFires(context.Background())
+}
+
+// detectMissedFires with a nil tracker is a clean no-op (degraded mode).
+func TestCronScheduler_DetectMissedFires_NilTrackerNoop(t *testing.T) {
+	exec := &recordingExecutor{}
+	s := newSchedulerForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.detectMissedFires(context.Background())
+}
+
+// detectMissedFires walks the recorded last-fired backwards and counts
+// how many fires the rule's schedule expected since. Uses a high-cadence
+// schedule (@every 1s) plus a record from 5 seconds ago to deterministic-
+// ally land in the missed-fires regime without sleeping.
+func TestCronScheduler_DetectMissedFires_CountsExpectedFires(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, tracker := newSchedulerWithTrackerForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Schedule = "@every 1s"
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+
+	// Record a fire 5 seconds ago. With @every 1s, detection should see
+	// "several" missed fires; we don't assert an exact count because
+	// schedule.Next semantics interact with wallclock granularity.
+	five := time.Now().Add(-5 * time.Second)
+	if err := tracker.RecordFire(context.Background(), rule.ID(), rule.ScheduleString(), five); err != nil {
+		t.Fatalf("RecordFire = %v", err)
+	}
+
+	// Detection must complete without panicking and without dispatching
+	// (log-only policy: no replay).
+	s.detectMissedFires(context.Background())
+	if exec.callCount() != 0 {
+		t.Errorf("Execute calls = %d, want 0 (missed-fire detection must NOT dispatch)", exec.callCount())
 	}
 }

--- a/processor/rule/cron_scheduler_test.go
+++ b/processor/rule/cron_scheduler_test.go
@@ -1,0 +1,411 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+// recordingExecutor is a test-only ActionExecutorInterface that records every
+// dispatched action. Concurrency-safe so the scheduler's goroutine model can
+// exercise it without races.
+type recordingExecutor struct {
+	mu      sync.Mutex
+	calls   []Action
+	errOnce error // returned for the first call only when set; subsequent calls succeed
+	delay   time.Duration
+	panicOn string // panic when action.Subject equals this token
+}
+
+func (r *recordingExecutor) Execute(_ context.Context, action Action, _ *ExecutionContext) error {
+	if r.panicOn != "" && action.Subject == r.panicOn {
+		panic("recordingExecutor forced panic")
+	}
+	if r.delay > 0 {
+		time.Sleep(r.delay)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, action)
+	if r.errOnce != nil {
+		err := r.errOnce
+		r.errOnce = nil
+		return err
+	}
+	return nil
+}
+
+func (r *recordingExecutor) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func newSchedulerForTest(t *testing.T, exec ActionExecutorInterface) *CronScheduler {
+	t.Helper()
+	s, err := NewCronScheduler(exec, slog.Default())
+	if err != nil {
+		t.Fatalf("NewCronScheduler = %v, want nil", err)
+	}
+	return s
+}
+
+func cronRuleForTest(t *testing.T, mutate func(*Definition)) *CronRule {
+	t.Helper()
+	def := validCronDef()
+	def.ID = "rule-" + t.Name()
+	if mutate != nil {
+		mutate(&def)
+	}
+	r, err := NewCronRule(def)
+	if err != nil {
+		t.Fatalf("NewCronRule = %v, want nil", err)
+	}
+	return r
+}
+
+func TestNewCronScheduler_RejectsNilExecutor(t *testing.T) {
+	_, err := NewCronScheduler(nil, slog.Default())
+	if err == nil {
+		t.Fatal("err = nil, want non-nil for nil executor")
+	}
+}
+
+func TestCronScheduler_RegisterAndDeregister(t *testing.T) {
+	exec := &recordingExecutor{}
+	s := newSchedulerForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v, want nil", err)
+	}
+	if got := s.RegisteredCount(); got != 1 {
+		t.Errorf("RegisteredCount = %d, want 1", got)
+	}
+
+	s.Deregister(rule.ID())
+	if got := s.RegisteredCount(); got != 0 {
+		t.Errorf("RegisteredCount after Deregister = %d, want 0", got)
+	}
+
+	// Deregister of unknown rule is a no-op (hot-reload calls it
+	// unconditionally).
+	s.Deregister("does-not-exist")
+}
+
+func TestCronScheduler_RegisterDuplicate(t *testing.T) {
+	s := newSchedulerForTest(t, &recordingExecutor{})
+	rule := cronRuleForTest(t, nil)
+
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("first Register = %v, want nil", err)
+	}
+	if err := s.Register(rule); err == nil {
+		t.Fatal("second Register err = nil, want non-nil")
+	}
+}
+
+func TestCronScheduler_RegisterSkipsDisabled(t *testing.T) {
+	s := newSchedulerForTest(t, &recordingExecutor{})
+	rule := cronRuleForTest(t, func(d *Definition) { d.Enabled = false })
+
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register disabled = %v, want nil (silent skip)", err)
+	}
+	if got := s.RegisteredCount(); got != 0 {
+		t.Errorf("RegisteredCount = %d, want 0 (disabled rule should not be registered)", got)
+	}
+}
+
+func TestCronScheduler_RegisterRejectsNil(t *testing.T) {
+	s := newSchedulerForTest(t, &recordingExecutor{})
+	if err := s.Register(nil); err == nil {
+		t.Fatal("Register(nil) err = nil, want non-nil")
+	}
+}
+
+func TestCronScheduler_StartTwiceFails(t *testing.T) {
+	s := newSchedulerForTest(t, &recordingExecutor{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("first Start = %v, want nil", err)
+	}
+	defer func() {
+		stopCtx := s.Stop()
+		<-stopCtx.Done()
+	}()
+
+	if err := s.Start(ctx); err == nil {
+		t.Fatal("second Start err = nil, want non-nil")
+	}
+}
+
+func TestCronScheduler_StartRejectsNilContext(t *testing.T) {
+	s := newSchedulerForTest(t, &recordingExecutor{})
+	if err := s.Start(nil); err == nil {
+		t.Fatal("Start(nil) err = nil, want non-nil")
+	}
+}
+
+func TestCronScheduler_StopOnNeverStartedIsSafe(t *testing.T) {
+	s := newSchedulerForTest(t, &recordingExecutor{})
+	stopCtx := s.Stop()
+	select {
+	case <-stopCtx.Done():
+		// Already-closed context; expected.
+	default:
+		t.Fatal("Stop() on never-started scheduler returned an open context")
+	}
+}
+
+// fire() is exercised directly because waiting for a real cron tick adds
+// minutes of test latency. The scheduler's contract for fire() is the same
+// whether triggered by robfig or test code.
+
+func TestCronScheduler_FireDispatchesAllActions(t *testing.T) {
+	exec := &recordingExecutor{}
+	s := newSchedulerForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Actions = []Action{
+			{Type: ActionTypePublish, Subject: "a"},
+			{Type: ActionTypePublish, Subject: "b"},
+		}
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	// Start sets parentCtx; required by fire's nil-check.
+	ctx := context.Background()
+	s.parentCtx = ctx
+
+	s.fire(rule.ID())
+
+	if got := exec.callCount(); got != 2 {
+		t.Errorf("Execute call count = %d, want 2 (one per action)", got)
+	}
+}
+
+func TestCronScheduler_FireFireEveryNGate(t *testing.T) {
+	exec := &recordingExecutor{}
+	s := newSchedulerForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.FireEveryNEvents = 3
+		d.Actions = []Action{{Type: ActionTypePublish, Subject: "a"}}
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	// Tick 6 times. With N=3, only ticks 3 and 6 fire actions → 2 dispatches.
+	for i := 0; i < 6; i++ {
+		s.fire(rule.ID())
+	}
+	if got := exec.callCount(); got != 2 {
+		t.Errorf("Execute calls = %d, want 2 (every-3 gate over 6 ticks)", got)
+	}
+}
+
+func TestCronScheduler_FireCooldownGate(t *testing.T) {
+	exec := &recordingExecutor{}
+	s := newSchedulerForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Cooldown = "10s"
+		d.Actions = []Action{{Type: ActionTypePublish, Subject: "a"}}
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	// First fire dispatches; second within 10s is skipped by cooldown.
+	s.fire(rule.ID())
+	s.fire(rule.ID())
+	if got := exec.callCount(); got != 1 {
+		t.Errorf("Execute calls = %d, want 1 (second fire suppressed by cooldown)", got)
+	}
+}
+
+func TestCronScheduler_FireInflightGuard(t *testing.T) {
+	// A slow first fire still in flight when a second fire arrives must
+	// drop the second fire — not queue or stack it. Verifies the atomic
+	// CAS gate.
+	exec := &recordingExecutor{delay: 200 * time.Millisecond}
+	s := newSchedulerForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Actions = []Action{{Type: ActionTypePublish, Subject: "a"}}
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); s.fire(rule.ID()) }()
+	// Give the first fire time to grab the inflight CAS.
+	time.Sleep(20 * time.Millisecond)
+	go func() { defer wg.Done(); s.fire(rule.ID()) }()
+	wg.Wait()
+
+	if got := exec.callCount(); got != 1 {
+		t.Errorf("Execute calls = %d, want 1 (overlapping fire dropped by inflight guard)", got)
+	}
+}
+
+func TestCronScheduler_FirePanicRecover(t *testing.T) {
+	// A panicking action must not propagate out of fire(). The deferred
+	// recover keeps robfig's internal goroutine alive.
+	exec := &recordingExecutor{panicOn: "boom"}
+	s := newSchedulerForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Actions = []Action{
+			{Type: ActionTypePublish, Subject: "boom"},
+			{Type: ActionTypePublish, Subject: "after-panic"},
+		}
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	// If recover were missing this would crash the test goroutine.
+	s.fire(rule.ID())
+	// Note: we don't assert on call count after the panic — the second
+	// action is intentionally not dispatched (panic unwinds the for-loop).
+	// The only invariant is that the test process is still alive here.
+}
+
+func TestCronScheduler_FireUnknownRuleIsNoop(t *testing.T) {
+	// Race window: a tick is delivered between Deregister and the fire
+	// closure's map lookup. Dropping silently is correct.
+	exec := &recordingExecutor{}
+	s := newSchedulerForTest(t, exec)
+	s.parentCtx = context.Background()
+
+	s.fire("never-registered")
+
+	if got := exec.callCount(); got != 0 {
+		t.Errorf("Execute calls = %d, want 0", got)
+	}
+}
+
+func TestCronScheduler_FireSurvivesActionError(t *testing.T) {
+	// One failing action does not stop sibling actions in the same tick —
+	// matches StatefulEvaluator best-effort semantics.
+	exec := &recordingExecutor{errOnce: errors.New("boom")}
+	s := newSchedulerForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Actions = []Action{
+			{Type: ActionTypePublish, Subject: "first-fails"},
+			{Type: ActionTypePublish, Subject: "second-runs"},
+		}
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID())
+
+	if got := exec.callCount(); got != 2 {
+		t.Errorf("Execute calls = %d, want 2 (best-effort: sibling action runs after error)", got)
+	}
+}
+
+func TestCronScheduler_StartIntegratesWithRegister(t *testing.T) {
+	// Smoke test: Start, Register, Deregister, Stop sequence — confirms
+	// the lifecycle wiring without waiting for a cron tick.
+	exec := &recordingExecutor{}
+	s := newSchedulerForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start = %v", err)
+	}
+
+	stopCtx := s.Stop()
+	select {
+	case <-stopCtx.Done():
+		// Drained cleanly.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop drain timed out")
+	}
+}
+
+func TestCronScheduler_StartActuallyFiresFromRobfig(t *testing.T) {
+	// Closes the gap between TestCronScheduler_FireDispatchesAllActions
+	// (calls fire() directly) and Chunk 6's testcontainer integration
+	// test. Proves robfig's internal goroutine actually invokes the
+	// closure we registered. Uses `@every 100ms` (robfig descriptor)
+	// so a single 1.5s wait is enough to catch at least one fire even
+	// on a busy CI host.
+	exec := &recordingExecutor{}
+	s := newSchedulerForTest(t, exec)
+
+	def := validCronDef()
+	def.ID = "rule-" + t.Name()
+	def.Schedule = "@every 100ms"
+	rule, err := NewCronRule(def)
+	if err != nil {
+		t.Fatalf("NewCronRule = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start = %v", err)
+	}
+	defer func() {
+		stopCtx := s.Stop()
+		<-stopCtx.Done()
+	}()
+
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if exec.callCount() >= 1 {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("expected at least 1 fire from robfig within 1.5s, got %d", exec.callCount())
+}
+
+// Sanity check: atomic counters in cronEntry behave under contention. Not
+// strictly needed (atomic.Int64 is std-lib), but documents the expectation
+// that tickCount and lastFiredNanos are read/written without a per-entry
+// lock.
+func TestCronEntry_AtomicCountersAreSafe(t *testing.T) {
+	var entry cronEntry
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			entry.tickCount.Add(1)
+			entry.lastFiredNanos.Store(time.Now().UnixNano())
+		}()
+	}
+	wg.Wait()
+	if got := entry.tickCount.Load(); got != 100 {
+		t.Errorf("tickCount = %d, want 100", got)
+	}
+	if entry.lastFiredNanos.Load() == 0 {
+		t.Error("lastFiredNanos = 0, want non-zero after 100 stores")
+	}
+}

--- a/processor/rule/cron_scheduler_test.go
+++ b/processor/rule/cron_scheduler_test.go
@@ -7,6 +7,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/c360studio/semstreams/metric"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 // recordingExecutor is a test-only ActionExecutorInterface that records every
@@ -46,7 +49,10 @@ func (r *recordingExecutor) callCount() int {
 
 func newSchedulerForTest(t *testing.T, exec ActionExecutorInterface) *CronScheduler {
 	t.Helper()
-	s, err := NewCronScheduler(exec, nil, slog.Default())
+	s, err := NewCronScheduler(CronSchedulerConfig{
+		Executor: exec,
+		Logger:   slog.Default(),
+	})
 	if err != nil {
 		t.Fatalf("NewCronScheduler = %v, want nil", err)
 	}
@@ -68,7 +74,7 @@ func cronRuleForTest(t *testing.T, mutate func(*Definition)) *CronRule {
 }
 
 func TestNewCronScheduler_RejectsNilExecutor(t *testing.T) {
-	_, err := NewCronScheduler(nil, nil, slog.Default())
+	_, err := NewCronScheduler(CronSchedulerConfig{Logger: slog.Default()})
 	if err == nil {
 		t.Fatal("err = nil, want non-nil for nil executor")
 	}
@@ -417,7 +423,11 @@ func newSchedulerWithTrackerForTest(t *testing.T, exec ActionExecutorInterface) 
 	t.Helper()
 	bucket := newMockKVBucket()
 	tracker := NewScheduleTracker(bucket, slog.Default())
-	s, err := NewCronScheduler(exec, tracker, slog.Default())
+	s, err := NewCronScheduler(CronSchedulerConfig{
+		Executor: exec,
+		Tracker:  tracker,
+		Logger:   slog.Default(),
+	})
 	if err != nil {
 		t.Fatalf("NewCronScheduler = %v", err)
 	}
@@ -714,4 +724,346 @@ type ecCapturingExecutor struct {
 func (e *ecCapturingExecutor) Execute(_ context.Context, _ Action, ec *ExecutionContext) error {
 	e.ec = ec
 	return nil
+}
+
+// newSchedulerWithMetricsForTest builds a scheduler wired to a fresh
+// MetricsRegistry-backed cronMetrics so test code can assert on counter
+// / gauge / histogram state without touching global Prometheus state.
+func newSchedulerWithMetricsForTest(t *testing.T, exec ActionExecutorInterface) (*CronScheduler, *cronMetrics) {
+	t.Helper()
+	m := getCronMetrics(metric.NewMetricsRegistry())
+	s, err := NewCronScheduler(CronSchedulerConfig{
+		Executor: exec,
+		Metrics:  m,
+		Logger:   slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewCronScheduler = %v", err)
+	}
+	return s, m
+}
+
+// Register flips the registered gauge and seeds the next-fire gauge.
+// Deregister reverses both. Together they prove hot-reload-time changes
+// are visible in Prometheus state.
+func TestCronScheduler_Metrics_RegisterDeregisterFlipsGauges(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	if got := testutil.ToFloat64(m.registered); got != 1 {
+		t.Errorf("registered after Register = %f, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.nextFireTimestampSecs.WithLabelValues(rule.ID())); got == 0 {
+		t.Errorf("next_fire = 0, want non-zero (Schedule.Next should be in the future)")
+	}
+
+	s.Deregister(rule.ID())
+	if got := testutil.ToFloat64(m.registered); got != 0 {
+		t.Errorf("registered after Deregister = %f, want 0", got)
+	}
+	if got := testutil.CollectAndCount(m.nextFireTimestampSecs); got != 0 {
+		t.Errorf("next_fire vector cardinality after Deregister = %d, want 0 (gauge should be cleared)", got)
+	}
+}
+
+// fire() records duration + status=success on a clean dispatch.
+func TestCronScheduler_Metrics_FireSuccessRecorded(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID())
+
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusSuccess)); got != 1 {
+		t.Errorf("fires{success} = %f, want 1", got)
+	}
+	if got := testutil.CollectAndCount(m.fireDurationSeconds); got == 0 {
+		t.Errorf("fire_duration histogram empty, want at least one observation")
+	}
+}
+
+// An action returning error downgrades the fire status to "error" while
+// still permitting subsequent actions in the same tick.
+func TestCronScheduler_Metrics_FireErrorRecorded(t *testing.T) {
+	exec := &recordingExecutor{errOnce: errors.New("boom")}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID())
+
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusError)); got != 1 {
+		t.Errorf("fires{error} = %f, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusSuccess)); got != 0 {
+		t.Errorf("fires{success} = %f, want 0 (action errored)", got)
+	}
+}
+
+// A panicking action surfaces as status=panic. The recover keeps
+// robfig's goroutine alive (the test doesn't crash); the metric
+// distinguishes this from status=error so an alert can page on the
+// programming-bug class specifically.
+func TestCronScheduler_Metrics_FirePanicRecordedAsPanic(t *testing.T) {
+	exec := &recordingExecutor{panicOn: "boom"}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Actions = []Action{{Type: ActionTypePublish, Subject: "boom"}}
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID()) // recover keeps the test alive
+
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusPanic)); got != 1 {
+		t.Errorf("fires{panic} = %f, want 1", got)
+	}
+}
+
+// A cooldown-skipped fire records under the dedicated status without
+// observing the duration histogram (skipped fires never dispatched).
+func TestCronScheduler_Metrics_CooldownSkippedRecorded(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Cooldown = "10s"
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID()) // first fire dispatches
+	s.fire(rule.ID()) // second within 10s is cooldown-skipped
+
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusSuccess)); got != 1 {
+		t.Errorf("fires{success} = %f, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusCooldownSkipped)); got != 1 {
+		t.Errorf("fires{cooldown_skipped} = %f, want 1", got)
+	}
+}
+
+// fire() must update the next-fire gauge after every successful
+// dispatch so the gauge always reflects the freshest schedule.Next.
+// The post-fire value must be strictly in the future from the test's
+// frame of reference — proves fire is actually writing the gauge,
+// without relying on wallclock-precision tricks across small sleeps.
+func TestCronScheduler_Metrics_FireUpdatesNextFireGauge(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Schedule = "@every 1h"
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID())
+
+	gauge := testutil.ToFloat64(m.nextFireTimestampSecs.WithLabelValues(rule.ID()))
+	now := float64(time.Now().Unix())
+	if gauge <= now {
+		t.Errorf("next_fire = %f, want > now (%f)", gauge, now)
+	}
+}
+
+// Start flips scheduler_running to 1; Stop returns it to 0. Catches
+// the "scheduler crashed but processor still alive" pathology.
+func TestCronScheduler_Metrics_SchedulerRunningGauge(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	if got := testutil.ToFloat64(m.schedulerRunning); got != 0 {
+		t.Errorf("running before Start = %f, want 0", got)
+	}
+
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start = %v", err)
+	}
+	if got := testutil.ToFloat64(m.schedulerRunning); got != 1 {
+		t.Errorf("running after Start = %f, want 1", got)
+	}
+
+	stopCtx := s.Stop()
+	<-stopCtx.Done()
+	if got := testutil.ToFloat64(m.schedulerRunning); got != 0 {
+		t.Errorf("running after Stop = %f, want 0", got)
+	}
+}
+
+// Panic-after-some-actions-succeed: status=panic must win over the
+// partial-success accumulated before the panic. Verifies the deferred
+// recover unconditionally overwrites the status that the dispatch loop
+// set, rather than leaving a previously-set "success" or "error".
+func TestCronScheduler_Metrics_PanicWinsOverPartialSuccess(t *testing.T) {
+	exec := &recordingExecutor{panicOn: "boom"}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Actions = []Action{
+			{Type: ActionTypePublish, Subject: "ok-1"},
+			{Type: ActionTypePublish, Subject: "ok-2"},
+			{Type: ActionTypePublish, Subject: "boom"},
+		}
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID()) // recover keeps the test alive
+
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusPanic)); got != 1 {
+		t.Errorf("fires{panic} = %f, want 1", got)
+	}
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusSuccess)); got != 0 {
+		t.Errorf("fires{success} = %f, want 0 (panic must overwrite partial success)", got)
+	}
+}
+
+// Hot-reload: Deregister followed by Register-with-same-id ends up with
+// registered=1 (Inc → Dec → Inc nets to +1). Pins the post-reload
+// gauge value so a future refactor that, e.g., made Register idempotent
+// without paired Deregister wouldn't double-count.
+func TestCronScheduler_Metrics_HotReloadKeepsRegisteredAtOne(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("first Register = %v", err)
+	}
+	s.Deregister(rule.ID())
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("re-Register = %v", err)
+	}
+
+	if got := testutil.ToFloat64(m.registered); got != 1 {
+		t.Errorf("registered after Register/Deregister/Register = %f, want 1", got)
+	}
+}
+
+// Disabled rules must not bump the registered gauge — Register
+// silently skips them. Pins "registered" as "running rules", not
+// "configured rules".
+func TestCronScheduler_Metrics_DisabledRuleNoGaugeBump(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) { d.Enabled = false })
+
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register disabled = %v", err)
+	}
+	if got := testutil.ToFloat64(m.registered); got != 0 {
+		t.Errorf("registered for disabled rule = %f, want 0", got)
+	}
+}
+
+// Cooldown-skipped fires must NOT update the next-fire gauge. The
+// gauge is meaningful only after a real dispatch advances Schedule.Next;
+// updating it on a skip would muddle the dashboard's time-until-next-fire
+// view.
+func TestCronScheduler_Metrics_CooldownSkippedDoesNotUpdateNextFire(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Cooldown = "10s"
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID()) // first fire dispatches; updates next_fire
+	afterFirstFire := testutil.ToFloat64(m.nextFireTimestampSecs.WithLabelValues(rule.ID()))
+
+	// Sleep past wallclock granularity so a real fire would advance
+	// the gauge — proves cooldown_skipped path doesn't.
+	time.Sleep(2 * time.Millisecond)
+	s.fire(rule.ID()) // cooldown-skipped
+
+	if got := testutil.ToFloat64(m.nextFireTimestampSecs.WithLabelValues(rule.ID())); got != afterFirstFire {
+		t.Errorf("next_fire after cooldown_skipped = %f, want unchanged %f", got, afterFirstFire)
+	}
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusCooldownSkipped)); got != 1 {
+		t.Errorf("fires{cooldown_skipped} = %f, want 1", got)
+	}
+}
+
+// Inflight-skipped surfaces the operator-error case of "actions are
+// slower than schedule, no cooldown configured". Distinct status from
+// cooldown_skipped because the operator action is different.
+func TestCronScheduler_Metrics_InflightSkippedRecorded(t *testing.T) {
+	// Slow executor causes the first fire to still be running when the
+	// second arrives. Inflight CAS rejects the second; metric should
+	// reflect inflight_skipped.
+	exec := &recordingExecutor{delay: 100 * time.Millisecond}
+	s, m := newSchedulerWithMetricsForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); s.fire(rule.ID()) }()
+	time.Sleep(10 * time.Millisecond) // let first fire grab the inflight CAS
+	go func() { defer wg.Done(); s.fire(rule.ID()) }()
+	wg.Wait()
+
+	if got := testutil.ToFloat64(m.firesTotal.WithLabelValues(rule.ID(), cronFireStatusInflightSkipped)); got != 1 {
+		t.Errorf("fires{inflight_skipped} = %f, want 1", got)
+	}
+}
+
+// restoreFromTracker increments missed_fires_total by the detected
+// count and missed_fires_capped_total when the cap fires.
+func TestCronScheduler_Metrics_RestoreRecordsMissedFires(t *testing.T) {
+	exec := &recordingExecutor{}
+	bucket := newMockKVBucket()
+	tracker := NewScheduleTracker(bucket, slog.Default())
+	m := getCronMetrics(metric.NewMetricsRegistry())
+	s, err := NewCronScheduler(CronSchedulerConfig{
+		Executor: exec,
+		Tracker:  tracker,
+		Metrics:  m,
+		Logger:   slog.Default(),
+	})
+	if err != nil {
+		t.Fatalf("NewCronScheduler = %v", err)
+	}
+
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Schedule = "@every 1s"
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+
+	// Seed a 5s-old record so the detector counts a few missed fires
+	// (exact count depends on schedule.Next semantics around wallclock
+	// granularity; we just assert > 0).
+	if err := tracker.RecordFire(context.Background(), rule.ID(), rule.ScheduleString(), time.Now().Add(-5*time.Second)); err != nil {
+		t.Fatalf("RecordFire = %v", err)
+	}
+
+	s.restoreFromTracker(context.Background())
+
+	if got := testutil.ToFloat64(m.missedFiresTotal.WithLabelValues(rule.ID())); got <= 0 {
+		t.Errorf("missed_fires = %f, want > 0", got)
+	}
 }

--- a/processor/rule/cron_scheduler_test.go
+++ b/processor/rule/cron_scheduler_test.go
@@ -501,45 +501,45 @@ func TestCronScheduler_FireOverwritesPriorRecord(t *testing.T) {
 	}
 }
 
-// detectMissedFires must skip rules with no persisted record — first
+// restoreFromTracker must skip rules with no persisted record — first
 // deploy is "fresh start", not "infinitely many missed fires".
-func TestCronScheduler_DetectMissedFires_NoRecordSkips(t *testing.T) {
+func TestCronScheduler_RestoreFromTracker_NoRecordSkips(t *testing.T) {
 	exec := &recordingExecutor{}
 	s, _ := newSchedulerWithTrackerForTest(t, exec)
 	rule := cronRuleForTest(t, nil)
 	if err := s.Register(rule); err != nil {
 		t.Fatalf("Register = %v", err)
 	}
-	// detectMissedFires must not error or panic; it simply has nothing
+	// restoreFromTracker must not error or panic; it simply has nothing
 	// to report.
-	s.detectMissedFires(context.Background())
+	s.restoreFromTracker(context.Background())
 }
 
-// detectMissedFires with a tracker but no rules registered must be a
+// restoreFromTracker with a tracker but no rules registered must be a
 // clean no-op; mirrors the bare-startup path before any cron rules
 // are loaded.
-func TestCronScheduler_DetectMissedFires_NoRulesNoop(t *testing.T) {
+func TestCronScheduler_RestoreFromTracker_NoRulesNoop(t *testing.T) {
 	exec := &recordingExecutor{}
 	s, _ := newSchedulerWithTrackerForTest(t, exec)
-	s.detectMissedFires(context.Background())
+	s.restoreFromTracker(context.Background())
 }
 
-// detectMissedFires with a nil tracker is a clean no-op (degraded mode).
-func TestCronScheduler_DetectMissedFires_NilTrackerNoop(t *testing.T) {
+// restoreFromTracker with a nil tracker is a clean no-op (degraded mode).
+func TestCronScheduler_RestoreFromTracker_NilTrackerNoop(t *testing.T) {
 	exec := &recordingExecutor{}
 	s := newSchedulerForTest(t, exec)
 	rule := cronRuleForTest(t, nil)
 	if err := s.Register(rule); err != nil {
 		t.Fatalf("Register = %v", err)
 	}
-	s.detectMissedFires(context.Background())
+	s.restoreFromTracker(context.Background())
 }
 
-// detectMissedFires walks the recorded last-fired backwards and counts
+// restoreFromTracker walks the recorded last-fired backwards and counts
 // how many fires the rule's schedule expected since. Uses a high-cadence
 // schedule (@every 1s) plus a record from 5 seconds ago to deterministic-
 // ally land in the missed-fires regime without sleeping.
-func TestCronScheduler_DetectMissedFires_CountsExpectedFires(t *testing.T) {
+func TestCronScheduler_RestoreFromTracker_CountsExpectedFires(t *testing.T) {
 	exec := &recordingExecutor{}
 	s, tracker := newSchedulerWithTrackerForTest(t, exec)
 	rule := cronRuleForTest(t, func(d *Definition) {
@@ -559,8 +559,159 @@ func TestCronScheduler_DetectMissedFires_CountsExpectedFires(t *testing.T) {
 
 	// Detection must complete without panicking and without dispatching
 	// (log-only policy: no replay).
-	s.detectMissedFires(context.Background())
+	s.restoreFromTracker(context.Background())
 	if exec.callCount() != 0 {
 		t.Errorf("Execute calls = %d, want 0 (missed-fire detection must NOT dispatch)", exec.callCount())
 	}
+}
+
+// restoreFromTracker must seed entry.lastFiredNanos from the persisted
+// record. This is the cross-restart cooldown / `$schedule.last_fired_at`
+// fix: without hydration the first post-restart fire would behave as
+// "never fired", losing both the cooldown gate's enforcement and the
+// substitution context.
+func TestCronScheduler_RestoreFromTracker_HydratesLastFiredNanos(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, tracker := newSchedulerWithTrackerForTest(t, exec)
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+
+	persisted := time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC)
+	if err := tracker.RecordFire(context.Background(), rule.ID(), rule.ScheduleString(), persisted); err != nil {
+		t.Fatalf("RecordFire = %v", err)
+	}
+
+	s.restoreFromTracker(context.Background())
+
+	s.mu.Lock()
+	entry, ok := s.entries[rule.ID()]
+	s.mu.Unlock()
+	if !ok {
+		t.Fatalf("entry missing after restore")
+	}
+	got := entry.lastFiredNanos.Load()
+	if got != persisted.UnixNano() {
+		t.Errorf("lastFiredNanos = %d, want %d (hydration from persisted record)", got, persisted.UnixNano())
+	}
+}
+
+// Cross-restart cooldown: a rule with a 1h cooldown that fired 1 minute
+// before "restart" (simulated by hydrating the in-memory cache from a
+// freshly-recorded persisted timestamp) must skip the next fire on the
+// cooldown gate. Without hydration this skip would not happen and the
+// post-restart fire would dispatch immediately, doubling actions.
+func TestCronScheduler_RestoreFromTracker_EnforcesCooldownAcrossRestart(t *testing.T) {
+	exec := &recordingExecutor{}
+	s, tracker := newSchedulerWithTrackerForTest(t, exec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Cooldown = "1h"
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	// Pretend the previous process fired one minute ago and persisted.
+	prev := time.Now().Add(-1 * time.Minute)
+	if err := tracker.RecordFire(context.Background(), rule.ID(), rule.ScheduleString(), prev); err != nil {
+		t.Fatalf("RecordFire = %v", err)
+	}
+
+	s.restoreFromTracker(context.Background())
+
+	// First fire after restart must hit the cooldown gate (1m elapsed,
+	// 1h cooldown).
+	s.fire(rule.ID())
+	if got := exec.callCount(); got != 0 {
+		t.Errorf("Execute calls = %d, want 0 (cooldown should suppress post-restart fire)", got)
+	}
+}
+
+// fire() must build an ExecutionContext with Schedule populated so cron
+// action templates can use `$schedule.id`, `$schedule.spec`, and
+// `$schedule.last_fired_at`. Verifies that the executor receives an ec
+// whose substitution renders the cron-namespace tokens correctly.
+func TestCronScheduler_FireBuildsScheduleContext(t *testing.T) {
+	rec := &ecCapturingExecutor{}
+	s, _ := newSchedulerWithTrackerForTest(t, rec)
+	rule := cronRuleForTest(t, func(d *Definition) {
+		d.Schedule = "0 9 * * MON"
+		d.Actions = []Action{{Type: ActionTypePublish, Subject: "$schedule.id"}}
+	})
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID())
+
+	ec := rec.ec
+	if ec == nil {
+		t.Fatal("executor did not receive ExecutionContext")
+	}
+	if ec.Schedule == nil {
+		t.Fatal("ec.Schedule = nil, want populated")
+	}
+	if ec.Schedule.ID != rule.ID() {
+		t.Errorf("Schedule.ID = %q, want %q", ec.Schedule.ID, rule.ID())
+	}
+	if ec.Schedule.Spec != "0 9 * * MON" {
+		t.Errorf("Schedule.Spec = %q, want %q", ec.Schedule.Spec, "0 9 * * MON")
+	}
+	// First fire: LastFiredAt is zero.
+	if !ec.Schedule.LastFiredAt.IsZero() {
+		t.Errorf("first fire LastFiredAt = %v, want zero", ec.Schedule.LastFiredAt)
+	}
+}
+
+// Second fire's ScheduleContext.LastFiredAt must reflect the first
+// fire's wallclock — the cooldown read and the substitution view of
+// "previous fire" must be the same value.
+func TestCronScheduler_FireScheduleContextSeesPriorFire(t *testing.T) {
+	rec := &ecCapturingExecutor{}
+	s, _ := newSchedulerWithTrackerForTest(t, rec)
+	rule := cronRuleForTest(t, nil)
+	if err := s.Register(rule); err != nil {
+		t.Fatalf("Register = %v", err)
+	}
+	s.parentCtx = context.Background()
+
+	s.fire(rule.ID())
+	firstFireNanos := time.Now().UnixNano()
+	rec.ec = nil // clear so the second fire's ec is captured fresh
+
+	// Sleep past clock resolution so the second fire sees a strictly
+	// earlier LastFiredAt.
+	time.Sleep(2 * time.Millisecond)
+	s.fire(rule.ID())
+
+	if rec.ec == nil || rec.ec.Schedule == nil {
+		t.Fatal("second fire did not deliver Schedule context")
+	}
+	if rec.ec.Schedule.LastFiredAt.IsZero() {
+		t.Error("second fire LastFiredAt is zero, want the first fire's wallclock")
+	}
+	if rec.ec.Schedule.LastFiredAt.UnixNano() > firstFireNanos {
+		t.Errorf("LastFiredAt = %d, want <= %d (must reflect first fire, not the in-progress second)",
+			rec.ec.Schedule.LastFiredAt.UnixNano(), firstFireNanos)
+	}
+}
+
+// ecCapturingExecutor is a recordingExecutor sibling that snapshots the
+// last ExecutionContext it received. Lets tests assert on the ec the
+// scheduler actually passed through.
+//
+// No mutex: callers invoke s.fire() synchronously from the test
+// goroutine, so the write+read ordering is single-threaded by
+// construction. Tests that fire concurrently (none today) should add
+// their own synchronization or migrate to a lock-protected variant.
+type ecCapturingExecutor struct {
+	ec *ExecutionContext
+}
+
+func (e *ecCapturingExecutor) Execute(_ context.Context, _ Action, ec *ExecutionContext) error {
+	e.ec = ec
+	return nil
 }

--- a/processor/rule/cron_substitution.go
+++ b/processor/rule/cron_substitution.go
@@ -1,0 +1,89 @@
+// Package rule - Cron-specific substitution context.
+//
+// CronRule fires have no entity in scope at MVP — the scheduler ticks on
+// a clock alone. Action templates therefore cannot use the
+// `$entity.*` / `$related.*` / `$state.*` namespaces that expression
+// rules populate from a matched entity. Instead, cron actions read
+// schedule-shaped context: `$schedule.id`, `$schedule.spec`,
+// `$schedule.last_fired_at`. Plus the existing `$now` token, which
+// SubstituteVariables already handles for every rule kind.
+//
+// # Retrofit-safe namespace seam
+//
+// `$schedule.*` is intentionally disjoint from `$entity.*`. When the
+// deferred per-entity fan-out extension lands (Definition.ForEach), each
+// iteration of the fan-out gets the existing `$entity.*` namespace
+// populated identically to expression-rule firing — the cron path
+// supplies an EntityID, an Entity (or *EntityState fetched on demand),
+// and a State; the substitution layer needs no changes. Adding
+// `for_each` is purely additive.
+//
+// A future `$trigger.*` namespace (planned for richer tick metadata —
+// e.g. `$trigger.attempt`, `$trigger.scheduled_for`) would land here as
+// a sibling shim. Do not overload `$schedule.*` to carry per-tick
+// metadata; keeping spec-shaped data and tick-shaped data in separate
+// namespaces preserves the door for that extension.
+package rule
+
+import (
+	"strings"
+	"time"
+)
+
+// ScheduleContext carries the cron-rule context that's available at fire
+// time but not derivable from any other rule field. ExecutionContext
+// holds a *ScheduleContext on cron-fire dispatches; expression-rule
+// dispatches leave the field nil and the substitution is a no-op.
+//
+// Fields are exported because the substitution layer reads them
+// directly; the type is constructed by the cron scheduler in fire() and
+// never mutated thereafter.
+type ScheduleContext struct {
+	// ID is the firing rule's stable identifier — same value as
+	// Definition.ID and CronRule.ID. Always non-empty for a cron fire.
+	ID string
+
+	// Spec is the cron expression as the rule was registered with it.
+	// Captured at fire time so a hot-reload that changes the schedule
+	// doesn't retroactively alter substitution output for in-flight
+	// dispatches. Always non-empty for a cron fire.
+	Spec string
+
+	// LastFiredAt is the wallclock of the most recent successful fire
+	// before this one. Zero value (time.IsZero) on the first fire of
+	// a freshly-registered rule, before any persisted record exists.
+	// The substitution renders zero as the empty string so authors can
+	// detect first-fire via `len("$schedule.last_fired_at") == 0` in
+	// downstream conditional templates.
+	LastFiredAt time.Time
+}
+
+// applyScheduleSubstitutions replaces `$schedule.*` tokens in template
+// against sc, returning the substituted string. A nil sc is the
+// no-op path — expression-rule fires call this through
+// ExecutionContext.SubstituteVariables and any `$schedule.*` token
+// will then survive substitution and trip the unresolved-template
+// warning in execution_context.go (= author error: cron-only token
+// in an expression rule).
+//
+// LastFiredAt's zero value renders as the empty string rather than
+// `0001-01-01T00:00:00Z`. Authors needing to detect first-fire can
+// branch on emptiness; rendering the Go zero-value would be
+// surprising and would push the burden of checking onto every
+// downstream template.
+func applyScheduleSubstitutions(template string, sc *ScheduleContext) string {
+	if sc == nil {
+		return template
+	}
+	result := template
+	result = strings.ReplaceAll(result, "$schedule.id", sc.ID)
+	result = strings.ReplaceAll(result, "$schedule.spec", sc.Spec)
+
+	var lastFired string
+	if !sc.LastFiredAt.IsZero() {
+		lastFired = sc.LastFiredAt.UTC().Format(time.RFC3339)
+	}
+	result = strings.ReplaceAll(result, "$schedule.last_fired_at", lastFired)
+
+	return result
+}

--- a/processor/rule/cron_substitution_test.go
+++ b/processor/rule/cron_substitution_test.go
@@ -1,0 +1,199 @@
+package rule
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+)
+
+func TestApplyScheduleSubstitutions_AllTokens(t *testing.T) {
+	t.Parallel()
+
+	sc := &ScheduleContext{
+		ID:          "weekly-planning",
+		Spec:        "0 9 * * MON",
+		LastFiredAt: time.Date(2026, 4, 27, 9, 0, 0, 0, time.UTC),
+	}
+
+	in := "rule=$schedule.id spec=$schedule.spec last=$schedule.last_fired_at"
+	want := "rule=weekly-planning spec=0 9 * * MON last=2026-04-27T09:00:00Z"
+	if got := applyScheduleSubstitutions(in, sc); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestApplyScheduleSubstitutions_NilContextIsNoop(t *testing.T) {
+	t.Parallel()
+
+	in := "rule=$schedule.id"
+	if got := applyScheduleSubstitutions(in, nil); got != in {
+		t.Errorf("got %q, want unchanged %q", got, in)
+	}
+}
+
+// First fire renders LastFiredAt as the empty string (not the Go zero
+// value `0001-01-01T00:00:00Z`). Authors then detect first-fire by
+// branching on emptiness without having to special-case the magic
+// literal.
+func TestApplyScheduleSubstitutions_FirstFireRendersEmpty(t *testing.T) {
+	t.Parallel()
+
+	sc := &ScheduleContext{
+		ID:   "fresh",
+		Spec: "@hourly",
+		// LastFiredAt left as zero value
+	}
+	out := applyScheduleSubstitutions("[$schedule.last_fired_at]", sc)
+	if out != "[]" {
+		t.Errorf("got %q, want %q (zero LastFiredAt should render empty)", out, "[]")
+	}
+}
+
+func TestApplyScheduleSubstitutions_NonUTCNormalised(t *testing.T) {
+	t.Parallel()
+
+	loc, _ := time.LoadLocation("America/New_York")
+	sc := &ScheduleContext{
+		ID:          "rule",
+		Spec:        "@hourly",
+		LastFiredAt: time.Date(2026, 4, 27, 5, 0, 0, 0, loc), // 09:00 UTC
+	}
+	out := applyScheduleSubstitutions("$schedule.last_fired_at", sc)
+	if !strings.HasSuffix(out, "Z") {
+		t.Errorf("got %q, want UTC RFC3339 (Z suffix)", out)
+	}
+	if out != "2026-04-27T09:00:00Z" {
+		t.Errorf("got %q, want 2026-04-27T09:00:00Z", out)
+	}
+}
+
+func TestApplyScheduleSubstitutions_UnknownTokenSurvives(t *testing.T) {
+	t.Parallel()
+
+	sc := &ScheduleContext{ID: "r", Spec: "@hourly"}
+	in := "$schedule.unknown_field"
+	out := applyScheduleSubstitutions(in, sc)
+	if out != in {
+		t.Errorf("got %q, want unchanged %q (unknown $schedule.* should survive substitution and trip warn-on-unresolved)", out, in)
+	}
+}
+
+// The cron substitution layer must compose cleanly with the existing
+// $entity.* / $state.* substitutions. Confirms the future per-entity
+// fan-out path: an ExecutionContext with both Schedule and Entity
+// populated substitutes both namespaces in a single template call.
+// [retrofit-safe]
+func TestExecutionContext_ScheduleAndEntityCoexist(t *testing.T) {
+	t.Parallel()
+
+	ec := &ExecutionContext{
+		EntityID: "drone.001",
+		Entity: &gtypes.EntityState{
+			ID: "drone.001",
+			Triples: []message.Triple{
+				{Subject: "drone.001", Predicate: "agent.role", Object: "scout"},
+			},
+		},
+		Schedule: &ScheduleContext{
+			ID:          "weekly",
+			Spec:        "0 9 * * MON",
+			LastFiredAt: time.Date(2026, 4, 27, 9, 0, 0, 0, time.UTC),
+		},
+	}
+
+	in := "rule=$schedule.id entity=$entity.id role=$entity.triple.agent.role last=$schedule.last_fired_at"
+	want := "rule=weekly entity=drone.001 role=scout last=2026-04-27T09:00:00Z"
+	if got := ec.SubstituteVariables(in); got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+// An expression rule (Schedule == nil) that mistakenly references
+// $schedule.* tokens must surface them via the unresolved-template
+// regex, NOT silently render as empty. This is the regression guard
+// for cross-namespace leakage.
+func TestExecutionContext_ScheduleTokenInExpressionRuleSurvives(t *testing.T) {
+	t.Parallel()
+
+	ec := &ExecutionContext{
+		EntityID: "drone.001",
+		// Schedule deliberately nil — we're an expression rule
+	}
+
+	in := "$schedule.id"
+	out := ec.SubstituteVariables(in)
+	if out != in {
+		t.Errorf("got %q, want unchanged %q (cron-only $schedule.* must not silently empty in expression-rule path)", out, in)
+	}
+}
+
+// Locks the current contract for re-substitution: schedule values are
+// substituted sequentially via strings.ReplaceAll, so a value that
+// contains another `$schedule.*` token will get expanded by a later
+// pass. Today this is benign because sc.ID and sc.Spec come from
+// author-controlled config (rule ID + cron expression — neither plausibly
+// holds a substitution token). The test pins the behavior so a future
+// refactor that switches to single-pass regex substitution makes a
+// deliberate, observable choice rather than silently changing semantics.
+func TestApplyScheduleSubstitutions_ValueWithEmbeddedToken(t *testing.T) {
+	t.Parallel()
+
+	sc := &ScheduleContext{
+		ID:   "$schedule.spec", // pathological, but we want to lock behavior
+		Spec: "@hourly",
+	}
+	out := applyScheduleSubstitutions("$schedule.id", sc)
+	// Current sequential implementation: $schedule.id → "$schedule.spec"
+	// → "@hourly" (second pass expands the embedded token).
+	if out != "@hourly" {
+		t.Errorf("got %q, want %q (sequential ReplaceAll re-expands embedded token; locks the contract)", out, "@hourly")
+	}
+}
+
+func TestExecutionContext_SubstituteVariables_ScheduleNamespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ec       *ExecutionContext
+		template string
+		want     string
+	}{
+		{
+			name: "schedule.id only",
+			ec: &ExecutionContext{
+				Schedule: &ScheduleContext{ID: "r1", Spec: "@hourly"},
+			},
+			template: "id=$schedule.id",
+			want:     "id=r1",
+		},
+		{
+			name: "schedule.spec only",
+			ec: &ExecutionContext{
+				Schedule: &ScheduleContext{ID: "r1", Spec: "0 9 * * MON"},
+			},
+			template: "spec=$schedule.spec",
+			want:     "spec=0 9 * * MON",
+		},
+		{
+			name: "schedule.last_fired_at first fire",
+			ec: &ExecutionContext{
+				Schedule: &ScheduleContext{ID: "r1", Spec: "@hourly"},
+			},
+			template: "last=[$schedule.last_fired_at]",
+			want:     "last=[]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.ec.SubstituteVariables(tt.template)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/processor/rule/execution_context.go
+++ b/processor/rule/execution_context.go
@@ -11,19 +11,20 @@ import (
 	gtypes "github.com/c360studio/semstreams/graph"
 )
 
-// unresolvedTemplateVarRe matches any $entity.*, $related.*, or $state.*
-// token that survived substitution. These should never appear in a final
-// string: if they do, either the predicate is missing from the entity at
-// fire-time (common with race-y triple arrival), the ExecutionContext
-// wasn't populated, or the author used a name that doesn't match any known
-// substitution.
+// unresolvedTemplateVarRe matches any $entity.*, $related.*, $state.*,
+// or $schedule.* token that survived substitution. These should never
+// appear in a final string: if they do, either the predicate is missing
+// from the entity at fire-time (common with race-y triple arrival), the
+// ExecutionContext wasn't populated (e.g. a cron-only $schedule.* token
+// reached an expression-rule path, or vice versa), or the author used a
+// name that doesn't match any known substitution.
 //
 // Pattern rationale: first character after the dot must be a word char
 // (letter/digit/underscore), then any run of word chars and dots lets us
 // match deep predicate paths like $entity.triple.agent.loop.role. We stop
 // at any other character so legitimate adjacent syntax (e.g. "$entity.id.")
 // doesn't over-match.
-var unresolvedTemplateVarRe = regexp.MustCompile(`\$(?:entity|related|state)\.\w[\w.]*`)
+var unresolvedTemplateVarRe = regexp.MustCompile(`\$(?:entity|related|state|schedule)\.\w[\w.]*`)
 
 // ExecutionContext carries typed data through the rule evaluation → action pipeline.
 // It replaces the previous (entityID, relatedID string) action signature, providing
@@ -44,6 +45,13 @@ type ExecutionContext struct {
 	// State is the current match state including iteration tracking.
 	// May be nil for first evaluation before state is persisted.
 	State *MatchState
+
+	// Schedule carries cron-rule context (rule ID, spec, prior fire
+	// timestamp). Populated by CronScheduler.fire on time-driven
+	// dispatches; nil for message-path and KV-watch rules. The
+	// `$schedule.*` substitution layer reads this; see
+	// cron_substitution.go for the namespace contract.
+	Schedule *ScheduleContext
 }
 
 // RuleID returns the originating rule's identifier, or an empty string if the
@@ -59,19 +67,24 @@ func (ec *ExecutionContext) RuleID() string {
 
 // SubstituteVariables replaces template variables with values from the execution context.
 // Supported variables:
+//   - $now: Current wallclock as RFC3339 UTC (always available)
 //   - $entity.id: The primary entity ID
 //   - $related.id: The related entity ID (for pair rules)
 //   - $state.iteration: Current iteration count
 //   - $state.max_iterations: Configured max iterations
+//   - $schedule.id: Cron rule ID (cron rules only)
+//   - $schedule.spec: Cron expression (cron rules only)
+//   - $schedule.last_fired_at: Prior fire timestamp, RFC3339 UTC; empty on first fire
 //
 // Entity triple values can be accessed via $entity.triple.<predicate> syntax.
 //
 // If any template variable survives substitution (e.g. $entity.triple.X
 // where X isn't on the entity at fire time — a common race with
-// late-arriving triples), the literal stays in the output and a warning is
-// logged so the author sees the silent-pass. Downstream callers that feed
-// the result into an identifier (KV key, NATS subject) will then get a
-// loud failure instead of mysteriously wrong behaviour.
+// late-arriving triples, or a cron-only $schedule.* token reaching an
+// expression rule), the literal stays in the output and a warning is
+// logged so the author sees the silent-pass. Downstream callers that
+// feed the result into an identifier (KV key, NATS subject) will then
+// get a loud failure instead of mysteriously wrong behaviour.
 func (ec *ExecutionContext) SubstituteVariables(template string) string {
 	result := template
 
@@ -95,6 +108,11 @@ func (ec *ExecutionContext) SubstituteVariables(template string) string {
 			result = strings.ReplaceAll(result, key, fmt.Sprintf("%v", triple.Object))
 		}
 	}
+
+	// Schedule substitutions (cron rules only). No-op when ec.Schedule
+	// is nil; unknown $schedule.* tokens will then trip the
+	// unresolved-template warning below.
+	result = applyScheduleSubstitutions(result, ec.Schedule)
 
 	ec.warnUnresolvedTemplateVars(template, result)
 

--- a/processor/rule/processor.go
+++ b/processor/rule/processor.go
@@ -611,7 +611,12 @@ func (rp *Processor) initializeCronScheduler() error {
 		return fmt.Errorf("cannot initialize cron scheduler: action executor not initialized")
 	}
 
-	scheduler, err := NewCronScheduler(rp.actionExecutor, rp.scheduleTracker, rp.logger)
+	scheduler, err := NewCronScheduler(CronSchedulerConfig{
+		Executor: rp.actionExecutor,
+		Tracker:  rp.scheduleTracker,
+		Metrics:  getCronMetrics(rp.metricsRegistry),
+		Logger:   rp.logger,
+	})
 	if err != nil {
 		return fmt.Errorf("create cron scheduler: %w", err)
 	}

--- a/processor/rule/processor.go
+++ b/processor/rule/processor.go
@@ -159,6 +159,14 @@ type Processor struct {
 	// register rules added after startup.
 	cronScheduler *CronScheduler
 
+	// scheduleTracker persists per-rule last-fired timestamps to the
+	// RULE_SCHEDULES KV bucket. Created in initializeScheduleTracker
+	// (called from Start before initializeCronScheduler so the scheduler
+	// can hold a reference). Nil when bucket creation fails — the
+	// scheduler degrades to in-memory-only firing (no missed-fire
+	// detection across restarts) rather than refusing to start.
+	scheduleTracker *ScheduleTracker
+
 	// Revision tracking for per-rule feedback loop prevention.
 	// Keyed by (ruleID, entityID) → KV revision → tracked-at timestamp.
 	// A watcher update at one of those revisions skips only the rule that
@@ -543,6 +551,52 @@ func (rp *Processor) initializeStateTracker(ctx context.Context) error {
 	return nil
 }
 
+// initializeScheduleTracker creates the RULE_SCHEDULES KV bucket and binds
+// a ScheduleTracker to it. The bucket holds per-rule last-fired timestamps
+// used by the cron scheduler for missed-fire detection on restart and by
+// out-of-process readers (governance startup hooks) that need to issue
+// catch-up sweeps.
+//
+// Bucket creation is best-effort: failure leaves rp.scheduleTracker nil
+// and the scheduler runs without persistence, matching the same
+// degrade-gracefully posture initializeStateTracker uses for RULE_STATE.
+// History=1 (only current state matters), no TTL (last-fired records
+// outlive any operationally meaningful interval), no size cap.
+func (rp *Processor) initializeScheduleTracker(ctx context.Context) error {
+	if rp.natsClient == nil {
+		// Test paths and graph-only deployments construct the processor
+		// without NATS. The scheduler tolerates a nil tracker; logging
+		// at Debug avoids noise in those paths.
+		rp.logger.Debug("Skipping schedule tracker init: no NATS client")
+		return nil
+	}
+
+	js, err := rp.natsClient.JetStream()
+	if err != nil {
+		return fmt.Errorf("get JetStream context: %w", err)
+	}
+
+	bucket, err := js.KeyValue(ctx, ScheduleBucketName)
+	if err != nil {
+		bucket, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+			Bucket:      ScheduleBucketName,
+			Description: "Per-rule last-fired timestamps for cron rule missed-fire detection",
+			TTL:         0,  // Records persist for the rule's lifecycle.
+			MaxBytes:    -1, // No size cap; one small record per cron rule.
+			History:     1,  // Only the most recent fire matters.
+		})
+		if err != nil {
+			return fmt.Errorf("create %s bucket: %w", ScheduleBucketName, err)
+		}
+		rp.logger.Info("Created RULE_SCHEDULES KV bucket for cron rule fire tracking")
+	} else {
+		rp.logger.Info("Using existing RULE_SCHEDULES KV bucket")
+	}
+
+	rp.scheduleTracker = NewScheduleTracker(bucket, rp.logger)
+	return nil
+}
+
 // initializeCronScheduler builds the CronScheduler against the shared
 // ActionExecutor and registers all cron rules already loaded by Initialize.
 // It is called from Start under rp.mu.Lock so the registration loop sees a
@@ -557,7 +611,7 @@ func (rp *Processor) initializeCronScheduler() error {
 		return fmt.Errorf("cannot initialize cron scheduler: action executor not initialized")
 	}
 
-	scheduler, err := NewCronScheduler(rp.actionExecutor, rp.logger)
+	scheduler, err := NewCronScheduler(rp.actionExecutor, rp.scheduleTracker, rp.logger)
 	if err != nil {
 		return fmt.Errorf("create cron scheduler: %w", err)
 	}
@@ -608,6 +662,16 @@ func (rp *Processor) Start(ctx context.Context) error {
 	if err := rp.initializeStateTracker(ctx); err != nil {
 		rp.logger.Warn("Failed to initialize state tracker, stateful rules will be disabled", "error", err)
 		// Don't fail - processor can still work with stateless rules
+	}
+
+	// Initialize ScheduleTracker for cron rule missed-fire detection.
+	// Must precede initializeCronScheduler so the scheduler can hold a
+	// reference. Failure leaves rp.scheduleTracker nil; the scheduler
+	// then runs without persistence (no missed-fire detection across
+	// restarts), which is the same posture as stateful-rule degradation.
+	if err := rp.initializeScheduleTracker(ctx); err != nil {
+		rp.logger.Warn("Failed to initialize schedule tracker, cron missed-fire detection disabled",
+			"error", err)
 	}
 
 	// Build the cron scheduler and register any cron rules already loaded by

--- a/processor/rule/processor.go
+++ b/processor/rule/processor.go
@@ -137,6 +137,28 @@ type Processor struct {
 	stateTracker      *StateTracker
 	statefulEvaluator *StatefulEvaluator
 
+	// actionExecutor is shared between the StatefulEvaluator (message-path
+	// and KV-watch firings) and the CronScheduler (time-driven firings).
+	// Constructed in initializeStateTracker; read without holding mu since
+	// it is set once before any goroutine that uses it can start.
+	actionExecutor ActionExecutorInterface
+
+	// cronRules holds parsed CronRule definitions, keyed by rule ID. Cron
+	// rules live in a parallel registry from rp.rules because CronRule does
+	// not implement the Rule interface (Subscribe/Evaluate/ExecuteEvents are
+	// message-driven concepts that don't fit time-driven firing). Writers:
+	// loadRules and applyRuleChanges, both under mu.Lock; reads only happen
+	// from those same paths so the map needs no separate synchronization.
+	cronRules map[string]*CronRule
+
+	// cronScheduler dispatches CronRule actions on cron schedules. Created
+	// in initializeCronScheduler (called from Start, after the state tracker
+	// and ActionExecutor are ready). Started in run(), drained in Stop().
+	// Nil when no cron rules are configured AND the scheduler hasn't been
+	// pre-built — currently we always build it at Start so hot-reload can
+	// register rules added after startup.
+	cronScheduler *CronScheduler
+
 	// Revision tracking for per-rule feedback loop prevention.
 	// Keyed by (ruleID, entityID) → KV revision → tracked-at timestamp.
 	// A watcher update at one of those revisions skips only the rule that
@@ -199,6 +221,7 @@ func NewProcessorWithMetrics(natsClient *natsclient.Client, config *Config, metr
 		ruleDefinitions:  make(map[string]Definition),
 		ruleConfigs:      make(map[string]map[string]any),
 		matchCounters:    make(map[string]*atomic.Int64),
+		cronRules:        make(map[string]*CronRule),
 		messageCache:     msgCache,
 		config:           config,
 		metricsRegistry:  metricsRegistry,
@@ -376,6 +399,28 @@ func (rp *Processor) run(ctx context.Context) {
 		return
 	}
 
+	// Start the cron scheduler now that watchers and subscriptions are up.
+	// Doing this after setupSubscriptions guarantees the publisher's NATS
+	// subjects are ready before the first cron tick can dispatch a publish
+	// action. The deferred Stop drains in-flight fires when run() returns
+	// (either via shutdown or ctx cancellation) before the rest of the
+	// processor's resources are torn down in Stop().
+	if rp.cronScheduler != nil {
+		if err := rp.cronScheduler.Start(ctx); err != nil {
+			rp.logger.Warn("Failed to start cron scheduler", "error", err)
+			// Drop the scheduler reference so RegisteredCount and any
+			// future metrics gauge cannot read a stale never-started
+			// instance. Subsequent hot-reload Register/Deregister calls
+			// fall through their `!= nil` guards and become no-ops, which
+			// matches the "scheduler unavailable" semantics.
+			rp.mu.Lock()
+			rp.cronScheduler = nil
+			rp.mu.Unlock()
+		} else {
+			defer rp.drainCronScheduler()
+		}
+	}
+
 	// NOW mark healthy - watchers established, subscriptions ready
 	rp.mu.Lock()
 	rp.health.Healthy = true
@@ -389,6 +434,30 @@ func (rp *Processor) run(ctx context.Context) {
 		rp.logger.Info("Rule processor shutdown requested")
 	case <-ctx.Done():
 		rp.logger.Info("Rule processor context cancelled", "error", ctx.Err())
+	}
+}
+
+// cronSchedulerDrainTimeout bounds how long run() will wait for in-flight
+// cron fires to complete on shutdown. Keeping it under the processor's own
+// 5-second Stop grace period avoids stacking timeouts; the worst case is a
+// single fire that's still running when the timer expires, which is logged
+// and abandoned (its action errors are already best-effort).
+const cronSchedulerDrainTimeout = 3 * time.Second
+
+// drainCronScheduler stops the scheduler and waits for in-flight fires to
+// complete, bounded by cronSchedulerDrainTimeout. Called from run() via a
+// deferred call so it executes after the shutdown select returns.
+func (rp *Processor) drainCronScheduler() {
+	if rp.cronScheduler == nil {
+		return
+	}
+	stopCtx := rp.cronScheduler.Stop()
+	select {
+	case <-stopCtx.Done():
+		rp.logger.Debug("Cron scheduler drained cleanly")
+	case <-time.After(cronSchedulerDrainTimeout):
+		rp.logger.Warn("Cron scheduler drain timeout — abandoning in-flight fires",
+			"timeout", cronSchedulerDrainTimeout)
 	}
 }
 
@@ -459,10 +528,52 @@ func (rp *Processor) initializeStateTracker(ctx context.Context) error {
 		setter.SetToolRegistry(rp.toolRegistry)
 	}
 
+	// Persist the executor on the processor so the cron scheduler
+	// (initializeCronScheduler) can dispatch through the same instance
+	// the StatefulEvaluator uses. Single shared executor keeps publishing
+	// semantics, triple-mutation feedback-loop tracking, and tool-registry
+	// resolution identical across the message-path, KV-watch, and
+	// time-driven firing paths.
+	rp.actionExecutor = actionExecutor
+
 	// Create StatefulEvaluator
 	rp.statefulEvaluator = NewStatefulEvaluator(rp.stateTracker, actionExecutor, rp.logger)
 
 	rp.logger.Info("State tracker initialized for stateful ECA rules")
+	return nil
+}
+
+// initializeCronScheduler builds the CronScheduler against the shared
+// ActionExecutor and registers all cron rules already loaded by Initialize.
+// It is called from Start under rp.mu.Lock so the registration loop sees a
+// stable rp.cronRules snapshot.
+//
+// The scheduler is built unconditionally — even if rp.cronRules is empty —
+// so hot-reloaded cron rules added after startup have a registry to land
+// in. Returns an error if the executor isn't ready (the state tracker init
+// failed and left rp.actionExecutor nil).
+func (rp *Processor) initializeCronScheduler() error {
+	if rp.actionExecutor == nil {
+		return fmt.Errorf("cannot initialize cron scheduler: action executor not initialized")
+	}
+
+	scheduler, err := NewCronScheduler(rp.actionExecutor, rp.logger)
+	if err != nil {
+		return fmt.Errorf("create cron scheduler: %w", err)
+	}
+
+	for ruleID, rule := range rp.cronRules {
+		if err := scheduler.Register(rule); err != nil {
+			rp.logger.Warn("Failed to register cron rule, skipping",
+				"rule_id", ruleID,
+				"error", err)
+			continue
+		}
+	}
+
+	rp.cronScheduler = scheduler
+	rp.logger.Info("Cron scheduler initialized",
+		"registered_rules", scheduler.RegisteredCount())
 	return nil
 }
 
@@ -497,6 +608,15 @@ func (rp *Processor) Start(ctx context.Context) error {
 	if err := rp.initializeStateTracker(ctx); err != nil {
 		rp.logger.Warn("Failed to initialize state tracker, stateful rules will be disabled", "error", err)
 		// Don't fail - processor can still work with stateless rules
+	}
+
+	// Build the cron scheduler and register any cron rules already loaded by
+	// Initialize. The scheduler is constructed even when the cronRules map is
+	// empty so that hot-reloaded cron rules added after startup have a place
+	// to land. Failure here is non-fatal: cron rules are skipped, expression
+	// rules continue to work.
+	if err := rp.initializeCronScheduler(); err != nil {
+		rp.logger.Warn("Failed to initialize cron scheduler, cron rules will be disabled", "error", err)
 	}
 
 	// Note: entityCoalescer is initialized in run() before spawning watchers

--- a/processor/rule/rule_factory.go
+++ b/processor/rule/rule_factory.go
@@ -53,6 +53,19 @@ type Definition struct {
 	// This is a parallel dimension to time-based AlertCooldownPeriod; neither
 	// replaces the other.
 	FireEveryNEvents int `json:"fire_every_n_events,omitempty"`
+
+	// Schedule is the cron expression for `type: "cron"` rules. Required
+	// when Type == "cron"; ignored otherwise. Supports POSIX 5-field
+	// (`min hour dom mon dow`) and the descriptors @hourly / @daily /
+	// @weekly / @monthly / @yearly. Parsed via robfig/cron/v3 at config
+	// load time; bad expressions fail rule construction.
+	Schedule string `json:"schedule,omitempty"`
+
+	// Actions is the action list for `type: "cron"` rules. Cron rules use
+	// this field instead of OnEnter/OnExit/WhileTrue because they have no
+	// state-transition semantics — every scheduled tick fires every Action
+	// here. Required when Type == "cron"; ignored otherwise.
+	Actions []Action `json:"actions,omitempty"`
 }
 
 // EntityConfig defines entity-specific configuration

--- a/processor/rule/rule_factory.go
+++ b/processor/rule/rule_factory.go
@@ -156,7 +156,12 @@ func GetRuleFactory(ruleType string) (Factory, bool) {
 	return factory, exists
 }
 
-// GetRegisteredRuleTypes returns all registered rule types
+// GetRegisteredRuleTypes returns all registered rule types.
+//
+// Note: built-in rule kinds that do not go through the factory registry
+// (today: "cron" — see CronRuleType) are not returned here. Callers that
+// need the complete known-types surface should also include them
+// explicitly. See isKnownRuleType for the validation-side equivalent.
 func GetRegisteredRuleTypes() []string {
 	factoryMutex.RLock()
 	defer factoryMutex.RUnlock()

--- a/processor/rule/rule_loader.go
+++ b/processor/rule/rule_loader.go
@@ -8,6 +8,50 @@ import (
 	"time"
 )
 
+// definitionToRuleMap converts a Definition to the same map[string]any
+// shape that hot-reload's KV-watcher delivers. Populated into
+// rp.ruleConfigs alongside rp.ruleDefinitions so the idempotency check
+// in applyCronRuleChange recognises the seed-then-reconcile reapply as
+// a no-op (preserves in-memory cron scheduler state — entry.lastFiredNanos
+// in particular — across the reconcile pass that immediately follows
+// seeding inline rules to KV).
+//
+// # Round-trip stability
+//
+// The reflect.DeepEqual idempotency check in applyCronRuleChange
+// requires that this function produces the SAME map shape as the
+// watcher path (KV.Get → json.Unmarshal-into-Definition → json.Marshal
+// → KV.Put → KV.Get → json.Unmarshal-into-map). Both paths converge
+// because every Definition field has a fixed-point JSON shape:
+//
+//   - Typed numerics stay typed (Conditions are typed Go slices, not
+//     interface{} containers — so the float64-vs-int worry that bites
+//     map[string]any users doesn't apply here).
+//   - nil-vs-empty-slice is preserved by Go's encoding/json.
+//   - Map-iteration order is irrelevant under reflect.DeepEqual.
+//   - The interface{} fields (Conditions[i].Value, Metadata) round-trip
+//     stably because they were written from JSON sources upstream.
+//
+// On marshal failure the function logs at Debug and returns nil. The
+// caller treats nil as "no cached config", so the idempotency check
+// just falls through and the reapply runs — same behaviour as before
+// this helper existed.
+func (rp *Processor) definitionToRuleMap(def Definition) map[string]any {
+	data, err := json.Marshal(def)
+	if err != nil {
+		rp.logger.Debug("definitionToRuleMap: marshal failed; idempotency cache miss",
+			"rule_id", def.ID, "error", err)
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		rp.logger.Debug("definitionToRuleMap: unmarshal failed; idempotency cache miss",
+			"rule_id", def.ID, "error", err)
+		return nil
+	}
+	return m
+}
+
 // loadRuleDefinitionsFromFiles loads rule definitions from JSON files
 func (rp *Processor) loadRuleDefinitionsFromFiles() ([]Definition, error) {
 	var allDefinitions []Definition
@@ -99,6 +143,7 @@ func (rp *Processor) loadRules() error {
 			}
 			rp.cronRules[def.ID] = cronRule
 			rp.ruleDefinitions[def.ID] = def
+			rp.ruleConfigs[def.ID] = rp.definitionToRuleMap(def)
 			rp.logger.Info("Loaded cron rule from definition",
 				"rule_id", def.ID,
 				"rule_name", def.Name,
@@ -119,6 +164,7 @@ func (rp *Processor) loadRules() error {
 
 		rp.rules[def.ID] = rule
 		rp.ruleDefinitions[def.ID] = def // Store definition for stateful evaluation
+		rp.ruleConfigs[def.ID] = rp.definitionToRuleMap(def)
 
 		// Initialize match counter for FireEveryNEvents gating. The counter
 		// starts at zero regardless of FireEveryNEvents value; the first Nth

--- a/processor/rule/rule_loader.go
+++ b/processor/rule/rule_loader.go
@@ -82,6 +82,31 @@ func (rp *Processor) loadRules() error {
 			continue
 		}
 
+		// Cron rules take a separate construction path: they don't go through
+		// the factory registry because CronRule does not implement the Rule
+		// interface (Subscribe/Evaluate/ExecuteEvents are message-driven and
+		// cron has no message). The scheduler picks them up later in
+		// initializeCronScheduler. Definition is stored on rp.ruleDefinitions
+		// so hot-reload, GetRuntimeConfig, and FireEveryNEvents accounting
+		// stay symmetric across rule kinds.
+		if def.Type == CronRuleType {
+			cronRule, err := NewCronRule(def)
+			if err != nil {
+				rp.logger.Error("Failed to create cron rule from definition",
+					"rule_id", def.ID,
+					"error", err)
+				continue
+			}
+			rp.cronRules[def.ID] = cronRule
+			rp.ruleDefinitions[def.ID] = def
+			rp.logger.Info("Loaded cron rule from definition",
+				"rule_id", def.ID,
+				"rule_name", def.Name,
+				"schedule", def.Schedule,
+				"action_count", len(def.Actions))
+			continue
+		}
+
 		// Create rule from definition
 		rule, err := CreateRuleFromDefinition(def, ruleDeps)
 		if err != nil {

--- a/processor/rule/runtime_config.go
+++ b/processor/rule/runtime_config.go
@@ -54,17 +54,26 @@ func (rp *Processor) ApplyConfigUpdate(changes map[string]any) error {
 
 // applyRuleChanges applies dynamic rule configuration changes
 func (rp *Processor) applyRuleChanges(rulesMap map[string]any) error {
-	// Ensure matchCounters and ruleDefinitions are initialized (struct-literal callers may omit them).
+	// Ensure maps are initialized (struct-literal callers may omit them).
 	if rp.matchCounters == nil {
 		rp.matchCounters = make(map[string]*atomic.Int64)
 	}
 	if rp.ruleDefinitions == nil {
 		rp.ruleDefinitions = make(map[string]Definition)
 	}
+	if rp.cronRules == nil {
+		rp.cronRules = make(map[string]*CronRule)
+	}
 
-	// Track rules to remove (existing rules not in new config)
+	// Track existing rules in both registries so we can compute removals at
+	// the end. Cron rules and expression rules share the same ID namespace
+	// — a rule cannot switch types in place; the deletion + re-add path
+	// handles type changes naturally.
 	currentRuleIDs := make(map[string]bool)
 	for ruleID := range rp.rules {
+		currentRuleIDs[ruleID] = true
+	}
+	for ruleID := range rp.cronRules {
 		currentRuleIDs[ruleID] = true
 	}
 
@@ -74,39 +83,21 @@ func (rp *Processor) applyRuleChanges(rulesMap map[string]any) error {
 
 		ruleMap := ruleConfig.(map[string]any) // Validated in ValidateConfigUpdate
 
-		// Create or update rule
-		newRule, def, err := rp.createRuleFromConfig(ruleID, ruleMap)
-		if err != nil {
-			return fmt.Errorf("failed to create rule %s: %w", ruleID, err)
+		if t, _ := ruleMap["type"].(string); t == CronRuleType {
+			if err := rp.applyCronRuleChange(ruleID, ruleMap); err != nil {
+				return err
+			}
+			continue
 		}
 
-		// Install new rule (replacing any existing rule).
-		rp.rules[ruleID] = newRule
-
-		// Store the full Definition so FireEveryNEvents gating and stateful actions
-		// (OnEnter/OnExit/WhileTrue) are honoured for hot-reloaded rules. Without
-		// this, hasDefinition==false in message_handler.go and both the sampling
-		// gate and stateful-action branches are bypassed.
-		rp.ruleDefinitions[ruleID] = def
-
-		// Store rule configuration for GetRuntimeConfig
-		rp.ruleConfigs[ruleID] = ruleMap
-
-		// Reset (or create) the match counter for this rule. A policy change
-		// implies a fresh rhythm: the caller's intent on update is "apply this
-		// new definition from here on," not "preserve the previous counter state."
-		rp.matchCounters[ruleID] = &atomic.Int64{}
-
-		rp.logger.Info("Applied rule configuration", "rule_id", ruleID, "rule_type", ruleMap["type"])
+		if err := rp.applyExpressionRuleChange(ruleID, ruleMap); err != nil {
+			return err
+		}
 	}
 
 	// Remove rules that are no longer configured
 	for ruleID := range currentRuleIDs {
-		delete(rp.rules, ruleID)
-		delete(rp.ruleDefinitions, ruleID)
-		delete(rp.ruleConfigs, ruleID)
-		delete(rp.matchCounters, ruleID)
-		rp.logger.Info("Removed rule", "rule_id", ruleID)
+		rp.removeRule(ruleID)
 	}
 
 	// Update active rules metric
@@ -115,6 +106,98 @@ func (rp *Processor) applyRuleChanges(rulesMap map[string]any) error {
 	}
 
 	return nil
+}
+
+// applyCronRuleChange installs or replaces a cron rule definition. If a
+// rule with the same ID already exists in either registry it is dropped
+// from both before the new cron rule is registered, which makes type
+// swaps (expression → cron) symmetric with applyExpressionRuleChange.
+//
+// Caller holds rp.mu.Lock.
+func (rp *Processor) applyCronRuleChange(ruleID string, ruleMap map[string]any) error {
+	def, err := definitionFromMap(ruleID, ruleMap)
+	if err != nil {
+		return fmt.Errorf("failed to parse cron rule %s: %w", ruleID, err)
+	}
+	cronRule, err := NewCronRule(def)
+	if err != nil {
+		return fmt.Errorf("failed to create cron rule %s: %w", ruleID, err)
+	}
+
+	// Validate-then-mutate ordering: register on the scheduler BEFORE we
+	// touch the rp.* maps. If Register fails, the rule isn't yet visible
+	// in cronRules/ruleDefinitions/ruleConfigs and the operator just sees
+	// the error — no inconsistent half-state where the maps say
+	// "registered" but the scheduler doesn't.
+	if rp.cronScheduler != nil {
+		// Deregister is a no-op when the rule isn't registered, so
+		// first-time additions and replacements share one path. The
+		// replacement is logically atomic from the operator's perspective;
+		// in the worst case a tick lands between Deregister and Register
+		// and is dropped, which matches the log-only missed-fire policy.
+		rp.cronScheduler.Deregister(ruleID)
+		if err := rp.cronScheduler.Register(cronRule); err != nil {
+			return fmt.Errorf("failed to register cron rule %s: %w", ruleID, err)
+		}
+	}
+
+	// Drop any previous Rule-typed entry under this ID (type swap), then
+	// install the new cron-side bookkeeping.
+	delete(rp.rules, ruleID)
+	delete(rp.matchCounters, ruleID)
+	rp.cronRules[ruleID] = cronRule
+	rp.ruleDefinitions[ruleID] = def
+	rp.ruleConfigs[ruleID] = ruleMap
+
+	rp.logger.Info("Applied cron rule configuration",
+		"rule_id", ruleID,
+		"schedule", def.Schedule,
+		"action_count", len(def.Actions))
+	return nil
+}
+
+// applyExpressionRuleChange installs or replaces an expression-style rule.
+// Drops any previous CronRule under the same ID first to keep type swaps
+// symmetric with applyCronRuleChange.
+//
+// Caller holds rp.mu.Lock.
+func (rp *Processor) applyExpressionRuleChange(ruleID string, ruleMap map[string]any) error {
+	newRule, def, err := rp.createRuleFromConfig(ruleID, ruleMap)
+	if err != nil {
+		return fmt.Errorf("failed to create rule %s: %w", ruleID, err)
+	}
+
+	if _, hadCron := rp.cronRules[ruleID]; hadCron {
+		if rp.cronScheduler != nil {
+			rp.cronScheduler.Deregister(ruleID)
+		}
+		delete(rp.cronRules, ruleID)
+	}
+
+	rp.rules[ruleID] = newRule
+	rp.ruleDefinitions[ruleID] = def
+	rp.ruleConfigs[ruleID] = ruleMap
+	rp.matchCounters[ruleID] = &atomic.Int64{}
+
+	rp.logger.Info("Applied rule configuration", "rule_id", ruleID, "rule_type", ruleMap["type"])
+	return nil
+}
+
+// removeRule drops a rule from every registry it might appear in (rules,
+// cronRules, scheduler, definitions, configs, matchCounters). Called from
+// the removals loop in applyRuleChanges. Caller holds rp.mu.Lock.
+func (rp *Processor) removeRule(ruleID string) {
+	if _, isCron := rp.cronRules[ruleID]; isCron {
+		if rp.cronScheduler != nil {
+			rp.cronScheduler.Deregister(ruleID)
+		}
+		delete(rp.cronRules, ruleID)
+	}
+	delete(rp.rules, ruleID)
+	delete(rp.ruleDefinitions, ruleID)
+	delete(rp.ruleConfigs, ruleID)
+	delete(rp.matchCounters, ruleID)
+	rp.logger.Info("Removed rule", "rule_id", ruleID)
 }
 
 // GetRuntimeConfig returns current runtime configuration

--- a/processor/rule/runtime_config.go
+++ b/processor/rule/runtime_config.go
@@ -1,6 +1,7 @@
 package rule
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 
@@ -172,6 +173,7 @@ func (rp *Processor) applyExpressionRuleChange(ruleID string, ruleMap map[string
 			rp.cronScheduler.Deregister(ruleID)
 		}
 		delete(rp.cronRules, ruleID)
+		rp.deleteScheduleRecord(ruleID)
 	}
 
 	rp.rules[ruleID] = newRule
@@ -192,12 +194,35 @@ func (rp *Processor) removeRule(ruleID string) {
 			rp.cronScheduler.Deregister(ruleID)
 		}
 		delete(rp.cronRules, ruleID)
+		rp.deleteScheduleRecord(ruleID)
 	}
 	delete(rp.rules, ruleID)
 	delete(rp.ruleDefinitions, ruleID)
 	delete(rp.ruleConfigs, ruleID)
 	delete(rp.matchCounters, ruleID)
 	rp.logger.Info("Removed rule", "rule_id", ruleID)
+}
+
+// deleteScheduleRecord clears the persisted last-fired record for a cron
+// rule that's being removed or type-swapped to expression. Best-effort:
+// failures log a Warn but do not block the rule removal — a stale record
+// is purely an observability concern, and a future re-add of the same
+// rule ID will overwrite the record on its first fire.
+//
+// Uses context.Background() because this runs under rp.mu.Lock from
+// hot-reload paths (ApplyConfigUpdate) where no caller-supplied context
+// is available. The KV Delete is fast and idempotent; the underlying
+// NATS client enforces its own request timeout, so an unbounded ctx
+// here is bounded in practice.
+func (rp *Processor) deleteScheduleRecord(ruleID string) {
+	if rp.scheduleTracker == nil {
+		return
+	}
+	if err := rp.scheduleTracker.Delete(context.Background(), ruleID); err != nil {
+		rp.logger.Warn("Failed to delete schedule record on rule removal",
+			"rule_id", ruleID,
+			"error", err)
+	}
 }
 
 // GetRuntimeConfig returns current runtime configuration

--- a/processor/rule/runtime_config.go
+++ b/processor/rule/runtime_config.go
@@ -3,6 +3,7 @@ package rule
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync/atomic"
 
 	"github.com/c360studio/semstreams/pkg/errs"
@@ -114,8 +115,24 @@ func (rp *Processor) applyRuleChanges(rulesMap map[string]any) error {
 // from both before the new cron rule is registered, which makes type
 // swaps (expression → cron) symmetric with applyExpressionRuleChange.
 //
+// Idempotent on identical re-applies: when ruleMap equals the previously-
+// stored config for this ID, the function is a no-op. This matters for
+// the seed-then-reconcile path used at startup with InlineRules — the
+// inline rules get seeded to the KV bucket and the watcher's reconcile
+// pass replays them. Without the idempotency check, that replay would
+// Deregister + Register every cron rule, resetting in-memory cooldown
+// state and causing a transient "ignored cooldown" window right at
+// process startup.
+//
 // Caller holds rp.mu.Lock.
 func (rp *Processor) applyCronRuleChange(ruleID string, ruleMap map[string]any) error {
+	if existing, ok := rp.ruleConfigs[ruleID]; ok && reflect.DeepEqual(existing, ruleMap) {
+		// Same definition already applied. Skip the deregister-register
+		// hop — preserves entry.lastFiredNanos, tickCount, and any other
+		// in-memory scheduler state across the reconcile pass.
+		return nil
+	}
+
 	def, err := definitionFromMap(ruleID, ruleMap)
 	if err != nil {
 		return fmt.Errorf("failed to parse cron rule %s: %w", ruleID, err)

--- a/processor/rule/schedule_tracker.go
+++ b/processor/rule/schedule_tracker.go
@@ -1,0 +1,248 @@
+// Package rule - Schedule tracking for cron rule firing.
+//
+// ScheduleTracker persists per-rule last-fired timestamps to the
+// RULE_SCHEDULES KV bucket so that:
+//
+//  1. Restart-recovery can detect missed fires by comparing the persisted
+//     last-fired timestamp against the cron schedule's expected next fire.
+//  2. Operators (and downstream components like governance startup hooks)
+//     can read last-fire state without coupling to scheduler internals.
+//
+// The bucket is intentionally simple: one JSON record per rule, keyed by
+// rule ID. Records are upserted on every successful fire; they have no
+// TTL (retention is the rule's own enable/disable lifecycle).
+//
+// # Key shape (retrofit-safe)
+//
+// MVP keys are the bare rule ID — `{ruleID}` — because every cron rule
+// fires once globally per tick. When the deferred per-entity fan-out
+// extension lands (Definition.ForEach), keys will gain a `.{entityID}`
+// suffix to track last-fired per fanout target. Existing single-fire
+// rules keep the bare-rule-ID shape; the suffix is purely additive and
+// requires no migration. See ADR-031 retrofit seams for context.
+//
+// # External read access
+//
+// Governance startup hooks (kill-switch sweeps, chain-hash audits) need
+// to read last-fired timestamps to issue catch-up sweeps when a missed
+// fire crosses a meaningful interval. Two access patterns are supported:
+//
+//  1. In-process callers hold a *ScheduleTracker reference and call
+//     LastFiredAt(ctx, ruleID).
+//  2. Out-of-process callers read RULE_SCHEDULES KV directly using the
+//     documented record shape (LastFireRecord). Bucket name and JSON
+//     shape are part of the framework's public contract.
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// ScheduleBucketName is the canonical NATS KV bucket name for per-rule
+// last-fired timestamps. Exported so out-of-process readers (governance
+// startup hooks, ops dashboards) can address the bucket without
+// stringly-typed duplication.
+const ScheduleBucketName = "RULE_SCHEDULES"
+
+// LastFireRecord is the on-disk shape of a per-rule last-fired record.
+// JSON field names are part of the framework's public contract — out-of-
+// process readers depend on them; renames require a migration.
+type LastFireRecord struct {
+	// RuleID is the cron rule's stable identifier. Duplicates the KV key
+	// so that List() consumers can decode a record without re-threading
+	// the key alongside it.
+	RuleID string `json:"rule_id"`
+
+	// ScheduleSpec is the rule's cron expression at the time of the
+	// recorded fire. Useful for operators reading the bucket directly
+	// and for missed-fire detection that wants to compute the expected
+	// fire interval without re-loading rule definitions.
+	ScheduleSpec string `json:"schedule_spec"`
+
+	// LastFiredAt is the wallclock at which the most recent fire began
+	// dispatching actions. UTC; serialised RFC3339Nano via Go's default
+	// time.Time JSON encoder. Nanosecond precision is preserved best-
+	// effort across platforms — callers that depend on exact equality
+	// (e.g. round-trip tests) should truncate to a known resolution
+	// before write rather than relying on the encoder.
+	LastFiredAt time.Time `json:"last_fired_at"`
+}
+
+// ErrScheduleRecordNotFound is returned by LastFiredAt when no fire has
+// been recorded for the requested rule. Callers should treat this as
+// "never fired" rather than an error condition — it is the expected
+// state for a freshly-deployed rule.
+var ErrScheduleRecordNotFound = errors.New("schedule record not found")
+
+// ScheduleTracker persists last-fired timestamps for cron rules to KV.
+// Methods are safe for concurrent use; the underlying NATS KV client
+// already serialises writes.
+type ScheduleTracker struct {
+	bucket jetstream.KeyValue
+	logger *slog.Logger
+}
+
+// NewScheduleTracker builds a tracker bound to the supplied bucket. A
+// nil bucket is permitted so the rule processor can degrade gracefully
+// when bucket creation fails on startup — every method returns an error
+// when bucket is nil rather than panicking, mirroring StateTracker's
+// nil-tolerant behaviour.
+func NewScheduleTracker(bucket jetstream.KeyValue, logger *slog.Logger) *ScheduleTracker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ScheduleTracker{
+		bucket: bucket,
+		logger: logger,
+	}
+}
+
+// LastFiredAt returns the most recent fire timestamp for the given rule.
+// Returns ErrScheduleRecordNotFound when no fire has been recorded — the
+// caller should treat that as "never fired", not as an error to surface.
+//
+// The schedule spec stored alongside the timestamp is returned too so
+// missed-fire detection can compute the expected interval without
+// re-loading the live rule definition (which may have been hot-reloaded
+// to a different spec since the last fire).
+func (st *ScheduleTracker) LastFiredAt(ctx context.Context, ruleID string) (LastFireRecord, error) {
+	if ruleID == "" {
+		return LastFireRecord{}, fmt.Errorf("rule ID cannot be empty")
+	}
+	if st.bucket == nil {
+		return LastFireRecord{}, fmt.Errorf("schedule tracker bucket is nil")
+	}
+
+	entry, err := st.bucket.Get(ctx, scheduleKey(ruleID))
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return LastFireRecord{}, ErrScheduleRecordNotFound
+		}
+		return LastFireRecord{}, fmt.Errorf("get schedule record: %w", err)
+	}
+
+	var rec LastFireRecord
+	if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+		return LastFireRecord{}, fmt.Errorf("unmarshal schedule record: %w", err)
+	}
+	return rec, nil
+}
+
+// RecordFire upserts the last-fired record for the given rule. Called by
+// CronScheduler.fire after a successful action dispatch. The schedule
+// spec is captured at the moment of the fire so a hot-reload that
+// changes the cron expression doesn't retroactively rewrite history.
+//
+// Errors are surfaced to the caller; the scheduler logs them as warnings
+// (a transient KV write failure must not crash the scheduler goroutine —
+// the next fire will overwrite the record).
+func (st *ScheduleTracker) RecordFire(ctx context.Context, ruleID, scheduleSpec string, firedAt time.Time) error {
+	if ruleID == "" {
+		return fmt.Errorf("rule ID cannot be empty")
+	}
+	if st.bucket == nil {
+		return fmt.Errorf("schedule tracker bucket is nil")
+	}
+
+	rec := LastFireRecord{
+		RuleID:       ruleID,
+		ScheduleSpec: scheduleSpec,
+		LastFiredAt:  firedAt.UTC(),
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshal schedule record: %w", err)
+	}
+	if _, err := st.bucket.Put(ctx, scheduleKey(ruleID), data); err != nil {
+		return fmt.Errorf("put schedule record: %w", err)
+	}
+	return nil
+}
+
+// Bucket returns the underlying jetstream.KeyValue handle. Exposed so
+// in-process callers (governance startup hooks, ops dashboards in the
+// same binary) can use the full KV API — Watch for live updates,
+// ListKeys for filtered scans — without re-resolving the bucket via
+// js.KeyValue. The returned handle may be nil if the tracker was
+// constructed in nil-bucket mode (degraded startup); callers must
+// nil-check.
+func (st *ScheduleTracker) Bucket() jetstream.KeyValue {
+	return st.bucket
+}
+
+// Delete removes the persisted record for a rule. Called when a rule is
+// removed from configuration so stale records don't linger. Missing
+// records are treated as success — Delete is idempotent.
+func (st *ScheduleTracker) Delete(ctx context.Context, ruleID string) error {
+	if st.bucket == nil {
+		return fmt.Errorf("schedule tracker bucket is nil")
+	}
+	err := st.bucket.Delete(ctx, scheduleKey(ruleID))
+	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
+		return fmt.Errorf("delete schedule record: %w", err)
+	}
+	return nil
+}
+
+// List returns every persisted last-fire record. Used by the scheduler
+// on Start to detect missed fires and by operators inspecting bucket
+// state. Records are returned in undefined order; callers that need a
+// stable order should sort by RuleID.
+//
+// A bucket with no records returns an empty slice and no error.
+func (st *ScheduleTracker) List(ctx context.Context) ([]LastFireRecord, error) {
+	if st.bucket == nil {
+		return nil, fmt.Errorf("schedule tracker bucket is nil")
+	}
+
+	keys, err := st.bucket.Keys(ctx)
+	if err != nil {
+		// NATS KV returns ErrNoKeysFound for an empty bucket; treat as
+		// empty rather than an error to keep the caller's branch count
+		// low (the on-startup walk runs against a clean bucket on first
+		// deploy).
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list schedule keys: %w", err)
+	}
+
+	records := make([]LastFireRecord, 0, len(keys))
+	for _, k := range keys {
+		entry, err := st.bucket.Get(ctx, k)
+		if err != nil {
+			// Skip records that disappeared between Keys and Get — the
+			// scheduler treats missing records as "never fired" anyway.
+			if errors.Is(err, jetstream.ErrKeyNotFound) {
+				continue
+			}
+			st.logger.Warn("Failed to read schedule record",
+				"key", k,
+				"error", err)
+			continue
+		}
+		var rec LastFireRecord
+		if err := json.Unmarshal(entry.Value(), &rec); err != nil {
+			st.logger.Warn("Skipping malformed schedule record",
+				"key", k,
+				"error", err)
+			continue
+		}
+		records = append(records, rec)
+	}
+	return records, nil
+}
+
+// scheduleKey returns the KV key for a rule's last-fire record. Kept as
+// a single chokepoint so the future per-entity fan-out extension can
+// add a suffix here without rewriting every call site.
+func scheduleKey(ruleID string) string {
+	return ruleID
+}

--- a/processor/rule/schedule_tracker_test.go
+++ b/processor/rule/schedule_tracker_test.go
@@ -1,0 +1,447 @@
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func newScheduleTrackerForTest() (*ScheduleTracker, *mockKVBucket) {
+	bucket := newMockKVBucket()
+	return NewScheduleTracker(bucket, slog.Default()), bucket
+}
+
+func TestScheduleTracker_RecordFire_AndRead(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	ctx := context.Background()
+	fired := time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC)
+
+	if err := tracker.RecordFire(ctx, "weekly-planning", "0 9 * * MON", fired); err != nil {
+		t.Fatalf("RecordFire = %v, want nil", err)
+	}
+
+	rec, err := tracker.LastFiredAt(ctx, "weekly-planning")
+	if err != nil {
+		t.Fatalf("LastFiredAt = %v, want nil", err)
+	}
+	if rec.RuleID != "weekly-planning" {
+		t.Errorf("RuleID = %q, want weekly-planning", rec.RuleID)
+	}
+	if rec.ScheduleSpec != "0 9 * * MON" {
+		t.Errorf("ScheduleSpec = %q, want 0 9 * * MON", rec.ScheduleSpec)
+	}
+	if !rec.LastFiredAt.Equal(fired) {
+		t.Errorf("LastFiredAt = %v, want %v", rec.LastFiredAt, fired)
+	}
+}
+
+func TestScheduleTracker_RecordFire_NormalizesToUTC(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	ctx := context.Background()
+
+	loc, _ := time.LoadLocation("America/New_York")
+	local := time.Date(2026, 4, 30, 5, 0, 0, 0, loc) // 09:00 UTC
+
+	if err := tracker.RecordFire(ctx, "weekly", "@hourly", local); err != nil {
+		t.Fatalf("RecordFire = %v", err)
+	}
+
+	rec, err := tracker.LastFiredAt(ctx, "weekly")
+	if err != nil {
+		t.Fatalf("LastFiredAt = %v", err)
+	}
+	if rec.LastFiredAt.Location() != time.UTC {
+		t.Errorf("LastFiredAt.Location = %v, want UTC", rec.LastFiredAt.Location())
+	}
+	if !rec.LastFiredAt.Equal(local) {
+		t.Errorf("LastFiredAt = %v, want %v", rec.LastFiredAt, local)
+	}
+}
+
+func TestScheduleTracker_LastFiredAt_NotFound(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	_, err := tracker.LastFiredAt(context.Background(), "never-fired")
+	if !errors.Is(err, ErrScheduleRecordNotFound) {
+		t.Errorf("err = %v, want ErrScheduleRecordNotFound", err)
+	}
+}
+
+func TestScheduleTracker_LastFiredAt_RejectsEmptyRuleID(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	if _, err := tracker.LastFiredAt(context.Background(), ""); err == nil {
+		t.Error("err = nil, want non-nil for empty ruleID")
+	}
+}
+
+func TestScheduleTracker_RecordFire_RejectsEmptyRuleID(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	if err := tracker.RecordFire(context.Background(), "", "@hourly", time.Now()); err == nil {
+		t.Error("err = nil, want non-nil for empty ruleID")
+	}
+}
+
+func TestScheduleTracker_NilBucket_AllMethodsError(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewScheduleTracker(nil, slog.Default())
+	ctx := context.Background()
+
+	if _, err := tracker.LastFiredAt(ctx, "any"); err == nil {
+		t.Error("LastFiredAt err = nil, want non-nil for nil bucket")
+	}
+	if err := tracker.RecordFire(ctx, "any", "@hourly", time.Now()); err == nil {
+		t.Error("RecordFire err = nil, want non-nil for nil bucket")
+	}
+	if err := tracker.Delete(ctx, "any"); err == nil {
+		t.Error("Delete err = nil, want non-nil for nil bucket")
+	}
+	if _, err := tracker.List(ctx); err == nil {
+		t.Error("List err = nil, want non-nil for nil bucket")
+	}
+}
+
+func TestScheduleTracker_Delete_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	ctx := context.Background()
+
+	// Delete on missing key must not error.
+	if err := tracker.Delete(ctx, "never-existed"); err != nil {
+		t.Errorf("Delete on missing key = %v, want nil", err)
+	}
+
+	// Delete after Record removes the record.
+	if err := tracker.RecordFire(ctx, "rule", "@hourly", time.Now()); err != nil {
+		t.Fatalf("RecordFire = %v", err)
+	}
+	if err := tracker.Delete(ctx, "rule"); err != nil {
+		t.Errorf("Delete = %v, want nil", err)
+	}
+	if _, err := tracker.LastFiredAt(ctx, "rule"); !errors.Is(err, ErrScheduleRecordNotFound) {
+		t.Errorf("LastFiredAt after Delete err = %v, want ErrScheduleRecordNotFound", err)
+	}
+}
+
+func TestScheduleTracker_List_EmptyBucket(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	records, err := tracker.List(context.Background())
+	if err != nil {
+		t.Fatalf("List = %v, want nil", err)
+	}
+	if len(records) != 0 {
+		t.Errorf("len(records) = %d, want 0", len(records))
+	}
+}
+
+func TestScheduleTracker_List_ReturnsAllRecords(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	ctx := context.Background()
+
+	t0 := time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC)
+	if err := tracker.RecordFire(ctx, "alpha", "@hourly", t0); err != nil {
+		t.Fatalf("RecordFire alpha = %v", err)
+	}
+	if err := tracker.RecordFire(ctx, "bravo", "@daily", t0.Add(time.Hour)); err != nil {
+		t.Fatalf("RecordFire bravo = %v", err)
+	}
+
+	records, err := tracker.List(ctx)
+	if err != nil {
+		t.Fatalf("List = %v, want nil", err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("len(records) = %d, want 2", len(records))
+	}
+
+	sort.Slice(records, func(i, j int) bool {
+		return records[i].RuleID < records[j].RuleID
+	})
+	if records[0].RuleID != "alpha" || records[1].RuleID != "bravo" {
+		t.Errorf("records = [%q, %q], want [alpha, bravo]", records[0].RuleID, records[1].RuleID)
+	}
+}
+
+func TestScheduleTracker_List_SkipsMalformedRecord(t *testing.T) {
+	t.Parallel()
+
+	tracker, bucket := newScheduleTrackerForTest()
+	ctx := context.Background()
+
+	// Write a malformed record directly. List must skip it instead of
+	// failing the whole call (one bad record shouldn't blind the
+	// scheduler to all sibling rules' missed-fire data).
+	if _, err := bucket.Put(ctx, "broken", []byte("not-json")); err != nil {
+		t.Fatalf("seed broken record = %v", err)
+	}
+
+	good := LastFireRecord{
+		RuleID:       "good",
+		ScheduleSpec: "@hourly",
+		LastFiredAt:  time.Now().UTC().Truncate(time.Second),
+	}
+	data, _ := json.Marshal(good)
+	if _, err := bucket.Put(ctx, "good", data); err != nil {
+		t.Fatalf("seed good record = %v", err)
+	}
+
+	records, err := tracker.List(ctx)
+	if err != nil {
+		t.Fatalf("List = %v, want nil", err)
+	}
+	if len(records) != 1 || records[0].RuleID != "good" {
+		t.Errorf("records = %v, want one entry with RuleID=good", records)
+	}
+}
+
+func TestScheduleTracker_LastFiredAt_MalformedRecord(t *testing.T) {
+	t.Parallel()
+
+	tracker, bucket := newScheduleTrackerForTest()
+	ctx := context.Background()
+
+	if _, err := bucket.Put(ctx, "rule", []byte("not-json")); err != nil {
+		t.Fatalf("seed broken record = %v", err)
+	}
+
+	if _, err := tracker.LastFiredAt(ctx, "rule"); err == nil {
+		t.Error("LastFiredAt err = nil, want non-nil for malformed record")
+	}
+}
+
+// Sanity: scheduleKey is the single chokepoint future per-entity fan-out
+// extends. Locking the MVP shape ({ruleID} bare) prevents accidental
+// drift before the deferred extension actually lands.
+func TestScheduleKey_MVPShapeIsBareRuleID(t *testing.T) {
+	t.Parallel()
+	if scheduleKey("weekly-planning") != "weekly-planning" {
+		t.Errorf("scheduleKey = %q, want %q (MVP key shape)",
+			scheduleKey("weekly-planning"), "weekly-planning")
+	}
+}
+
+// Compile-time guard against drift in the JSON wire shape — out-of-process
+// readers (governance startup hooks) depend on these field names.
+func TestLastFireRecord_JSONFieldNames(t *testing.T) {
+	t.Parallel()
+
+	rec := LastFireRecord{
+		RuleID:       "weekly-planning",
+		ScheduleSpec: "0 9 * * MON",
+		LastFiredAt:  time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC),
+	}
+	data, err := json.Marshal(rec)
+	if err != nil {
+		t.Fatalf("Marshal = %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal = %v", err)
+	}
+	for _, field := range []string{"rule_id", "schedule_spec", "last_fired_at"} {
+		if _, ok := raw[field]; !ok {
+			t.Errorf("missing public field %q in JSON: %s", field, data)
+		}
+	}
+}
+
+// Tests that the LastFireRecord round-trips cleanly through the bucket —
+// guards against a future change to the on-disk encoding that would
+// silently corrupt records cross-deploy.
+func TestScheduleTracker_RoundTripPreservesRecord(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	ctx := context.Background()
+
+	original := LastFireRecord{
+		RuleID:       "rule-1",
+		ScheduleSpec: "@every 5m",
+		// Truncate to second resolution to avoid round-trip mismatch
+		// from JSON's RFC3339Nano default (sub-microsecond drift on
+		// some platforms).
+		LastFiredAt: time.Now().UTC().Truncate(time.Second),
+	}
+
+	if err := tracker.RecordFire(ctx, original.RuleID, original.ScheduleSpec, original.LastFiredAt); err != nil {
+		t.Fatalf("RecordFire = %v", err)
+	}
+
+	got, err := tracker.LastFiredAt(ctx, original.RuleID)
+	if err != nil {
+		t.Fatalf("LastFiredAt = %v", err)
+	}
+	if got != original {
+		t.Errorf("round-trip mismatch:\n  got  %+v\n  want %+v", got, original)
+	}
+}
+
+// Bucket() exposes the underlying KV handle for in-process governance
+// reads. Returns the live bucket reference (not a copy) and nil when
+// the tracker is in degraded mode.
+func TestScheduleTracker_BucketAccessor(t *testing.T) {
+	t.Parallel()
+
+	tracker, bucket := newScheduleTrackerForTest()
+	if got := tracker.Bucket(); got == nil {
+		t.Fatal("Bucket() = nil for live tracker, want non-nil")
+	}
+	// The accessor returns the same handle the tracker writes through —
+	// confirms in-process callers operate on the same KV state.
+	if any(tracker.Bucket()) != any(bucket) {
+		t.Error("Bucket() returned a different handle than the underlying mock")
+	}
+
+	nilTracker := NewScheduleTracker(nil, slog.Default())
+	if got := nilTracker.Bucket(); got != nil {
+		t.Errorf("Bucket() = %v on nil-bucket tracker, want nil", got)
+	}
+}
+
+// Static guard: ErrScheduleRecordNotFound must compose with errors.Is
+// (consumer code branches on it).
+func TestScheduleTracker_ErrIsCompatible(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	_, err := tracker.LastFiredAt(context.Background(), "absent")
+	if err == nil {
+		t.Fatal("err = nil, want ErrScheduleRecordNotFound")
+	}
+	if !errors.Is(err, ErrScheduleRecordNotFound) {
+		t.Errorf("errors.Is = false, want true (sentinel must be wrapped or returned bare)")
+	}
+}
+
+// Defence-in-depth: an unexpected error from the underlying bucket must
+// not be silently coerced to ErrScheduleRecordNotFound (which would mask
+// outages as "rule never fired"). This test wires a flaky mock that
+// returns a custom error, then asserts the tracker surfaces it.
+func TestScheduleTracker_LastFiredAt_PassesThroughUnexpectedErr(t *testing.T) {
+	t.Parallel()
+
+	bucket := &flakyKVBucket{
+		mockKVBucket: newMockKVBucket(),
+		err:          errors.New("nats: connection lost"),
+	}
+	tracker := NewScheduleTracker(bucket, slog.Default())
+
+	_, err := tracker.LastFiredAt(context.Background(), "rule")
+	if err == nil {
+		t.Fatal("err = nil, want non-nil")
+	}
+	if errors.Is(err, ErrScheduleRecordNotFound) {
+		t.Error("err matched ErrScheduleRecordNotFound, want pass-through of underlying error")
+	}
+}
+
+// flakyKVBucket overrides Get on a real mockKVBucket to return a custom
+// error for every key. Embedding the real mock keeps the rest of the
+// jetstream.KeyValue surface satisfied without re-stubbing each method.
+type flakyKVBucket struct {
+	*mockKVBucket
+	err error
+}
+
+func (f *flakyKVBucket) Get(_ context.Context, _ string) (jetstream.KeyValueEntry, error) {
+	return nil, f.err
+}
+
+// Regression: rule removal must purge the schedule record. The reviewer
+// flagged this as a must-fix in Chunk 3 because a wired-up-but-not-called
+// Delete API would let RULE_SCHEDULES grow unboundedly across hot-reload
+// rule churn.
+func TestProcessor_RemoveRule_DeletesScheduleRecord(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	ctx := context.Background()
+	const ruleID = "removed-rule"
+
+	// Seed a record as if the rule had previously fired.
+	if err := tracker.RecordFire(ctx, ruleID, "@hourly", time.Now()); err != nil {
+		t.Fatalf("seed RecordFire = %v", err)
+	}
+
+	// Build a minimal Processor that includes the cron registry and
+	// schedule tracker; removeRule expects these.
+	rp := &Processor{
+		logger:          slog.Default(),
+		rules:           make(map[string]Rule),
+		ruleDefinitions: make(map[string]Definition),
+		ruleConfigs:     make(map[string]map[string]any),
+		matchCounters:   make(map[string]*atomic.Int64),
+		cronRules:       map[string]*CronRule{ruleID: {id: ruleID}},
+		scheduleTracker: tracker,
+	}
+
+	rp.removeRule(ruleID)
+
+	if _, err := tracker.LastFiredAt(ctx, ruleID); !errors.Is(err, ErrScheduleRecordNotFound) {
+		t.Errorf("LastFiredAt after removeRule = %v, want ErrScheduleRecordNotFound", err)
+	}
+}
+
+// Regression: a cron→expression type swap on hot-reload must purge the
+// cron rule's schedule record. Mirror of the removeRule test for the
+// applyExpressionRuleChange code path.
+func TestProcessor_TypeSwap_DeletesScheduleRecord(t *testing.T) {
+	t.Parallel()
+
+	tracker, _ := newScheduleTrackerForTest()
+	ctx := context.Background()
+	const ruleID = "swapping-rule"
+
+	if err := tracker.RecordFire(ctx, ruleID, "@hourly", time.Now()); err != nil {
+		t.Fatalf("seed RecordFire = %v", err)
+	}
+
+	// Direct exercise of the type-swap helper code path: simulate the
+	// "had cron, now removing" branch by populating cronRules and then
+	// calling deleteScheduleRecord. The applyExpressionRuleChange wraps
+	// that branch with rule-creation work irrelevant to record deletion.
+	rp := &Processor{
+		logger:          slog.Default(),
+		cronRules:       map[string]*CronRule{ruleID: {id: ruleID}},
+		scheduleTracker: tracker,
+	}
+
+	rp.deleteScheduleRecord(ruleID)
+
+	if _, err := tracker.LastFiredAt(ctx, ruleID); !errors.Is(err, ErrScheduleRecordNotFound) {
+		t.Errorf("LastFiredAt after type-swap delete = %v, want ErrScheduleRecordNotFound", err)
+	}
+}
+
+// deleteScheduleRecord with no tracker must be a clean no-op (degraded-
+// mode startups must not crash hot-reload paths).
+func TestProcessor_DeleteScheduleRecord_NilTrackerNoop(t *testing.T) {
+	t.Parallel()
+
+	rp := &Processor{
+		logger: slog.Default(),
+	}
+	rp.deleteScheduleRecord("any-rule") // must not panic
+}

--- a/schemas/rule-processor.v1.json
+++ b/schemas/rule-processor.v1.json
@@ -48,6 +48,127 @@
       "items": {
         "type": "object",
         "properties": {
+          "actions": {
+            "type": "array",
+            "description": "actions",
+            "items": {
+              "type": "object",
+              "properties": {
+                "boid_signal_type": {
+                  "type": "string",
+                  "description": "boid_signal_type"
+                },
+                "boid_strength": {
+                  "type": "number",
+                  "description": "boid_strength"
+                },
+                "bucket": {
+                  "type": "string",
+                  "description": "bucket"
+                },
+                "context_data": {
+                  "type": "object",
+                  "description": "context_data"
+                },
+                "key": {
+                  "type": "string",
+                  "description": "key"
+                },
+                "merge": {
+                  "type": "boolean",
+                  "description": "merge"
+                },
+                "model": {
+                  "type": "string",
+                  "description": "model"
+                },
+                "object": {
+                  "type": "string",
+                  "description": "object"
+                },
+                "payload": {
+                  "type": "object",
+                  "description": "payload"
+                },
+                "predicate": {
+                  "type": "string",
+                  "description": "predicate"
+                },
+                "prompt": {
+                  "type": "string",
+                  "description": "prompt"
+                },
+                "properties": {
+                  "type": "object",
+                  "description": "properties"
+                },
+                "role": {
+                  "type": "string",
+                  "description": "role"
+                },
+                "subject": {
+                  "type": "string",
+                  "description": "subject"
+                },
+                "tools": {
+                  "type": "array",
+                  "description": "tools",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ttl": {
+                  "type": "string",
+                  "description": "ttl"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "type"
+                },
+                "when": {
+                  "type": "array",
+                  "description": "when",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "field": {
+                        "type": "string",
+                        "description": "field"
+                      },
+                      "from": {
+                        "type": "string",
+                        "description": "from"
+                      },
+                      "operator": {
+                        "type": "string",
+                        "description": "operator"
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "required"
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "value"
+                      }
+                    }
+                  }
+                },
+                "workflow_id": {
+                  "type": "string",
+                  "description": "workflow_id"
+                },
+                "workflow_slug": {
+                  "type": "string",
+                  "description": "workflow_slug"
+                },
+                "workflow_step": {
+                  "type": "string",
+                  "description": "workflow_step"
+                }
+              }
+            }
+          },
           "conditions": {
             "type": "array",
             "description": "conditions",
@@ -503,6 +624,10 @@
           "rerun_on_recovery": {
             "type": "boolean",
             "description": "rerun_on_recovery"
+          },
+          "schedule": {
+            "type": "string",
+            "description": "schedule"
           },
           "type": {
             "type": "string",


### PR DESCRIPTION
## Summary

Implements [ADR-031](docs/adr/031-time-trigger-primitive.md) Option A — a `"type": "cron"` rule kind layered into the existing rule processor, plus the supporting persistence, substitution, and observability surface. Closes the cadence-driven dispatch gap that semteams' onboarding flow surfaced (operating-model entries with `Cadence` / `Trigger` fields the framework couldn't act on).

**The simplest beta.26 → beta.27 upgrade is to do nothing.** Existing deployments without cron rules see no behaviour change. Activation requires authoring a `"type": "cron"` rule.

Migration guide: [`docs/operations/migration-beta26-to-beta27.md`](docs/operations/migration-beta26-to-beta27.md).

## What ships

| Surface | Status |
|---|---|
| New rule kind: `"type": "cron"` | Additive — opt-in per rule |
| New KV bucket: `RULE_SCHEDULES` | Additive — created on demand |
| New substitution namespace: `$schedule.*` | Additive — cron rules only |
| New Prometheus metrics: `semstreams_cron_*` (7 collectors) | Additive |
| New Grafana dashboard: `cron-scheduler.json` | Additive — opt-in import |
| Existing expression rules | **Unchanged** — no behavioural delta |
| Public API | **No breakage** |

## Chunks (each pre-commit go-reviewer'd)

| Chunk | Commit | Surface |
|---|---|---|
| 1 | `8ca3cc2` | `CronRule` type + factory + `Definition` extensions (`Schedule`, `Actions`). `robfig/cron/v3` pulled (zero transitive deps). |
| 2 | `339773a` | `CronScheduler` core + lifecycle wiring (`Register`/`Deregister`/`Start`/`Stop`, FireEveryN gate, cooldown gate, inflight CAS, panic backstop). |
| 3 | `b0902de` | `RULE_SCHEDULES` KV bucket + `ScheduleTracker` + missed-fire detection on startup (log-only per ADR-031). |
| 4 | `49b08a4` | `$schedule.*` substitution context + cross-restart `lastFiredNanos` hydration (closes a latent cooldown-cross-restart bug). |
| 5 | `65a56f2` | Seven Prometheus metrics + Grafana dashboard with dedicated panic-rate panel. |
| 6 | `6a4c7a1` | testcontainer-NATS integration tests + two latent bug fixes (see below). |
| 7 | `98d2144` | Migration guide, ADR final-status update, concept-doc paragraphs, governance-shaped example. |

## Drive-by latent bug fixes (Chunk 6)

Two pre-existing latent bugs surfaced during integration testing. Neither was reachable from beta.26 production state (both required cron rules to trigger):

1. **`definitionFromMap` panicked on null `conditions` field.** `Definition.Conditions` has no `omitempty`, so a Definition with no conditions JSON-marshals as `"conditions": null`. The hot-reload parser's type assertion panicked on nil. Only reachable via cron rules (the only Type that legitimately has no conditions). Fixed with explicit nil-guard plus defensive type assertions throughout.

2. **Seed-then-reconcile reset cron rule cooldown state.** Hot-reload's startup path was Deregister + Register-ing every cron rule on the watcher's first reconcile pass, resetting `entry.lastFiredNanos`. Fixed with a `reflect.DeepEqual` idempotency check + new `definitionToRuleMap` helper that pre-populates `rp.ruleConfigs` at load time.

## Three retrofit-safe seams

MVP is single-user but design avoids painting corners that a future per-tenant pass would have to back out of:

1. `RULE_SCHEDULES` keyed by bare `{ruleID}` for MVP; `scheduleKey()` is the single chokepoint a future `.{entityID}` suffix would extend.
2. `$schedule.*` is cron-context-only and disjoint from `$entity.*`; future `for_each` per-entity fan-out populates `$entity.*` per iteration alongside `$schedule.*`.
3. `Definition.Schedule` is global today; `Definition.ForEach` would be additive — rules that don't set it keep current single-fire semantics.

## Test plan

- [x] `task lint` clean across all chunks (zero warnings)
- [x] `go test -race ./processor/rule/...` passes (~10s)
- [x] `go test -tags=integration -race ./processor/rule/` passes (~47s, includes 4 testcontainer-NATS end-to-end tests covering FiresOnSchedule, PersistsLastFiredToKV, DetectsMissedFiresAcrossRestart, CooldownAcrossRestart)
- [x] `task schema:generate` produces no drift
- [x] Existing `TestHotReload_*` integration suite still passes (verified the seed-reconcile fix didn't regress expression-rule behaviour)
- [ ] Manual smoke: import `configs/grafana/dashboards/cron-scheduler.json`, register a cron rule, verify all 7 metrics populate
- [ ] Manual smoke: configure an alert on `rate(semstreams_cron_rule_fires_total{status="panic"}[5m]) > 0`

## Worked examples

- `configs/rules/cron/heartbeat-example.json` — smallest worked example, every-minute heartbeat using every `$schedule.*` token.
- `configs/rules/cron/governance-example.json` — daily kill-switch sweep using the cron → `publish_agent` → ops-role coordinator pattern (per ADR-028 Phase 1 read-only). Worked starting point for governance authors.

Refs #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)