### PR TITLE
feat(agentic-loop,agentic): stamp RelatedLoops as lineage triples on spawned entity

### DIFF
--- a/agentic/tools.go
+++ b/agentic/tools.go
@@ -124,6 +124,36 @@ const MetadataKeyDecideActionAllowlist = "agent.decide.action_allowlist"
 // a Go string) — readers coerce on access.
 const MetadataKeyRelatedLoops = "agent.related_loops"
 
+// LineageTriplePrefix is the predicate prefix for cross-arc loop-ID
+// lineage triples stamped on a spawned loop's entity at loop-creation
+// time. Each entry in TaskMessage.Metadata[MetadataKeyRelatedLoops]
+// becomes a triple of the form:
+//
+//	subject:   <spawned loop entity ID>
+//	predicate: lineage.<roleKey>          // e.g. lineage.researcher
+//	object:    <upstream loop ID string>
+//
+// Downstream rules that fire on the spawned entity read these via the
+// existing $entity.triple.<predicate> substitution, e.g.
+// $entity.triple.lineage.researcher resolves to the upstream loop ID
+// without any new substitution-token, tool, or persona-driven echo
+// forwarding.
+//
+// Stable namespace: ops-agent (ADR-027) and the operating-curve
+// observability primitives (ADR-033) aggregate cross-arc lineage by
+// scanning predicates with this prefix. Codifying as a public constant
+// keeps producers and consumers aligned without string-literal drift.
+const LineageTriplePrefix = "lineage."
+
+// LineageTriplePredicate returns the canonical predicate for a
+// RelatedLoops role key. Centralises the prefix join so producers
+// (rule.executePublishAgent / agentic-loop loop-creation path) and
+// consumers (rule authors using $entity.triple.lineage.<key>,
+// ops-agent aggregations) cannot drift on the format.
+func LineageTriplePredicate(roleKey string) string {
+	return LineageTriplePrefix + roleKey
+}
+
 // ToolErrorKind classifies the source or nature of a tool execution failure.
 // It is the structured counterpart to ToolResult.Error and feeds the
 // agent.step.error_category graph predicate for queryable failure analysis.

--- a/agentic/tools_test.go
+++ b/agentic/tools_test.go
@@ -6,6 +6,7 @@ package agentic_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic"
@@ -660,6 +661,36 @@ func TestToolCall_Metadata_JSONRoundTrip(t *testing.T) {
 	}
 	if decoded.Metadata["domain"] != "robotics" {
 		t.Errorf("Metadata[domain] = %v, want robotics", decoded.Metadata["domain"])
+	}
+}
+
+// TestLineageTriplePredicate verifies the helper concatenation. The
+// predicate format is contractual: ops-agent (ADR-027) and the
+// operating-curve observability primitives (ADR-033) aggregate
+// cross-arc lineage by predicate-prefix scan, so any drift here
+// would break consumer queries silently.
+func TestLineageTriplePredicate(t *testing.T) {
+	tests := []struct {
+		roleKey string
+		want    string
+	}{
+		{"researcher", "lineage.researcher"},
+		{"planner", "lineage.planner"},
+		{"", "lineage."}, // edge case — caller's responsibility to pass a non-empty key
+		{"deeply.dotted.label", "lineage.deeply.dotted.label"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.roleKey, func(t *testing.T) {
+			got := agentic.LineageTriplePredicate(tc.roleKey)
+			if got != tc.want {
+				t.Errorf("LineageTriplePredicate(%q) = %q, want %q", tc.roleKey, got, tc.want)
+			}
+		})
+	}
+
+	// Defence-in-depth: the helper must use the published prefix.
+	if !strings.HasPrefix(agentic.LineageTriplePredicate("x"), agentic.LineageTriplePrefix) {
+		t.Errorf("helper must use LineageTriplePrefix")
 	}
 }
 

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -847,6 +847,18 @@ func (c *Component) handleTaskMessage(ctx context.Context, data []byte) {
 		slog.String("loop_id", result.LoopID),
 		slog.String("task_id", task.TaskID))
 
+	// Stamp cross-arc lineage triples on the spawned loop's entity.
+	// Each entry in task.Metadata[MetadataKeyRelatedLoops] (set by
+	// rule.executePublishAgent from rule.Action.RelatedLoops) becomes
+	// a lineage.<key> triple. Downstream rules read via the existing
+	// $entity.triple.<predicate> substitution. No-op when the producer
+	// didn't set RelatedLoops (back-compat).
+	if c.graphWriter != nil {
+		if rawLineage, ok := task.Metadata[agentic.MetadataKeyRelatedLoops].(map[string]any); ok {
+			c.graphWriter.WriteLineageTriples(ctx, result.LoopID, rawLineage)
+		}
+	}
+
 	// Publish output messages
 	c.publishResults(ctx, result)
 

--- a/processor/agentic-loop/export_test.go
+++ b/processor/agentic-loop/export_test.go
@@ -48,3 +48,6 @@ func (g *GraphWriterForTest) WriteLoopCancellation(ctx context.Context, e *agent
 func (g *GraphWriterForTest) WriteTrajectorySteps(ctx context.Context, loopID string, trajectory *agentic.Trajectory) {
 	g.w.WriteTrajectorySteps(ctx, loopID, trajectory)
 }
+func (g *GraphWriterForTest) WriteLineageTriples(ctx context.Context, loopID string, related map[string]any) {
+	g.w.WriteLineageTriples(ctx, loopID, related)
+}

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -234,6 +234,87 @@ func (w *graphWriter) WriteTrajectorySteps(ctx context.Context, loopID string, t
 	}
 }
 
+// WriteLineageTriples emits cross-arc lineage triples on a spawned
+// loop's entity from the RelatedLoops map threaded by the producer
+// rule (rule.Action.RelatedLoops → TaskMessage.Metadata under
+// agentic.MetadataKeyRelatedLoops). Each map entry produces one
+// triple of the form:
+//
+//	subject:   <spawned loop entity ID>
+//	predicate: lineage.<roleKey>           // via agentic.LineageTriplePredicate
+//	object:    <upstream loop ID string>
+//
+// Downstream rules that fire on the spawned entity read these via
+// the existing $entity.triple.<predicate> substitution, e.g.
+// $entity.triple.lineage.researcher. No substitution-layer changes
+// needed; multi-segment predicates already work.
+//
+// `related` is typed map[string]any because the Metadata round-trips
+// through JSON (each value is a Go string, just typed as any).
+// Non-string values are skipped — they should never appear given the
+// rule.Action.RelatedLoops map[string]string type, but defensive
+// skipping keeps a malformed product from polluting the graph.
+//
+// Failure handling: per-entry errors are logged and continue, matching
+// the configureLoopMetadata + WriteLoopCompletion precedent. A failed
+// write surfaces downstream as $entity.triple.lineage.X passing
+// through the unresolvedTemplateVarRe warning — same shape as
+// late-arriving triples.
+func (w *graphWriter) WriteLineageTriples(ctx context.Context, loopID string, related map[string]any) {
+	if w.natsClient == nil {
+		return
+	}
+	if w.platform.Org == "" || w.platform.Platform == "" {
+		w.logger.Warn("graph_writer: cannot write lineage triples, platform identity missing",
+			"loop_id", loopID, "org", w.platform.Org, "platform", w.platform.Platform)
+		return
+	}
+	if len(related) == 0 {
+		return
+	}
+
+	loopEntityID := agentic.LoopExecutionEntityID(w.platform.Org, w.platform.Platform, loopID)
+	triples := buildLineageTriples(loopEntityID, related)
+	for _, t := range triples {
+		if err := w.writeTriple(ctx, t); err != nil {
+			w.logger.Warn("graph_writer: failed to write lineage triple",
+				"loop_id", loopID, "predicate", t.Predicate, "error", err)
+		}
+	}
+}
+
+// buildLineageTriples converts a RelatedLoops map into lineage triples
+// on the spawned loop's entity. Pure (no NATS, no clock-injection
+// support beyond now()) so it's straightforward to unit-test.
+//
+// Non-string values and empty strings are skipped: the producer-side
+// type is map[string]string, so a non-string here means the wire
+// format was tampered with or a non-rule-engine producer wrote
+// malformed metadata. Either way, dropping is safer than emitting
+// garbage triples.
+func buildLineageTriples(loopEntityID string, related map[string]any) []message.Triple {
+	if len(related) == 0 {
+		return nil
+	}
+	now := time.Now()
+	triples := make([]message.Triple, 0, len(related))
+	for roleKey, raw := range related {
+		loopIDStr, ok := raw.(string)
+		if !ok || loopIDStr == "" {
+			continue
+		}
+		triples = append(triples, message.Triple{
+			Subject:    loopEntityID,
+			Predicate:  agentic.LineageTriplePredicate(roleKey),
+			Object:     loopIDStr,
+			Source:     graphWriterSource,
+			Timestamp:  now,
+			Confidence: 1.0,
+		})
+	}
+	return triples
+}
+
 // WriteLoopCancellation emits triples for a loop that was cancelled.
 func (w *graphWriter) WriteLoopCancellation(ctx context.Context, event *agentic.LoopCancelledEvent) {
 	if w.natsClient == nil {

--- a/processor/agentic-loop/graph_writer_integration_test.go
+++ b/processor/agentic-loop/graph_writer_integration_test.go
@@ -488,6 +488,86 @@ func TestWriteModelEndpoints_MissingPlatform_NoOp(t *testing.T) {
 	}
 }
 
+// TestWriteLineageTriples_Integration verifies the end-to-end NATS
+// roundtrip: a RelatedLoops map (typed map[string]any after JSON
+// round-trip) emits one lineage.<key> triple per entry through
+// graph.mutation.triple.add. The spawned-loop entity ID format and
+// the predicate prefix are both contractual surfaces — drift breaks
+// downstream rule substitution and ops-agent aggregation.
+func TestWriteLineageTriples_Integration(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
+	ctx := context.Background()
+
+	collector := &tripleCollector{}
+	_, err := tc.Client.SubscribeForRequests(ctx, "graph.mutation.triple.add", collector.handler)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
+
+	related := map[string]any{
+		"researcher": "loop-research-001",
+		"planner":    "loop-plan-002",
+	}
+	w.WriteLineageTriples(ctx, "architect-loop-xyz", related)
+
+	triples := collector.getTriples()
+	if len(triples) != 2 {
+		t.Fatalf("expected 2 lineage triples, got %d", len(triples))
+	}
+
+	// Both triples must point at the spawned loop's entity ID.
+	wantSubject := agentic.LoopExecutionEntityID("acme", "ops", "architect-loop-xyz")
+	for _, tr := range triples {
+		if tr.Subject != wantSubject {
+			t.Errorf("subject = %q, want %q", tr.Subject, wantSubject)
+		}
+		if !message.IsValidEntityID(tr.Subject) {
+			t.Errorf("subject %q is not a valid 6-part entity ID", tr.Subject)
+		}
+	}
+
+	preds := collector.predicateSet()
+	for _, key := range []string{"researcher", "planner"} {
+		want := agentic.LineageTriplePredicate(key)
+		if !preds[want] {
+			t.Errorf("missing predicate %q", want)
+		}
+	}
+}
+
+// TestWriteLineageTriples_NilClient_NoOp verifies no-panic on a
+// missing NATS client (mirrors the nil-client safety the other
+// writer methods carry).
+func TestWriteLineageTriples_NilClient_NoOp(t *testing.T) {
+	w := agenticloop.NewGraphWriterForTest(nil, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
+	// Should be a no-op and not panic.
+	w.WriteLineageTriples(context.Background(), "any-loop", map[string]any{"researcher": "x"})
+}
+
+// TestWriteLineageTriples_MissingPlatform_NoOp verifies platform-
+// identity gating: a writer with empty Org/Platform skips the write
+// (and logs a warning, but the warning side-effect is observable
+// only via the production logger).
+func TestWriteLineageTriples_MissingPlatform_NoOp(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
+	ctx := context.Background()
+
+	collector := &tripleCollector{}
+	_, err := tc.Client.SubscribeForRequests(ctx, "graph.mutation.triple.add", collector.handler)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{}) // no Org/Platform
+	w.WriteLineageTriples(ctx, "any-loop", map[string]any{"researcher": "x"})
+
+	if got := len(collector.getTriples()); got != 0 {
+		t.Errorf("missing platform identity should skip the write, got %d triples", got)
+	}
+}
+
 func TestWriteMutationFailure_Integration(t *testing.T) {
 	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
 	ctx := context.Background()

--- a/processor/agentic-loop/graph_writer_test.go
+++ b/processor/agentic-loop/graph_writer_test.go
@@ -995,3 +995,125 @@ func TestComputeCost(t *testing.T) {
 		})
 	}
 }
+
+// --- buildLineageTriples ---
+
+// TestBuildLineageTriples_StampsLineagePredicates verifies that each
+// entry in the RelatedLoops map (typed map[string]any after JSON
+// round-trip through BaseMessage) becomes one triple of the form
+// <loopEntityID> lineage.<roleKey> <upstream loop ID>.
+func TestBuildLineageTriples_StampsLineagePredicates(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.architect-loop-001"
+	related := map[string]any{
+		"researcher": "loop-research-abc",
+		"planner":    "loop-plan-xyz",
+	}
+
+	triples := buildLineageTriples(loopEntityID, related)
+
+	if len(triples) != 2 {
+		t.Fatalf("expected 2 triples, got %d", len(triples))
+	}
+
+	for _, tr := range triples {
+		if tr.Subject != loopEntityID {
+			t.Errorf("subject = %q, want %q", tr.Subject, loopEntityID)
+		}
+		if tr.Source != graphWriterSource {
+			t.Errorf("source = %q, want %q", tr.Source, graphWriterSource)
+		}
+		if tr.Confidence != 1.0 {
+			t.Errorf("confidence = %v, want 1.0", tr.Confidence)
+		}
+	}
+
+	predicates := predicateSet(triples)
+	wantPredicates := []string{
+		agentic.LineageTriplePredicate("researcher"),
+		agentic.LineageTriplePredicate("planner"),
+	}
+	for _, want := range wantPredicates {
+		if !predicates[want] {
+			t.Errorf("missing expected predicate %q in %v", want, predicates)
+		}
+	}
+
+	// Object pairings — predicate→object must round-trip.
+	for _, tr := range triples {
+		switch tr.Predicate {
+		case agentic.LineageTriplePredicate("researcher"):
+			if tr.Object != "loop-research-abc" {
+				t.Errorf("researcher object = %v, want loop-research-abc", tr.Object)
+			}
+		case agentic.LineageTriplePredicate("planner"):
+			if tr.Object != "loop-plan-xyz" {
+				t.Errorf("planner object = %v, want loop-plan-xyz", tr.Object)
+			}
+		default:
+			t.Errorf("unexpected predicate: %q", tr.Predicate)
+		}
+	}
+}
+
+// TestBuildLineageTriples_EmptyAndNilNoops verifies that nil and
+// empty maps produce no triples (back-compat: products that don't
+// opt into RelatedLoops see no graph mutation).
+func TestBuildLineageTriples_EmptyAndNilNoops(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.x"
+
+	if got := buildLineageTriples(loopEntityID, nil); got != nil {
+		t.Errorf("nil related: got %d triples, want 0 (nil)", len(got))
+	}
+	if got := buildLineageTriples(loopEntityID, map[string]any{}); got != nil {
+		t.Errorf("empty related: got %d triples, want 0 (nil)", len(got))
+	}
+}
+
+// TestBuildLineageTriples_NonStringValuesSkipped verifies defensive
+// dropping of malformed entries. The producer-side type is
+// map[string]string so non-strings should never appear, but defensive
+// skipping keeps a malformed product / future schema bug from
+// polluting the graph with garbage triples.
+func TestBuildLineageTriples_NonStringValuesSkipped(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.x"
+	related := map[string]any{
+		"researcher": "loop-research-abc",
+		"planner":    42, // wrong type — should be skipped
+		"reviewer":   "", // empty string — should be skipped
+		"architect":  nil,
+	}
+
+	triples := buildLineageTriples(loopEntityID, related)
+
+	if len(triples) != 1 {
+		t.Fatalf("expected 1 triple (only valid string entry survives), got %d", len(triples))
+	}
+	if triples[0].Predicate != agentic.LineageTriplePredicate("researcher") {
+		t.Errorf("predicate = %q, want %q",
+			triples[0].Predicate, agentic.LineageTriplePredicate("researcher"))
+	}
+	if triples[0].Object != "loop-research-abc" {
+		t.Errorf("object = %v, want loop-research-abc", triples[0].Object)
+	}
+}
+
+// TestBuildLineageTriples_PredicatePrefix verifies that all generated
+// predicates use the LineageTriplePrefix exposed in agentic/tools.go.
+// This is the contract ops-agent (ADR-027) and the operating-curve
+// observability primitives (ADR-033) rely on for cross-arc / cross-
+// run aggregation. Drift here breaks consumer aggregation queries.
+func TestBuildLineageTriples_PredicatePrefix(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.x"
+	related := map[string]any{
+		"researcher":             "loop-research",
+		"some.dotted.role.label": "loop-other",
+	}
+
+	triples := buildLineageTriples(loopEntityID, related)
+
+	for _, tr := range triples {
+		if !strings.HasPrefix(tr.Predicate, agentic.LineageTriplePrefix) {
+			t.Errorf("predicate %q missing prefix %q", tr.Predicate, agentic.LineageTriplePrefix)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes the cross-arc lineage last-mile gap from beta.50 PR #33. The `RelatedLoops` map already threads onto `TaskMessage.Metadata` and from there onto every `ToolCall.Metadata`, but the rule layer couldn't read it back — substitution surface covered `\$entity.id` / `\$entity.triple.X` / etc. but nothing read `task.Metadata` or `entity.Metadata`. So a downstream rule N hops past the original spawn could not substitute an upstream loop ID into the next spawn's prompt.

This auto-stamps each entry in `task.Metadata[MetadataKeyRelatedLoops]` as a triple on the spawned loop's entity at loop-creation time, so the existing `\$entity.triple.X` substitution picks it up via `\$entity.triple.lineage.<key>` — no substitution-layer changes.

## The threading completion

```
RelatedLoops: {"researcher": "loop-research-abc"}
  ↓ existing (PR #33) — written by stampRelatedLoops in actions.go
TaskMessage.Metadata["agent.related_loops"]["researcher"]
  ↓ NEW — at HandleTask completion in component.go
spawnedEntity.triple.lineage.researcher = "loop-research-abc"
  ↓ existing — \$entity.triple.X iterates Entity.Triples
next rule's \$entity.triple.lineage.researcher → "loop-research-abc"
```

## What's new

**`agentic/tools.go`:**
- `LineageTriplePrefix = "lineage."` const — stable namespace ops-agent (ADR-027) and operating-curve observability (ADR-033) aggregate against
- `LineageTriplePredicate(roleKey)` helper centralising the prefix join

**`processor/agentic-loop/graph_writer.go`:**
- `WriteLineageTriples(ctx, loopID, related map[string]any)` method on graphWriter — iterates the post-JSON-roundtrip shape, emits one triple per entry via the existing writeTriple path
- `buildLineageTriples` pure builder — defensive: non-string and empty-string values skipped to keep a malformed non-rule-engine producer from polluting the graph

**`processor/agentic-loop/component.go`:**
- `handleTaskMessage` calls `WriteLineageTriples` after `HandleTask` returns success, before `publishResults`
- No-op when `task.Metadata` has no `MetadataKeyRelatedLoops` entry — pure additive on opt-in

## Failure handling

Per-entry write failures log and continue, matching the existing `configureLoopMetadata` + `WriteLoopCompletion` precedent. Downstream fallout: `\$entity.triple.lineage.X` substitution falls through and trips `warnUnresolvedTemplateVars` — same shape as late-arriving triples, so the operator sees a loud signal rather than a silent gap.

## Tests

| Test | Layer | Purpose |
|---|---|---|
| `TestLineageTriplePredicate` | agentic | Helper contract incl. dotted role keys |
| `TestBuildLineageTriples_StampsLineagePredicates` | agentic-loop unit | Basic threading |
| `TestBuildLineageTriples_EmptyAndNilNoops` | agentic-loop unit | Back-compat |
| `TestBuildLineageTriples_NonStringValuesSkipped` | agentic-loop unit | Defensive skipping |
| `TestBuildLineageTriples_PredicatePrefix` | agentic-loop unit | Invariant for ops-agent |
| `TestWriteLineageTriples_Integration` | agentic-loop integration | Full NATS round-trip |
| `TestWriteLineageTriples_NilClient_NoOp` | agentic-loop integration | Nil-client safety |
| `TestWriteLineageTriples_MissingPlatform_NoOp` | agentic-loop integration | Platform-identity gating |

Multi-hop chain verification belongs in semteams's `e2e:agentic` journey fixtures (semteams agreed on this cut — don't over-engineer upstream).

## Pre-tag sweep

- [x] `go test -race ./agentic/... ./processor/agentic-loop/... ./processor/rule/...` — green
- [x] `task lint` — clean (revive, vet, fmt)
- [x] `go vet -tags=integration ./...` — clean
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `task schema:generate` — empty diff

## Use case (semteams smoke #8 run-2)

With this landed, the wedge is solved without persona-driven echo-forwarding (rejected by ADR-035 §D2) and without a new tool surface:

- `rule_03` writes `related_loops: {"researcher": "\$entity.triple.prior_loop_id"}` on the planner's spawn
- Each subsequent dev-via-spec rule chains `related_loops: {"researcher": "\$entity.triple.lineage.researcher"}` forward
- Architect's spawn rule prompt substitutes the literal loop_id into the prompt body
- Architect calls `read_loop_result(loop_id=<literal>)` — done

## Lane discipline

`agentic/`, `processor/agentic-loop/` only. Sister's recently-merged work was in `graph/clustering/` (TF*IDF) and e2e infrastructure — zero overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)