### PR TITLE
fix(agentic-loop,agentic-tools,github-webhook): close three silent-failure modes from 2026-05-08 audit

### DIFF
--- a/input/github-webhook/component.go
+++ b/input/github-webhook/component.go
@@ -78,7 +78,14 @@ func NewInput(name string, natsClient *natsclient.Client, cfg Config, logger *sl
 		logger = slog.Default()
 	}
 
-	// Resolve output subjects from port config.
+	// Resolve output subjects from port config. The publish call sites
+	// (dispatch func) index this map by the canonical port names below;
+	// an operator-renamed port (e.g. Name:"issues" instead of
+	// "github.event.issue") would silently land in the map under the
+	// rename while publish lookups by canonical key returned the default
+	// subject — events publish to the default while operator's intended
+	// subscribers see nothing. Validate up front and fail loud on
+	// unknown names. Audit finding 2026-05-08.
 	subjects := map[string]string{
 		"github.event.issue":   "github.event.issue",
 		"github.event.pr":      "github.event.pr",
@@ -87,6 +94,12 @@ func NewInput(name string, natsClient *natsclient.Client, cfg Config, logger *sl
 	}
 	if cfg.Ports != nil {
 		for _, p := range cfg.Ports.Outputs {
+			if _, canonical := subjects[p.Name]; !canonical {
+				return nil, errs.WrapInvalid(
+					fmt.Errorf("unknown output port name %q (must be one of: github.event.issue, github.event.pr, github.event.review, github.event.comment)", p.Name),
+					"github_webhook", "NewInput", "port name validation",
+				)
+			}
 			if p.Subject != "" {
 				subjects[p.Name] = p.Subject
 			}

--- a/input/github-webhook/component_port_validation_test.go
+++ b/input/github-webhook/component_port_validation_test.go
@@ -1,0 +1,152 @@
+package githubwebhook
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// TestNewInput_RejectsUnknownOutputPortNames closes the silent-rename
+// gap from the 2026-05-08 audit (project_audit_findings_2026_05_08.md
+// Finding 1). Pre-fix, an operator config that renamed an output port
+// (e.g. Name:"issues" instead of "github.event.issue") silently landed
+// in the outputSubjects map under the rename, while publish call sites
+// indexed by the canonical key still returned the default subject.
+// Events kept publishing to the default — operator's intended
+// subscribers saw nothing while the framework happily delivered to
+// noone.
+//
+// Loud-not-silent fix: validate operator-supplied port names against
+// the four canonical event types at construction; error on unknown.
+//
+// natsClient must be non-nil (early NewInput check) but no methods
+// are invoked before port validation, so a zero-value client suffices.
+func TestNewInput_RejectsUnknownOutputPortNames(t *testing.T) {
+	tests := []struct {
+		name          string
+		ports         *component.PortConfig
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		{
+			name:    "nil Ports — accepted (uses canonical defaults)",
+			ports:   nil,
+			wantErr: false,
+		},
+		{
+			name: "empty Outputs — accepted (no overrides to validate)",
+			ports: &component.PortConfig{
+				Outputs: []component.PortDefinition{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "all four canonical names with subject overrides — accepted",
+			ports: &component.PortConfig{
+				Outputs: []component.PortDefinition{
+					{Name: "github.event.issue", Subject: "custom.issues"},
+					{Name: "github.event.pr", Subject: "custom.prs"},
+					{Name: "github.event.review", Subject: "custom.reviews"},
+					{Name: "github.event.comment", Subject: "custom.comments"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "subset of canonical names — accepted (partial overrides preserve defaults)",
+			ports: &component.PortConfig{
+				Outputs: []component.PortDefinition{
+					{Name: "github.event.issue", Subject: "custom.issues"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "operator-renamed port — rejected loud (the audit-finding shape)",
+			ports: &component.PortConfig{
+				Outputs: []component.PortDefinition{
+					{Name: "issues", Subject: "custom.issues"},
+				},
+			},
+			wantErr:       true,
+			wantErrSubstr: "unknown output port name",
+		},
+		{
+			name: "typo in canonical name — rejected loud",
+			ports: &component.PortConfig{
+				Outputs: []component.PortDefinition{
+					{Name: "github.event.issuue", Subject: "custom.issues"},
+				},
+			},
+			wantErr:       true,
+			wantErrSubstr: "unknown output port name",
+		},
+		{
+			name: "mix of canonical and unknown — rejected on first unknown",
+			ports: &component.PortConfig{
+				Outputs: []component.PortDefinition{
+					{Name: "github.event.issue", Subject: "custom.issues"},
+					{Name: "github.event.bogus", Subject: "custom.bogus"},
+				},
+			},
+			wantErr:       true,
+			wantErrSubstr: "github.event.bogus",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				HTTPPort: 8090,
+				Path:     "/github/webhook",
+				Ports:    tt.ports,
+			}
+			_, err := NewInput("github-webhook-test", &natsclient.Client{}, cfg, nil)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewInput() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.wantErrSubstr != "" && !strings.Contains(err.Error(), tt.wantErrSubstr) {
+				t.Errorf("NewInput() error = %v, expected to contain %q", err, tt.wantErrSubstr)
+			}
+		})
+	}
+}
+
+// TestNewInput_PreservesOperatorSubjectOverrides asserts that when the
+// operator supplies a canonical port name with an overridden Subject,
+// the publish path actually picks up that override. This is the
+// flip-side of the validation test: validation rejects unknown names
+// so the keyed-by-Name lookup is sound; this test confirms the
+// override flows through.
+func TestNewInput_PreservesOperatorSubjectOverrides(t *testing.T) {
+	cfg := Config{
+		HTTPPort: 8090,
+		Path:     "/github/webhook",
+		Ports: &component.PortConfig{
+			Outputs: []component.PortDefinition{
+				{Name: "github.event.issue", Subject: "custom.issue.subject"},
+				{Name: "github.event.pr", Subject: "custom.pr.subject"},
+			},
+		},
+	}
+	in, err := NewInput("github-webhook-test", &natsclient.Client{}, cfg, nil)
+	if err != nil {
+		t.Fatalf("NewInput() error: %v", err)
+	}
+
+	if got := in.outputSubjects["github.event.issue"]; got != "custom.issue.subject" {
+		t.Errorf("outputSubjects[issue] = %q, want %q", got, "custom.issue.subject")
+	}
+	if got := in.outputSubjects["github.event.pr"]; got != "custom.pr.subject" {
+		t.Errorf("outputSubjects[pr] = %q, want %q", got, "custom.pr.subject")
+	}
+	// Non-overridden ports keep the canonical default
+	if got := in.outputSubjects["github.event.review"]; got != "github.event.review" {
+		t.Errorf("outputSubjects[review] = %q, want canonical default", got)
+	}
+	if got := in.outputSubjects["github.event.comment"]; got != "github.event.comment" {
+		t.Errorf("outputSubjects[comment] = %q, want canonical default", got)
+	}
+}

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -950,6 +950,20 @@ func (c *Component) handleLoopFailure(ctx context.Context, loopID string, entity
 }
 
 // publishFailureEvents publishes failure events including workflow callback.
+//
+// Same write-before-publish ordering as persistHandlerResult (post-beta.57):
+// KV state and graph triples are stamped BEFORE the JetStream publish so any
+// subscriber consuming the failure event and immediately reading
+// COMPLETE_{loopID} from the loops KV bucket — rules engine, execution-manager,
+// future ops/analytics — finds the state already there. Pre-fix order had
+// publish first, KV write last, leaving the same race that beta.57 closed for
+// the success path. Audit finding 2026-05-08 (project_audit_findings_2026_05_08.md).
+//
+// Graph write goes through stampLoopFailureWithBudget so a degraded
+// graph-gateway never holds the publish indefinitely (mirrors the beta.57
+// stampLoopCompletionWithBudget pattern). KV write is a single fast Put;
+// the existing errorCtx 5s detached timeout already bounds the whole
+// function so no separate budget is needed.
 func (c *Component) publishFailureEvents(ctx context.Context, loopID, reason, errorMsg string) {
 	errorCtx, cancel := natsclient.DetachContextWithTrace(ctx, 5*time.Second)
 	defer cancel()
@@ -960,22 +974,26 @@ func (c *Component) publishFailureEvents(ctx context.Context, loopID, reason, er
 		return
 	}
 
-	// Emit failure entity to graph (non-fatal)
-	if c.graphWriter != nil && failure != nil {
-		c.graphWriter.WriteLoopFailure(errorCtx, failure)
+	// Persist failure to KV first so watchers (rules engine,
+	// execution-manager) see COMPLETE_{loopID} when they react to the
+	// failure event below.
+	if failure != nil {
+		c.persistFailureState(errorCtx, loopID, failure)
 	}
 
+	// Stamp graph triples second (under budget). The reorder is the
+	// load-bearing change vs pre-fix; the budget cap mirrors the success
+	// path's stampLoopCompletionWithBudget so a slow graph-gateway can't
+	// stall the publish.
+	if failure != nil {
+		c.stampLoopFailureWithBudget(errorCtx, loopID, failure)
+	}
+
+	// Publish last — every observable side effect is now in place.
 	for _, msg := range failMsgs {
 		if pubErr := c.natsClient.PublishToStream(errorCtx, msg.Subject, msg.Data); pubErr != nil {
 			c.logger.Error("Failed to publish failure event", "error", pubErr, "loop_id", loopID)
 		}
-	}
-
-	// Persist failure to KV so watchers (rules engine, execution-manager) can detect it.
-	// Without this, loops that fail (max iterations, handler_error) silently disappear
-	// from the KV watch perspective — only the NATS stream gets the failure event.
-	if failure != nil {
-		c.persistFailureState(errorCtx, loopID, failure)
 	}
 }
 

--- a/processor/agentic-tools/config.go
+++ b/processor/agentic-tools/config.go
@@ -71,8 +71,53 @@ func (c *Config) Validate() error {
 		return errs.WrapInvalid(fmt.Errorf("timeout must be positive"), "Config", "Validate", "check timeout value")
 	}
 
+	// When the operator supplied a Ports block, enforce that Inputs and
+	// Outputs are non-empty whenever DefaultConfig declares ports in
+	// those directions. Pre-fix, an operator config that overrode Ports
+	// without any Inputs (or set inputs:[]) started the component
+	// running and healthy with zero JetStream consumers — silent
+	// dispatch death. Symmetric to the publishResult silent-drop bug
+	// closed in beta.57. Audit finding 2026-05-08.
+	//
+	// Validation is by-presence-of-any-port, not by-canonical-name:
+	// operators can rename ports freely, override subjects, etc., as
+	// long as they don't omit the entire direction. Subject coherence
+	// across components is an operator concern; per-component validation
+	// only catches structural emptiness.
+	if c.Ports != nil {
+		if err := c.validatePortsNonEmpty(); err != nil {
+			return err
+		}
+	}
+
 	// AllowedTools can be nil or empty (both mean allow all tools)
 	// No validation needed for allowed_tools
+
+	return nil
+}
+
+// validatePortsNonEmpty enforces that when the operator supplied a Ports
+// block, neither Inputs nor Outputs is empty (provided DefaultConfig
+// declares ports in those directions). Catches the silent-broken case
+// where Ports is overridden but a direction is forgotten.
+func (c *Config) validatePortsNonEmpty() error {
+	defaults := DefaultConfig()
+	if defaults.Ports == nil {
+		return nil
+	}
+
+	if len(defaults.Ports.Inputs) > 0 && len(c.Ports.Inputs) == 0 {
+		return errs.WrapInvalid(
+			fmt.Errorf("Ports.Inputs is empty but DefaultConfig declares %d input port(s); agentic-tools cannot run without consumers — supply at least one input port or omit the Ports block to use canonical defaults", len(defaults.Ports.Inputs)),
+			"Config", "validatePortsNonEmpty", "input port presence",
+		)
+	}
+	if len(defaults.Ports.Outputs) > 0 && len(c.Ports.Outputs) == 0 {
+		return errs.WrapInvalid(
+			fmt.Errorf("Ports.Outputs is empty but DefaultConfig declares %d output port(s); tool.result publishes will silently drop — supply at least one output port or omit the Ports block to use canonical defaults", len(defaults.Ports.Outputs)),
+			"Config", "validatePortsNonEmpty", "output port presence",
+		)
+	}
 
 	return nil
 }

--- a/processor/agentic-tools/config_ports_nonempty_test.go
+++ b/processor/agentic-tools/config_ports_nonempty_test.go
@@ -1,0 +1,111 @@
+package agentictools_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/component"
+	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
+)
+
+// TestConfig_Validate_PortsNonEmpty closes the silent-broken-input gap
+// from the 2026-05-08 audit (project_audit_findings_2026_05_08.md
+// Finding 3). Pre-fix, an operator config that supplied a Ports block
+// without any Inputs (or set inputs:[]) started the component running
+// and healthy with zero JetStream consumers — silent dispatch death.
+// Symmetric to the publishResult silent-drop bug closed in beta.57;
+// that one was outputs, this catches inputs (and outputs as well, for
+// symmetry with the same shape on the publish side).
+//
+// Validation is by-presence-of-any-port, not by-canonical-name —
+// operators can rename ports freely (`Name: "input"` with the canonical
+// Subject is a working config). What's caught is the structural
+// "operator supplied Ports but forgot a direction entirely."
+func TestConfig_Validate_PortsNonEmpty(t *testing.T) {
+	tests := []struct {
+		name          string
+		ports         *component.PortConfig
+		wantErr       bool
+		wantErrSubstr string
+	}{
+		{
+			name:    "nil Ports uses DefaultConfig — accepted",
+			ports:   nil,
+			wantErr: false,
+		},
+		{
+			name: "empty Inputs slice — rejected (silent-dispatch-death case)",
+			ports: &component.PortConfig{
+				Inputs: []component.PortDefinition{},
+				Outputs: []component.PortDefinition{
+					{Name: "tool.result", Type: "jetstream", Subject: "tool.result.*"},
+				},
+			},
+			wantErr:       true,
+			wantErrSubstr: "Ports.Inputs is empty",
+		},
+		{
+			name: "empty Outputs slice — rejected (silent-publish-drop case)",
+			ports: &component.PortConfig{
+				Inputs: []component.PortDefinition{
+					{Name: "tool.execute", Type: "jetstream", Subject: "tool.execute.>"},
+				},
+				Outputs: []component.PortDefinition{},
+			},
+			wantErr:       true,
+			wantErrSubstr: "Ports.Outputs is empty",
+		},
+		{
+			name: "operator-renamed ports with canonical subjects — accepted",
+			ports: &component.PortConfig{
+				Inputs: []component.PortDefinition{
+					{Name: "input", Type: "nats", Subject: "tool.execute.>"},
+				},
+				Outputs: []component.PortDefinition{
+					{Name: "output", Type: "nats", Subject: "tool.result.*"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "operator-renamed ports with operator subjects — accepted",
+			ports: &component.PortConfig{
+				Inputs: []component.PortDefinition{
+					{Name: "myinput", Type: "jetstream", Subject: "custom.tool.execute.>"},
+				},
+				Outputs: []component.PortDefinition{
+					{Name: "myoutput", Type: "jetstream", Subject: "custom.tool.result.*"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "canonical defaults — accepted",
+			ports: &component.PortConfig{
+				Inputs: []component.PortDefinition{
+					{Name: "tool.execute", Type: "jetstream", Subject: "tool.execute.>"},
+				},
+				Outputs: []component.PortDefinition{
+					{Name: "tool.result", Type: "jetstream", Subject: "tool.result.*"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := agentictools.Config{
+				Timeout: "60s",
+				Ports:   tt.ports,
+			}
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.wantErrSubstr != "" && !strings.Contains(err.Error(), tt.wantErrSubstr) {
+				t.Errorf("Validate() error = %v, expected to contain %q", err, tt.wantErrSubstr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3 audit follow-ups (`project_audit_findings_2026_05_08.md`). Three findings bundled into one PR — same audit, same silent-failure theme, all loud-not-silent fixes.

### Finding 2 (HIGH) — agentic-loop publishFailureEvents reorder

Same shape as the persistHandlerResult bug closed in beta.57, in the same file, on the failure path. Pre-fix order: graph stamp → publish → KV write. The trailing KV write (`persistFailureState` writes `COMPLETE_{loopID}`) means a fast subscriber to the failure event finds no `COMPLETE_` key when it reacts.

Reorder: persistFailureState → stampLoopFailureWithBudget → publish. Mirrors post-beta.57 `persistHandlerResult` exactly, including the `runWithBudget(graphWritePublishBudget=2s)` cap on the graph write. Reuses well-tested helpers from beta.57.

### Finding 1 (MEDIUM) — github-webhook validate operator port names

Pre-fix `outputSubjects` map keyed by `p.Name`, publish call sites indexed by hardcoded canonical names. Operator JSON with renamed ports silently lands in the map under the rename; publish returns the default subject. Events publish to the default while operator's intended subscribers see nothing.

Validate at construction: output port names must be in `{github.event.issue, github.event.pr, github.event.review, github.event.comment}`. Operator with typo/rename sees the failure at startup.

### Finding 3 (MEDIUM) — agentic-tools validate Ports non-empty

Pre-fix, operator config overriding Ports without any Inputs started the component running and healthy with zero JetStream consumers — silent dispatch death. Symmetric to the publishResult silent-drop bug closed in beta.57.

Validation by-presence-of-any-port, not by-canonical-name — operators can rename ports freely with custom subjects, what's caught is the structural "forgot a direction entirely." Existing `TestNewComponent_ValidConfig` (which uses `Name:"input"` with canonical Subject) still passes.

## Behavior changes for downstreams

- **agentic-loop failure-event subscribers**: COMPLETE_{loopID} now visible by the time the failure event arrives in the common path. Above 2s graph-gateway latency, the existing beta.57 timeout counter trips.
- **github-webhook deployments with operator-renamed output ports**: startup now fails loud. Pre-fix, the same config silently mis-routed events. Surfaces latent breakage that was already silent-broken.
- **agentic-tools deployments with empty Inputs or Outputs**: startup now fails loud. Pre-fix, the same config started the component running and healthy with no work to do.

The two operator-facing rejections surface latent breakage that was already silent-broken. This is "making broken configs visible," not "introducing a new break."

## Test plan

- [x] `task lint` clean (revive, vet, fmt)
- [x] `go test -race ./...` full suite green (incl. fixed `TestNewComponent_ValidConfig` which uses renamed ports + canonical subjects — confirms by-presence validation doesn't break legitimate renames)
- [x] `go vet -tags=integration ./...` clean
- [x] `go vet -tags=live_llm ./...` clean
- [x] `task schema:generate` diff empty
- [x] 13 new test cases (Finding 1: 7 cases + 1 flip-side; Finding 3: 6 cases). Finding 2's reorder reuses beta.57's `runWithBudget` (5 unit tests) + `stampLoopFailureWithBudget` helpers.
- [x] `task e2e:agentic` green (16.22s, 3 loops, 2 tool executions, 14 graph_loop_triples + 5 graph_model_triples — same shape as beta.57 baseline)
- [ ] semspec/semteams to confirm their test deployments still load (pin guidance: post-merge tag will be beta.58)

## Audit baseline status

This PR closes 3 of the 5 audit findings. Remaining:

- Finding 4 (LOW) — `oasf-generator` `EntityState` shadow strips StorageRef/MessageType/Version (latent; only `Triples` read today)
- Finding 5 (LOW) — `Port.UnmarshalJSON` missing dashed `kv-watch`/`kv-write`/`store-read` variants (fails LOUD, not silent)

Both deferred to a future cleanup batch — neither has active operator impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)