### PR TITLE
fix(agentic-loop): write graph triples before publishing agent.complete (semteams ADR-038 PR B race)

### DIFF
--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -1035,25 +1035,122 @@ func (c *Component) recordTerminalState(result HandlerResult, entity agentic.Loo
 	}
 }
 
+// graphWritePublishBudget bounds how long persistHandlerResult delays
+// publishResults waiting for WriteLoopCompletion / WriteLoopFailure to
+// stamp the loop-execution entity in graph KV. Each writeTriple inside
+// the writer has its own 5s graphWriterTimeout with retry, so this
+// budget caps the total tail latency when retries cascade or the NATS
+// subscription hasn't propagated yet.
+//
+// 2s is generous for healthy graph-gateway (a typical completion stamps
+// ~10-15 triples in well under a second). When the budget expires we
+// publish anyway and emit a Prom counter so operators can dashboard
+// the tail. Tighten if production sees significant tail; widen only
+// after confirming the writer's retry budget is the actual bottleneck.
+const graphWritePublishBudget = 2 * time.Second
+
 // persistHandlerResult publishes messages and persists state from a handler result.
+//
+// The terminal-state branch reorders graph writes BEFORE publishResults
+// so any subscriber consuming agent.complete.<loop_id> from JetStream
+// can immediately walk loop-entity triples (agent.loop.parent etc.)
+// without racing the writer. Pre-fix order had publishResults first,
+// which meant a fast subscriber could resolve ancestry against a
+// missing parent triple. Concrete consumer was semteams ADR-038 PR B
+// chain.evidence.* (project_open_work_2026_05_08.md bug class 4).
+//
+// runWithBudget caps how long we delay the publish on a slow graph
+// write — graph-gateway hiccups must NOT silently swallow the
+// agent.complete.* event downstream rules wait on. On budget timeout,
+// publish proceeds with a loud log and Prom counter increment.
 func (c *Component) persistHandlerResult(ctx context.Context, result HandlerResult) {
-	c.publishResults(ctx, result)
 	c.persistLoopState(ctx, result.LoopID)
 
-	// Finalize terminal states
 	if result.State == agentic.LoopStateComplete || result.State == agentic.LoopStateFailed {
 		c.finalizeTrajectory(ctx, result.LoopID, result.State)
 		c.cleanupBoidPosition(ctx, result.LoopID)
 		if result.CompletionState != nil {
 			c.persistCompletionState(ctx, result.LoopID, result.CompletionState)
-			// Emit loop execution entity to graph (non-fatal)
-			if c.graphWriter != nil {
-				c.graphWriter.WriteLoopCompletion(ctx, result.CompletionState)
-			}
-		} else if result.FailureState != nil && c.graphWriter != nil {
-			c.graphWriter.WriteLoopFailure(ctx, result.FailureState)
+			c.stampLoopCompletionWithBudget(ctx, result.LoopID, result.CompletionState)
+		} else if result.FailureState != nil {
+			c.stampLoopFailureWithBudget(ctx, result.LoopID, result.FailureState)
 		}
 		c.writeTrajectoryToGraph(ctx, result.LoopID)
+	}
+
+	c.publishResults(ctx, result)
+}
+
+// stampLoopCompletionWithBudget invokes WriteLoopCompletion under the
+// graphWritePublishBudget. Records a Prom timeout when the budget
+// expires before the writer returns; publish proceeds either way.
+func (c *Component) stampLoopCompletionWithBudget(ctx context.Context, loopID string, completion *agentic.LoopCompletedEvent) {
+	if c.graphWriter == nil {
+		return
+	}
+	timedOut := runWithBudget(ctx, graphWritePublishBudget, func(bctx context.Context) {
+		c.graphWriter.WriteLoopCompletion(bctx, completion)
+	})
+	if timedOut {
+		c.logger.Warn("graph write budget expired before completion stamp returned; publishing agent.complete anyway",
+			"loop_id", loopID,
+			"budget", graphWritePublishBudget,
+			"state", "complete")
+		if c.metrics != nil {
+			c.metrics.recordGraphWritePublishTimeout("complete")
+		}
+	}
+}
+
+// stampLoopFailureWithBudget mirrors stampLoopCompletionWithBudget for
+// the failure branch. semteams smoke-#7 reproduced the race on
+// researcher-failure specifically (failed loops still need
+// agent.loop.parent visible for ancestry walks), so the failure path
+// gets the same budgeted-write treatment as completion.
+func (c *Component) stampLoopFailureWithBudget(ctx context.Context, loopID string, failure *agentic.LoopFailedEvent) {
+	if c.graphWriter == nil {
+		return
+	}
+	timedOut := runWithBudget(ctx, graphWritePublishBudget, func(bctx context.Context) {
+		c.graphWriter.WriteLoopFailure(bctx, failure)
+	})
+	if timedOut {
+		c.logger.Warn("graph write budget expired before failure stamp returned; publishing agent.complete anyway",
+			"loop_id", loopID,
+			"budget", graphWritePublishBudget,
+			"state", "failure")
+		if c.metrics != nil {
+			c.metrics.recordGraphWritePublishTimeout("failure")
+		}
+	}
+}
+
+// runWithBudget runs fn in a goroutine and waits for it to return,
+// bounded by budget. Returns true if the budget expired before fn
+// returned (the goroutine continues running with a cancelled child
+// context; its inner NATS calls will see ctx.Done and abort cleanly).
+//
+// Extracted so the timeout-vs-completion contract is unit-testable
+// without mocking the natsclient or graphWriter. The function is
+// deliberately small: testing it covers the bounded-wait shape;
+// testing the reorder-before-publish behavior is left to e2e:agentic
+// where the full graph-stamp-then-publish path runs against real
+// NATS and subscribers can observe the ordering effect.
+func runWithBudget(ctx context.Context, budget time.Duration, fn func(context.Context)) (timedOut bool) {
+	bctx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn(bctx)
+	}()
+
+	select {
+	case <-done:
+		return false
+	case <-bctx.Done():
+		return true
 	}
 }
 

--- a/processor/agentic-loop/metrics.go
+++ b/processor/agentic-loop/metrics.go
@@ -49,6 +49,9 @@ type loopMetrics struct {
 	boidSignalsReceived  *prometheus.CounterVec
 	boidPositionUpdates  prometheus.Counter
 	boidEntitiesFiltered prometheus.Counter
+
+	// Graph-write-before-publish ordering
+	graphWritePublishTimeouts *prometheus.CounterVec
 }
 
 // Package-level metrics (registered once to avoid duplicate registration errors)
@@ -219,6 +222,13 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 				Name:      "boid_entities_filtered_total",
 				Help:      "Total times entities were reordered by Boid steering",
 			}),
+
+			graphWritePublishTimeouts: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "agentic_loop",
+				Name:      "graph_write_publish_timeout_total",
+				Help:      "Total times the graph-write-before-publish budget expired before WriteLoopCompletion/WriteLoopFailure returned. The agent.complete.* event was published anyway (best-effort preserved), but the loop entity's graph triples may not yet be visible to subscribers walking ancestry. Sustained non-zero rate points at graph-gateway latency or NATS subscription propagation issues; a tightenable budget is at graphWritePublishBudget in component.go.",
+			}, []string{"state"}),
 		}
 
 		// Register metrics with the metrics registry if available
@@ -245,6 +255,7 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 			_ = registry.RegisterCounter("agentic-loop", "context_compactions_total", metrics.contextCompactionsTotal)
 			_ = registry.RegisterHistogram("agentic-loop", "context_compaction_tokens_saved", metrics.contextCompactionTokensSaved)
 			_ = registry.RegisterGauge("agentic-loop", "context_compacted_region_tokens", metrics.contextCompactedRegionTokens)
+			_ = registry.RegisterCounterVec("agentic-loop", "graph_write_publish_timeout_total", metrics.graphWritePublishTimeouts)
 		} else {
 			// Fallback to default prometheus registry for testing
 			_ = prometheus.DefaultRegisterer.Register(metrics.loopsCreated)
@@ -269,9 +280,18 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextCompactionsTotal)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextCompactionTokensSaved)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextCompactedRegionTokens)
+			_ = prometheus.DefaultRegisterer.Register(metrics.graphWritePublishTimeouts)
 		}
 	})
 	return metrics
+}
+
+// recordGraphWritePublishTimeout increments the counter when the
+// graph-write-before-publish budget expired before WriteLoopCompletion
+// or WriteLoopFailure returned. State is "complete" or "failure" to
+// match persistHandlerResult's terminal-state branches.
+func (m *loopMetrics) recordGraphWritePublishTimeout(state string) {
+	m.graphWritePublishTimeouts.WithLabelValues(state).Inc()
 }
 
 // recordLoopCreated increments the loops created counter and active gauge.

--- a/processor/agentic-loop/persist_handler_result_test.go
+++ b/processor/agentic-loop/persist_handler_result_test.go
@@ -1,0 +1,121 @@
+package agenticloop
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestRunWithBudget_ReturnsCompletedFalseWhenFnReturnsFast asserts the
+// happy path: when fn returns well within the budget, runWithBudget
+// reports timedOut=false. This is the case persistHandlerResult relies
+// on for the publish-after-stamp ordering — the publish proceeds with
+// the graph triple guaranteed visible.
+func TestRunWithBudget_ReturnsCompletedFalseWhenFnReturnsFast(t *testing.T) {
+	var ran atomic.Bool
+	timedOut := runWithBudget(context.Background(), 100*time.Millisecond, func(_ context.Context) {
+		ran.Store(true)
+	})
+	if timedOut {
+		t.Errorf("expected timedOut=false for fast fn, got true")
+	}
+	if !ran.Load() {
+		t.Errorf("expected fn to have run")
+	}
+}
+
+// TestRunWithBudget_ReturnsTimedOutTrueWhenFnExceedsBudget asserts the
+// degraded-graph-gateway path: when fn exceeds the budget,
+// runWithBudget returns timedOut=true and the caller proceeds with
+// publishResults. The fn goroutine's bctx is cancelled so its inner
+// NATS request aborts cleanly without leaking.
+func TestRunWithBudget_ReturnsTimedOutTrueWhenFnExceedsBudget(t *testing.T) {
+	var bctxCancelled atomic.Bool
+	timedOut := runWithBudget(context.Background(), 20*time.Millisecond, func(bctx context.Context) {
+		select {
+		case <-bctx.Done():
+			bctxCancelled.Store(true)
+		case <-time.After(500 * time.Millisecond):
+			t.Errorf("fn ran past 500ms — bctx should have been cancelled at 20ms")
+		}
+	})
+	if !timedOut {
+		t.Errorf("expected timedOut=true when fn exceeds budget")
+	}
+	// Give the goroutine a beat to observe its bctx cancellation
+	time.Sleep(50 * time.Millisecond)
+	if !bctxCancelled.Load() {
+		t.Errorf("expected fn's bctx to have been cancelled when budget expired")
+	}
+}
+
+// TestRunWithBudget_ParentContextCancellationPropagates asserts that a
+// caller-side ctx cancellation (e.g. component shutdown) reaches fn.
+// runWithBudget's bctx is derived from ctx, so cancelling ctx cancels
+// bctx, which cancels fn. timedOut is true (since bctx.Done fired),
+// matching the contract: any reason for not completing returns true.
+//
+// fnObserved is a channel rather than an atomic.Value so the test
+// deterministically waits for the goroutine to record the cancellation
+// before asserting — runWithBudget can return BEFORE the goroutine has
+// run to its bctx-read, which would race a value-based assertion.
+func TestRunWithBudget_ParentContextCancellationPropagates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before runWithBudget so bctx is born cancelled
+	fnObserved := make(chan error, 1)
+	timedOut := runWithBudget(ctx, 1*time.Second, func(bctx context.Context) {
+		<-bctx.Done()
+		fnObserved <- bctx.Err()
+	})
+	if !timedOut {
+		t.Errorf("expected timedOut=true on parent-ctx cancellation")
+	}
+	select {
+	case err := <-fnObserved:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected fn to see context.Canceled, got %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Errorf("fn never observed bctx cancellation")
+	}
+}
+
+// TestRunWithBudget_GoroutineDoesNotBlockReturnAfterTimeout asserts the
+// non-leaking property: after timedOut=true, runWithBudget returns
+// immediately even if fn is still running. The lingering goroutine
+// will exit on its own once it hits a bctx-aware syscall. This is the
+// production guarantee: a hung graph write does not block the publish
+// or the next handler iteration.
+func TestRunWithBudget_GoroutineDoesNotBlockReturnAfterTimeout(t *testing.T) {
+	start := time.Now()
+	timedOut := runWithBudget(context.Background(), 10*time.Millisecond, func(_ context.Context) {
+		// Deliberately ignore the bctx — simulates a NATS request that
+		// hasn't yet hit a checkpoint where ctx is observed.
+		time.Sleep(200 * time.Millisecond)
+	})
+	elapsed := time.Since(start)
+	if !timedOut {
+		t.Errorf("expected timedOut=true")
+	}
+	// Allow generous slack for CI scheduler noise; the assertion is
+	// "well under 200ms" not "exactly 10ms".
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("runWithBudget blocked %v waiting for slow fn to return; should bound at budget+ε", elapsed)
+	}
+}
+
+// TestGraphWritePublishBudget_IsReasonable is a guard against
+// accidentally setting the budget to zero or to a value so large it
+// defeats the bounded-wait property. 2s is the chosen value (see
+// const doc); this test fires if someone changes the constant without
+// thinking. Tighten/widen here when changing the constant.
+func TestGraphWritePublishBudget_IsReasonable(t *testing.T) {
+	if graphWritePublishBudget < 100*time.Millisecond {
+		t.Errorf("graphWritePublishBudget too tight (%v); healthy graph-gateway will trip the timeout under normal load", graphWritePublishBudget)
+	}
+	if graphWritePublishBudget > 10*time.Second {
+		t.Errorf("graphWritePublishBudget too wide (%v); defeats the bounded-wait property — publish can be delayed by a degraded graph-gateway", graphWritePublishBudget)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of the 2026-05-08 audit (`project_open_work_2026_05_08.md` bug class 4). Closes the write-publish ordering race in `persistHandlerResult` that semteams flagged as a follow-on to the failed-loop ancestry fix (beta.55/.56).

## The race

Pre-fix `persistHandlerResult` (lines 1040-1057) ran `publishResults` (which sends `agent.complete.<loop_id>` to JetStream) BEFORE `graphWriter.WriteLoopCompletion` synchronously stamped the loop entity's `agent.loop.parent` triple. JetStream subscribers run on separate goroutines/processes; a fast subscriber consuming the published event and immediately reading `agent.loop.parent` could see no triple — the writer hadn't gotten there yet.

Concrete consumer: `cmd/semteams/evidence/preprocessor.go::stampChainTriples` walks ancestry via `chain.Resolver` to compute `chain_entity_id`. When the race fired, resolver found no parent triple, returned `chain_id == builder_loop_id`, and `chain.evidence.*` landed on a phantom chain entity. Behavioral impact today is zero (rule_07 reads loop-entity triples directly during ADR-038 PR B drift-safe phasing); becomes silent data corruption once cross-arc consumers (ops agent, future analytics) walk the chain entity.

## The fix — Option A from semteams' alternatives

Reorder so `WriteLoopCompletion` / `WriteLoopFailure` complete BEFORE `publishResults`. Both terminal-state branches reordered (semteams smoke-#7 reproduced the race on researcher *failure* specifically).

Bounded by `graphWritePublishBudget = 2s` so a degraded graph-gateway never holds the publish indefinitely. On budget timeout: publish proceeds anyway, log loud, increment Prom counter `semstreams_agentic_loop_graph_write_publish_timeout_total{state}`. Preserves the prior best-effort property — graph-store hiccups must not silently swallow `agent.complete.*` that downstream rules wait on.

The ordering is implemented via `runWithBudget(ctx, budget, fn)` — a small standalone helper that's testable in isolation without mocking natsclient or graphWriter.

## Why Option A over Option C (separate barrier event)

Option A makes the existing `agent.complete.*` semantically honest ("complete means complete") — every existing subscriber benefits, no migration. Option C (add `agent.complete.stamped.<loop_id>`, leave the original racy) papers over the bug class without fixing the naming-vs-meaning mismatch.

In this codebase no existing subscriber depends on the fast-publish behavior Option C preserves. Option A is neutral re: a future Option C — adding a richer barrier event later is purely additive, not a migration. Future-direction note captured for if/when richer post-completion semantics surface.

## Behavior changes for downstreams

- **Ancestry-walking consumers** (semteams `chain.evidence.*`, future ops/analytics): parent triple now visible by the time the JetStream event arrives, in the common path. On graph-gateway latency above 2s, the timeout counter trips and the consumer falls back to the same race window as today.
- **Existing fast-only subscribers** (rules engine, semteams direct loop-entity readers): no behavior change in the common path; in pathological graph-gateway-degraded cases see up to 2s additional latency on `agent.complete.*` delivery.

Behaviorally additive — nothing previously working breaks; the only new observable is an event that already arrived now arrives slightly later in the success case.

## Test plan

- [x] `task lint` clean (revive, vet, fmt)
- [x] `go test -race ./...` full suite green
- [x] `task schema:generate` diff empty (no payload schema change)
- [x] 5 new unit tests for `runWithBudget` + budget-constant guard, all green
- [x] `task e2e:agentic` green (15.97s, 3 loops, 2 tool executions, 14 graph_loop_triples + 5 graph_model_triples). Same shape as Phase 1 baseline (15.87s) — reorder adds no observable end-to-end latency at e2e scale.
- [ ] Reviewer to confirm 2s budget is reasonable (default; tightenable by changing `graphWritePublishBudget` const)
- [ ] Reviewer to confirm Prom counter shape matches dashboard conventions
- [ ] semteams to confirm `chain.evidence.*` resolves correctly post-merge (dev env smoke)

## Independent of PR #45

This branches off main, not PR #45. Different files (agentic-loop only), no merge conflicts. Either order of merge works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)