### PR TITLE
feat(rule,agentic,agentic-loop): thread ResponseFormat through TaskMessage to AgentRequest

### DIFF
--- a/agentic/user_types.go
+++ b/agentic/user_types.go
@@ -291,6 +291,14 @@ type TaskMessage struct {
 	// (e.g. "30s"). Empty means fall through to endpoint, capability, or
 	// component-level timeout. Highest precedence when set.
 	Timeout string `json:"timeout,omitempty"`
+
+	// ResponseFormat constrains the model's output to a JSON object or
+	// JSON-schema-conformant JSON for this task. ADR-034. The agentic-loop
+	// caches it on initial build and threads it onto every AgentRequest in
+	// the loop. Nil means tool-calling behaviour is unchanged. Set this
+	// from a rule.Action (publish_agent path) or from a dispatcher when
+	// the task needs structured output.
+	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
 }
 
 // ConstructedContext is an alias for types.ConstructedContext.
@@ -321,6 +329,11 @@ func (t TaskMessage) Validate() error {
 	}
 	if t.ToolChoice != nil {
 		if err := t.ToolChoice.Validate(); err != nil {
+			return err
+		}
+	}
+	if t.ResponseFormat != nil {
+		if err := t.ResponseFormat.Validate(); err != nil {
 			return err
 		}
 	}

--- a/agentic/user_types_test.go
+++ b/agentic/user_types_test.go
@@ -605,6 +605,108 @@ func TestTaskMessage_Tools_JSONRoundTrip(t *testing.T) {
 	assert.Equal(t, "ops", decoded.Metadata["org"])
 }
 
+// TestTaskMessage_ResponseFormat_JSONRoundTrip verifies that
+// ResponseFormat threads through JSON serialization on TaskMessage.
+// ADR-034. Both helpers (NewJSONSchemaFormat, NewJSONObjectFormat)
+// must round-trip with the Type / Schema / Name / Strict fields intact.
+func TestTaskMessage_ResponseFormat_JSONRoundTrip(t *testing.T) {
+	t.Run("JSONSchema strict mode", func(t *testing.T) {
+		rf := NewJSONSchemaFormat("decision", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"action": map[string]any{"type": "string"},
+			},
+			"required": []any{"action"},
+		})
+		original := TaskMessage{
+			TaskID:         "task-rf-schema",
+			Role:           "planner",
+			Model:          "qwen3:7b",
+			Prompt:         "decide",
+			ResponseFormat: rf,
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded TaskMessage
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.NotNil(t, decoded.ResponseFormat)
+		assert.Equal(t, ResponseFormatJSONSchema, decoded.ResponseFormat.Type)
+		assert.Equal(t, "decision", decoded.ResponseFormat.Name)
+		assert.True(t, decoded.ResponseFormat.Strict)
+		require.NotNil(t, decoded.ResponseFormat.Schema)
+		assert.Equal(t, "object", decoded.ResponseFormat.Schema["type"])
+	})
+
+	t.Run("JSONObject bare mode", func(t *testing.T) {
+		original := TaskMessage{
+			TaskID:         "task-rf-object",
+			Role:           "general",
+			Model:          "qwen3:7b",
+			Prompt:         "respond as JSON",
+			ResponseFormat: NewJSONObjectFormat(),
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var decoded TaskMessage
+		require.NoError(t, json.Unmarshal(data, &decoded))
+
+		require.NotNil(t, decoded.ResponseFormat)
+		assert.Equal(t, ResponseFormatJSONObject, decoded.ResponseFormat.Type)
+		assert.Empty(t, decoded.ResponseFormat.Name)
+		assert.False(t, decoded.ResponseFormat.Strict)
+	})
+
+	t.Run("nil omits field via omitempty", func(t *testing.T) {
+		original := TaskMessage{
+			TaskID: "task-rf-nil",
+			Role:   "general",
+			Model:  "fast",
+			Prompt: "no constraint",
+			// ResponseFormat omitted
+		}
+
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		// `omitempty` on a pointer means absent JSON key when nil.
+		// The receiver sees a nil ResponseFormat after unmarshal — back-compat
+		// for every caller that doesn't opt in.
+		assert.NotContains(t, string(data), "response_format",
+			"nil ResponseFormat should be omitted from JSON entirely")
+
+		var decoded TaskMessage
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Nil(t, decoded.ResponseFormat)
+	})
+}
+
+// TestTaskMessage_ResponseFormat_ValidatePropagates verifies that an
+// invalid ResponseFormat surfaces from TaskMessage.Validate (e.g., a
+// json_schema type without a name field). ADR-034 invariant: validation
+// at the TaskMessage boundary catches malformed schemas before they hit
+// the LLM client and produce confusing 400s.
+func TestTaskMessage_ResponseFormat_ValidatePropagates(t *testing.T) {
+	task := TaskMessage{
+		TaskID: "task-bad-rf",
+		Role:   "general",
+		Model:  "fast",
+		Prompt: "x",
+		ResponseFormat: &ResponseFormat{
+			Type: ResponseFormatJSONSchema,
+			// Missing Name and Schema — both required when Type == JSONSchema
+		},
+	}
+	err := task.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name required",
+		"TaskMessage.Validate should propagate ResponseFormat.Validate failures")
+}
+
 // TestTaskMessage_Tools_NilVsEmptyPreserved verifies that Tools serialises
 // faithfully for both nil and explicit empty slices. The distinction is
 // load-bearing: the spawner uses nil to mean "no override, discover tools"

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -609,6 +609,13 @@ func (h *MessageHandler) HandleTask(ctx context.Context, task TaskMessage) (Hand
 		h.loopManager.CacheRequestTimeout(loopID, task.Timeout)
 	}
 
+	// Cache per-task response_format (ADR-034) so continuation iterations
+	// reuse the structured-output constraint. Nil leaves tool-calling
+	// behaviour unchanged across the loop.
+	if task.ResponseFormat != nil {
+		h.loopManager.CacheResponseFormat(loopID, task.ResponseFormat)
+	}
+
 	return h.buildTaskRequest(loopID, task, entity, messages, tools)
 }
 
@@ -616,14 +623,15 @@ func (h *MessageHandler) HandleTask(ctx context.Context, task TaskMessage) (Hand
 // event, returning the assembled HandlerResult.
 func (h *MessageHandler) buildTaskRequest(loopID string, task TaskMessage, entity agentic.LoopEntity, messages []agentic.ChatMessage, tools []agentic.ToolDefinition) (HandlerResult, error) {
 	request := agentic.AgentRequest{
-		RequestID:  h.loopManager.GenerateRequestID(loopID),
-		LoopID:     loopID,
-		Role:       task.Role,
-		Model:      task.Model,
-		Messages:   messages,
-		Tools:      tools,
-		ToolChoice: task.ToolChoice,
-		Timeout:    task.Timeout,
+		RequestID:      h.loopManager.GenerateRequestID(loopID),
+		LoopID:         loopID,
+		Role:           task.Role,
+		Model:          task.Model,
+		Messages:       messages,
+		Tools:          tools,
+		ToolChoice:     task.ToolChoice,
+		Timeout:        task.Timeout,
+		ResponseFormat: task.ResponseFormat,
 	}
 
 	h.loopManager.TrackRequest(request.RequestID, loopID)
@@ -1256,14 +1264,15 @@ func (h *MessageHandler) emitRetryRequest(ctx context.Context, loopID string, en
 	toolChoice := h.loopManager.GetCachedToolChoice(loopID)
 
 	request := agentic.AgentRequest{
-		RequestID:  h.loopManager.GenerateRequestID(loopID),
-		LoopID:     loopID,
-		Role:       entity.Role,
-		Model:      entity.Model,
-		Messages:   messages,
-		Tools:      tools,
-		ToolChoice: toolChoice,
-		Timeout:    h.loopManager.GetCachedRequestTimeout(loopID),
+		RequestID:      h.loopManager.GenerateRequestID(loopID),
+		LoopID:         loopID,
+		Role:           entity.Role,
+		Model:          entity.Model,
+		Messages:       messages,
+		Tools:          tools,
+		ToolChoice:     toolChoice,
+		Timeout:        h.loopManager.GetCachedRequestTimeout(loopID),
+		ResponseFormat: h.loopManager.GetCachedResponseFormat(loopID),
 	}
 
 	h.loopManager.TrackRequest(request.RequestID, loopID)
@@ -1717,14 +1726,15 @@ func (h *MessageHandler) handleToolsComplete(
 
 	// All tools complete - send next agent request with full conversation
 	request := agentic.AgentRequest{
-		RequestID:  h.loopManager.GenerateRequestID(loopID),
-		LoopID:     loopID,
-		Role:       entity.Role,
-		Model:      entity.Model,
-		Messages:   messages,
-		Tools:      tools,
-		ToolChoice: toolChoice,
-		Timeout:    h.loopManager.GetCachedRequestTimeout(loopID),
+		RequestID:      h.loopManager.GenerateRequestID(loopID),
+		LoopID:         loopID,
+		Role:           entity.Role,
+		Model:          entity.Model,
+		Messages:       messages,
+		Tools:          tools,
+		ToolChoice:     toolChoice,
+		Timeout:        h.loopManager.GetCachedRequestTimeout(loopID),
+		ResponseFormat: h.loopManager.GetCachedResponseFormat(loopID),
 	}
 
 	// Track request ID to loop ID mapping (cache for fast lookup)

--- a/processor/agentic-loop/handlers_test.go
+++ b/processor/agentic-loop/handlers_test.go
@@ -1725,6 +1725,107 @@ func TestHandleTask_PropagatesTimeoutToAgentRequest(t *testing.T) {
 	t.Error("HandleTask() should publish agent.request message")
 }
 
+// TestHandleTask_PropagatesResponseFormatToAgentRequest verifies the
+// ADR-034 threading path: TaskMessage.ResponseFormat → cached on
+// LoopManager → set on the AgentRequest published to agent.request.*.
+// Continuation iterations re-use the cached value (covered separately
+// by integration tests that exercise multi-iteration loops).
+func TestHandleTask_PropagatesResponseFormatToAgentRequest(t *testing.T) {
+	handler := agenticloop.NewMessageHandler(createTestConfig())
+
+	rf := agentic.NewJSONSchemaFormat("decision", map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"action": map[string]any{"type": "string"},
+		},
+		"required": []any{"action"},
+	})
+
+	task := agenticloop.TaskMessage{
+		TaskID:         "task-response-format",
+		Role:           "planner",
+		Model:          "test-model",
+		Prompt:         "Decide",
+		ResponseFormat: rf,
+	}
+
+	ctx := context.Background()
+	result, err := handler.HandleTask(ctx, task)
+	if err != nil {
+		t.Fatalf("HandleTask() error = %v", err)
+	}
+
+	for _, msg := range result.PublishedMessages {
+		if !containsIgnoreCase(msg.Subject, "agent.request") {
+			continue
+		}
+		var envelope map[string]any
+		if err := json.Unmarshal(msg.Data, &envelope); err != nil {
+			t.Fatalf("Failed to unmarshal envelope: %v", err)
+		}
+		payload, ok := envelope["payload"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected payload in BaseMessage envelope")
+		}
+		got, ok := payload["response_format"].(map[string]any)
+		if !ok {
+			t.Fatalf("AgentRequest.response_format missing or wrong type: %T", payload["response_format"])
+		}
+		if got["type"] != agentic.ResponseFormatJSONSchema {
+			t.Errorf("AgentRequest.response_format.type = %q, want %q", got["type"], agentic.ResponseFormatJSONSchema)
+		}
+		if got["name"] != "decision" {
+			t.Errorf("AgentRequest.response_format.name = %q, want %q", got["name"], "decision")
+		}
+		if got["strict"] != true {
+			t.Errorf("AgentRequest.response_format.strict = %v, want true", got["strict"])
+		}
+		return
+	}
+	t.Error("HandleTask() should publish agent.request message")
+}
+
+// TestHandleTask_NoResponseFormatPreservesNil verifies that omitting
+// ResponseFormat on TaskMessage leaves AgentRequest.response_format
+// absent — back-compat for every caller that doesn't opt into ADR-034.
+func TestHandleTask_NoResponseFormatPreservesNil(t *testing.T) {
+	handler := agenticloop.NewMessageHandler(createTestConfig())
+
+	task := agenticloop.TaskMessage{
+		TaskID: "task-no-rf",
+		Role:   "general",
+		Model:  "test-model",
+		Prompt: "no constraint",
+	}
+
+	ctx := context.Background()
+	result, err := handler.HandleTask(context.Background(), task)
+	if err != nil {
+		t.Fatalf("HandleTask() error = %v", err)
+	}
+	_ = ctx
+
+	for _, msg := range result.PublishedMessages {
+		if !containsIgnoreCase(msg.Subject, "agent.request") {
+			continue
+		}
+		var envelope map[string]any
+		if err := json.Unmarshal(msg.Data, &envelope); err != nil {
+			t.Fatalf("Failed to unmarshal envelope: %v", err)
+		}
+		payload, ok := envelope["payload"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected payload in BaseMessage envelope")
+		}
+		if _, present := payload["response_format"]; present {
+			t.Errorf("response_format should be absent when not set on TaskMessage; got %v", payload["response_format"])
+		}
+		return
+	}
+	t.Error("HandleTask() should publish agent.request message")
+}
+
 // --- ToolCallFilter tests ---
 
 // mockFilter implements agentic.ToolCallFilter for testing

--- a/processor/agentic-loop/state.go
+++ b/processor/agentic-loop/state.go
@@ -24,6 +24,7 @@ type LoopManager struct {
 	cachedToolChoice     map[string]*agentic.ToolChoice      // loopID -> tool choice (runtime cache, not persisted)
 	cachedMetadata       map[string]map[string]any           // loopID -> metadata (domain context, not persisted)
 	cachedRequestTimeout map[string]string                   // loopID -> request timeout (from TaskMessage.Timeout, not persisted)
+	cachedResponseFormat map[string]*agentic.ResponseFormat  // loopID -> response_format (from TaskMessage.ResponseFormat, not persisted)
 	taskPrompts          map[string]string                   // loopID -> original task prompt (for context recovery)
 	requestToLoop        map[string]string                   // requestID -> loopID
 	toolCallToLoop       map[string]string                   // callID -> loopID
@@ -74,6 +75,7 @@ func NewLoopManager(opts ...LoopManagerOption) *LoopManager {
 		cachedToolChoice:        make(map[string]*agentic.ToolChoice),
 		cachedMetadata:          make(map[string]map[string]any),
 		cachedRequestTimeout:    make(map[string]string),
+		cachedResponseFormat:    make(map[string]*agentic.ResponseFormat),
 		taskPrompts:             make(map[string]string),
 		requestToLoop:           make(map[string]string),
 		toolCallToLoop:          make(map[string]string),
@@ -102,6 +104,7 @@ func NewLoopManagerWithConfig(contextConfig ContextConfig, opts ...LoopManagerOp
 		cachedToolChoice:        make(map[string]*agentic.ToolChoice),
 		cachedMetadata:          make(map[string]map[string]any),
 		cachedRequestTimeout:    make(map[string]string),
+		cachedResponseFormat:    make(map[string]*agentic.ResponseFormat),
 		taskPrompts:             make(map[string]string),
 		requestToLoop:           make(map[string]string),
 		toolCallToLoop:          make(map[string]string),
@@ -412,6 +415,26 @@ func (m *LoopManager) GetCachedRequestTimeout(loopID string) string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.cachedRequestTimeout[loopID]
+}
+
+// CacheResponseFormat stores the per-task response_format for a loop (from
+// TaskMessage.ResponseFormat). Reused for all continuation iterations so the
+// structured-output constraint persists across LLM calls in the same loop.
+// ADR-034.
+func (m *LoopManager) CacheResponseFormat(loopID string, rf *agentic.ResponseFormat) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cachedResponseFormat[loopID] = rf
+}
+
+// GetCachedResponseFormat retrieves the cached response_format for a loop.
+// Returns nil when no task-level response_format was set, in which case
+// AgentRequest.ResponseFormat stays nil and tool-calling behaviour is
+// preserved.
+func (m *LoopManager) GetCachedResponseFormat(loopID string) *agentic.ResponseFormat {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.cachedResponseFormat[loopID]
 }
 
 // CacheTaskPrompt stores the original task prompt for context recovery.

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -106,6 +106,20 @@ type Action struct {
 	// the workflow config that already owns role/model/prompt/tools.
 	ActionAllowlist []string `json:"action_allowlist,omitempty"`
 
+	// ResponseFormat constrains the spawned loop's model output to a
+	// JSON object or JSON-schema-conformant JSON. ADR-034. When non-nil,
+	// executePublishAgent stamps it onto the TaskMessage.ResponseFormat;
+	// the agentic-loop caches it and threads it onto every AgentRequest
+	// in the loop. Nil leaves tool-calling behaviour unchanged.
+	//
+	// Use the agentic.NewJSONSchemaFormat / agentic.NewJSONObjectFormat
+	// helpers to construct. See ADR-034 + docs/operations/13-structured-output.md
+	// for provider support; small/local models (qwen3, deepseek-r1, gemma3,
+	// sub-30B) are the primary use case. Frontier-cloud models keep
+	// preferring tool-calling — set this only when the loop is bound to a
+	// model that honours response_format.
+	ResponseFormat *agentic.ResponseFormat `json:"response_format,omitempty"`
+
 	// WorkflowID is the workflow identifier for trigger_workflow actions
 	WorkflowID string `json:"workflow_id,omitempty"`
 
@@ -678,6 +692,16 @@ func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action,
 			allowlist = append(allowlist, a)
 		}
 		task.Metadata[agentic.MetadataKeyDecideActionAllowlist] = allowlist
+	}
+
+	// Per-spawn structured-output constraint. ADR-034. Pass-through:
+	// rule.Action.ResponseFormat → TaskMessage.ResponseFormat. The
+	// agentic-loop caches it on initial build and threads it onto every
+	// AgentRequest in the loop. Nil leaves tool-calling behaviour
+	// unchanged. No substitution applied — the schema body is structured
+	// JSON, not a template.
+	if action.ResponseFormat != nil {
+		task.ResponseFormat = action.ResponseFormat
 	}
 
 	if e.logger != nil {

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -1054,6 +1054,80 @@ func TestAction_PublishAgent_ActionAllowlist(t *testing.T) {
 	assert.Equal(t, "needs_clarification", allowlist[1])
 }
 
+// TestAction_PublishAgent_ResponseFormat verifies that
+// action.ResponseFormat threads onto TaskMessage.ResponseFormat as a
+// pointer pass-through. ADR-034. Both helpers (NewJSONSchemaFormat,
+// NewJSONObjectFormat) round-trip through the BaseMessage envelope.
+func TestAction_PublishAgent_ResponseFormat(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	rf := agentic.NewJSONSchemaFormat("decision", map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"action": map[string]any{"type": "string"},
+		},
+		"required": []any{"action"},
+	})
+
+	action := Action{
+		Type:           ActionTypePublishAgent,
+		Subject:        "agent.task.test",
+		Role:           "planner",
+		Model:          "mock-model",
+		Prompt:         "p",
+		ResponseFormat: rf,
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	require.NotNil(t, task.ResponseFormat, "ResponseFormat should round-trip onto TaskMessage")
+	assert.Equal(t, agentic.ResponseFormatJSONSchema, task.ResponseFormat.Type)
+	assert.Equal(t, "decision", task.ResponseFormat.Name)
+	assert.True(t, task.ResponseFormat.Strict, "NewJSONSchemaFormat should produce strict-mode")
+	require.NotNil(t, task.ResponseFormat.Schema)
+	assert.Equal(t, "object", task.ResponseFormat.Schema["type"])
+}
+
+// TestAction_PublishAgent_EmptyResponseFormat verifies that an unset
+// ResponseFormat leaves TaskMessage.ResponseFormat nil (back-compat:
+// existing flows that don't opt in keep their pre-ADR-034 tool-calling
+// behaviour).
+func TestAction_PublishAgent_EmptyResponseFormat(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.test",
+		Role:    "general",
+		Model:   "mock-model",
+		Prompt:  "p",
+		// ResponseFormat omitted
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	assert.Nil(t, task.ResponseFormat, "ResponseFormat should remain nil when action.ResponseFormat unset")
+}
+
 // TestAction_PublishAgent_EmptyActionAllowlist verifies that an unset
 // ActionAllowlist leaves Metadata's allowlist key unset (back-compat:
 // existing flows that don't opt in keep their pre-F2 free-form decide

--- a/schemas/rule-processor.v1.json
+++ b/schemas/rule-processor.v1.json
@@ -121,6 +121,28 @@
                   "type": "string",
                   "description": "reason"
                 },
+                "response_format": {
+                  "type": "object",
+                  "description": "response_format",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "name"
+                    },
+                    "schema": {
+                      "type": "object",
+                      "description": "schema"
+                    },
+                    "strict": {
+                      "type": "boolean",
+                      "description": "strict"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "type"
+                    }
+                  }
+                },
                 "role": {
                   "type": "string",
                   "description": "role"
@@ -343,6 +365,28 @@
                   "type": "string",
                   "description": "reason"
                 },
+                "response_format": {
+                  "type": "object",
+                  "description": "response_format",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "name"
+                    },
+                    "schema": {
+                      "type": "object",
+                      "description": "schema"
+                    },
+                    "strict": {
+                      "type": "boolean",
+                      "description": "strict"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "type"
+                    }
+                  }
+                },
                 "role": {
                   "type": "string",
                   "description": "role"
@@ -483,6 +527,28 @@
                   "type": "string",
                   "description": "reason"
                 },
+                "response_format": {
+                  "type": "object",
+                  "description": "response_format",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "name"
+                    },
+                    "schema": {
+                      "type": "object",
+                      "description": "schema"
+                    },
+                    "strict": {
+                      "type": "boolean",
+                      "description": "strict"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "type"
+                    }
+                  }
+                },
                 "role": {
                   "type": "string",
                   "description": "role"
@@ -622,6 +688,28 @@
                 "reason": {
                   "type": "string",
                   "description": "reason"
+                },
+                "response_format": {
+                  "type": "object",
+                  "description": "response_format",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "name"
+                    },
+                    "schema": {
+                      "type": "object",
+                      "description": "schema"
+                    },
+                    "strict": {
+                      "type": "boolean",
+                      "description": "strict"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "type"
+                    }
+                  }
                 },
                 "role": {
                   "type": "string",
@@ -781,6 +869,28 @@
                 "reason": {
                   "type": "string",
                   "description": "reason"
+                },
+                "response_format": {
+                  "type": "object",
+                  "description": "response_format",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "name"
+                    },
+                    "schema": {
+                      "type": "object",
+                      "description": "schema"
+                    },
+                    "strict": {
+                      "type": "boolean",
+                      "description": "strict"
+                    },
+                    "type": {
+                      "type": "string",
+                      "description": "type"
+                    }
+                  }
                 },
                 "role": {
                   "type": "string",


### PR DESCRIPTION
## Summary

Closes the ADR-034 plumbing gap that semspec hit: `AgentRequest.ResponseFormat` was reachable only at the agentic-loop boundary; `rule.Action.publish_agent` had no field to pass it from. Same plumbing shape semteams flagged on the adjacent question of threading additional fields through loops/chains.

The bug-shape report from semspec/semteams: **agentic msgs need to thread fields through loops and chains for much of the new work.** Beta.48 added `ResponseFormat` to `AgentRequest` but didn't thread it backward to the rule action surface. So `processor/planner/component.go` (and any other rule-driven publisher) couldn't set it.

## The threading path

Mirrors how Tools and ActionAllowlist already thread:

```
rule.Action.ResponseFormat
   ↓ executePublishAgent stamps onto
TaskMessage.ResponseFormat
   ↓ buildTaskRequest copies onto
AgentRequest.ResponseFormat                 (initial iteration)
   ↓ LoopManager.CacheResponseFormat
AgentRequest.ResponseFormat                 (continuation iterations, both post-tool sites)
```

## What's new

**Three typed fields** (omitempty pointer to `*agentic.ResponseFormat`):
- `rule.Action.ResponseFormat`
- `agentic.TaskMessage.ResponseFormat`
- `LoopManager.cachedResponseFormat` (runtime cache, not persisted)

**Two new LoopManager methods** (mirror `CacheRequestTimeout` / `GetCachedRequestTimeout`):
- `CacheResponseFormat(loopID, *ResponseFormat)`
- `GetCachedResponseFormat(loopID) *ResponseFormat`

**Validation:** `TaskMessage.Validate` now propagates `ResponseFormat.Validate` errors so a `json_schema` type without a `name` field surfaces at the TaskMessage boundary instead of producing a confusing 400 mid-LLM-call.

## Tests

- `TestTaskMessage_ResponseFormat_JSONRoundTrip` (3 sub-tests: JSONSchema strict / JSONObject bare / nil omits via omitempty)
- `TestTaskMessage_ResponseFormat_ValidatePropagates`
- `TestAction_PublishAgent_ResponseFormat`
- `TestAction_PublishAgent_EmptyResponseFormat`
- `TestHandleTask_PropagatesResponseFormatToAgentRequest`
- `TestHandleTask_NoResponseFormatPreservesNil`

All pass with `-race`.

## Use case

Small/local models (qwen3 7B/14B, deepseek-r1, gemma3, sub-30B) where structured output via `response_format` is the reliability tool, not tool-calling. Frontier-cloud models (Anthropic, Gemini, OpenAI proper) keep preferring tool-calling; this is opt-in per rule.

Example: a rule.Action.publish_agent for the architect role can now declare:

```json
{
  "type": "publish_agent",
  "subject": "agent.task.architect",
  "role": "architect",
  "model": "qwen3-architect",
  "prompt": "...",
  "action_allowlist": ["planned", "needs_clarification"],
  "response_format": {
    "type": "json_schema",
    "name": "decision",
    "strict": true,
    "schema": { "type": "object", "properties": { ... } }
  }
}
```

The architect's loop is now bound to that schema across iterations — small-model tool-call-failure paths converge instead of drifting.

## Back-compat

Pure additive. Nil `ResponseFormat` preserves pre-ADR-034 tool-calling behaviour. No payload-registry changes. Schema regenerated for `rule-processor.v1.json`.

## Lane discipline

This branch touches `agentic/`, `processor/rule/`, `processor/agentic-loop/`. Sister's `fix/graph-query-globalsearch-debug` line is in `graph-query/`, `gateway/`, `service/`, `e2e/` — no overlap.

## Test plan

- [x] `go test -race ./agentic/... ./processor/rule/... ./processor/agentic-loop/...` — all green
- [x] `task lint` — clean (revive, vet, fmt)
- [x] `go vet -tags=integration ./...` — clean (per memory `feedback_pre_tag_sweep_includes_build_tags`)
- [x] `go vet -tags=live_llm ./processor/agentic-model/...` — clean
- [x] `task schema:generate` — `schemas/rule-processor.v1.json` updated, committed
- [ ] Reviewer pass on the cache pattern + validation propagation

🤖 Generated with [Claude Code](https://claude.com/claude-code)