### PR TITLE
docs(adr,concepts): rename polar → operating curves throughout ADR-033 + concept 19

### DIFF
--- a/docs/adr/033-operating-curve-based-observability.md
+++ b/docs/adr/033-operating-curve-based-observability.md
@@ -1,4 +1,4 @@
-# ADR-033: Polar-Based Observability — Drift Detection Primitives for Agentic Systems
+# ADR-033: Operating-Curve-Based Observability — Drift Detection Primitives for Agentic Systems
 
 ## Status
 
@@ -8,6 +8,24 @@ SemTeams second-pass sign-off received same day with verdict
 "Accept. The ADR is now in shape to flip Status: Proposed →
 Accepted, which unblocks the semspec/pkg/health type hoist and
 SemTeams' Phase 2 adoption work."
+
+**Terminology revision (2026-05-07):** Earlier drafts of this ADR
+and the concept doc used the aerodynamics term *polar* for what is
+now called *operating curve*. The aero term is historical (Eiffel's
+early lift/drag experiments at Champ-de-Mars used polar coordinates;
+the name stuck through Lilienthal and NACA even after the field
+switched to Cartesian L/D plots) and parsed badly outside aerospace
+contexts. *Operating curve* carries the same engineering discipline
+without the historical baggage. Substantive content unchanged; type
+names, agvocab predicates, storage bucket names, and prose all
+updated. Affected identifiers: `OperatingCurve` (was `Polar`),
+`CurveSample` (was `PolarSample`), `CurveID` / `CurveRefs` (was
+`PolarID` / `PolarRefs`), `ops.curve_departure.*` (was
+`ops.polar_departure.*`), `OBSERVABILITY_CURVES` (was
+`OBSERVABILITY_POLARS`). Filename also renamed:
+`033-polar-based-observability.md` →
+`033-operating-curve-based-observability.md`. No code-level
+migration needed since the type hoist had not yet started.
 
 This unblocks:
 
@@ -37,11 +55,11 @@ structural revisions integrated below:
    ship without waiting. Specific G2/G4/G8 axes that depend on
    ADR-032 enforcement gates remain sequenced after that work
    resumes; they are not Phase 1 prerequisites.
-2. **Sweep → polar pipeline scoped explicitly to a later phase.**
-   The ADR establishes that polars are curves (not points) and that
+2. **Sweep → operating-curve pipeline scoped explicitly to a later phase.**
+   The ADR establishes that operating curves are curves (not points) and that
    sweeps across reasoning_effort / model tier / persona-fragment
    variants / max_iteration produce them. *How* a sweep becomes a
-   stored polar — the harness side, not the data side — is product-
+   stored operating curve — the harness side, not the data side — is product-
    flavored tooling that lives in Phase 4 alongside coordinator-
    driven adjustment, not in the framework primitives.
 3. **Policy-surface concern reframed as diagnosis-only-default,
@@ -78,7 +96,7 @@ Type hoist (`semspec/pkg/health` → SemStreams) gated on this ADR
 flipping Status: Proposed → Accepted.
 
 The conceptual foundation lives in
-[docs/concepts/19-observability-as-polars.md](../concepts/19-observability-as-polars.md).
+[docs/concepts/19-observability-as-operating-curves.md](../concepts/19-observability-as-operating-curves.md).
 This ADR distills that framing into the structural commitments
 SemStreams takes on, the framework/product boundary, and the
 ops-agent → coordinator signal contract that the framing doc
@@ -89,7 +107,7 @@ When this ADR is accepted:
 - ADR-027 (ops-agent meta-harness) is **refined**, not superseded.
   Phase 1 (read-only diagnosis via `emit_diagnosis`) stays. The
   per-axis Pareto-frontier framing in ADR-027 Phase 3 is reframed
-  here as polar-library curves with regime annotations. The seven
+  here as operating-curve-library curves with regime annotations. The seven
   tunable harness axes from ADR-027 §"Tunable harness elements" stay
   valid; this ADR adds the discipline that bounds *how* the ops-agent
   reasons over them.
@@ -149,16 +167,16 @@ left for a later ADR. This ADR resolves it.
 SemStreams commits to **four structural decisions** that scope the
 ops-agent and shape the framework/product boundary.
 
-### D1. Polars are the observability frame; single scalars live inside regimes
+### D1. Operating curves are the observability frame; single scalars live inside regimes
 
 The objective-spec README's single-scalar discipline is correct
 *within a regime*. Across regimes (model upgrade, persona-fragment
 edit, capability-surface change), single scalars hide axis
-divergence and load Goodhart proxies. Polars — curves indexed by
+divergence and load Goodhart proxies. Operating curves — curves indexed by
 operating point and tagged with regime — are the discipline above
 the per-flow objective spec.
 
-**Polars do not solve the single-measure problem; they make it
+**Operating curves do not solve the single-measure problem; they make it
 visible.** That visibility is what the ops-agent earns its keep on.
 This is layered on top of objective specs, not in competition with
 them.
@@ -168,7 +186,7 @@ them.
 The ops-agent is a **stateless reader of the predicate stream.**
 It proposes sweeps, identifies inflection points, flags drift, emits
 structured signals. It does not write into flow configuration. It
-cannot rewrite its own scope. Flows do not see the polar library
+cannot rewrite its own scope. Flows do not see the operating-curve library
 and do not optimise against it.
 
 This forecloses semdragon's character-XP failure mode (closed-loop
@@ -193,10 +211,10 @@ allowed and necessary.
 
 The OWASP ASI 2026 catalog and Microsoft AGT enforcement set the
 governance vocabulary. That vocabulary feeds the same predicate
-stream and the same polar library as quality axes. The split exists
+stream and the same operating-curve library as quality axes. The split exists
 for traceability and for conversations with auditors. Internally,
 quality axes (Q1–Q5 in the catalog) and governance axes (G1–G10)
-share the same Detector / Diagnosis / Polar machinery.
+share the same Detector / Diagnosis / operating-curve machinery.
 
 ADR-032 is the IPS (block at the gate). This ADR is the IDS (watch
 for drift toward the gate). They compose. The framing doc's §3 is
@@ -212,14 +230,14 @@ cut. SemStreams ships **opinion-free machinery**. Products ship
 | Concern | Lives in | Why |
 |---|---|---|
 | `Detector` interface, `Diagnosis` shape, `EvidenceRef` shape, `Bundle` shape | SemStreams (framework) | Pure, deterministic, no product knowledge. Working precedent in `semspec/pkg/health`. |
-| `Polar`, `RegimeAnnotation`, `SentinelRun` data shapes | SemStreams (framework) | Mechanical observability infrastructure. Storage layout for the polar library. |
+| `OperatingCurve`, `RegimeAnnotation`, `SentinelRun` data shapes | SemStreams (framework) | Mechanical observability infrastructure. Storage layout for the operating-curve library. |
 | Sentinel-run scheduler | SemStreams (framework, reusing ADR-031 cron rule) | A sentinel run is a cron rule with a fixture-controlled prompt set and a regime-tagged result write-back. No new scheduler. |
-| Stationarity-check primitive (variance comparison vs. established curve) | SemStreams (framework) | Mechanical, no LLM judgment. Pure function over `Polar` + new sample. |
-| Signal taxonomy as agvocab predicates: `ops.polar_departure.*`, `ops.threshold_crossed.*`, `ops.regime_expired.*` | SemStreams (framework) | Vocabulary, not opinion. Same shape as `coordinator.next_action`. |
+| Stationarity-check primitive (variance comparison vs. established curve) | SemStreams (framework) | Mechanical, no LLM judgment. Pure function over `OperatingCurve` + new sample. |
+| Signal taxonomy as agvocab predicates: `ops.curve_departure.*`, `ops.threshold_crossed.*`, `ops.regime_expired.*` | SemStreams (framework) | Vocabulary, not opinion. Same shape as `coordinator.next_action`. |
 | Ops-agent state machine (read predicate stream → mechanical detect → emit signal) | SemStreams (framework) | Generic orchestration loop. Reuses `agentic-loop`. |
 | The axis catalog itself (Q1–Q5, G1–G10, future axes) | Product (semteams, semspec) | Curated against this product's failure modes. Different products care about different axes. |
 | Detector implementations (`ThinkingSpiral`, `RapidShallowToolCalls`, `EmptyStopAfterToolCalls`, terminal-artifact validators, etc.) | Product | Each detects a failure mode specific to product flows. |
-| Ops-agent diagnosis persona (LLM prompt for "why did this polar drift") | Product | Voice, tone, evidence framing — product-shaped. SemTeams ≠ SemSpec here. |
+| Ops-agent diagnosis persona (LLM prompt for "why did this operating curve drift") | Product | Voice, tone, evidence framing — product-shaped. SemTeams ≠ SemSpec here. |
 | Objective spec (per-flow declarations) | Product | Per-flow product authoring. |
 | Sentinel prompt curation (which N prompts represent the system) | Product | Product-specific calibration set. |
 
@@ -241,9 +259,9 @@ The ops-agent emits three families of typed agvocab predicates:
 
 | Predicate family | Fields | Emitted when |
 |---|---|---|
-| `ops.polar_departure` | `axis`, `magnitude`, `duration`, `polar_id`, `evidence_refs[]` | A new sample sits off the established polar by more than the configured variance, sustained across N consecutive runs |
-| `ops.threshold_crossed` | `metric`, `direction`, `sustained_for`, `threshold_value`, `evidence_refs[]` | A scalar metric tracked alongside polars (cost, latency, fallback rate) crosses a declared threshold |
-| `ops.regime_expired` | `polar_id`, `expiration_cause`, `last_validated`, `evidence_refs[]` | A regime-annotated polar's underlying regime invariants change (model upgrade, persona-fragment edit, tool-execution-path change) |
+| `ops.curve_departure` | `axis`, `magnitude`, `duration`, `curve_id`, `evidence_refs[]` | A new sample sits off the established operating curve by more than the configured variance, sustained across N consecutive runs |
+| `ops.threshold_crossed` | `metric`, `direction`, `sustained_for`, `threshold_value`, `evidence_refs[]` | A scalar metric tracked alongside operating curves (cost, latency, fallback rate) crosses a declared threshold |
+| `ops.regime_expired` | `curve_id`, `expiration_cause`, `last_validated`, `evidence_refs[]` | A regime-annotated operating-curve underlying regime invariants change (model upgrade, persona-fragment edit, tool-execution-path change) |
 
 These predicates are **stable and enumerable** — coordinator rules
 fire on them via the existing rule-DSL pattern (ADR-028 Layer 2).
@@ -274,16 +292,16 @@ ops.adjustment.regime     — regime annotation snapshot (model, persona version
 
 This record is diff-able, audit-friendly, and **becomes the regime
 annotation** that §5 of the framing doc requires. Pre-adjustment
-data on the affected polar is preserved and tagged with the prior
+data on the affected operating curve is preserved and tagged with the prior
 regime; post-adjustment data starts a new sub-curve. Successful
 adjustment cannot mask underlying drift because the regime boundary
-is visible in the polar library.
+is visible in the operating-curve library.
 
 ### Rollback
 
 Rollback is **a separate signal**, not an automatic property. If a
 post-adjustment sentinel run shows the adjustment made things worse
-on the same axis, the ops-agent emits `ops.polar_departure` against
+on the same axis, the ops-agent emits `ops.curve_departure` against
 the new sub-curve. The coordinator's rule for that axis decides
 whether to roll back, subject to the same objective-spec bounds.
 Rollback is symmetric to forward adjustment — same machinery, same
@@ -295,7 +313,7 @@ lives (ADR-026, ADR-028 Layer 3), not in the ops-agent.
 
 ## Stationarity discipline
 
-Sentinel runs are how the polar library survives non-stationary
+Sentinel runs are how the operating-curve library survives non-stationary
 underpinnings. This ADR formalises:
 
 - **Curated set, not full corpus.** Single-digit count of prompts
@@ -307,12 +325,12 @@ underpinnings. This ADR formalises:
   spend is measured against measured-traffic spend. On-trigger
   catches the highest-value drift events regardless of cadence.
 - **Mechanical comparison.** Stationarity check is a pure function
-  over the polar's variance envelope. No LLM judgment.
+  over the operating curves variance envelope. No LLM judgment.
 - **LLM judgment for diagnosis only.** When a sentinel falls off the
   curve, the *why* earns LLM reasoning — but only after the
   mechanical detector flagged.
-- **Polars expire; mark them.** Every polar carries a regime
-  annotation. The ops-agent invariant: *no polar is consulted past
+- **Operating curves expire; mark them.** Every operating curve carries a regime
+  annotation. The ops-agent invariant: *no operating curve is consulted past
   its regime boundary without flagging.*
 - **Coordinator-driven adjustments are regime annotations.** The
   `ops.adjustment` record above is the regime annotation. Pre- and
@@ -335,8 +353,8 @@ hiding it.
 - **No new scheduler.** Sentinel runs ride on ADR-031's cron rule
   type. The substrate already exists; the discipline is what's new.
 - **ADR-027 Phase 1 stays valid.** `emit_diagnosis` and
-  `ops.diagnosis.*` predicates remain. This ADR adds the polar-
-  library substrate they live within. No code retracted.
+  `ops.diagnosis.*` predicates remain. This ADR adds the
+  operating-curve-library substrate they live within. No code retracted.
 - **OWASP ASI 2026 / Microsoft AGT integration is structural, not
   bolted-on.** Governance is a curated axis class within the same
   machinery, not a parallel subsystem.
@@ -362,14 +380,14 @@ hiding it.
   with measured runs. Aerospace doesn't have this problem; we do.
   Mitigated by fixture-controlled prompts and regime annotations,
   but never fully eliminated within a single deployment.
-- **Polar storage cost.** Regime-indexed curves accumulate over time.
-  Storage layout committed (see Phase 1): polars in ObjectStore,
+- **Operating-curve storage cost.** Regime-indexed curves accumulate over time.
+  Storage layout committed (see Phase 1): operating curves in ObjectStore,
   regime annotations in KV. Retention policy (when does an expired
-  polar get archived?) is a Phase 1 implementation decision; default
+  operating curve get archived?) is a Phase 1 implementation decision; default
   is "never auto-archive" until a real ObjectStore-volume problem
   surfaces.
 - **Coordinator's policy surface grows only on opt-in.** The
-  ops-agent emits `ops.polar_departure` / `ops.threshold_crossed` /
+  ops-agent emits `ops.curve_departure` / `ops.threshold_crossed` /
   `ops.regime_expired` regardless of whether any axis has been
   opted into tuning. *Diagnosis is the default; tuning is per-axis
   opt-in via objective-spec.* The coordinator's rule set only grows
@@ -398,18 +416,18 @@ hiding it.
 Optimise the harness against one declared scalar, single-axis Pareto
 tracking. **Rejected** as the overall posture (§2.2 of framing
 doc). Right inside a regime, wrong as the system-level discipline.
-The framing doc's polar reframe is the point of departure from this
+The framing doc's operating-curve reframe is the point of departure from this
 lineage — it does not optimise; it observes.
 
 This ADR's signal taxonomy is structurally incompatible with a
-scalar autoresearcher: `ops.polar_departure` requires a curve; a
+scalar autoresearcher: `ops.curve_departure` requires a curve; a
 single scalar cannot depart from a curve.
 
 ### B. Move ops-agent out of SemStreams (sidecar pattern, semspec watcher writ large)
 
-Ship the polar library as a separate `semops` binary that polls live
+Ship the operating-curve library as a separate `semops` binary that polls live
 systems from outside. **Rejected:** every product ends up
-reinventing the polar machinery, sentinel scheduler, and
+reinventing the operating-curve machinery, sentinel scheduler, and
 stationarity-check primitive. Worse: framework-level integration
 points (predicate stream consumption, regime annotation write-back)
 become external API surface, harder to evolve.
@@ -516,29 +534,29 @@ blocker.
   `semspec/pkg/health` into a new SemStreams package
   (`pkg/observability` is the working name; finalised at hoist time;
   see Appendix A for proposed shapes).
-- Add `Polar`, `RegimeAnnotation`, `SentinelRun` data shapes
+- Add `OperatingCurve`, `RegimeAnnotation`, `SentinelRun` data shapes
   (Appendix A).
 - **Storage layout** (committed):
-  - **Polars in ObjectStore** — dense numerical sample sets; large;
+  - **Operating curves in ObjectStore** — dense numerical sample sets; large;
     revision-immutable; well-suited to bucket-keyed blob storage.
-    Bucket: `OBSERVABILITY_POLARS`.
+    Bucket: `OBSERVABILITY_CURVES`.
   - **Regime annotations in KV** — small, structured, fast-lookup,
     KV-Twofer-eligible (state + change-fanout in one write). Bucket:
     `OBSERVABILITY_REGIMES`.
   - **Sentinel-run records in KV** — small per-run metadata
-    (timestamp, prompt-set ID, regime ID, result polar refs).
+    (timestamp, prompt-set ID, regime ID, result curve refs).
     Bucket: `OBSERVABILITY_SENTINELS`. The actual per-run sample
-    data references its parent polar in ObjectStore.
+    data references its parent operating curve in ObjectStore.
 - Wire the three signal predicate families
-  (`ops.polar_departure.*`, `ops.threshold_crossed.*`,
+  (`ops.curve_departure.*`, `ops.threshold_crossed.*`,
   `ops.regime_expired.*`) into the agvocab constants.
 - Wire the `ops.adjustment` record schema.
 - Sentinel-run scheduler: a thin shim over ADR-031 cron rule that
   tags results with regime metadata, writes the run record to
   `OBSERVABILITY_SENTINELS`, and triggers the stationarity-check
-  primitive against the parent polar.
-- Stationarity-check primitive: pure function over `Polar` + sample,
-  emits `ops.polar_departure` when variance envelope is breached.
+  primitive against the parent operating curve.
+- Stationarity-check primitive: pure function over `OperatingCurve` + sample,
+  emits `ops.curve_departure` when variance envelope is breached.
 - Migration guide: how SemSpec converges its watcher onto upstream
   primitives without breaking its existing detectors.
 
@@ -552,7 +570,7 @@ not.
 - **Q3 detector** — three-state classifier on tool-call outcomes
   (parsed-clean / fallback-rescued / failed) per beta.41 + beta.44
   SAP work. Triples already structurally emitted; detector lifts
-  them into the polar pair.
+  them into the axis pair.
 - **G3 detector** — header-vs-body identity-source classifier per
   `xUserIDIdentityMiddleware` already-emitted structural signal.
   Metric emission is additive.
@@ -579,38 +597,38 @@ not.
 - A second adopter (TBD) authors their own catalog from scratch. If
   they can do it without touching framework code, the cut held.
 
-### Phase 4 — coordinator-driven tuning + sweep → polar pipeline
+### Phase 4 — coordinator-driven tuning + sweep → operating-curve pipeline
 
 Two related workstreams ship together here, both opt-in per axis.
 
 **Coordinator-driven tuning:**
 
-- Coordinator gains a rule that fires on `ops.polar_departure` /
+- Coordinator gains a rule that fires on `ops.curve_departure` /
   `ops.threshold_crossed` / `ops.regime_expired` and, when an
   objective-spec bound permits, emits `ops.adjustment`.
 - Adjustment apply path uses the existing ADR-026 runtime
   composition tools — same approval gates, same audit trail.
-- Rollback symmetric: post-adjustment polar departure → coordinator
+- Rollback symmetric: post-adjustment curve departure → coordinator
   rule → reverse adjustment within the same bounds.
 
-**Sweep → polar pipeline:**
+**Sweep → operating-curve pipeline:**
 
-The framing doc (§2.3) describes polars as curves produced by
+The framing doc (§2.3) describes operating curves as curves produced by
 sweeps across reasoning_effort / model tier / persona-fragment
 variants / max_iteration. *How* a sweep is authored, executed, and
-collated into a stored polar is **product-flavored harness work**,
+collated into a stored operating curve is **product-flavored harness work**,
 not framework primitive — different products will sweep different
 axis grids over different flows. Phase 4 establishes:
 
 - The framework-side **sweep-result write API** that lands sample
-  points in an existing or new polar in ObjectStore with regime
+  points in an existing or new operating curve in ObjectStore with regime
   annotation in KV.
 - A **reference sweep tool** (product-side, in `cmd/semteams/...`)
   that drives a sweep across declared axis points and writes
   results via the framework API.
 - The coordinator's **sweep-trigger rule** — when an
   `ops.regime_expired` signal fires, the coordinator may trigger
-  a re-sweep against the new regime to repopulate the polar.
+  a re-sweep against the new regime to repopulate the operating curve.
 
 Phase 4 can ship incrementally per axis. Not all axes need
 coordinator-driven tuning *or* sweep automation; some stay
@@ -622,20 +640,20 @@ Concrete shapes for the three new framework primitives. Anchor for
 the type hoist; final names and field tags get reviewed at
 implementation time. Storage layout (Phase 1) is given alongside.
 
-### A.1 Polar — stored in ObjectStore
+### A.1 OperatingCurve — stored in ObjectStore
 
-A polar is a curve, not a single sample: a set of `(x, y)` points
+An operating curve is a sequence, not a single sample: a set of `(x, y)` points
 collected by sweeping an input axis (the "x") against a measured
 axis (the "y") under a fixed regime. The shape carries enough
 metadata to compute stationarity-check variance envelopes and to
 plot the curve for human review.
 
 ```go
-// Polar — one curve in the polar library. Stored in ObjectStore
-// keyed by ID; the bucket is OBSERVABILITY_POLARS.
-type Polar struct {
+// OperatingCurve — one curve in the operating-curve library. Stored in ObjectStore
+// keyed by ID; the bucket is OBSERVABILITY_CURVES.
+type OperatingCurve struct {
     // ID is stable across sweeps; new sweeps under the same regime
-    // append samples to the existing polar.
+    // append samples to the existing operating curve.
     ID         string
 
     // AxisX/AxisY name what's plotted. AxisX is typically the
@@ -648,14 +666,14 @@ type Polar struct {
 
     // RegimeID is the foreign key into OBSERVABILITY_REGIMES KV.
     // A regime change spawns a new sub-curve under the same
-    // PolarID, distinguished by its RegimeID. Pre-/post-adjustment
+    // CurveID, distinguished by its RegimeID. Pre-/post-adjustment
     // data are tagged distinctly via RegimeID, never mixed.
     RegimeID   string
 
     // Samples is the curve itself. Order is insertion order;
     // (x, y) need not be monotonic. Sweeps append; nothing
     // mutates existing samples in place.
-    Samples    []PolarSample
+    Samples    []CurveSample
 
     // Variance envelope is computed lazily over Samples; cached
     // here for the stationarity-check primitive.
@@ -667,7 +685,7 @@ type Polar struct {
     SweepRefs  []string // SentinelRun.ID values that contributed samples
 }
 
-type PolarSample struct {
+type CurveSample struct {
     X         float64
     Y         float64
     Timestamp time.Time
@@ -689,14 +707,14 @@ type VarianceEnvelope struct {
 ### A.2 RegimeAnnotation — stored in KV
 
 A regime annotation captures the underlying invariants under which
-a polar's samples were collected. When any invariant changes
+an operating curves samples were collected. When any invariant changes
 (model upgrade, persona-fragment commit, capability-surface change,
 coordinator-driven adjustment), a new RegimeAnnotation is written
-and the polar's RegimeID flips — pre-adjustment data stays
+and the operating curves RegimeID flips — pre-adjustment data stays
 queryable under the prior RegimeID.
 
 ```go
-// RegimeAnnotation — invariants under which a polar's samples
+// RegimeAnnotation — invariants under which an operating curves samples
 // are valid. Stored in KV under bucket OBSERVABILITY_REGIMES,
 // keyed by ID. KV-Twofer-eligible: state plus change-fanout to
 // any subscriber that needs to know "regime changed."
@@ -704,7 +722,7 @@ type RegimeAnnotation struct {
     ID                string
 
     // The invariants. These are the things that, when they change,
-    // invalidate the polar.
+    // invalidate the operating curve.
     ModelEndpoint     string  // capability+endpoint resolution
     PersonaFragments  []FragmentRef // ID + content hash
     CapabilitySurface string  // hash of model registry + tool registry snapshot
@@ -734,7 +752,7 @@ type FragmentRef struct {
 A sentinel run is one execution of the curated prompt set against
 the live system, plus the result-classification metadata that
 downstream stationarity-check consumes. The actual per-sample
-points land in the relevant polar's `Samples`; the SentinelRun
+points land in the relevant operating curves `Samples`; the SentinelRun
 record is the run's metadata.
 
 ```go
@@ -755,11 +773,11 @@ type SentinelRun struct {
     StartedAt     time.Time
     CompletedAt   time.Time
 
-    // What polars received samples from this run.
-    PolarRefs     []string
+    // What operating curves received samples from this run.
+    CurveRefs     []string
 
-    // Stationarity-check outcome — emitted as ops.polar_departure
-    // when at least one polar's Samples-from-this-run breach the
+    // Stationarity-check outcome — emitted as ops.curve_departure
+    // when at least one operating curves Samples-from-this-run breach the
     // variance envelope.
     StationaryAxes    []string  // axes where samples sat on the curve
     DeparturesFound   []DepartureRef // axes where they didn't
@@ -770,7 +788,7 @@ type SentinelRun struct {
 }
 
 type DepartureRef struct {
-    PolarID    string
+    CurveID    string
     Magnitude  float64
     Direction  string  // "above" | "below"
     SampleRefs []EvidenceRef
@@ -845,26 +863,26 @@ The relationships between the shapes:
 ```
 SentinelRun.RegimeID  ─────► RegimeAnnotation.ID
                               │
-                              └─► used by Polar to tag samples
-SentinelRun.PolarRefs ─────► Polar.ID (many)
-Polar.RegimeID        ─────► RegimeAnnotation.ID
-Polar.SweepRefs       ─────► SentinelRun.ID (many)
-Polar.Samples[].SourceRef ► EvidenceRef (any kind)
+                              └─► used by OperatingCurve to tag samples
+SentinelRun.CurveRefs ─────► OperatingCurve.ID (many)
+OperatingCurve.RegimeID        ─────► RegimeAnnotation.ID
+OperatingCurve.SweepRefs       ─────► SentinelRun.ID (many)
+OperatingCurve.Samples[].SourceRef ► EvidenceRef (any kind)
 
 ops.adjustment.regime ─────► RegimeAnnotation.ID
 RegimeAnnotation.AdjustmentRef ► ops.adjustment.id (when created by adjustment)
 ```
 
-Pre- / post-adjustment query is `Polar(ID=X).Samples WHERE RegimeID
+Pre- / post-adjustment query is `OperatingCurve(ID=X).Samples WHERE RegimeID
 = prior` vs. `WHERE RegimeID = post`. Same machinery answers
-"what did this polar look like before the model upgrade" and "what
+"what did this operating curve look like before the model upgrade" and "what
 did it look like before the coordinator's tuning action."
 
 ## Related decisions
 
 - [ADR-027](027-ops-agent-meta-harness.md) — refined by this ADR.
   Phase 1 (`emit_diagnosis`, `ops.diagnosis.*` predicates) stays;
-  the polar-library substrate is added underneath.
+  the operating-curve-library substrate is added underneath.
 - [ADR-028](028-orchestration-architecture.md) — names the ops-agent
   as Layer 4. This ADR scopes Layer 4's reasoning discipline.
 - [ADR-026](026-coordinator-agent-dynamic-flow-composition.md) — the
@@ -878,11 +896,11 @@ did it look like before the coordinator's tuning action."
 - [ADR-030](030-http-middleware-and-identity-pattern.md) — provides
   G3 (identity-abuse) and G9 (human-agent trust) enforcement; this
   ADR adds the metric emission layer.
-- [docs/concepts/19-observability-as-polars.md](../concepts/19-observability-as-polars.md)
+- [docs/concepts/19-observability-as-operating-curves.md](../concepts/19-observability-as-operating-curves.md)
   — the conceptual foundation. This ADR distills the structural
   commitments; the concept doc holds the full reasoning.
 - [docs/objectives/README.md](../objectives/README.md) — per-flow
-  objective spec discipline that polars layer on top of, not replace.
+  objective spec discipline that operating curves layer on top of, not replace.
 
 ## References
 
@@ -890,7 +908,7 @@ did it look like before the coordinator's tuning action."
 - Microsoft Agent Governance Toolkit (April 2026),
   `github.com/microsoft/agent-governance-toolkit`.
 - Stanford Meta-Harness, Lee et al. — single-scalar lineage this
-  ADR's polar discipline reframes.
+  ADR's operating-curve discipline reframes.
 - `semspec/pkg/health/detector.go` — working prototype of the
   detector primitives this ADR proposes hoisting.
 - `semspec/cmd/semspec/watch.go`, `watch_live.go` — operator-facing

--- a/docs/concepts/19-observability-as-operating-curves.md
+++ b/docs/concepts/19-observability-as-operating-curves.md
@@ -1,17 +1,29 @@
-# Observability as Polars: Framing for the Ops Agent and Governance
+# Observability as Operating Curves: Framing for the Ops Agent and Governance
 
 **Status:** Concept doc — the conceptual foundation for
-[ADR-033](../adr/033-polar-based-observability.md) (Polar-Based
-Observability). Sections 1–3 are framing; section 4 is the working
-axis catalog and is expected to grow as new failure modes are
-observed.
+[ADR-033](../adr/033-operating-curve-based-observability.md)
+(Operating-Curve-Based Observability). Sections 1–3 are framing;
+section 4 is the working axis catalog and is expected to grow as
+new failure modes are observed.
 
-ADR-033 distills the structural commitments and resolves the §7.4
-ops-agent → coordinator signal contract that this doc deferred. This
-concept doc remains the durable home for the full reasoning behind
-the polar/coefficient/stationarity/separation framing.
+ADR-033 distills the structural commitments and resolves the §7
+ops-agent → coordinator signal contract that this doc deferred.
+This concept doc remains the durable home for the full reasoning
+behind the operating-curve / coefficient / stationarity / separation
+framing.
 
-**Date:** 2026-05-04
+**Terminology note (2026-05-07):** Earlier drafts of this doc and
+ADR-033 used the aerodynamics term *polar* for what we now call
+*operating curves*. The aero term is historical (Eiffel ran early
+lift/drag experiments in polar coordinates; the name stuck even
+after the field switched to Cartesian L/D plots) and confused
+readers without aero fluency. *Operating curve* carries the same
+discipline — measure these systematically across regimes, treat
+them as engineering artifacts — without the historical baggage.
+Where this doc needs the original aero term for clarity (drag
+polar, lift polar), it uses it explicitly with the aero qualifier.
+
+**Date:** 2026-05-04 (terminology revised 2026-05-07)
 
 ## 1. Why this doc exists
 
@@ -43,7 +55,7 @@ ops-agent is built so that the ops-agent's design can be evaluated
 *against* the frame, rather than the frame being reverse-engineered
 from whatever the ops-agent ends up doing.
 
-## 2. The framing: coefficients, polars, and stationarity
+## 2. The framing: coefficients, operating curves, and stationarity
 
 ### 2.1 Why this is empirical, not derivational
 
@@ -108,15 +120,33 @@ over this by demanding a number. They are right to demand it —
 without one you can't optimise — but the number they get is often a
 Goodhart loader for the actual goal.
 
-### 2.3 Polars as the reframe
+### 2.3 Operating curves as the reframe
 
-A polar in aerodynamics is not a number. It is a curve — typically
-lift coefficient plotted against drag coefficient across angle of
-attack. The interesting engineering knowledge is not any single
-point on it. It is the curve's *shape*: where lift is linear, where
-it rolls off, where stall happens, how stall behaves (gentle vs.
-abrupt), what the L/D maximum is and at what angle. Different
-missions select different operating points on the same polar.
+A *polar* in aerodynamics is not a number. It is a curve —
+typically lift coefficient plotted against drag coefficient across
+angle of attack. The term is historical: Eiffel ran his early
+lift/drag experiments at Champ-de-Mars using polar coordinates, and
+the name stuck through Lilienthal and into NACA's systematic
+airfoil studies even after the field switched to Cartesian L/D
+plots. So today's "drag polar" is polar-only-by-history; the
+geometry isn't polar in any meaningful sense. The discipline the
+term carries — *measure these curves systematically across regimes
+and treat them as engineering artifacts* — is what we want. The
+historical name itself confuses readers outside aerospace.
+
+We'll call them **operating curves**. Same engineering discipline,
+less historical baggage, parses correctly for software and
+governance audiences without aero fluency. Where this doc needs
+the original aerospace term for clarity (drag polar, lift polar),
+it uses it explicitly with the aero qualifier; everywhere else,
+operating curves.
+
+The interesting engineering knowledge in any operating curve is
+not a single point on it. It is the curve's *shape*: where the
+relationship is linear, where it rolls off, where it stalls, how
+stall behaves (gentle vs. abrupt), what the optimum trade-off is
+and at what operating condition. Different missions select
+different operating points on the same curve.
 
 The agentic analog: don't ask *what's the quality of this flow.*
 Ask *what does the quality-vs-cost curve look like, and where do
@@ -126,19 +156,19 @@ variants, max_iteration caps produces a *curve*, not a point. The
 adopter who wants throughput operates at one point; the adopter who
 wants maximum spec fidelity operates at another.
 
-Polars don't solve the single-measure problem. They reframe it.
-The field still has to commit to *which axes to plot*. The honest
-gain is narrower:
+Operating curves don't solve the single-measure problem. They
+reframe it. The field still has to commit to *which axes to plot.*
+The honest gain is narrower:
 
-> Polars push the unsolved part to a place where it's visible
-> rather than hidden, and visibility is most of what you need to
-> maintain a system over time.
+> Operating curves push the unsolved part to a place where it's
+> visible rather than hidden, and visibility is most of what you
+> need to maintain a system over time.
 
-Single-scalar approaches blind you to axis divergence. Polar-based
-approaches at least *show you* the loader as it forms. When two
-metrics that historically tracked stop tracking, that is the early
-signal that one of them has become a Goodhart proxy for the other.
-That visibility is what the ops-agent is for.
+Single-scalar approaches blind you to axis divergence.
+Curve-based approaches at least *show you* the loader as it forms.
+When two metrics that historically tracked stop tracking, that is
+the early signal that one of them has become a Goodhart proxy for
+the other. That visibility is what the ops-agent is for.
 
 ### 2.4 Stationarity is the meta-axis
 
@@ -146,23 +176,24 @@ There is one disanalogy with aerodynamics that we have to take
 seriously. Aerodynamic polars are stationary. The lift curve of a
 NACA 0012 airfoil at Re=6M is the same today as it was in 1947.
 
-Agentic system polars are not stationary. The curve for *claude-
-sonnet-4-6 with this persona on this flow* will be a different
-curve when 4-7 ships, when a persona fragment is edited, when an
-underlying tool-execution path changes its retry behaviour. Polars
-have shelf life.
+Agentic system operating curves are not stationary. The curve for
+*claude-sonnet-4-6 with this persona on this flow* will be a
+different curve when 4-7 ships, when a persona fragment is edited,
+when an underlying tool-execution path changes its retry behaviour.
+Operating curves have shelf life.
 
 This is the deepest job of the ops-agent, and the place where most
 of its long-term value sits: **maintain a living, regime-indexed
-polar library that knows when it is stale.** Aerospace doesn't have
-to do this because air doesn't change. We do, because models do.
+operating-curve library that knows when it is stale.** Aerospace
+doesn't have to do this because air doesn't change. We do, because
+models do.
 
 The mechanism is sentinel runs. A curated, fixed set of prompts
 re-executed on schedule against the live system, with their results
-compared against the established polar. Stationary regime: results
+compared against the established curve. Stationary regime: results
 sit on the curve within variance. Regime shift: a step. Drift: a
 slope. The stationarity check itself is mechanical and requires no
-LLM judgment. The diagnosis of *why* a polar drifted is where LLM
+LLM judgment. The diagnosis of *why* a curve drifted is where LLM
 reasoning earns its keep, but only after the mechanical detector
 has flagged that something drifted.
 
@@ -189,10 +220,10 @@ judgment; tester-from-builder collapse rejected on the same
 grounds): **separate the measurer from the measured.** The
 ops-agent should be a stateless reader of the predicate stream. It
 proposes sweeps, identifies inflection points, flags stationarity
-drift. The agents running the actual flows do not see the polar
-library, do not optimise against accumulated XP, do not "level up."
-They do the job. A separate observer infrastructure builds polars
-from outside.
+drift. The agents running the actual flows do not see the
+operating-curve library, do not optimise against accumulated XP,
+do not "level up." They do the job. A separate observer
+infrastructure builds operating curves from outside.
 
 This is also why the objective-spec model is structurally better
 than any intrinsic evidence-accumulation model. The spec is
@@ -214,9 +245,9 @@ cross the gate.*
 
 This is the classic IDS-vs-IPS distinction from network security.
 AGT is largely an IPS — it blocks the action. The ops-agent +
-polar library this doc proposes is largely an IDS — it watches for
-patterns suggesting a previously-good system is degrading. They
-answer different questions:
+operating-curve library this doc proposes is largely an IDS — it
+watches for patterns suggesting a previously-good system is
+degrading. They answer different questions:
 
 - AGT: *is this specific action allowed right now?*
 - Ops-agent: *is this system's behaviour pattern stable, or is it
@@ -226,17 +257,17 @@ A system with AGT and not the second is well-defended against
 known threats and blind to novel drift. A system with the second
 and not AGT detects drift but lets bad actions through while it's
 diagnosing them. **You want both, and they compose.** AGT is the
-policy floor; the polar library is the observability ceiling. The
-OWASP/ASI catalog is the bridge — it gives both layers a shared
-vocabulary for what "known bad" means.
+policy floor; the operating-curve library is the observability
+ceiling. The OWASP/ASI catalog is the bridge — it gives both
+layers a shared vocabulary for what "known bad" means.
 
 The structural claim this doc makes: **governance is not a
 separate concern; it is a curated set of axes within the existing
 observability discipline.** Quality axes (the failure modes we have
 directly observed in our own smoke runs) and governance axes (the
 externally-curated failure catalog we adopt) feed the same
-predicate stream, the same polar library, the same ops-agent
-diagnoses. The split exists for traceability and for the
+predicate stream, the same operating-curve library, the same
+ops-agent diagnoses. The split exists for traceability and for the
 conversation with auditors and adopters. Internally, it is the
 same machinery.
 
@@ -251,12 +282,13 @@ no longer matters under the current regime.
 
 The catalog is split into *quality axes* and *governance axes* for
 traceability. The split is documentary, not structural — both
-classes feed the same predicate stream and the same polar library.
+classes feed the same predicate stream and the same operating-curve
+library.
 
 ### 4.1 Quality axes
 
 Failure modes observed directly in SemTeams smoke runs and
-code-review pivots, with the polar pair that surfaces each one and
+code-review pivots, with the axis pair that surfaces each one and
 the triples required to compute it.
 
 **Q1. Substance vs. ceremony**
@@ -264,7 +296,7 @@ the triples required to compute it.
 - Failure history: R3.4a (22 loops, $8, no terminal artifact)
   vs. R3.4b (6 loops, $1.50, terminal artifact). ADR-031
   §addendum 2026-05-02.
-- Polar pair: cumulative cost (or loops) vs. terminal-artifact
+- Axis pair: cumulative cost (or loops) vs. terminal-artifact
   structural-validator pass rate.
 - Healthy regime: cost and validation rate track. More cost buys
   more validated artifacts.
@@ -274,7 +306,7 @@ the triples required to compute it.
   terminal-artifact validator result keyed to chain ID. The third
   is the structural validator from ADR-031 §addendum 2026-05-02
   final note — *not yet shipped.* Shipping it is partly motivated
-  by needing it as a polar y-axis.
+  by needing it as a curve y-axis.
 
 **Q2. Self-grounding vs. real grounding**
 
@@ -282,7 +314,7 @@ the triples required to compute it.
   authored against builder-authored mock; "tests pass" satisfied
   without exercising any real integration boundary. The Goodhart
   case study that motivated the test-harness-as-flow conversation.
-- Polar pair: tests-passing claims vs. integration-point coverage
+- Axis pair: tests-passing claims vs. integration-point coverage
   against non-builder-authored fixtures.
 - Healthy regime: claims and coverage track.
 - Failure signature: tests-passing high, integration-point coverage
@@ -298,7 +330,7 @@ the triples required to compute it.
   parse rate degrading silently until Semantic Aligned Parsers
   were added with loud triggering. Not directly a SemTeams
   failure, but the pattern transfers.
-- Polar pair: tool calls attempted vs. tool calls successfully
+- Axis pair: tool calls attempted vs. tool calls successfully
   parsed without fallback intervention.
 - Healthy regime: parse-clean rate stable near 1.0.
 - Failure signature: parse-clean rate falls, fallback-rescue rate
@@ -320,7 +352,7 @@ the triples required to compute it.
 - Failure history: not yet observed; this is the axis that will
   settle the challenger-earns-its-keep question raised in the
   early-adopter / BMAD conversation.
-- Polar pair: per-role invocations vs. role-induced revisions
+- Axis pair: per-role invocations vs. role-induced revisions
   citing concerns the predecessor role didn't catch.
 - Healthy regime for an earning-its-keep role: a non-trivial
   fraction of `concerns_raised` (or `insufficient`) outcomes cite
@@ -344,7 +376,7 @@ the triples required to compute it.
   observed when claude-sonnet-4-7 ships, when persona fragments
   are edited at scale, or when underlying capability behaviour
   changes.
-- Polar pair: time vs. sentinel-run results on any other axis the
+- Axis pair: time vs. sentinel-run results on any other axis the
   catalog tracks.
 - Healthy regime: flat line within variance.
 - Failure signatures: step function (regime shift), gradual slope
@@ -353,20 +385,20 @@ the triples required to compute it.
   predicate-stream replay capability. This is observability
   *infrastructure* — not metric emission. The flows don't need to
   know they're sentinels; the ops-agent does.
-- This is the axis that protects the polar library from itself.
+- This is the axis that protects the operating-curve library from itself.
   Without it, the library accumulates evidence that silently mixes
   across regimes.
 
 ### 4.2 Governance axes
 
 Adopted from OWASP Agentic Top 10 / ASI 2026 taxonomy. Each is
-mapped to the polar pair that surfaces it, the triples needed, and
+mapped to the axis pair that surfaces it, the triples needed, and
 the relationship to existing SemTeams enforcement (so we know
 where we already have the gate but lack the metric).
 
 **G1. Goal hijacking (ASI01) — prompt injection in tool results**
 
-- Polar pair: instructions-from-user acted upon vs. instructions-
+- Axis pair: instructions-from-user acted upon vs. instructions-
   from-tool-results acted upon.
 - Failure signature: actions-on-tool-result-instructions rate rises
   above baseline.
@@ -378,7 +410,7 @@ where we already have the gate but lack the metric).
 
 **G2. Tool misuse (ASI02)**
 
-- Polar pair: persona-allowed tool calls vs. allowlist denials.
+- Axis pair: persona-allowed tool calls vs. allowlist denials.
 - Failure signature: denial rate rising trend.
 - Triples: per-tool-call, persona at call time, allowlist outcome.
 - Existing enforcement: `agentic-governance.enable_tool_governance`
@@ -387,7 +419,7 @@ where we already have the gate but lack the metric).
 
 **G3. Identity abuse (ASI03)**
 
-- Polar pair: header-verified identity rate vs. body-fallback
+- Axis pair: header-verified identity rate vs. body-fallback
   identity rate.
 - Failure signature: body-fallback rate rising — identical pattern
   to Q3's fallback-rate-as-early-warning.
@@ -398,7 +430,7 @@ where we already have the gate but lack the metric).
 
 **G4. Supply chain (ASI04)**
 
-- Polar pair: source ingestion from approved namespaces vs.
+- Axis pair: source ingestion from approved namespaces vs.
   ingestion attempts blocked.
 - Failure signature: blocked-ingestion rate rising; sources from
   unfamiliar namespaces appearing in the trusted-source set.
@@ -410,16 +442,16 @@ where we already have the gate but lack the metric).
 
 **G5. Cascading failures (ASI05)**
 
-- Polar pair: chain depth vs. terminal-artifact validator pass rate.
+- Axis pair: chain depth vs. terminal-artifact validator pass rate.
 - Failure signature: long chains with falling validation rate —
   cascading retry without convergence.
-- Triples: same as Q1; this is the same machinery, different polar
+- Triples: same as Q1; this is the same machinery, different axis
   pair.
 - Existing enforcement: `max_iterations` caps on rules.
 
 **G6. Memory poisoning (ASI06)**
 
-- Polar pair: predicates from trusted sources vs. predicates with
+- Axis pair: predicates from trusted sources vs. predicates with
   provenance to ingested external content acted upon downstream.
 - Failure signature: cross-grounding rate against untrusted sources
   rising; downstream artifacts citing predicates whose lineage
@@ -433,7 +465,7 @@ where we already have the gate but lack the metric).
 
 **G7. Insecure communication (ASI07)**
 
-- Polar pair: inter-agent messages signed vs. unsigned.
+- Axis pair: inter-agent messages signed vs. unsigned.
 - Failure signature: any unsigned message in a signed-only
   pathway.
 - Triples: per-message, signature presence.
@@ -444,7 +476,7 @@ where we already have the gate but lack the metric).
 
 **G8. Code execution (ASI08)**
 
-- Polar pair: sandboxed-bash invocations within default capability
+- Axis pair: sandboxed-bash invocations within default capability
   set vs. invocations with non-default capabilities.
 - Failure signature: non-default-capability rate rising.
 - Triples: per-bash-execution, capability set, sandbox profile.
@@ -454,7 +486,7 @@ where we already have the gate but lack the metric).
 
 **G9. Human-agent trust exploitation (ASI09)**
 
-- Polar pair: approvals granted vs. approval outcomes correlated
+- Axis pair: approvals granted vs. approval outcomes correlated
   with downstream artifact validity.
 - Failure signature: high approval rate, low correlation between
   approved actions and validated downstream artifacts —
@@ -467,7 +499,7 @@ where we already have the gate but lack the metric).
 
 **G10. Rogue agents (ASI10)**
 
-- Polar pair: loops spawned by user/rule vs. loops with anomalous
+- Axis pair: loops spawned by user/rule vs. loops with anomalous
   spawn provenance (no rule trigger, no user message, no
   recognised parent).
 - Failure signature: any non-zero rate of anomalous spawn
@@ -512,7 +544,7 @@ A few patterns worth naming once rather than repeating per-axis:
 
 ## 5. Stationarity discipline
 
-Sentinel runs are how the polar library survives non-stationary
+Sentinel runs are how the operating-curve library survives non-stationary
 underpinnings. The discipline:
 
 - **Curated set, not full corpus.** A handful (single-digit) of
@@ -524,28 +556,28 @@ underpinnings. The discipline:
   trigger for explicit regime shifts (model upgrade, persona
   fragment edit, capability surface change).
 - **Compare against established curve.** Mechanical: did the
-  result sit on the polar within established variance? This check
+  result sit on the curve within established variance? This check
   uses no LLM judgment.
 - **LLM judgment only for diagnosis.** When a sentinel falls off
   the curve, *why* is the question that earns LLM reasoning. The
   detection is mechanical; the diagnosis is interpretive. Keep
   the boundary clean.
-- **Polars expire; mark them.** Every polar in the library has a
-  regime annotation: which model, which prompt, which persona
-  versions, which capability surface. When any of those change,
-  the polar is suspect until re-validated. The ops-agent's
-  invariant: *no polar is consulted past its regime boundary
-  without flagging.*
+- **Operating curves expire; mark them.** Every curve in the
+  library has a regime annotation: which model, which prompt,
+  which persona versions, which capability surface. When any of
+  those change, the curve is suspect until re-validated. The
+  ops-agent's invariant: *no curve is consulted past its regime
+  boundary without flagging.*
 - **Coordinator-driven adjustments are regime annotations too.**
   When the coordinator acts on an ops-agent signal to tune a
   parameter within objective-spec bounds (§6), the adjustment is
-  recorded on the affected polars exactly the same way a model
+  recorded on the affected curves exactly the same way a model
   upgrade is. Pre-adjustment data is preserved and tagged;
   post-adjustment data starts a new sub-curve. This is what
   prevents successful adjustment from masking underlying drift —
   the symptom may be compensated, but the regime boundary is
-  visible in the polar library, and the next sentinel pass reads
-  the post-adjustment curve on its own terms.
+  visible in the operating-curve library, and the next sentinel
+  pass reads the post-adjustment curve on its own terms.
 
 ## 6. What this is not
 
@@ -577,18 +609,19 @@ nearby attractors that this design deliberately rejects:
   on signals the measurer emits within bounds something else
   authored.
 - **Not an autoresearcher.** The ops-agent does not optimise
-  against a single scalar. It maintains polars and respects the
-  unsolved-ness of single-measure as documented in §2.2.
-- **Not a tester.** Tests gate; polars observe. The structural
-  validators that already exist (and the ones ADR-031 §addendum
-  proposes shipping) are the gating layer. The ops-agent reads
-  the predicates the validators emit, but it does not replace
-  them.
+  against a single scalar. It maintains operating curves and
+  respects the unsolved-ness of single-measure as documented in
+  §2.2.
+- **Not a tester.** Tests gate; operating curves observe. The
+  structural validators that already exist (and the ones ADR-031
+  §addendum proposes shipping) are the gating layer. The ops-agent
+  reads the predicates the validators emit, but it does not
+  replace them.
 - **Not a replacement for AGT-style policy enforcement.** §3
-  argues the layered position. The polar library complements
+  argues the layered position. The operating-curve library complements
   policy enforcement; it does not substitute.
 - **Not intrinsic to the flows.** The separation principle (§2.5)
-  means flows do not see the polar library and do not optimise
+  means flows do not see the operating-curve library and do not optimise
   against it. Any design that violates this is reverting to
   semdragon's XP coupling and inherits its survivorship-bias
   failure mode.
@@ -606,7 +639,7 @@ nearby attractors that this design deliberately rejects:
 
 - **What is the right schedule for sentinel runs?** Daily seems
   cheap for cost/latency; weekly for validation; the model-upgrade
-  trigger is what keeps the polar library current. Open: whether
+  trigger is what keeps the operating-curve library current. Open: whether
   to run sentinels in a dedicated environment vs. piggybacking on
   the live system. Aerospace runs in a dedicated wind tunnel for a
   reason — measurement environment matters. Equivalent here may
@@ -614,10 +647,10 @@ nearby attractors that this design deliberately rejects:
 
 - **How does this interact with ADR-027 Phase 1's ops-agent
   scope?** The objective-spec README is shaped for per-flow specs.
-  This doc proposes a meta-layer above per-flow specs (the polar
-  library, regime-indexed). They compose, but the relationship
-  needs to be explicit in whatever ADR formalises the ops-agent
-  design.
+  This doc proposes a meta-layer above per-flow specs (the
+  operating-curve library, regime-indexed). They compose, but the
+  relationship needs to be explicit in whatever ADR formalises the
+  ops-agent design.
 
 - **What does the ops-agent → coordinator signal/action contract
   look like?** §6 establishes that ops-agent emits signals and
@@ -626,9 +659,9 @@ nearby attractors that this design deliberately rejects:
   pieces:
 
   - *Signal taxonomy.* What predicates does ops-agent emit? Working
-    list: polar-departure (axis, magnitude, duration), threshold-
+    list: curve-departure (axis, magnitude, duration), threshold-
     crossed (metric, direction, sustained-for), regime-expired
-    (polar identity, expiration cause). These need to be enumerable
+    (curve identity, expiration cause). These need to be enumerable
     and stable because the coordinator's rules will fire on them.
   - *Adjustment record schema.* Probably a typed payload the
     coordinator emits per ADR-031's `emit_*_artifact` pattern —
@@ -655,6 +688,77 @@ nearby attractors that this design deliberately rejects:
   powerful. ADR-030's allowlist machinery is closer to template;
   worth understanding why before deciding.
 
+- **Does the operating-curve library become a topology with
+  enough data?** Volume alone doesn't drive this. What would drive
+  it is systematic sweep coverage across the *design choices*
+  themselves — persona-set variants, role decompositions,
+  rule-gating shapes — not just sweeps of continuous knobs
+  (reasoning_effort, model tier, max_iterations) within a fixed
+  design choice.
+
+  The shape this points at: each design choice is a *node*.
+  Inside a node, the continuous knobs trace out a *surface* of
+  curves — vary reasoning_effort smoothly, the curve moves
+  smoothly. Between nodes, the transitions are *discrete* — you
+  either have the challenger role or you don't; there is no
+  smooth path between four-role and three-role chains. So the
+  right object isn't a single connected manifold; it's a graph
+  of design-choice nodes with a surface attached at each node.
+
+  Some §4 observations already gesture at this. Q1 and G5
+  sharing machinery is two slices that are *the same slice* —
+  same surface, different label. Fallback-rate-as-universal-
+  early-warning (§4.3) is a *structural pattern* that recurs
+  across multiple surfaces (Q3, G3, future graceful-degradation
+  paths) — the same local shape appearing at different nodes of
+  the design graph. These are the kinds of regularities a
+  topology view makes legible that a flat list of curves doesn't.
+
+  Three sub-questions before this earns its keep:
+
+  - *At what coverage threshold does the graph-of-surfaces
+    framing pay off over independent curves?* Probably when we've
+    actually run sweeps that vary discrete design choices (not
+    just continuous knobs) — and we mostly haven't yet. The
+    R3.4a → R3.4b pivot is one such sweep; we need more before
+    the topology view is anything other than aspirational.
+  - *How does the non-stationarity from §2.4 propagate?* A model
+    upgrade doesn't just shift one curve; it potentially deforms
+    every surface at every node. The operating-curve library
+    going stale becomes "the whole graph going stale."
+    Stationarity discipline scales, but the bookkeeping gets
+    harder and the sentinel-run schedule may need to be node-
+    aware rather than curve-aware.
+  - *How do we distinguish measured shape from fitted-and-
+    therefore-asserted shape?* Reaching for topology too early
+    is its own Goodhart trap — an asserted surface implies
+    relationships between points that might not be real, and
+    decisions made against the asserted surface optimise against
+    something the measurements don't actually support. Same
+    discipline as §6's "not an autoresearcher" — the framing
+    must stay descriptive of what was measured, not predictive
+    of what would happen at points not yet measured.
+
+  Probably premature to commit on any of these before the per-
+  curve discipline has shipped and stabilised. *But:* every
+  smoke run should already record its full design-point
+  coordinates — not just measured outcomes — so future topology
+  assembly is possible without re-running. That's a small
+  instrumentation discipline that costs nothing now and preserves
+  the option. Worth flagging in whatever ADR formalises predicate
+  emission.
+
+  The deeper reason to hold this open question even while
+  deferring it: the topology framing is what would let governance
+  arguments become structural rather than per-axis. *"This region
+  of the design space satisfies these governance bounds; this
+  region doesn't; the boundary between them has these
+  properties"* is a different kind of argument than *"axis G3
+  looks healthy."* Auditors and policy reviewers will eventually
+  want the structural argument. Knowing that's the destination
+  affects what data we collect now in ways that make the
+  topology recoverable later.
+
 - **At what point does this become an ADR?** Probably when §4
   has been validated against two or three real failure-mode
   observations rather than the one (R3.4a→b) it currently rests
@@ -678,7 +782,7 @@ nearby attractors that this design deliberately rejects:
 - Stanford Meta-Harness, Lee et al. — referenced in
   `docs/objectives/README.md`.
 - Karpathy autoresearch lineage — single-scalar optimisation
-  framing this doc reframes via polars.
+  framing this doc reframes via operating curves.
 - Conversational lineage: 2026-05-04 framing conversation
   (aerodynamics analogy, polar/coefficient distinction,
   separation principle from semdragon).


### PR DESCRIPTION
## Summary

Wholesale terminology cleanup of ADR-033 and concept doc 19. The aero term "polar" was historical baggage that parsed badly outside aerospace contexts. "Operating curve" carries the same engineering discipline without the confusion.

## Why now

The new framing doc draft (verbatim source for concept doc 19) committed to "operating curves" terminology. ADR-033 was Accepted on 2026-05-05 but the type hoist hasn't started yet — this is the cheapest moment to clean up identifiers before code lands referencing them.

## File renames

```
docs/adr/033-polar-based-observability.md
  → docs/adr/033-operating-curve-based-observability.md

docs/concepts/19-observability-as-polars.md
  → docs/concepts/19-observability-as-operating-curves.md
```

## Identifier renames (no code-level migration needed yet)

| Was | Becomes |
|---|---|
| `Polar` (Go struct) | `OperatingCurve` |
| `PolarSample` | `CurveSample` |
| `PolarID` / `PolarRefs` (fields) | `CurveID` / `CurveRefs` |
| `ops.polar_departure.*` (agvocab) | `ops.curve_departure.*` |
| `polar_id` field | `curve_id` field |
| `OBSERVABILITY_POLARS` bucket | `OBSERVABILITY_CURVES` bucket |

## Phrase substitutions throughout prose

- "polar library" → "operating-curve library"
- "polar pair" → "axis pair"
- "polar machinery" → "operating-curve machinery"
- "polar discipline" → "operating-curve discipline"
- "polar reframe" → "operating-curve reframe"
- "Polar storage cost" → "Operating-curve storage cost"
- "Sweep → polar pipeline" → "Sweep → operating-curve pipeline"
- ~30 other singular/plural lowercase forms throughout

## ADR Status block

Gained a **Terminology revision (2026-05-07)** note recording the rename and listing the affected identifiers, so future readers can resolve old references.

## Concept doc 19

Replaced with the latest framing-doc draft (operating-curves terminology). New content beyond terminology: an additional §7 open question about whether the operating-curve library becomes a topology of design-choice nodes once sweep coverage is sufficient. Kept as forward-looking open question, **not in scope** for the Accepted ADR — it's a future-ADR concern.

## What didn't change

- D1-D4 decisions stand verbatim
- Framework/product cut table stands
- Six SemTeams answers stand
- Phase 1-4 sequencing stands
- Appendix A data shapes stand structurally; only the type names changed
- Storage layout (ObjectStore for curves, KV for regimes/sentinel runs) stands

## Memory updated

Index in `MEMORY.md` and the two `project_adr033_*.md` files renamed to use operating-curves terminology. Memory lives outside git but is updated alongside.

## Test plan

- [x] `grep -r "polar"` shows no software-context references in either file (only the explicit terminology-revision migration note)
- [x] Cross-reference diagram in Appendix A renders with correct type names
- [x] Both relative file links resolve
- [ ] Final sanity read by reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)