### PR TITLE
fix(timeout-chain): align defaults across NATS / agentic-model / gateway / capability layers

### DIFF
--- a/docs/operations/14-timeout-chain.md
+++ b/docs/operations/14-timeout-chain.md
@@ -1,0 +1,191 @@
+# Timeout Chain
+
+A semstreams deployment has six layers of timeout knobs. They are not
+independent — every layer carries an implicit contract with its
+neighbours, and tuning one without the others produces silent
+redelivery, premature 504s, or paid-LLM duplicate billing. This page
+documents the chain, the two operational postures it supports, and the
+recipe for tuning each layer in lockstep.
+
+## The chain
+
+```
+┌─ NATS JetStream consumer (per subject) ──────────────────────────────┐
+│  ack_wait      // server reaps unacked work after this                │
+│  heartbeat     // client InProgress() interval — must fit inside      │
+│                // ack_wait with comfortable margin                    │
+│  max_deliver   // cap on redelivery attempts                          │
+│  max_ack_pending // per-consumer in-flight cap                        │
+└──────────────────────────────────────────────────────────────────────┘
+            ↓ work goroutine receives workCtx (cancel on heartbeat fail)
+┌─ Per-task LLM call wallclock budget ─────────────────────────────────┐
+│  precedence (high → low):                                             │
+│   1. req.Timeout                  // per-task TaskMessage override    │
+│   2. endpoint.RequestTimeout      // per-endpoint config              │
+│   3. capability.Timeout           // per-capability config            │
+│   4. component.messageTimeout     // cached from agentic-model Config │
+│   5. 110s hardcoded fallback      // STRICTLY LESS THAN ack_wait      │
+│  Wraps the SDK call via context.WithTimeout(ctx, resolved).           │
+└──────────────────────────────────────────────────────────────────────┘
+            ↓
+┌─ Model HTTP client (model.NewHTTPClient — beta.43 invariant) ────────┐
+│  http.Client.Timeout=0          // context-driven, no whole-request   │
+│                                 // ceiling beyond ctx.Done            │
+│  IdleConnTimeout=30s            // shed pooled conns before upstream  │
+│                                 // LB drops them                      │
+│  MaxIdleConnsPerHost=1                                                │
+│  HTTP/2 ReadIdleTimeout=15s     // PINGs before peer close            │
+│  HTTP/2 PingTimeout=5s                                                │
+│  EndpointConfig fields override: IdleConnTimeout,                     │
+│                                  ResponseHeaderTimeout,               │
+│                                  DisableKeepAlives                    │
+└──────────────────────────────────────────────────────────────────────┘
+            ↓
+┌─ Capability-scoped inner bound (graph-query, graph-clustering, etc.) ┐
+│  community_summary             default 60s                            │
+│  anomaly_review                default 60s                            │
+│  answer_synthesis              default 15s   (ADR-024)                │
+│  query_classification          default  5s   (ADR-024)                │
+│  intent_classification         default 15s                            │
+│  layer_normalization           default 30s                            │
+│  embedding                     default 30s                            │
+│  All resolved via model.ResolveCapabilityTimeout — endpoint           │
+│  override > capability config > caller-supplied default.              │
+└──────────────────────────────────────────────────────────────────────┘
+            ↑
+┌─ Service HTTP front door (service/service_manager.go) ───────────────┐
+│  http_read_timeout=30s          // body read budget                   │
+│  http_write_timeout=120s        // beta.49 fix; LLM-aware default     │
+│  http_idle_timeout=60s                                                │
+└──────────────────────────────────────────────────────────────────────┘
+            ↓ proxies to graph-gateway
+┌─ graph-gateway query path ───────────────────────────────────────────┐
+│  query_timeout=60s              // wraps the GraphQL/MCP/HTTP handler │
+│  StandaloneServer (when used):                                        │
+│    read=30s, write=60s, idle=120s                                     │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+## The contract — inequalities that must hold
+
+Every adjacent pair has an inequality the operator must preserve when
+tuning. Violating any of them produces a class of bugs the framework
+has hit at least once.
+
+| # | Constraint | Why |
+|---|---|---|
+| 1 | `ack_wait > heartbeat × 1.5` (margin) | One heartbeat reset per ack window with margin for jitter. Default is 90s/60s for agentic-loop's task port (1.5×) and 120s/90s for agentic-model (1.33× — tighter, intentional). |
+| 2 | `ack_wait > req.Timeout` (or component fallback) | The LLM call must cancel via context.Done **before** NATS reaps the work. Heartbeats save you in the steady state; the wallclock budget guarantees clean cancel even when heartbeats stop firing. **The 10s gap between agentic-model's 120s ack_wait and the 110s component fallback is load-bearing.** |
+| 3 | `service.http_write_timeout > worst-case LLM wallclock` | Mid-write EOFs killed every LLM-backed handler before beta.49. 120s default covers synthesis (15s) + classification (5s) + headroom; raise it if you raise capability budgets. |
+| 4 | `gateway.query_timeout > inner LLM bounded budget` | If the gateway gives up before the synthesizer's bounded sub-call returns, the client gets a 504 even though the framework's degraded fallback worked. Default 60s; bumping any synthesis/classification budget past 50s combined requires bumping this in lockstep. |
+| 5 | `model.IdleConnTimeout < upstream LB idle timeout` | Stale pooled connections EOF on next reuse. Beta.43 set a conservative 30s under most LB defaults (60–90s). |
+| 6 | `capability.Timeout ≤ req.Timeout` (when both set) | The inner bound binds first; setting capability.Timeout above the per-task budget wastes a layer of the chain. Default capability values are well below the 110s task fallback, so this holds out of the box. |
+
+## Two operational postures
+
+The framework defaults serve **forgiving redelivery** — transient
+hiccups don't permanently fail tasks. For paid-LLM-with-strict-cost
+deployments, **fail-loud-once** is preferred. The choice has
+config-shape implications across the chain, not just one knob.
+
+### Posture A — forgiving (default, framework out-of-the-box)
+
+```yaml
+# agentic-loop consumer (agent.task / response / tool.result)
+ack_wait: 90s
+max_deliver: 2
+max_ack_pending: 1
+heartbeat: 60s
+backoff: [30s, 2m]
+
+# agentic-model
+timeout: 110s          # framework default
+# consumer (hardcoded today)
+# ack_wait: 120s, max_deliver: 2, heartbeat: 90s
+```
+
+A transient consumer hiccup or sidecar pause that exceeds `ack_wait`
+results in a redelivery; the dedup short-circuit at
+`HandleTask` (`processor/agentic-loop/handlers.go`) catches the
+duplicate so no double LLM work fires. The `active_loops` gauge stays
+correct since beta.52.
+
+### Posture B — fail-loud-once (cost-sensitive paid LLM)
+
+```yaml
+# agentic-loop consumer
+ack_wait: 300s          # exceed worst-case request budget; never reap working tasks
+max_deliver: 1          # no redelivery, ever
+max_ack_pending: 1
+heartbeat: 60s
+backoff: []             # empty — no retry-after-Nak schedule
+
+# agentic-model
+timeout: 270s           # strictly less than ack_wait, leaves 30s for
+                        # cancellation propagation + failure publish + KV write
+
+# Required downstream contract
+# - Wire a DLQ or surface failures via a dedicated agent.failed.* counter;
+#   max_deliver: 1 means a Nak'd message is gone forever from the consumer.
+# - Prefer streaming endpoints (endpoint.stream: true) so cancel-mid-flight
+#   saves provider tokens past the cancel point.
+```
+
+The tradeoff: any consumer-side network blip or restart that exceeds
+`ack_wait` becomes a permanent task failure. For paid LLMs with
+$0.X/1K-token charges, that's the right tradeoff. For local llama.cpp
+or hobbyist deployments, posture A is cheaper.
+
+## What happens when a heartbeat fails
+
+The cancellation path is end-to-end and verified in code:
+
+1. `natsclient/heartbeat.go:33` — `ConsumeWithHeartbeat` derives
+   `workCtx, workCancel := context.WithCancel(ctx)`.
+2. Ticker fires `msg.InProgress()` every `heartbeat` interval.
+3. On InProgress() failure (NATS connection lost, server flap),
+   `workCancel()` runs — `heartbeat.go:51`.
+4. `workCtx` cancels.
+5. The work goroutine's `agenticmodel.Client.ChatCompletion(ctx, ...)`
+   sees ctx.Done.
+6. Calls `c.client.CreateChatCompletion(ctx, ...)` — go-openai SDK.
+7. SDK builds via `http.NewRequestWithContext(ctx, ...)` — verified at
+   `internal/request_builder.go:44`.
+8. Go's `http.Transport` aborts the in-flight request, closes the TCP
+   connection (RST if data was in flight, FIN otherwise).
+
+The provider sees a closed connection. **Whether the provider stops
+billing depends on the provider's policy** — not something semstreams
+controls:
+
+| Provider | Mid-stream cancel | Mid-non-streaming cancel |
+|---|---|---|
+| OpenAI direct | Bills only tokens streamed | Bills inferred response if generation completed |
+| Anthropic | Bills only tokens streamed | Same |
+| OpenRouter | Forwards cancel; depends on underlying provider | Same |
+| vLLM / sparky / llama.cpp | Inference typically halts on TCP close | Same |
+
+**Streaming is the cost-sensitive lever** orthogonal to redelivery —
+even with perfect cancellation, a non-streaming cancel may bill for
+the full response the upstream finished generating.
+
+## Default values reference
+
+For the actual current values across the codebase, the audit table in
+the [beta.53 release notes][beta53-tag] is the canonical snapshot.
+Out-of-tree config in `configs/*.json` overrides framework defaults
+where present.
+
+[beta53-tag]: https://github.com/C360Studio/semstreams/releases/tag/v1.0.0-beta.53
+
+## Related ADRs and concepts
+
+- ADR-024 (`docs/adr/024-layered-llm-timeouts.md`) — graph-query
+  bounded sub-timeouts (synthesis 15s, classification 5s).
+- ADR-033 (`docs/adr/033-operating-curve-based-observability.md`) —
+  end-to-end latency observability where cap-budgets meet the
+  operating-curve framework.
+- `docs/concepts/03-streams-vs-kv-watches.md` — the facts-vs-requests
+  decision that determines which JetStream knobs apply.
+- `docs/operations/12-openai-client-keepalive.md` — the keepalive saga
+  beta.34→43 that produced the unified-HTTP-client invariant.

--- a/gateway/graph-gateway/component.go
+++ b/gateway/graph-gateway/component.go
@@ -106,7 +106,7 @@ func (c *Config) ApplyDefaults() {
 		c.BindAddress = "localhost:8080"
 	}
 	if c.QueryTimeout == 0 {
-		c.QueryTimeout = 30 * time.Second
+		c.QueryTimeout = 60 * time.Second
 	}
 	if c.Ports == nil {
 		// Apply full default port config
@@ -188,7 +188,7 @@ func DefaultConfig() Config {
 		MCPPath:          "/mcp",
 		BindAddress:      "localhost:8080",
 		EnablePlayground: false,
-		QueryTimeout:     30 * time.Second,
+		QueryTimeout:     60 * time.Second,
 	}
 }
 

--- a/gateway/graph-gateway/component_test.go
+++ b/gateway/graph-gateway/component_test.go
@@ -238,6 +238,12 @@ func TestConfig_ApplyDefaults(t *testing.T) {
 	assert.Equal(t, "/mcp", config.MCPPath, "MCPPath should default to /mcp")
 	assert.Equal(t, "localhost:8080", config.BindAddress, "BindAddress should default to localhost:8080")
 	assert.False(t, config.EnablePlayground, "EnablePlayground should default to false")
+	// QueryTimeout 60s gives synthesis (15s) + classification (5s) + headroom
+	// for semantic search + enrichment + serialization on commodity-CPU LLM
+	// runtimes. Beta.51 bumped the e2e config to 60s; beta.52 brings the
+	// in-binary default in line so deployments without explicit config don't
+	// 504 on long-tail globalSearch queries.
+	assert.Equal(t, 60*time.Second, config.QueryTimeout, "QueryTimeout should default to 60s — keeps gateway above LLM-backed query budget without explicit config")
 }
 
 func TestDefaultConfig_ReturnsValidConfig(t *testing.T) {
@@ -255,6 +261,7 @@ func TestDefaultConfig_ReturnsValidConfig(t *testing.T) {
 	assert.Equal(t, "/mcp", config.MCPPath)
 	assert.Equal(t, "localhost:8080", config.BindAddress)
 	assert.False(t, config.EnablePlayground)
+	assert.Equal(t, 60*time.Second, config.QueryTimeout)
 }
 
 // ====================================================================================

--- a/processor/agentic-dispatch/intent_classifier.go
+++ b/processor/agentic-dispatch/intent_classifier.go
@@ -110,7 +110,15 @@ Respond with JSON: {"type": "<intent_type>", "loop_id": "<if applicable>", "sign
 	client.SetAdapter(agenticmodel.AdapterFor(ep.Provider))
 	client.SetLogger(c.logger)
 
-	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	// Resolve per-call LLM timeout via the model registry's capability ladder
+	// (endpoint.request_timeout → capability.timeout → fallback). 15s mirrors
+	// the historical hardcoded value and remains the right ceiling for a
+	// single-token-budget JSON classifier; operators running the classifier
+	// against a slower local model raise it via capability.timeout. See
+	// docs/operations/14-timeout-chain.md for the full chain.
+	const intentClassificationTimeoutDefault = 15 * time.Second
+	classifyTimeout := model.ResolveCapabilityTimeout(c.modelRegistry, model.CapabilityIntentClassification, intentClassificationTimeoutDefault, c.logger)
+	reqCtx, cancel := context.WithTimeout(ctx, classifyTimeout)
 	defer cancel()
 
 	resp, err := client.ChatCompletion(reqCtx, agentic.AgentRequest{

--- a/processor/agentic-model/component.go
+++ b/processor/agentic-model/component.go
@@ -117,7 +117,7 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 	}
 
 	// Parse timeout for message processing
-	messageTimeout := 120 * time.Second // default
+	messageTimeout := 110 * time.Second // default — kept 10s below consumer AckWait 120s so context.Done propagates before NATS redelivery (see resolveTimeout precedence and feedback_class_of_bugs_to_invariant.md)
 	if config.Timeout != "" {
 		var err error
 		messageTimeout, err = time.ParseDuration(config.Timeout)
@@ -151,7 +151,7 @@ func NewComponentWithOptions(rawConfig json.RawMessage, deps component.Dependenc
 		return nil, errs.WrapInvalid(errs.ErrMissingConfig, "Component", "NewComponentWithOptions", "model registry is required")
 	}
 
-	messageTimeout := 120 * time.Second
+	messageTimeout := 110 * time.Second
 	if config.Timeout != "" {
 		var err error
 		messageTimeout, err = time.ParseDuration(config.Timeout)
@@ -739,13 +739,21 @@ func (c *Component) executeRequest(
 //  2. endpoint.RequestTimeout
 //  3. capability.Timeout (looked up via registry when capability is non-empty)
 //  4. component messageTimeout (cached from config.Timeout at construction)
-//  5. hardcoded 120s safety default
+//  5. hardcoded 110s safety default
+//
+// The 110s fallback sits 10s below the agentic-model consumer AckWait
+// (120s, component.go:269). When every override is unset, we still want
+// the LLM call to cancel cleanly — context.Done propagating to the SDK's
+// in-flight HTTP request — before NATS would otherwise redeliver. The
+// dedup short-circuit catches the redelivery if it happens, but a
+// strictly-less-than budget means redelivery doesn't fire on a healthy
+// long-tail call. See docs/operations/14-timeout-chain.md.
 //
 // Invalid duration strings at levels 1-3 log a warning and fall through to the
 // next level, so a malformed per-message override never blocks a task. The
 // selected source is logged at debug level as timeout_source.
 func (c *Component) resolveTimeout(req agentic.AgentRequest, endpoint *model.EndpointConfig, capability string) time.Duration {
-	const fallback = 120 * time.Second
+	const fallback = 110 * time.Second
 
 	tryParse := func(value, source string) (time.Duration, bool) {
 		if value == "" {

--- a/processor/agentic-model/config.go
+++ b/processor/agentic-model/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	StreamName           string                `json:"stream_name"          schema:"type:string,description:JetStream stream name for agentic messages,category:basic,default:AGENT"`
 	ConsumerNameSuffix   string                `json:"consumer_name_suffix" schema:"type:string,description:Suffix appended to consumer names for uniqueness,category:advanced"`
 	DeleteConsumerOnStop bool                  `json:"delete_consumer_on_stop,omitempty" schema:"type:bool,description:Delete durable consumers on Stop (use for tests only),category:advanced,default:false"`
-	Timeout              string                `json:"timeout"              schema:"type:string,description:Request timeout,category:advanced,default:120s"`
+	Timeout              string                `json:"timeout"              schema:"type:string,description:Per-request LLM call timeout. Sized 10s below the agentic-model JetStream consumer AckWait (120s) so the LLM context.Done propagates and the call closes cleanly before NATS would otherwise redeliver. Operators raising this past ~115s should also raise the consumer AckWait in lockstep.,category:advanced,default:110s"`
 	Retry                RetryConfig           `json:"retry"                schema:"type:object,description:Retry configuration,category:advanced"`
 }
 
@@ -159,7 +159,7 @@ func DefaultConfig() Config {
 			Outputs: outputDefs,
 		},
 		StreamName: "AGENT",
-		Timeout:    "120s",
+		Timeout:    "110s",
 		Retry: RetryConfig{
 			MaxAttempts:         3,
 			MaxRateLimitRetries: 5,

--- a/processor/agentic-model/config_test.go
+++ b/processor/agentic-model/config_test.go
@@ -142,9 +142,12 @@ func TestRetryConfig_Validate(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := agenticmodel.DefaultConfig()
 
-	// Verify default timeout
-	if cfg.Timeout != "120s" {
-		t.Errorf("DefaultConfig() timeout = %s, want 120s", cfg.Timeout)
+	// Verify default timeout. 110s sits 10s below the agentic-model
+	// consumer AckWait (120s, component.go:269) so context.Done propagates
+	// and the LLM call closes cleanly before NATS would otherwise redeliver.
+	// See docs/operations/14-timeout-chain.md.
+	if cfg.Timeout != "110s" {
+		t.Errorf("DefaultConfig() timeout = %s, want 110s", cfg.Timeout)
 	}
 
 	// Verify default retry config

--- a/processor/agentic-model/resolve_timeout_test.go
+++ b/processor/agentic-model/resolve_timeout_test.go
@@ -84,7 +84,11 @@ func TestResolveTimeout_PrecedenceChain(t *testing.T) {
 			endpoint:   endpointNoTimeout,
 			capability: "",
 			componentT: 0,
-			want:       120 * time.Second,
+			// 110s sits 10s below the agentic-model consumer AckWait (120s,
+			// component.go:269) so context.Done propagates and the LLM call
+			// closes cleanly before NATS would otherwise redeliver. See
+			// docs/operations/14-timeout-chain.md for the full chain.
+			want: 110 * time.Second,
 		},
 		{
 			name:       "invalid task timeout falls through to endpoint",

--- a/processor/graph-embedding/component.go
+++ b/processor/graph-embedding/component.go
@@ -619,26 +619,31 @@ func (c *Component) createEmbedder() error {
 		c.logger.Info("using BM25 embedder", slog.Int("dimensions", 384))
 
 	case "http":
-		// TODO: align with graph-clustering / graph-query — use
-		// model.ResolveEndpointWithConfig + model.ResolveCapabilityTimeout
-		// so embedding.timeout / endpoint.request_timeout reach the wire,
-		// and plumb the EndpointConfig connection-hygiene fields
-		// (DisableKeepAlives, IdleConnTimeout, ResponseHeaderTimeout) into
-		// embedding.HTTPConfig (those fields exist on HTTPConfig but the
-		// call site ignores them). Same shape as the
-		// fix/graph-clustering-capability-timeout work; deferred because
-		// embedding's per-call latency budget differs from LLM inference.
-		resolved, err := model.ResolveEndpoint(c.modelRegistry, model.CapabilityEmbedding)
+		// Aligned with graph-clustering / graph-query (beta.47) — capability
+		// timeout via model.ResolveCapabilityTimeout, endpoint connection-
+		// hygiene via ResolveEndpointWithConfig. Embedding's per-call budget
+		// is distinct from inference (no token streaming, fixed-size body),
+		// hence its own DefaultEmbeddingTimeout constant rather than reusing
+		// the synthesis or summary defaults.
+		resolved, epCfg, err := model.ResolveEndpointWithConfig(c.modelRegistry, model.CapabilityEmbedding)
 		if err != nil {
 			return errs.Wrap(err, "Component", "createEmbedder", "resolve embedding endpoint")
 		}
-		httpEmbedder, err := embedding.NewHTTPEmbedder(embedding.HTTPConfig{
+		const defaultEmbeddingTimeout = 30 * time.Second
+		embedTimeout := model.ResolveCapabilityTimeout(c.modelRegistry, model.CapabilityEmbedding, defaultEmbeddingTimeout, c.logger)
+		httpCfg := embedding.HTTPConfig{
 			BaseURL: resolved.URL,
 			Model:   resolved.Model,
 			APIKey:  resolved.APIKey,
-			Timeout: 30 * time.Second,
+			Timeout: embedTimeout,
 			Logger:  c.logger,
-		})
+		}
+		if epCfg != nil {
+			httpCfg.IdleConnTimeout = epCfg.IdleConnTimeout
+			httpCfg.ResponseHeaderTimeout = epCfg.ResponseHeaderTimeout
+			httpCfg.DisableKeepAlives = epCfg.DisableKeepAlives
+		}
+		httpEmbedder, err := embedding.NewHTTPEmbedder(httpCfg)
 		if err != nil {
 			return errs.Wrap(err, "Component", "createEmbedder", "HTTP embedder creation")
 		}

--- a/schemas/agentic-model.v1.json
+++ b/schemas/agentic-model.v1.json
@@ -76,8 +76,8 @@
     },
     "timeout": {
       "type": "string",
-      "description": "Request timeout",
-      "default": "120s",
+      "description": "Per-request LLM call timeout. Sized 10s below the agentic-model JetStream consumer AckWait (120s) so the LLM context.Done propagates and the call closes cleanly before NATS would otherwise redeliver. Operators raising this past ~115s should also raise the consumer AckWait in lockstep.",
+      "default": "110s",
       "category": "advanced"
     }
   },


### PR DESCRIPTION
## Summary

Audit pass over the six-layer timeout chain (NATS consumer ack_wait, agentic-loop request budget, model HTTP client, capability-scoped LLM inner bounds, service front-door, graph-gateway query_timeout). Closes four gaps + adds canonical doc.

semspec's two questions on the gauge fix (#38) prompted this — the gauge bug was a symptom of timeouts coupling that wasn't documented anywhere. Postures, inequalities, and cancellation-propagation contract now live in `docs/operations/14-timeout-chain.md`.

## What changed

### 1. graph-gateway `query_timeout` 30s → 60s (binary default)
Beta.51 raised the e2e config to 60s; binary default was still 30s. Any deployment without explicit config 504s on long-tail `globalSearch` queries. New default matches e2e and the LLM-aware inner-bound budget. Tests assert the new default.

### 2. agentic-model `messageTimeout` fallback 120s → 110s
The hardcoded fallback matched the agentic-model consumer's `AckWait` (120s) exactly — heartbeats saved it in practice, but the gauge bug semspec hit (beta.52 fix) exposed how delicate the timing was. New 110s sits 10s strictly below ack_wait, leaving margin for context.Done() to propagate through the SDK to http.Transport before NATS would redeliver. Schema description rewritten to document the AckWait coupling so operators raising past ~115s know to bump consumer AckWait in lockstep.

### 3. agentic-dispatch `intent_classification` via `ResolveCapabilityTimeout`
Last remaining LLM call site with a hardcoded `context.WithTimeout(ctx, 15*time.Second)`. Now uses the same capability-resolution shape as `community_summary` / `anomaly_review` / `answer_synthesis` / `query_classification` (beta.47).

### 4. graph-embedding TODO closure (beta.47 deferred)
`createEmbedder` switched to `ResolveEndpointWithConfig` + `ResolveCapabilityTimeout`. Connection-hygiene fields (`DisableKeepAlives`, `IdleConnTimeout`, `ResponseHeaderTimeout`) plumbed through — fields existed on `embedding.HTTPConfig` but the call site was ignoring them.

### 5. `docs/operations/14-timeout-chain.md` (new)
Six-layer chain diagram, six adjacent-pair inequalities, two operational postures (forgiving default vs fail-loud-once for paid LLMs per semspec's question), and the verified-in-code cancellation propagation path. Documents the provider-policy matrix for cancel-mid-flight billing (OpenAI / Anthropic / OpenRouter / vLLM-class).

## Out of scope (deferred)

- agentic-model consumer config (ack_wait / heartbeat / max_deliver) is still hardcoded — config-driven parity with agentic-loop is its own workstream. Values themselves are correct (120s / 90s / 2 with 1.33× margin).
- `service.http_idle_timeout` (60s, hardcoded) — separate audit.

## Test plan

- [x] `task lint` clean
- [x] `go vet -tags=integration ./...` — clean
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `go test -race -count=1 ./...` — full suite green
- [x] `task schema:generate` — `schemas/agentic-model.v1.json` regenerated; committed
- [x] `task e2e:agentic` — green (15.85s, 3 loops completed, 2 tool executions through changed paths)
- [x] `TestConfig_ApplyDefaults` / `TestDefaultConfig_ReturnsValidConfig` — assert new graph-gateway 60s default
- [x] `TestDefaultConfig` / `TestResolveTimeout` (agentic-model) — assert new 110s defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)