### PR TITLE
docs(adr): flip ADR-033 Status to Accepted on SemTeams sign-off

### DIFF
--- a/docs/adr/033-polar-based-observability.md
+++ b/docs/adr/033-polar-based-observability.md
@@ -2,8 +2,23 @@
 
 ## Status
 
-**Proposed (2026-05-04).** Revised 2026-05-05 from SemTeams review;
-now incorporating their accept-with-revisions verdict.
+**Accepted (2026-05-05).** Originally proposed 2026-05-04; revised
+2026-05-05 incorporating SemTeams accept-with-revisions feedback;
+SemTeams second-pass sign-off received same day with verdict
+"Accept. The ADR is now in shape to flip Status: Proposed →
+Accepted, which unblocks the semspec/pkg/health type hoist and
+SemTeams' Phase 2 adoption work."
+
+This unblocks:
+
+- **Type hoist** — `semspec/pkg/health` types (`Detector`,
+  `Diagnosis`, `EvidenceRef`, `Bundle`) hoist into SemStreams as
+  framework primitives. New SemStreams package (working name
+  `pkg/observability`) added alongside in the same workstream.
+- **SemTeams Phase 2 adoption** — Q3 + G3 detector implementations
+  in `cmd/semteams/observability/detectors/`, objective-spec template
+  schema authoring, sentinel prompt curation as budgeted product
+  work.
 
 ### SemTeams review (2026-05-05) — accept with revisions
 


### PR DESCRIPTION
## Summary

SemTeams second-pass sign-off received 2026-05-05:

> Accept. The ADR is now in shape to flip Status: Proposed → Accepted, which unblocks the semspec/pkg/health type hoist and SemTeams' Phase 2 adoption work (Q3 + G3 detectors, objective-spec template schema, sentinel prompt curation as budgeted product work).

This PR flips ADR-033 Status: Proposed → **Accepted (2026-05-05)** with a brief lineage note (originally proposed 2026-05-04, revisions integrated 2026-05-05 via PR #28, sign-off received same day) and an explicit list of what this unblocks:

- **Type hoist** — `semspec/pkg/health` types (`Detector`, `Diagnosis`, `EvidenceRef`, `Bundle`) hoist into SemStreams as framework primitives. New SemStreams package (working name `pkg/observability`) added alongside in the same workstream.
- **SemTeams Phase 2 adoption** — Q3 + G3 detector implementations in `cmd/semteams/observability/detectors/`, objective-spec template schema authoring, sentinel prompt curation as budgeted product work.

## Diff

Single doc-only file change: 17 insertions, 2 deletions in the Status section. Body of the ADR (decisions, signal taxonomy, framework/product cut, Appendix A) untouched.

## Test plan

- [x] Status section parses cleanly
- [x] Lineage note (Proposed → Revised → Accepted with timestamps) accurate
- [x] What-this-unblocks list aligns with SemTeams verdict
- [ ] Merge — once this lands, the type hoist is the next workstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)