### PR TITLE
feat(agentic,rule): chain execution entity ID + auto-set ParentLoopID on rule-fanned loop spawns

### DIFF
--- a/agentic/entity_ids.go
+++ b/agentic/entity_ids.go
@@ -95,6 +95,68 @@ func TrajectoryStepEntityID(org, platform, loopID string, stepIndex int) string 
 	return id
 }
 
+// ChainExecutionEntityID constructs a 6-part entity ID for a cross-arc agent chain.
+// Format: {org}.{platform}.agent.chain.execution.{chainID}
+//
+// Example: ChainExecutionEntityID("c360", "ops", "abc123")
+// Returns: "c360.ops.agent.chain.execution.abc123"
+//
+// A chain entity is the canonical anchor for cross-arc data flow: rules and
+// product subscribers stamp milestone triples (chain.dispatched_at,
+// chain.research_artifact_loop, chain.spec_artifact_loop, chain.paused.*,
+// chain.decision.*, ...) on this entity. The chain_id is the dispatch loop's
+// UUID — no new ID generation required at chain start. See semteams ADR-038
+// for the chain-anchor pattern. `chain` is a sibling component to
+// `agentic-loop` within the `agent` domain.
+//
+// Panics if any input part is empty or contains a dot, as these represent
+// programming errors — the caller is responsible for supplying well-formed identifiers.
+func ChainExecutionEntityID(org, platform, chainID string) string {
+	if err := validatePart("org", org); err != nil {
+		panic(fmt.Sprintf("ChainExecutionEntityID: %s", err))
+	}
+	if err := validatePart("platform", platform); err != nil {
+		panic(fmt.Sprintf("ChainExecutionEntityID: %s", err))
+	}
+	if err := validatePart("chainID", chainID); err != nil {
+		panic(fmt.Sprintf("ChainExecutionEntityID: %s", err))
+	}
+
+	id := fmt.Sprintf("%s.%s.agent.chain.execution.%s", org, platform, chainID)
+
+	if !message.IsValidEntityID(id) {
+		panic(fmt.Sprintf("ChainExecutionEntityID: constructed id %q failed IsValidEntityID — check input values", id))
+	}
+
+	return id
+}
+
+// LoopIDFromExecutionEntityID extracts the loop_id segment from a 6-part
+// entity ID matching the LoopExecutionEntityID shape:
+// {org}.{platform}.agent.agentic-loop.execution.{loopID}
+//
+// Returns ("", false) when the input is not a valid 6-part entity ID, or
+// when it doesn't match the agent.agentic-loop.execution.* shape (e.g.
+// model-registry endpoints, trajectory steps, chain entities, or non-agent
+// entity IDs). Used by the rule engine's publish_agent action to set
+// task.ParentLoopID when a rule fires on a loop-execution-shaped trigger
+// entity, so rule-fanned chains carry their parent linkage natively
+// (semteams ADR-038 §D2).
+//
+// Pure parser: no validation of the loop_id's content beyond IsValidEntityID's
+// alphanumeric/hyphen/underscore guard.
+func LoopIDFromExecutionEntityID(entityID string) (string, bool) {
+	if !message.IsValidEntityID(entityID) {
+		return "", false
+	}
+	parts := strings.Split(entityID, ".")
+	// IsValidEntityID guarantees exactly 6 parts; the indexed reads are safe.
+	if parts[2] != "agent" || parts[3] != "agentic-loop" || parts[4] != "execution" {
+		return "", false
+	}
+	return parts[5], true
+}
+
 // validatePart checks that a single entity ID component is non-empty and contains no dots.
 // Dots are reserved as part separators in the 6-part entity ID format.
 func validatePart(name, value string) error {

--- a/agentic/entity_ids_test.go
+++ b/agentic/entity_ids_test.go
@@ -242,3 +242,139 @@ func TestTrajectoryStepEntityID(t *testing.T) {
 		}, "negative stepIndex should panic")
 	})
 }
+
+func TestChainExecutionEntityID(t *testing.T) {
+	t.Run("valid constructions", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			org      string
+			platform string
+			chainID  string
+			want     string
+		}{
+			{
+				name:     "simple alphanumeric chain ID",
+				org:      "c360",
+				platform: "ops",
+				chainID:  "abc123",
+				want:     "c360.ops.agent.chain.execution.abc123",
+			},
+			{
+				name:     "chain ID is the dispatch loop UUID",
+				org:      "c360",
+				platform: "ops",
+				chainID:  "550e8400-e29b-41d4-a716-446655440000",
+				want:     "c360.ops.agent.chain.execution.550e8400-e29b-41d4-a716-446655440000",
+			},
+			{
+				name:     "different org and platform",
+				org:      "acme",
+				platform: "prod",
+				chainID:  "x1",
+				want:     "acme.prod.agent.chain.execution.x1",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got := agentic.ChainExecutionEntityID(tt.org, tt.platform, tt.chainID)
+				require.Equal(t, tt.want, got)
+				assert.True(t, message.IsValidEntityID(got), "result %q must pass IsValidEntityID", got)
+			})
+		}
+	})
+
+	t.Run("panics on invalid input", func(t *testing.T) {
+		assert.Panics(t, func() { agentic.ChainExecutionEntityID("", "ops", "abc123") }, "empty org should panic")
+		assert.Panics(t, func() { agentic.ChainExecutionEntityID("c360", "", "abc123") }, "empty platform should panic")
+		assert.Panics(t, func() { agentic.ChainExecutionEntityID("c360", "ops", "") }, "empty chainID should panic")
+		assert.Panics(t, func() { agentic.ChainExecutionEntityID("c360.studio", "ops", "abc123") }, "dot in org should panic")
+		assert.Panics(t, func() { agentic.ChainExecutionEntityID("c360", "ops.prod", "abc123") }, "dot in platform should panic")
+		assert.Panics(t, func() { agentic.ChainExecutionEntityID("c360", "ops", "chain.1") }, "dot in chainID should panic")
+	})
+}
+
+// TestLoopIDFromExecutionEntityID asserts the parser only matches loop-execution
+// shaped entity IDs and rejects every other 6-part shape. Used by the rule
+// engine's publish_agent action to set task.ParentLoopID when a rule fires
+// on a loop-shaped trigger entity (semteams ADR-038).
+func TestLoopIDFromExecutionEntityID(t *testing.T) {
+	t.Run("matches loop execution shape", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			input    string
+			wantID   string
+			wantHave bool
+		}{
+			{
+				name:     "simple loop ID",
+				input:    "c360.ops.agent.agentic-loop.execution.abc123",
+				wantID:   "abc123",
+				wantHave: true,
+			},
+			{
+				name:     "UUID loop ID",
+				input:    "c360.ops.agent.agentic-loop.execution.550e8400-e29b-41d4-a716-446655440000",
+				wantID:   "550e8400-e29b-41d4-a716-446655440000",
+				wantHave: true,
+			},
+			{
+				name:     "loop ID with underscores",
+				input:    "myorg.staging.agent.agentic-loop.execution.loop_42",
+				wantID:   "loop_42",
+				wantHave: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, ok := agentic.LoopIDFromExecutionEntityID(tt.input)
+				assert.Equal(t, tt.wantHave, ok)
+				assert.Equal(t, tt.wantID, got)
+			})
+		}
+	})
+
+	t.Run("rejects non-loop shapes", func(t *testing.T) {
+		// Other 6-part entity IDs that share the canonical shape but are
+		// not loop executions. Each MUST return ("", false) — the rule
+		// engine relies on this to leave task.ParentLoopID unset for
+		// rules fired on non-loop trigger entities (model endpoints,
+		// trajectory steps, chain entities, ops findings, telemetry).
+		tests := []string{
+			"c360.ops.agent.model-registry.endpoint.claude-sonnet", // ModelEndpointEntityID shape
+			"c360.ops.agent.agentic-loop.step.abc123-0",            // TrajectoryStepEntityID shape
+			"c360.ops.agent.chain.execution.abc123",                // ChainExecutionEntityID shape
+			"c360.ops.ops.diagnosis.finding.uuid-here",             // ops domain finding
+			"c360.ops.robotics.gcs.drone.001",                      // domain telemetry
+			"c360.ops.agent.agentic-loop.completion.abc123",        // type segment differs (completion vs execution)
+			"c360.ops.agent.something-else.execution.abc123",       // system segment differs
+		}
+		for _, input := range tests {
+			t.Run(input, func(t *testing.T) {
+				got, ok := agentic.LoopIDFromExecutionEntityID(input)
+				assert.False(t, ok, "should not match: %s", input)
+				assert.Equal(t, "", got)
+			})
+		}
+	})
+
+	t.Run("rejects malformed input", func(t *testing.T) {
+		// Each is rejected by IsValidEntityID before the segment check
+		// even runs — empty, wrong part count, illegal characters.
+		tests := []string{
+			"",
+			"abc",
+			"too.few.parts.here",
+			"too.many.parts.here.in.this.string",
+			"c360.ops.agent.agentic-loop.execution.has spaces",
+			"c360.ops.agent.agentic-loop.execution..", // empty trailing parts
+		}
+		for _, input := range tests {
+			t.Run(input, func(t *testing.T) {
+				got, ok := agentic.LoopIDFromExecutionEntityID(input)
+				assert.False(t, ok)
+				assert.Equal(t, "", got)
+			})
+		}
+	})
+}

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -705,6 +705,21 @@ func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action,
 		WorkflowStep: ec.SubstituteVariables(action.WorkflowStep),
 	}
 
+	// Inherit ParentLoopID when the trigger entity is a loop execution. Without
+	// this, rule-fanned chains carry no parent linkage natively — only the
+	// depth-tracked architect→editor subagent path that sets ParentLoopID
+	// at TaskMessage construction time gets the agent.loop.parent triple
+	// stamped at completion (handlers.go:264 → SetParentLoopID → state.go).
+	// With this wired in, every rule-fanned spawn from a loop entity has a
+	// walkable agent.loop.parent ancestry, so product code (semteams chain,
+	// future chain consumers) can derive chain_id by walking parent without
+	// per-rule lineage threading. Required for semteams ADR-038's chain
+	// entity pattern; preserves backward-compat for rule-fanned spawns
+	// triggered by non-loop entities (no ParentLoopID set, current behavior).
+	if parentLoopID, ok := agentic.LoopIDFromExecutionEntityID(entityID); ok {
+		task.ParentLoopID = parentLoopID
+	}
+
 	// Resolve per-agent tool allowlist from the global registry. Nil
 	// action.Tools leaves task.Tools unset (loop falls back to global
 	// discovery). An explicit empty slice produces non-nil empty

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -1245,6 +1245,85 @@ func TestAction_PublishAgent_EmptyRelatedLoops(t *testing.T) {
 	}
 }
 
+// TestAction_PublishAgent_ParentLoopIDFromLoopEntity asserts that when a
+// publish_agent action fires on a loop-execution-shaped trigger entity, the
+// resulting TaskMessage carries task.ParentLoopID extracted from the
+// trigger entity's loop_id segment. This gives rule-fanned spawns the
+// same parent linkage that depth-tracked subagent spawns already have via
+// the SetParentLoopID path, so product code (semteams chain consumers per
+// ADR-038, future cross-arc personas) can derive chain anchors by walking
+// agent.loop.parent without per-rule lineage threading.
+func TestAction_PublishAgent_ParentLoopIDFromLoopEntity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.architect",
+		Role:    "architect",
+		Model:   "mock-model",
+		Prompt:  "p",
+	}
+
+	// Trigger entity is a loop execution — parent linkage should appear.
+	loopEntityID := "c360.ops.agent.agentic-loop.execution.loop-research-abc"
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: loopEntityID}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+	assert.Equal(t, "loop-research-abc", task.ParentLoopID,
+		"ParentLoopID should be set to the trigger loop's UUID when the entity matches LoopExecutionEntityID shape")
+}
+
+// TestAction_PublishAgent_NonLoopTriggerLeavesParentLoopIDUnset asserts the
+// negative case: a publish_agent action triggered by a non-loop entity
+// (telemetry, ops finding, chain entity, model endpoint) leaves
+// ParentLoopID empty. Back-compat for every rule today that fires on
+// non-loop triggers — they continue to spawn root-of-chain loops.
+func TestAction_PublishAgent_NonLoopTriggerLeavesParentLoopIDUnset(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		entityID string
+	}{
+		{"telemetry entity", "c360.ops.robotics.gcs.drone.001"},
+		{"model endpoint", "c360.ops.agent.model-registry.endpoint.claude-sonnet"},
+		{"trajectory step", "c360.ops.agent.agentic-loop.step.loop-1-0"},
+		{"chain execution", "c360.ops.agent.chain.execution.chain-abc"},
+		{"non-canonical entity ID", "e.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockPublisher{}
+			executor := NewActionExecutorFull(nil, nil, mock)
+			action := Action{
+				Type:    ActionTypePublishAgent,
+				Subject: "agent.task.test",
+				Role:    "general",
+				Model:   "mock-model",
+				Prompt:  "p",
+			}
+			require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: tt.entityID}))
+			require.Len(t, mock.published, 1)
+
+			baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+			require.NoError(t, err)
+			task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+			require.True(t, ok)
+			assert.Equal(t, "", task.ParentLoopID,
+				"ParentLoopID should remain unset when trigger entity is not a loop execution (got entity %q)", tt.entityID)
+		})
+	}
+}
+
 // TestAction_PublishAgent_EmptyActionAllowlist verifies that an unset
 // ActionAllowlist leaves Metadata's allowlist key unset (back-compat:
 // existing flows that don't opt in keep their pre-F2 free-form decide


### PR DESCRIPTION
## Summary

Two upstream primitives semteams ADR-038 needs for cross-arc data flow. Pure additive — no behavior change for existing callers.

### 1. `agentic.ChainExecutionEntityID(org, platform, chainID) string`
6-part entity ID constructor for `c360.<platform>.agent.chain.execution.<chain_id>`. Mirrors `LoopExecutionEntityID` / `TrajectoryStepEntityID` / `ModelEndpointEntityID` validation discipline (panic on empty / dotted inputs, `IsValidEntityID` self-check). `chain` is a sibling component to `agentic-loop` within the `agent` domain. The `chain_id` is the dispatch loop's UUID per ADR-038 — no new ID generation at chain start.

### 2. `agentic.LoopIDFromExecutionEntityID(entityID) (string, bool)`
Pure parser; returns the loop_id segment when the input matches the `LoopExecutionEntityID` shape, `("", false)` otherwise. Rejects every other 6-part shape (model-endpoint, trajectory-step, chain, ops-finding, telemetry) and every non-canonical input.

### 3. `executePublishAgent` sets `task.ParentLoopID` when triggered by a loop entity
Five-line addition after `TaskMessage` construction in `processor/rule/actions.go`. `ParentLoopID` is already a `TaskMessage` field and already plumbed end-to-end (`handlers.go:264` → `SetParentLoopID` → `state.go` writes `agent.loop.parent` triple at completion). Today only the depth-tracked architect→editor subagent path sets it; rule-fanned spawns are root-of-chain from the framework's perspective. With this wired in, every rule-fanned spawn from a loop entity carries walkable `agent.loop.parent` ancestry, so product code (semteams chain, future chain consumers) can derive chain_id by walking parent without per-rule lineage threading.

Closes the slice 4c lineage-threading anti-pattern called out in ADR-038 §D2.

## Out of scope (semteams declined)

- Auto-stamp `chain_id` triple at loop creation. Originally proposed but retracted after walking the framework code — ancestry-walk via `agent.loop.parent` is sufficient. `graph_writer` remains write-only by design.
- `chain.dispatched_at` auto-mint stays product-shell semantics.
- Per-arc `chain.<milestone>.<field>` predicate vocabulary stays product.

## Back-compat

Rules fired on non-loop entities (telemetry, ops findings, model endpoints, chain entities, non-canonical IDs) leave `ParentLoopID` empty — current behavior. Verified by `TestAction_PublishAgent_NonLoopTriggerLeavesParentLoopIDUnset` covering five distinct shapes.

## Test plan

- [x] `TestChainExecutionEntityID` — valid constructions + 6 panic cases mirroring sibling patterns
- [x] `TestLoopIDFromExecutionEntityID` — positive matches + rejection cases for every other 6-part shape + malformed inputs
- [x] `TestAction_PublishAgent_ParentLoopIDFromLoopEntity` — happy path
- [x] `TestAction_PublishAgent_NonLoopTriggerLeavesParentLoopIDUnset` — 5 non-loop trigger shapes
- [x] `task lint` clean
- [x] `go test -race ./...` — full suite green
- [x] `go vet -tags=integration ./...` — clean
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `task schema:generate` diff — empty
- [x] `task e2e:agentic` — green (15.85s, 3 loops completed, 3 tool executions through unchanged paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)