### PR TITLE
feat(rule,agentic-tools): per-spawn action_allowlist on publish_agent + decide enforcement

### DIFF
--- a/agentic/tools.go
+++ b/agentic/tools.go
@@ -80,8 +80,6 @@ func (t *ToolCall) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, (*Alias)(t))
 }
 
-// ToolErrorKind classifies the source or nature of a tool execution failure.
-// It is the structured counterpart to ToolResult.Error and feeds the
 // MetadataKeyDecideActionAllowlist is the TaskMessage.Metadata /
 // ToolCall.Metadata key under which a closed action vocabulary for
 // the decide tool flows from the spawning rule down to the executor.
@@ -99,6 +97,8 @@ func (t *ToolCall) UnmarshalJSON(data []byte) error {
 // structurally on the wire.
 const MetadataKeyDecideActionAllowlist = "agent.decide.action_allowlist"
 
+// ToolErrorKind classifies the source or nature of a tool execution failure.
+// It is the structured counterpart to ToolResult.Error and feeds the
 // agent.step.error_category graph predicate for queryable failure analysis.
 type ToolErrorKind string
 

--- a/agentic/tools.go
+++ b/agentic/tools.go
@@ -82,6 +82,22 @@ func (t *ToolCall) UnmarshalJSON(data []byte) error {
 
 // ToolErrorKind classifies the source or nature of a tool execution failure.
 // It is the structured counterpart to ToolResult.Error and feeds the
+// MetadataKeyDecideActionAllowlist is the TaskMessage.Metadata /
+// ToolCall.Metadata key under which a closed action vocabulary for
+// the decide tool flows from the spawning rule down to the executor.
+//
+// When set, the decide executor validates its `action` argument
+// against the contained []string and rejects non-members with
+// ToolErrorInvalidArgs (the message names the valid set so the LLM
+// can correct on retry).
+//
+// Empty/missing leaves decide free-form (back-compat).
+//
+// Set by rule.executePublishAgent from rule.Action.ActionAllowlist.
+// See semteams smoke #7 (project_smoke7_findings.md F2 slice) for
+// the planner-wedge incident this enforces against.
+const MetadataKeyDecideActionAllowlist = "agent.decide.action_allowlist"
+
 // agent.step.error_category graph predicate for queryable failure analysis.
 type ToolErrorKind string
 

--- a/agentic/tools.go
+++ b/agentic/tools.go
@@ -94,8 +94,9 @@ func (t *ToolCall) UnmarshalJSON(data []byte) error {
 // Empty/missing leaves decide free-form (back-compat).
 //
 // Set by rule.executePublishAgent from rule.Action.ActionAllowlist.
-// See semteams smoke #7 (project_smoke7_findings.md F2 slice) for
-// the planner-wedge incident this enforces against.
+// Belt-and-suspenders for persona prose: the persona enumerates the
+// vocabulary in the LLM's system prompt; this allowlist enforces it
+// structurally on the wire.
 const MetadataKeyDecideActionAllowlist = "agent.decide.action_allowlist"
 
 // agent.step.error_category graph predicate for queryable failure analysis.

--- a/docs/operations/migration-beta40-to-beta41.md
+++ b/docs/operations/migration-beta40-to-beta41.md
@@ -1,0 +1,132 @@
+# Migration Guide: beta.40 → beta.41
+
+## Summary
+
+Beta.41 adds a per-spawn `action_allowlist` field on the
+`publish_agent` rule action that flows down to the spawned loop's
+`decide` tool, so coordinator personas can structurally enforce a
+closed action vocabulary on the wire — not just in persona prose.
+
+This is the structural counterpart to beta.40's description hygiene
+(stripping pre-loaded action examples from the decide tool description).
+beta.40 stopped the decide tool from biasing the LLM toward a hardcoded
+example list; beta.41 lets the rule author *enforce* the persona's
+enumerated vocabulary on every call.
+
+| Surface | Status |
+|---|---|
+| New field `rule.Action.ActionAllowlist []string` on `publish_agent` actions | **Additive** |
+| New constant `agentic.MetadataKeyDecideActionAllowlist` (wire key `agent.decide.action_allowlist`) | **Additive** |
+| `decide` tool validates `action` against the allowlist when present | **Behavioural — opt-in** |
+| Existing `publish_agent` rules without the new field | **Unchanged** |
+| Existing decide tool calls without the metadata key | **Unchanged — free-form** |
+| Schema (`schemas/rule-processor.v1.json`) gains `action_allowlist` on every `publish_agent` action surface | **Additive** |
+
+**The simplest beta.40 → beta.41 upgrade is to do nothing.** Existing
+deployments keep their current free-form `decide` behaviour. Rules
+that opt into `action_allowlist` get structural enforcement; rules
+that don't are unaffected.
+
+## What's new
+
+### Per-spawn `action_allowlist`
+
+Set on a `publish_agent` action to declare the closed set of action
+values the spawned loop's `decide` tool will accept:
+
+```jsonc
+{
+  "type": "publish_agent",
+  "role": "dev-via-spec-planner",
+  "tools": ["read_loop_result", "decide"],
+  "action_allowlist": ["planned", "needs_clarification"],
+  "prompt": "..."
+}
+```
+
+When the LLM emits `decide(action="anything-else", reason=...)`, the
+executor returns `ToolErrorInvalidArgs` with the valid set quoted in
+the error message:
+
+> action `"anything-else"` is not in the allowed set for this role:
+> `[planned, needs_clarification]`. The action vocabulary your role
+> accepts is closed; pick one of these and re-emit.
+
+The error feeds back into the LLM's next iteration, giving it a
+concrete correction signal without any third-party hint.
+
+### Wire path
+
+```
+rule.Action.ActionAllowlist
+  → executePublishAgent stamps onto TaskMessage.Metadata
+  → JSON wire (encoded as []any)
+  → agentic-loop propagates Metadata onto each ToolCall
+  → DecideExecutor.decide reads & validates
+```
+
+The wire shape is `[]any` (the JSON round-trip from `TaskMessage` →
+`agent.task` subject → `ToolCall` produces this), and the decide
+executor's `coerceAllowlist` handles both `[]any` and `[]string` so
+in-process callers and JSON-decoded callers behave identically.
+
+### Empty vs. missing semantics
+
+Symmetric with `task.Tools`:
+
+- **Missing field** (no `action_allowlist` key in the rule): free-form
+  decide behaviour. Back-compat for every existing rule.
+- **Explicit empty array** (`"action_allowlist": []`): also free-form.
+  Rule authors who set an empty array haven't accidentally locked the
+  spawned loop out of every action.
+- **Non-empty array**: closed enforcement. Only the listed values
+  validate.
+
+## The wedge that motivated this
+
+semteams smoke #7 (R3.7.2.l′, 2026-05-04). The
+`dev-via-spec-planner` persona enumerated `"planned"` as its terminal
+action. The decide tool description (pre-beta.40) pre-loaded
+`(e.g. fan_out, synthesize, retry, done)`. Real claude-sonnet-4-6
+emitted `decide(action="fan_out", reason=<3000-word plan>)`; no
+rule's `coordinator.next_action` condition matched; the chain
+wedged at 7 of 12 expected loops.
+
+beta.40 closed the description-leak class. beta.41 closes the
+wire-vocabulary class so future flows can't get bitten by a different
+persona-vs-tool-surface drift.
+
+## Migration steps
+
+### To opt in (per rule)
+
+Add `action_allowlist` to the relevant `publish_agent` actions in
+your rule config. Names must match exactly — this is a literal
+string-set membership check, not a pattern match.
+
+### Existing rules and configs
+
+Unchanged. The new field defaults to nil/empty (free-form), so any
+rule that doesn't set it keeps the pre-beta.41 behaviour exactly.
+
+## Backward compatibility
+
+- Existing rules without `action_allowlist`: unchanged behaviour.
+- Existing decide tool calls without the metadata key on the wire:
+  unchanged behaviour.
+- Existing tool-result schemas: no change.
+- The error message on rejection uses the existing
+  `ToolErrorInvalidArgs` kind — no new error type, no new client-side
+  handling required.
+
+## Cross-references
+
+- `processor/rule/actions.go:Action.ActionAllowlist` — the new field
+- `processor/rule/actions.go:executePublishAgent` — the producer
+- `agentic/tools.go:MetadataKeyDecideActionAllowlist` — the wire-key
+  constant
+- `processor/agentic-tools/decide.go:validateActionAllowlist` — the
+  consumer (with `coerceAllowlist` handling the JSON wire shape)
+- `schemas/rule-processor.v1.json` — schema regen
+- semteams smoke #7 findings (the empirical case study)
+- beta.40: decide tool description hygiene (sibling, complementary fix)

--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
@@ -141,6 +142,19 @@ func (e *DecideExecutor) decide(ctx context.Context, call agentic.ToolCall) (age
 		}, nil
 	}
 
+	// Per-spawn action allowlist (set by rule.executePublishAgent via
+	// TaskMessage.Metadata, propagated onto ToolCall.Metadata by the
+	// agentic-loop). When present, validate args.Action against it and
+	// return InvalidArgs with the valid set in the error message so the
+	// LLM can correct on retry. Empty/missing leaves decide free-form.
+	if msg := validateActionAllowlist(call.Metadata, args.Action); msg != "" {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     msg,
+			ErrorKind: agentic.ToolErrorInvalidArgs,
+		}, nil
+	}
+
 	if call.LoopID == "" {
 		return agentic.ToolResult{
 			CallID:    call.ID,
@@ -205,6 +219,62 @@ func (e *DecideExecutor) decide(ctx context.Context, call agentic.ToolCall) (age
 			"has_retry_hint": args.RetryHint != "",
 		},
 	}, nil
+}
+
+// validateActionAllowlist returns "" when the action is permitted (no
+// allowlist set, or allowlist contains it). Returns a non-empty error
+// message when the allowlist is set AND the action is not in it. The
+// message names the valid set so the LLM can correct on retry.
+//
+// Reads from ToolCall.Metadata under
+// agentic.MetadataKeyDecideActionAllowlist. The value flows through the
+// JSON wire as []any (TaskMessage.Metadata → ToolCall.Metadata round
+// trip); coerce to []string at validation time. Other shapes
+// (missing key, nil, non-array) are treated as "no allowlist set" —
+// no compatibility hazard for unenforced flows.
+func validateActionAllowlist(metadata map[string]any, action string) string {
+	if metadata == nil {
+		return ""
+	}
+	raw, ok := metadata[agentic.MetadataKeyDecideActionAllowlist]
+	if !ok || raw == nil {
+		return ""
+	}
+	allowlist := coerceAllowlist(raw)
+	if len(allowlist) == 0 {
+		return ""
+	}
+	for _, a := range allowlist {
+		if a == action {
+			return ""
+		}
+	}
+	return fmt.Sprintf(
+		"action %q is not in the allowed set for this role: [%s]. "+
+			"The action vocabulary your role accepts is closed; pick one of these and re-emit.",
+		action,
+		strings.Join(allowlist, ", "),
+	)
+}
+
+// coerceAllowlist accepts the JSON-unmarshalled metadata value and
+// returns the contained string slice. Handles []any (the round-trip
+// shape from BaseMessage), []string (in-process callers), and nil/other
+// (treated as empty).
+func coerceAllowlist(raw any) []string {
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
 }
 
 // parseDecideArgs reads the untyped tool arguments into decideArgs and

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -136,6 +136,150 @@ func TestDecideExecutor_DescriptionDoesNotPreloadActions(t *testing.T) {
 	}
 }
 
+// TestDecideExecutor_ActionAllowlist_Accepts verifies that a decide call
+// with action in the allowlist (passed via ToolCall.Metadata under
+// MetadataKeyDecideActionAllowlist) executes normally — triples are
+// published, StopLoop=true, payload returned. Allowlist enforcement is
+// silent on the happy path; only rejections produce error responses.
+func TestDecideExecutor_ActionAllowlist_Accepts(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutor(pub)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Metadata: map[string]any{
+			agentic.MetadataKeyDecideActionAllowlist: []any{"planned", "needs_clarification"},
+		},
+		Arguments: map[string]any{
+			"action": "planned",
+			"reason": "plan emitted",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.Error != "" {
+		t.Errorf("tool error on allowed action: %q", res.Error)
+	}
+	if !res.StopLoop {
+		t.Errorf("expected StopLoop=true on allowed action")
+	}
+	if len(pub.triples) != 2 {
+		t.Errorf("expected 2 triples published on allowed action, got %d", len(pub.triples))
+	}
+}
+
+// TestDecideExecutor_ActionAllowlist_Rejects verifies that a decide call
+// with action OUTSIDE the allowlist returns ToolErrorInvalidArgs (so the
+// LLM gets a chance to retry with a valid name) and does NOT publish
+// triples. Error message names the valid set so the LLM can converge
+// without a third-party hint. This is the smoke-#7 fan_out scenario:
+// the planner persona enumerates "planned" but the LLM hallucinated
+// "fan_out"; allowlist gate rejects, LLM corrects.
+func TestDecideExecutor_ActionAllowlist_Rejects(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutor(pub)
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Metadata: map[string]any{
+			agentic.MetadataKeyDecideActionAllowlist: []any{"planned"},
+		},
+		Arguments: map[string]any{
+			"action": "fan_out",
+			"reason": "<plan body>",
+		},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("ErrorKind = %v, want ToolErrorInvalidArgs (allowlist gate)", res.ErrorKind)
+	}
+	if res.Error == "" {
+		t.Errorf("expected non-empty Error message naming the valid action set")
+	}
+	for _, want := range []string{"fan_out", "planned"} {
+		if !contains(res.Error, want) {
+			t.Errorf("expected Error message to mention %q for LLM convergence; got %q", want, res.Error)
+		}
+	}
+	if res.StopLoop {
+		t.Errorf("StopLoop should be false on allowlist rejection — let the loop iterate")
+	}
+	if len(pub.triples) != 0 {
+		t.Errorf("no triples should be published on allowlist rejection, got %d", len(pub.triples))
+	}
+}
+
+// TestDecideExecutor_ActionAllowlist_NoAllowlistMeansFreeform verifies
+// that a decide call without MetadataKeyDecideActionAllowlist (the
+// pre-F2 wire shape) accepts any action — back-compat for flows that
+// haven't adopted the allowlist field on their publish_agent rules.
+func TestDecideExecutor_ActionAllowlist_NoAllowlistMeansFreeform(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutor(pub)
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		// No Metadata at all.
+		Arguments: map[string]any{
+			"action": "completely_made_up",
+			"reason": "no allowlist set",
+		},
+	})
+	if res.Error != "" {
+		t.Errorf("free-form mode rejected an action: %q", res.Error)
+	}
+	if !res.StopLoop {
+		t.Errorf("expected StopLoop=true in free-form mode")
+	}
+}
+
+// TestDecideExecutor_ActionAllowlist_EmptyAllowlistMeansFreeform
+// verifies that an explicitly-empty allowlist is also free-form (rule
+// authors who set an empty array shouldn't be silently locked out of
+// every action). Symmetric with how task.Tools handles its nil-vs-empty
+// distinction.
+func TestDecideExecutor_ActionAllowlist_EmptyAllowlistMeansFreeform(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutor(pub)
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Metadata: map[string]any{
+			agentic.MetadataKeyDecideActionAllowlist: []any{},
+		},
+		Arguments: map[string]any{
+			"action": "anything",
+			"reason": "empty allowlist",
+		},
+	})
+	if res.Error != "" {
+		t.Errorf("empty-allowlist mode rejected: %q", res.Error)
+	}
+}
+
+// contains is a tiny substring-presence check — kept here rather than
+// reaching for strings.Contains to keep test imports minimal.
+func contains(haystack, needle string) bool {
+	return len(needle) == 0 || (len(haystack) >= len(needle) && stringIndex(haystack, needle) >= 0)
+}
+
+func stringIndex(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}
+
 // TestDecideExecutor_HappyPath verifies a valid decide call emits the two
 // expected triples on the coordinator's loop entity, returns StopLoop=true,
 // and puts the full args in the tool result Content so downstream agents

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic"
@@ -201,7 +202,7 @@ func TestDecideExecutor_ActionAllowlist_Rejects(t *testing.T) {
 		t.Errorf("expected non-empty Error message naming the valid action set")
 	}
 	for _, want := range []string{"fan_out", "planned"} {
-		if !contains(res.Error, want) {
+		if !strings.Contains(res.Error, want) {
 			t.Errorf("expected Error message to mention %q for LLM convergence; got %q", want, res.Error)
 		}
 	}
@@ -263,21 +264,6 @@ func TestDecideExecutor_ActionAllowlist_EmptyAllowlistMeansFreeform(t *testing.T
 	if res.Error != "" {
 		t.Errorf("empty-allowlist mode rejected: %q", res.Error)
 	}
-}
-
-// contains is a tiny substring-presence check — kept here rather than
-// reaching for strings.Contains to keep test imports minimal.
-func contains(haystack, needle string) bool {
-	return len(needle) == 0 || (len(haystack) >= len(needle) && stringIndex(haystack, needle) >= 0)
-}
-
-func stringIndex(haystack, needle string) int {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return i
-		}
-	}
-	return -1
 }
 
 // TestDecideExecutor_HappyPath verifies a valid decide call emits the two

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -89,6 +89,22 @@ type Action struct {
 	// role name, model, and prompt for the spawned agent.
 	Tools []string `json:"tools,omitempty"`
 
+	// ActionAllowlist is the closed set of action values the spawned
+	// loop's `decide` tool will accept. When non-nil, executePublishAgent
+	// stamps it onto the TaskMessage's Metadata under
+	// MetadataKeyDecideActionAllowlist; the agentic-loop propagates that
+	// onto each ToolCall's Metadata; the decide tool's executor
+	// validates the action argument against this list and returns
+	// ToolErrorInvalidArgs (with the valid set in the message) if the
+	// model picks a name outside it.
+	//
+	// Empty/nil disables the gate (back-compat: action stays free-form).
+	// Belt-and-suspenders for persona prose: the persona enumerates the
+	// vocabulary, this field enforces it. See semteams smoke #7
+	// (project_smoke7_findings.md F2 slice) for the incident that
+	// motivated landing this on the rule rather than as a wrapper tool.
+	ActionAllowlist []string `json:"action_allowlist,omitempty"`
+
 	// WorkflowID is the workflow identifier for trigger_workflow actions
 	WorkflowID string `json:"workflow_id,omitempty"`
 
@@ -607,6 +623,27 @@ func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action,
 			resolved = []agentic.ToolDefinition{}
 		}
 		task.Tools = resolved
+	}
+
+	// Per-spawn action_allowlist for the decide tool. The agentic-loop
+	// propagates TaskMessage.Metadata onto each ToolCall.Metadata; the
+	// decide tool's executor reads this key, validates the action
+	// argument, and returns ToolErrorInvalidArgs (with the valid set in
+	// the message) if the model picks a name outside the allowlist.
+	// Belt-and-suspenders for persona prose.
+	//
+	// The slice is stored as []any (not []string) so the JSON round-trip
+	// through TaskMessage→agent.task→ToolCall preserves shape; decide's
+	// validator coerces back at read time. Nil/empty leaves the gate off.
+	if len(action.ActionAllowlist) > 0 {
+		if task.Metadata == nil {
+			task.Metadata = map[string]any{}
+		}
+		allowlist := make([]any, 0, len(action.ActionAllowlist))
+		for _, a := range action.ActionAllowlist {
+			allowlist = append(allowlist, a)
+		}
+		task.Metadata[agentic.MetadataKeyDecideActionAllowlist] = allowlist
 	}
 
 	if e.logger != nil {

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -100,9 +100,10 @@ type Action struct {
 	//
 	// Empty/nil disables the gate (back-compat: action stays free-form).
 	// Belt-and-suspenders for persona prose: the persona enumerates the
-	// vocabulary, this field enforces it. See semteams smoke #7
-	// (project_smoke7_findings.md F2 slice) for the incident that
-	// motivated landing this on the rule rather than as a wrapper tool.
+	// vocabulary in the LLM's system prompt; this field enforces it
+	// structurally on the wire. Putting the gate on the rule (rather
+	// than introducing a wrapper tool) keeps role→action decisions in
+	// the workflow config that already owns role/model/prompt/tools.
 	ActionAllowlist []string `json:"action_allowlist,omitempty"`
 
 	// WorkflowID is the workflow identifier for trigger_workflow actions

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -1006,6 +1006,87 @@ func TestAction_PublishAgent_EmptyToolsLeavesUnset(t *testing.T) {
 	assert.Empty(t, task.Tools, "empty action.Tools should leave TaskMessage.Tools unset")
 }
 
+// TestAction_PublishAgent_ActionAllowlist verifies that
+// action.ActionAllowlist threads onto TaskMessage.Metadata under
+// agentic.MetadataKeyDecideActionAllowlist as a []any (the JSON wire
+// shape). Empty/nil leaves Metadata unset for that key.
+//
+// The smoke-#7 wedge motivated this: a planner LLM hallucinated an
+// out-of-vocabulary action ("fan_out" instead of the persona's
+// "planned"). With this allowlist plumbed through, the decide
+// executor will reject and let the LLM correct.
+func TestAction_PublishAgent_ActionAllowlist(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:            ActionTypePublishAgent,
+		Subject:         "agent.task.test",
+		Role:            "dev-via-spec-planner",
+		Model:           "mock-model",
+		Prompt:          "p",
+		ActionAllowlist: []string{"planned", "needs_clarification"},
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	require.NotNil(t, task.Metadata, "Metadata should be initialised when ActionAllowlist is set")
+	rawAllowlist, ok := task.Metadata[agentic.MetadataKeyDecideActionAllowlist]
+	require.True(t, ok, "MetadataKeyDecideActionAllowlist should be set")
+
+	// The metadata round-trips through JSON as []any (the BaseMessage
+	// wire shape). The decide executor's coerceAllowlist handles the
+	// type-erasure on the read side. We assert the wire shape here so
+	// future refactors don't accidentally break the producer/consumer
+	// contract.
+	allowlist, ok := rawAllowlist.([]any)
+	require.True(t, ok, "expected []any after JSON round-trip; got %T", rawAllowlist)
+	require.Len(t, allowlist, 2)
+	assert.Equal(t, "planned", allowlist[0])
+	assert.Equal(t, "needs_clarification", allowlist[1])
+}
+
+// TestAction_PublishAgent_EmptyActionAllowlist verifies that an unset
+// ActionAllowlist leaves Metadata's allowlist key unset (back-compat:
+// existing flows that don't opt in keep their pre-F2 free-form decide
+// behaviour).
+func TestAction_PublishAgent_EmptyActionAllowlist(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.test",
+		Role:    "general",
+		Model:   "mock-model",
+		Prompt:  "p",
+		// ActionAllowlist omitted
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	if task.Metadata != nil {
+		_, has := task.Metadata[agentic.MetadataKeyDecideActionAllowlist]
+		assert.False(t, has, "no allowlist field should be set on Metadata when ActionAllowlist is empty")
+	}
+}
+
 // stubToolExecutor is a minimal ToolExecutor for the global-registry test.
 // It does no work; resolveToolNames only reads the ToolDefinition it exposes.
 type stubToolExecutor struct{ name string }

--- a/schemas/rule-processor.v1.json
+++ b/schemas/rule-processor.v1.json
@@ -54,6 +54,13 @@
             "items": {
               "type": "object",
               "properties": {
+                "action_allowlist": {
+                  "type": "array",
+                  "description": "action_allowlist",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "boid_signal_type": {
                   "type": "string",
                   "description": "boid_signal_type"
@@ -261,6 +268,13 @@
             "items": {
               "type": "object",
               "properties": {
+                "action_allowlist": {
+                  "type": "array",
+                  "description": "action_allowlist",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "boid_signal_type": {
                   "type": "string",
                   "description": "boid_signal_type"
@@ -386,6 +400,13 @@
             "items": {
               "type": "object",
               "properties": {
+                "action_allowlist": {
+                  "type": "array",
+                  "description": "action_allowlist",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "boid_signal_type": {
                   "type": "string",
                   "description": "boid_signal_type"
@@ -511,6 +532,13 @@
             "items": {
               "type": "object",
               "properties": {
+                "action_allowlist": {
+                  "type": "array",
+                  "description": "action_allowlist",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "boid_signal_type": {
                   "type": "string",
                   "description": "boid_signal_type"
@@ -655,6 +683,13 @@
             "items": {
               "type": "object",
               "properties": {
+                "action_allowlist": {
+                  "type": "array",
+                  "description": "action_allowlist",
+                  "items": {
+                    "type": "string"
+                  }
+                },
                 "boid_signal_type": {
                   "type": "string",
                   "description": "boid_signal_type"


### PR DESCRIPTION
## Summary

Adds a per-spawn allowed-action enum that flows from a rule's \`publish_agent\` action down to the spawned loop's \`decide\` tool, so the LLM can't drift outside the role's persona-enumerated vocabulary.

Belt-and-suspenders for persona prose: the persona enumerates valid actions (textually); this allowlist enforces them (structurally). Same Goodhart shape as PR #24 — persona is interpreted, tool surfaces are authoritative — but tighter, since #24 only fixed the description; F2 enforces the contract on the wire.

## Wedge that motivated this

semteams smoke #7 (R3.7.2.l′, 2026-05-04). The dev-via-spec-planner persona enumerated \`\"planned\"\` as its terminal action. The decide tool description (pre-F1) pre-loaded \`(e.g. fan_out, synthesize, retry, done)\`. Real claude-sonnet-4-6 emitted \`decide(action=\"fan_out\", reason=<3000-word plan>)\`; no rule's \`coordinator.next_action\` condition matched; chain wedged at 7 of 12 expected loops.

PR #24 closes the description-leak class; this PR closes the wire-vocabulary class so future flows can't get bitten by a different persona-vs-tool-surface drift.

## Wire shape

- **\`rule.Action.ActionAllowlist []string\`** (new) — set on publish_agent rule actions. Empty/nil leaves the gate off (back-compat).
- **\`executePublishAgent\`** stamps the allowlist onto \`TaskMessage.Metadata\` under **\`agentic.MetadataKeyDecideActionAllowlist\`** (new constant, \`\"agent.decide.action_allowlist\"\`). Stored as \`[]any\` so the JSON round-trip through BaseMessage preserves type erasure cleanly.
- **\`agentic-loop\`** already propagates \`TaskMessage.Metadata\` onto each \`ToolCall.Metadata\` via the cached-metadata path (\`handlers.go:1102-1107\`). No change there.
- **\`DecideExecutor.decide\`** validates \`args.Action\` against the allowlist read from \`call.Metadata\`. Unrecognised actions return \`ToolErrorInvalidArgs\` with the valid set quoted in the error message — the LLM gets a clear correction signal on the next iteration.
- **\`coerceAllowlist\`** handles both wire shapes (\`[]any\` from JSON round-trip; \`[]string\` from in-process callers) so tests match production behaviour.
- **Empty allowlist** (explicit \`[]string{}\`) is treated as \"no allowlist set\" — symmetric with how \`task.Tools\` handles its nil-vs-empty distinction. Rule authors who want a closed set populate the array; an empty array is permissive.

## Tests

- \`TestDecideExecutor_ActionAllowlist_Accepts\` — allowed action publishes triples, StopLoop=true.
- \`TestDecideExecutor_ActionAllowlist_Rejects\` — drift path: out-of-allowlist action returns InvalidArgs with the valid set in the message; no triples; StopLoop stays false (LLM corrects on next iteration).
- \`TestDecideExecutor_ActionAllowlist_NoAllowlistMeansFreeform\` — back-compat: no Metadata key keeps free-form behaviour.
- \`TestDecideExecutor_ActionAllowlist_EmptyAllowlistMeansFreeform\` — symmetric: explicit empty array matches \"no allowlist.\"
- \`TestAction_PublishAgent_ActionAllowlist\` — rule-side: allowlist threads onto TaskMessage.Metadata as \`[]any\` after JSON round-trip.
- \`TestAction_PublishAgent_EmptyActionAllowlist\` — rule-side: unset ActionAllowlist leaves Metadata's allowlist key absent.

## Schema

\`schemas/rule-processor.v1.json\` regenerated to expose \`action_allowlist\` on the publish_agent action surface.

## Test plan

- [x] \`go test ./processor/agentic-tools/...\` — green (4 new tests)
- [x] \`go test ./processor/rule/...\` — green (2 new tests)
- [x] \`go test -race ./...\` — full repo green
- [x] \`task schema:generate\` — clean

## Cross-repo references

- semteams smoke #7 findings: \`project_smoke7_findings.md\`
- F1 (sibling PR #24): \`decide\` tool description hygiene
- F3 (semteams PR #72): chain-wedge report — operator-facing diagnostic

## Adoption pattern (semteams will land in a follow-on PR)

\`\`\`json
{
  \"type\": \"publish_agent\",
  \"role\": \"dev-via-spec-planner\",
  \"tools\": [\"read_loop_result\", \"decide\"],
  \"action_allowlist\": [\"planned\", \"needs_clarification\"],
  \"prompt\": \"...\"
}
\`\`\`

Existing rules without \`action_allowlist\` are unaffected — the gate is opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)