### PR TITLE
feat(agentic,agentic-loop): stamp agent.loop.parent on failed loops for ancestry walks (semteams ADR-038 PR B)

### DIFF
--- a/agentic/events.go
+++ b/agentic/events.go
@@ -103,17 +103,27 @@ func (e *LoopCompletedEvent) UnmarshalJSON(data []byte) error {
 
 // LoopFailedEvent is published when a loop fails.
 type LoopFailedEvent struct {
-	LoopID       string    `json:"loop_id"`
-	TaskID       string    `json:"task_id"`
-	Outcome      string    `json:"outcome"` // OutcomeFailed
-	Reason       string    `json:"reason"`
-	Error        string    `json:"error"`
-	Role         string    `json:"role"`
-	Prompt       string    `json:"prompt,omitempty"` // Original user task prompt; enables NL/BM25 search
-	Model        string    `json:"model"`
-	Iterations   int       `json:"iterations"`
-	TokensIn     int       `json:"tokens_in"`
-	TokensOut    int       `json:"tokens_out"`
+	LoopID     string `json:"loop_id"`
+	TaskID     string `json:"task_id"`
+	Outcome    string `json:"outcome"` // OutcomeFailed
+	Reason     string `json:"reason"`
+	Error      string `json:"error"`
+	Role       string `json:"role"`
+	Prompt     string `json:"prompt,omitempty"` // Original user task prompt; enables NL/BM25 search
+	Model      string `json:"model"`
+	Iterations int    `json:"iterations"`
+	TokensIn   int    `json:"tokens_in"`
+	TokensOut  int    `json:"tokens_out"`
+	// ParentLoopID enables ancestry walks from failed loops — required by
+	// chain-aware failure handlers (e.g. semteams chainpause writing
+	// chain.paused.* triples to the canonical chain entity per ADR-038).
+	// Without this, the agent.loop.parent triple wasn't stamped on the
+	// failed loop, so an ancestry walk terminated at the failure and
+	// returned chain_id == failed_loop_id even when the failed loop
+	// wasn't the chain root. Populated at construction the same way
+	// LoopCompletedEvent.ParentLoopID is — entity.ParentLoopID flows
+	// through.
+	ParentLoopID string    `json:"parent_loop,omitempty"`
 	WorkflowSlug string    `json:"workflow_slug,omitempty"`
 	WorkflowStep string    `json:"workflow_step,omitempty"`
 	FailedAt     time.Time `json:"failed_at"`

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -182,7 +182,7 @@ func (w *graphWriter) WriteLoopFailure(ctx context.Context, event *agentic.LoopF
 
 	cost := computeCost(w.modelRegistry, event.Model, event.TokensIn, event.TokensOut)
 
-	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, cost)
+	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, cost, w.platform.Org, w.platform.Platform)
 	for _, t := range triples {
 		if err := w.writeTriple(ctx, t); err != nil {
 			w.logger.Warn("graph_writer: failed to write loop failure triple",
@@ -438,11 +438,15 @@ func buildLoopCompletionTriples(
 
 // buildLoopFailureTriples constructs triples for a loop that terminated with an error.
 // cost should be pre-computed via computeCost; pass 0.0 to omit the cost triple.
+// org and platform are required to construct the parent loop's 6-part entity ID
+// when event.ParentLoopID is set — required for ancestry walks from failed loops
+// (semteams ADR-038 chainpause).
 func buildLoopFailureTriples(
 	loopEntityID string,
 	event *agentic.LoopFailedEvent,
 	modelEntityID string,
 	cost float64,
+	org, platform string,
 ) []message.Triple {
 	now := time.Now()
 	triple := func(predicate string, object any) message.Triple {
@@ -471,6 +475,15 @@ func buildLoopFailureTriples(
 	}
 	if cost > 0 {
 		triples = append(triples, triple(agvocab.LoopCostUSD, cost))
+	}
+	if event.ParentLoopID != "" {
+		// Mirrors buildLoopCompletionTriples — ancestry walks need the
+		// agent.loop.parent triple on failed loops too. Without this,
+		// chain-aware failure handlers (chainpause writing chain.paused.*
+		// to the canonical chain entity) terminate the walk at the
+		// failure and stamp triples on the wrong entity. ADR-038.
+		parentEntityID := agentic.LoopExecutionEntityID(org, platform, event.ParentLoopID)
+		triples = append(triples, triple(agvocab.LoopParent, parentEntityID))
 	}
 	if event.WorkflowSlug != "" {
 		triples = append(triples, triple(agvocab.LoopWorkflow, event.WorkflowSlug))

--- a/processor/agentic-loop/graph_writer_ops_test.go
+++ b/processor/agentic-loop/graph_writer_ops_test.go
@@ -96,7 +96,7 @@ func TestOpsQuery_LoopOutcomeByRole(t *testing.T) {
 				Iterations: r.iterations,
 				FailedAt:   time.Now(),
 			}
-			allTriples = append(allTriples, buildLoopFailureTriples(entityID, event, "", 0)...)
+			allTriples = append(allTriples, buildLoopFailureTriples(entityID, event, "", 0, "acme", "ops")...)
 		}
 	}
 

--- a/processor/agentic-loop/graph_writer_test.go
+++ b/processor/agentic-loop/graph_writer_test.go
@@ -334,7 +334,7 @@ func TestBuildLoopFailureTriples_PromptEmittedAsDescription(t *testing.T) {
 		FailedAt:   time.Now(),
 	}
 
-	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, 0)
+	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, 0, "acme", "ops")
 
 	if got := objectFor(triples, agvocab.LoopDescription); got != prompt {
 		t.Errorf("%s: got %v, want %q", agvocab.LoopDescription, got, prompt)
@@ -454,7 +454,7 @@ func TestBuildLoopFailureTriples_RequiredFields(t *testing.T) {
 		FailedAt:   time.Now(),
 	}
 
-	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, 0)
+	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, 0, "acme", "ops")
 	predicates := predicateSet(triples)
 
 	required := []string{
@@ -496,14 +496,60 @@ func TestBuildLoopFailureTriples_OptionalFieldsOmittedWhenEmpty(t *testing.T) {
 		FailedAt:   time.Now(),
 	}
 
-	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, 0)
+	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, 0, "acme", "ops")
 	predicates := predicateSet(triples)
 
-	optional := []string{agvocab.LoopWorkflow, agvocab.LoopWorkflowStep, agvocab.LoopUser}
+	// ParentLoopID belongs to the optional set — when empty (failure on a
+	// chain root or a non-chain-fanned spawn), no agent.loop.parent triple
+	// should be emitted.
+	optional := []string{agvocab.LoopWorkflow, agvocab.LoopWorkflowStep, agvocab.LoopUser, agvocab.LoopParent}
 	for _, pred := range optional {
 		if predicates[pred] {
 			t.Errorf("expected predicate %s to be omitted when empty", pred)
 		}
+	}
+}
+
+// TestBuildLoopFailureTriples_StampsParentLoopID closes the ancestry-walk
+// gap from semteams ADR-038 PR B: chain-aware failure handlers
+// (chainpause writing chain.paused.* to the canonical chain entity) need
+// agent.loop.parent stamped on failed loops to walk ancestry from the
+// failure to the chain root. Mirrors
+// TestBuildLoopCompletionTriples_OptionalFieldsPresentWhenSet's parent
+// assertion. Without this, the walk terminates at the failure and stamps
+// chain triples to the wrong entity.
+func TestBuildLoopFailureTriples_StampsParentLoopID(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.loopFailChild"
+	modelEntityID := "acme.ops.agent.model-registry.endpoint.claude"
+
+	event := &agentic.LoopFailedEvent{
+		LoopID:       "loopFailChild",
+		TaskID:       "task-fail-child",
+		Outcome:      "failed",
+		Role:         "researcher",
+		Model:        "claude",
+		Iterations:   3,
+		ParentLoopID: "loopParentXYZ",
+		FailedAt:     time.Now(),
+	}
+
+	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, 0, "acme", "ops")
+	predicates := predicateSet(triples)
+
+	if !predicates[agvocab.LoopParent] {
+		t.Fatalf("expected agent.loop.parent triple on failure path; got predicates: %v", predicates)
+	}
+
+	parent, ok := objectFor(triples, agvocab.LoopParent).(string)
+	if !ok {
+		t.Fatal("LoopParent object is not a string")
+	}
+	want := "acme.ops.agent.agentic-loop.execution.loopParentXYZ"
+	if parent != want {
+		t.Errorf("LoopParent = %q, want %q", parent, want)
+	}
+	if !message.IsValidEntityID(parent) {
+		t.Errorf("LoopParent %q is not a valid 6-part entity ID", parent)
 	}
 }
 
@@ -527,7 +573,7 @@ func TestBuildLoopFailureTriples_OptionalFieldsPresentWhenSet(t *testing.T) {
 	}
 
 	cost := 0.005
-	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, cost)
+	triples := buildLoopFailureTriples(loopEntityID, event, modelEntityID, cost, "acme", "ops")
 	predicates := predicateSet(triples)
 
 	optional := []string{
@@ -569,7 +615,7 @@ func TestBuildLoopFailureTriples_EmptyModelOmitsModelUsed(t *testing.T) {
 		FailedAt:   time.Now(),
 	}
 
-	triples := buildLoopFailureTriples(loopEntityID, event, "", 0)
+	triples := buildLoopFailureTriples(loopEntityID, event, "", 0, "acme", "ops")
 	predicates := predicateSet(triples)
 
 	if predicates[agvocab.LoopModelUsed] {

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -1844,6 +1844,7 @@ func (h *MessageHandler) buildFailureEvent(loopID, reason, errorMsg string) (*ag
 		Prompt:       h.loopManager.GetTaskPrompt(loopID),
 		Model:        entity.Model,
 		Iterations:   entity.Iterations,
+		ParentLoopID: entity.ParentLoopID,
 		WorkflowSlug: entity.WorkflowSlug,
 		WorkflowStep: entity.WorkflowStep,
 		FailedAt:     time.Now(),


### PR DESCRIPTION
## Summary

Closes the failed-loop ancestry gap semteams flagged for chainpause. `buildLoopCompletionTriples` stamps `agent.loop.parent` on success; `buildLoopFailureTriples` didn't, and `LoopFailedEvent` had no `ParentLoopID` field at all. With the gap, an ancestry walk from a failed loop terminated at the failure and returned `chain_id == failed_loop_id` — chainpause's `chain.paused.*` triples landed on a sibling chain entity whenever a non-root role failed. Verified at `processor/agentic-loop/graph_writer.go:441-489` against beta.54.

## Changes

1. **`agentic.LoopFailedEvent.ParentLoopID`** — `json:"parent_loop,omitempty"`, mirrors `LoopCompletedEvent.ParentLoopID`. Pure schema addition.
2. **`buildFailureEvent` populates `ParentLoopID: entity.ParentLoopID`** — same flow as the completion event. `entity.ParentLoopID` is already set by `SetParentLoopID` from `TaskMessage.ParentLoopID`, including the rule-fanned spawns beta.54 PR #40 added.
3. **`buildLoopFailureTriples` stamps `agvocab.LoopParent`** when `event.ParentLoopID != ""`, mirroring `buildLoopCompletionTriples:419-422`. Signature gains `org, platform` parameters to construct the parent's 6-part entity ID via `LoopExecutionEntityID`. `WriteLoopFailure` caller + six test call sites updated.
4. **`TestBuildLoopFailureTriples_StampsParentLoopID`** — new test asserts the triple is emitted with the correct 6-part entity ID. Existing optional-omitted test extended to confirm the parent triple is omitted when `ParentLoopID` is empty (back-compat for chain-root failures).

## Out of scope (semteams scoping)

- `LoopCancelledEvent` has the same shape gap. semteams scoped this PR to the failure path because chainpause's smoke #8 repro is researcher-with-source-acquisition failure. Cancellation ancestry deferred pending a separate ask.
- Chain-aware subjects on the failure event itself. Resolver derives chain_id from the ancestry walk; failure event stays minimal per ADR-038.

## Test plan

- [x] `TestBuildLoopFailureTriples_StampsParentLoopID` — happy path, 6-part entity ID assertion
- [x] `TestBuildLoopFailureTriples_OptionalFieldsOmittedWhenEmpty` — extended to assert `agvocab.LoopParent` omitted when `ParentLoopID == ""`
- [x] `task lint` clean
- [x] `go test -race ./...` — full suite green
- [x] `go vet -tags=integration ./...` — clean
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `task schema:generate` diff — empty
- [x] `task e2e:agentic` — green (15.82s, 3 loops, 2 tool executions through unchanged success paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)