### PR TITLE
fix(agentic-tools): strip pre-loaded action examples from decide tool description

### DIFF
--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -63,11 +63,20 @@ func NewDecideExecutor(publisher TriplePublisher, platform types.PlatformMeta) *
 // coordinator's system prompt enumerates valid values per flow; downstream
 // rules match on specific action values via the CoordinatorNextAction
 // predicate.
+//
+// Description must NOT pre-load example action names. Real-LLM models
+// (claude-sonnet-4-6 observed in semteams smoke #7, 2026-05-04) treat
+// tool descriptions as more authoritative than persona prose. Naming
+// "fan_out" / "synthesize" / "retry" / "done" in the description biased
+// the planner persona's terminal action away from the persona's
+// enumerated `"planned"` toward `"fan_out"`, wedging the chain at an
+// unhandled coordinator.next_action triple. The action vocabulary lives
+// strictly in the role's system prompt.
 func (e *DecideExecutor) ListTools() []agentic.ToolDefinition {
 	return []agentic.ToolDefinition{
 		{
 			Name:        DecideToolName,
-			Description: "Terminal decision tool for coordinator agents. Call exactly once with the action your flow's coordinator persona enumerates (e.g. fan_out, synthesize, retry, done). Emits a coordinator.next_action triple on this loop's entity so downstream rules can route; the full args stay in the loop's Result for any agent that needs supporting data (subtopics, retry_hint).",
+			Description: "Terminal decision tool for coordinator agents. Call exactly once with the action your role's system prompt enumerates. Emits a coordinator.next_action triple on this loop's entity so downstream rules can route; the full args stay in the loop's Result for any agent that needs supporting data.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -82,11 +91,11 @@ func (e *DecideExecutor) ListTools() []agentic.ToolDefinition {
 					"subtopics": map[string]any{
 						"type":        "array",
 						"items":       map[string]any{"type": "string"},
-						"description": "Optional. When action=fan_out, the list of subtopics to investigate.",
+						"description": "Optional. List of sub-targets when the chosen action represents a multi-target investigation; populate only when your role's contract names this field.",
 					},
 					"retry_hint": map[string]any{
 						"type":        "string",
-						"description": "Optional. When action=retry, a hint describing how the retry should differ from the previous attempt.",
+						"description": "Optional. Free-form guidance for a downstream pass; populate only when your role's contract names this field.",
 					},
 				},
 				"required": []string{"action", "reason"},

--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -65,13 +65,19 @@ func NewDecideExecutor(publisher TriplePublisher, platform types.PlatformMeta) *
 // predicate.
 //
 // Description must NOT pre-load example action names. Real-LLM models
-// (claude-sonnet-4-6 observed in semteams smoke #7, 2026-05-04) treat
-// tool descriptions as more authoritative than persona prose. Naming
-// "fan_out" / "synthesize" / "retry" / "done" in the description biased
-// the planner persona's terminal action away from the persona's
-// enumerated `"planned"` toward `"fan_out"`, wedging the chain at an
-// unhandled coordinator.next_action triple. The action vocabulary lives
-// strictly in the role's system prompt.
+// (claude-sonnet-class observed against a downstream product flow,
+// 2026-05) treat tool descriptions as more authoritative than persona
+// prose. When the description named a handful of example actions,
+// models biased their terminal choice toward those examples,
+// overriding the persona's enumerated value and wedging chains at an
+// unhandled coordinator.next_action triple. The action vocabulary
+// lives strictly in the role's system prompt; flows that want
+// structural enforcement use the per-spawn allowlist threaded through
+// TaskMessage.Metadata under MetadataKeyDecideActionAllowlist (see
+// agentic/tools.go).
+//
+// TestDecideExecutor_DescriptionDoesNotPreloadActions guards the
+// regression — see its pattern checks for the leak shapes.
 func (e *DecideExecutor) ListTools() []agentic.ToolDefinition {
 	return []agentic.ToolDefinition{
 		{

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -67,11 +67,11 @@ func TestDecideExecutor_ListTools(t *testing.T) {
 // names (those are downstream-flow concerns). Instead it pattern-matches
 // the SHAPES that leak example vocabulary into the LLM's context:
 //
-//   1. `e\.g\.` followed by identifier-shaped tokens — the
-//      "give the LLM a worked example" anti-pattern.
-//   2. `action=<identifier>` style references in property
-//      descriptions — the "tell the LLM when to populate this field"
-//      anti-pattern that embeds specific action names.
+//  1. `e\.g\.` followed by identifier-shaped tokens — the
+//     "give the LLM a worked example" anti-pattern.
+//  2. `action=<identifier>` style references in property
+//     descriptions — the "tell the LLM when to populate this field"
+//     anti-pattern that embeds specific action names.
 //
 // Future flows that need new action names enumerate them in the
 // persona/system prompt. Adding examples here re-opens the smoke-#7

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic"
@@ -54,18 +55,27 @@ func TestDecideExecutor_ListTools(t *testing.T) {
 	}
 }
 
-// TestDecideExecutor_DescriptionDoesNotPreloadActions guards against
-// regressing the smoke-#7 wedge: if the tool Description mentions
-// specific action names, real-LLM models read them as authoritative
-// over persona prose and bias their terminal choice toward whichever
-// the description names. The action vocabulary belongs strictly in the
-// role's system prompt — see the comment block above ListTools().
+// TestDecideExecutor_DescriptionDoesNotPreloadActions guards the
+// shape of the leak that motivated this slice: tool descriptions
+// MUST NOT enumerate example action names. Real-LLM models read tool
+// descriptions as authoritative and bias their terminal choice toward
+// whichever the description names — overriding the persona's enumerated
+// vocabulary. The action vocabulary belongs strictly in each role's
+// system prompt.
 //
-// The test covers the four action names that previously appeared in
-// the description, plus a few common drifts. If a future flow legitimately
-// adds a new action name, that's a persona/system-prompt concern; it
-// must NOT be mentioned here or in the tool descriptions returned by
-// ListTools.
+// The test is product-agnostic. It does NOT enumerate specific action
+// names (those are downstream-flow concerns). Instead it pattern-matches
+// the SHAPES that leak example vocabulary into the LLM's context:
+//
+//   1. `e\.g\.` followed by identifier-shaped tokens — the
+//      "give the LLM a worked example" anti-pattern.
+//   2. `action=<identifier>` style references in property
+//      descriptions — the "tell the LLM when to populate this field"
+//      anti-pattern that embeds specific action names.
+//
+// Future flows that need new action names enumerate them in the
+// persona/system prompt. Adding examples here re-opens the smoke-#7
+// drift class regardless of which specific names get leaked.
 func TestDecideExecutor_DescriptionDoesNotPreloadActions(t *testing.T) {
 	e := newDecideExecutor(&recordingPublisher{})
 	tools := e.ListTools()
@@ -74,65 +84,56 @@ func TestDecideExecutor_DescriptionDoesNotPreloadActions(t *testing.T) {
 	}
 
 	// The full text the LLM sees: top-level Description + every nested
-	// `description` field on properties. All of these contribute to the
-	// LLM's understanding of when to pick which action.
-	var llmVisibleText []string
-	llmVisibleText = append(llmVisibleText, tools[0].Description)
+	// `description` field on properties. All contribute to the LLM's
+	// understanding of when to pick which action.
+	type labelled struct {
+		label string
+		text  string
+	}
+	var llmVisibleText []labelled
+	llmVisibleText = append(llmVisibleText, labelled{"Description", tools[0].Description})
 	if props, ok := tools[0].Parameters["properties"].(map[string]any); ok {
-		for _, prop := range props {
+		for name, prop := range props {
 			if propMap, ok := prop.(map[string]any); ok {
 				if desc, ok := propMap["description"].(string); ok {
-					llmVisibleText = append(llmVisibleText, desc)
+					llmVisibleText = append(llmVisibleText, labelled{"properties." + name + ".description", desc})
 				}
 			}
 		}
 	}
 
-	bannedActions := []string{
-		"fan_out", "synthesize", "retry", "done",
-		"planned", "approved", "rejected", "accept", "reject",
-		"insufficient", "needs_clarification",
-		"tests_passing", "tests_failing",
-		"seed_requirements_emitted",
+	// Anti-pattern 1: "e.g." followed by identifier-shaped tokens
+	// (lowercase or snake_case words). Matches the original leak
+	// `(e.g. fan_out, synthesize, retry, done)` regardless of which
+	// specific names appear.
+	exampleListPattern := regexp.MustCompile(`(?i)e\.g\.\s+[a-z][a-z0-9_]*`)
+
+	// Anti-pattern 2: `action=<identifier>` references (the
+	// "when action=X" shape that embedded specific values into the
+	// subtopics/retry_hint property descriptions).
+	actionEqPattern := regexp.MustCompile(`(?i)action\s*=\s*[a-z][a-z0-9_]*`)
+
+	// snippet returns a bounded slice of text starting at idx for
+	// inclusion in the failure message — bounded so a multi-paragraph
+	// description doesn't dump 500 chars into the test output.
+	snippet := func(text string, start, end int) string {
+		stop := end + 30
+		if stop > len(text) {
+			stop = len(text)
+		}
+		return text[start:stop]
 	}
 
-	for _, text := range llmVisibleText {
-		for _, action := range bannedActions {
-			// Use a word-boundary check so legitimate prose like
-			// "the action your role names" doesn't match "action".
-			if containsWord(text, action) {
-				t.Errorf("LLM-visible decide tool text leaks action name %q (text: %q). Action vocabulary belongs in the role's system prompt, not the tool description — see ListTools comment for the smoke #7 rationale.", action, text)
-			}
+	for _, lt := range llmVisibleText {
+		if loc := exampleListPattern.FindStringIndex(lt.text); loc != nil {
+			t.Errorf("decide tool %s leaks an example-action list at %q. The action vocabulary belongs in the role's system prompt, not in framework tool text. See ListTools comment for the smoke-#7 rationale.",
+				lt.label, snippet(lt.text, loc[0], loc[1]))
+		}
+		if loc := actionEqPattern.FindStringIndex(lt.text); loc != nil {
+			t.Errorf("decide tool %s embeds action=<identifier> at %q. Property descriptions must not name specific actions — describe the field's purpose flow-agnostically.",
+				lt.label, snippet(lt.text, loc[0], loc[1]))
 		}
 	}
-}
-
-// containsWord returns true if s contains word as a whole token (bounded
-// by start/end of string or non-word characters). Tighter than
-// strings.Contains so that "satisfaction" doesn't trigger on "action".
-func containsWord(s, word string) bool {
-	for i := 0; i+len(word) <= len(s); i++ {
-		if s[i:i+len(word)] != word {
-			continue
-		}
-		// Check left boundary
-		if i > 0 {
-			c := s[i-1]
-			if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
-				continue
-			}
-		}
-		// Check right boundary
-		j := i + len(word)
-		if j < len(s) {
-			c := s[j]
-			if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
-				continue
-			}
-		}
-		return true
-	}
-	return false
 }
 
 // TestDecideExecutor_HappyPath verifies a valid decide call emits the two

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -54,6 +54,87 @@ func TestDecideExecutor_ListTools(t *testing.T) {
 	}
 }
 
+// TestDecideExecutor_DescriptionDoesNotPreloadActions guards against
+// regressing the smoke-#7 wedge: if the tool Description mentions
+// specific action names, real-LLM models read them as authoritative
+// over persona prose and bias their terminal choice toward whichever
+// the description names. The action vocabulary belongs strictly in the
+// role's system prompt — see the comment block above ListTools().
+//
+// The test covers the four action names that previously appeared in
+// the description, plus a few common drifts. If a future flow legitimately
+// adds a new action name, that's a persona/system-prompt concern; it
+// must NOT be mentioned here or in the tool descriptions returned by
+// ListTools.
+func TestDecideExecutor_DescriptionDoesNotPreloadActions(t *testing.T) {
+	e := newDecideExecutor(&recordingPublisher{})
+	tools := e.ListTools()
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	// The full text the LLM sees: top-level Description + every nested
+	// `description` field on properties. All of these contribute to the
+	// LLM's understanding of when to pick which action.
+	var llmVisibleText []string
+	llmVisibleText = append(llmVisibleText, tools[0].Description)
+	if props, ok := tools[0].Parameters["properties"].(map[string]any); ok {
+		for _, prop := range props {
+			if propMap, ok := prop.(map[string]any); ok {
+				if desc, ok := propMap["description"].(string); ok {
+					llmVisibleText = append(llmVisibleText, desc)
+				}
+			}
+		}
+	}
+
+	bannedActions := []string{
+		"fan_out", "synthesize", "retry", "done",
+		"planned", "approved", "rejected", "accept", "reject",
+		"insufficient", "needs_clarification",
+		"tests_passing", "tests_failing",
+		"seed_requirements_emitted",
+	}
+
+	for _, text := range llmVisibleText {
+		for _, action := range bannedActions {
+			// Use a word-boundary check so legitimate prose like
+			// "the action your role names" doesn't match "action".
+			if containsWord(text, action) {
+				t.Errorf("LLM-visible decide tool text leaks action name %q (text: %q). Action vocabulary belongs in the role's system prompt, not the tool description — see ListTools comment for the smoke #7 rationale.", action, text)
+			}
+		}
+	}
+}
+
+// containsWord returns true if s contains word as a whole token (bounded
+// by start/end of string or non-word characters). Tighter than
+// strings.Contains so that "satisfaction" doesn't trigger on "action".
+func containsWord(s, word string) bool {
+	for i := 0; i+len(word) <= len(s); i++ {
+		if s[i:i+len(word)] != word {
+			continue
+		}
+		// Check left boundary
+		if i > 0 {
+			c := s[i-1]
+			if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
+				continue
+			}
+		}
+		// Check right boundary
+		j := i + len(word)
+		if j < len(s) {
+			c := s[j]
+			if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' {
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
 // TestDecideExecutor_HappyPath verifies a valid decide call emits the two
 // expected triples on the coordinator's loop entity, returns StopLoop=true,
 // and puts the full args in the tool result Content so downstream agents


### PR DESCRIPTION
## Summary

semteams smoke #7 (R3.7.2.l′ of ADR-034, real-LLM OSH-Meshtastic e2e on 2026-05-04) wedged at the dev-via-spec-planner role: real claude-sonnet-4-6 emitted \`decide(action=\"fan_out\", reason=<3000-word plan>)\` instead of the persona-canonical \`decide(action=\"planned\", ...)\`. The chain dead-ended because no rule's \`coordinator.next_action\` condition matches \"fan_out\".

Root cause was **structural, not persona drift.** The decide tool description pre-loaded four example actions: \`(e.g. fan_out, synthesize, retry, done)\`. Real-LLM treated the tool description as more authoritative than the persona's enumerated \"planned\" and picked from the description's list. Same Goodhart shape as the semteams \`feedback_format_compliance_goodhart.md\` finding: tool descriptions are interpreted as authoritative, persona prose is soft.

## Changes

- **\`processor/agentic-tools/decide.go\`** — removed \`(e.g. ...)\` action examples from the top-level Description; reworded \`subtopics\` + \`retry_hint\` property descriptions to be flow-agnostic (\"when your role's contract names this field\" instead of \"when action=fan_out\"/\"when action=retry\"). Added a comment block above \`ListTools\` naming the smoke-#7 incident so a future reader can't reintroduce the pattern without explanation.
- **\`processor/agentic-tools/decide_test.go\`** — new \`TestDecideExecutor_DescriptionDoesNotPreloadActions\` guards the regression. Walks every LLM-visible string (top-level Description + every property description) and asserts none contains a known action-name token. Word-boundary check so legitimate prose like \"the action your role names\" doesn't false-match.

Action vocabulary now lives strictly in each role's system prompt. Flows that need new action names just enumerate them in the persona; no decide-tool-description change needed.

## Test plan

- [x] \`go test ./processor/agentic-tools/...\` — green (including the new regression test)
- [x] \`go test -race ./...\` — full repo green

## Cross-repo references

- semteams smoke #7 findings: \`project_smoke7_findings.md\` (memory record, full per-loop trajectory + cost analysis)
- semteams persona that this change unblocks: \`configs/personas/fragments/dev-via-spec-planner/10-output-contract.md\`
- semteams ADR: \`docs/adr/034-qa-runner-pattern-adoption.md\` §addendum 2026-05-04 #3

## Follow-on (not in this PR)

Two related semstreams gaps surfaced by the same smoke; tracked separately:

1. **F2** (proposed) — Per-spawn \`action_allowlist\` field on \`publish_agent\` rule action so the spawned loop's decide tool description (or schema) reflects exactly the actions the persona permits. Belt-and-suspenders for F1.
2. **F4b** (investigation needed) — \`agentic-dispatch.default_tools\` doesn't appear to constrain the LLM tool catalog at runtime. Despite the source path \`component.go:710\` setting \`task.Tools\` and \`agentic-loop/handlers.go:590\` using it, real-LLM Loop A had access to tools outside the configured allowlist. Repro: NATS-direct subscribe to \`agent.task.*\` on the next dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)