### PR TITLE
fix(agentic-loop): stop active_loops gauge from leaking on dedup + tool-driven failure

### DIFF
--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -838,9 +838,21 @@ func (c *Component) handleTaskMessage(ctx context.Context, data []byte) {
 		return
 	}
 
-	// Record loop creation
-	if c.metrics != nil {
+	// Record loop creation only when HandleTask actually created a new loop.
+	// The dedup short-circuit (handlers.go HandleTask) returns Created=false
+	// for redelivered TaskMessages whose task_id already has an active loop.
+	// Gating here prevents the active_loops gauge from drifting upward on
+	// every JetStream redelivery — the original loop's eventual completion
+	// only fires one Dec(), so each ungated redelivery would leak +1.
+	if c.metrics != nil && result.Created {
 		c.metrics.recordLoopCreated()
+	}
+
+	if !result.Created {
+		c.logger.Debug("Task deduplicated — loop already active",
+			slog.String("loop_id", result.LoopID),
+			slog.String("task_id", task.TaskID))
+		return
 	}
 
 	c.logger.Debug("Loop created",
@@ -984,12 +996,30 @@ func (c *Component) recordResponseMetrics(response *agentic.AgentResponse, resul
 		}
 	}
 
-	// Record terminal state metrics
-	if entity.ID == "" {
+	var failureReason string
+	switch response.Status {
+	case agentic.StatusError:
+		failureReason = "model_error"
+	case agentic.StatusLengthTruncated:
+		failureReason = "length_truncated"
+	default:
+		failureReason = "unknown"
+	}
+	c.recordTerminalState(result, entity, failureReason)
+}
+
+// recordTerminalState fires the active_loops decrement and the matching
+// terminal counter for a loop that has just transitioned to LoopStateComplete
+// or LoopStateFailed. No-op for non-terminal states. Pulled out of
+// recordResponseMetrics so the tool-result path (handleToolResultMessage)
+// can decrement the gauge when handleToolsComplete transitions a loop to
+// LoopStateFailed (max iterations) without going through a model response —
+// without this, every max-iterations failure leaks one unit on the gauge.
+func (c *Component) recordTerminalState(result HandlerResult, entity agentic.LoopEntity, failureReason string) {
+	if c.metrics == nil || entity.ID == "" {
 		return
 	}
 	duration := time.Since(entity.StartedAt).Seconds()
-
 	switch result.State {
 	case agentic.LoopStateComplete:
 		c.metrics.recordLoopCompleted(entity.Iterations, duration)
@@ -997,19 +1027,11 @@ func (c *Component) recordResponseMetrics(response *agentic.AgentResponse, resul
 			slog.String("loop_id", result.LoopID),
 			slog.Int("iterations", entity.Iterations))
 	case agentic.LoopStateFailed:
-		var reason string
-		switch response.Status {
-		case agentic.StatusError:
-			reason = "model_error"
-		case agentic.StatusLengthTruncated:
-			reason = "length_truncated"
-		default:
-			reason = "unknown"
-		}
-		c.metrics.recordLoopFailed(reason, entity.Iterations, duration)
+		c.metrics.recordLoopFailed(failureReason, entity.Iterations, duration)
 		c.logger.Warn("Loop failed",
 			slog.String("loop_id", result.LoopID),
-			slog.Int("iterations", entity.Iterations))
+			slog.Int("iterations", entity.Iterations),
+			slog.String("reason", failureReason))
 	}
 }
 
@@ -1095,12 +1117,27 @@ func (c *Component) handleToolResultMessage(ctx context.Context, data []byte) {
 	// Update Boid position if enabled
 	c.updateBoidPositionFromToolResult(ctx, loopID, toolResult)
 
+	// Decrement active_loops if HandleToolResult drove the loop to a terminal
+	// state. handleToolsComplete (handlers.go) transitions to LoopStateFailed
+	// when max_iterations trips while tools were in flight; without this
+	// recording the gauge would not be decremented for that path. The
+	// model-response path (handleResponseMessage) records via
+	// recordResponseMetrics and is unchanged.
+	if result.State == agentic.LoopStateComplete || result.State == agentic.LoopStateFailed {
+		failureReason := "unknown"
+		if result.MaxIterationsReached {
+			failureReason = "max_iterations"
+		}
+		if entity, entErr := c.handler.GetLoop(loopID); entErr == nil {
+			c.recordTerminalState(result, entity, failureReason)
+		}
+	}
+
 	// Publish results, persist state, and handle terminal states (StopLoop).
 	// persistHandlerResult covers publishResults + persistLoopState for all states,
 	// plus finalizeTrajectory, persistCompletionState, and writeTrajectoryToGraph
 	// when the loop reaches a terminal state.
 	c.persistHandlerResult(ctx, result)
-
 }
 
 // publishResults publishes all output messages from a handler result using JetStream.

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -36,6 +36,12 @@ type HandlerResult struct {
 	ContextEvents        []agentic.ContextEvent
 	RetryScheduled       bool
 	MaxIterationsReached bool
+	// Created is true only when HandleTask actually created a new loop.
+	// False on the dedup short-circuit path (TaskMessage redelivered for
+	// an already-active task). Component uses this to gate
+	// recordLoopCreated so the active_loops gauge does not drift on
+	// JetStream redelivery.
+	Created bool
 	// CompletionState contains enriched completion data for KV persistence.
 	// This is populated when a loop completes and is used by component.go
 	// to write to the loops bucket with key pattern COMPLETE_{loopID}.
@@ -651,8 +657,9 @@ func (h *MessageHandler) buildTaskRequest(loopID string, task TaskMessage, entit
 	}
 
 	return HandlerResult{
-		LoopID: loopID,
-		State:  entity.State,
+		LoopID:  loopID,
+		State:   entity.State,
+		Created: true,
 		PublishedMessages: []PublishedMessage{
 			{
 				Subject: component.ResolveSubject(h.config.Ports.Outputs, "agent.request", loopID),

--- a/processor/agentic-loop/handlers_test.go
+++ b/processor/agentic-loop/handlers_test.go
@@ -1826,6 +1826,52 @@ func TestHandleTask_NoResponseFormatPreservesNil(t *testing.T) {
 	t.Error("HandleTask() should publish agent.request message")
 }
 
+// TestHandleTask_DuplicateTaskID_DedupReturnsCreatedFalse asserts the
+// dedup short-circuit reports Created=false when a TaskMessage arrives
+// for a task_id that already has an active loop. This is the load-bearing
+// signal that gates recordLoopCreated() in handleTaskMessage so the
+// active_loops gauge does not drift on JetStream redelivery — without
+// the gate, every redelivered TaskMessage adds +1 to the gauge while
+// the original loop's eventual completion only fires one matching Dec().
+func TestHandleTask_DuplicateTaskID_DedupReturnsCreatedFalse(t *testing.T) {
+	handler := agenticloop.NewMessageHandler(createTestConfig())
+
+	task := agenticloop.TaskMessage{
+		TaskID: "task-dedup-001",
+		Role:   "general",
+		Model:  "test-model",
+		Prompt: "first dispatch",
+	}
+
+	ctx := context.Background()
+	first, err := handler.HandleTask(ctx, task)
+	if err != nil {
+		t.Fatalf("first HandleTask() error = %v", err)
+	}
+	if !first.Created {
+		t.Fatal("first HandleTask() Created = false, want true")
+	}
+	if first.LoopID == "" {
+		t.Fatal("first HandleTask() LoopID empty")
+	}
+
+	// Second dispatch with same task_id simulates a JetStream redelivery
+	// (transient heartbeat failure, consumer ack delay, etc.).
+	second, err := handler.HandleTask(ctx, task)
+	if err != nil {
+		t.Fatalf("second HandleTask() error = %v", err)
+	}
+	if second.Created {
+		t.Error("second HandleTask() Created = true, want false (dedup short-circuit)")
+	}
+	if second.LoopID != first.LoopID {
+		t.Errorf("second HandleTask() LoopID = %s, want %s (existing loop_id should be returned)", second.LoopID, first.LoopID)
+	}
+	if len(second.PublishedMessages) != 0 {
+		t.Errorf("dedup result should not publish messages, got %d", len(second.PublishedMessages))
+	}
+}
+
 // --- ToolCallFilter tests ---
 
 // mockFilter implements agentic.ToolCallFilter for testing


### PR DESCRIPTION
## Summary

semspec hit a wedge where `semstreams_agentic_loop_active_loops` stayed pinned at 10 for 12+ minutes after every active loop in a run had emitted `outcome=success`. Bundle snapshots confirmed 12/12 trajectories with `outcome=success` and KV-derived active count = 0 — the gauge was the lie, not the workload.

Two leak paths fixed:

### 1. Dedup short-circuit Inc without matching Dec (the primary bug)
`handleTaskMessage` was calling `recordLoopCreated()` unconditionally after `HandleTask` returned nil. But `HandleTask` has a dedup short-circuit (`handlers.go:511`) that returns the existing `loop_id` when a `TaskMessage` redelivers for an already-active task — guarding against duplicate LLM work after a JetStream redelivery (heartbeat hiccup, consumer ack delay, sidecar pause).

The original loop's eventual completion only fires one `Dec()`; each ungated redelivery was leaking +1 on the gauge permanently. semspec's stuck-at-10 with 12 successes implied ~22 `Inc` and 12 `Dec`, consistent with 10 redeliveries during the run's 8-min mid-run sidecar silence.

**Fix:** new `HandlerResult.Created bool`. `buildTaskRequest` (the only path through to a freshly created loop) sets `Created=true`; the dedup branch falls through to zero-value `false`. `handleTaskMessage` gates `recordLoopCreated()` on `result.Created` and early-returns on the dedup branch so we don't double-publish `agent.created`/`agent.request`, re-stamp lineage triples, or rewrite the initial Boid position.

### 2. Tool-driven terminal transitions skipped the gauge entirely (latent second leak)
`handleToolResultMessage` never called `recordResponseMetrics` or any sibling. When `handleToolsComplete` (`handlers.go:1660`) transitioned a loop to `LoopStateFailed` on `max_iterations`, `persistHandlerResult` wrote terminal KV state and published failure events, but the gauge was never decremented. Doesn't explain semspec's `outcome=success` repro, but is a real second leak class for any run that exhausts the iteration budget mid-tool-cycle.

**Fix:** pulled the terminal switch out of `recordResponseMetrics` into a reusable `recordTerminalState(result, entity, failureReason)` helper. `handleToolResultMessage` calls it after `HandleToolResult` returns, with reason `"max_iterations"` when `result.MaxIterationsReached`. `recordResponseMetrics` behavior is unchanged (same response-status-to-reason mapping, same log lines).

## Mitigation note for downstream

semspec watch's local `active_loops=N (kv:0)` annotation (semspec `3cb2046`) can be retired once they pin a release including this fix. The KV count was authoritative; the gauge can now be trusted again.

## Test plan

- [x] `TestHandleTask_DuplicateTaskID_DedupReturnsCreatedFalse` — first dispatch returns `Created=true`, second dispatch with same `TaskID` returns `Created=false`, same `LoopID`, no published messages
- [x] `task lint` clean (revive, vet, fmt)
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `go vet -tags=integration ./...` — clean
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `task schema:generate` — no diff
- [x] `task e2e:agentic` — green, 15.8s, 3 loops completed + 3 tool executions through the changed paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)