### PR TITLE
Investigate semspec globalSearch bug: stack rehab + observability + first-layer classifier defense

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,43 @@ go test ./test/contract/...  # Contract tests
 - Race conditions detected in tests
 - Unformatted code (`go fmt` not run)
 
+## Breaking changes — E2E required before merge (HARD RULE)
+
+Any commit/tag marked **BREAKING** in the changelog or commit message
+MUST have at least one relevant e2e tier green BEFORE the breaking
+commit lands on main. Unit + integration tests do not exercise the
+full ingest → entity → graph store → query path; registry singleton
+retirements and similar migrations can leave a sister binary
+half-migrated and silently break every flow that uses it.
+
+Concrete case (2026-05-07): beta.18 retired the payload-registry
+singleton. `cmd/e2e-semstreams/main.go` got the migration;
+`cmd/semstreams/main.go` did not. Three months of beta releases
+shipped on top of a silently broken Docker semantic stack because no
+one ran `task e2e:semantic` on main between the migration and the
+forensic discovery.
+
+Before tagging anything labeled BREAKING:
+
+```bash
+task e2e:semantic            # Or whichever tier covers the touched path
+# Confirm green. If the tier doesn't cover the path, that's a coverage
+# gap — file it before tagging.
+```
+
+After landing a registry-retirement-style migration (singletons,
+init() shims, factory + payload split), grep for every binary that
+imports the migrated package and verify each has the explicit
+registration call:
+
+```bash
+grep -rn "iotsensor\." cmd/   # Or whichever package was migrated
+```
+
+If only `cmd/e2e-semstreams` has it, the framework binary is
+half-migrated. See `feedback_e2e_required_for_breaking_changes.md`
+for the full case study.
+
 ## Architectural Identity (Not an Event Bus)
 
 SemStreams is NOT a simple event bus or pub/sub framework. It is a knowledge graph engine where the communication model is a consequence of the data model.

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -133,10 +133,11 @@ func run() error {
 	// BEFORE the tools registry so any boot path that needs payload
 	// resolution (e.g., a stateful tool unmarshaling stored messages)
 	// has the registry available. Mirrors the tools-registry shape
-	// shipped in beta.16.
-	payloadReg := payloadregistry.New()
-	if err := payloadbuiltins.Register(payloadReg); err != nil {
-		return fmt.Errorf("register builtin payloads: %w", err)
+	// shipped in beta.16. See registerPayloads for the example-processor
+	// migration (post-beta.18 payload-registry singleton retirement).
+	payloadReg, err := registerPayloads()
+	if err != nil {
+		return err
 	}
 
 	// 9b. Build the shared tool registry and register builtins. Done
@@ -615,6 +616,27 @@ func registerExampleComponents(registry *component.Registry) error {
 		return fmt.Errorf("register document: %w", err)
 	}
 	return nil
+}
+
+// registerPayloads builds the payload registry, registers framework
+// builtins, then registers payload types for every example processor
+// imported by this binary. Mirrors cmd/e2e-semstreams/main.go's
+// equivalent block. Post-beta.18 payload-registry singleton retirement,
+// every binary that uses example payload types must call this — missing
+// the registration silently breaks every flow that produces those types
+// (BaseMessage.UnmarshalJSON returns "unregistered payload type: X").
+func registerPayloads() (*payloadregistry.Registry, error) {
+	reg := payloadregistry.New()
+	if err := payloadbuiltins.Register(reg); err != nil {
+		return nil, fmt.Errorf("register builtin payloads: %w", err)
+	}
+	if err := iotsensor.RegisterPayloads(reg); err != nil {
+		return nil, fmt.Errorf("register iot_sensor payloads: %w", err)
+	}
+	if err := document.RegisterPayloads(reg); err != nil {
+		return nil, fmt.Errorf("register document payloads: %w", err)
+	}
+	return reg, nil
 }
 
 // startPProfServer starts the pprof HTTP server for profiling.

--- a/configs/semantic.json
+++ b/configs/semantic.json
@@ -16,7 +16,7 @@
       "seminstruct": {
         "provider": "openai",
         "url": "http://seminstruct:8083/v1",
-        "model": "qwen2.5-0.5b-instruct-q4-k-m",
+        "model": "qwen3-0.6b",
         "max_tokens": 4096
       },
       "semembed": {

--- a/docker/compose/services.yml
+++ b/docker/compose/services.yml
@@ -58,32 +58,21 @@ services:
           memory: 512M
           cpus: "0.5"
 
-  # Shimmy - Inference backend (model loading, heavy compute)
-  # Downloads and runs Mistral-7B-Instruct for LLM inference
-  # Provides: Raw model inference endpoint
-  shimmy:
-    profiles: ["inference", "all"]
-    image: ghcr.io/michael-a-kuykendall/shimmy:latest
-    container_name: semstreams-shimmy
-    environment:
-      - RUST_LOG=info
-    volumes:
-      # Model cache persistence (~4GB first run for Mistral-7B)
-      - shimmy-cache:/root/.cache/huggingface
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 120s # Model download takes time
-    networks:
-      - semstreams-services
-    restart: unless-stopped
-
-  # SemInstruct - OpenAI-compatible proxy to shimmy
-  # Optional: LLM-based community summarization (automatic statistical fallback if unavailable)
-  # Provides: OpenAI-compatible /v1/chat/completions endpoint
-  # Uses: Lightweight proxy with retry logic and metrics
+  # SemInstruct - OpenAI-compatible inference (llama.cpp self-hosted)
+  # Optional: LLM-based community summarization (automatic statistical
+  # fallback if unavailable)
+  # Provides: OpenAI-compatible /v1/chat/completions on :8083
+  #
+  # Image variants (CI publishes by Qwen3 model size):
+  #   :latest    → :qwen3-0.6b (hot tier, classification, ~440MB)
+  #   :qwen3-1.7b (mid tier, answer synthesis)
+  #   :qwen3-8b   (quality tier, community summarization)
+  #
+  # Concurrency: -np 4 -cb baked in (4 parallel slots, continuous
+  # batching). MODEL_CONTEXT is divided across MODEL_PARALLEL — the
+  # 16384/4 default = 4096 tokens per slot.
+  #
+  # Replaces the retired shimmy + seminstruct-proxy pair.
   seminstruct:
     profiles: ["inference", "all"]
     image: ghcr.io/c360studio/seminstruct:latest
@@ -91,21 +80,33 @@ services:
     ports:
       - "8083:8083" # OpenAI-compatible /v1/chat/completions endpoint
     environment:
-      - SEMINSTRUCT_SHIMMY_URL=http://shimmy:8080
-      - SEMINSTRUCT_PORT=8083
-      - RUST_LOG=info
-    depends_on:
-      shimmy:
-        condition: service_healthy
+      - MODEL_ALIAS=qwen3-0.6b
+      - MODEL_REASONING=off
+      - MODEL_CONTEXT=16384
+      - MODEL_PARALLEL=4
+      # MODEL_THREADS: empty = auto. Set explicitly on shared hosts to
+      # prevent CPU oversubscription (llama.cpp's OpenMP grabs all cores
+      # by default).
+      # - MODEL_THREADS=
+      # MODEL_API_KEY: empty = no auth. Set to require Bearer token.
+      # - MODEL_API_KEY=
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8083/health"]
-      interval: 10s
-      timeout: 5s
+      interval: 30s
+      timeout: 10s
       retries: 3
-      start_period: 10s
+      start_period: 30s # llama.cpp model load
     networks:
       - semstreams-services
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "4.0"
+        reservations:
+          memory: 1G
+          cpus: "1.0"
 
   # Step-CA Certificate Authority (Tier 3 ACME)
   # Required by: TLS-enabled components when using automated cert management
@@ -235,8 +236,6 @@ networks:
 
 volumes:
   semembed-cache:
-    driver: local
-  shimmy-cache:
     driver: local
   step-ca-data:
     driver: local

--- a/docker/compose/tiered.yml
+++ b/docker/compose/tiered.yml
@@ -11,7 +11,7 @@
 # Profiles:
 #   - structural: NATS + semstreams (rules-only, no ML dependencies)
 #   - statistical: NATS + semstreams (BM25 fallback, no ML dependencies)
-#   - semantic: NATS + semembed + seminstruct + shimmy + semstreams-ml (full ML)
+#   - semantic: NATS + semembed + seminstruct + semstreams-ml (full ML)
 #
 # Usage:
 #   docker compose -f docker/compose/tiered.yml --profile structural up -d
@@ -51,30 +51,16 @@ services:
       retries: 3
       start_period: 30s
 
-  # Shimmy - Inference backend (model loading, heavy compute)
-  # Downloads and runs Mistral-7B-Instruct for LLM inference
+  # SemInstruct - OpenAI-compatible inference (llama.cpp self-hosted)
   # PROFILE: semantic - Only started when --profile semantic is specified
-  shimmy:
-    image: ghcr.io/c360studio/semshimmy:latest
-    container_name: semstreams-tiered-shimmy
-    profiles:
-      - semantic
-    environment:
-      - RUST_LOG=info
-    volumes:
-      - shimmy-tiered-cache:/root/.cache/huggingface
-    networks:
-      - semstreams-tiered-net
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11435/health"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 120s # Model download takes time (~4GB first run)
-
-  # SemInstruct - OpenAI-compatible proxy to shimmy
-  # Lightweight proxy with retry logic and metrics
-  # PROFILE: semantic - Only started when --profile semantic is specified
+  #
+  # Image variants (CI publishes by Qwen3 model size):
+  #   :latest    → :qwen3-0.6b (hot tier, classification, ~440MB)
+  #   :qwen3-1.7b (mid tier, answer synthesis)
+  #   :qwen3-8b   (quality tier, community summarization)
+  #
+  # Concurrency: -np 4 -cb baked in (4 parallel slots, continuous
+  # batching). Replaces the retired shimmy + seminstruct-proxy pair.
   seminstruct:
     image: ghcr.io/c360studio/seminstruct:latest
     container_name: semstreams-tiered-seminstruct
@@ -83,20 +69,21 @@ services:
     ports:
       - "38084:8083" # OpenAI-compatible /v1/chat/completions (3xxxx range)
     environment:
-      - SEMINSTRUCT_SHIMMY_URL=http://shimmy:11435
-      - SEMINSTRUCT_PORT=8083
-      - RUST_LOG=info
-    depends_on:
-      shimmy:
-        condition: service_healthy
+      - MODEL_ALIAS=qwen3-0.6b
+      - MODEL_REASONING=off
+      - MODEL_CONTEXT=16384
+      - MODEL_PARALLEL=4
+      # MODEL_THREADS: empty = auto. Set explicitly when sharing CPU
+      # with other services (llama.cpp's OpenMP grabs all cores).
+      # - MODEL_THREADS=
     networks:
       - semstreams-tiered-net
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8083/health"]
-      interval: 10s
-      timeout: 5s
+      interval: 30s
+      timeout: 10s
       retries: 3
-      start_period: 10s
+      start_period: 30s # llama.cpp model load
 
   # NATS Server with JetStream
   nats:
@@ -277,6 +264,4 @@ volumes:
   nats-semstreams-tiered-data:
     driver: local
   semembed-tiered-cache:
-    driver: local
-  shimmy-tiered-cache:
     driver: local

--- a/examples/processors/iot_sensor/payload.go
+++ b/examples/processors/iot_sensor/payload.go
@@ -81,12 +81,18 @@ func buildSensorReading(fields map[string]any) (any, error) {
 	return msg, nil
 }
 
-// RegisterPayloads registers the SensorReading payload type
-// (iot.sensor.v1) with the supplied registry. Called by binaries that
-// want to load this example processor's payload — typically
-// cmd/e2e-semstreams/main.go.
+// RegisterPayloads registers the SensorReading (iot.sensor.v1) and
+// Zone (facility.zone.v1) payload types with the supplied registry.
+// Called by binaries that want to load this example processor's
+// payloads — cmd/semstreams and cmd/e2e-semstreams.
+//
+// Both types must register: SensorReading triples reference Zone
+// entity IDs, and graph-ingest needs to deserialize both payload
+// shapes. Registering only iot.sensor.v1 leaves facility.zone.v1
+// messages unrouteable, which silently breaks every flow that
+// produces zone entities.
 func RegisterPayloads(reg *payloadregistry.Registry) error {
-	return reg.Register(&payloadregistry.Registration{
+	if err := reg.Register(&payloadregistry.Registration{
 		Domain:      "iot",
 		Category:    "sensor",
 		Version:     "v1",
@@ -102,6 +108,24 @@ func RegisterPayloads(reg *payloadregistry.Registry) error {
 			"Unit":       "celsius",
 			"OrgID":      "acme",
 			"Platform":   "logistics",
+		},
+	}); err != nil {
+		return err
+	}
+	return reg.Register(&payloadregistry.Registration{
+		Domain:      "facility",
+		Category:    "zone",
+		Version:     "v1",
+		Description: "Facility zone entity referenced by IoT sensor triples",
+		Factory: func() any {
+			return &Zone{}
+		},
+		Example: map[string]any{
+			"ZoneID":   "warehouse-7",
+			"ZoneType": "warehouse",
+			"Name":     "Main Warehouse",
+			"OrgID":    "acme",
+			"Platform": "logistics",
 		},
 	})
 }

--- a/graph/clustering/doc.go
+++ b/graph/clustering/doc.go
@@ -89,7 +89,7 @@
 //
 // LLMSummarizer:
 //   - OpenAI-compatible LLM for natural language summaries
-//   - Works with shimmy, OpenAI, Ollama, vLLM, etc.
+//   - Works with seminstruct, OpenAI, Ollama, vLLM, etc.
 //   - Falls back to statistical on service unavailability
 //
 // ProgressiveSummarizer:

--- a/graph/clustering/summarizer.go
+++ b/graph/clustering/summarizer.go
@@ -435,7 +435,7 @@ func extractTerms(text string) []string {
 // This summarizer calls an external LLM service for higher quality natural language summaries.
 //
 // It works with any OpenAI-compatible backend:
-//   - shimmy (recommended for local inference)
+//   - seminstruct (recommended for local llama.cpp inference)
 //   - OpenAI cloud
 //   - Ollama, vLLM, etc.
 type LLMSummarizer struct {

--- a/graph/llm/client.go
+++ b/graph/llm/client.go
@@ -1,7 +1,7 @@
 // Package llm provides LLM client abstractions for OpenAI-compatible APIs.
 //
 // This package enables semstreams to use any OpenAI-compatible LLM service
-// (shimmy, OpenAI, Anthropic via proxy, Ollama, etc.) for:
+// (seminstruct, OpenAI, vLLM, Ollama, etc.) for:
 //   - Community summarization
 //   - Search answer generation
 //   - General inference tasks

--- a/graph/llm/config.go
+++ b/graph/llm/config.go
@@ -14,13 +14,13 @@ type Config struct {
 
 	// BaseURL is the base URL of the LLM service.
 	// Examples:
-	//   - "http://shimmy:8080/v1" (local shimmy)
+	//   - "http://seminstruct:8083/v1" (local seminstruct, llama.cpp)
 	//   - "https://api.openai.com/v1" (OpenAI cloud)
 	BaseURL string `json:"base_url"`
 
 	// Model is the model identifier to use.
 	// Examples:
-	//   - "mistral-7b-instruct" (shimmy)
+	//   - "qwen3-0.6b" (seminstruct hot tier)
 	//   - "gpt-4" (OpenAI)
 	Model string `json:"model"`
 

--- a/graph/llm/doc.go
+++ b/graph/llm/doc.go
@@ -9,7 +9,7 @@
 // # Supported Backends
 //
 // The package uses the OpenAI SDK, so it works with any compatible backend:
-//   - semshimmy + seminstruct (recommended for local inference)
+//   - seminstruct (recommended for local llama.cpp inference)
 //   - OpenAI cloud
 //   - Ollama
 //   - vLLM
@@ -20,8 +20,8 @@
 // Create a client:
 //
 //	cfg := llm.OpenAIConfig{
-//	    BaseURL: "http://shimmy:8080/v1",
-//	    Model:   "mistral-7b-instruct",
+//	    BaseURL: "http://seminstruct:8083/v1",
+//	    Model:   "qwen3-0.6b",
 //	}
 //	client, err := llm.NewOpenAIClient(cfg)
 //
@@ -55,8 +55,8 @@
 //	{
 //	    "llm": {
 //	        "provider": "openai",
-//	        "base_url": "http://shimmy:8080/v1",
-//	        "model": "mistral-7b-instruct"
+//	        "base_url": "http://seminstruct:8083/v1",
+//	        "model": "qwen3-0.6b"
 //	    }
 //	}
 package llm

--- a/graph/llm/openai_client.go
+++ b/graph/llm/openai_client.go
@@ -25,9 +25,9 @@ const (
 // OpenAIClient implements Client using the OpenAI SDK.
 //
 // This implementation works with:
-//   - shimmy (local inference server) - recommended
+//   - seminstruct (local llama.cpp inference server) - recommended
 //   - OpenAI (cloud)
-//   - Any OpenAI-compatible API (Ollama, LocalAI, vLLM, etc.)
+//   - Any OpenAI-compatible API (Ollama, vLLM, LocalAI, etc.)
 //
 // Uses the standard OpenAI SDK for consistency with the embedding package.
 type OpenAIClient struct {
@@ -41,20 +41,20 @@ type OpenAIClient struct {
 type OpenAIConfig struct {
 	// BaseURL is the base URL of the LLM service.
 	// Examples:
-	//   - "http://shimmy:8080/v1" (shimmy local inference)
-	//   - "http://localhost:8080/v1" (local development)
+	//   - "http://seminstruct:8083/v1" (seminstruct local inference)
+	//   - "http://localhost:8083/v1" (local development)
 	//   - "https://api.openai.com/v1" (OpenAI cloud)
 	BaseURL string
 
 	// Model is the model to use for chat completions.
 	// Examples:
-	//   - "mistral-7b-instruct" (shimmy with Mistral)
+	//   - "qwen3-0.6b" (seminstruct hot tier)
 	//   - "gpt-4" (OpenAI)
 	//   - "llama2" (Ollama)
 	Model string
 
 	// APIKey for authentication (optional for local services).
-	// Required for OpenAI, optional for shimmy/Ollama.
+	// Required for OpenAI, optional for seminstruct/Ollama.
 	APIKey string
 
 	// Timeout for HTTP requests (default: 60s for LLM inference).

--- a/graph/query/classifier_llm_adapter.go
+++ b/graph/query/classifier_llm_adapter.go
@@ -27,7 +27,7 @@ const DefaultClassificationTimeout = 5 * time.Second
 // LLMClientAdapter adapts a graph/llm.Client to the query.LLMClient interface.
 //
 // This allows the existing OpenAI-compatible LLM infrastructure (ollama, seminstruct,
-// shimmy, OpenAI) to be used as the T3 classifier backend.
+// vLLM, OpenAI) to be used as the T3 classifier backend.
 //
 // Each ClassifyQuery call is bounded by an internal timeout (see
 // timeout field) so a slow upstream model cannot consume the parent

--- a/processor/graph-clustering/component.go
+++ b/processor/graph-clustering/component.go
@@ -1102,7 +1102,7 @@ func (c *Component) startEnhancementWorker(ctx context.Context, provider cluster
 
 	// Probe LLM endpoint before committing workers — a fast health check
 	// prevents per-community blocking when the endpoint is unreachable
-	// (e.g., shimmy unhealthy, LLM disabled in deployment).
+	// (e.g., seminstruct unhealthy, LLM disabled in deployment).
 	probeCtx, probeCancel := context.WithTimeout(ctx, 5*time.Second)
 	if err := probeLLMEndpoint(probeCtx, resolved.URL); err != nil {
 		probeCancel()

--- a/processor/graph-query/classifier_defense_test.go
+++ b/processor/graph-query/classifier_defense_test.go
@@ -1,0 +1,62 @@
+package graphquery
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestClassifierTemplatePattern(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		match bool
+	}{
+		{"angle-bracket placeholder", "<entity_type>", true},
+		{"angle-bracket open only", "<unclosed", true},
+		{"curly-brace placeholder", "{type}", true},
+		{"dollar-sign placeholder", "$type_filter", true},
+		{"plain entity type", "sensor", false},
+		{"plain numeric type", "drone", false},
+		{"empty string", "", false},
+		{"contains brackets in middle", "thing<x>", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifierTemplatePattern.MatchString(tt.value)
+			if got != tt.match {
+				t.Errorf("MatchString(%q) = %v, want %v", tt.value, got, tt.match)
+			}
+		})
+	}
+}
+
+func TestFilterClassifierTemplates(t *testing.T) {
+	logger := slog.Default()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"all valid", []string{"sensor", "drone"}, []string{"sensor", "drone"}},
+		{"all template", []string{"<entity_type>", "{type}"}, []string{}},
+		{"mixed — drop templates only", []string{"sensor", "<entity_type>", "drone"}, []string{"sensor", "drone"}},
+		{"empty", []string{}, []string{}},
+		{"whitespace-padded template", []string{"  <entity_type>  "}, []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use nil metrics to skip the increment path; we're testing
+			// the filtering logic, not metrics emission.
+			got := filterClassifierTemplates(tt.in, logger, nil)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v (len=%d), want %v (len=%d)", got, len(got), tt.want, len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/processor/graph-query/graphrag.go
+++ b/processor/graph-query/graphrag.go
@@ -418,6 +418,24 @@ func (c *Component) extractSearchRefinements(cr *query.ClassificationResult, raw
 	return searchQuery, typeFilters
 }
 
+// recordGlobalSearchOutcome records the Prometheus signals for a globalSearch
+// response: the entity-count histogram, the empty-with-reason counter (when
+// Count is zero and a non-empty reason is supplied), and the degraded counter
+// (when Degraded is true). Single helper keeps the strategy bodies under the
+// revive function-length cap.
+func (c *Component) recordGlobalSearchOutcome(strategy string, resp *GlobalSearchResponse, emptyReason string) {
+	if c.promMetrics == nil {
+		return
+	}
+	c.promMetrics.observeGlobalSearchResponseCount(resp.Count)
+	if resp.Count == 0 && emptyReason != "" {
+		c.promMetrics.recordGlobalSearchEmpty(strategy, emptyReason)
+	}
+	if resp.Degraded {
+		c.promMetrics.recordGlobalSearchDegraded(resp.DegradedReason)
+	}
+}
+
 // minScore returns the smallest Score in hits, or 0 when hits is empty.
 // Used only for diagnostic logs in the globalSearch paths.
 func minScore(hits []SemanticHit) float64 {
@@ -534,6 +552,9 @@ func (c *Component) handleGlobalSearch(ctx context.Context, data []byte) ([]byte
 	searchQuery, typeFilters := c.extractSearchRefinements(classResult, req.Query)
 
 	strategy := c.resolveStrategy(classResult)
+	if c.promMetrics != nil {
+		c.promMetrics.recordGlobalSearchStrategy(strategy)
+	}
 	c.logger.Debug("globalSearch strategy resolved",
 		"query", req.Query,
 		"refined_query", searchQuery,
@@ -666,6 +687,7 @@ func (c *Component) handleStrategyGraphRAG(ctx context.Context, searchQuery stri
 			if req.IncludeSources {
 				response.Sources = c.buildSources(entities, semanticHits, communityMatches)
 			}
+			c.recordGlobalSearchOutcome("graphrag", &response, "")
 			c.recordSuccess(requestSize, 0)
 			return json.Marshal(response)
 		}
@@ -675,6 +697,21 @@ func (c *Component) handleStrategyGraphRAG(ctx context.Context, searchQuery stri
 	}
 
 	// Tier 2: Fall back to text-based community scoring.
+	return c.graphRAGTier2Fallback(ctx, req, startTime, requestSize, err)
+}
+
+// graphRAGTier2Fallback handles the graphrag fall-through when tier-1 semantic
+// search is empty or errored. Records the tier transition Prometheus signal
+// and either returns an empty response (community cache unavailable) or
+// delegates to the text-based community search.
+func (c *Component) graphRAGTier2Fallback(ctx context.Context, req *GlobalSearchRequest, startTime time.Time, requestSize int, semanticErr error) ([]byte, error) {
+	tierReason := "empty_hits"
+	if semanticErr != nil {
+		tierReason = "err"
+	}
+	if c.promMetrics != nil {
+		c.promMetrics.recordGlobalSearchTierTransition("semantic", "community_text", tierReason)
+	}
 	// Return an empty result instead of an error when the community cache
 	// is unavailable — callers should not receive a hard error just because
 	// clustering hasn't run yet.
@@ -689,9 +726,9 @@ func (c *Component) handleStrategyGraphRAG(ctx context.Context, searchQuery stri
 		if req.shouldIncludeSummaries() {
 			response.CommunitySummaries = []CommunitySummary{}
 		}
+		c.recordGlobalSearchOutcome("graphrag", &response, "no_community_cache")
 		return json.Marshal(response)
 	}
-
 	return c.globalSearchTextBased(ctx, *req, startTime, requestSize)
 }
 
@@ -763,6 +800,10 @@ func (c *Component) handleStrategySemantic(ctx context.Context, searchQuery stri
 		c.logger.Debug("semantic strategy: search unavailable",
 			"query", searchQuery,
 			"error", err)
+		if c.promMetrics != nil {
+			c.promMetrics.recordGlobalSearchEmpty("semantic", "semantic_unavailable")
+			c.promMetrics.observeGlobalSearchResponseCount(0)
+		}
 		// Graceful degradation: return empty rather than hard error.
 		return json.Marshal(GlobalSearchResponse{
 			Entities:   []*gtypes.EntityState{},
@@ -790,6 +831,9 @@ func (c *Component) handleStrategySemantic(ctx context.Context, searchQuery stri
 		"query", searchQuery,
 		"survived", len(filtered),
 		"dropped", len(semanticHits)-len(filtered))
+	if c.promMetrics != nil {
+		c.promMetrics.recordGlobalSearchHitsDropped("threshold", len(semanticHits)-len(filtered))
+	}
 
 	entityIDs := make([]string, len(filtered))
 	for i, h := range filtered {
@@ -803,6 +847,9 @@ func (c *Component) handleStrategySemantic(ctx context.Context, searchQuery stri
 			"types", typeFilters,
 			"before", before,
 			"after", len(entityIDs))
+		if c.promMetrics != nil {
+			c.promMetrics.recordGlobalSearchHitsDropped("type_filter", before-len(entityIDs))
+		}
 	}
 
 	entities, loadErr := c.loadEntities(ctx, entityIDs)
@@ -817,6 +864,16 @@ func (c *Component) handleStrategySemantic(ctx context.Context, searchQuery stri
 	}
 
 	c.enrichGlobalResponse(ctx, &response, searchQuery, entityIDs)
+
+	if c.promMetrics != nil {
+		c.promMetrics.observeGlobalSearchResponseCount(response.Count)
+		if response.Count == 0 {
+			// Pure semantic strategy + non-empty pipeline + zero entities → either
+			// threshold or type filter wiped them; the per-stage drop counters
+			// pin which one. The empty counter aggregates the total class.
+			c.promMetrics.recordGlobalSearchEmpty("semantic", "filtered_to_empty")
+		}
+	}
 
 	c.recordSuccess(requestSize, 0)
 	return json.Marshal(response)
@@ -969,6 +1026,7 @@ func (c *Component) globalSearchTextBased(ctx context.Context, req GlobalSearchR
 		if req.shouldIncludeSummaries() {
 			response.CommunitySummaries = []CommunitySummary{}
 		}
+		c.recordGlobalSearchOutcome("graphrag", &response, "no_communities")
 		return json.Marshal(response)
 	}
 
@@ -1060,6 +1118,7 @@ func (c *Component) globalSearchTextBased(ctx context.Context, req GlobalSearchR
 		response.Sources = c.buildSources(matchedEntities, nil, summaries)
 	}
 
+	c.recordGlobalSearchOutcome("graphrag", &response, "relevance_filter")
 	c.recordSuccess(requestSize, 0)
 	return json.Marshal(response)
 }

--- a/processor/graph-query/graphrag.go
+++ b/processor/graph-query/graphrag.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -398,24 +400,75 @@ func (c *Component) classifyQuery(ctx context.Context, queryText string) *query.
 	return c.classifier.ClassifyQuery(ctx, queryText)
 }
 
+// classifierTemplatePattern matches template-placeholder strings that small
+// classifier models (e.g. qwen3-0.6b) sometimes emit verbatim from their
+// response template instead of resolving — `<entity_type>`, `{type}`,
+// `$placeholder`. When seen in a type_filters slot, the literal placeholder
+// reaches filterEntityIDsByType where it matches no real entity and silently
+// drops every hit. See semspec Meshtastic report (2026-05-07).
+var classifierTemplatePattern = regexp.MustCompile(`^[<{$].*[>}]?$`)
+
 // extractSearchRefinements pulls query reformulation and type filters from a
 // classification result. Returns the raw query unchanged when no hints are available.
+//
+// Hardening (post-Meshtastic incident, 2026-05-07):
+//
+//  1. Single-token rawQuery (no spaces) bypasses classifier query refinement —
+//     small models tend to replace proper-noun queries with generic example
+//     templates ("Meshtastic" → "find paths between entities") that lose the
+//     original intent.
+//  2. Type filters that look like template placeholders (`<...>`, `{...}`,
+//     `$...`) are dropped with a WARN — the classifier emitted its template
+//     verbatim instead of resolving. Better to send the request without
+//     filtering than to drop every hit silently.
 func (c *Component) extractSearchRefinements(cr *query.ClassificationResult, rawQuery string) (string, []string) {
 	searchQuery := rawQuery
 	var typeFilters []string
 	if cr == nil {
 		return searchQuery, typeFilters
 	}
+	singleToken := !strings.ContainsAny(strings.TrimSpace(rawQuery), " \t\n")
 	if q, ok := cr.Options["query"].(string); ok && q != "" {
-		searchQuery = q
-		c.logger.Debug("using classifier-refined query",
-			"original", rawQuery,
-			"refined", searchQuery)
+		switch {
+		case singleToken && !strings.Contains(strings.ToLower(q), strings.ToLower(rawQuery)):
+			c.logger.Warn("classifier-refined query dropped — single-token original not preserved",
+				"original", rawQuery,
+				"refined", q)
+			if c.promMetrics != nil {
+				c.promMetrics.recordClassifierGarbage("query_dropped")
+			}
+		default:
+			searchQuery = q
+			c.logger.Debug("using classifier-refined query",
+				"original", rawQuery,
+				"refined", searchQuery)
+		}
 	}
 	if t, ok := cr.Options["types"].([]string); ok && len(t) > 0 {
-		typeFilters = t
+		typeFilters = filterClassifierTemplates(t, c.logger, c.promMetrics)
 	}
 	return searchQuery, typeFilters
+}
+
+// filterClassifierTemplates removes template-shaped placeholder strings from
+// a list of classifier-emitted type filters, logs a WARN per dropped value,
+// and increments the classifier-garbage counter. Returns the filtered list.
+func filterClassifierTemplates(types []string, logger *slog.Logger, m *queryMetrics) []string {
+	out := make([]string, 0, len(types))
+	for _, t := range types {
+		if classifierTemplatePattern.MatchString(strings.TrimSpace(t)) {
+			if logger != nil {
+				logger.Warn("classifier-emitted type filter dropped — template placeholder",
+					"value", t)
+			}
+			if m != nil {
+				m.recordClassifierGarbage("template_filter")
+			}
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
 }
 
 // recordGlobalSearchOutcome records the Prometheus signals for a globalSearch

--- a/processor/graph-query/graphrag.go
+++ b/processor/graph-query/graphrag.go
@@ -418,6 +418,36 @@ func (c *Component) extractSearchRefinements(cr *query.ClassificationResult, raw
 	return searchQuery, typeFilters
 }
 
+// minScore returns the smallest Score in hits, or 0 when hits is empty.
+// Used only for diagnostic logs in the globalSearch paths.
+func minScore(hits []SemanticHit) float64 {
+	if len(hits) == 0 {
+		return 0
+	}
+	m := hits[0].Score
+	for _, h := range hits[1:] {
+		if h.Score < m {
+			m = h.Score
+		}
+	}
+	return m
+}
+
+// maxScore returns the largest Score in hits, or 0 when hits is empty.
+// Used only for diagnostic logs in the globalSearch paths.
+func maxScore(hits []SemanticHit) float64 {
+	if len(hits) == 0 {
+		return 0
+	}
+	m := hits[0].Score
+	for _, h := range hits[1:] {
+		if h.Score > m {
+			m = h.Score
+		}
+	}
+	return m
+}
+
 // MinSemanticRelevancePure is the minimum similarity score for pure semantic strategy
 // queries (e.g. "find similar to X"). Higher than MinSemanticRelevance because pure
 // semantic queries should only return genuinely similar entities.
@@ -506,7 +536,11 @@ func (c *Component) handleGlobalSearch(ctx context.Context, data []byte) ([]byte
 	strategy := c.resolveStrategy(classResult)
 	c.logger.Debug("globalSearch strategy resolved",
 		"query", req.Query,
-		"strategy", strategy)
+		"refined_query", searchQuery,
+		"strategy", strategy,
+		"type_filters", typeFilters,
+		"req_level", req.Level,
+		"req_max_communities", req.MaxCommunities)
 
 	switch strategy {
 	case "entity_lookup":
@@ -535,6 +569,12 @@ func (c *Component) handleStrategyGraphRAG(ctx context.Context, searchQuery stri
 	// Tier 1: Try semantic search first (via graph-embedding).
 	// Semantic search works independently of the community cache.
 	semanticHits, err := c.searchEntitiesSemantic(ctx, searchQuery, 100)
+	c.logger.Debug("graphrag tier-1 semantic call",
+		"query", searchQuery,
+		"err", err,
+		"hits", len(semanticHits),
+		"min_score", minScore(semanticHits),
+		"max_score", maxScore(semanticHits))
 	if err == nil && len(semanticHits) > 0 {
 		c.logger.Debug("using semantic search results",
 			"query", searchQuery,
@@ -731,6 +771,13 @@ func (c *Component) handleStrategySemantic(ctx context.Context, searchQuery stri
 		})
 	}
 
+	c.logger.Debug("semantic strategy: raw hits",
+		"query", searchQuery,
+		"hits", len(semanticHits),
+		"min_score", minScore(semanticHits),
+		"max_score", maxScore(semanticHits),
+		"threshold", MinSemanticRelevancePure)
+
 	// Apply higher relevance threshold for pure semantic queries.
 	filtered := make([]SemanticHit, 0, len(semanticHits))
 	for _, h := range semanticHits {
@@ -739,13 +786,23 @@ func (c *Component) handleStrategySemantic(ctx context.Context, searchQuery stri
 		}
 	}
 
+	c.logger.Debug("semantic strategy: after threshold filter",
+		"query", searchQuery,
+		"survived", len(filtered),
+		"dropped", len(semanticHits)-len(filtered))
+
 	entityIDs := make([]string, len(filtered))
 	for i, h := range filtered {
 		entityIDs[i] = h.EntityID
 	}
 
 	if len(typeFilters) > 0 {
+		before := len(entityIDs)
 		entityIDs = filterEntityIDsByType(entityIDs, typeFilters)
+		c.logger.Debug("semantic strategy: after type filter",
+			"types", typeFilters,
+			"before", before,
+			"after", len(entityIDs))
 	}
 
 	entities, loadErr := c.loadEntities(ctx, entityIDs)
@@ -894,6 +951,14 @@ func parseEntityIDsFromResults(data []byte) ([]string, error) {
 func (c *Component) globalSearchTextBased(ctx context.Context, req GlobalSearchRequest, startTime time.Time, requestSize int) ([]byte, error) {
 	// Get all communities at the specified level from cache
 	communities := c.communityCache.GetCommunitiesByLevel(req.Level)
+	stats := c.communityCache.Stats()
+	c.logger.Debug("globalSearchTextBased: cache fetch",
+		"req_level", req.Level,
+		"communities_at_level", len(communities),
+		"cache_total_communities", stats.TotalCommunities,
+		"cache_total_entities", stats.TotalEntities,
+		"cache_by_level", stats.ByLevel,
+		"cache_ready", stats.Ready)
 	if len(communities) == 0 {
 		response := GlobalSearchResponse{
 			Entities:   []*gtypes.EntityState{},

--- a/processor/graph-query/metrics.go
+++ b/processor/graph-query/metrics.go
@@ -28,6 +28,14 @@ type queryMetrics struct {
 	globalSearchTierTransition *prometheus.CounterVec // labels: from, to, reason
 	globalSearchHitsDropped    *prometheus.CounterVec // labels: stage (threshold|type_filter)
 	globalSearchDegraded       *prometheus.CounterVec // labels: reason — closes beta.45 debt
+
+	// classifierGarbage tracks defenses firing against classifier output
+	// emitted verbatim from a response template (e.g. qwen3-0.6b returning
+	// `<entity_type>` as a literal type filter, or replacing a proper-noun
+	// query with a generic example string). High rate indicates the
+	// classifier model is too thin for the workload — operators should
+	// upsize or relax single-token-bypass thresholds.
+	classifierGarbage *prometheus.CounterVec // labels: type (template_filter|query_dropped)
 }
 
 // Package-level metrics (registered once to avoid duplicate registration errors)
@@ -131,6 +139,13 @@ func getMetrics(registry *metric.MetricsRegistry) *queryMetrics {
 				Name:      "global_search_degraded_total",
 				Help:      "Global search responses returned with Degraded=true, by reason (answer_synthesis_timeout|answer_synthesis_cancelled|answer_synthesis_error). Closes beta.45's flag-without-counter gap.",
 			}, []string{"reason"}),
+
+			classifierGarbage: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_query",
+				Name:      "classifier_garbage_total",
+				Help:      "Defenses triggered against malformed classifier output: template_filter (literal placeholder in type_filters) or query_dropped (single-token original query replaced by classifier-emitted template). High rate = classifier model too thin for workload.",
+			}, []string{"type"}),
 		}
 
 		// Register metrics with the metrics registry if available
@@ -148,6 +163,7 @@ func getMetrics(registry *metric.MetricsRegistry) *queryMetrics {
 			_ = registry.RegisterCounterVec("graph-query", "global_search_tier_transition_total", metrics.globalSearchTierTransition)
 			_ = registry.RegisterCounterVec("graph-query", "global_search_hits_dropped_total", metrics.globalSearchHitsDropped)
 			_ = registry.RegisterCounterVec("graph-query", "global_search_degraded_total", metrics.globalSearchDegraded)
+			_ = registry.RegisterCounterVec("graph-query", "classifier_garbage_total", metrics.classifierGarbage)
 		} else {
 			// Fallback to default prometheus registry for testing
 			_ = prometheus.DefaultRegisterer.Register(metrics.communityCacheHits)
@@ -163,6 +179,7 @@ func getMetrics(registry *metric.MetricsRegistry) *queryMetrics {
 			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchTierTransition)
 			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchHitsDropped)
 			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchDegraded)
+			_ = prometheus.DefaultRegisterer.Register(metrics.classifierGarbage)
 		}
 	})
 	return metrics
@@ -239,4 +256,12 @@ func (m *queryMetrics) recordGlobalSearchHitsDropped(stage string, n int) {
 // _cancelled, _error). Closes the flag-without-counter gap.
 func (m *queryMetrics) recordGlobalSearchDegraded(reason string) {
 	m.globalSearchDegraded.WithLabelValues(reason).Inc()
+}
+
+// recordClassifierGarbage records a defense firing against malformed classifier
+// output. Type is "template_filter" (literal `<...>` etc. in type_filters) or
+// "query_dropped" (single-token original replaced by classifier template).
+// LOUD signal — paired with a Warn log at the call site.
+func (m *queryMetrics) recordClassifierGarbage(garbageType string) {
+	m.classifierGarbage.WithLabelValues(garbageType).Inc()
 }

--- a/processor/graph-query/metrics.go
+++ b/processor/graph-query/metrics.go
@@ -17,6 +17,17 @@ type queryMetrics struct {
 	communityLookups       *prometheus.CounterVec
 	localSearchRequests    prometheus.Counter
 	globalSearchRequests   prometheus.Counter
+
+	// globalSearch path observability — added to surface the bug class where
+	// queries silently route to a dead-end strategy / get filtered to empty.
+	// Without these, "globalSearch returned count=0" is only visible via user
+	// reports.
+	globalSearchStrategy       *prometheus.CounterVec // labels: strategy
+	globalSearchResponseCount  prometheus.Histogram   // distribution of returned entity counts
+	globalSearchEmpty          *prometheus.CounterVec // labels: strategy, reason
+	globalSearchTierTransition *prometheus.CounterVec // labels: from, to, reason
+	globalSearchHitsDropped    *prometheus.CounterVec // labels: stage (threshold|type_filter)
+	globalSearchDegraded       *prometheus.CounterVec // labels: reason — closes beta.45 debt
 }
 
 // Package-level metrics (registered once to avoid duplicate registration errors)
@@ -77,6 +88,49 @@ func getMetrics(registry *metric.MetricsRegistry) *queryMetrics {
 				Name:      "global_search_requests_total",
 				Help:      "Total GraphRAG global search requests",
 			}),
+
+			globalSearchStrategy: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_query",
+				Name:      "global_search_strategy_total",
+				Help:      "Global search requests by resolved strategy (entity_lookup|pathrag|semantic|temporal|spatial|graphrag)",
+			}, []string{"strategy"}),
+
+			globalSearchResponseCount: prometheus.NewHistogram(prometheus.HistogramOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_query",
+				Name:      "global_search_response_count",
+				Help:      "Distribution of entity counts returned by globalSearch responses (0 bucket flags 'returned nothing')",
+				Buckets:   []float64{0, 1, 5, 10, 25, 50, 100, 250, 500, 1000},
+			}),
+
+			globalSearchEmpty: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_query",
+				Name:      "global_search_empty_total",
+				Help:      "Global search requests that returned zero entities, by strategy and reason (no_communities|no_semantic_hits|threshold_filter|type_filter|relevance_filter|semantic_unavailable)",
+			}, []string{"strategy", "reason"}),
+
+			globalSearchTierTransition: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_query",
+				Name:      "global_search_tier_transition_total",
+				Help:      "Tier transitions inside graphrag/path strategies, from=tier1 to=tier2 reason=(empty_hits|err)",
+			}, []string{"from", "to", "reason"}),
+
+			globalSearchHitsDropped: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_query",
+				Name:      "global_search_hits_dropped_total",
+				Help:      "Semantic hits dropped during globalSearch processing, labelled by the stage that dropped them (threshold|type_filter)",
+			}, []string{"stage"}),
+
+			globalSearchDegraded: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_query",
+				Name:      "global_search_degraded_total",
+				Help:      "Global search responses returned with Degraded=true, by reason (answer_synthesis_timeout|answer_synthesis_cancelled|answer_synthesis_error). Closes beta.45's flag-without-counter gap.",
+			}, []string{"reason"}),
 		}
 
 		// Register metrics with the metrics registry if available
@@ -88,6 +142,12 @@ func getMetrics(registry *metric.MetricsRegistry) *queryMetrics {
 			_ = registry.RegisterCounterVec("graph-query", "community_lookups_total", metrics.communityLookups)
 			_ = registry.RegisterCounter("graph-query", "local_search_requests_total", metrics.localSearchRequests)
 			_ = registry.RegisterCounter("graph-query", "global_search_requests_total", metrics.globalSearchRequests)
+			_ = registry.RegisterCounterVec("graph-query", "global_search_strategy_total", metrics.globalSearchStrategy)
+			_ = registry.RegisterHistogram("graph-query", "global_search_response_count", metrics.globalSearchResponseCount)
+			_ = registry.RegisterCounterVec("graph-query", "global_search_empty_total", metrics.globalSearchEmpty)
+			_ = registry.RegisterCounterVec("graph-query", "global_search_tier_transition_total", metrics.globalSearchTierTransition)
+			_ = registry.RegisterCounterVec("graph-query", "global_search_hits_dropped_total", metrics.globalSearchHitsDropped)
+			_ = registry.RegisterCounterVec("graph-query", "global_search_degraded_total", metrics.globalSearchDegraded)
 		} else {
 			// Fallback to default prometheus registry for testing
 			_ = prometheus.DefaultRegisterer.Register(metrics.communityCacheHits)
@@ -97,6 +157,12 @@ func getMetrics(registry *metric.MetricsRegistry) *queryMetrics {
 			_ = prometheus.DefaultRegisterer.Register(metrics.communityLookups)
 			_ = prometheus.DefaultRegisterer.Register(metrics.localSearchRequests)
 			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchRequests)
+			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchStrategy)
+			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchResponseCount)
+			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchEmpty)
+			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchTierTransition)
+			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchHitsDropped)
+			_ = prometheus.DefaultRegisterer.Register(metrics.globalSearchDegraded)
 		}
 	})
 	return metrics
@@ -133,4 +199,44 @@ func (m *queryMetrics) recordLocalSearch() {
 // recordGlobalSearch records a global search request.
 func (m *queryMetrics) recordGlobalSearch() {
 	m.globalSearchRequests.Inc()
+}
+
+// recordGlobalSearchStrategy records the resolved dispatch strategy for a globalSearch request.
+func (m *queryMetrics) recordGlobalSearchStrategy(strategy string) {
+	m.globalSearchStrategy.WithLabelValues(strategy).Inc()
+}
+
+// observeGlobalSearchResponseCount records the entity count returned in a globalSearch response.
+// The 0 bucket flags "returned nothing" — sudden ratio shifts toward 0 indicate the bug class
+// where queries silently route to a dead-end strategy or get filtered to empty.
+func (m *queryMetrics) observeGlobalSearchResponseCount(count int) {
+	m.globalSearchResponseCount.Observe(float64(count))
+}
+
+// recordGlobalSearchEmpty records a globalSearch response with zero entities, with the strategy
+// that produced it and the proximate reason (no_communities, no_semantic_hits, threshold_filter,
+// type_filter, relevance_filter, semantic_unavailable).
+func (m *queryMetrics) recordGlobalSearchEmpty(strategy, reason string) {
+	m.globalSearchEmpty.WithLabelValues(strategy, reason).Inc()
+}
+
+// recordGlobalSearchTierTransition records a fall-through inside graphrag/path strategies, e.g.
+// from semantic to community-text-based when semantic returns empty.
+func (m *queryMetrics) recordGlobalSearchTierTransition(from, to, reason string) {
+	m.globalSearchTierTransition.WithLabelValues(from, to, reason).Inc()
+}
+
+// recordGlobalSearchHitsDropped records semantic hits dropped by an internal filter stage,
+// labelled by the stage that dropped them (threshold or type_filter). Use Add(N) for the count.
+func (m *queryMetrics) recordGlobalSearchHitsDropped(stage string, n int) {
+	if n > 0 {
+		m.globalSearchHitsDropped.WithLabelValues(stage).Add(float64(n))
+	}
+}
+
+// recordGlobalSearchDegraded records a globalSearch response returned with Degraded=true.
+// Reasons match SynthesisOutcome.DegradedReason classes from beta.45 (answer_synthesis_timeout,
+// _cancelled, _error). Closes the flag-without-counter gap.
+func (m *queryMetrics) recordGlobalSearchDegraded(reason string) {
+	m.globalSearchDegraded.WithLabelValues(reason).Inc()
 }

--- a/service/service_manager.go
+++ b/service/service_manager.go
@@ -937,8 +937,8 @@ func (m *Manager) completeHTTPSetup() error {
 			}
 			return context.Background()
 		},
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		ReadTimeout:  m.config.ResolvedHTTPReadTimeout(),
+		WriteTimeout: m.config.ResolvedHTTPWriteTimeout(),
 		IdleTimeout:  60 * time.Second,
 	}
 
@@ -988,8 +988,8 @@ func (m *Manager) startHTTPServer() error {
 			}
 			return context.Background()
 		},
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		ReadTimeout:  m.config.ResolvedHTTPReadTimeout(),
+		WriteTimeout: m.config.ResolvedHTTPWriteTimeout(),
 		IdleTimeout:  60 * time.Second,
 	}
 

--- a/service/service_manager_config.go
+++ b/service/service_manager_config.go
@@ -1,6 +1,9 @@
 package service
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // ManagerConfig holds configuration for the Manager HTTP server
 // Simple struct - no UnmarshalJSON, no Enabled field
@@ -8,14 +11,72 @@ type ManagerConfig struct {
 	HTTPPort   int      `json:"http_port"`
 	SwaggerUI  bool     `json:"swagger_ui"`
 	ServerInfo InfoSpec `json:"server_info"`
+
+	// HTTPReadTimeout caps how long the server waits for the request body.
+	// Go duration string (e.g. "30s"). Empty falls back to
+	// DefaultHTTPReadTimeout. Bump for paths that stream large request
+	// bodies; the default is enough for typical JSON GraphQL queries.
+	HTTPReadTimeout string `json:"http_read_timeout,omitempty"`
+
+	// HTTPWriteTimeout caps how long the server takes to write the
+	// response. Go duration string (e.g. "120s"). Empty falls back to
+	// DefaultHTTPWriteTimeout. CRITICAL for LLM-backed paths (globalSearch
+	// answer synthesis, classifier, etc.) — the prior hardcoded 10s
+	// killed every long-running query mid-write with EOF on the client
+	// side. Set to >= 2× the slowest expected handler time.
+	HTTPWriteTimeout string `json:"http_write_timeout,omitempty"`
 }
+
+// HTTP server timeout defaults. Tuned for LLM-backed workloads — the
+// prior 10s/10s defaults killed every long graph query with EOF. See
+// commit message + feedback memory for the case study.
+const (
+	DefaultHTTPReadTimeout  = 30 * time.Second
+	DefaultHTTPWriteTimeout = 120 * time.Second
+)
 
 // Validate checks if the configuration is valid
 func (c ManagerConfig) Validate() error {
 	if c.HTTPPort < 0 || c.HTTPPort > 65535 {
 		return fmt.Errorf("invalid HTTP port: %d", c.HTTPPort)
 	}
+	if c.HTTPReadTimeout != "" {
+		if _, err := time.ParseDuration(c.HTTPReadTimeout); err != nil {
+			return fmt.Errorf("invalid http_read_timeout %q: %w", c.HTTPReadTimeout, err)
+		}
+	}
+	if c.HTTPWriteTimeout != "" {
+		if _, err := time.ParseDuration(c.HTTPWriteTimeout); err != nil {
+			return fmt.Errorf("invalid http_write_timeout %q: %w", c.HTTPWriteTimeout, err)
+		}
+	}
 	// SwaggerUI is a boolean (no validation needed)
 	// ServerInfo fields can be empty (will get defaults)
 	return nil
+}
+
+// ResolvedHTTPReadTimeout returns the configured read timeout or the
+// default when unset/invalid.
+func (c ManagerConfig) ResolvedHTTPReadTimeout() time.Duration {
+	if c.HTTPReadTimeout == "" {
+		return DefaultHTTPReadTimeout
+	}
+	d, err := time.ParseDuration(c.HTTPReadTimeout)
+	if err != nil {
+		return DefaultHTTPReadTimeout
+	}
+	return d
+}
+
+// ResolvedHTTPWriteTimeout returns the configured write timeout or the
+// default when unset/invalid.
+func (c ManagerConfig) ResolvedHTTPWriteTimeout() time.Duration {
+	if c.HTTPWriteTimeout == "" {
+		return DefaultHTTPWriteTimeout
+	}
+	d, err := time.ParseDuration(c.HTTPWriteTimeout)
+	if err != nil {
+		return DefaultHTTPWriteTimeout
+	}
+	return d
 }

--- a/taskfiles/e2e/common.yml
+++ b/taskfiles/e2e/common.yml
@@ -31,7 +31,6 @@ tasks:
       - docker compose -f docker/compose/tiered.yml --profile semantic down -v --timeout 15 2>/dev/null || true
       - docker volume ls -q --filter name=semstreams | xargs -r docker volume rm 2>/dev/null || true
       - docker volume ls -q --filter name=semembed | xargs -r docker volume rm 2>/dev/null || true
-      - docker volume ls -q --filter name=shimmy | xargs -r docker volume rm 2>/dev/null || true
       - docker volume ls -q --filter name=nats-semstreams | xargs -r docker volume rm 2>/dev/null || true
       - echo "[OK] E2E environment cleaned"
 

--- a/test/e2e/scenarios/tiered.go
+++ b/test/e2e/scenarios/tiered.go
@@ -314,6 +314,11 @@ func (s *TieredScenario) getStagesForVariant(variant string) []stage {
 		// === Tier 2: Semantic capabilities (semantic only) ===
 		{"test-graphrag-local", s.executeTestGraphRAGLocal, []string{"semantic"}},
 		{"test-graphrag-global", s.executeTestGraphRAGGlobal, []string{"semantic"}},
+		// validate-globalsearch-known-answer is the load-bearing guard against
+		// the "globalSearch returns count=0 for content that exists" bug class
+		// (see semspec Meshtastic report). Probes deterministic single-word
+		// terms and HARD-FAILs when the response is empty or unrelated.
+		{"validate-globalsearch-known-answer", s.executeValidateGlobalSearchKnownAnswer, []string{"semantic"}},
 		{"validate-llm-enhancement", s.executeValidateLLMEnhancement, []string{"semantic"}},
 		{"validate-anomaly-detection", s.executeValidateAnomalyDetection, []string{"statistical", "semantic"}},
 		{"validate-virtual-edges", s.executeValidateVirtualEdges, []string{"semantic"}},

--- a/test/e2e/scenarios/tiered_semantic_known_answer.go
+++ b/test/e2e/scenarios/tiered_semantic_known_answer.go
@@ -1,0 +1,268 @@
+package scenarios
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// knownAnswerTerm describes a single-word search term that should reliably
+// match content in the semantic-tier fixtures (testdata/semantic/*.jsonl).
+// Each term must appear in at least two fixture files so a stray ingestion
+// failure on one fixture doesn't false-fail the assertion.
+type knownAnswerTerm struct {
+	term string
+	// substrAny is the lowercased substring patterns that should appear in
+	// at least one entity ID OR community summary text. Loose enough to
+	// tolerate ID-shape variation (different entityID parts may carry the
+	// substring) and summary phrasing.
+	substrAny []string
+}
+
+// knownAnswerTerms are the corpus probes for the semantic-tier known-answer
+// test. Adding a new term requires confirming it appears in at least two
+// fixture files in testdata/semantic/.
+var knownAnswerTerms = []knownAnswerTerm{
+	{
+		term:      "forklift",
+		substrAny: []string{"forklift", "fl-042", "fl_042"},
+	},
+	{
+		term:      "hydraulic",
+		substrAny: []string{"hydraulic", "fluid", "cylinder"},
+	},
+	{
+		term:      "temperature",
+		substrAny: []string{"temperature", "temp-sensor", "cold storage", "cold_storage"},
+	},
+}
+
+// executeValidateGlobalSearchKnownAnswer is the semantic-tier guard against
+// the "globalSearch returns count=0 for content that demonstrably exists"
+// bug class (see semspec Meshtastic report, 2026-05-07). Earlier
+// executeTestGraphRAGGlobal probes a broad query and only WARNs on empty
+// results; this stage uses single-word queries that match deterministic
+// fixture content and HARD-FAILs when:
+//
+//   - The response count is 0 for any known-answer term.
+//   - None of the term's expected substrings appear in any returned entity
+//     ID or community summary text (the search may return entities, but if
+//     none are related to the term the search is broken).
+//
+// Probes use level=0 because that's the level the bug surfaced at. If a
+// future deployment's communities live at a different level, change the
+// constant below alongside the assertion.
+func (s *TieredScenario) executeValidateGlobalSearchKnownAnswer(ctx context.Context, result *Result) error {
+	gatewayURL := s.config.GraphQLURL
+	if gatewayURL == "" {
+		result.Warnings = append(result.Warnings,
+			"executeValidateGlobalSearchKnownAnswer: no GraphQL URL configured, skipping")
+		return nil
+	}
+
+	level := 0 // matches the level the Meshtastic bug surfaced at
+
+	results := make([]map[string]any, 0, len(knownAnswerTerms))
+	var failures []string
+
+	for _, ka := range knownAnswerTerms {
+		probe := s.runKnownAnswerProbe(ctx, gatewayURL, ka, level)
+		results = append(results, probe.detail)
+		if probe.failure != "" {
+			failures = append(failures, probe.failure)
+		}
+	}
+
+	result.Details["global_search_known_answer"] = map[string]any{
+		"level":   level,
+		"probes":  results,
+		"failed":  len(failures),
+		"checked": len(knownAnswerTerms),
+	}
+	result.Metrics["global_search_known_answer_probes"] = len(knownAnswerTerms)
+	result.Metrics["global_search_known_answer_failures"] = len(failures)
+
+	if len(failures) > 0 {
+		return fmt.Errorf("globalSearch known-answer assertion failed for %d/%d probes: %s",
+			len(failures), len(knownAnswerTerms), strings.Join(failures, "; "))
+	}
+	return nil
+}
+
+// knownAnswerProbeResult captures the outcome of a single term probe.
+type knownAnswerProbeResult struct {
+	detail  map[string]any
+	failure string // non-empty when the probe failed an assertion
+}
+
+// runKnownAnswerProbe runs a single globalSearch + known-answer assertion.
+func (s *TieredScenario) runKnownAnswerProbe(ctx context.Context, gatewayURL string, ka knownAnswerTerm, level int) knownAnswerProbeResult {
+	resp, latency, err := s.sendGlobalSearchAtLevel(ctx, gatewayURL, ka.term, level)
+	if err != nil {
+		return knownAnswerProbeResult{
+			detail: map[string]any{
+				"term":  ka.term,
+				"error": err.Error(),
+			},
+			failure: fmt.Sprintf("term %q: request failed: %v", ka.term, err),
+		}
+	}
+
+	gs := resp.Data.GlobalSearch
+	matched := matchKnownAnswerTerm(ka, gs)
+
+	detail := map[string]any{
+		"term":           ka.term,
+		"count":          gs.Count,
+		"entities":       len(gs.Entities),
+		"communities":    len(gs.CommunitySummaries),
+		"latency_ms":     latency.Milliseconds(),
+		"matched_substr": matched.substring,
+		"match_location": matched.location,
+	}
+
+	if gs.Count == 0 {
+		return knownAnswerProbeResult{
+			detail:  detail,
+			failure: fmt.Sprintf("term %q: count=0 at level=%d (entities=%d communities=%d)", ka.term, level, len(gs.Entities), len(gs.CommunitySummaries)),
+		}
+	}
+	if matched.substring == "" {
+		return knownAnswerProbeResult{
+			detail:  detail,
+			failure: fmt.Sprintf("term %q: count=%d but no entity ID or community summary contained any of %v", ka.term, gs.Count, ka.substrAny),
+		}
+	}
+	return knownAnswerProbeResult{detail: detail}
+}
+
+// knownAnswerMatch records WHERE a substring was found (for diagnostics).
+type knownAnswerMatch struct {
+	substring string
+	location  string // "entity_id" | "community_summary" | "community_keywords"
+}
+
+// matchKnownAnswerTerm scans a globalSearch response for any of ka.substrAny
+// in entity IDs, community summaries, or community keywords. Case-insensitive.
+// Returns the first match (substring + location) or zero value when no match.
+func matchKnownAnswerTerm(ka knownAnswerTerm, gs globalSearchPayload) knownAnswerMatch {
+	for _, e := range gs.Entities {
+		idLower := strings.ToLower(e.ID)
+		for _, sub := range ka.substrAny {
+			if strings.Contains(idLower, sub) {
+				return knownAnswerMatch{substring: sub, location: "entity_id"}
+			}
+		}
+	}
+	for _, cs := range gs.CommunitySummaries {
+		summaryLower := strings.ToLower(cs.Summary)
+		for _, sub := range ka.substrAny {
+			if strings.Contains(summaryLower, sub) {
+				return knownAnswerMatch{substring: sub, location: "community_summary"}
+			}
+		}
+		for _, kw := range cs.Keywords {
+			kwLower := strings.ToLower(kw)
+			for _, sub := range ka.substrAny {
+				if strings.Contains(kwLower, sub) {
+					return knownAnswerMatch{substring: sub, location: "community_keywords"}
+				}
+			}
+		}
+	}
+	return knownAnswerMatch{}
+}
+
+// globalSearchPayload is the shape of GraphQL globalSearch we depend on for
+// known-answer assertions. Subset of graphRAGGlobalResponse.Data.GlobalSearch
+// in tiered_statistical.go — kept distinct so changes here don't affect the
+// existing graphrag-global stage.
+type globalSearchPayload struct {
+	Entities []struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	} `json:"entities"`
+	CommunitySummaries []struct {
+		CommunityID string   `json:"communityId"`
+		Summary     string   `json:"summary"`
+		Keywords    []string `json:"keywords"`
+		Level       int      `json:"level"`
+	} `json:"communitySummaries"`
+	Count int `json:"count"`
+}
+
+// knownAnswerResponse is the GraphQL envelope for the globalSearch query.
+type knownAnswerResponse struct {
+	Data struct {
+		GlobalSearch globalSearchPayload `json:"globalSearch"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// sendGlobalSearchAtLevel issues a globalSearch GraphQL query for the given
+// query + level and returns the parsed response. Mirrors the pattern of
+// sendGraphRAGGlobalRequest but with explicit level (the existing helper
+// hard-codes level=1).
+func (s *TieredScenario) sendGlobalSearchAtLevel(ctx context.Context, gatewayURL, query string, level int) (*knownAnswerResponse, time.Duration, error) {
+	graphqlQuery := map[string]any{
+		"query": `query($query: String!, $level: Int, $maxCommunities: Int) {
+			globalSearch(query: $query, level: $level, maxCommunities: $maxCommunities) {
+				entities { id type }
+				communitySummaries { communityId summary keywords level }
+				count
+			}}`,
+		"variables": map[string]any{
+			"query":          query,
+			"level":          level,
+			"maxCommunities": 10,
+		},
+	}
+
+	queryJSON, err := json.Marshal(graphqlQuery)
+	if err != nil {
+		return nil, 0, fmt.Errorf("marshal query: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", gatewayURL, bytes.NewReader(queryJSON))
+	if err != nil {
+		return nil, 0, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	start := time.Now()
+	resp, err := httpClient.Do(req)
+	latency := time.Since(start)
+	if err != nil {
+		return nil, latency, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, latency, fmt.Errorf("returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, latency, fmt.Errorf("read response: %w", err)
+	}
+
+	var graphqlResp knownAnswerResponse
+	if err := json.Unmarshal(bodyBytes, &graphqlResp); err != nil {
+		return nil, latency, fmt.Errorf("parse response: %w", err)
+	}
+
+	if len(graphqlResp.Errors) > 0 {
+		return nil, latency, fmt.Errorf("GraphQL error: %s", graphqlResp.Errors[0].Message)
+	}
+
+	return &graphqlResp, latency, nil
+}

--- a/test/e2e/scenarios/tiered_semantic_known_answer.go
+++ b/test/e2e/scenarios/tiered_semantic_known_answer.go
@@ -236,7 +236,12 @@ func (s *TieredScenario) sendGlobalSearchAtLevel(ctx context.Context, gatewayURL
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	httpClient := &http.Client{Timeout: 10 * time.Second}
+	// 60s budget covers classifier → embedding search → community scoring →
+	// answer synthesis on local llama.cpp models (qwen3-0.6b throughput
+	// ~25 tok/s warm). The existing test-graphrag-global stage uses 10s
+	// and silently times out on every probe — don't replicate that. If the
+	// real query path is slow enough to need >60s, that itself is a bug.
+	httpClient := &http.Client{Timeout: 60 * time.Second}
 	start := time.Now()
 	resp, err := httpClient.Do(req)
 	latency := time.Since(start)


### PR DESCRIPTION
## Summary

Started as an investigation into semspec's `globalSearch(query: "Meshtastic")` returning `count=0` while the same query against `semanticSimilarity` returned 0.7+ scored hits. The investigation surfaced and fixed multiple unrelated bugs that had been silently breaking the stack; the original bug is partially defended against, with the remaining shape (broad-but-irrelevant results) flagged for a follow-up session.

## What this PR ships

**Investigation infrastructure (still useful when the next probe lands):**
- `029859f` — Debug logs across globalSearch strategy resolution, threshold filter, type filter, tier-2 fall-through, community cache fetch
- `6e06067` — 6 new Prometheus metrics on the globalSearch path (`strategy_total`, `response_count` histogram, `empty_total{strategy,reason}`, `tier_transition_total`, `hits_dropped_total{stage}`, `degraded_total{reason}` — the last closes a beta.45 flag-without-counter gap)
- `2ff854e` — New e2e stage `validate-globalsearch-known-answer` in the semantic tier; **first hard-failing assertion** on globalSearch result quality (existing `test-graphrag-global` only warns)

**Stack rehabilitation (pre-existing infra debt the investigation surfaced):**
- `cd77928` — `shimmy` (retired upstream by sister-team) removed from compose; `seminstruct` now self-hosts llama.cpp directly with config-driven Qwen3 model size (0.6b / 1.7b / 8b). Comment-only renames in 8 Go files; doc rewrite deferred.
- `bedadeb` — `cmd/semstreams/main.go` was half-migrated for the beta.18 payload-registry singleton retirement (registered example *factories* but not example *payloads*). Three months of beta releases shipped on top of this silent break — every flow that produced `iot.sensor.v1` or `facility.zone.v1` messages failed `BaseMessage.UnmarshalJSON`. Bonus fix: `iot_sensor.RegisterPayloads` was missing the `Zone` (`facility.zone.v1`) registration.
- `e8b9881` — E2E known-answer HTTP client timeout 10s → 60s; the existing `test-graphrag-global` runs at 10s and silently times out on every probe (the weak-assertion gap that motivated this new stage).
- `2465ed8` — **EOF root cause.** `service_manager.go` hardcoded `WriteTimeout: 10s` on the front-door HTTP server. LLM-backed handlers routinely take 10–30s; every long request was being killed mid-write, surfacing as `EOF` on the client. Now config-driven (`http_read_timeout` / `http_write_timeout`) with LLM-aware defaults (30s read, 120s write).

**First-layer fix for the original semspec bug:**
- `8a56248` — Defenses against classifier template emission. Two layers in `extractSearchRefinements`:
  1. Single-token rawQuery bypasses classifier query refinement (small models replace proper-noun queries with generic templates: `"Meshtastic"` → `"find paths between entities"`).
  2. Type filters matching `<...>`, `{...}`, `$...` (template placeholders) are stripped before reaching `filterEntityIDsByType` (verbatim-emitted `<entity_type>` was matching no real type and silently dropping every hit).
  
  Both defenses are LOUD — log Warn + new `classifier_garbage_total{type=template_filter|query_dropped}` metric so a sustained non-zero rate signals "classifier model too thin for workload".

**CLAUDE.md hard rule:**
Breaking changes (registry singleton retirements, config schema, component interface signatures) MUST run `task e2e:semantic` (or appropriate tier) green before merge. Unit + integration tier doesn't exercise the full ingest → entity → graph store → query path; this PR's `bedadeb` commit is the case study.

## What's still open (next session)

For multi-letter common nouns (`hydraulic`, `temperature`) the new known-answer stage shows `count > 0` but the entities returned have nothing to do with the query — different shape than semspec's `count=0` and not addressed by this PR's classifier defenses (those queries don't trigger garbage). The 504 on `forklift` is yet another shape: gateway QueryTimeout=30s firing on a slow LLM path. Both shapes need a proper investigation with `task e2e:semantic:debug` + live container logs.

## Test plan
- [x] `go build ./...` clean
- [x] `go test -race -count=1 ./...` clean
- [x] `task lint` clean (revive zero warnings)
- [x] `task e2e:semantic` runs end-to-end (189 entities, 17 communities, structural pipeline green); only `validate-globalsearch-known-answer` fails — that's the test correctly hard-failing on the open bug class.
- [x] New unit tests cover regex + filter logic for classifier defenses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)