### PR TITLE
fix(component): PortDefinition.UnmarshalJSON populates typed Config (was always map[string]any from JSON)

### DIFF
--- a/component/port_test.go
+++ b/component/port_test.go
@@ -1009,6 +1009,166 @@ func TestConsumerConfigDefaults(t *testing.T) {
 	}
 }
 
+// TestPortDefinition_UnmarshalJSON_JetStreamConfig is the load-bearing
+// regression test for the beta.55 hotfix: a JSON-loaded PortDefinition
+// must place a JetStreamPort struct into Config (not a map[string]any),
+// otherwise every consumer-config field declared in YAML/JSON is
+// silently dropped at the type assertion in BuildPortFromDefinition
+// and applyJetStreamConsumerConfig.
+//
+// The semspec repro (2026-05-07) showed AckWait/HeartbeatInterval/
+// MaxDeliver/DeliverPolicy all reaching zero values at runtime even
+// though they were declared in the port's `config` block.
+func TestPortDefinition_UnmarshalJSON_JetStreamConfig(t *testing.T) {
+	raw := []byte(`{
+		"name": "agent.request",
+		"type": "jetstream",
+		"subject": "agent.request.>",
+		"config": {
+			"deliver_policy": "all",
+			"ack_policy": "explicit",
+			"max_deliver": 1,
+			"consumer_name": "model-consumer",
+			"ack_wait": "300s",
+			"heartbeat_interval": "60s"
+		}
+	}`)
+
+	var pd PortDefinition
+	if err := json.Unmarshal(raw, &pd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if pd.Name != "agent.request" || pd.Type != "jetstream" || pd.Subject != "agent.request.>" {
+		t.Errorf("top-level fields lost: %+v", pd)
+	}
+
+	js, ok := pd.Config.(JetStreamPort)
+	if !ok {
+		t.Fatalf("Config = %T, want JetStreamPort (the bug semspec repro'd)", pd.Config)
+	}
+	if js.DeliverPolicy != "all" {
+		t.Errorf("DeliverPolicy = %q, want %q", js.DeliverPolicy, "all")
+	}
+	if js.AckPolicy != "explicit" {
+		t.Errorf("AckPolicy = %q, want %q", js.AckPolicy, "explicit")
+	}
+	if js.MaxDeliver != 1 {
+		t.Errorf("MaxDeliver = %d, want 1", js.MaxDeliver)
+	}
+	if js.ConsumerName != "model-consumer" {
+		t.Errorf("ConsumerName = %q, want %q", js.ConsumerName, "model-consumer")
+	}
+	if js.AckWait != "300s" {
+		t.Errorf("AckWait = %q, want %q", js.AckWait, "300s")
+	}
+	if js.HeartbeatInterval != "60s" {
+		t.Errorf("HeartbeatInterval = %q, want %q", js.HeartbeatInterval, "60s")
+	}
+}
+
+// TestPortDefinition_UnmarshalJSON_RoundTripsToConsumerConfig closes the
+// loop by going JSON → PortDefinition → ConsumerConfig — the path every
+// agentic-model / agentic-tools consumer uses at runtime. This is the
+// end-to-end test that would have caught the beta.54 ship-to-runtime gap.
+func TestPortDefinition_UnmarshalJSON_RoundTripsToConsumerConfig(t *testing.T) {
+	raw := []byte(`{
+		"name": "agent.request",
+		"type": "jetstream",
+		"subject": "agent.request.>",
+		"config": {
+			"max_deliver": 1,
+			"ack_wait": "5m",
+			"heartbeat_interval": "2m"
+		}
+	}`)
+
+	var pd PortDefinition
+	if err := json.Unmarshal(raw, &pd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	cfg := GetConsumerConfigFromDefinition(pd)
+	if cfg.MaxDeliver != 1 {
+		t.Errorf("MaxDeliver = %d, want 1 (Posture B fail-loud-once value must reach the consumer)", cfg.MaxDeliver)
+	}
+	if cfg.AckWait != 5*time.Minute {
+		t.Errorf("AckWait = %v, want 5m", cfg.AckWait)
+	}
+	if cfg.HeartbeatInterval != 2*time.Minute {
+		t.Errorf("HeartbeatInterval = %v, want 2m", cfg.HeartbeatInterval)
+	}
+}
+
+// TestPortDefinition_UnmarshalJSON_NoConfig asserts an entry with no
+// `config` block round-trips cleanly (no panic, Config stays nil).
+func TestPortDefinition_UnmarshalJSON_NoConfig(t *testing.T) {
+	raw := []byte(`{"name":"x","type":"jetstream","subject":"x.>"}`)
+
+	var pd PortDefinition
+	if err := json.Unmarshal(raw, &pd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pd.Config != nil {
+		t.Errorf("Config = %v, want nil when JSON had no config block", pd.Config)
+	}
+}
+
+// TestPortDefinition_UnmarshalJSON_UnknownType falls back to map[string]any
+// so custom port types not yet known to the framework are forward-compat.
+func TestPortDefinition_UnmarshalJSON_UnknownType(t *testing.T) {
+	raw := []byte(`{"name":"x","type":"custom-future-type","config":{"key":"value"}}`)
+
+	var pd PortDefinition
+	if err := json.Unmarshal(raw, &pd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	m, ok := pd.Config.(map[string]any)
+	if !ok {
+		t.Fatalf("Config = %T, want map[string]any for unknown types", pd.Config)
+	}
+	if m["key"] != "value" {
+		t.Errorf("map missing key/value: %v", m)
+	}
+}
+
+// TestBuildPortFromDefinition_CopiesAckWaitAndHeartbeat asserts the second
+// half of the beta.55 fix: even with a Go-constructed PortDefinition
+// (not JSON-loaded), BuildPortFromDefinition's jetstream case must copy
+// AckWait + HeartbeatInterval into the resulting Port's JetStreamPort.
+// Beta.54 added these fields to the struct but didn't add the merge
+// branch.
+func TestBuildPortFromDefinition_CopiesAckWaitAndHeartbeat(t *testing.T) {
+	pd := PortDefinition{
+		Name:    "agent.request",
+		Type:    "jetstream",
+		Subject: "agent.request.>",
+		Config: JetStreamPort{
+			AckWait:           "300s",
+			HeartbeatInterval: "60s",
+			MaxDeliver:        1,
+			DeliverPolicy:     "all",
+		},
+	}
+	port := BuildPortFromDefinition(pd, DirectionInput)
+	js, ok := port.Config.(JetStreamPort)
+	if !ok {
+		t.Fatalf("Config = %T, want JetStreamPort", port.Config)
+	}
+	if js.AckWait != "300s" {
+		t.Errorf("AckWait = %q, want %q", js.AckWait, "300s")
+	}
+	if js.HeartbeatInterval != "60s" {
+		t.Errorf("HeartbeatInterval = %q, want %q", js.HeartbeatInterval, "60s")
+	}
+	if js.MaxDeliver != 1 {
+		t.Errorf("MaxDeliver = %d, want 1", js.MaxDeliver)
+	}
+	if js.DeliverPolicy != "all" {
+		t.Errorf("DeliverPolicy = %q, want %q", js.DeliverPolicy, "all")
+	}
+}
+
 // TestGetConsumerConfig_AckWaitAndHeartbeat verifies the per-port AckWait
 // and HeartbeatInterval fields parse from string ("90s", "2m") into a
 // time.Duration on ConsumerConfig, and that empty/invalid values produce

--- a/component/ports.go
+++ b/component/ports.go
@@ -1,7 +1,13 @@
 // Package component provides port configuration and management for component connections.
 package component
 
-import "strings"
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/pkg/errs"
+)
 
 // ResolveSubject returns the configured subject for the named port,
 // replacing the trailing wildcard (`*` or `>`) with suffix. This lets
@@ -40,6 +46,104 @@ type PortDefinition struct {
 
 	// Config holds type-specific port configuration (e.g., JetStreamPort for consumer settings)
 	Config any `json:"config,omitempty" schema:"editable,type:object,description:Type-specific port configuration"`
+}
+
+// UnmarshalJSON populates PortDefinition.Config with the typed struct
+// matching p.Type, instead of leaving it as a generic map[string]any from
+// the default decoder. Without this, every type assertion against
+// def.Config (e.g. def.Config.(JetStreamPort) at BuildPortFromDefinition
+// and applyJetStreamConsumerConfig) silently fails on JSON-loaded port
+// configs — meaning per-port consumer fields (DeliverPolicy, AckPolicy,
+// MaxDeliver, AckWait, HeartbeatInterval, ConsumerName) never reach the
+// consumer at runtime even though they were declared in the YAML/JSON.
+//
+// Symmetric with Port.UnmarshalJSON's type-discriminated path
+// (component/port.go:78). The wire shape differs: Port wraps its config
+// in a `{"type":"...","data":{...}}` envelope, whereas PortDefinition
+// uses the top-level `type` field as the discriminator and the `config`
+// object holds the typed payload directly:
+//
+//	{"name":"agent.request","type":"jetstream","config":{"ack_wait":"5m"}}
+//
+// Unknown types fall through to map[string]any (matches pre-fix
+// behaviour for forward-compat with custom port types).
+func (p *PortDefinition) UnmarshalJSON(data []byte) error {
+	type Alias PortDefinition
+	aux := &struct {
+		Config json.RawMessage `json:"config,omitempty"`
+		*Alias
+	}{
+		Alias: (*Alias)(p),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+
+	if len(aux.Config) == 0 || string(aux.Config) == "null" {
+		return nil
+	}
+
+	switch p.Type {
+	case "jetstream":
+		var js JetStreamPort
+		if err := json.Unmarshal(aux.Config, &js); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "jetstream config")
+		}
+		p.Config = js
+	case "nats":
+		var n NATSPort
+		if err := json.Unmarshal(aux.Config, &n); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "nats config")
+		}
+		p.Config = n
+	case "nats-request":
+		var nr NATSRequestPort
+		if err := json.Unmarshal(aux.Config, &nr); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "nats-request config")
+		}
+		p.Config = nr
+	case "kvwatch", "kv-watch":
+		var kv KVWatchPort
+		if err := json.Unmarshal(aux.Config, &kv); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "kvwatch config")
+		}
+		p.Config = kv
+	case "kv", "kv-write", "kvwrite":
+		var kv KVWritePort
+		if err := json.Unmarshal(aux.Config, &kv); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "kvwrite config")
+		}
+		p.Config = kv
+	case "timer":
+		var t TimerPort
+		if err := json.Unmarshal(aux.Config, &t); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "timer config")
+		}
+		p.Config = t
+	case "network", "http", "grpc", "websocket-server":
+		var n NetworkPort
+		if err := json.Unmarshal(aux.Config, &n); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "network config")
+		}
+		p.Config = n
+	case "file":
+		var f FilePort
+		if err := json.Unmarshal(aux.Config, &f); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "file config")
+		}
+		p.Config = f
+	default:
+		// Unknown port type — preserve pre-fix behaviour by decoding the
+		// raw config into a generic map. Forward-compat for custom port
+		// types not yet known to the framework.
+		var m map[string]any
+		if err := json.Unmarshal(aux.Config, &m); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON",
+				fmt.Sprintf("unknown port type %q config", p.Type))
+		}
+		p.Config = m
+	}
+	return nil
 }
 
 // PortConfig represents port configuration in component config
@@ -108,7 +212,11 @@ func BuildPortFromDefinition(def PortDefinition, direction Direction) Port {
 			StreamName: def.StreamName,
 			Subjects:   []string{def.Subject}, // Convert single subject to array
 		}
-		// Merge additional config if provided
+		// Merge additional config if provided. PortDefinition.UnmarshalJSON
+		// guarantees def.Config is a JetStreamPort struct (not a generic
+		// map[string]any) when the raw JSON had `"type":"jetstream"`, so
+		// the type assertion succeeds for both Go-constructed and JSON-
+		// loaded definitions.
 		if configPort, ok := def.Config.(JetStreamPort); ok {
 			if configPort.DeliverPolicy != "" {
 				jsPort.DeliverPolicy = configPort.DeliverPolicy
@@ -121,6 +229,12 @@ func BuildPortFromDefinition(def PortDefinition, direction Direction) Port {
 			}
 			if configPort.ConsumerName != "" {
 				jsPort.ConsumerName = configPort.ConsumerName
+			}
+			if configPort.AckWait != "" {
+				jsPort.AckWait = configPort.AckWait
+			}
+			if configPort.HeartbeatInterval != "" {
+				jsPort.HeartbeatInterval = configPort.HeartbeatInterval
 			}
 		}
 		port.Config = jsPort


### PR DESCRIPTION
## Summary

semspec walked beta.54 against a deterministic JSON repro and found the new per-port `AckWait`/`HeartbeatInterval` fields land on the right structs but **the JSON unmarshal path doesn't reach them.** Worse, the bug also drops the **pre-existing** `MaxDeliver`/`DeliverPolicy`/`AckPolicy`/`ConsumerName` fields whenever they're set inside a port's `config: {...}` block — so any operator who thought they were tuning consumer config via YAML/JSON has been silently running default values.

## Root cause

`PortDefinition.Config` is typed `any`. Default JSON unmarshal puts a `map[string]interface{}` there, never a `JetStreamPort` struct. Every type assertion downstream (`BuildPortFromDefinition`, `applyJetStreamConsumerConfig`) silently fails on JSON-loaded configs and falls through to defaults.

## Three gaps closed

### Gap A — `PortDefinition.UnmarshalJSON`
New custom unmarshal mirrors `Port.UnmarshalJSON`'s type-discriminated pattern, switching on `p.Type` and unmarshaling raw config into the matching typed struct. Supports `jetstream` / `nats` / `nats-request` / `kvwatch` / `kvwrite` / `timer` / `network`/`http`/`grpc`/`websocket-server` / `file`. Unknown types fall through to `map[string]any` for forward-compat.

### Gap B — `BuildPortFromDefinition` jetstream case missing `AckWait` + `HeartbeatInterval`
Beta.54 added the fields to `JetStreamPort` but didn't add the merge branch in `BuildPortFromDefinition`. Two if-non-empty assignments mirroring the existing pattern.

### Gap C — Round-trip tests close the load-bearing path
Five new tests covering JSON → PortDefinition → ConsumerConfig end-to-end, no-config round-trip, unknown-type forward-compat, and the Go-constructed BuildPortFromDefinition merge.

## Test plan

- [x] `TestPortDefinition_UnmarshalJSON_JetStreamConfig` — full 6-field unmarshal (the test that would have caught beta.54 pre-merge)
- [x] `TestPortDefinition_UnmarshalJSON_RoundTripsToConsumerConfig` — JSON → PortDefinition → GetConsumerConfigFromDefinition end-to-end
- [x] `TestPortDefinition_UnmarshalJSON_NoConfig` — missing config block, no panic
- [x] `TestPortDefinition_UnmarshalJSON_UnknownType` — forward-compat
- [x] `TestBuildPortFromDefinition_CopiesAckWaitAndHeartbeat` — second half of Gap B
- [x] `task lint` clean
- [x] `go test -race ./...` — full suite green
- [x] `go vet -tags=integration ./...` — clean
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `task schema:generate` diff — empty
- [x] `task e2e:agentic` — green (15.85s, 3 loops, 3 tool executions)

## Test gap (broader concern)

The class of bug — type-assertion on a JSON-loaded `any` field — is not unique to PortDefinition. Worth a follow-up audit for every other `.Config.(SomeType)` assertion in the codebase to verify each has an end-to-end JSON test, not just a Go-constructed one. Will scope after this hotfix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)