### PR TITLE
feat(agentic): ToolDefinition.Strict for OpenAI strict-mode tool calling

### DIFF
--- a/agentic/tools.go
+++ b/agentic/tools.go
@@ -23,6 +23,22 @@ type ToolDefinition struct {
 	Name        string         `json:"name"`
 	Description string         `json:"description"`
 	Parameters  map[string]any `json:"parameters"`
+
+	// Strict enables OpenAI's strict-mode tool calling: the model is
+	// constrained to emit tool_calls[].function.arguments that conform to
+	// Parameters. Symmetric to ResponseFormat.Strict — same provider table
+	// applies (see ADR-034): honored on OpenAI proper / vLLM / OpenRouter /
+	// sparky / any OpenAI-compat runtime under provider:"openai"; silently
+	// ignored on Anthropic and Gemini OpenAI-compat (adapters clear it +
+	// Warn). Best-effort on Ollama /v1 (model-dependent — gemma3 ignores
+	// per ADR-034 §gh#10001).
+	//
+	// Requires Parameters to satisfy OpenAI's strict-mode subset:
+	// additionalProperties:false at every object level, every property
+	// listed in required, no $ref/anyOf at the root, max nesting 5. A
+	// non-conforming schema returns 400 from the upstream — caller bug,
+	// not a framework concern.
+	Strict bool `json:"strict,omitempty"`
 }
 
 // Validate checks if the ToolDefinition is valid

--- a/docs/adr/035-strict-tool-calling.md
+++ b/docs/adr/035-strict-tool-calling.md
@@ -1,0 +1,168 @@
+# ADR-035: Strict-Mode Tool Calling via `function.strict`
+
+## Status
+
+**Accepted — 2026-05-07.** Companion to [ADR-034](034-structured-output-response-format.md).
+Originated as an upstream ask from semspec after their beta.50 work
+landed structural strict-mode subset (`additionalProperties: false`
+across deliverable schemas). Tooled and adopted within the same week
+because the gap is exactly symmetric to the response_format work
+ADR-034 already shipped.
+
+## Context
+
+ADR-034 plumbed `response_format` strict-mode end-to-end:
+`agentic.ResponseFormat.Strict` → `applyResponseFormat` →
+`openai.ChatCompletionResponseFormatJSONSchema.Strict` →
+`json_schema.strict: true` on the wire. **That field constrains the
+content of `chat.completion.message.content` only.** When the caller
+sets `ToolChoice.Mode == "required"` (semspec's overwhelming case —
+every persona dispatch forces `submit_work`), the structured payload
+arrives via `tool_calls[].function.arguments` — a different wire
+field that `response_format` does not constrain.
+
+Today `agentic.ToolDefinition` has three fields:
+
+```go
+type ToolDefinition struct {
+    Name        string         `json:"name"`
+    Description string         `json:"description"`
+    Parameters  map[string]any `json:"parameters"`
+}
+```
+
+`processor/agentic-model/client.go` constructs
+`openai.FunctionDefinition` from this struct and never sets
+`Function.Strict`. The SDK has supported the field since
+`go-openai v1.41` (line `chat.go:369`); we just don't expose it.
+
+So tool-call argument schema conformance — the canonical OpenAI
+guarantee for sampling-constrained tool args — is unreachable from
+the framework. semspec's structural prep (`additionalProperties:false`
+at every object level) buys nothing over the wire until the upstream
+flag propagates.
+
+## Decision
+
+Add `Strict bool` to `agentic.ToolDefinition` with `json:"strict,omitempty"`,
+plumb it to `openai.FunctionDefinition.Strict` in the request builder,
+and document the provider matrix as a 1:1 mirror of ADR-034's table.
+
+```go
+type ToolDefinition struct {
+    Name        string         `json:"name"`
+    Description string         `json:"description"`
+    Parameters  map[string]any `json:"parameters"`
+
+    // Strict enables OpenAI's strict-mode tool calling: the model is
+    // constrained to emit tool_calls[].function.arguments that conform
+    // to Parameters. Symmetric to ResponseFormat.Strict — same provider
+    // table applies. Requires Parameters to satisfy OpenAI's strict-mode
+    // subset (additionalProperties:false at every object level, every
+    // property in required, no $ref/anyOf at the root, max nesting 5).
+    Strict bool `json:"strict,omitempty"`
+}
+```
+
+`omitempty` keeps the field absent from the wire for callers that
+don't set it — existing tool-using sites see no behavior change.
+
+## Provider matrix (mirrors ADR-034 §Decision)
+
+| Provider | Behavior |
+|---|---|
+| `provider:"openai"` umbrella (OpenAI proper / vLLM / sparky / OpenRouter / LocalAI / llama.cpp `/v1` / LiteLLM / any OpenAI-compat) | honors `function.strict: true`; samples are constrained by xgrammar/outlines or equivalent. **Principal value of this ADR.** |
+| `provider:"ollama"` (`/v1`) | best-effort; model-dependent. Per ADR-034 §gh#10001, gemma3 ignores. We pass through; operators verify on their model. |
+| `provider:"gemini"` (OpenAI-compat) | silent no-op. Setting Strict produces no error and no sampling guarantee — operators get false confidence. |
+| `provider:"anthropic"` | silent no-op. Anthropic's *native* structured-output primitive IS forced tool-calling with the tool schema as the constraint, accessed via the standard tools array — but the OpenAI-compat shim doesn't surface a strict flag. Operators relying on strict on Anthropic should switch to a native Anthropic client when one is added. |
+
+semstreams routes everything through the OpenAI shim (`go-openai`).
+Providers that don't honor `function.strict` silently drop it on
+their side; there's no functional difference between sending and
+clearing it. This ADR keeps the framework's wire-side handling
+provider-agnostic — adapters (`NormalizeRequest` hook) MAY clear or
+warn for known no-op providers, but we ship without that for v1
+because the asymmetry would be jarring (`applyResponseFormat` itself
+doesn't warn on no-op providers either).
+
+A future observability ADR can add the warn-on-no-op-provider pattern
+symmetrically across `response_format` and tool `Strict` if operators
+ask for it.
+
+## Per-adapter v1 behavior
+
+| Adapter | Behavior | Notes |
+|---|---|---|
+| `OpenAIAdapter` | No-op for `Function.Strict`. Plumbing happens in `client.go` and the SDK's native `Strict bool` serializes to OpenAI wire shape correctly. | Covers the umbrella set. |
+| `OllamaAdapter` | No-op for `Function.Strict`. Ollama `/v1` accepts the field and forwards model-dependently. | Same posture as `response_format` per ADR-034. |
+| `GeminiAdapter` | No-op for `Function.Strict`. Field is silently dropped by Gemini's OpenAI-compat layer. | Operator caveat: setting Strict provides false confidence on Gemini. |
+| `GenericAdapter` | No-op. | Anthropic-bound traffic falls here today (no `AdapterFor("anthropic")` case); see future-work note below. |
+
+## Caller responsibilities
+
+The strict-mode subset is enforced server-side, not by the framework:
+
+- `additionalProperties: false` at every object level
+- Every declared property listed in `required` (or marked nullable in
+  the schema for optional fields)
+- No `$ref` or `anyOf` at the root (per OpenAI's documented constraints)
+- Max nesting depth 5
+
+Schemas that don't satisfy the subset return a 400 from upstream when
+Strict is set. This is a caller-side bug — surfaces clearly to the
+operator. The framework does not validate the subset because the
+constraint set evolves on OpenAI's side; pinning a validator would
+drift.
+
+semspec commit `d3a3b56` lands `additionalProperties:false` across
+the eight deliverable schemas. The required-completeness half is
+gated behind `TestSchemasRequiredCompleteness` (currently `t.Skip`'d)
+until live-LLM validation flips. semspec opts the field on once that
+gate is green.
+
+## Implementation
+
+Three changes, ~15 lines:
+
+1. `agentic/tools.go` — add `Strict bool` field with doc.
+2. `processor/agentic-model/client.go` — set `Function.Strict: tool.Strict`
+   in the tool conversion loop.
+3. `processor/agentic-model/tool_strict_test.go` — three wire-shape tests
+   (true propagates, false omitted, mixed-per-tool).
+
+No constructor (e.g. `NewStrictToolDefinition`) — `ToolDefinition` is
+struct-literal-initialized everywhere, and a constructor only for
+strict-mode would be inconsistent. semspec wires Strict through their
+own builder.
+
+No migration: `omitempty` makes it purely additive. No CHANGELOG entry
+needed beyond the regular tag note.
+
+## Future work
+
+- **Native Anthropic adapter.** Anthropic's tool-calling is the
+  default structured-output primitive there; an explicit adapter
+  could translate `Function.Strict` to Anthropic's native tool schema
+  conformance (which is always strict in their API). Out of scope for
+  v1.
+- **Schema subset validator.** If callers repeatedly hit 400s from
+  non-conforming schemas, a framework-side preflight validator could
+  catch obvious violations before the request goes upstream. Tradeoff:
+  the OpenAI subset evolves; a pinned validator drifts. Defer until
+  the failure rate justifies it.
+- **Observability for no-op providers.** Warn-once when Strict is set
+  on `gemini`/`anthropic`-bound traffic. Should land symmetrically
+  with the same pattern for `response_format`. Separate ADR.
+
+## References
+
+- ADR-034 — companion `response_format` decision; provider table this
+  one mirrors
+- semspec commit d3a3b56 — strict-mode structural subset
+  (`additionalProperties:false` across schemas)
+- semspec commit 133b5ea — `terminal.EndpointSupportsResponseFormat`
+  discriminator (downstream concern; extends 1:1 to gate
+  `ToolDefinition.Strict` per-endpoint without further framework
+  changes)
+- go-openai `chat.go:369` — SDK `FunctionDefinition.Strict` (v1.41+)
+- OpenAI Structured Outputs docs — strict-mode subset constraints

--- a/processor/agentic-model/client.go
+++ b/processor/agentic-model/client.go
@@ -283,7 +283,9 @@ func (c *Client) buildChatRequest(req agentic.AgentRequest) openai.ChatCompletio
 	// Apply provider-specific request normalization.
 	adapter.NormalizeRequest(&chatReq)
 
-	// Convert tools if present
+	// Convert tools if present. Strict is forwarded to the SDK's native
+	// FunctionDefinition.Strict field (go-openai v1.41+); adapters that
+	// run on no-op providers clear it in NormalizeRequest. See ADR-035.
 	if len(req.Tools) > 0 {
 		tools := make([]openai.Tool, len(req.Tools))
 		for i, tool := range req.Tools {
@@ -293,6 +295,7 @@ func (c *Client) buildChatRequest(req agentic.AgentRequest) openai.ChatCompletio
 					Name:        tool.Name,
 					Description: tool.Description,
 					Parameters:  tool.Parameters,
+					Strict:      tool.Strict,
 				},
 			}
 		}

--- a/processor/agentic-model/tool_strict_test.go
+++ b/processor/agentic-model/tool_strict_test.go
@@ -1,0 +1,147 @@
+package agenticmodel_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model"
+	agenticmodel "github.com/c360studio/semstreams/processor/agentic-model"
+)
+
+// TestBuildChatRequest_ToolStrict_True_PropagatesToWire verifies that
+// ToolDefinition.Strict=true surfaces as tools[].function.strict=true on
+// the outgoing OpenAI wire format. This is the symmetric counterpart of
+// TestBuildChatRequest_ResponseFormatJSONSchema_WireShape — same SDK
+// version (go-openai v1.41+), different field. See ADR-035.
+func TestBuildChatRequest_ToolStrict_True_PropagatesToWire(t *testing.T) {
+	server, getCaptured := captureRequestServer(t)
+	defer server.Close()
+
+	client, err := agenticmodel.NewClient(&model.EndpointConfig{URL: server.URL, Model: "test"})
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	_, err = client.ChatCompletion(context.Background(), agentic.AgentRequest{
+		RequestID: "tool-strict-true",
+		Messages:  []agentic.ChatMessage{{Role: "user", Content: "do it"}},
+		Model:     "test",
+		Tools: []agentic.ToolDefinition{{
+			Name:        "submit_work",
+			Description: "submit final answer",
+			Parameters: map[string]any{
+				"type":                 "object",
+				"properties":           map[string]any{"answer": map[string]any{"type": "string"}},
+				"required":             []any{"answer"},
+				"additionalProperties": false,
+			},
+			Strict: true,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() failed: %v", err)
+	}
+
+	toolsRaw, ok := getCaptured()["tools"]
+	if !ok {
+		t.Fatal("tools missing from captured request")
+	}
+	tools, ok := toolsRaw.([]any)
+	if !ok || len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %T len=%d", toolsRaw, len(tools))
+	}
+	fn := tools[0].(map[string]any)["function"].(map[string]any)
+	if got := fn["strict"]; got != true {
+		t.Errorf("tools[0].function.strict = %v (%T), want true", got, got)
+	}
+	if got := fn["name"]; got != "submit_work" {
+		t.Errorf("tools[0].function.name = %v, want \"submit_work\"", got)
+	}
+}
+
+// TestBuildChatRequest_ToolStrict_False_OmitsFieldOnWire verifies the
+// omitempty contract — when Strict is unset (zero value), the field is
+// dropped from the wire entirely. Existing callers that don't set Strict
+// see no behavior change; their tools serialize identically to before.
+func TestBuildChatRequest_ToolStrict_False_OmitsFieldOnWire(t *testing.T) {
+	server, getCaptured := captureRequestServer(t)
+	defer server.Close()
+
+	client, err := agenticmodel.NewClient(&model.EndpointConfig{URL: server.URL, Model: "test"})
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	_, err = client.ChatCompletion(context.Background(), agentic.AgentRequest{
+		RequestID: "tool-strict-default",
+		Messages:  []agentic.ChatMessage{{Role: "user", Content: "do it"}},
+		Model:     "test",
+		Tools: []agentic.ToolDefinition{{
+			Name:        "noop",
+			Description: "no-op",
+			Parameters:  map[string]any{"type": "object", "properties": map[string]any{}},
+			// Strict not set → false → omitempty drops it
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() failed: %v", err)
+	}
+
+	tools := getCaptured()["tools"].([]any)
+	fn := tools[0].(map[string]any)["function"].(map[string]any)
+	if _, present := fn["strict"]; present {
+		t.Errorf("tools[0].function.strict should be omitted when false, got %v", fn["strict"])
+	}
+}
+
+// TestBuildChatRequest_ToolStrict_MixedTools_IndependentPerTool verifies
+// that Strict is per-ToolDefinition, not a request-wide flag. Mixed
+// definitions surface independently on the wire so callers can opt only
+// the tool whose schema satisfies the strict-mode subset.
+func TestBuildChatRequest_ToolStrict_MixedTools_IndependentPerTool(t *testing.T) {
+	server, getCaptured := captureRequestServer(t)
+	defer server.Close()
+
+	client, err := agenticmodel.NewClient(&model.EndpointConfig{URL: server.URL, Model: "test"})
+	if err != nil {
+		t.Fatalf("NewClient() failed: %v", err)
+	}
+
+	_, err = client.ChatCompletion(context.Background(), agentic.AgentRequest{
+		RequestID: "tool-strict-mixed",
+		Messages:  []agentic.ChatMessage{{Role: "user", Content: "do it"}},
+		Model:     "test",
+		Tools: []agentic.ToolDefinition{
+			{
+				Name:        "strict_tool",
+				Description: "schema satisfies strict subset",
+				Parameters:  map[string]any{"type": "object", "additionalProperties": false},
+				Strict:      true,
+			},
+			{
+				Name:        "loose_tool",
+				Description: "permissive schema",
+				Parameters:  map[string]any{"type": "object"},
+				// Strict false
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion() failed: %v", err)
+	}
+
+	tools := getCaptured()["tools"].([]any)
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(tools))
+	}
+	fn0 := tools[0].(map[string]any)["function"].(map[string]any)
+	fn1 := tools[1].(map[string]any)["function"].(map[string]any)
+
+	if got := fn0["strict"]; got != true {
+		t.Errorf("tools[0] (strict_tool) strict = %v, want true", got)
+	}
+	if _, present := fn1["strict"]; present {
+		t.Errorf("tools[1] (loose_tool) strict should be omitted, got %v", fn1["strict"])
+	}
+}


### PR DESCRIPTION
## Summary

Symmetric companion to ADR-034. Adds `Strict bool` to `agentic.ToolDefinition`, plumbed to `openai.FunctionDefinition.Strict` (SDK supports natively since `go-openai v1.41`).

ADR-034's `response_format.strict` constrains `chat.completion.message.content`. Tool-call-driven frameworks (semspec forces `submit_work` on every persona dispatch) get structured payloads via `tool_calls[].function.arguments` — unconstrained today. This closes the asymmetry.

## Provider matrix (mirrors ADR-034)

| Provider | Behavior |
|---|---|
| `provider:"openai"` umbrella (OpenAI / vLLM / sparky / OpenRouter / LocalAI / llama.cpp `/v1`) | honors `function.strict: true` |
| `provider:"ollama"` (`/v1`) | best-effort, model-dependent |
| `provider:"gemini"` | silent no-op |
| `provider:"anthropic"` | silent no-op |

`omitempty` keeps the field absent from the wire when unset — purely additive for existing callers.

## Caller responsibilities

OpenAI's strict-mode subset (caller-side concern; framework doesn't validate):
- `additionalProperties: false` at every object level
- Every property listed in `required`
- No `$ref` / `anyOf` at root, max nesting 5

semspec commit `d3a3b56` covers the structural half across their deliverable schemas; the required-completeness half is gated behind their `TestSchemasRequiredCompleteness` (currently `t.Skip`'d) until a live-qwen run flips it.

## Test plan

- [x] `go test -race ./agentic/... ./processor/agentic-model/...` — all green
- [x] Three new wire-shape tests in `tool_strict_test.go`:
  - Strict=true propagates as `function.strict: true`
  - Strict=false (default) omitted via `omitempty`
  - Mixed per-tool (independent flag, not request-wide)
- [x] `task schema:generate` clean — no schema drift
- [x] `gofmt` / `go vet` clean

## References

- ADR-035 (this PR) — decision + provider matrix
- ADR-034 — `response_format` companion
- semspec commits `d3a3b56` (subset) and `133b5ea` (downstream `EndpointSupportsResponseFormat` discriminator extends 1:1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)