### PR TITLE
fix(clustering): TF*IDF keywords + preserve through LLM + test surface scan

### DIFF
--- a/graph/clustering/lpa.go
+++ b/graph/clustering/lpa.go
@@ -276,6 +276,25 @@ func (d *LPADetector) detectCommunitiesAtLevel(
 	// Build communities from labels
 	communities := d.buildCommunities(labels, level, parentID)
 
+	// Pre-compute corpus-wide document frequency once for the level so the
+	// statistical summarizer's keyword extraction can weight by IDF instead
+	// of TF only. Without this, predicates ("location") and entity-type
+	// parts ("sensor") that appear on nearly every entity dominate the
+	// top-N keyword cap and crowd out distinctive low-frequency terms
+	// like "hydraulic" — the surface globalSearch's known-answer probes
+	// depend on. See StatisticalSummarizer.corpusDF doc + 2026-05-07 bug.
+	if d.summarizer != nil && d.entityProvider != nil {
+		if dfBuilder, ok := d.summarizer.(corpusDFBuilder); ok {
+			allEntities, err := d.entityProvider.GetEntities(ctx, entityIDs)
+			if err != nil {
+				d.logger.Warn("Failed to fetch entities for corpus DF — falling back to TF-only keywords",
+					"level", level, "error", err)
+			} else {
+				dfBuilder.BuildCorpusDF(allEntities)
+			}
+		}
+	}
+
 	// Persist communities (with optional summarization and event publishing)
 	for _, community := range communities {
 		// Generate summary if summarizer is configured

--- a/graph/clustering/summarizer.go
+++ b/graph/clustering/summarizer.go
@@ -37,6 +37,15 @@ type StatisticalSummarizer struct {
 
 	// MaxRepEntities limits the number of representative entities
 	MaxRepEntities int
+
+	// corpusDF is the corpus-wide document-frequency map: term → number of
+	// entities containing the term at least once. When non-nil and corpusN > 0,
+	// extractKeywords uses TF*IDF scoring instead of TF*log(1+freq), which
+	// promotes distinctive low-frequency terms over community-dominant common
+	// ones (e.g. "hydraulic" over "sensor" in a sensor community). Populated
+	// once per clustering pass via BuildCorpusDF.
+	corpusDF map[string]int
+	corpusN  int
 }
 
 // NewStatisticalSummarizer creates a statistical summarizer with default settings
@@ -45,6 +54,36 @@ func NewStatisticalSummarizer() *StatisticalSummarizer {
 		MaxKeywords:    10,
 		MaxRepEntities: 5,
 	}
+}
+
+// corpusDFBuilder is implemented by summarizers that benefit from corpus-wide
+// document-frequency hints. The clustering orchestrator type-asserts on this
+// interface and calls BuildCorpusDF once per pass before per-community
+// summarization. Wrappers (LLM, Progressive) forward to the underlying
+// statistical summarizer they delegate keyword extraction to.
+type corpusDFBuilder interface {
+	BuildCorpusDF(entities []*gtypes.EntityState)
+}
+
+// BuildCorpusDF populates the corpus-wide document-frequency map from the
+// given entity slice. DF[T] counts entities containing term T at least once
+// (set semantics, not occurrence count). Term extraction matches
+// extractKeywords via the shared termOccurrencesForEntity helper. Empty input
+// clears the map. Safe to call multiple times.
+func (s *StatisticalSummarizer) BuildCorpusDF(entities []*gtypes.EntityState) {
+	if len(entities) == 0 {
+		s.corpusDF = nil
+		s.corpusN = 0
+		return
+	}
+	df := make(map[string]int)
+	for _, entity := range entities {
+		for term := range termOccurrencesForEntity(entity) {
+			df[term]++
+		}
+	}
+	s.corpusDF = df
+	s.corpusN = len(entities)
 }
 
 // SummarizeCommunity generates a statistical summary of the community
@@ -88,39 +127,48 @@ func (s *StatisticalSummarizer) SummarizeCommunity(
 	return community, nil
 }
 
-// extractKeywords extracts key terms from entity types and properties
-func (s *StatisticalSummarizer) extractKeywords(entities []*gtypes.EntityState) []string {
-	termFreq := make(map[string]int)
+// termOccurrencesForEntity returns term → occurrence count for one entity,
+// using the same extraction rules as extractKeywords (type parts, triple
+// predicates, string-value terms). Shared between extractKeywords (TF
+// counting) and BuildCorpusDF (DF counting via the keyset) so the two stay
+// in lockstep — divergence here would silently break IDF weighting.
+func termOccurrencesForEntity(entity *gtypes.EntityState) map[string]int {
+	terms := make(map[string]int)
 
-	for _, entity := range entities {
-		// Extract terms from entity type
-		// e.g., "robotics.drone" -> ["robotics", "drone"]
-		typeParts := strings.Split(extractEntityType(entity.ID), ".")
-		for _, part := range typeParts {
-			if part != "" {
-				termFreq[part]++
-			}
+	// Entity type parts: "robotics.drone" → ["robotics", "drone"].
+	for _, part := range strings.Split(extractEntityType(entity.ID), ".") {
+		if part != "" {
+			terms[part]++
 		}
+	}
 
-		// Extract terms from property triples (string values only)
-		for _, triple := range entity.Triples {
-			if !triple.IsRelationship() {
-				// Add predicate as a term
-				termFreq[triple.Predicate]++
-
-				// If value is string, extract terms
-				if strVal, ok := triple.Object.(string); ok {
-					// Split on common delimiters and extract terms
-					terms := extractTerms(strVal)
-					for _, term := range terms {
-						termFreq[term]++
-					}
-				}
+	// Property triples: predicate name + extracted terms from string values.
+	for _, triple := range entity.Triples {
+		if triple.IsRelationship() {
+			continue
+		}
+		terms[triple.Predicate]++
+		if strVal, ok := triple.Object.(string); ok {
+			for _, t := range extractTerms(strVal) {
+				terms[t]++
 			}
 		}
 	}
 
-	// Sort terms by frequency
+	return terms
+}
+
+// extractKeywords extracts key terms from entity types and properties.
+// Scores are TF*IDF when corpusDF has been populated (via BuildCorpusDF),
+// else TF*log(1+freq) — see corpusDF doc on the struct for why this matters.
+func (s *StatisticalSummarizer) extractKeywords(entities []*gtypes.EntityState) []string {
+	termFreq := make(map[string]int)
+	for _, entity := range entities {
+		for term, count := range termOccurrencesForEntity(entity) {
+			termFreq[term] += count
+		}
+	}
+
 	type termScore struct {
 		term  string
 		score float64
@@ -128,26 +176,35 @@ func (s *StatisticalSummarizer) extractKeywords(entities []*gtypes.EntityState) 
 
 	scores := make([]termScore, 0, len(termFreq))
 	totalEntities := float64(len(entities))
+	useIDF := s.corpusDF != nil && s.corpusN > 0
+	corpusN := float64(s.corpusN)
 
 	for term, freq := range termFreq {
-		// Calculate TF-IDF-like score
-		// TF: term frequency normalized by total entities
-		// We don't have document frequency, so we use frequency as importance
 		tf := float64(freq) / totalEntities
-		score := tf * math.Log(1.0+float64(freq))
-
-		scores = append(scores, termScore{
-			term:  term,
-			score: score,
-		})
+		var weight float64
+		if useIDF {
+			// DF[term] is at least 1 here (the term is present in this
+			// community, so it's present in ≥1 corpus entity). Guard with max(1)
+			// anyway so a stale DF map never produces division-by-zero or a
+			// negative log. IDF = log(N/DF); rare terms get the high score.
+			df := max(s.corpusDF[term], 1)
+			weight = math.Log(corpusN / float64(df))
+			// Smooth: a term whose DF equals corpus size gets log(1)=0,
+			// which would zero its score outright. Add a small floor so
+			// near-universal terms still have a tie-breakable score.
+			if weight <= 0 {
+				weight = 0.01
+			}
+		} else {
+			weight = math.Log(1.0 + float64(freq))
+		}
+		scores = append(scores, termScore{term: term, score: tf * weight})
 	}
 
-	// Sort by score descending
 	sort.Slice(scores, func(i, j int) bool {
 		return scores[i].score > scores[j].score
 	})
 
-	// Take top N keywords
 	maxKeywords := s.MaxKeywords
 	if len(scores) < maxKeywords {
 		maxKeywords = len(scores)
@@ -601,6 +658,14 @@ func (s *LLMSummarizer) SummarizeCommunity(
 	return community, nil
 }
 
+// BuildCorpusDF forwards to the fallback statistical summarizer so IDF
+// scoring applies to the keyword path that LLMSummarizer reuses.
+func (s *LLMSummarizer) BuildCorpusDF(entities []*gtypes.EntityState) {
+	if s.FallbackSummarizer != nil {
+		s.FallbackSummarizer.BuildCorpusDF(entities)
+	}
+}
+
 // parseEntityID extracts the 6 parts from a federated entity ID.
 // Entity ID format: {org}.{platform}.{domain}.{system}.{type}.{instance}
 func parseEntityID(entityID string) llm.EntityParts {
@@ -767,6 +832,13 @@ func (s *ProgressiveSummarizer) SummarizeCommunity(
 	community.LLMSummary = ""
 
 	return community, nil
+}
+
+// BuildCorpusDF forwards to the wrapped statistical summarizer.
+func (s *ProgressiveSummarizer) BuildCorpusDF(entities []*gtypes.EntityState) {
+	if s.statistical != nil {
+		s.statistical.BuildCorpusDF(entities)
+	}
 }
 
 // min returns the smaller of two integers

--- a/graph/clustering/summarizer.go
+++ b/graph/clustering/summarizer.go
@@ -586,9 +586,17 @@ func (s *LLMSummarizer) SummarizeCommunity(
 	default:
 	}
 
-	// Use statistical summarizer for keywords and rep entities
-	// (LLM will generate the narrative summary)
-	keywords := s.FallbackSummarizer.extractKeywords(entities)
+	// Reuse LPA-computed keywords when present (set during community detection
+	// with corpus-DF weighting). Recomputing here would lose the corpus-wide
+	// IDF context — the worker only sees this one community's entities, not
+	// the full corpus, so a fresh extraction reverts to TF-only ranking and
+	// re-introduces the universal-predicate dominance the IDF fix corrected.
+	// Fall back to fresh extraction only when Keywords is unset (direct
+	// callers that bypass the LPA pipeline).
+	keywords := community.Keywords
+	if len(keywords) == 0 {
+		keywords = s.FallbackSummarizer.extractKeywords(entities)
+	}
 	repEntities := s.FallbackSummarizer.findRepresentativeEntities(ctx, entities)
 
 	// Fetch entity content internally if ContentFetcher is configured

--- a/graph/clustering/summarizer_test.go
+++ b/graph/clustering/summarizer_test.go
@@ -2,12 +2,14 @@ package clustering
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
 )
 
 func TestStatisticalSummarizer_SummarizeCommunity(t *testing.T) {
@@ -246,4 +248,89 @@ func TestExtractTerms(t *testing.T) {
 			assert.ElementsMatch(t, tt.expected, result)
 		})
 	}
+}
+
+// TestStatisticalSummarizer_IDFLiftsRareTerms is the regression guard for
+// the 2026-05-07 globalSearch known-answer bug: niche query-relevant nouns
+// (e.g. "hydraulic" sourced from a sensor's location property) were being
+// crowded out of community.Keywords by universal predicates ("location",
+// "unit") because keyword scoring was TF-only with no IDF. After the fix,
+// BuildCorpusDF computes corpus-wide document frequency once per pass and
+// extractKeywords scores by TF*IDF when DF is set, de-weighting universal
+// terms and surfacing distinctive ones.
+func TestStatisticalSummarizer_IDFLiftsRareTerms(t *testing.T) {
+	mkSensor := func(id, locationValue string) *gtypes.EntityState {
+		return &gtypes.EntityState{
+			ID: id,
+			Triples: []message.Triple{
+				{Subject: id, Predicate: "location", Object: locationValue},
+				{Subject: id, Predicate: "unit", Object: "percent"},
+			},
+		}
+	}
+
+	// Three communities of 5 sensors each. Each community has a distinctive
+	// location term; the predicates "location" and "unit" + the value
+	// "percent" are universal across all 15 entities.
+	mkCommunity := func(typePart, locationValue string) []*gtypes.EntityState {
+		out := make([]*gtypes.EntityState, 5)
+		for i := range out {
+			out[i] = mkSensor(
+				fmt.Sprintf("c360.facility.warehouse.zone.%s.%d", typePart, i),
+				locationValue,
+			)
+		}
+		return out
+	}
+	communityA := mkCommunity("level", "hydraulic-reservoir")
+	communityB := mkCommunity("temperature", "cold-storage")
+	communityC := mkCommunity("pressure", "dock-bay")
+
+	allEntities := append(append(append([]*gtypes.EntityState{},
+		communityA...), communityB...), communityC...)
+
+	summarizer := NewStatisticalSummarizer()
+	summarizer.MaxKeywords = 5
+
+	tfOnly := summarizer.extractKeywords(communityA)
+	t.Logf("TF-only keywords for community A: %v", tfOnly)
+
+	summarizer.BuildCorpusDF(allEntities)
+	withIDF := summarizer.extractKeywords(communityA)
+	t.Logf("TF*IDF keywords for community A: %v", withIDF)
+
+	idfSet := make(map[string]bool, len(withIDF))
+	for _, kw := range withIDF {
+		idfSet[kw] = true
+	}
+
+	// "hydraulic" appears in 5 of 15 entities (rare). With IDF=log(15/5)≈1.10
+	// it should clear the top-5 cap. Without IDF it competes against
+	// universal predicates each at TF=5/5=1.0 and tends to lose to
+	// log(1+freq)-weighted "location"/"unit" with their high raw counts.
+	assert.True(t, idfSet["hydraulic"],
+		"corpus-wide DF should lift 'hydraulic' (rare) into top-5; got %v", withIDF)
+
+	// Universal predicates ("location", "unit") have DF=15, IDF=log(1)=0
+	// (smoothed to 0.01 in the impl). They must NOT win the top slot.
+	assert.NotEqual(t, "location", withIDF[0],
+		"universal predicate 'location' should not be top keyword under IDF")
+	assert.NotEqual(t, "unit", withIDF[0],
+		"universal predicate 'unit' should not be top keyword under IDF")
+}
+
+// TestStatisticalSummarizer_BuildCorpusDF_Resets verifies that calling
+// BuildCorpusDF with an empty slice clears prior state — guards against
+// stale DF leaking across clustering passes.
+func TestStatisticalSummarizer_BuildCorpusDF_Resets(t *testing.T) {
+	s := NewStatisticalSummarizer()
+	s.BuildCorpusDF([]*gtypes.EntityState{
+		{ID: "c360.facility.warehouse.zone.level.1"},
+	})
+	require.NotNil(t, s.corpusDF)
+	require.Equal(t, 1, s.corpusN)
+
+	s.BuildCorpusDF(nil)
+	assert.Nil(t, s.corpusDF, "BuildCorpusDF(nil) should clear the map")
+	assert.Zero(t, s.corpusN, "BuildCorpusDF(nil) should reset corpusN")
 }

--- a/test/e2e/scenarios/tiered_semantic_known_answer.go
+++ b/test/e2e/scenarios/tiered_semantic_known_answer.go
@@ -131,7 +131,7 @@ func (s *TieredScenario) runKnownAnswerProbe(ctx context.Context, gatewayURL str
 
 	if gs.Count == 0 {
 		return knownAnswerProbeResult{
-			detail:  detail,
+			detail: detail,
 			failure: fmt.Sprintf("term %q: count=0 at level=%d (entities=%d ids=%d digests=%d communities=%d)",
 				ka.term, level, len(gs.Entities), len(gs.EntityIDs), len(gs.EntityDigests), len(gs.CommunitySummaries)),
 		}

--- a/test/e2e/scenarios/tiered_semantic_known_answer.go
+++ b/test/e2e/scenarios/tiered_semantic_known_answer.go
@@ -119,7 +119,10 @@ func (s *TieredScenario) runKnownAnswerProbe(ctx context.Context, gatewayURL str
 	detail := map[string]any{
 		"term":           ka.term,
 		"count":          gs.Count,
+		"summarized":     gs.Summarized,
 		"entities":       len(gs.Entities),
+		"entity_ids":     len(gs.EntityIDs),
+		"entity_digests": len(gs.EntityDigests),
 		"communities":    len(gs.CommunitySummaries),
 		"latency_ms":     latency.Milliseconds(),
 		"matched_substr": matched.substring,
@@ -129,13 +132,15 @@ func (s *TieredScenario) runKnownAnswerProbe(ctx context.Context, gatewayURL str
 	if gs.Count == 0 {
 		return knownAnswerProbeResult{
 			detail:  detail,
-			failure: fmt.Sprintf("term %q: count=0 at level=%d (entities=%d communities=%d)", ka.term, level, len(gs.Entities), len(gs.CommunitySummaries)),
+			failure: fmt.Sprintf("term %q: count=0 at level=%d (entities=%d ids=%d digests=%d communities=%d)",
+				ka.term, level, len(gs.Entities), len(gs.EntityIDs), len(gs.EntityDigests), len(gs.CommunitySummaries)),
 		}
 	}
 	if matched.substring == "" {
 		return knownAnswerProbeResult{
-			detail:  detail,
-			failure: fmt.Sprintf("term %q: count=%d but no entity ID or community summary contained any of %v", ka.term, gs.Count, ka.substrAny),
+			detail: detail,
+			failure: fmt.Sprintf("term %q: count=%d (summarized=%v ids=%d digests=%d communities=%d) — none of %v in any surface",
+				ka.term, gs.Count, gs.Summarized, len(gs.EntityIDs), len(gs.EntityDigests), len(gs.CommunitySummaries), ka.substrAny),
 		}
 	}
 	return knownAnswerProbeResult{detail: detail}
@@ -144,56 +149,99 @@ func (s *TieredScenario) runKnownAnswerProbe(ctx context.Context, gatewayURL str
 // knownAnswerMatch records WHERE a substring was found (for diagnostics).
 type knownAnswerMatch struct {
 	substring string
-	location  string // "entity_id" | "community_summary" | "community_keywords"
+	// location is one of: "entity", "entity_id", "entity_digest",
+	// "community_summary", "community_keywords".
+	location string
 }
 
-// matchKnownAnswerTerm scans a globalSearch response for any of ka.substrAny
-// in entity IDs, community summaries, or community keywords. Case-insensitive.
-// Returns the first match (substring + location) or zero value when no match.
+// matchKnownAnswerTerm scans a globalSearch response for any of ka.substrAny.
+// Case-insensitive. globalSearch returns two distinct response shapes:
+//
+//   - Non-summarized (count ≤ summarize_threshold): `entities` populated with
+//     id/type/label tuples; `entity_ids`, `entity_digests` empty.
+//   - Summarized (count > threshold, default 50): `entities` is null;
+//     `entity_ids` and `entity_digests` carry the result set, with
+//     `entity_digests` providing labels (often the human-readable surface,
+//     e.g. "Forklift Hydraulic System Repair").
+//
+// Both shapes may include `community_summaries`. The matcher scans every
+// surface globalSearch actually exposes — looking only at `entities` made
+// the test silently miss every summarized response (the 2026-05-07
+// known-answer regression).
 func matchKnownAnswerTerm(ka knownAnswerTerm, gs globalSearchPayload) knownAnswerMatch {
-	for _, e := range gs.Entities {
-		idLower := strings.ToLower(e.ID)
+	containsAny := func(haystack string) string {
+		hl := strings.ToLower(haystack)
 		for _, sub := range ka.substrAny {
-			if strings.Contains(idLower, sub) {
-				return knownAnswerMatch{substring: sub, location: "entity_id"}
+			if strings.Contains(hl, sub) {
+				return sub
 			}
+		}
+		return ""
+	}
+
+	for _, e := range gs.Entities {
+		if m := containsAny(e.ID); m != "" {
+			return knownAnswerMatch{substring: m, location: "entity"}
+		}
+		if m := containsAny(e.Label); m != "" {
+			return knownAnswerMatch{substring: m, location: "entity"}
+		}
+	}
+	for _, id := range gs.EntityIDs {
+		if m := containsAny(id); m != "" {
+			return knownAnswerMatch{substring: m, location: "entity_id"}
+		}
+	}
+	for _, d := range gs.EntityDigests {
+		if m := containsAny(d.ID); m != "" {
+			return knownAnswerMatch{substring: m, location: "entity_digest"}
+		}
+		if m := containsAny(d.Label); m != "" {
+			return knownAnswerMatch{substring: m, location: "entity_digest"}
 		}
 	}
 	for _, cs := range gs.CommunitySummaries {
-		summaryLower := strings.ToLower(cs.Summary)
-		for _, sub := range ka.substrAny {
-			if strings.Contains(summaryLower, sub) {
-				return knownAnswerMatch{substring: sub, location: "community_summary"}
-			}
+		if m := containsAny(cs.Summary); m != "" {
+			return knownAnswerMatch{substring: m, location: "community_summary"}
 		}
 		for _, kw := range cs.Keywords {
-			kwLower := strings.ToLower(kw)
-			for _, sub := range ka.substrAny {
-				if strings.Contains(kwLower, sub) {
-					return knownAnswerMatch{substring: sub, location: "community_keywords"}
-				}
+			if m := containsAny(kw); m != "" {
+				return knownAnswerMatch{substring: m, location: "community_keywords"}
 			}
 		}
 	}
 	return knownAnswerMatch{}
 }
 
-// globalSearchPayload is the shape of GraphQL globalSearch we depend on for
-// known-answer assertions. Subset of graphRAGGlobalResponse.Data.GlobalSearch
-// in tiered_statistical.go — kept distinct so changes here don't affect the
-// existing graphrag-global stage.
+// globalSearchPayload mirrors the wire format graph-query emits for
+// globalSearch. The component speaks snake_case JSON (Go struct tags) and
+// the gateway forwards that wire format directly — GraphQL response shaping
+// at this gateway is bypass-style, so query-side aliases don't apply.
+// Both summarized and non-summarized response shapes are covered here so the
+// matcher above can scan whichever fields the server populated.
 type globalSearchPayload struct {
+	// Non-summarized response: full entities list.
 	Entities []struct {
-		ID   string `json:"id"`
-		Type string `json:"type"`
+		ID    string `json:"id"`
+		Type  string `json:"type"`
+		Label string `json:"label"`
 	} `json:"entities"`
+	// Summarized response: entities is null; ids + digests populated.
+	EntityIDs     []string `json:"entity_ids"`
+	EntityDigests []struct {
+		ID    string `json:"id"`
+		Type  string `json:"type"`
+		Label string `json:"label"`
+	} `json:"entity_digests"`
+	// Community summaries surface in both shapes when available.
 	CommunitySummaries []struct {
-		CommunityID string   `json:"communityId"`
+		CommunityID string   `json:"community_id"`
 		Summary     string   `json:"summary"`
 		Keywords    []string `json:"keywords"`
 		Level       int      `json:"level"`
-	} `json:"communitySummaries"`
-	Count int `json:"count"`
+	} `json:"community_summaries"`
+	Count      int  `json:"count"`
+	Summarized bool `json:"summarized"`
 }
 
 // knownAnswerResponse is the GraphQL envelope for the globalSearch query.
@@ -211,12 +259,20 @@ type knownAnswerResponse struct {
 // sendGraphRAGGlobalRequest but with explicit level (the existing helper
 // hard-codes level=1).
 func (s *TieredScenario) sendGlobalSearchAtLevel(ctx context.Context, gatewayURL, query string, level int) (*knownAnswerResponse, time.Duration, error) {
+	// Note: the gateway forwards the graph-query JSON wire format (snake_case)
+	// directly, so response field names are snake_case regardless of the
+	// camelCase used in this query. The struct tags on globalSearchPayload
+	// match the wire format. Request both summarized and non-summarized
+	// surfaces so the matcher can scan whichever the server populated.
 	graphqlQuery := map[string]any{
 		"query": `query($query: String!, $level: Int, $maxCommunities: Int) {
 			globalSearch(query: $query, level: $level, maxCommunities: $maxCommunities) {
-				entities { id type }
+				entities { id type label }
+				entity_ids
+				entity_digests { id type label }
 				communitySummaries { communityId summary keywords level }
 				count
+				summarized
 			}}`,
 		"variables": map[string]any{
 			"query":          query,


### PR DESCRIPTION
## Summary

Three contained fixes that together close the globalSearch known-answer regression for `hydraulic` and `temperature` (forklift is addressed by the sibling chore PR).

- **TF*IDF keyword extraction**: `extractKeywords` was TF-only with a frank "We don't have document frequency" comment. Universal predicates (`location`, `unit`) and dominant entity types saturated the top-N cap, crowding out distinctive nouns. Now `lpa.go` pre-computes corpus-wide DF once per pass and feeds it to the summarizer; rare terms get the IDF lift.
- **Preserve LPA keywords through enhancement**: `LLMSummarizer.SummarizeCommunity` was unconditionally re-running `extractKeywords` (without DF, since the worker only sees one community), then overwriting `community.Keywords`. Wired to reuse pre-set keywords; falls back to fresh extraction only when unset.
- **e2e test scans the right response surface**: `globalSearch` returns `entities` populated only when `count ≤ summarize_threshold` (default 50). Above that, `entity_ids` + `entity_digests` carry the data and `entities` is null. The known-answer matcher only looked at `entities` — silently missing every summarized response. The previous JSON tags also used camelCase (`communitySummaries`) but the wire format is snake_case, so community fields never deserialized either. Matcher now scans every surface globalSearch actually exposes.

## Test plan

- [x] `go test ./graph/clustering/...` — new IDF unit test passes; existing keyword test unchanged
- [x] `go build ./...` — clean
- [x] e2e validation (against the sibling chore branch's infra): `validate-globalsearch-known-answer` now passes 3/3

## Notes

Independent of the e2e infra changes in `chore/seminstruct-multi-tier-e2e`. Both can land in either order; full e2e green requires both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)