### PR TITLE
feat(rule,agentic): thread RelatedLoops cross-arc lineage through Action → TaskMessage.Metadata

### DIFF
--- a/agentic/tools.go
+++ b/agentic/tools.go
@@ -97,6 +97,33 @@ func (t *ToolCall) UnmarshalJSON(data []byte) error {
 // structurally on the wire.
 const MetadataKeyDecideActionAllowlist = "agent.decide.action_allowlist"
 
+// MetadataKeyRelatedLoops is the TaskMessage.Metadata /
+// ToolCall.Metadata key under which cross-arc loop-ID lineage flows
+// from a spawning rule down to the spawned loop and into its tool
+// calls. The value is a map[string]string keyed by role name (or any
+// product-specific lineage label) where the value is the related
+// loop ID.
+//
+// Use case: a downstream role needs to read_loop_result against an
+// upstream loop without the loop ID being baked into the spawn
+// prompt. Architect needing the researcher's loop ID for harness
+// selection (semteams smoke #8 run-2 wedge cause); challenger
+// cross-grounding back to planner; ops-agent / ADR-033 chain_id
+// stability.
+//
+// String-to-string only by design. Non-string values are out of
+// scope: if a future case needs structured data, it earns a
+// dedicated typed field (the Tools / ToolChoice / Timeout
+// precedent), not a generalized escape hatch through this map.
+//
+// Empty/missing leaves no lineage threaded (back-compat).
+//
+// Set by rule.executePublishAgent from rule.Action.RelatedLoops.
+// JSON round-trip note: like ActionAllowlist, the value comes back
+// from BaseMessage decode as map[string]any (with each value still
+// a Go string) — readers coerce on access.
+const MetadataKeyRelatedLoops = "agent.related_loops"
+
 // ToolErrorKind classifies the source or nature of a tool execution failure.
 // It is the structured counterpart to ToolResult.Error and feeds the
 // agent.step.error_category graph predicate for queryable failure analysis.

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -120,6 +120,29 @@ type Action struct {
 	// model that honours response_format.
 	ResponseFormat *agentic.ResponseFormat `json:"response_format,omitempty"`
 
+	// RelatedLoops is cross-arc loop-ID lineage threaded onto the
+	// spawned task so a downstream role can read_loop_result against
+	// upstream loops without the IDs being baked into the prompt. Map
+	// keys are role names (or product-specific lineage labels);
+	// values are loop ID strings. When non-empty, executePublishAgent
+	// substitutes variables in each value and stamps the resolved map
+	// onto TaskMessage.Metadata under MetadataKeyRelatedLoops; the
+	// agentic-loop propagates that onto each ToolCall.Metadata.
+	//
+	// String-to-string only by design. The use case is loop-ID
+	// forwarding; non-string values are out of scope and would earn
+	// a dedicated typed field (Tools / ToolChoice / Timeout
+	// precedent) rather than nesting structured data here.
+	//
+	// Variable substitution applies to values, so rule authors can
+	// write `"researcher": "$entity.triple.research_loop_id"` and
+	// the resolved loop ID flows through. Substitution is NOT
+	// applied to keys (they are role/lineage labels, not data).
+	//
+	// Empty/nil leaves no lineage threaded (back-compat: pre-existing
+	// flows that don't opt in see no Metadata change).
+	RelatedLoops map[string]string `json:"related_loops,omitempty"`
+
 	// WorkflowID is the workflow identifier for trigger_workflow actions
 	WorkflowID string `json:"workflow_id,omitempty"`
 
@@ -625,6 +648,28 @@ func (e *ActionExecutor) resolveToolNames(names []string) []agentic.ToolDefiniti
 	return resolved
 }
 
+// stampRelatedLoops writes the cross-arc loop-ID lineage map onto
+// the TaskMessage.Metadata under agentic.MetadataKeyRelatedLoops.
+// Each value goes through ec.SubstituteVariables so rule authors can
+// declare `"researcher": "$entity.triple.research_loop_id"` and the
+// resolved loop ID flows through. String-to-string by design — see
+// agentic.MetadataKeyRelatedLoops. Empty/nil RelatedLoops is a no-op
+// (back-compat: pre-existing flows that don't opt in see no
+// Metadata change).
+func stampRelatedLoops(task *agentic.TaskMessage, related map[string]string, ec *ExecutionContext) {
+	if len(related) == 0 {
+		return
+	}
+	if task.Metadata == nil {
+		task.Metadata = map[string]any{}
+	}
+	resolved := make(map[string]any, len(related))
+	for label, loopID := range related {
+		resolved[label] = ec.SubstituteVariables(loopID)
+	}
+	task.Metadata[agentic.MetadataKeyRelatedLoops] = resolved
+}
+
 // executePublishAgent executes a publish_agent action, triggering an agentic loop.
 // It publishes a TaskMessage to the specified NATS subject.
 func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action, ec *ExecutionContext) error {
@@ -703,6 +748,10 @@ func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action,
 	if action.ResponseFormat != nil {
 		task.ResponseFormat = action.ResponseFormat
 	}
+
+	// Per-spawn cross-arc loop-ID lineage. Mirrors the ActionAllowlist
+	// Metadata stamping pattern. See stampRelatedLoops for the why.
+	stampRelatedLoops(&task, action.RelatedLoops, ec)
 
 	if e.logger != nil {
 		e.logger.Debug("Triggering agent task",

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -1128,6 +1128,123 @@ func TestAction_PublishAgent_EmptyResponseFormat(t *testing.T) {
 	assert.Nil(t, task.ResponseFormat, "ResponseFormat should remain nil when action.ResponseFormat unset")
 }
 
+// TestAction_PublishAgent_RelatedLoops verifies that
+// action.RelatedLoops threads onto TaskMessage.Metadata under
+// agentic.MetadataKeyRelatedLoops as a map[string]any (the JSON wire
+// shape after BaseMessage round-trip). String-to-string by design.
+//
+// Use case: dev-via-spec architect needs the researcher's loop ID
+// for harness selection (semteams smoke #8 run-2); challenger
+// cross-grounding back to planner; ops-agent / ADR-033 chain_id
+// stability.
+func TestAction_PublishAgent_RelatedLoops(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.architect",
+		Role:    "architect",
+		Model:   "mock-model",
+		Prompt:  "p",
+		RelatedLoops: map[string]string{
+			"researcher": "loop-research-abc",
+			"planner":    "loop-plan-xyz",
+		},
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	require.NotNil(t, task.Metadata, "Metadata should be initialised when RelatedLoops is set")
+	rawLineage, ok := task.Metadata[agentic.MetadataKeyRelatedLoops]
+	require.True(t, ok, "MetadataKeyRelatedLoops should be set")
+
+	// JSON round-trip turns map[string]string into map[string]any.
+	// Each value is a Go string, just typed as any — readers coerce.
+	lineage, ok := rawLineage.(map[string]any)
+	require.True(t, ok, "expected map[string]any after JSON round-trip; got %T", rawLineage)
+	assert.Equal(t, "loop-research-abc", lineage["researcher"])
+	assert.Equal(t, "loop-plan-xyz", lineage["planner"])
+}
+
+// TestAction_PublishAgent_RelatedLoops_VariableSubstitution verifies
+// that substitution tokens in RelatedLoops values resolve at execute
+// time. The load-bearing case: rule configs declare
+// `"researcher": "$entity.triple.research_loop_id"` (or any
+// supported substitution token) and the resolved ID flows onto the
+// Metadata.
+func TestAction_PublishAgent_RelatedLoops_VariableSubstitution(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.architect",
+		Role:    "architect",
+		Model:   "mock-model",
+		Prompt:  "p",
+		RelatedLoops: map[string]string{
+			"researcher": "$entity.id",
+		},
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "loop-research-from-entity"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	rawLineage := task.Metadata[agentic.MetadataKeyRelatedLoops]
+	lineage, ok := rawLineage.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "loop-research-from-entity", lineage["researcher"],
+		"$entity.id should substitute to ExecutionContext.EntityID")
+}
+
+// TestAction_PublishAgent_EmptyRelatedLoops verifies that an unset
+// RelatedLoops leaves Metadata's lineage key unset (back-compat:
+// existing flows that don't opt in see no Metadata change).
+func TestAction_PublishAgent_EmptyRelatedLoops(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.test",
+		Role:    "general",
+		Model:   "mock-model",
+		Prompt:  "p",
+		// RelatedLoops omitted
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	if task.Metadata != nil {
+		_, has := task.Metadata[agentic.MetadataKeyRelatedLoops]
+		assert.False(t, has, "no related_loops field should be set on Metadata when RelatedLoops is empty")
+	}
+}
+
 // TestAction_PublishAgent_EmptyActionAllowlist verifies that an unset
 // ActionAllowlist leaves Metadata's allowlist key unset (back-compat:
 // existing flows that don't opt in keep their pre-F2 free-form decide

--- a/schemas/rule-processor.v1.json
+++ b/schemas/rule-processor.v1.json
@@ -121,6 +121,10 @@
                   "type": "string",
                   "description": "reason"
                 },
+                "related_loops": {
+                  "type": "object",
+                  "description": "related_loops"
+                },
                 "response_format": {
                   "type": "object",
                   "description": "response_format",
@@ -365,6 +369,10 @@
                   "type": "string",
                   "description": "reason"
                 },
+                "related_loops": {
+                  "type": "object",
+                  "description": "related_loops"
+                },
                 "response_format": {
                   "type": "object",
                   "description": "response_format",
@@ -527,6 +535,10 @@
                   "type": "string",
                   "description": "reason"
                 },
+                "related_loops": {
+                  "type": "object",
+                  "description": "related_loops"
+                },
                 "response_format": {
                   "type": "object",
                   "description": "response_format",
@@ -688,6 +700,10 @@
                 "reason": {
                   "type": "string",
                   "description": "reason"
+                },
+                "related_loops": {
+                  "type": "object",
+                  "description": "related_loops"
                 },
                 "response_format": {
                   "type": "object",
@@ -869,6 +885,10 @@
                 "reason": {
                   "type": "string",
                   "description": "reason"
+                },
+                "related_loops": {
+                  "type": "object",
+                  "description": "related_loops"
                 },
                 "response_format": {
                   "type": "object",


### PR DESCRIPTION
## Summary

Adds `Action.RelatedLoops map[string]string` and threads to `TaskMessage.Metadata` under `agentic.MetadataKeyRelatedLoops`. Mirrors the existing `ActionAllowlist` pattern. Companion to PR #32 (ResponseFormat threading) — different ask, same lane (Action → TaskMessage plumbing).

## The ask, sharper than "Properties"

Earlier framing called this "Properties" and proposed `map[string]any`. SemTeams correctly narrowed: this is **typed cross-arc lineage references** — string IDs pointing at upstream loops. The typing concern dissolves under the string-to-string constraint.

Concrete cases:
- **semteams smoke #8 run-2 wedge** — dev-via-spec architect needs the researcher's loop ID for harness selection; baking it into the prompt fights persona-prose-as-architecture
- challenger cross-grounding back to planner (deferred per ADR-035 §D2 but a known future ask)
- ops-agent / ADR-033 `chain_id` stability for operating-curve regime annotation

## Threading path

```
rule.Action.RelatedLoops (map[string]string)
   ↓ executePublishAgent → stampRelatedLoops helper
   ↓ ec.SubstituteVariables applied to each value
TaskMessage.Metadata[agentic.MetadataKeyRelatedLoops]
   (= map[string]any after JSON round-trip; readers coerce on access)
   ↓ agentic-loop propagates onto each ToolCall.Metadata
   ↓ persona / tool reads task.Metadata["related_loops"]["researcher"]
   ↓ read_loop_result(loop_id=…)
```

## Why string-to-string only

Non-string values are out of scope by design. If a future case needs structured data, it earns a dedicated typed field (the `Tools` / `ToolChoice` / `Timeout` precedent on `TaskMessage`, or the `ResponseFormat` field PR #32 adds) — not nested JSON through this escape hatch. The typing concern from earlier "Properties" discussions stays addressed by holding this constraint.

## Variable substitution

Values go through `ec.SubstituteVariables` so rule authors can write:

```json
{
  "type": "publish_agent",
  "subject": "agent.task.architect",
  "role": "architect",
  "model": "qwen3-architect",
  "prompt": "...",
  "related_loops": {
    "researcher": "$entity.triple.research_loop_id",
    "planner": "$entity.triple.planner_loop_id"
  }
}
```

…and the resolved IDs flow through. Substitution is NOT applied to keys (they are role/lineage labels, not data).

## Helper extraction

`stampRelatedLoops` extracted from `executePublishAgent` to keep that function under revive's function-length cap. Same pattern as `resolveToolNames` already does for the Tools threading.

## Tests

- `TestAction_PublishAgent_RelatedLoops` — basic threading + the JSON-round-trip `map[string]any` shape
- `TestAction_PublishAgent_RelatedLoops_VariableSubstitution` — the load-bearing case (`$entity.id` resolves to `ExecutionContext.EntityID`)
- `TestAction_PublishAgent_EmptyRelatedLoops` — back-compat: nil leaves Metadata unchanged

All `-race` clean. Lint clean (function-length warning surfaced after the initial draft; helper extraction fixed it). Integration build-tags compile clean.

## Back-compat

Pure additive. Empty/nil `RelatedLoops` is a no-op for Metadata — pre-existing flows that don't opt in see no change. No new payload-registry types. Schema regenerated for `rule-processor.v1.json`.

## Lane discipline

Only `agentic/tools.go` (new constant) + `processor/rule/actions.go` + tests + schema. No overlap with sister's `fix/graph-query-globalsearch-debug` or in-progress TF*IDF clustering work.

## Test plan

- [x] `go test -race ./agentic/... ./processor/rule/...` — all green
- [x] `task lint` — clean (revive, vet, fmt; function-length cap respected)
- [x] `go vet -tags=integration ./...` — clean
- [x] `task schema:generate` — `schemas/rule-processor.v1.json` updated, committed
- [ ] Reviewer pass on the substitution-on-values-not-keys discipline
- [ ] semteams reproduces smoke #8 run-2 with `related_loops` set on the architect publish_agent rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)