### PR TITLE
feat(model): lift 3 hidden LLM call sites into capability constants

### DIFF
--- a/docs/operations/05-model-registry.md
+++ b/docs/operations/05-model-registry.md
@@ -98,47 +98,57 @@ Defined in `model/registry.go:124-140`.
 
 ## LLM Capability Inventory
 
-The registry defines five capability constants in `model/registry.go:11-25`.
-Components resolve them via `model.ResolveEndpoint(registry, model.Capability*)`.
+The registry defines eight capability constants in `model/registry.go:11-37`.
+Components resolve them via `model.ResolveEndpoint(registry, model.Capability*)`
+or, where the call site has its own resolution chain, by passing the
+capability constant as the resolution key.
 
-| Capability | Constant | Caller | Workload tier | Default route |
+| Capability | Constant | Caller | Workload tier | Default route when unbound |
 |---|---|---|---|---|
 | `summarization` | `model.CapabilitySummarization` | agentic-loop context compaction (`processor/agentic-loop/component.go:184`) | User-facing, blocking — fires inline when a loop hits its token budget | Largest-context endpoint when no binding; ops/deep-research configs typically bind `"fast"` |
 | `community_summary` | `model.CapabilityCommunitySummary` | graph-clustering enhancement worker (`processor/graph-clustering/component.go:1072`) | Background batch — async after community detection | `seminstruct` |
 | `query_classification` | `model.CapabilityQueryClassification` | graph-query T3 classifier fallback (`processor/graph-query/component.go:372`) | User-facing, slow path — only fires when keyword/spatial/temporal classifiers fail | Unbound by default; degrades gracefully to keyword-only |
 | `answer_synthesis` | `model.CapabilityAnswerSynthesis` | graph-query `globalSearch` answer composition (`processor/graph-query/component.go:406`) | User-facing, blocking | Unbound by default; falls back to template synthesis |
 | `embedding` | `model.CapabilityEmbedding` | graph-embedding (`processor/graph-embedding/component.go:622`) | Background batch | `semembed` (HTTP embedder, **not** chat completions — different protocol) |
+| `intent_classification` | `model.CapabilityIntentClassification` | agentic-dispatch (`processor/agentic-dispatch/intent_classifier.go`) — fires on every incoming user message | User-facing, blocking — most-frequent user-facing LLM call in the system | Falls through to `defaults.model` |
+| `layer_normalization` | `model.CapabilityLayerNormalization` | agentic-dispatch (`processor/agentic-dispatch/normalize_extractor.go`) — extracts structured operating-model entries from freeform onboarding answers | User-facing, async during onboarding | Falls through to `defaults.model` |
+| `anomaly_review` | `model.CapabilityAnomalyReview` | graph-inference ReviewWorker (`graph/inference/review_worker.go`) — classifies suggested missing relationships | Background batch | Falls through to the `community_summary` endpoint (legacy piggyback preserved) |
 
 Per-capability **model selection guidance** (input/output envelope,
 required model traits, latency budget, suggested probe prompts) lives
 in [11-llm-routing-and-model-selection.md](11-llm-routing-and-model-selection.md).
 
-### Known Gaps — workloads that bypass the registry
+### Resolution semantics for the last three capabilities
 
-Three production LLM call sites are **not yet capability-bound**.
-Operators reading the registry have no dedicated dial for them; they
-inherit routing implicitly. A future cleanup pass will lift each into
-its own capability constant. Document them here so the gap is visible.
+`intent_classification`, `layer_normalization`, and `anomaly_review`
+were lifted into capabilities in Phase 2 from previously hardcoded call
+sites. To keep upgrades zero-ceremony, each has slightly different
+fallback semantics:
 
-| Site | File | Current routing | Why this matters |
-|---|---|---|---|
-| **Anomaly relationship review** | `graph/inference/review_worker.go:408` | Receives the `LLMClient` graph-clustering resolved via `community_summary`. No separate dial. | Anomaly review prompts are short and structured (APPROVE/REJECT). Community summarization prompts are open-ended narrative. They share an endpoint by accident, not design. |
-| **Onboarding layer normalization** | `processor/agentic-dispatch/normalize_extractor.go:43` | Hardcoded `extractionModelName = "default"` — resolves to whatever endpoint `defaults.model` names. | Looks like `defaults.model` is the dial, but it actually serves multiple unrelated workloads. Editing `defaults.model` for one purpose silently affects this call. |
-| **Intent classification** (every user message) | `processor/agentic-dispatch/intent_classifier.go:57` | `modelName` defaults to `"default"`; same fallback chain as above. | The most-frequent user-facing LLM call in the system. Fires on every user message with a 15s timeout. Operators must be able to bind it to a fast endpoint independently of the agentic chat itself. |
+- **`intent_classification` and `layer_normalization`** — when the
+  capability is not bound, the call-site's resolution chain falls
+  through to `defaults.model`. This is the same endpoint these calls
+  used pre-Phase-2 via the hardcoded `"default"` string. Operators who
+  previously tuned `defaults.model` for these workloads see no change;
+  binding the capability gives them a per-site override.
+- **`anomaly_review`** — when the capability is not bound, the review
+  worker reuses graph-clustering's `community_summary` LLM client, the
+  same endpoint it piggybacked on pre-Phase-2. Operators who want a
+  separate model for review (e.g. a smaller, faster classifier) bind
+  `anomaly_review` explicitly.
 
-If you hit the limits of these implicit routes today (e.g. you want a
-distinct fast endpoint for intent classification), the workaround is to
-set `defaults.model` to the endpoint that should serve all three of
-these calls collectively. There is no per-site override yet.
+In all three cases, **doing nothing on upgrade preserves prior
+behavior bit-for-bit.** Binding the new capability is opt-in.
 
 ## Defaults
 
 `defaults.model` is the endpoint used when a capability resolves nowhere
-else (no preferred chain, no fallback). It is also the **silent backstop
-for the three Known Gaps above** — operators should be aware that
-changing `defaults.model` affects intent classification, layer
-normalization, and the implicit anomaly-review path even though the
-registry doesn't show those bindings explicitly.
+else (no preferred chain, no fallback). For the `intent_classification`
+and `layer_normalization` capabilities, `defaults.model` is the
+fallback target when those capabilities are not bound — preserving the
+pre-Phase-2 hardcoded behavior. Operators who want per-site routing for
+those workloads should bind the relevant capability explicitly rather
+than reshaping `defaults.model`.
 
 `defaults.capability` is used when an `AgentRequest` arrives without a
 specified `Model` or `Capability`. The named capability is resolved

--- a/docs/operations/11-llm-routing-and-model-selection.md
+++ b/docs/operations/11-llm-routing-and-model-selection.md
@@ -43,9 +43,9 @@ dedicated endpoint than from concurrency.
 
 | Tier | Concurrency wins | Capabilities |
 |---|---|---|
-| **Background batch** — fires async after some other event; user not waiting | Yes — pile-ups are common after community detection or KV queue drains | `community_summary`, anomaly review (piggyback), `embedding` |
-| **Slow path / tolerant** — user-facing but tolerant of fallback to deterministic alternative | Yes — only fires when faster paths fail | `query_classification` (T3 fallback), `summarization` (compaction) |
-| **Latency-critical** — fires inline on every user request or every loop step | Concurrency helps less than co-location with a fast model | `answer_synthesis`, intent classification (every user message), agentic chat itself |
+| **Background batch** — fires async after some other event; user not waiting | Yes — pile-ups are common after community detection or KV queue drains | `community_summary`, `anomaly_review`, `embedding` |
+| **Slow path / tolerant** — user-facing but tolerant of fallback to deterministic alternative | Yes — only fires when faster paths fail | `query_classification` (T3 fallback), `summarization` (compaction), `layer_normalization` (onboarding async) |
+| **Latency-critical** — fires inline on every user request or every loop step | Concurrency helps less than co-location with a fast model | `answer_synthesis`, `intent_classification` (every user message), agentic chat itself |
 
 The **agentic chat itself** is not in the table because it isn't a
 capability binding — it routes per-`AgentRequest` based on
@@ -54,11 +54,12 @@ loop is built around. Keep it on whatever fast endpoint your loops use.
 
 ## Capability Spec Sheets
 
-Each sheet is a structured table the seminstruct agent can parse. Five
-capabilities are bound via `model.Capability*` constants in
-`model/registry.go:11-25`. Three more sites are **not yet capability-
-bound** — they're documented here so model fit can be checked anyway,
-with a clear "Status: bypass" warning.
+Each sheet is a structured table the seminstruct agent can parse. All
+eight LLM call sites are bound via `model.Capability*` constants in
+`model/registry.go:11-37`. The last three (`intent_classification`,
+`layer_normalization`, `anomaly_review`) were lifted in Phase 2 — see
+their fallback notes for the legacy behavior preserved when the
+capability isn't bound.
 
 ### `summarization` — Agentic-Loop Context Compaction
 
@@ -130,57 +131,47 @@ with a clear "Status: bypass" warning.
 | **Fallback** | If no endpoint resolves, graph-embedding starts in degraded mode (statistical-only Tier 1). No semantic Tier 2 features. |
 | **Bound endpoint** | Conventionally `semembed` (the SemStreams embedding service running a sentence-transformer model). **Do not bind a chat model here** — different protocol. |
 
----
-
-### Bypass sites (not yet capability-bound)
-
-The three sites below are documented for completeness and so the
-seminstruct agent can audit model fit even though there's no per-site
-binding to point at today. A future cleanup will lift each into its
-own `model.Capability*` constant. Until then, all three resolve through
-`defaults.model`.
-
-### Anomaly Relationship Review (bypass)
+### `intent_classification` — Agentic-Dispatch Intent Router
 
 | Field | Value |
 |---|---|
-| **Status** | **Bypass** — receives the `LLMClient` graph-clustering resolved via `community_summary`. No separate capability constant. |
-| **Caller** | `graph/inference/review_worker.go:408` (`llmReview`); wired in `processor/graph-clustering/component.go` via `LLMClient: c.llmClient` |
-| **Job** | Decide whether a structurally-suggested missing relationship between two graph entities should be added. APPROVE or REJECT plus reasoning. Only fires when confidence falls between auto-approve/auto-reject thresholds. |
-| **Input envelope** | Structured: anomaly type, confidence, entity A/B IDs and contexts, evidence (similarity, structural distance, core level). Typically 500–2000 tokens. |
-| **Output envelope** | First word `APPROVE` or `REJECT`, followed by free-form reasoning. Parsed by `parseLLMDecision` in `review_worker.go`. |
-| **Required model traits** | Basic instruction following — the system prompt is concise and the output format is simple. Temperature held at 0.1 for deterministic decisions. **Tool calling: not required.** |
-| **Latency budget** | Configurable via `ReviewTimeout` config field, default `30s` (`graph/inference/review_worker.go:393`). Background batch — drains `ANOMALY_INDEX` KV queue. |
-| **Fallback** | On LLM error or no LLM client, falls through to human review (if `FallbackToHuman` configured) or auto-rejects with a "no LLM or human review" reason. |
-| **Prompt source** | `graph/inference/review_worker.go:635-647` (`reviewSystemPrompt`) + `buildReviewPrompt` |
-
-### Onboarding Layer Normalization (bypass)
-
-| Field | Value |
-|---|---|
-| **Status** | **Bypass** — hardcoded `extractionModelName = "default"` (`processor/agentic-dispatch/normalize_extractor.go:43`) |
-| **Caller** | `processor/agentic-dispatch/normalize_extractor.go:59` (`normalizeLayerAnswerWithLLM`); injected into the component via `SetLayerNormalizer` |
-| **Job** | Convert a freeform user answer (during onboarding interview) into structured `[]operatingmodel.Entry` for the user's operating-model layers. Capped at 4096 bytes of input. |
-| **Input envelope** | System prompt with per-layer focus hint + user answer fenced as `<<<USER_ANSWER … END_USER_ANSWER>>>` (prompt-injection mitigation). Typically 1K–3K tokens. |
-| **Output envelope** | **Strict JSON object** of shape `{"entries": [{"title": "...", "summary": "...", ...}]}`. MaxTokens=2048 (`processor/agentic-dispatch/normalize_extractor.go:31`) sized to absorb verbose JSON from smaller models. |
-| **Required model traits** | **JSON-mode reliability is critical.** Instruction following must hold against prompt-injection attempts inside the data fence. Faithful extraction without invention. 3B+ models handle this; 1B models often hallucinate fields. **Tool calling: not required.** |
-| **Latency budget** | Hardcoded `extractionTimeoutDefault = 30s` (`processor/agentic-dispatch/normalize_extractor.go:36`). User-facing but async during onboarding. |
-| **Fallback** | On any error, returns `(nil, err)` so the caller falls back to the deterministic `NormalizeLayerAnswer` stub (a simple keyword-matching extractor). The user's answer is still recorded; layer entries are coarser. |
-| **Prompt source** | `processor/agentic-dispatch/normalize_extractor.go:223-281` (`buildNormalizationMessages` + `normalizationSystemPrompt` + `layerFocusHint`) |
-
-### Intent Classification (bypass)
-
-| Field | Value |
-|---|---|
-| **Status** | **Bypass** — `modelName` defaults to `"default"` (`processor/agentic-dispatch/intent_classifier.go:57`) |
+| **Status** | Capability-bound (`model.CapabilityIntentClassification`) |
 | **Caller** | `processor/agentic-dispatch/intent_classifier.go:67` (`Classify`). **Fires on every incoming user message.** |
 | **Job** | Classify a user message into one of five intents (`new_task`, `continue`, `signal`, `question`, `meta`) so dispatch can route it to the right handler. |
 | **Input envelope** | System prompt enumerating the five intents + active-loops context + the user message. Typically 200–800 tokens. |
 | **Output envelope** | **Strict JSON object** of shape `{"type": "...", "loop_id": "...", "signal_type": "...", "confidence": 0.0–1.0}`. MaxTokens=128 (`processor/agentic-dispatch/intent_classifier.go:118`). |
 | **Required model traits** | **JSON-mode reliability + low-latency response.** Temperature held at 0.1 for determinism. The five-intent taxonomy is small enough that 1B models can do it well if their JSON-mode is reliable. **Tool calling: not required.** |
 | **Latency budget** | Hardcoded 15s timeout (`processor/agentic-dispatch/intent_classifier.go:107`). **This is the most-frequent user-facing LLM call in the system** — every user message hits it before anything else can happen. |
-| **Fallback** | On endpoint-not-found, client-creation error, LLM error, or unparseable response → returns `IntentNewTask` with `confidence=0.5`. The user's message still gets handled but as a brand-new task even if it was a follow-up. |
+| **Fallback** | On endpoint-not-found, client-creation error, LLM error, or unparseable response → returns `IntentNewTask` with `confidence=0.5`. The user's message still gets handled but as a brand-new task even if it was a follow-up. When the capability is not bound, the resolution chain falls through to `defaults.model` (preserving the pre-Phase-2 piggyback). |
 | **Prompt source** | `processor/agentic-dispatch/intent_classifier.go:78-90` (system prompt) |
+
+### `layer_normalization` — Onboarding Operating-Model Extractor
+
+| Field | Value |
+|---|---|
+| **Status** | Capability-bound (`model.CapabilityLayerNormalization`) |
+| **Caller** | `processor/agentic-dispatch/normalize_extractor.go:59` (`normalizeLayerAnswerWithLLM`); injected into the component via `SetLayerNormalizer` |
+| **Job** | Convert a freeform user answer (during onboarding interview) into structured `[]operatingmodel.Entry` for the user's operating-model layers. Capped at 4096 bytes of input. |
+| **Input envelope** | System prompt with per-layer focus hint + user answer fenced as `<<<USER_ANSWER … END_USER_ANSWER>>>` (prompt-injection mitigation). Typically 1K–3K tokens. |
+| **Output envelope** | **Strict JSON object** of shape `{"entries": [{"title": "...", "summary": "...", ...}]}`. MaxTokens=2048 (`processor/agentic-dispatch/normalize_extractor.go:31`) sized to absorb verbose JSON from smaller models. |
+| **Required model traits** | **JSON-mode reliability is critical.** Instruction following must hold against prompt-injection attempts inside the data fence. Faithful extraction without invention. 3B+ models handle this; 1B models often hallucinate fields. **Tool calling: not required.** |
+| **Latency budget** | Hardcoded `extractionTimeoutDefault = 30s` (`processor/agentic-dispatch/normalize_extractor.go:36`). User-facing but async during onboarding. |
+| **Fallback** | On any error, returns `(nil, err)` so the caller falls back to the deterministic `NormalizeLayerAnswer` stub (a simple keyword-matching extractor). The user's answer is still recorded; layer entries are coarser. When the capability is not bound, the resolution chain falls through to `defaults.model`. |
+| **Prompt source** | `processor/agentic-dispatch/normalize_extractor.go:223-281` (`buildNormalizationMessages` + `normalizationSystemPrompt` + `layerFocusHint`) |
+
+### `anomaly_review` — Graph Inference Relationship Reviewer
+
+| Field | Value |
+|---|---|
+| **Status** | Capability-bound (`model.CapabilityAnomalyReview`) |
+| **Caller** | `graph/inference/review_worker.go:408` (`llmReview`); wired in `processor/graph-clustering/component.go` via `resolveReviewLLMClient`. |
+| **Job** | Decide whether a structurally-suggested missing relationship between two graph entities should be added. APPROVE or REJECT plus reasoning. Only fires when confidence falls between auto-approve/auto-reject thresholds. |
+| **Input envelope** | Structured: anomaly type, confidence, entity A/B IDs and contexts, evidence (similarity, structural distance, core level). Typically 500–2000 tokens. |
+| **Output envelope** | First word `APPROVE` or `REJECT`, followed by free-form reasoning. Parsed by `parseLLMDecision` in `review_worker.go`. |
+| **Required model traits** | Basic instruction following — the system prompt is concise and the output format is simple. Temperature held at 0.1 for deterministic decisions. **Tool calling: not required.** |
+| **Latency budget** | Configurable via `ReviewTimeout` config field, default `30s` (`graph/inference/review_worker.go:393`). Background batch — drains `ANOMALY_INDEX` KV queue. |
+| **Fallback** | On LLM error or no LLM client, falls through to human review (if `FallbackToHuman` configured) or auto-rejects with a "no LLM or human review" reason. **When the capability is not bound, the review worker reuses the `community_summary` LLM client** (legacy piggyback preserved). To run anomaly review on a different endpoint than community summarization, bind `anomaly_review` explicitly. |
+| **Prompt source** | `graph/inference/review_worker.go:635-647` (`reviewSystemPrompt`) + `buildReviewPrompt` |
 
 ## Small-Model Suitability Guidance
 
@@ -191,11 +182,11 @@ capability. These are starting points; always validate with the
 | Capability | Smallest reasonable | Sweet spot | What goes wrong below the floor |
 |---|---|---|---|
 | `embedding` | n/a — sentence-transformer model, separate sizing concerns | `all-MiniLM-L6-v2` (~22M params) is fine for many use cases | Wrong protocol entirely if you bind a chat model |
-| Intent classification (bypass) | 1B if JSON-mode is reliable | 3B | Hallucinated intent values or malformed JSON → silent fallback to `new_task` for everything |
+| `intent_classification` | 1B if JSON-mode is reliable | 3B | Hallucinated intent values or malformed JSON → silent fallback to `new_task` for everything |
 | `query_classification` | 3B for tool-free chat models | 7B for reasoning models | `<think>` block leakage into JSON, hallucinated SearchOptions fields |
 | `community_summary` | 3B | 7B | Boring template-y output that doesn't leverage the entity-ID structure the prompt teaches |
-| Anomaly review (bypass) | 3B | 7B | Inverted decisions (APPROVE for things that should reject) or unparseable first-word verdict |
-| Layer normalization (bypass) | 3B | 7B–8B | Prompt-injection vulnerabilities materialize at small sizes; invented entries appear |
+| `anomaly_review` | 3B | 7B | Inverted decisions (APPROVE for things that should reject) or unparseable first-word verdict |
+| `layer_normalization` | 3B | 7B–8B | Prompt-injection vulnerabilities materialize at small sizes; invented entries appear |
 | `summarization` | 3B–7B (depends on context window) | 7B+ with long-context support | Faithfulness drops — entity IDs and error messages get paraphrased away |
 | `answer_synthesis` | 7B | 7B+ tuned for instruction following | Speculation beyond input clusters; missing citations |
 
@@ -347,11 +338,14 @@ the small-model backend (or whatever the deployment uses).
       }
     },
     "capabilities": {
-      "summarization":        { "preferred": ["seminstruct-concurrent"], "fallback": ["agentic-fast"], "timeout": "60s" },
-      "community_summary":    { "preferred": ["seminstruct-concurrent"], "timeout": "120s" },
-      "query_classification": { "preferred": ["seminstruct-concurrent"], "timeout": "30s" },
-      "answer_synthesis":     { "preferred": ["seminstruct-concurrent"], "timeout": "30s" },
-      "embedding":            { "preferred": ["semembed"] }
+      "summarization":          { "preferred": ["seminstruct-concurrent"], "fallback": ["agentic-fast"], "timeout": "60s" },
+      "community_summary":      { "preferred": ["seminstruct-concurrent"], "timeout": "120s" },
+      "query_classification":   { "preferred": ["seminstruct-concurrent"], "timeout": "30s" },
+      "answer_synthesis":       { "preferred": ["seminstruct-concurrent"], "timeout": "30s" },
+      "anomaly_review":         { "preferred": ["seminstruct-concurrent"], "timeout": "30s" },
+      "intent_classification":  { "preferred": ["agentic-fast"], "timeout": "15s" },
+      "layer_normalization":    { "preferred": ["seminstruct-concurrent"], "timeout": "30s" },
+      "embedding":              { "preferred": ["semembed"] }
     },
     "defaults": {
       "model": "agentic-fast"
@@ -360,10 +354,13 @@ the small-model backend (or whatever the deployment uses).
 }
 ```
 
-Note that `defaults.model = "agentic-fast"` continues to silently serve
-the three bypass sites (intent classification, layer normalization,
-anomaly review) until those get their own capabilities. Pick a `defaults.model` endpoint that can handle JSON output (intent
-classification + layer normalization both demand it).
+`intent_classification` is bound to `agentic-fast` (not the concurrent
+backend) because it fires on every user message and benefits more from
+co-location than concurrency — every user-perceptible response waits
+for it. The other lifted capabilities (`anomaly_review`,
+`layer_normalization`) move to the concurrent backend with the rest of
+the offload set. If you omit any binding, the resolution falls back as
+documented in each capability's spec sheet above.
 
 ### Single-backend deployment (semantic.json shape)
 

--- a/model/registry.go
+++ b/model/registry.go
@@ -22,6 +22,20 @@ const (
 	// CapabilityAnswerSynthesis is used by graph-query to synthesize natural language
 	// answers from community summaries and entity digests in globalSearch responses.
 	CapabilityAnswerSynthesis = "answer_synthesis"
+	// CapabilityIntentClassification is used by agentic-dispatch to classify
+	// every incoming user message into an intent (new_task / continue / signal /
+	// question / meta) before routing. The most-frequent user-facing LLM call
+	// in the system. Unbound deployments fall back to defaults.model.
+	CapabilityIntentClassification = "intent_classification"
+	// CapabilityLayerNormalization is used by agentic-dispatch to extract
+	// structured operating-model entries from freeform onboarding answers.
+	// Unbound deployments fall back to defaults.model.
+	CapabilityLayerNormalization = "layer_normalization"
+	// CapabilityAnomalyReview is used by graph/inference's ReviewWorker to
+	// classify suggested missing relationships as approve/reject. Unbound
+	// deployments fall back to the community_summary endpoint (the legacy
+	// piggyback behavior preserved for backward compatibility).
+	CapabilityAnomalyReview = "anomaly_review"
 )
 
 // ResolvedEndpoint holds the resolved connection details for a capability endpoint.

--- a/model/registry_test.go
+++ b/model/registry_test.go
@@ -949,3 +949,32 @@ func slicesEqual(a, b []string) bool {
 	}
 	return true
 }
+
+// TestCapabilityConstants_Values pins the wire string for every capability
+// constant. The strings appear in production model_registry JSON so they
+// are part of the operator-facing config contract — renaming one is a
+// breaking change. Locking the value in a test makes accidental drift
+// impossible.
+func TestCapabilityConstants_Values(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"summarization", CapabilitySummarization, "summarization"},
+		{"community_summary", CapabilityCommunitySummary, "community_summary"},
+		{"embedding", CapabilityEmbedding, "embedding"},
+		{"query_classification", CapabilityQueryClassification, "query_classification"},
+		{"answer_synthesis", CapabilityAnswerSynthesis, "answer_synthesis"},
+		{"intent_classification", CapabilityIntentClassification, "intent_classification"},
+		{"layer_normalization", CapabilityLayerNormalization, "layer_normalization"},
+		{"anomaly_review", CapabilityAnomalyReview, "anomaly_review"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("constant = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}

--- a/processor/agentic-dispatch/intent_classifier.go
+++ b/processor/agentic-dispatch/intent_classifier.go
@@ -52,9 +52,15 @@ type LLMIntentClassifier struct {
 
 // NewLLMIntentClassifier creates a classifier that uses the model registry
 // to resolve an endpoint and make classification calls.
+//
+// The default modelName is model.CapabilityIntentClassification. When that
+// capability is unbound in the registry, resolveEndpoint walks the standard
+// fallback chain (configured name → fallback chain → defaults.model), so
+// existing deployments without an explicit binding continue to use
+// defaults.model exactly as they did before this capability existed.
 func NewLLMIntentClassifier(registry model.RegistryReader, modelName string, logger *slog.Logger) *LLMIntentClassifier {
 	if modelName == "" {
-		modelName = "default"
+		modelName = model.CapabilityIntentClassification
 	}
 	return &LLMIntentClassifier{
 		modelRegistry: registry,

--- a/processor/agentic-dispatch/intent_classifier_test.go
+++ b/processor/agentic-dispatch/intent_classifier_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -166,4 +167,27 @@ func TestMockIntentClassifier_FallbackOnError(t *testing.T) {
 
 	_, err := classifier.Classify(context.Background(), msg, nil)
 	assert.Error(t, err)
+}
+
+// TestNewLLMIntentClassifier_DefaultsToCapabilityConstant verifies the
+// no-modelName-supplied path uses model.CapabilityIntentClassification
+// instead of the previous hardcoded "default" string. The capability
+// constant resolves through the registry's standard fallback chain, so
+// unbound deployments still land on defaults.model — preserving the
+// pre-Phase-2 piggyback behavior.
+func TestNewLLMIntentClassifier_DefaultsToCapabilityConstant(t *testing.T) {
+	c := NewLLMIntentClassifier(nil, "", nil)
+	require.NotNil(t, c)
+	assert.Equal(t, model.CapabilityIntentClassification, c.modelName,
+		"empty modelName should default to the intent_classification capability constant")
+}
+
+// TestNewLLMIntentClassifier_ExplicitModelNamePreserved verifies that an
+// explicit modelName (endpoint or capability) overrides the default. This
+// is the existing escape hatch for deployments that want to point intent
+// classification at a specific endpoint by name.
+func TestNewLLMIntentClassifier_ExplicitModelNamePreserved(t *testing.T) {
+	c := NewLLMIntentClassifier(nil, "fast-classifier", nil)
+	require.NotNil(t, c)
+	assert.Equal(t, "fast-classifier", c.modelName)
 }

--- a/processor/agentic-dispatch/normalize_extractor.go
+++ b/processor/agentic-dispatch/normalize_extractor.go
@@ -35,12 +35,13 @@ const extractionMaxTokens = 2048
 // AgentRequest below) overrides endpoint and capability defaults.
 const extractionTimeoutDefault = 30 * time.Second
 
-// extractionModelName is the capability/endpoint name used to resolve a
-// model for normalization. The registry resolves it through the standard
-// fallback chain (configured name → fallback chain → default), so a
-// deployment that registers a "default" capability (the convention) gets
-// normalization for free without a dispatch config knob.
-const extractionModelName = "default"
+// extractionModelName is the capability name used to resolve a model for
+// normalization. The registry resolves it through the standard fallback
+// chain (configured name → fallback chain → defaults.model). When the
+// capability is unbound, resolveModelEndpoint falls through to
+// defaults.model — preserving the pre-capability behavior where this call
+// site shared whatever endpoint defaults.model named.
+const extractionModelName = model.CapabilityLayerNormalization
 
 // extractionAnswerMaxBytes caps how much of a freeform user answer is
 // forwarded to the model. The bound mitigates two classes of failure:

--- a/processor/agentic-dispatch/normalize_extractor_test.go
+++ b/processor/agentic-dispatch/normalize_extractor_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	operatingmodel "github.com/c360studio/semstreams/agentic/operating-model"
+	"github.com/c360studio/semstreams/model"
 )
 
 func TestNormalizeLayerAnswer_StubWhenNoNormalizer(t *testing.T) {
@@ -271,5 +272,17 @@ func TestFinalizeExtractedEntries_AssignsFreshEntryIDs(t *testing.T) {
 			t.Errorf("duplicate EntryID %q", e.EntryID)
 		}
 		seen[e.EntryID] = true
+	}
+}
+
+// TestExtractionModelName_BoundToCapabilityConstant verifies the resolution
+// key used by the layer normalizer is the layer_normalization capability
+// constant, not a hardcoded "default" string. Operators binding the
+// capability in the registry get a dedicated route; unbound deployments
+// continue to fall through to defaults.model via resolveModelEndpoint.
+func TestExtractionModelName_BoundToCapabilityConstant(t *testing.T) {
+	if extractionModelName != model.CapabilityLayerNormalization {
+		t.Errorf("extractionModelName = %q, want model.CapabilityLayerNormalization (%q)",
+			extractionModelName, model.CapabilityLayerNormalization)
 	}
 }

--- a/processor/graph-clustering/component.go
+++ b/processor/graph-clustering/component.go
@@ -299,8 +299,12 @@ type Component struct {
 	enhancementWorker *clustering.EnhancementWorker
 	llmClient         llm.Client
 
-	// Review worker (optional, for anomaly approval workflow)
-	reviewWorker *inference.ReviewWorker
+	// Review worker (optional, for anomaly approval workflow). The review
+	// worker may use a dedicated LLM client when the operator binds
+	// model.CapabilityAnomalyReview to a different endpoint than
+	// community_summary; otherwise it shares llmClient.
+	reviewWorker    *inference.ReviewWorker
+	reviewLLMClient llm.Client // non-nil only when distinct from llmClient
 
 	// Lifecycle state
 	mu                sync.RWMutex
@@ -675,6 +679,13 @@ func (c *Component) Stop(timeout time.Duration) error {
 	if c.llmClient != nil {
 		if err := c.llmClient.Close(); err != nil {
 			c.logger.Warn("LLM client close error", slog.Any("error", err))
+		}
+	}
+
+	// Close the dedicated review LLM client if distinct from the shared one.
+	if c.reviewLLMClient != nil {
+		if err := c.reviewLLMClient.Close(); err != nil {
+			c.logger.Warn("review LLM client close error", slog.Any("error", err))
 		}
 	}
 
@@ -1200,16 +1211,26 @@ func (c *Component) monitorLLMHealth(ctx context.Context, endpointURL string, wo
 // startReviewWorker initializes and starts the anomaly review worker.
 // The review worker processes pending anomalies and can auto-approve/reject
 // based on confidence thresholds, optionally using LLM for uncertain cases.
+//
+// LLM client selection precedence:
+//  1. If model.CapabilityAnomalyReview is bound in the registry, create a
+//     dedicated client for that endpoint. Stored in c.reviewLLMClient for
+//     cleanup.
+//  2. Otherwise fall back to c.llmClient (the community_summary endpoint),
+//     preserving the pre-capability piggyback behavior. May be nil for
+//     human-only mode.
 func (c *Component) startReviewWorker(ctx context.Context) error {
 	// Create relationship applier for approved anomalies
 	// Uses the mutation API to go through graph-ingest for proper indexing
 	applier := inference.NewMutationRelationshipApplier(c.natsClient, c.logger)
 
-	// Create review worker - llmClient may be nil for human-only mode
+	reviewClient := c.resolveReviewLLMClient()
+
+	// Create review worker - reviewClient may be nil for human-only mode
 	reviewWorker, err := inference.NewReviewWorker(&inference.ReviewWorkerConfig{
 		AnomalyBucket: c.anomalyBucket,
 		Storage:       c.anomalyStorage,
-		LLMClient:     c.llmClient, // May be nil for human-only mode
+		LLMClient:     reviewClient,
 		Applier:       applier,
 		Config:        c.config.AnomalyConfig.Review,
 		Logger:        c.logger,
@@ -1227,11 +1248,56 @@ func (c *Component) startReviewWorker(ctx context.Context) error {
 
 	c.logger.Info("review worker started",
 		slog.Int("workers", c.config.AnomalyConfig.Review.Workers),
-		slog.Bool("llm_enabled", c.llmClient != nil),
+		slog.Bool("llm_enabled", reviewClient != nil),
+		slog.Bool("llm_dedicated", c.reviewLLMClient != nil),
 		slog.Float64("auto_approve_threshold", c.config.AnomalyConfig.Review.AutoApproveThreshold),
 		slog.Float64("auto_reject_threshold", c.config.AnomalyConfig.Review.AutoRejectThreshold))
 
 	return nil
+}
+
+// resolveReviewLLMClient returns the LLM client the review worker should
+// use. Creates a dedicated client only when CapabilityAnomalyReview is
+// *explicitly* bound in the registry — otherwise (capability not present,
+// or any client construction error) falls back to c.llmClient, preserving
+// the legacy piggyback on the community_summary endpoint.
+//
+// We check explicit binding via GetCapability rather than ResolveEndpoint
+// because Resolve falls through to defaults.model for unknown capabilities;
+// using ResolveEndpoint would create a dedicated client for every
+// deployment even when no operator opted in, which doubles the connection
+// pool against the same endpoint and defeats the point of the fallback.
+func (c *Component) resolveReviewLLMClient() llm.Client {
+	if c.modelRegistry == nil {
+		return c.llmClient
+	}
+	if c.modelRegistry.GetCapability(model.CapabilityAnomalyReview) == nil {
+		// Capability not explicitly bound — preserve legacy piggyback.
+		return c.llmClient
+	}
+	resolved, err := model.ResolveEndpoint(c.modelRegistry, model.CapabilityAnomalyReview)
+	if err != nil {
+		c.logger.Warn("anomaly_review capability bound but endpoint resolution failed; falling back to community_summary client",
+			slog.Any("error", err))
+		return c.llmClient
+	}
+	client, err := llm.NewOpenAIClient(llm.OpenAIConfig{
+		BaseURL: resolved.URL,
+		Model:   resolved.Model,
+		APIKey:  resolved.APIKey,
+		Logger:  c.logger,
+	})
+	if err != nil {
+		c.logger.Warn("failed to create dedicated anomaly review LLM client; falling back to community_summary client",
+			slog.Any("error", err),
+			slog.String("endpoint", resolved.URL))
+		return c.llmClient
+	}
+	c.reviewLLMClient = client
+	c.logger.Info("anomaly review using dedicated LLM endpoint",
+		slog.String("endpoint", resolved.URL),
+		slog.String("model", resolved.Model))
+	return client
 }
 
 // ============================================================================

--- a/processor/graph-clustering/review_client_test.go
+++ b/processor/graph-clustering/review_client_test.go
@@ -1,0 +1,95 @@
+package graphclustering
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/c360studio/semstreams/graph/llm"
+	"github.com/c360studio/semstreams/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resolveReviewLLMClient is the seam Phase 2 introduced when lifting the
+// anomaly review LLM call out of its silent piggyback on the
+// community_summary endpoint. These tests pin its three branches:
+//
+//  1. modelRegistry == nil → falls back to c.llmClient.
+//  2. CapabilityAnomalyReview unbound → falls back to c.llmClient
+//     (preserves legacy piggyback behavior for unmigrated deployments).
+//  3. CapabilityAnomalyReview bound → creates a dedicated client and
+//     stores it on c.reviewLLMClient for cleanup.
+
+func TestResolveReviewLLMClient_NilRegistry_ReusesCommunityClient(t *testing.T) {
+	communityClient := &fakeLLMClient{}
+	c := &Component{
+		modelRegistry: nil,
+		llmClient:     communityClient,
+		logger:        slog.Default(),
+	}
+
+	got := c.resolveReviewLLMClient()
+	assert.Same(t, communityClient, got, "nil registry should reuse community_summary client")
+	assert.Nil(t, c.reviewLLMClient, "no dedicated client should be stored")
+}
+
+func TestResolveReviewLLMClient_CapabilityUnbound_ReusesCommunityClient(t *testing.T) {
+	communityClient := &fakeLLMClient{}
+	c := &Component{
+		modelRegistry: &model.Registry{
+			Endpoints: map[string]*model.EndpointConfig{
+				"seminstruct": {Provider: "openai", URL: "http://seminstruct:8083/v1", Model: "qwen", MaxTokens: 4096},
+			},
+			// Note: no anomaly_review capability.
+			Capabilities: map[string]*model.CapabilityConfig{
+				"community_summary": {Preferred: []string{"seminstruct"}},
+			},
+			Defaults: model.DefaultsConfig{Model: "seminstruct"},
+		},
+		llmClient: communityClient,
+		logger:    slog.Default(),
+	}
+
+	got := c.resolveReviewLLMClient()
+	assert.Same(t, communityClient, got, "unbound anomaly_review should reuse community_summary client (legacy piggyback)")
+	assert.Nil(t, c.reviewLLMClient, "no dedicated client should be stored when capability is unbound")
+}
+
+func TestResolveReviewLLMClient_CapabilityBound_CreatesDedicatedClient(t *testing.T) {
+	communityClient := &fakeLLMClient{}
+	c := &Component{
+		modelRegistry: &model.Registry{
+			Endpoints: map[string]*model.EndpointConfig{
+				"seminstruct": {Provider: "openai", URL: "http://seminstruct:8083/v1", Model: "qwen", MaxTokens: 4096},
+				"review-fast": {Provider: "openai", URL: "http://review-fast:8084/v1", Model: "qwen-fast", MaxTokens: 4096},
+			},
+			Capabilities: map[string]*model.CapabilityConfig{
+				"community_summary": {Preferred: []string{"seminstruct"}},
+				"anomaly_review":    {Preferred: []string{"review-fast"}},
+			},
+			Defaults: model.DefaultsConfig{Model: "seminstruct"},
+		},
+		llmClient: communityClient,
+		logger:    slog.Default(),
+	}
+
+	got := c.resolveReviewLLMClient()
+	require.NotNil(t, got, "bound anomaly_review should produce a client")
+	assert.NotSame(t, communityClient, got, "bound anomaly_review should not reuse the community client")
+	assert.NotNil(t, c.reviewLLMClient, "dedicated client should be stored for cleanup")
+	assert.Same(t, got, c.reviewLLMClient, "returned client and stored client should match")
+}
+
+// fakeLLMClient is a stub llm.Client used to verify pointer identity
+// without standing up a real OpenAI client. None of these tests exercise
+// the LLM call path itself — only the resolution branching.
+type fakeLLMClient struct {
+	model string
+}
+
+func (f *fakeLLMClient) ChatCompletion(_ context.Context, _ llm.ChatRequest) (*llm.ChatResponse, error) {
+	return nil, nil
+}
+func (f *fakeLLMClient) Model() string { return f.model }
+func (f *fakeLLMClient) Close() error  { return nil }


### PR DESCRIPTION
## Summary

Phase 2 of the LLM capability baseline (Phase 1 was #21 — the docs that surfaced the gaps). Closes the three call sites that bypassed the model registry by hardcoding magic strings or piggybacking on `community_summary`'s LLM client.

Each lifted site is now a first-class capability with **backward-compatible fallback** to the pre-Phase-2 routing. **Doing nothing on upgrade preserves prior behavior bit-for-bit.**

| Site | New capability | Fallback when unbound |
|---|---|---|
| Intent classification (every user message) | `model.CapabilityIntentClassification` | `defaults.model` (same as the pre-Phase-2 hardcoded `"default"` string did) |
| Onboarding layer normalization | `model.CapabilityLayerNormalization` | `defaults.model` (same as before) |
| Anomaly relationship review | `model.CapabilityAnomalyReview` | Reuses graph-clustering's `community_summary` LLM client (legacy piggyback preserved) |

## Why each fallback is safe

- **`intent_classification` and `layer_normalization`** — both call sites have a resolution chain that goes `endpoint name → capability → defaults.model`. With the old hardcoded `"default"` string, the chain practically resolved to `defaults.model` for every realistic config (no operator names an endpoint or capability `"default"`). With the new capability constants, the chain still resolves to `defaults.model` when the new capability is not bound. Same destination, different (better) name.
- **`anomaly_review`** — the review worker previously got its `LLMClient` field injected from graph-clustering's wiring. New `resolveReviewLLMClient` helper checks `GetCapability` (not `ResolveEndpoint`) before creating a dedicated client; an unbound capability returns `c.llmClient` unchanged. Using `GetCapability` matters: `ResolveEndpoint` falls through to `defaults.model` for unknown capabilities, which would create a redundant second client against the same endpoint. The fallback path stores nothing on `c.reviewLLMClient`, so `Close()` only frees the dedicated client when one was actually created.

## Tests

- `TestCapabilityConstants_Values` — pins all 8 wire strings (5 existing + 3 new). Renaming a constant breaks the registry config contract.
- `TestNewLLMIntentClassifier_DefaultsToCapabilityConstant` + `_ExplicitModelNamePreserved` — verify the empty/explicit modelName paths.
- `TestExtractionModelName_BoundToCapabilityConstant` — pin for the layer normalizer.
- `review_client_test.go` (new file, 3 cases): nil registry / capability unbound / capability bound. Verifies the right client is returned and `c.reviewLLMClient` is set only on the dedicated path.

## Docs

- `docs/operations/05-model-registry.md`: replaces the \"Known Gaps\" subsection with the expanded 8-capability inventory. Adds a \"Resolution semantics for the last three capabilities\" section documenting the upgrade-safe fallback story.
- `docs/operations/11-llm-routing-and-model-selection.md`: bypass spec sheets folded into the main capability list. Workload tier matrix and small-model sizing table use capability names. Configuration example shows the recommended bindings (intent_classification co-located with the agentic backend; anomaly_review and layer_normalization on the concurrent seminstruct backend).

## Test plan

- [x] `task lint` clean
- [x] `go test -race -count=1 ./...` all packages pass
- [x] `task schema:generate` clean (no drift)
- [x] Contract tests pass
- [x] Capability inventory parity between docs (8 in both)
- [ ] Reviewer dry run: deploy a config that binds none of the three new capabilities, verify intent classification, layer normalization, and anomaly review behave identically to pre-Phase-2
- [ ] Reviewer dry run: bind `anomaly_review` to a different endpoint than `community_summary`, verify graph-clustering creates a separate connection pool and review traffic flows to the new endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)