### PR TITLE
feat(adr-036): agent-private observable state — write_todos + compaction-survival

### DIFF
--- a/agentic/entity_ids.go
+++ b/agentic/entity_ids.go
@@ -41,26 +41,51 @@ func ModelEndpointEntityID(org, platform, endpointName string) string {
 // Example: LoopExecutionEntityID("c360", "ops", "abc123")
 // Returns: "c360.ops.agent.agentic-loop.execution.abc123"
 //
-// Panics if any input part is empty or contains a dot, as these represent
-// programming errors — the caller is responsible for supplying well-formed identifiers.
+// Panics if any input part is empty or contains a dot. Suitable for
+// boot-time and post-completion paths where invalid input represents
+// a programming error that should fail loud (operator config check at
+// startup; framework bug in event-payload construction).
+//
+// Runtime tool executors (where a panic silently kills the dispatch
+// goroutine and the agent fails opaquely) should use
+// TryLoopExecutionEntityID and surface the error as ToolErrorInternal
+// instead. ADR-036 Stage 3.8 documents the panic-class concern; the
+// beta.36 read_loop_result wedge is the in-tree precedent.
 func LoopExecutionEntityID(org, platform, loopID string) string {
-	if err := validatePart("org", org); err != nil {
+	id, err := TryLoopExecutionEntityID(org, platform, loopID)
+	if err != nil {
 		panic(fmt.Sprintf("LoopExecutionEntityID: %s", err))
+	}
+	return id
+}
+
+// TryLoopExecutionEntityID is the error-returning variant of
+// LoopExecutionEntityID. Use this from runtime hot paths (tool
+// executors, per-iteration prompt assembly) where a panic would
+// silently crash the dispatch goroutine and the agent would fail
+// opaquely. Boot-time and post-completion callers can keep using the
+// panicking LoopExecutionEntityID.
+//
+// Returns ("", error) when any input part is empty or contains a dot,
+// or when the constructed ID fails IsValidEntityID.
+func TryLoopExecutionEntityID(org, platform, loopID string) (string, error) {
+	if err := validatePart("org", org); err != nil {
+		return "", fmt.Errorf("LoopExecutionEntityID: %w", err)
 	}
 	if err := validatePart("platform", platform); err != nil {
-		panic(fmt.Sprintf("LoopExecutionEntityID: %s", err))
+		return "", fmt.Errorf("LoopExecutionEntityID: %w", err)
 	}
 	if err := validatePart("loopID", loopID); err != nil {
-		panic(fmt.Sprintf("LoopExecutionEntityID: %s", err))
+		return "", fmt.Errorf("LoopExecutionEntityID: %w", err)
 	}
 
 	id := fmt.Sprintf("%s.%s.agent.agentic-loop.execution.%s", org, platform, loopID)
 
 	if !message.IsValidEntityID(id) {
-		panic(fmt.Sprintf("LoopExecutionEntityID: constructed id %q failed IsValidEntityID — check input values", id))
+		return "", fmt.Errorf("LoopExecutionEntityID: constructed id %q failed IsValidEntityID — check input values", id)
 	}
 
-	return id
+	return id, nil
 }
 
 // TrajectoryStepEntityID constructs a 6-part entity ID for a trajectory step.

--- a/agentic/entity_ids_test.go
+++ b/agentic/entity_ids_test.go
@@ -159,6 +159,47 @@ func TestLoopExecutionEntityID(t *testing.T) {
 	})
 }
 
+// TestTryLoopExecutionEntityID pins the error-returning variant
+// (ADR-036 Stage 3.8). Runtime tool executors call this so a
+// malformed loopID — the beta.36-class bug where a 6-part entity ID
+// gets stamped where a bare ID was expected — surfaces as a tool
+// error instead of crashing the dispatch goroutine.
+func TestTryLoopExecutionEntityID(t *testing.T) {
+	t.Run("happy path matches LoopExecutionEntityID", func(t *testing.T) {
+		got, err := agentic.TryLoopExecutionEntityID("c360", "ops", "abc123")
+		assert.NoError(t, err)
+		assert.Equal(t, "c360.ops.agent.agentic-loop.execution.abc123", got)
+	})
+
+	t.Run("returns error instead of panicking on bad input", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			org      string
+			platform string
+			loopID   string
+		}{
+			{"empty org", "", "ops", "abc"},
+			{"empty platform", "c360", "", "abc"},
+			{"empty loopID", "c360", "ops", ""},
+			{"dot in org", "c360.studio", "ops", "abc"},
+			{"dot in platform", "c360", "ops.prod", "abc"},
+			{"dot in loopID (beta.36 class)", "c360", "ops", "c360.ops.agent.agentic-loop.execution.abc"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				got, err := agentic.TryLoopExecutionEntityID(tt.org, tt.platform, tt.loopID)
+				assert.Error(t, err)
+				assert.Equal(t, "", got)
+				// Sanity: the panicking sibling should panic on the
+				// same input — both paths must agree on what's invalid.
+				assert.Panics(t, func() {
+					agentic.LoopExecutionEntityID(tt.org, tt.platform, tt.loopID)
+				}, "panicking variant must reject the same inputs")
+			})
+		}
+	})
+}
+
 func TestTrajectoryStepEntityID(t *testing.T) {
 	t.Run("valid constructions", func(t *testing.T) {
 		tests := []struct {

--- a/docs/adr/036-agent-private-observable-state.md
+++ b/docs/adr/036-agent-private-observable-state.md
@@ -1,0 +1,447 @@
+# ADR-036: Agent-Private Observable State
+
+## Status
+
+**Proposed — 2026-05-08.** Generalises a primitive that has been
+implicit in [ADR-027](027-ops-agent-meta-harness.md) (ops agent reads
+loop telemetry) and [ADR-028](028-orchestration-architecture.md)
+(rules carry references, not content) but has never been named or
+disciplined. First concrete instance is a TodoWrite-shaped scratchpad
+available to any agent role; the principle scales to any future
+per-loop working memory.
+
+## Context
+
+Long-horizon agent flows in semstreams (`processor/agentic-loop`,
+the dev-via-spec chains in semteams, semspec's plan→requirements→
+scenarios→review pipeline) reconstruct their plan from prose every
+turn. The trajectory is the only durable record of "where am I in
+this task," and trajectory gets compacted (beta.21 length-truncation
+handler, alpha.90 age-based GC retirement). After compaction, the
+agent's plan exists only in compressed paraphrase. Coordinators
+re-derive next-action from this each iteration; planner agents
+re-emit step lists every turn; reviewers re-parse plans from
+markdown.
+
+Three forces meet here:
+
+1. **Compaction erases plans.** Anything held only in chat history
+   is at risk. Structured state held outside the chat history
+   survives, and can be re-injected at prompt assembly time
+   (`processor/agentic-loop/prompt/assembler.go`).
+
+2. **Rules can match structured facts but not prose.** CLAUDE.md
+   commits hard to "rules can't make quality judgments over
+   unstructured text — that's coordinator work." A predicate like
+   `agent.todo.status = pending` is exactly the structural surface
+   the rule engine *can* branch on; a predicate like
+   "todo content mentions X" is exactly what it cannot.
+
+3. **LLM-on-LLM checklist contracts Goodhart.** semteams's
+   `feedback_format_compliance_goodhart.md` documented the failure
+   mode: when one LLM grades another against a format checklist,
+   the producer optimises conformance away from substance. The
+   chain converged on ceremony. This is a real risk for any
+   structured agent state primitive that becomes a contract between
+   roles.
+
+What's missing is a principle that says *what kind of structured
+agent state is safe* — the absence has meant projects either avoid
+the primitive entirely (today) or risk recreating the semteams
+checklist failure mode if they introduce one.
+
+## Decision
+
+Commit to the pattern of **agent-private observable state**:
+structured working memory held on an entity owned by the agent that
+produces it, with asymmetric access discipline.
+
+### Access asymmetry
+
+| Role | Access | Stake |
+|---|---|---|
+| Owning agent (writer of this loop's state) | read-write | uses state as personal working memory |
+| Any reader of the graph (humans, ops agent, debug UI, downstream rules) | read-only | observes; does not interpret content |
+| Authorised actuator agents (per ADR-026 deploy surface) | indirect — may write to *other* entities (configs, prompts, rules) on the basis of what was observed | learns from patterns across many loops, never edits a live loop's private state |
+
+The writer is the **sole writer** and the **sole interpreter of
+content**. Other parties may read structural facts (existence,
+counts, status enums, timestamps, transitions). They may not
+predicate on content, and they may not write back into the
+owner's state mid-loop.
+
+### Three discipline rules
+
+These keep the asymmetry intact. Drop any one and Goodhart returns.
+
+**Rule 1 — Rules predicate on structural facts only.**
+The rule engine may match `agent.todo.status_count.pending = 0`,
+`agent.todo.last_transition > 30s ago`, or
+`agent.todo.completion_ratio >= 1.0`. It may not match
+`agent.todo.content contains "X"` or otherwise branch on what the
+agent wrote in free-form fields. The moment a rule reads content,
+content becomes a contract and the agent will optimise to satisfy
+the rule rather than reflect actual progress.
+
+**Rule 2 — Persona prompts describe state descriptively, not
+prescriptively.**
+"Maintain a working list for yourself — what you plan to do, where
+you are" is descriptive. "You must produce ≥3 todos with format
+`### Goal / ### Steps / ### Checks`" is prescriptive and recreates
+the semteams checklist Goodhart. The persona surfaces the tool;
+the agent decides what to put in it.
+
+**Rule 3 — Authorised feedback flows via ADR-026's deploy surface,
+never via direct mutation of live private state.**
+Ops agent (ADR-027) and any future authorised actuator agent may
+read agent-private state across many completed loops, diagnose
+patterns, and propose changes through ADR-026's runtime composition
+tools — `create_rule`, `manage_flow`, persona edits, model
+selection. Those changes are reviewed and approval-gated per
+ADR-026's safety model and ADR-027's phased delivery. They flow
+back through *configuration*, not by writing into the owner's
+todos or scratchpad. Human review and authorised-agent action are
+both downstream of the same diagnosis surface; the two consumers
+share the gradient discipline.
+
+This third rule preserves the asymmetry under a non-trivial
+condition: the gradient from observation to behaviour change is
+slow (config-time, not per-token sampling), visible (governance and
+approval per ADR-026), and indirect (through configuration entities,
+not through the live owner's state). That is what makes it
+categorically different from a per-decision LLM-on-LLM checklist.
+
+## First instance — `write_todos`
+
+The principle's first concrete realisation is a TodoWrite-shaped
+tool available to any agent role. The Goodhart discipline is
+asymmetric per loop, not per role: every agent is the sole writer
+of its own todos and the sole interpreter of its own content. No
+cross-role contract forms regardless of which role calls the
+tool, so role-gating buys no safety. Long-horizon work shows up
+in many roles — coordinator decisions, planner step-emission,
+developer test-fix cycles, researcher citation chasing,
+reviewer pass-criteria walking — and all benefit equally from
+externalised plan state surviving compaction.
+
+### Tool definition
+
+```go
+// In processor/agentic-tools/executors/register_write_todos.go
+const ToolNameWriteTodos = "write_todos"
+
+// Argument shape:
+//   {
+//     "todos": [
+//       {"id": "1", "content": "Survey existing rules", "status": "completed"},
+//       {"id": "2", "content": "Draft new rule", "status": "in_progress"},
+//       {"id": "3", "content": "Wire e2e test", "status": "pending"}
+//     ]
+//   }
+```
+
+The executor is a passthrough: it validates the argument shape,
+writes one triple per todo onto the loop entity, and returns
+`ToolResult.Content` with a compact summary. Following the decide
+tool pattern (`processor/agentic-tools/decide.go`), validation
+errors surface as `ToolErrorInvalidArgs` with the canonical schema
+in the message so the LLM can self-correct.
+
+`StopLoop=false` — unlike `decide`, this tool is meant to be called
+many times in a single loop. It is working memory, not a terminal.
+
+### Predicates
+
+Add to `vocabulary/agentic/predicates.go` under a new `Todo`
+constant block:
+
+```go
+const (
+    TodoID         = "agent.todo.id"          // string
+    TodoContent    = "agent.todo.content"     // string — opaque to rules
+    TodoStatus     = "agent.todo.status"      // enum: pending|in_progress|completed
+    TodoPosition   = "agent.todo.position"    // int — order within list
+    TodoUpdatedAt  = "agent.todo.updated_at"  // timestamp
+)
+```
+
+`TodoContent` is registered with metadata flagging it as
+**rule-opaque**: rule validators reject any rule that predicates on
+this field. (Implementation: extend `processor/rule/config_validation.go`
+with a `RuleOpaquePredicates` denylist sourced from vocabulary
+metadata. Same machinery serves any future content-bearing
+predicate that follows this pattern.)
+
+### Compaction survival
+
+`processor/agentic-loop/prompt/assembler.go` reads the current todo
+list from the loop entity at every prompt build and injects it
+into the system message as a structured block. Trajectory may be
+compacted; the todo state is reconstructed from triples each turn.
+This is the load-bearing reason for the primitive — without it,
+the value of the tool collapses to a pretty version of "write notes
+in your reply."
+
+### Goodhart cross-checks
+
+Following `feedback_format_compliance_goodhart.md`'s lesson, add
+one structural cross-check that catches the obvious failure mode:
+a todo marked `completed` should plausibly correspond to evidence
+in the loop's trajectory or graph. The implementation is a
+periodic ops-agent diagnosis (Phase 1 territory), not a hard
+runtime gate. Hard runtime gating would itself be a contract and
+recreates the failure mode.
+
+## Future candidates
+
+The principle generalises beyond todos. Anything with the shape
+"the agent wants to externalise working memory; observers want to
+diagnose patterns; the agent should be the sole interpreter" is
+a candidate:
+
+| Future primitive | Use | Owner |
+|---|---|---|
+| `agent.hypothesis.*` | Researcher tracks hypotheses under test | Researcher |
+| `agent.scratch.*` | Free-form notes across iterations | Any role |
+| `agent.breadcrumb.*` | Exploration trail (visited states / tried approaches) | Coordinator, debugger |
+| `agent.budget.*` | Self-imposed limits (iterations remaining, tokens spent) | Any role |
+
+Each would follow the same pattern: a tool that writes triples to
+the loop entity, content fields flagged rule-opaque, persona
+surface descriptive not prescriptive, ops agent observes
+post-hoc, authorised actuators feed back through configuration.
+
+## Consequences
+
+**Positive.**
+- Long-horizon flows survive compaction without losing plan state.
+- Rules gain a deterministic predicate surface for plan progress
+  (status counts, transitions, durations) without violating the
+  ADR-028 content/rule firewall.
+- Ops agent (ADR-027 Phase 1) gains a richer observation substrate;
+  Phase 2/3 authorised actuators get the same surface without
+  needing privileged access to live loops.
+- One discipline pattern serves all future agent-private state
+  primitives — no per-feature reasoning about Goodhart risk.
+
+**Negative.**
+- Per-deployment tool-surface tuning. The framework default
+  registers `write_todos` for all roles. Operators running
+  small-model deployments where every tool slot competes for
+  attention may still want to opt specific roles out via the
+  persona's tool set — but this is a deployment-tuning decision,
+  not a framework-level safety boundary. semteams smoke #7
+  (decide-tool action allowlist drift, beta.40/41/44) is the
+  reference case for "small models drown when the tool surface
+  widens"; persona-level opt-out remains the right lever.
+- Rule-validator complexity. Enforcing the rule-opaque predicate
+  list at config-load is new machinery (a few dozen LOC, but it
+  needs tests). Trade-off worth taking because the same machinery
+  protects every future content-bearing predicate.
+- Persona-prompt discipline is convention-enforced, not
+  framework-enforced. A persona author can still write "you must
+  produce ≥3 todos." Mitigation: review checklist for new
+  personas, with the rule called out explicitly. (Memorialise in
+  CLAUDE.md alongside the existing "rules carry references" rule.)
+
+**Neutral.**
+- `write_todos` does not interact with parent/child loop
+  spawning. Each loop owns its own todo state; child loops do not
+  inherit the parent's todos. Cross-loop plan handoff (parent
+  decomposes; children solve items) routes through the existing
+  rule-mediated `publish_agent` path with `RelatedLoops` lineage
+  (beta.50 PR #33, beta.51 PR #36). The two primitives compose
+  cleanly without coupling.
+
+## Relationship to other ADRs
+
+- **ADR-027** (ops agent): this ADR formalises the read-side
+  contract Phase 1 ops already operates under, and disciplines
+  the feedback flow Phase 2/3 will introduce.
+- **ADR-028** (orchestration architecture): the rule-opaque
+  predicate convention is the structural extension of ADR-028's
+  "rules carry references not content" principle to agent-owned
+  state.
+- **ADR-026** (coordinator runtime composition): authorised
+  feedback flows from ops observations land here, not as direct
+  mutations of agent-private state. Same approval gates apply.
+- **ADR-035 / ADR-034** (strict tool calling, response format):
+  `write_todos` should ship with `Strict: true` on its
+  `ToolDefinition`. The argument schema is small and structural —
+  a perfect candidate for sampling-constrained tool args.
+
+## Appendix A — Trigger pattern (when to call `write_todos`)
+
+The framework provides the tool; personas teach the model when to
+reach for it. This appendix sets a starting threshold and three
+fragment templates. It is intentionally a starting point: the ops
+agent (ADR-027 Phase 1) will diagnose whether deployed personas
+under-use or over-use the primitive, and the threshold should evolve
+with that empirical signal.
+
+### Baseline — Claude Code's published heuristic
+
+The reference pattern Claude Code surfaces to its agents (and that
+its TodoWrite tool documentation describes):
+
+- Use it when work has **3+ distinct steps** the model will need to
+  track across multiple tool calls.
+- Use it for **multi-file changes** where the model benefits from
+  visible per-file progress.
+- Use it when **dependencies between subtasks** matter — B requires
+  A's output, and the model might forget partway through.
+- **Do not** use it for single-step lookups, trivial fixes, one-shot
+  Q&A, or tasks that complete in one tool call.
+- **Mark items completed immediately** after the underlying work
+  finishes — never batch status updates at the end. (This is what
+  makes the list a faithful record rather than a post-hoc summary.)
+
+This is the right baseline to copy because it's been pressure-tested
+against millions of real agent-loop sessions, but three runtime
+properties shift the threshold downward for semstreams.
+
+### Three properties that shift the threshold
+
+**1. Compaction is more aggressive than Claude Code's default.**
+Small-model deployments (qwen3:0.6b classifier, 1.7b mid-tier in
+the seminstruct topology beta.51 split) hit context pressure faster
+than Claude Code's typical Sonnet/Opus configurations. The
+agentic-loop's `processor/agentic-loop/prompt/assembler.go` rebuilds
+the prompt every iteration; anything not held in durable state
+outside the chat history is at risk on the next compaction. The
+threshold for "worth tracking in a todo list" should be **2+ steps
+that span a compaction-eligible iteration boundary**, not Claude
+Code's 3+ rule.
+
+**2. Multi-iteration loops are the norm, with hard iteration caps.**
+The dev-via-spec builder runs `max_iterations = 30`
+(`configs/personas/fragments/dev-via-spec-builder/10-bash-iteration-contract.md`,
+calibrated 8 → 30 per smoke #6 evidence). Researcher and reviewer
+loops also commonly exceed Claude Code's typical few-iteration
+envelope. Any role with `max_iterations > ~5` is a candidate.
+
+**3. Cross-loop handoff is observable and matters.**
+Claude Code's Task tool returns synchronously; semstreams's
+parent-child via `publish_agent` does not — the parent terminates
+and gets re-invoked when the child completes. A coordinator's todos
+that track "spawned researcher for X (loop_id=...); awaiting
+reviewer for Y" stay coherent across that gap in a way Claude
+Code's pattern doesn't need to.
+
+### Empirical evidence — Exhibit A: dev-via-spec builder Step 2
+
+The builder fragment's `10-bash-iteration-contract.md` already
+encodes a planning step:
+
+> **Step 2 — plan locally, then execute.** Inside the prose part
+> of your message (not in bash), think about what files you need to
+> produce and in what order. Do not turn this into a multi-paragraph
+> design exercise — the dev-via-spec chain already designed. State
+> your build plan in 3–6 bullets, then start writing.
+
+That's exactly the shape `write_todos` formalises. Today the plan
+lives only in chat-history prose and dies on compaction; with the
+tool, the same 3–6 bullets become structured state on the loop
+entity, observable to the architect on retry, queryable by ops
+agent for "did builders that wrote ≥3 todos finish more reliably
+than those who didn't?" diagnoses, and re-injected by the prompt
+assembler every iteration.
+
+This is the canonical case. Other personas with implicit
+"state-your-plan-then-execute" guidance (architect's output
+contract, reviewer's evaluation walk-through) are next-priority
+adopters.
+
+### Counter-case — Claude Code coordinator (chat front door)
+
+The semteams coordinator's `00-identity.md`:
+
+> Your loop is short. One-to-two iterations per user message in the
+> common case: classify, delegate, done.
+
+A two-iteration classify-and-delegate flow does not need
+`write_todos`. A four-iteration follow-up flow tracking parallel
+specialist invocations *does*. The trigger language must
+distinguish between "my work is short" and "my work has spawned
+work I'm waiting on" — the latter is where the coordinator's todo
+list earns its keep, listing each in-flight delegation by `loop_id`.
+
+### Three fragment templates
+
+Persona authors copy and adapt these. They are descriptive
+(per Rule 2 from the §Decision section), not prescriptive — they
+tell the model what kind of work benefits, not what format the
+todos must take.
+
+**Template — coordinator-shape (short loop, may delegate).**
+
+```markdown
+## Tracking in-flight delegations
+
+If you spawn parallel specialists you'll wait on, record each
+delegation as a todo item with the spawned `loop_id` so the next
+iteration of yourself (after specialists complete) knows what was
+in flight. For pure classify-and-delegate flows that finish in one
+or two iterations, you do not need todos — write them only when
+your work spans iterations.
+```
+
+**Template — planner-shape / multi-step builder.**
+
+```markdown
+## Tracking your plan
+
+When you take on work that has 2+ distinct steps you'll need to
+track across iterations — especially if the work crosses a
+compaction-eligible boundary or involves multiple files,
+dependencies, or test-fix cycles — call `write_todos` near the
+start of your loop with the plan as a list. Update each item's
+status as you complete it (don't batch at the end). For
+single-step work or one-shot tool calls, skip todos entirely.
+```
+
+**Template — researcher / reviewer (read-heavy, may chase leads).**
+
+```markdown
+## Tracking lines of inquiry
+
+If your work fans out across multiple sources, citations, or
+hypotheses you intend to circle back on, list them as todos. This
+keeps the trail visible if your loop iterates further than one
+turn and survives any compaction the loop hits. For a single
+look-up or a one-shot synthesis, skip the tool.
+```
+
+### Tool-surface budget — the per-deployment lever
+
+The builder persona's `00-identity.md` is explicit:
+
+> small models degrade with tool sprawl, and bash is the most
+> heavily-trained-on tool surface.
+
+For roles like the dev-via-spec builder where the toolset is
+deliberately kept at 4 tools, persona authors deploying small
+models may opt out of `write_todos` and instead keep the
+existing prose-plan guidance. This is a per-deployment tuning
+decision (see §Consequences), not a framework default. The
+framework registers the tool; the persona decides whether to
+expose it.
+
+### Iteration plan post-launch
+
+Land `write_todos` with the three templates above as the canonical
+starting point. After the tool has been deployed for ~2 weeks
+across the existing journey fixtures (dev-via-spec, deep-research,
+research-iterative, ops-agent-baseline), have the ops agent
+diagnose:
+
+- Per-role todo-call frequency (calls per loop, distribution).
+- Correlation between todo presence and loop outcome (`agent.loop.outcome`).
+- Compaction events on loops with vs. without active todos —
+  did plan state survive?
+- Status-marker discipline — are agents marking items completed
+  in the same iteration the work happened, or batching at the end?
+
+Revise the threshold and templates based on what surfaces. The
+trigger pattern is empirical, not theoretical, and ADR-027's
+infrastructure exists precisely to drive this kind of revision.

--- a/docs/operations/15-agent-private-state.md
+++ b/docs/operations/15-agent-private-state.md
@@ -1,0 +1,202 @@
+# Agent-private observable state — operations guide
+
+This guide is the operator-facing companion to
+[ADR-036](../adr/036-agent-private-observable-state.md). It covers
+when to enable `write_todos` for a role, how to phrase the persona
+fragment that teaches the model when to use it, and what to look for
+in the graph when diagnosing whether a deployment uses the primitive
+well.
+
+## Quick read
+
+The framework registers `write_todos` for every role by default. The
+tool writes structured working memory onto the calling loop's entity
+that survives context compaction. Personas decide when to reach for
+it; the discipline is descriptive (in the persona prompt), not
+prescriptive (no rule, no validator gates content).
+
+## When the tool earns its keep
+
+ADR-036 Appendix A documents the threshold in detail. Short version:
+
+| Signal | Use `write_todos`? |
+|---|---|
+| 2+ steps the model tracks across iterations | Yes |
+| Iteration cap is generous (>5) and work spans iterations | Yes |
+| Cross-loop coordination — parent waits on spawned children | Yes |
+| Single-step lookup or one-shot synthesis | No |
+| Coordinator that finishes in 1–2 iterations (chat front door) | No |
+| Tiny-model deployments with already-busy tool surface | Persona-level opt-out |
+
+Three runtime properties of semstreams shift the threshold downward
+relative to Claude Code's `TodoWrite`:
+
+- Compaction is more aggressive on small-model deployments.
+- Multi-iteration loops with hard caps are the norm — `max_iterations
+  = 30` on the dev-via-spec builder is typical, not exceptional.
+- Cross-loop handoffs via `publish_agent` are async; the parent
+  terminates and gets re-invoked when children complete, so todos
+  that track in-flight delegations stay coherent across that gap.
+
+## Persona fragment templates
+
+Persona authors copy and adapt one of these paragraphs into the
+role's persona file. They are descriptive — they tell the model what
+kind of work benefits, not what format the todos must take. ADR-036
+§Decision Rule 2 is the canonical statement: prescriptive format
+demands ("you must produce ≥3 todos with this exact shape")
+recreate a known LLM-on-LLM Goodhart failure mode where the
+producer optimises for ceremony rather than substance, so the
+templates below ARE descriptive ("if your work has X, do Y") rather
+than prescriptive.
+
+### Coordinator-shape (short loop, may delegate)
+
+```markdown
+## Tracking in-flight delegations
+
+If you spawn parallel specialists you'll wait on, record each
+delegation as a todo item with the spawned `loop_id` so the next
+iteration of yourself (after specialists complete) knows what was
+in flight. For pure classify-and-delegate flows that finish in one
+or two iterations, you do not need todos — write them only when
+your work spans iterations.
+```
+
+### Planner / multi-step builder
+
+```markdown
+## Tracking your plan
+
+When you take on work that has 2+ distinct steps you'll need to
+track across iterations — especially if the work crosses a
+compaction-eligible boundary or involves multiple files,
+dependencies, or test-fix cycles — call `write_todos` near the
+start of your loop with the plan as a list. Update each item's
+status as you complete it (don't batch at the end). For
+single-step work or one-shot tool calls, skip todos entirely.
+```
+
+### Researcher / reviewer (read-heavy, may chase leads)
+
+```markdown
+## Tracking lines of inquiry
+
+If your work fans out across multiple sources, citations, or
+hypotheses you intend to circle back on, list them as todos. This
+keeps the trail visible if your loop iterates further than one
+turn and survives any compaction the loop hits. For a single
+look-up or a one-shot synthesis, skip the tool.
+```
+
+## How the prompt assembler shows todos to the model
+
+Every iteration after the first call to `write_todos`, the agent's
+system message prefix carries a compact block right after the
+iteration-budget warning:
+
+```text
+[Iteration Budget] Iteration 4 of 30 (13% used).
+
+[Working list — your private working memory; you maintain this via write_todos]
+[x] Survey existing rules
+[~] Draft new rule
+[ ] Wire e2e test
+```
+
+Status markers:
+
+- `[x]` — completed
+- `[~]` — in_progress
+- `[ ]` — pending
+- `[?]` — unrecognised (defensive — Stage 3 validates to the canonical
+  enum, so `[?]` only appears if a future tool/persona writes outside
+  the enum)
+
+## What rules and ops can match on (and what they can't)
+
+`agent.todo.id`, `agent.todo.status`, `agent.todo.position`,
+`agent.todo.updated_at` are rule-matchable. Useful predicates:
+
+- `agent.todo.status = "in_progress"` — find loops with active work.
+- `agent.todo.updated_at < now-30m AND agent.todo.status =
+  "in_progress"` — wedge detector.
+- Count of `agent.todo.status = "completed"` — completion ratio.
+
+`agent.todo.content` is **rule-opaque**. The vocabulary registry
+flags it `RuleOpaque: true`; the rule-validator rejects any rule
+whose `condition.field` names this predicate. This is the structural
+mechanism that keeps content out of the rule-engine's branching
+surface — see ADR-036 §Decision Rule 1 for why.
+
+If you find yourself wanting a rule that reads todo content, you
+need a coordinator agent in that path instead. Rules don't make
+quality judgments over unstructured text (`CLAUDE.md` lines
+161-170).
+
+## Per-deployment opt-out
+
+For small-model deployments where every tool slot competes for the
+model's attention, persona authors can opt the role out of
+`write_todos`:
+
+```json
+{
+  "role": "researcher",
+  "default_tools": ["graph_query", "web_search", "submit_work"]
+}
+```
+
+`write_todos` is registered globally but only surfaces to a role's
+calls when included in the role's tool allowlist (or omitted from
+the persona's exclusion list, depending on your deployment's tool
+discovery shape). The framework default is "available unless
+configured out."
+
+This is a deployment-tuning decision, not a framework-level safety
+boundary — opacity is per-loop, not per-role. See the ADR-036
+discussion of why role-gating buys no Goodhart safety.
+
+## Observability
+
+| Signal | Where | What it tells you |
+|---|---|---|
+| `agent.todo.*` triples on `agent.execution.*` entities | graph | Current and historical working lists |
+| `[Working list...]` system message in trajectory | loop trajectory | What the model saw on a given iteration |
+| Iteration count vs `agent.todo.status` distribution | graph queries | Are roles using the primitive? |
+| `agent.todo.updated_at` lag | graph queries | Are agents updating status promptly, or batching at the end? |
+
+The ops agent (ADR-027 Phase 1) is the natural consumer of these
+signals. After ~2 weeks of deployment, file an ops-agent diagnosis
+asking the four questions in ADR-036 Appendix A: per-role todo-call
+frequency, correlation with loop outcome, compaction-survival
+behaviour, and status-marker discipline. Use what surfaces to
+revise the threshold and templates.
+
+## Failure modes
+
+- **Tool call fails mid-write** (e.g. graph-ingest unreachable
+  between the 5 RemoveByPredicate calls and the batch add): the loop
+  entity is in a half-cleared state. Next call to `write_todos`
+  with the same args is idempotent — empty predicates are no-op
+  removes, then the batch add commits. Convergence in two calls.
+- **Read fails on iteration build**: the model just doesn't see the
+  working-list block this iteration. Next iteration retries. The
+  per-iteration read budget caps at 2s — the LLM call's latency is
+  unaffected.
+- **Model emits invalid status enum**: rejected pre-CAS as
+  `ToolErrorInvalidArgs` with the canonical enum names in the error
+  message. The model can self-correct without retrying through the
+  loop's outer retry policy.
+
+## Related ADRs
+
+- [ADR-036](../adr/036-agent-private-observable-state.md) — the
+  principle and the discipline rules.
+- [ADR-027](../adr/027-ops-agent-meta-harness.md) — the read-side
+  consumer of these signals.
+- [ADR-028](../adr/028-orchestration-architecture.md) — the
+  rules-don't-carry-content firewall this primitive extends.
+- [ADR-035](../adr/035-strict-tool-calling.md) — `write_todos`
+  ships with `Strict: true` so providers that honour
+  `function.strict` constrain status to the enum.

--- a/graph/mutation_requests.go
+++ b/graph/mutation_requests.go
@@ -59,6 +59,23 @@ type AddTripleRequest struct {
 	RequestID string         `json:"request_id,omitempty"`
 }
 
+// AddTriplesBatchRequest adds many triples in one request, atomically
+// per-entity (one CAS per distinct triple.Subject). Optimised for tools
+// that emit multiple triples in a single tool call (e.g. write_todos
+// per ADR-036 — 5 triples per todo × N todos all on the same loop
+// entity collapse to 1 CAS round-trip).
+//
+// The batch is NOT atomic across entities — if a write to entity A
+// succeeds but a CAS conflict on entity B exhausts retries, the
+// response surfaces the partial-failure shape and triples for A
+// remain written. Single-entity callers (the common case) see this
+// as fully atomic because there is only one CAS group.
+type AddTriplesBatchRequest struct {
+	Triples   []message.Triple `json:"triples"`
+	TraceID   string           `json:"trace_id,omitempty"`
+	RequestID string           `json:"request_id,omitempty"`
+}
+
 // RemoveTripleRequest removes a triple from an entity
 type RemoveTripleRequest struct {
 	Subject   string `json:"subject"`

--- a/graph/mutation_responses.go
+++ b/graph/mutation_responses.go
@@ -61,6 +61,32 @@ type AddTripleResponse struct {
 	Triple *message.Triple `json:"triple,omitempty"`
 }
 
+// AddTriplesBatchResponse response for batched triple addition.
+// Success is true iff all entities in the batch were updated. On
+// partial failure, FailedSubjects names the entity IDs that did not
+// commit, mapped to their error messages, so the caller can decide
+// whether to retry the failed subset, fall back to per-triple
+// AddTriple, or surface to the user. WrittenCount is the number of
+// triples that successfully committed across all entities.
+//
+// Discriminating rejection phases on Success=false:
+//
+//   - FailedSubjects empty/nil + WrittenCount=0 → pre-CAS validation
+//     rejected the whole batch (e.g. empty Subject/Predicate, malformed
+//     envelope). Nothing committed; safe to retry after fixing the
+//     input.
+//   - FailedSubjects non-empty → CAS phase reached. Per-entity
+//     atomicity means subjects NOT in FailedSubjects DID commit (their
+//     triples are durable); subjects in FailedSubjects rolled back. The
+//     caller can retry just the failed subset.
+//   - Success=true, FailedSubjects empty, WrittenCount>0 → all
+//     entities committed.
+type AddTriplesBatchResponse struct {
+	MutationResponse
+	WrittenCount   int               `json:"written_count"`
+	FailedSubjects map[string]string `json:"failed_subjects,omitempty"`
+}
+
 // RemoveTripleResponse response for triple removal
 type RemoveTripleResponse struct {
 	MutationResponse

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -155,6 +155,15 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 		}
 	}
 
+	// Wire the per-iteration write_todos reader (ADR-036 Stage 4) so
+	// every iteration's prompt prefix carries the current working
+	// list. NATS-less deployments (rare — most tests stub the client)
+	// silently skip the read.
+	if deps.NATSClient != nil {
+		handler.SetTodoReader(NewNATSTodoReader(deps.NATSClient))
+	}
+	handler.SetPlatform(deps.Platform)
+
 	comp := &Component{
 		config:         config,
 		handler:        handler,

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/c360studio/semstreams/model"
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/processor/agentic-loop/prompt"
+	"github.com/c360studio/semstreams/types"
 )
 
 // TaskMessage is an alias for agentic.TaskMessage for backward compatibility.
@@ -61,6 +62,17 @@ type MessageHandler struct {
 	modelRegistry     model.RegistryReader
 	toolRegistry      component.ToolRegistryReader
 	logger            *slog.Logger
+
+	// todoReader fetches the current write_todos list for a loop entity
+	// at iteration-build time (ADR-036 Stage 4). Nil disables the
+	// per-iteration todo block — fragments and trajectory still work.
+	// Set via SetTodoReader at component boot.
+	todoReader TodoReader
+
+	// platform identifies the org/platform pair used to construct loop
+	// entity IDs. Empty Org/Platform skips the todo read silently —
+	// the loop entity ID is unrecoverable without it.
+	platform types.PlatformMeta
 
 	// promptRegistry is the static fragment registry seeded with
 	// prompt.DefaultFragments at Component.Start. Nil means no assembler
@@ -150,6 +162,54 @@ func (h *MessageHandler) SetPromptRegistry(r *prompt.Registry) {
 // nil disables the per-task refresh; the registry is used as-is.
 func (h *MessageHandler) SetPersonaFragments(src PersonaFragmentSource) {
 	h.personaFragments = src
+}
+
+// SetTodoReader installs the reader the handler uses to fetch each
+// loop's write_todos list at iteration-build time (ADR-036 Stage 4).
+// Passing nil disables the per-iteration todo block.
+func (h *MessageHandler) SetTodoReader(r TodoReader) {
+	h.todoReader = r
+}
+
+// SetPlatform installs the org/platform pair used to construct loop
+// entity IDs for todo reads. The same identity is also used by other
+// graph paths in this package (graph_writer); typically wired once
+// from the same source at component boot.
+func (h *MessageHandler) SetPlatform(p types.PlatformMeta) {
+	h.platform = p
+}
+
+// maybeBuildTodoMessage reads the loop's current todo list and
+// formats it as a system message. Returns the zero ChatMessage on
+// disabled reader, missing platform, empty list, or read failure.
+// Read errors are logged at Debug level — the model just doesn't see
+// the block for this iteration; the next iteration retries.
+func (h *MessageHandler) maybeBuildTodoMessage(ctx context.Context, loopID string) agentic.ChatMessage {
+	if h.todoReader == nil || h.platform.Org == "" || h.platform.Platform == "" || loopID == "" {
+		return agentic.ChatMessage{}
+	}
+	loopEntityID := agentic.LoopExecutionEntityID(h.platform.Org, h.platform.Platform, loopID)
+	todos, err := h.todoReader.ReadTodos(ctx, loopEntityID)
+	if err != nil {
+		h.logger.Debug("todo read failed; iteration omits the todo block",
+			slog.String("loop_id", loopID),
+			slog.String("loop_entity_id", loopEntityID),
+			slog.Any("error", err))
+		return agentic.ChatMessage{}
+	}
+	return BuildTodoStateMessage(todos)
+}
+
+// prependIterationContext is the canonical prefix the loop attaches
+// to every iteration's message slice: the iteration-budget warning
+// (mandatory) followed by the optional working-list block. Both go
+// at the top so the model sees them before any prior conversation.
+func (h *MessageHandler) prependIterationContext(ctx context.Context, loopID string, iteration, maxIterations int, messages []agentic.ChatMessage) []agentic.ChatMessage {
+	prefix := []agentic.ChatMessage{BuildIterationBudgetMessage(iteration, maxIterations)}
+	if todoMsg := h.maybeBuildTodoMessage(ctx, loopID); todoMsg.Content != "" {
+		prefix = append(prefix, todoMsg)
+	}
+	return append(prefix, messages...)
 }
 
 // lookupLoopUserID resolves the owning user for a loop, returning "" when the
@@ -583,9 +643,10 @@ func (h *MessageHandler) HandleTask(ctx context.Context, task TaskMessage) (Hand
 
 	// Build messages for initial request with iteration budget. Pass the
 	// already-assembled system prompt so we avoid assembling a second time.
+	// prependIterationContext also injects the working-list block from
+	// write_todos when the loop has any todos (ADR-036 Stage 4).
 	messages := h.buildInitialMessagesWithPrompt(task, assembled)
-	budgetMsg := BuildIterationBudgetMessage(1, entity.MaxIterations)
-	messages = append([]agentic.ChatMessage{budgetMsg}, messages...)
+	messages = h.prependIterationContext(ctx, loopID, 1, entity.MaxIterations, messages)
 
 	// Per-task tools: if the spawner set task.Tools (including an explicit
 	// empty slice from e.g. `"default_tools": []`), respect it. Only fall
@@ -1264,8 +1325,7 @@ func (h *MessageHandler) emitRetryRequest(ctx context.Context, loopID string, en
 		messages = h.recoverEmptyContext(loopID, cm, entity.Iterations, 0)
 	}
 
-	budgetMsg := BuildIterationBudgetMessage(entity.Iterations, entity.MaxIterations)
-	messages = append([]agentic.ChatMessage{budgetMsg}, messages...)
+	messages = h.prependIterationContext(ctx, loopID, entity.Iterations, entity.MaxIterations, messages)
 
 	tools := h.loopManager.GetCachedTools(loopID)
 	toolChoice := h.loopManager.GetCachedToolChoice(loopID)
@@ -1718,9 +1778,9 @@ func (h *MessageHandler) handleToolsComplete(
 		messages = h.recoverEmptyContext(loopID, cm, newIteration, 0)
 	}
 
-	// Prepend iteration budget so the model sees its budget early in context
-	budgetMsg := BuildIterationBudgetMessage(newIteration, entity.MaxIterations)
-	messages = append([]agentic.ChatMessage{budgetMsg}, messages...)
+	// Prepend iteration budget + working list so the model sees both
+	// at the top of context.
+	messages = h.prependIterationContext(ctx, loopID, newIteration, entity.MaxIterations, messages)
 
 	// Check for cancellation before building request
 	if err := ctx.Err(); err != nil {

--- a/processor/agentic-loop/todos.go
+++ b/processor/agentic-loop/todos.go
@@ -1,0 +1,280 @@
+package agenticloop
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+// notFoundPrefix is the prefix natsclient.SubscribeForRequests stamps
+// onto handler-side errors when the responder returns a Go error
+// instead of structured response data. graph-ingest's
+// handleQueryEntityNATS returns "not found: <id>" as a Go error on
+// missing entities; the client sees that as a *successful* NATS
+// response whose body starts with "error: not found:".
+//
+// We detect that prefix and treat it as an empty-list signal so a
+// fresh loop's first iteration doesn't emit a JSON-unmarshal Debug
+// log line per check. Any other "error: ..." payload (e.g.
+// "error: internal error: ...") falls through and surfaces as an
+// unmarshal error that the caller logs.
+var notFoundPrefix = []byte("error: not found")
+
+// queryEntitySubject is the NATS subject for single-entity reads from
+// graph-ingest. Mirrors processor/graph-ingest/query.go.
+const queryEntitySubject = "graph.ingest.query.entity"
+
+// readTodosTimeout bounds the per-iteration todo-reconstruction read.
+// Failure surfaces silently — the model just doesn't see the todo
+// block for this iteration; the next iteration retries. ADR-036
+// §Stage 4 favours availability over consistency: a one-iteration
+// omission is better than blocking the whole loop on a transient
+// graph-gateway blip.
+const readTodosTimeout = 2 * time.Second
+
+// todoTripleStride is the count of agent.todo.* triples per todo
+// item. write_todos writes [id, content, status, position,
+// updated_at] interleaved per item in array order; the assembler
+// reads them back in the same stride.
+const todoTripleStride = 5
+
+// TodoState is the reconstructed shape of one todo item, assembled
+// from the five agent.todo.* triples on a loop entity.
+type TodoState struct {
+	ID        string
+	Content   string
+	Status    string
+	Position  int
+	UpdatedAt string
+}
+
+// TodoReader is the narrow surface MessageHandler uses to fetch the
+// current todo list for a loop. Production satisfies it via a NATS
+// adapter against graph.ingest.query.entity; tests substitute an
+// in-memory implementation.
+type TodoReader interface {
+	ReadTodos(ctx context.Context, loopEntityID string) ([]TodoState, error)
+}
+
+// natsTodoReader adapts natsclient.Client to TodoReader by issuing a
+// graph.ingest.query.entity request and reconstructing TodoState
+// values from the entity's triples. Treats "entity not found" as an
+// empty list (the loop has never written todos).
+type natsTodoReader struct {
+	client *natsclient.Client
+}
+
+// NewNATSTodoReader builds a TodoReader backed by the
+// graph.ingest.query.entity NATS surface.
+func NewNATSTodoReader(client *natsclient.Client) TodoReader {
+	return &natsTodoReader{client: client}
+}
+
+func (r *natsTodoReader) ReadTodos(ctx context.Context, loopEntityID string) ([]TodoState, error) {
+	req := struct {
+		ID string `json:"id"`
+	}{ID: loopEntityID}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal query request: %w", err)
+	}
+
+	respData, err := r.client.Request(ctx, queryEntitySubject, reqData, readTodosTimeout)
+	if err != nil {
+		// Transport-layer errors (timeout, no responders) — propagate.
+		// Handler-layer errors land in the response body via
+		// natsclient's "error: ..." payload convention, NOT in this
+		// err return; see notFoundPrefix above.
+		return nil, fmt.Errorf("request %s: %w", queryEntitySubject, err)
+	}
+
+	return parseQueryEntityTodos(respData)
+}
+
+// parseQueryEntityTodos decodes a graph.ingest.query.entity response
+// payload into TodoState values. Treats the "error: not found"
+// payload prefix as an empty list (fresh-loop case) so callers don't
+// log a JSON-unmarshal Debug line on every first iteration. Other
+// "error: ..." payloads fall through and surface as unmarshal
+// errors. Factored out so the not-found contract is testable
+// without a NATS test cluster.
+func parseQueryEntityTodos(respData []byte) ([]TodoState, error) {
+	if bytes.HasPrefix(respData, notFoundPrefix) {
+		return nil, nil
+	}
+
+	var entity graph.EntityState
+	if err := json.Unmarshal(respData, &entity); err != nil {
+		return nil, fmt.Errorf("unmarshal entity: %w", err)
+	}
+
+	return ReconstructTodos(entity.Triples), nil
+}
+
+// ReconstructTodos rebuilds the ordered todo list from a loop
+// entity's triples. Filters to agent.todo.* predicates, groups them
+// into todo items, and returns the items sorted by Position (the
+// agent's original array order).
+//
+// Stage 3's write_todos appends triples in the interleaved order
+// [id, content, status, position, updated_at] for each item in array
+// order, then graph-ingest preserves arrival order in the entity's
+// triple slice. So filtered triples come back in groups of five with
+// a known per-group field order. We parse in stride and skip any
+// malformed group (partial mid-write state, e.g. remove-then-add
+// failure with stale triples on disk).
+func ReconstructTodos(triples []message.Triple) []TodoState {
+	filtered := filterTodoTriples(triples)
+	if len(filtered) < todoTripleStride {
+		return nil
+	}
+
+	out := make([]TodoState, 0, len(filtered)/todoTripleStride)
+	for start := 0; start+todoTripleStride <= len(filtered); start += todoTripleStride {
+		group := filtered[start : start+todoTripleStride]
+		state, ok := projectTodoGroup(group)
+		if !ok {
+			continue
+		}
+		out = append(out, state)
+	}
+
+	// Sort by Position for the canonical output order. The triple
+	// order on disk is usually already in position order (write_todos
+	// emits them that way), but sorting defends against append-after-
+	// partial-clear states where the second batch's triples follow
+	// stale ones from a half-cleared first batch.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Position < out[j].Position })
+	return out
+}
+
+// filterTodoTriples drops any triple whose Predicate is outside the
+// agent.todo.* family, preserving slice order.
+func filterTodoTriples(triples []message.Triple) []message.Triple {
+	out := make([]message.Triple, 0, len(triples))
+	for _, t := range triples {
+		switch t.Predicate {
+		case agvocab.TodoID, agvocab.TodoContent, agvocab.TodoStatus, agvocab.TodoPosition, agvocab.TodoUpdatedAt:
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// projectTodoGroup maps a group of five triples in canonical order
+// (id, content, status, position, updated_at) onto a TodoState.
+// Returns ok=false when the group's predicate sequence doesn't match
+// the canonical order — caller skips that group.
+func projectTodoGroup(group []message.Triple) (TodoState, bool) {
+	if len(group) != todoTripleStride {
+		return TodoState{}, false
+	}
+	expected := [todoTripleStride]string{
+		agvocab.TodoID,
+		agvocab.TodoContent,
+		agvocab.TodoStatus,
+		agvocab.TodoPosition,
+		agvocab.TodoUpdatedAt,
+	}
+	for i, t := range group {
+		if t.Predicate != expected[i] {
+			return TodoState{}, false
+		}
+	}
+	id, ok := tripleObjectAsString(group[0].Object)
+	if !ok || id == "" {
+		return TodoState{}, false
+	}
+	content, ok := tripleObjectAsString(group[1].Object)
+	if !ok || content == "" {
+		return TodoState{}, false
+	}
+	status, ok := tripleObjectAsString(group[2].Object)
+	if !ok || status == "" {
+		return TodoState{}, false
+	}
+	position, ok := tripleObjectAsInt(group[3].Object)
+	if !ok {
+		return TodoState{}, false
+	}
+	updatedAt, _ := tripleObjectAsString(group[4].Object)
+
+	return TodoState{
+		ID:        id,
+		Content:   content,
+		Status:    status,
+		Position:  position,
+		UpdatedAt: updatedAt,
+	}, true
+}
+
+// tripleObjectAsString coerces a triple Object to string.
+func tripleObjectAsString(o any) (string, bool) {
+	switch v := o.(type) {
+	case string:
+		return v, true
+	case fmt.Stringer:
+		return v.String(), true
+	}
+	return "", false
+}
+
+// tripleObjectAsInt coerces a triple Object to int. Position
+// triples are written as int but JSON round-trips through float64.
+func tripleObjectAsInt(o any) (int, bool) {
+	switch v := o.(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case float64:
+		return int(v), true
+	case json.Number:
+		if n, err := v.Int64(); err == nil {
+			return int(n), true
+		}
+	}
+	return 0, false
+}
+
+// BuildTodoStateMessage formats the current todo list as a system
+// message the agent sees at the top of its iteration. Empty list
+// returns the zero ChatMessage (handler skips appending).
+//
+// Format is compact and mirrors Claude Code's TodoWrite display:
+// per-status marker + content, one per line. Operators reading the
+// prompt see what the agent sees.
+func BuildTodoStateMessage(todos []TodoState) agentic.ChatMessage {
+	if len(todos) == 0 {
+		return agentic.ChatMessage{}
+	}
+
+	var b strings.Builder
+	b.WriteString("[Working list — your private working memory; you maintain this via write_todos]\n")
+	for _, t := range todos {
+		fmt.Fprintf(&b, "%s %s\n", todoStatusMarker(t.Status), t.Content)
+	}
+	return agentic.ChatMessage{Role: "system", Content: strings.TrimRight(b.String(), "\n")}
+}
+
+func todoStatusMarker(status string) string {
+	switch status {
+	case "completed":
+		return "[x]"
+	case "in_progress":
+		return "[~]"
+	case "pending":
+		return "[ ]"
+	}
+	return "[?]"
+}

--- a/processor/agentic-loop/todos_integration_test.go
+++ b/processor/agentic-loop/todos_integration_test.go
@@ -1,0 +1,144 @@
+//go:build integration
+
+package agenticloop_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	agenticloop "github.com/c360studio/semstreams/processor/agentic-loop"
+	graphingest "github.com/c360studio/semstreams/processor/graph-ingest"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_TodoWriteReadRoundTrip is the end-to-end proof of
+// the ADR-036 compaction-survival mechanism: triples written to the
+// loop entity via the Stage 2 batch handler are reconstructible via
+// the Stage 4 NATS reader, in the original array order, with no
+// state held in the agent's chat history.
+//
+// The test deliberately does NOT boot the full agentic-loop: it
+// exercises only the contract Stage 4's reader depends on (write
+// triples → query the loop entity → reconstruct todos). This is the
+// invariant that makes context compaction safe to run without
+// destroying the working list.
+func TestIntegration_TodoWriteReadRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	streams := []natsclient.TestStreamConfig{
+		{Name: "ENTITY", Subjects: []string{"entity.>"}},
+	}
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+	natsClient := testClient.Client
+
+	// Boot graph-ingest to handle the mutation/query NATS surfaces.
+	config := graphingest.DefaultConfig()
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := graphingest.CreateGraphIngest(configJSON, component.Dependencies{NATSClient: natsClient})
+	require.NoError(t, err)
+	c := comp.(*graphingest.Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Stop(5 * time.Second) })
+	time.Sleep(100 * time.Millisecond) // wait for handlers to register
+
+	const loopID = "compaction-survival-001"
+	loopEntityID := agentic.LoopExecutionEntityID("acme", "ops", loopID)
+
+	// Iteration 1 — agent calls write_todos with three items.
+	// Build the same triple shape Stage 3's executor emits.
+	now := time.Now()
+	items := []struct {
+		id      string
+		content string
+		status  string
+	}{
+		{"1", "Survey existing rules", "completed"},
+		{"2", "Draft new rule", "in_progress"},
+		{"3", "Wire e2e test", "pending"},
+	}
+
+	triples := make([]message.Triple, 0, len(items)*5)
+	for i, it := range items {
+		triples = append(triples,
+			message.Triple{Subject: loopEntityID, Predicate: agvocab.TodoID, Object: it.id, Timestamp: now, Confidence: 1.0, Source: "agent-write-todos"},
+			message.Triple{Subject: loopEntityID, Predicate: agvocab.TodoContent, Object: it.content, Timestamp: now, Confidence: 1.0, Source: "agent-write-todos"},
+			message.Triple{Subject: loopEntityID, Predicate: agvocab.TodoStatus, Object: it.status, Timestamp: now, Confidence: 1.0, Source: "agent-write-todos"},
+			message.Triple{Subject: loopEntityID, Predicate: agvocab.TodoPosition, Object: i, Timestamp: now, Confidence: 1.0, Source: "agent-write-todos"},
+			message.Triple{Subject: loopEntityID, Predicate: agvocab.TodoUpdatedAt, Object: now.Format(time.RFC3339Nano), Timestamp: now, Confidence: 1.0, Source: "agent-write-todos"},
+		)
+	}
+
+	written, failed, err := c.AddTriples(ctx, triples)
+	require.NoError(t, err)
+	require.Empty(t, failed)
+	require.Equal(t, len(triples), written)
+
+	// Iteration 2 — context has been "compacted" (irrelevant to this
+	// test — the assembler doesn't read trajectory; it reads triples).
+	// The reader fetches from the loop entity and reconstructs the list.
+	reader := agenticloop.NewNATSTodoReader(natsClient)
+	got, err := reader.ReadTodos(ctx, loopEntityID)
+	require.NoError(t, err)
+	require.Len(t, got, len(items), "compaction-survival: all 3 todos reconstructed from triples")
+
+	for i, want := range items {
+		assert.Equal(t, want.id, got[i].ID, "todos[%d].ID", i)
+		assert.Equal(t, want.content, got[i].Content, "todos[%d].Content", i)
+		assert.Equal(t, want.status, got[i].Status, "todos[%d].Status", i)
+		assert.Equal(t, i, got[i].Position, "todos[%d].Position", i)
+	}
+
+	// Format as the system message — pin the operator-visible output
+	// matches what the prompt assembler actually injects.
+	msg := agenticloop.BuildTodoStateMessage(got)
+	require.Equal(t, "system", msg.Role)
+	assert.Contains(t, msg.Content, "[Working list", "header line")
+	assert.Contains(t, msg.Content, "[x] Survey existing rules", "completed marker")
+	assert.Contains(t, msg.Content, "[~] Draft new rule", "in_progress marker")
+	assert.Contains(t, msg.Content, "[ ] Wire e2e test", "pending marker")
+}
+
+// TestIntegration_FreshLoopReturnsEmptyList covers the case Stage 4's
+// reviewer flagged H1 on: a loop with no entity yet (first iteration,
+// agent hasn't called write_todos) must return an empty list, NOT a
+// JSON-unmarshal error. Without the fix, every fresh loop's first
+// iteration would emit a Debug log line.
+func TestIntegration_FreshLoopReturnsEmptyList(t *testing.T) {
+	ctx := context.Background()
+
+	streams := []natsclient.TestStreamConfig{
+		{Name: "ENTITY", Subjects: []string{"entity.>"}},
+	}
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+	natsClient := testClient.Client
+
+	config := graphingest.DefaultConfig()
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := graphingest.CreateGraphIngest(configJSON, component.Dependencies{NATSClient: natsClient})
+	require.NoError(t, err)
+	c := comp.(*graphingest.Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Stop(5 * time.Second) })
+	time.Sleep(100 * time.Millisecond)
+
+	loopEntityID := agentic.LoopExecutionEntityID("acme", "ops", "fresh-loop-never-wrote-todos")
+
+	reader := agenticloop.NewNATSTodoReader(natsClient)
+	got, err := reader.ReadTodos(ctx, loopEntityID)
+	require.NoError(t, err, "missing entity must not surface as an error — fail-open contract from Stage 4")
+	assert.Nil(t, got, "fresh loop returns nil/empty list")
+}

--- a/processor/agentic-loop/todos_test.go
+++ b/processor/agentic-loop/todos_test.go
@@ -1,0 +1,326 @@
+package agenticloop
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/types"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+// todoFixtureLoopEntityID is the canonical loop entity ID used by
+// the todo unit tests. Avoids the name todoFixtureLoopEntityID which
+// graph_writer_ops_test.go owns as a function.
+var todoFixtureLoopEntityID = agentic.LoopExecutionEntityID(testOrg, testPlatform, "loop123")
+
+func todoTestPlatform() types.PlatformMeta {
+	return types.PlatformMeta{Org: testOrg, Platform: testPlatform}
+}
+
+func todoTestLogger() *slog.Logger { return slog.Default() }
+
+var errTodoReadFailed = errors.New("graph-gateway transient unavailable")
+
+// makeTodoBatch produces the canonical 5-triple sequence write_todos
+// emits per item, in the same interleaved order. Tests use it to
+// avoid hand-rolling the fixture format.
+func makeTodoBatch(t *testing.T, items []TodoState, ts time.Time) []message.Triple {
+	t.Helper()
+	out := make([]message.Triple, 0, len(items)*todoTripleStride)
+	for i, item := range items {
+		out = append(out,
+			message.Triple{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoID, Object: item.ID, Timestamp: ts, Confidence: 1.0},
+			message.Triple{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoContent, Object: item.Content, Timestamp: ts, Confidence: 1.0},
+			message.Triple{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoStatus, Object: item.Status, Timestamp: ts, Confidence: 1.0},
+			message.Triple{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoPosition, Object: i, Timestamp: ts, Confidence: 1.0},
+			message.Triple{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoUpdatedAt, Object: ts.Format(time.RFC3339Nano), Timestamp: ts, Confidence: 1.0},
+		)
+	}
+	return out
+}
+
+func TestReconstructTodos_HappyPath(t *testing.T) {
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	items := []TodoState{
+		{ID: "1", Content: "Survey rules", Status: "completed"},
+		{ID: "2", Content: "Draft new rule", Status: "in_progress"},
+		{ID: "3", Content: "Wire e2e test", Status: "pending"},
+	}
+	got := ReconstructTodos(makeTodoBatch(t, items, now))
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	for i, want := range items {
+		if got[i].ID != want.ID {
+			t.Errorf("got[%d].ID = %q, want %q", i, got[i].ID, want.ID)
+		}
+		if got[i].Content != want.Content {
+			t.Errorf("got[%d].Content = %q, want %q", i, got[i].Content, want.Content)
+		}
+		if got[i].Status != want.Status {
+			t.Errorf("got[%d].Status = %q, want %q", i, got[i].Status, want.Status)
+		}
+		if got[i].Position != i {
+			t.Errorf("got[%d].Position = %d, want %d", i, got[i].Position, i)
+		}
+	}
+}
+
+// TestReconstructTodos_EmptyAndIrrelevant verifies non-todo triples
+// don't bleed in and an empty triple slice yields nil.
+func TestReconstructTodos_EmptyAndIrrelevant(t *testing.T) {
+	if got := ReconstructTodos(nil); got != nil {
+		t.Errorf("nil triples → got %v, want nil", got)
+	}
+	now := time.Now()
+	mixed := []message.Triple{
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.LoopOutcome, Object: "success", Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: "rule.spawned_task", Object: "x", Timestamp: now},
+	}
+	if got := ReconstructTodos(mixed); got != nil {
+		t.Errorf("non-todo triples → got %v, want nil", got)
+	}
+}
+
+// TestReconstructTodos_FewerThanStride drops a partial group instead
+// of emitting a half-formed item — matches the mid-write-failure
+// recovery contract.
+func TestReconstructTodos_FewerThanStride(t *testing.T) {
+	now := time.Now()
+	partial := []message.Triple{
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoID, Object: "1", Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoContent, Object: "x", Timestamp: now},
+		// status, position, updated_at missing — simulates a write that
+		// got partially flushed before the loop entity was read.
+	}
+	if got := ReconstructTodos(partial); len(got) != 0 {
+		t.Errorf("partial group → got %v, want empty", got)
+	}
+}
+
+// TestReconstructTodos_OutOfOrderGroupSkipped pins that the parser
+// tolerates a desynchronised triple stream rather than emitting
+// scrambled state. If a future graph-ingest change reorders the
+// stored slice, the assembler degrades gracefully.
+func TestReconstructTodos_OutOfOrderGroupSkipped(t *testing.T) {
+	now := time.Now()
+	scrambled := []message.Triple{
+		// Group 1 — order matches contract (id, content, status, position, updated_at).
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoID, Object: "1", Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoContent, Object: "ok", Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoStatus, Object: "pending", Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoPosition, Object: 0, Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoUpdatedAt, Object: now.Format(time.RFC3339Nano), Timestamp: now},
+		// Group 2 — predicate order scrambled (status before id). Skipped.
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoStatus, Object: "completed", Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoID, Object: "2", Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoContent, Object: "skipped", Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoPosition, Object: 1, Timestamp: now},
+		{Subject: todoFixtureLoopEntityID, Predicate: agvocab.TodoUpdatedAt, Object: now.Format(time.RFC3339Nano), Timestamp: now},
+	}
+	got := ReconstructTodos(scrambled)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (only the first group is in canonical order)", len(got))
+	}
+	if got[0].ID != "1" {
+		t.Errorf("got[0].ID = %q, want %q", got[0].ID, "1")
+	}
+}
+
+func TestBuildTodoStateMessage_FormatAndStatusMarkers(t *testing.T) {
+	msg := BuildTodoStateMessage([]TodoState{
+		{ID: "1", Content: "done thing", Status: "completed", Position: 0},
+		{ID: "2", Content: "in flight", Status: "in_progress", Position: 1},
+		{ID: "3", Content: "next up", Status: "pending", Position: 2},
+		{ID: "4", Content: "weird", Status: "wat", Position: 3},
+	})
+	if msg.Role != "system" {
+		t.Errorf("Role = %q, want system", msg.Role)
+	}
+	for _, want := range []string{
+		"[Working list",  // header
+		"[x] done thing", // completed
+		"[~] in flight",  // in_progress
+		"[ ] next up",    // pending
+		"[?] weird",      // unrecognised
+	} {
+		if !strings.Contains(msg.Content, want) {
+			t.Errorf("content missing %q\n--- content ---\n%s", want, msg.Content)
+		}
+	}
+}
+
+func TestBuildTodoStateMessage_EmptyReturnsZeroValue(t *testing.T) {
+	msg := BuildTodoStateMessage(nil)
+	if msg.Role != "" || msg.Content != "" {
+		t.Errorf("empty list should return zero ChatMessage, got %+v", msg)
+	}
+}
+
+// TestParseQueryEntityTodos_NotFoundIsEmptyList pins the fresh-loop
+// fail-open contract. graph-ingest's handler returns a Go error on
+// missing entity, but natsclient.SubscribeForRequests wraps it as a
+// successful NATS response whose body is "error: not found: <id>".
+// We must detect that prefix and return an empty list rather than
+// emit a JSON-unmarshal Debug log per iteration of every fresh loop.
+// Regression: the prior implementation checked err.Error() on the
+// Request return, which never fires on this protocol path.
+func TestParseQueryEntityTodos_NotFoundIsEmptyList(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   string
+		wantNil   bool
+		wantError bool
+	}{
+		{"exact prefix", "error: not found", true, false},
+		{"with id suffix", "error: not found: acme.test.foo.bar.loop.001", true, false},
+		// Other "error: ..." payloads fall through and surface as
+		// unmarshal failures — the caller logs Debug, the model just
+		// doesn't see the block this iteration. Tested here so a
+		// future protocol change that broadens the not-found prefix
+		// (e.g. to "error:" alone) trips this case.
+		{"other handler error", "error: internal error: db down", false, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			todos, err := parseQueryEntityTodos([]byte(tt.payload))
+			if tt.wantNil {
+				if err != nil {
+					t.Errorf("payload %q: got err %v, want nil", tt.payload, err)
+				}
+				if todos != nil {
+					t.Errorf("payload %q: got todos %v, want nil", tt.payload, todos)
+				}
+				return
+			}
+			if tt.wantError && err == nil {
+				t.Errorf("payload %q: expected unmarshal error, got nil", tt.payload)
+			}
+		})
+	}
+}
+
+// fakeTodoReader is the minimal in-process TodoReader for handler-level tests.
+type fakeTodoReader struct {
+	todos []TodoState
+	err   error
+}
+
+func (f *fakeTodoReader) ReadTodos(_ context.Context, _ string) ([]TodoState, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.todos, nil
+}
+
+// TestMessageHandler_PrependIterationContext_TodoBlock verifies that
+// when a TodoReader is wired and returns todos, the handler's
+// per-iteration prefix carries both the budget message AND the
+// working-list block (in that order).
+func TestMessageHandler_PrependIterationContext_TodoBlock(t *testing.T) {
+	h := &MessageHandler{
+		config:   Config{},
+		platform: todoTestPlatform(),
+		todoReader: &fakeTodoReader{
+			todos: []TodoState{{ID: "1", Content: "track me", Status: "in_progress"}},
+		},
+	}
+	h.logger = todoTestLogger()
+
+	prefixed := h.prependIterationContext(context.Background(), "loop-x", 1, 10, []agentic.ChatMessage{
+		{Role: "user", Content: "go"},
+	})
+	if len(prefixed) != 3 {
+		t.Fatalf("len = %d, want 3 (budget + todo + user)", len(prefixed))
+	}
+	if !strings.Contains(prefixed[0].Content, "Iteration Budget") {
+		t.Errorf("prefix[0] should be the iteration budget; got %q", prefixed[0].Content)
+	}
+	if !strings.Contains(prefixed[1].Content, "[~] track me") {
+		t.Errorf("prefix[1] should be the working-list block; got %q", prefixed[1].Content)
+	}
+	if prefixed[2].Role != "user" {
+		t.Errorf("prefix[2] should be the original user message; got %+v", prefixed[2])
+	}
+}
+
+// TestMessageHandler_PrependIterationContext_NoTodoReader verifies
+// that without a TodoReader (NATS-less test path), the handler still
+// prepends only the budget message and doesn't crash.
+func TestMessageHandler_PrependIterationContext_NoTodoReader(t *testing.T) {
+	h := &MessageHandler{
+		config:   Config{},
+		platform: todoTestPlatform(),
+	}
+	h.logger = todoTestLogger()
+	prefixed := h.prependIterationContext(context.Background(), "loop-x", 1, 10, []agentic.ChatMessage{
+		{Role: "user", Content: "go"},
+	})
+	if len(prefixed) != 2 {
+		t.Fatalf("len = %d, want 2 (budget + user)", len(prefixed))
+	}
+}
+
+// TestMessageHandler_PrependIterationContext_EmptyTodos verifies the
+// empty-list case — TodoReader returns no items, handler skips the
+// block.
+func TestMessageHandler_PrependIterationContext_EmptyTodos(t *testing.T) {
+	h := &MessageHandler{
+		config:     Config{},
+		platform:   todoTestPlatform(),
+		todoReader: &fakeTodoReader{todos: nil},
+	}
+	h.logger = todoTestLogger()
+	prefixed := h.prependIterationContext(context.Background(), "loop-x", 1, 10, nil)
+	if len(prefixed) != 1 {
+		t.Fatalf("len = %d, want 1 (just the budget; no todo block when list is empty)", len(prefixed))
+	}
+	if !strings.Contains(prefixed[0].Content, "Iteration Budget") {
+		t.Errorf("prefix[0] should be the iteration budget; got %q", prefixed[0].Content)
+	}
+}
+
+// TestMessageHandler_PrependIterationContext_ReadFailure_FailsOpen
+// verifies that read errors are swallowed silently — the handler
+// just doesn't see a todo block this iteration; the next iteration
+// retries.
+func TestMessageHandler_PrependIterationContext_ReadFailure_FailsOpen(t *testing.T) {
+	h := &MessageHandler{
+		config:     Config{},
+		platform:   todoTestPlatform(),
+		todoReader: &fakeTodoReader{err: errTodoReadFailed},
+	}
+	h.logger = todoTestLogger()
+	prefixed := h.prependIterationContext(context.Background(), "loop-x", 1, 10, nil)
+	if len(prefixed) != 1 {
+		t.Fatalf("len = %d, want 1 (failure surfaces as no todo block, not as a panic)", len(prefixed))
+	}
+}
+
+// TestMessageHandler_PrependIterationContext_MissingPlatformSkipsRead
+// verifies that an unset platform (e.g. unit test that didn't call
+// SetPlatform) doesn't attempt to construct a loop entity ID — the
+// helper returns the budget message only.
+func TestMessageHandler_PrependIterationContext_MissingPlatformSkipsRead(t *testing.T) {
+	h := &MessageHandler{
+		config: Config{},
+		// platform intentionally zero-valued
+		todoReader: &fakeTodoReader{
+			todos: []TodoState{{ID: "1", Content: "should not appear", Status: "pending"}},
+		},
+	}
+	h.logger = todoTestLogger()
+	prefixed := h.prependIterationContext(context.Background(), "loop-x", 1, 10, nil)
+	if len(prefixed) != 1 {
+		t.Fatalf("len = %d, want 1 (zero platform skips the todo read)", len(prefixed))
+	}
+	if strings.Contains(prefixed[0].Content, "should not appear") {
+		t.Errorf("zero-platform path must not invoke the reader; got %q", prefixed[0].Content)
+	}
+}

--- a/processor/agentic-tools/categories.go
+++ b/processor/agentic-tools/categories.go
@@ -35,6 +35,9 @@ var toolCategoryMu sync.RWMutex
 var toolCategories = map[string]ToolCategory{
 	// Core
 	"submit_work": CategoryCore,
+	// write_todos: agent-private observable state (ADR-036). Core
+	// because every role can use it; opacity is per-loop, not per-role.
+	"write_todos": CategoryCore,
 
 	// Knowledge
 	"graph_query":   CategoryKnowledge,

--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -230,7 +230,14 @@ func (e *DecideExecutor) decide(ctx context.Context, call agentic.ToolCall) (age
 		}, errs.WrapInvalid(fmt.Errorf("tool call missing loop_id"), "DecideExecutor", "decide", "resolve loop entity")
 	}
 
-	loopEntityID := agentic.LoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("construct loop entity ID: %v", err),
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(err, "DecideExecutor", "decide", "construct loop entity ID")
+	}
 
 	now := time.Now()
 	triples := []message.Triple{

--- a/processor/agentic-tools/emit_diagnosis.go
+++ b/processor/agentic-tools/emit_diagnosis.go
@@ -177,7 +177,14 @@ func (e *EmitDiagnosisExecutor) emitDiagnosis(ctx context.Context, call agentic.
 	// oklog/ulid is not in go.mod; uuid is equivalent for uniqueness purposes.
 	diagnosisID := uuid.New().String()
 	diagnosisEntityID := agentic.OpsDiagnosisEntityID(e.platform.Org, e.platform.Platform, diagnosisID)
-	loopEntityID := agentic.LoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("construct loop entity ID: %v", err),
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(err, "EmitDiagnosisExecutor", "emitDiagnosis", "construct loop entity ID")
+	}
 
 	now := time.Now()
 

--- a/processor/agentic-tools/executors/register.go
+++ b/processor/agentic-tools/executors/register.go
@@ -103,6 +103,7 @@ func RegisterBuiltins(ctx context.Context, reg *agentictools.ExecutorRegistry, d
 		track(registerDecide(reg, deps.NATSClient, deps.Platform, logger))
 		track(registerEmitDiagnosis(reg, deps.NATSClient, deps.Platform, logger))
 		track(registerGraphQuery(ctx, reg, deps.NATSClient, logger))
+		track(registerWriteTodos(reg, deps.NATSClient, deps.Platform, logger))
 	}
 
 	// Pattern-B registry-backed tools. A nil manager is a legal skip;

--- a/processor/agentic-tools/executors/register_write_todos.go
+++ b/processor/agentic-tools/executors/register_write_todos.go
@@ -1,0 +1,30 @@
+package executors
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/natsclient"
+	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
+)
+
+// registerWriteTodos wires the ADR-036 write_todos tool. The tool
+// writes agent-private todo state on the calling loop's entity via
+// the graph.mutation.triple.add_batch (Stage 2) and
+// graph.mutation.triple.remove NATS surfaces. Available to all roles
+// (per ADR-036 §First Instance — opacity is per-loop, not per-role);
+// persona authors opt out via tool allowlists for tiny-model
+// deployments.
+func registerWriteTodos(reg *agentictools.ExecutorRegistry, natsClient *natsclient.Client, platform component.PlatformMeta, logger *slog.Logger) error {
+	writer := agentictools.NewNATSTodoWriter(natsClient)
+	executor := agentictools.NewWriteTodosExecutor(writer, platform)
+	executor.SetLogger(logger)
+	if err := reg.RegisterTool(agentictools.WriteTodosToolName, executor); err != nil {
+		return fmt.Errorf("register write_todos: %w", err)
+	}
+	logger.Info("Registered write_todos tool",
+		slog.String("org", platform.Org),
+		slog.String("platform", platform.Platform))
+	return nil
+}

--- a/processor/agentic-tools/write_todos.go
+++ b/processor/agentic-tools/write_todos.go
@@ -218,7 +218,14 @@ func (e *WriteTodosExecutor) write(ctx context.Context, call agentic.ToolCall) (
 			ErrorKind: agentic.ToolErrorInternal,
 		}, errs.WrapInvalid(fmt.Errorf("tool call missing loop_id"), "WriteTodosExecutor", "write", "resolve loop entity")
 	}
-	loopEntityID := agentic.LoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("construct loop entity ID: %v", err),
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(err, "WriteTodosExecutor", "write", "construct loop entity ID")
+	}
 
 	// Step 1 — clear prior todo state. Each predicate is one CAS on the
 	// loop entity. A future Stage 3.5 may collapse these to a single

--- a/processor/agentic-tools/write_todos.go
+++ b/processor/agentic-tools/write_todos.go
@@ -96,18 +96,36 @@ type WriteTodosExecutor struct {
 	writer   TodoWriter
 	platform types.PlatformMeta
 	logger   *slog.Logger
+	now      func() time.Time
 }
 
 // NewWriteTodosExecutor constructs the executor given a writer and
-// the platform identity used to resolve loop entity IDs.
+// the platform identity used to resolve loop entity IDs. The clock
+// defaults to time.Now; tests inject a frozen clock via SetClock.
 func NewWriteTodosExecutor(writer TodoWriter, platform types.PlatformMeta) *WriteTodosExecutor {
-	return &WriteTodosExecutor{writer: writer, platform: platform, logger: slog.Default()}
+	return &WriteTodosExecutor{
+		writer:   writer,
+		platform: platform,
+		logger:   slog.Default(),
+		now:      time.Now,
+	}
 }
 
 // SetLogger replaces the default logger. nil-safe.
 func (e *WriteTodosExecutor) SetLogger(logger *slog.Logger) {
 	if logger != nil {
 		e.logger = logger
+	}
+}
+
+// SetClock replaces the time source the executor stamps onto
+// triples (Triple.Timestamp and the agent.todo.updated_at value).
+// nil-safe — passing nil preserves the existing clock. Used by
+// tests for deterministic timestamp assertions; production should
+// not call this.
+func (e *WriteTodosExecutor) SetClock(now func() time.Time) {
+	if now != nil {
+		e.now = now
 	}
 }
 
@@ -219,7 +237,7 @@ func (e *WriteTodosExecutor) write(ctx context.Context, call agentic.ToolCall) (
 
 	// Step 2 — write the new set as a single batch (one CAS on the
 	// loop entity for all 5N triples thanks to ADR-036 Stage 2).
-	triples := buildTodoTriples(loopEntityID, args.Todos, time.Now())
+	triples := buildTodoTriples(loopEntityID, args.Todos, e.now())
 	if len(triples) > 0 {
 		if err := e.writer.AddTriplesBatch(ctx, triples); err != nil {
 			return agentic.ToolResult{

--- a/processor/agentic-tools/write_todos.go
+++ b/processor/agentic-tools/write_todos.go
@@ -1,0 +1,433 @@
+package agentictools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/types"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+// WriteTodosToolName is the name agents use to invoke the write_todos
+// tool. ADR-036 §First Instance.
+const WriteTodosToolName = "write_todos"
+
+// writeTodosBatchSubject is the NATS subject for the batched
+// add-triple path. Stage 2 of ADR-036; matches
+// processor/graph-ingest/mutations.go SubjectTripleAddBatch.
+const writeTodosBatchSubject = "graph.mutation.triple.add_batch"
+
+// writeTodosRemoveSubject is the NATS subject the executor uses to
+// clear prior todo state. Mirrors decide.go's mutation surface.
+const writeTodosRemoveSubject = "graph.mutation.triple.remove"
+
+// writeTodosTimeout bounds each individual round-trip to graph-ingest.
+// The tool issues one remove per todo predicate (len(todoPredicates))
+// plus one batch add per call; the per-call worst case is roughly
+// (len(todoPredicates)+1) * writeTodosTimeout * RetryAttempts and is
+// otherwise only bounded by the caller's outer context deadline.
+const writeTodosTimeout = 5 * time.Second
+
+// writeTodosToolSource is the Source field on triples this tool
+// writes. Lets operators distinguish todo writes from rule-driven or
+// coordinator-decision triples in graph queries.
+const writeTodosToolSource = "agent-write-todos"
+
+// todoPredicates lists the predicate names that compose one todo
+// item. write_todos clears all triples on the loop entity matching
+// any of these before writing the new set, implementing full-list
+// replace semantics.
+var todoPredicates = []string{
+	agvocab.TodoID,
+	agvocab.TodoContent,
+	agvocab.TodoStatus,
+	agvocab.TodoPosition,
+	agvocab.TodoUpdatedAt,
+}
+
+// validTodoStatuses enumerates the ADR-036 status enum. The executor
+// rejects any other value with ToolErrorInvalidArgs so the LLM can
+// self-correct rather than emitting silently-broken state.
+var validTodoStatuses = map[string]struct{}{
+	"pending":     {},
+	"in_progress": {},
+	"completed":   {},
+}
+
+// TodoWriter is the narrow surface WriteTodosExecutor uses to mutate
+// the graph. Production satisfies it with a NATS-backed adapter; tests
+// substitute an in-memory recorder.
+//
+// RemoveByPredicate clears all triples on `subject` whose Predicate
+// matches `predicate` — the canonical full-list-replace primitive at
+// the predicate granularity. Idempotent on repeat or empty subjects.
+//
+// AddTriplesBatch atomically appends a slice of triples grouped per
+// Subject (single CAS per entity at the graph-ingest end, ADR-036
+// Stage 2). For write_todos every triple shares the loop entity ID,
+// so the call is fully atomic in practice.
+type TodoWriter interface {
+	RemoveByPredicate(ctx context.Context, subject, predicate string) error
+	AddTriplesBatch(ctx context.Context, triples []message.Triple) error
+}
+
+// WriteTodosExecutor implements the write_todos tool from ADR-036.
+// It writes agent-private todo state onto the calling loop's entity
+// — the agent is the sole writer and sole interpreter of content
+// (the persona's discipline, not enforced at the executor level).
+//
+// Each call has full-list-replace semantics: every existing
+// agent.todo.* triple on the loop entity is cleared before the new
+// triples are written. The agent submits the entire desired list on
+// every call.
+//
+// All public methods are safe for concurrent use across loops; the
+// executor holds no per-call mutable state. Within a single loop,
+// the agentic-loop already serialises tool calls.
+type WriteTodosExecutor struct {
+	writer   TodoWriter
+	platform types.PlatformMeta
+	logger   *slog.Logger
+}
+
+// NewWriteTodosExecutor constructs the executor given a writer and
+// the platform identity used to resolve loop entity IDs.
+func NewWriteTodosExecutor(writer TodoWriter, platform types.PlatformMeta) *WriteTodosExecutor {
+	return &WriteTodosExecutor{writer: writer, platform: platform, logger: slog.Default()}
+}
+
+// SetLogger replaces the default logger. nil-safe.
+func (e *WriteTodosExecutor) SetLogger(logger *slog.Logger) {
+	if logger != nil {
+		e.logger = logger
+	}
+}
+
+// ListTools returns the write_todos tool definition. The schema is
+// strict-mode-compliant (ADR-035): every property listed in required,
+// every nested object closes with additionalProperties:false, the
+// status field is an enum so providers that honour function.strict
+// constrain the model's sample to canonical values.
+func (e *WriteTodosExecutor) ListTools() []agentic.ToolDefinition {
+	return []agentic.ToolDefinition{{
+		Name: WriteTodosToolName,
+		Description: "Maintain a working list of items to track for yourself across this loop's iterations. " +
+			"Submit the entire current list on each call — every call replaces the prior list, so include items already completed if you want them remembered. " +
+			"Use this when work has multiple steps that span iterations, when steps depend on prior results, or when context compaction may evict your plan from the conversation. " +
+			"Skip it for single-step lookups or one-shot tool calls where there is nothing to track.",
+		Parameters: map[string]any{
+			"type":                 "object",
+			"required":             []string{"todos"},
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"todos": map[string]any{
+					"type":        "array",
+					"description": "The complete current list. Order is preserved. Provide an empty array to clear the list.",
+					"items": map[string]any{
+						"type":                 "object",
+						"required":             []string{"id", "content", "status"},
+						"additionalProperties": false,
+						"properties": map[string]any{
+							"id": map[string]any{
+								"type":        "string",
+								"description": "Stable identifier you assign — keep it stable across calls so progress is observable.",
+							},
+							"content": map[string]any{
+								"type":        "string",
+								"description": "What the item is. Free-form, owner-interpretable; only you read this.",
+							},
+							"status": map[string]any{
+								"type":        "string",
+								"enum":        []string{"pending", "in_progress", "completed"},
+								"description": "Mark items completed in the same iteration the work happened — never batch at the end.",
+							},
+						},
+					},
+				},
+			},
+		},
+		Strict: true,
+	}}
+}
+
+// todoArg is the parsed shape of one todo item from the tool args.
+type todoArg struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+	Status  string `json:"status"`
+}
+
+// writeTodosArgs is the parsed shape of the write_todos arguments.
+type writeTodosArgs struct {
+	Todos []todoArg `json:"todos"`
+}
+
+// Execute routes the tool call. Any name other than write_todos is a
+// routing bug at the dispatcher layer.
+func (e *WriteTodosExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agentic.ToolResult, error) {
+	if call.Name != WriteTodosToolName {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("unknown tool: %s", call.Name),
+			ErrorKind: agentic.ToolErrorNotFound,
+		}, errs.WrapInvalid(fmt.Errorf("unknown tool: %s", call.Name), "WriteTodosExecutor", "Execute", "route tool")
+	}
+	return e.write(ctx, call)
+}
+
+func (e *WriteTodosExecutor) write(ctx context.Context, call agentic.ToolCall) (agentic.ToolResult, error) {
+	args, err := parseWriteTodosArgs(call.Arguments)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     err.Error(),
+			ErrorKind: agentic.ToolErrorInvalidArgs,
+		}, nil
+	}
+
+	if call.LoopID == "" {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     "write_todos invoked without a loop_id; cannot resolve the loop entity",
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(fmt.Errorf("tool call missing loop_id"), "WriteTodosExecutor", "write", "resolve loop entity")
+	}
+	loopEntityID := agentic.LoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+
+	// Step 1 — clear prior todo state. Each predicate is one CAS on the
+	// loop entity. A future Stage 3.5 may collapse these to a single
+	// atomic update_entity_with_triples handler; for now sequential is
+	// correct and the IO cost is bounded to len(todoPredicates) round-
+	// trips per call.
+	for _, predicate := range todoPredicates {
+		if err := e.writer.RemoveByPredicate(ctx, loopEntityID, predicate); err != nil {
+			return agentic.ToolResult{
+				CallID:    call.ID,
+				Error:     fmt.Sprintf("clear prior %s: %v", predicate, err),
+				ErrorKind: agentic.ToolErrorNetwork,
+			}, errs.WrapTransient(err, "WriteTodosExecutor", "write", "clear prior todos")
+		}
+	}
+
+	// Step 2 — write the new set as a single batch (one CAS on the
+	// loop entity for all 5N triples thanks to ADR-036 Stage 2).
+	triples := buildTodoTriples(loopEntityID, args.Todos, time.Now())
+	if len(triples) > 0 {
+		if err := e.writer.AddTriplesBatch(ctx, triples); err != nil {
+			return agentic.ToolResult{
+				CallID:    call.ID,
+				Error:     fmt.Sprintf("batch write todos: %v", err),
+				ErrorKind: agentic.ToolErrorNetwork,
+			}, errs.WrapTransient(err, "WriteTodosExecutor", "write", "batch add triples")
+		}
+	}
+
+	// Build a compact summary for ToolResult.Content. The agent reads
+	// this back via the trajectory; the prompt assembler reconstructs
+	// the full list each iteration from the loop-entity triples (ADR-036
+	// Stage 4) so this content is informational, not load-bearing.
+	summary := buildWriteTodosSummary(args.Todos)
+	payload, err := json.Marshal(summary)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("marshal summary: %v", err),
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(err, "WriteTodosExecutor", "write", "marshal summary")
+	}
+
+	e.logger.Debug("write_todos applied",
+		"loop_id", call.LoopID,
+		"loop_entity_id", loopEntityID,
+		"todo_count", len(args.Todos),
+		"triple_count", len(triples))
+
+	return agentic.ToolResult{
+		CallID:  call.ID,
+		Content: string(payload),
+		Metadata: map[string]any{
+			"loop_entity_id": loopEntityID,
+			"todo_count":     len(args.Todos),
+			"triple_count":   len(triples),
+		},
+	}, nil
+}
+
+// parseWriteTodosArgs decodes and validates the tool arguments.
+// Validation errors return ToolErrorInvalidArgs strings so the LLM
+// can self-correct without surfacing as fatal Go errors.
+func parseWriteTodosArgs(raw map[string]any) (writeTodosArgs, error) {
+	var args writeTodosArgs
+	if raw == nil {
+		return args, fmt.Errorf("missing required argument %q", "todos")
+	}
+
+	rawTodos, ok := raw["todos"]
+	if !ok {
+		return args, fmt.Errorf("missing required argument %q", "todos")
+	}
+
+	// Round-trip through JSON so the array-of-object shape is
+	// canonical even if the caller passed map[string]any inside an []any.
+	encoded, err := json.Marshal(rawTodos)
+	if err != nil {
+		return args, fmt.Errorf("encode todos: %w", err)
+	}
+	if err := json.Unmarshal(encoded, &args.Todos); err != nil {
+		return args, fmt.Errorf("decode todos: must be an array of {id, content, status}")
+	}
+
+	seenIDs := make(map[string]struct{}, len(args.Todos))
+	for i, t := range args.Todos {
+		if t.ID == "" {
+			return args, fmt.Errorf("todos[%d].id must be a non-empty string", i)
+		}
+		if t.Content == "" {
+			return args, fmt.Errorf("todos[%d].content must be a non-empty string", i)
+		}
+		if _, ok := validTodoStatuses[t.Status]; !ok {
+			return args, fmt.Errorf("todos[%d].status %q is invalid; must be one of pending|in_progress|completed", i, t.Status)
+		}
+		if _, dup := seenIDs[t.ID]; dup {
+			return args, fmt.Errorf("todos[%d].id %q is a duplicate; ids must be unique within a call", i, t.ID)
+		}
+		seenIDs[t.ID] = struct{}{}
+	}
+
+	return args, nil
+}
+
+// buildTodoTriples produces the five triples per todo item that the
+// prompt assembler reconstructs the list from. Position is derived
+// from the array index (0-based); updated_at is the caller-supplied
+// wall-clock time so tests can pin it deterministically.
+func buildTodoTriples(loopEntityID string, todos []todoArg, now time.Time) []message.Triple {
+	if len(todos) == 0 {
+		return nil
+	}
+	triples := make([]message.Triple, 0, len(todos)*len(todoPredicates))
+	updatedAt := now.UTC().Format(time.RFC3339Nano)
+	for i, t := range todos {
+		triples = append(triples,
+			message.Triple{
+				Subject: loopEntityID, Predicate: agvocab.TodoID,
+				Object: t.ID, Source: writeTodosToolSource, Timestamp: now, Confidence: 1.0,
+			},
+			message.Triple{
+				Subject: loopEntityID, Predicate: agvocab.TodoContent,
+				Object: t.Content, Source: writeTodosToolSource, Timestamp: now, Confidence: 1.0,
+			},
+			message.Triple{
+				Subject: loopEntityID, Predicate: agvocab.TodoStatus,
+				Object: t.Status, Source: writeTodosToolSource, Timestamp: now, Confidence: 1.0,
+			},
+			message.Triple{
+				Subject: loopEntityID, Predicate: agvocab.TodoPosition,
+				Object: i, Source: writeTodosToolSource, Timestamp: now, Confidence: 1.0,
+			},
+			message.Triple{
+				Subject: loopEntityID, Predicate: agvocab.TodoUpdatedAt,
+				Object: updatedAt, Source: writeTodosToolSource, Timestamp: now, Confidence: 1.0,
+			},
+		)
+	}
+	return triples
+}
+
+// writeTodosSummary is the compact JSON the executor returns in
+// ToolResult.Content. Not load-bearing for compaction survival —
+// Stage 4's prompt assembler reads triples directly from the loop
+// entity. This is informational for the trajectory.
+type writeTodosSummary struct {
+	Count int           `json:"count"`
+	Todos []todoSummary `json:"todos,omitempty"`
+}
+
+type todoSummary struct {
+	ID       string `json:"id"`
+	Status   string `json:"status"`
+	Position int    `json:"position"`
+}
+
+func buildWriteTodosSummary(todos []todoArg) writeTodosSummary {
+	if len(todos) == 0 {
+		return writeTodosSummary{Count: 0}
+	}
+	out := writeTodosSummary{
+		Count: len(todos),
+		Todos: make([]todoSummary, 0, len(todos)),
+	}
+	for i, t := range todos {
+		out.Todos = append(out.Todos, todoSummary{ID: t.ID, Status: t.Status, Position: i})
+	}
+	return out
+}
+
+// natsTodoWriter adapts natsclient.Client to TodoWriter using the
+// graph.mutation.triple.add_batch (ADR-036 Stage 2) and
+// graph.mutation.triple.remove subjects. Kept local because
+// write_todos is the only current caller; adopting it elsewhere
+// would justify hoisting into a shared package.
+type natsTodoWriter struct {
+	client *natsclient.Client
+}
+
+// NewNATSTodoWriter builds a TodoWriter backed by the
+// graph-ingest mutation surfaces.
+func NewNATSTodoWriter(client *natsclient.Client) TodoWriter {
+	return &natsTodoWriter{client: client}
+}
+
+func (w *natsTodoWriter) RemoveByPredicate(ctx context.Context, subject, predicate string) error {
+	req := graph.RemoveTripleRequest{Subject: subject, Predicate: predicate}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal remove-triple request: %w", err)
+	}
+	respData, err := w.client.RequestWithRetry(ctx, writeTodosRemoveSubject, reqData, writeTodosTimeout, natsclient.DefaultRetryConfig())
+	if err != nil {
+		return fmt.Errorf("request %s: %w", writeTodosRemoveSubject, err)
+	}
+	var resp graph.RemoveTripleResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return fmt.Errorf("unmarshal remove response: %w", err)
+	}
+	if !resp.Success {
+		// "entity not found" is not an error for our use case — first
+		// write_todos call on a fresh loop has nothing to clear. The
+		// graph-ingest handler returns Success=true for missing
+		// entities (RemoveTriple returns nil); other failures
+		// (network, marshal) surface the error string.
+		return fmt.Errorf("graph-ingest rejected remove: %s", resp.Error)
+	}
+	return nil
+}
+
+func (w *natsTodoWriter) AddTriplesBatch(ctx context.Context, triples []message.Triple) error {
+	req := graph.AddTriplesBatchRequest{Triples: triples}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal batch-add request: %w", err)
+	}
+	respData, err := w.client.RequestWithRetry(ctx, writeTodosBatchSubject, reqData, writeTodosTimeout, natsclient.DefaultRetryConfig())
+	if err != nil {
+		return fmt.Errorf("request %s: %w", writeTodosBatchSubject, err)
+	}
+	var resp graph.AddTriplesBatchResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return fmt.Errorf("unmarshal batch response: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("graph-ingest rejected batch (written=%d, failed=%v): %s",
+			resp.WrittenCount, resp.FailedSubjects, resp.Error)
+	}
+	return nil
+}

--- a/processor/agentic-tools/write_todos_test.go
+++ b/processor/agentic-tools/write_todos_test.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/types"
 	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+	"github.com/stretchr/testify/require"
 )
 
 // recordingTodoWriter implements TodoWriter in-process so tests can
@@ -367,6 +369,42 @@ func TestWriteTodosExecutor_UnknownToolNameIsRoutingBug(t *testing.T) {
 	}
 	if res.ErrorKind != agentic.ToolErrorNotFound {
 		t.Errorf("ErrorKind = %q, want %q", res.ErrorKind, agentic.ToolErrorNotFound)
+	}
+}
+
+// TestWriteTodosExecutor_DeterministicClock pins the SetClock contract
+// (Stage 3.7). Tests inject a frozen clock; the executor stamps that
+// time onto Triple.Timestamp and the agent.todo.updated_at value, so
+// assertions about timestamp equality become deterministic instead of
+// "today, ish" tolerances.
+func TestWriteTodosExecutor_DeterministicClock(t *testing.T) {
+	w := &recordingTodoWriter{}
+	e := newWriteTodosExecutor(w)
+	frozen := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	e.SetClock(func() time.Time { return frozen })
+
+	_, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c",
+		Name:   WriteTodosToolName,
+		LoopID: "loop-x",
+		Arguments: todosArg(
+			map[string]any{"id": "1", "content": "x", "status": "pending"},
+		),
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	require.Len(t, w.addedBatches, 1)
+	for i, tr := range w.addedBatches[0] {
+		if !tr.Timestamp.Equal(frozen) {
+			t.Errorf("triple[%d].Timestamp = %v, want %v", i, tr.Timestamp, frozen)
+		}
+		if tr.Predicate == agvocab.TodoUpdatedAt {
+			got, _ := tr.Object.(string)
+			if got != frozen.Format(time.RFC3339Nano) {
+				t.Errorf("TodoUpdatedAt object = %q, want %q", got, frozen.Format(time.RFC3339Nano))
+			}
+		}
 	}
 }
 

--- a/processor/agentic-tools/write_todos_test.go
+++ b/processor/agentic-tools/write_todos_test.go
@@ -408,6 +408,39 @@ func TestWriteTodosExecutor_DeterministicClock(t *testing.T) {
 	}
 }
 
+// TestWriteTodosExecutor_MalformedLoopIDSurfacesAsInternal pins
+// ADR-036 Stage 3.8: a loop_id that contains dots (the beta.36-class
+// bug where an upstream stamps a 6-part entity ID into call.LoopID)
+// must surface as ToolErrorInternal with a descriptive Go error,
+// NOT crash the dispatch goroutine via panic from
+// LoopExecutionEntityID.
+func TestWriteTodosExecutor_MalformedLoopIDSurfacesAsInternal(t *testing.T) {
+	w := &recordingTodoWriter{}
+	e := newWriteTodosExecutor(w)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c",
+		Name:   WriteTodosToolName,
+		LoopID: "acme.test.agent.agentic-loop.execution.abc123", // 6-part ID, has dots
+		Arguments: todosArg(
+			map[string]any{"id": "1", "content": "x", "status": "pending"},
+		),
+	})
+	if err == nil {
+		t.Fatal("expected Go error for dotted loop_id (panic-class regression)")
+	}
+	if res.ErrorKind != agentic.ToolErrorInternal {
+		t.Errorf("ErrorKind = %q, want %q", res.ErrorKind, agentic.ToolErrorInternal)
+	}
+	if !strings.Contains(res.Error, "loop entity ID") {
+		t.Errorf("Error %q should reference the loop entity ID construction", res.Error)
+	}
+	if len(w.removes) != 0 || len(w.addedBatches) != 0 {
+		t.Errorf("malformed loop_id rejection must not touch writer; saw removes=%d batches=%d",
+			len(w.removes), len(w.addedBatches))
+	}
+}
+
 // TestWriteTodos_CategoryIsCore pins the per-loop-not-per-role
 // discipline from ADR-036: write_todos lives in CategoryCore so it's
 // available to every role; persona authors opt out per-deployment.

--- a/processor/agentic-tools/write_todos_test.go
+++ b/processor/agentic-tools/write_todos_test.go
@@ -1,0 +1,383 @@
+package agentictools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/types"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+// recordingTodoWriter implements TodoWriter in-process so tests can
+// assert on the exact remove/add operations write_todos emitted.
+// Mirror of recordingPublisher in decide_test.go.
+type recordingTodoWriter struct {
+	removes      []removeOp
+	addedBatches [][]message.Triple
+	removeErr    error
+	addErr       error
+}
+
+type removeOp struct {
+	subject   string
+	predicate string
+}
+
+func (w *recordingTodoWriter) RemoveByPredicate(_ context.Context, subject, predicate string) error {
+	if w.removeErr != nil {
+		return w.removeErr
+	}
+	w.removes = append(w.removes, removeOp{subject: subject, predicate: predicate})
+	return nil
+}
+
+func (w *recordingTodoWriter) AddTriplesBatch(_ context.Context, triples []message.Triple) error {
+	if w.addErr != nil {
+		return w.addErr
+	}
+	cp := make([]message.Triple, len(triples))
+	copy(cp, triples)
+	w.addedBatches = append(w.addedBatches, cp)
+	return nil
+}
+
+func newWriteTodosExecutor(writer TodoWriter) *WriteTodosExecutor {
+	return NewWriteTodosExecutor(writer, types.PlatformMeta{Org: "acme", Platform: "test"})
+}
+
+func todosArg(items ...map[string]any) map[string]any {
+	return map[string]any{"todos": items}
+}
+
+func TestWriteTodosExecutor_ListTools(t *testing.T) {
+	e := newWriteTodosExecutor(&recordingTodoWriter{})
+	tools := e.ListTools()
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+	if tools[0].Name != WriteTodosToolName {
+		t.Errorf("name = %q, want %q", tools[0].Name, WriteTodosToolName)
+	}
+	if !tools[0].Strict {
+		t.Errorf("ADR-035 says write_todos should ship Strict=true; got false")
+	}
+	// Description must teach when to call vs skip — pin both shapes.
+	desc := tools[0].Description
+	if !strings.Contains(desc, "replaces the prior list") {
+		t.Errorf("description should clarify full-list-replace semantics; got: %s", desc)
+	}
+	if !strings.Contains(desc, "Skip it") || !strings.Contains(desc, "single-step") {
+		t.Errorf("description should call out skip-for-trivial cases; got: %s", desc)
+	}
+}
+
+// TestWriteTodosExecutor_HappyPath pins the canonical write shape:
+// one remove per todo predicate (order matches todoPredicates), then
+// one batch add carrying 5 triples per todo on the loop entity.
+func TestWriteTodosExecutor_HappyPath(t *testing.T) {
+	w := &recordingTodoWriter{}
+	e := newWriteTodosExecutor(w)
+
+	args := todosArg(
+		map[string]any{"id": "1", "content": "Survey rules", "status": "completed"},
+		map[string]any{"id": "2", "content": "Draft new rule", "status": "in_progress"},
+		map[string]any{"id": "3", "content": "Wire e2e test", "status": "pending"},
+	)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "call-1",
+		Name:      WriteTodosToolName,
+		LoopID:    "loop-abc",
+		Arguments: args,
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("ToolResult.Error = %q, want empty", res.Error)
+	}
+	if res.StopLoop {
+		t.Errorf("write_todos must NOT stop the loop (it is called repeatedly)")
+	}
+
+	// Removes happen first, in the canonical predicate order. Pinning
+	// both order and contents keeps the load-bearing full-list-replace
+	// invariant from drifting silently.
+	if got, want := len(w.removes), len(todoPredicates); got != want {
+		t.Fatalf("remove count = %d, want %d (one per predicate)", got, want)
+	}
+	wantLoopEntityID := agentic.LoopExecutionEntityID("acme", "test", "loop-abc")
+	for i, op := range w.removes {
+		if op.subject != wantLoopEntityID {
+			t.Errorf("remove[%d].subject = %q, want %q", i, op.subject, wantLoopEntityID)
+		}
+		if op.predicate != todoPredicates[i] {
+			t.Errorf("remove[%d].predicate = %q, want %q", i, op.predicate, todoPredicates[i])
+		}
+	}
+
+	// Single batch carries 3 todos × 5 predicates = 15 triples.
+	if got, want := len(w.addedBatches), 1; got != want {
+		t.Fatalf("batch count = %d, want %d (single CAS for all triples)", got, want)
+	}
+	batch := w.addedBatches[0]
+	if got, want := len(batch), 3*len(todoPredicates); got != want {
+		t.Fatalf("triple count = %d, want %d", got, want)
+	}
+
+	// Every triple lands on the loop entity, not anywhere else.
+	for i, tr := range batch {
+		if tr.Subject != wantLoopEntityID {
+			t.Errorf("batch[%d].subject = %q, want %q", i, tr.Subject, wantLoopEntityID)
+		}
+		if tr.Source != writeTodosToolSource {
+			t.Errorf("batch[%d].source = %q, want %q (operator distinguishes write_todos from other writers)",
+				i, tr.Source, writeTodosToolSource)
+		}
+	}
+
+	// Position is derived from array index, not user-supplied. Verify
+	// the third todo has position=2.
+	foundThirdPosition := false
+	for _, tr := range batch {
+		if tr.Predicate != agvocab.TodoPosition {
+			continue
+		}
+		if tr.Object == 2 {
+			foundThirdPosition = true
+		}
+	}
+	if !foundThirdPosition {
+		t.Errorf("expected one TodoPosition triple with object=2 (third todo); did not find it")
+	}
+
+	// ToolResult content is informational — the agent reads back via
+	// trajectory. Pin the count and the position-derivation in the
+	// summary.
+	var summary writeTodosSummary
+	if err := json.Unmarshal([]byte(res.Content), &summary); err != nil {
+		t.Fatalf("decode result content: %v", err)
+	}
+	if summary.Count != 3 {
+		t.Errorf("summary.count = %d, want 3", summary.Count)
+	}
+	if len(summary.Todos) != 3 || summary.Todos[2].Position != 2 || summary.Todos[2].ID != "3" {
+		t.Errorf("summary.todos[2] = %+v, want id=3 position=2", summary.Todos[2])
+	}
+
+	// Metadata surfaces the loop entity ID for debug consumers.
+	if got, _ := res.Metadata["loop_entity_id"].(string); got != wantLoopEntityID {
+		t.Errorf("metadata.loop_entity_id = %q, want %q", got, wantLoopEntityID)
+	}
+}
+
+// TestWriteTodosExecutor_EmptyListClears verifies that submitting an
+// empty array clears prior state without writing anything new — the
+// agent's way to "delete the list."
+func TestWriteTodosExecutor_EmptyListClears(t *testing.T) {
+	w := &recordingTodoWriter{}
+	e := newWriteTodosExecutor(w)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "call-1",
+		Name:      WriteTodosToolName,
+		LoopID:    "loop-clear",
+		Arguments: todosArg(),
+	})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("ToolResult.Error = %q, want empty", res.Error)
+	}
+	if got, want := len(w.removes), len(todoPredicates); got != want {
+		t.Errorf("remove count = %d, want %d", got, want)
+	}
+	if len(w.addedBatches) != 0 {
+		t.Errorf("empty list must not add anything; got %d batch(es)", len(w.addedBatches))
+	}
+}
+
+// TestWriteTodosExecutor_ValidationRejection covers the per-arg
+// rejection shapes — each must surface ToolErrorInvalidArgs without
+// touching the writer (LLM gets to self-correct).
+func TestWriteTodosExecutor_ValidationRejection(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantSub string
+	}{
+		{
+			name:    "missing todos arg",
+			args:    map[string]any{},
+			wantSub: `missing required argument "todos"`,
+		},
+		{
+			name: "todo missing id",
+			args: todosArg(
+				map[string]any{"content": "x", "status": "pending"},
+			),
+			wantSub: ".id must be a non-empty string",
+		},
+		{
+			name: "todo missing content",
+			args: todosArg(
+				map[string]any{"id": "1", "status": "pending"},
+			),
+			wantSub: ".content must be a non-empty string",
+		},
+		{
+			name: "invalid status",
+			args: todosArg(
+				map[string]any{"id": "1", "content": "x", "status": "blocked"},
+			),
+			wantSub: "must be one of pending|in_progress|completed",
+		},
+		{
+			name: "duplicate id",
+			args: todosArg(
+				map[string]any{"id": "1", "content": "x", "status": "pending"},
+				map[string]any{"id": "1", "content": "y", "status": "pending"},
+			),
+			wantSub: "is a duplicate",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &recordingTodoWriter{}
+			e := newWriteTodosExecutor(w)
+			res, err := e.Execute(context.Background(), agentic.ToolCall{
+				ID:        "c",
+				Name:      WriteTodosToolName,
+				LoopID:    "loop-x",
+				Arguments: tt.args,
+			})
+			if err != nil {
+				t.Fatalf("Execute returned Go error (validation should surface as ToolResult.Error): %v", err)
+			}
+			if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+				t.Errorf("ErrorKind = %q, want %q", res.ErrorKind, agentic.ToolErrorInvalidArgs)
+			}
+			if !strings.Contains(res.Error, tt.wantSub) {
+				t.Errorf("Error = %q, want substring %q", res.Error, tt.wantSub)
+			}
+			if len(w.removes) != 0 || len(w.addedBatches) != 0 {
+				t.Errorf("validation rejection must not touch writer; saw removes=%d batches=%d",
+					len(w.removes), len(w.addedBatches))
+			}
+		})
+	}
+}
+
+// TestWriteTodosExecutor_MissingLoopIDIsInternal surfaces a
+// dispatcher-layer bug rather than a self-correctable args mistake.
+func TestWriteTodosExecutor_MissingLoopIDIsInternal(t *testing.T) {
+	w := &recordingTodoWriter{}
+	e := newWriteTodosExecutor(w)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "c",
+		Name:      WriteTodosToolName,
+		Arguments: todosArg(map[string]any{"id": "1", "content": "x", "status": "pending"}),
+	})
+	if err == nil {
+		t.Fatal("expected Go error for missing loop_id (dispatcher bug)")
+	}
+	if res.ErrorKind != agentic.ToolErrorInternal {
+		t.Errorf("ErrorKind = %q, want %q", res.ErrorKind, agentic.ToolErrorInternal)
+	}
+	if len(w.removes) != 0 {
+		t.Errorf("dispatcher-bug rejection must not touch writer")
+	}
+}
+
+// TestWriteTodosExecutor_RemoveErrorSurfaces verifies the network
+// error from clearing prior state surfaces with ToolErrorNetwork so
+// the loop's retry policy applies the right strategy.
+func TestWriteTodosExecutor_RemoveErrorSurfaces(t *testing.T) {
+	w := &recordingTodoWriter{removeErr: errors.New("graph-ingest unavailable")}
+	e := newWriteTodosExecutor(w)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c",
+		Name:   WriteTodosToolName,
+		LoopID: "loop-x",
+		Arguments: todosArg(
+			map[string]any{"id": "1", "content": "x", "status": "pending"},
+		),
+	})
+	if err == nil {
+		t.Fatal("expected wrapped Go error for transient network failure")
+	}
+	if res.ErrorKind != agentic.ToolErrorNetwork {
+		t.Errorf("ErrorKind = %q, want %q", res.ErrorKind, agentic.ToolErrorNetwork)
+	}
+	if !strings.Contains(res.Error, "graph-ingest unavailable") {
+		t.Errorf("Error should propagate underlying message; got %q", res.Error)
+	}
+}
+
+// TestWriteTodosExecutor_AddErrorSurfaces verifies post-clear batch
+// failures also surface as ToolErrorNetwork — the retry policy
+// shouldn't differ based on which round-trip failed.
+func TestWriteTodosExecutor_AddErrorSurfaces(t *testing.T) {
+	w := &recordingTodoWriter{addErr: errors.New("CAS conflict, exhausted retries")}
+	e := newWriteTodosExecutor(w)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c",
+		Name:   WriteTodosToolName,
+		LoopID: "loop-x",
+		Arguments: todosArg(
+			map[string]any{"id": "1", "content": "x", "status": "pending"},
+		),
+	})
+	if err == nil {
+		t.Fatal("expected wrapped Go error for batch failure")
+	}
+	if res.ErrorKind != agentic.ToolErrorNetwork {
+		t.Errorf("ErrorKind = %q, want %q", res.ErrorKind, agentic.ToolErrorNetwork)
+	}
+	// Removes ran before the add failed — that's fine, full-list-replace
+	// semantics mean a retry is safe.
+	if len(w.removes) != len(todoPredicates) {
+		t.Errorf("removes should have completed before the failed add; got %d", len(w.removes))
+	}
+}
+
+// TestWriteTodosExecutor_UnknownToolNameIsRoutingBug protects the
+// dispatcher contract: the executor should never see a name other
+// than WriteTodosToolName.
+func TestWriteTodosExecutor_UnknownToolNameIsRoutingBug(t *testing.T) {
+	w := &recordingTodoWriter{}
+	e := newWriteTodosExecutor(w)
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c",
+		Name:   "not_write_todos",
+		LoopID: "loop-x",
+	})
+	if err == nil {
+		t.Fatal("expected Go error for unknown tool name")
+	}
+	if res.ErrorKind != agentic.ToolErrorNotFound {
+		t.Errorf("ErrorKind = %q, want %q", res.ErrorKind, agentic.ToolErrorNotFound)
+	}
+}
+
+// TestWriteTodos_CategoryIsCore pins the per-loop-not-per-role
+// discipline from ADR-036: write_todos lives in CategoryCore so it's
+// available to every role; persona authors opt out per-deployment.
+// If a future refactor moves it to CategoryOrchestration or similar,
+// it changes the access semantics — this test catches the drift.
+func TestWriteTodos_CategoryIsCore(t *testing.T) {
+	if got := GetToolCategory("write_todos"); got != CategoryCore {
+		t.Errorf("write_todos category = %q, want %q (ADR-036 §First Instance — available to any role)",
+			got, CategoryCore)
+	}
+}

--- a/processor/graph-ingest/batch_integration_test.go
+++ b/processor/graph-ingest/batch_integration_test.go
@@ -187,6 +187,58 @@ func TestIntegration_HandleTripleAddBatch_RoundTrip(t *testing.T) {
 	assert.Empty(t, resp.FailedSubjects)
 }
 
+// TestIntegration_AddTriples_PreservesInputOrderWithinSubject pins the
+// invariant that ADR-036 Stage 4's prompt assembler depends on:
+// triples emitted in input order are stored in input order on the
+// entity. write_todos writes [id, content, status, position,
+// updated_at] interleaved per item; ReconstructTodos parses the
+// stored slice in stride-of-5 to recover items. If a future
+// graph-ingest change reorders, dedups, or sorts triples on write
+// (e.g. for query efficiency), this test fails loudly so the change
+// also needs an ADR-036 Stage 4 update.
+func TestIntegration_AddTriples_PreservesInputOrderWithinSubject(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.batch.order.loop.001"
+	now := time.Now()
+
+	// Emit a known sequence: A, B, C, D, E across the same subject.
+	// The retrieved Triples slice must come back in this exact order.
+	want := []string{"A", "B", "C", "D", "E"}
+	triples := make([]message.Triple, 0, len(want))
+	for _, label := range want {
+		triples = append(triples, message.Triple{
+			Subject:    entityID,
+			Predicate:  "test.order.label",
+			Object:     label,
+			Timestamp:  now,
+			Confidence: 1.0,
+		})
+	}
+
+	written, failed, err := c.AddTriples(ctx, triples)
+	require.NoError(t, err)
+	require.Empty(t, failed)
+	assert.Equal(t, len(want), written)
+
+	entry, err := c.entityBucket.Get(ctx, entityID)
+	require.NoError(t, err)
+
+	var entity graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &entity))
+	require.Len(t, entity.Triples, len(want))
+
+	got := make([]string, len(entity.Triples))
+	for i, tr := range entity.Triples {
+		s, ok := tr.Object.(string)
+		if !ok {
+			t.Fatalf("triple[%d].Object expected string, got %T", i, tr.Object)
+		}
+		got[i] = s
+	}
+	assert.Equal(t, want, got, "ADR-036 Stage 4 ReconstructTodos parses by stride; input order must be preserved")
+}
+
 // TestIntegration_HandleTripleAddBatch_InvalidJSON pins the
 // malformed-envelope behaviour: handler returns Success=false with a
 // descriptive error, rather than crashing or silently dropping.

--- a/processor/graph-ingest/batch_integration_test.go
+++ b/processor/graph-ingest/batch_integration_test.go
@@ -1,0 +1,203 @@
+//go:build integration
+
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// startBatchTestComponent boots a graph-ingest Component against a real
+// JetStream test cluster and returns it ready for use. Mirrors the
+// CAS-integration-test setup so behavioural drift between the two paths
+// is easy to spot at review time.
+func startBatchTestComponent(t *testing.T) (context.Context, *Component) {
+	t.Helper()
+	ctx := context.Background()
+
+	streams := []natsclient.TestStreamConfig{
+		{Name: "ENTITY", Subjects: []string{"entity.>"}},
+	}
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+	natsClient := testClient.Client
+
+	config := DefaultConfig()
+	deps := component.Dependencies{NATSClient: natsClient}
+
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := CreateGraphIngest(configJSON, deps)
+	require.NoError(t, err)
+
+	c := comp.(*Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() {
+		_ = c.Stop(5 * time.Second)
+	})
+
+	time.Sleep(100 * time.Millisecond)
+	return ctx, c
+}
+
+// TestIntegration_AddTriples_SingleSubjectIsOneCAS pins the load-bearing
+// optimisation behind ADR-036 §Stage 2: many triples sharing one Subject
+// commit in a single CAS round-trip. Failure shows up as multiple
+// version increments (one per triple) instead of one.
+func TestIntegration_AddTriples_SingleSubjectIsOneCAS(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.batch.single.loop.001"
+	now := time.Now()
+
+	triples := []message.Triple{
+		{Subject: entityID, Predicate: "agent.todo.id", Object: "1", Timestamp: now, Confidence: 1.0},
+		{Subject: entityID, Predicate: "agent.todo.content", Object: "Write code", Timestamp: now, Confidence: 1.0},
+		{Subject: entityID, Predicate: "agent.todo.status", Object: "pending", Timestamp: now, Confidence: 1.0},
+		{Subject: entityID, Predicate: "agent.todo.position", Object: 0, Timestamp: now, Confidence: 1.0},
+		{Subject: entityID, Predicate: "agent.todo.updated_at", Object: now.Format(time.RFC3339), Timestamp: now, Confidence: 1.0},
+	}
+
+	written, failed, err := c.AddTriples(ctx, triples)
+	require.NoError(t, err)
+	require.Empty(t, failed)
+	assert.Equal(t, 5, written)
+
+	// Single CAS → entity version increments by exactly 1, not 5.
+	entry, err := c.entityBucket.Get(ctx, entityID)
+	require.NoError(t, err)
+
+	var entity graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &entity))
+
+	assert.Equal(t, 5, len(entity.Triples), "all 5 triples present")
+	assert.Equal(t, uint64(1), entity.Version, "single CAS commit, version=1 (not 5)")
+}
+
+// TestIntegration_AddTriples_MultiSubjectGroupsByEntity verifies multi-subject
+// batches issue one CAS per entity, not one per triple. Two entities × N
+// triples each → 2 CAS round-trips, each entity reaches version=1.
+func TestIntegration_AddTriples_MultiSubjectGroupsByEntity(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const idA = "c360.test.batch.multi.loop.a01"
+	const idB = "c360.test.batch.multi.loop.b02"
+	now := time.Now()
+
+	triples := []message.Triple{
+		{Subject: idA, Predicate: "agent.todo.id", Object: "1", Timestamp: now, Confidence: 1.0},
+		{Subject: idB, Predicate: "agent.todo.id", Object: "1", Timestamp: now, Confidence: 1.0},
+		{Subject: idA, Predicate: "agent.todo.status", Object: "pending", Timestamp: now, Confidence: 1.0},
+		{Subject: idB, Predicate: "agent.todo.status", Object: "in_progress", Timestamp: now, Confidence: 1.0},
+		{Subject: idA, Predicate: "agent.todo.position", Object: 0, Timestamp: now, Confidence: 1.0},
+	}
+
+	written, failed, err := c.AddTriples(ctx, triples)
+	require.NoError(t, err)
+	require.Empty(t, failed)
+	assert.Equal(t, 5, written)
+
+	entryA, err := c.entityBucket.Get(ctx, idA)
+	require.NoError(t, err)
+	var entityA graph.EntityState
+	require.NoError(t, json.Unmarshal(entryA.Value, &entityA))
+	assert.Equal(t, 3, len(entityA.Triples))
+	assert.Equal(t, uint64(1), entityA.Version)
+
+	entryB, err := c.entityBucket.Get(ctx, idB)
+	require.NoError(t, err)
+	var entityB graph.EntityState
+	require.NoError(t, json.Unmarshal(entryB.Value, &entityB))
+	assert.Equal(t, 2, len(entityB.Triples))
+	assert.Equal(t, uint64(1), entityB.Version)
+}
+
+// TestIntegration_AddTriples_ValidationRejectsWholeBatch ensures a single
+// malformed triple fails the entire batch before any CAS — partial
+// validation would be surprising.
+func TestIntegration_AddTriples_ValidationRejectsWholeBatch(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.batch.invalid.loop.001"
+	now := time.Now()
+
+	triples := []message.Triple{
+		{Subject: entityID, Predicate: "agent.todo.id", Object: "1", Timestamp: now, Confidence: 1.0},
+		{Subject: "", Predicate: "agent.todo.status", Object: "pending", Timestamp: now, Confidence: 1.0}, // bad
+	}
+
+	written, failed, err := c.AddTriples(ctx, triples)
+	require.Error(t, err)
+	assert.Empty(t, failed, "pre-CAS validation failure has no FailedSubjects")
+	assert.Equal(t, 0, written)
+
+	// Confirm the valid triple was NOT silently committed.
+	_, err = c.entityBucket.Get(ctx, entityID)
+	assert.Error(t, err, "no partial commit on validation failure")
+}
+
+// TestIntegration_AddTriples_EmptyBatchIsNoop covers the degenerate case.
+func TestIntegration_AddTriples_EmptyBatchIsNoop(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	written, failed, err := c.AddTriples(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, failed)
+	assert.Equal(t, 0, written)
+}
+
+// TestIntegration_HandleTripleAddBatch_RoundTrip exercises the
+// NATS-handler path end-to-end via direct invocation of the handler
+// callback (the same shape natsclient.SubscribeForRequests delivers).
+// Validates the wire-format envelope, success/failure flag, and
+// FailedSubjects population.
+func TestIntegration_HandleTripleAddBatch_RoundTrip(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.batch.handler.loop.001"
+	now := time.Now()
+
+	req := graph.AddTriplesBatchRequest{
+		Triples: []message.Triple{
+			{Subject: entityID, Predicate: "agent.todo.id", Object: "1", Timestamp: now, Confidence: 1.0},
+			{Subject: entityID, Predicate: "agent.todo.status", Object: "pending", Timestamp: now, Confidence: 1.0},
+		},
+	}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleTripleAddBatch(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.AddTriplesBatchResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	assert.True(t, resp.Success)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, 2, resp.WrittenCount)
+	assert.Empty(t, resp.FailedSubjects)
+}
+
+// TestIntegration_HandleTripleAddBatch_InvalidJSON pins the
+// malformed-envelope behaviour: handler returns Success=false with a
+// descriptive error, rather than crashing or silently dropping.
+func TestIntegration_HandleTripleAddBatch_InvalidJSON(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	respBytes, err := c.handleTripleAddBatch(ctx, []byte("not json"))
+	require.NoError(t, err)
+
+	var resp graph.AddTriplesBatchResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	assert.False(t, resp.Success)
+	assert.Contains(t, resp.Error, "invalid request")
+}

--- a/processor/graph-ingest/batch_unit_test.go
+++ b/processor/graph-ingest/batch_unit_test.go
@@ -1,0 +1,116 @@
+package graphingest
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// TestAddTriples_ValidationRejectsBeforeCAS pins the validation phase
+// in isolation. The CAS path needs a real KV bucket (covered by the
+// integration tests in batch_integration_test.go); the validation
+// path is pure CPU and runs here in the fast unit-test bucket.
+//
+// Future ADR-036 stages may layer additional validation (predicate
+// allowlist, entity-ID-shape) on top of the empty-Subject /
+// empty-Predicate checks. Having a unit harness here means
+// regressions surface in milliseconds instead of via integration runs.
+func TestAddTriples_ValidationRejectsBeforeCAS(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	tests := []struct {
+		name          string
+		triples       []message.Triple
+		wantInvalid   bool
+		wantSubstring string
+	}{
+		{
+			name:    "empty slice — noop, not an error",
+			triples: nil,
+		},
+		{
+			name: "empty Subject on first triple",
+			triples: []message.Triple{
+				{Subject: "", Predicate: "p.q.r", Object: "x", Timestamp: now, Confidence: 1.0},
+			},
+			wantInvalid:   true,
+			wantSubstring: "subject cannot be empty",
+		},
+		{
+			name: "empty Predicate on first triple",
+			triples: []message.Triple{
+				{Subject: "a.b.c.d.e.001", Predicate: "", Object: "x", Timestamp: now, Confidence: 1.0},
+			},
+			wantInvalid:   true,
+			wantSubstring: "predicate cannot be empty",
+		},
+		{
+			name: "valid first, malformed second — whole batch rejected",
+			triples: []message.Triple{
+				{Subject: "a.b.c.d.e.001", Predicate: "p.q.r", Object: "x", Timestamp: now, Confidence: 1.0},
+				{Subject: "", Predicate: "p.q.r", Object: "y", Timestamp: now, Confidence: 1.0},
+			},
+			wantInvalid:   true,
+			wantSubstring: "subject cannot be empty",
+		},
+		{
+			name: "valid first, empty-predicate second — whole batch rejected",
+			triples: []message.Triple{
+				{Subject: "a.b.c.d.e.001", Predicate: "p.q.r", Object: "x", Timestamp: now, Confidence: 1.0},
+				{Subject: "a.b.c.d.e.001", Predicate: "", Object: "y", Timestamp: now, Confidence: 1.0},
+			},
+			wantInvalid:   true,
+			wantSubstring: "predicate cannot be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// AddTriples touches c.entityBucket only AFTER validation
+			// passes. Cases that should reject pre-CAS never reach the
+			// nil bucket. The two cases that pass validation (empty
+			// slice; single valid triple) either short-circuit
+			// (nil-slice noop) or fail at CAS — we only assert the
+			// validation phase here.
+			c := &Component{}
+			written, failed, err := c.AddTriples(context.Background(), tt.triples)
+
+			if tt.wantInvalid {
+				if err == nil {
+					t.Fatalf("expected validation error, got nil (written=%d failed=%v)", written, failed)
+				}
+				if !errs.IsInvalid(err) {
+					t.Errorf("expected ErrorInvalid class, got %T: %v", err, err)
+				}
+				if tt.wantSubstring != "" && !strings.Contains(err.Error(), tt.wantSubstring) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.wantSubstring)
+				}
+				if written != 0 {
+					t.Errorf("validation rejection must not commit any triples (written=%d)", written)
+				}
+				if len(failed) != 0 {
+					t.Errorf("validation rejection has no FailedSubjects (got %v)", failed)
+				}
+				return
+			}
+
+			// Empty-slice case: nil-slice noop, no error, no work.
+			if len(tt.triples) == 0 {
+				if err != nil {
+					t.Errorf("empty batch should be a noop, got err=%v", err)
+				}
+				if written != 0 {
+					t.Errorf("empty batch must not commit anything (written=%d)", written)
+				}
+			}
+		})
+	}
+}

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1211,6 +1212,118 @@ func (c *Component) AddTriple(ctx context.Context, triple message.Triple) error 
 	}
 
 	return nil
+}
+
+// AddTriples adds many triples in one call, batching per entity. Triples
+// sharing the same Subject collapse to a single CAS read-modify-write on
+// that entity's KV record — N triples on the same loop entity become
+// 1 round-trip to graph-ingest, not N. Triples spanning multiple
+// entities issue one CAS per entity in deterministic subject order.
+//
+// Atomicity scope: per-entity, not cross-entity. If two entities are
+// in the batch and the first commits but the second exhausts CAS
+// retries, the first stays committed. This trade-off is acceptable
+// for the primary use case (write_todos, ADR-036) where every triple
+// shares one Subject (the loop entity). Multi-subject callers that
+// need cross-entity atomicity should use UpdateEntityWithTriples
+// instead.
+//
+// Returns nil on full success. On partial failure returns an error
+// whose message names the failing subjects; the per-subject error
+// detail surfaces via the handler's FailedSubjects response field.
+func (c *Component) AddTriples(ctx context.Context, triples []message.Triple) (writtenCount int, failedSubjects map[string]string, err error) {
+	if len(triples) == 0 {
+		return 0, nil, nil
+	}
+
+	// Validate before any write. Reject the whole batch on the first
+	// malformed triple — partial validation would be surprising.
+	for i, t := range triples {
+		if t.Subject == "" {
+			return 0, nil, errs.WrapInvalid(errs.ErrInvalidData, "Component", "AddTriples", fmt.Sprintf("triple[%d] subject cannot be empty", i))
+		}
+		if t.Predicate == "" {
+			return 0, nil, errs.WrapInvalid(errs.ErrInvalidData, "Component", "AddTriples", fmt.Sprintf("triple[%d] predicate cannot be empty", i))
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return 0, nil, errs.Wrap(err, "Component", "AddTriples", "context cancelled")
+	}
+
+	// Group triples by Subject so each entity sees a single CAS.
+	// Map iteration is non-deterministic; we sort subject keys before
+	// committing so retries replay in stable order (helpful for tests
+	// and for any operator reading a partial-failure trace).
+	bySubject := make(map[string][]message.Triple, len(triples))
+	for _, t := range triples {
+		bySubject[t.Subject] = append(bySubject[t.Subject], t)
+	}
+	subjects := make([]string, 0, len(bySubject))
+	for s := range bySubject {
+		subjects = append(subjects, s)
+	}
+	sort.Strings(subjects)
+
+	failedSubjects = make(map[string]string)
+	for i, subject := range subjects {
+		// Short-circuit on context cancellation: don't burn the retry
+		// budget for every remaining subject when the caller has
+		// already given up. Mark the rest as failed-due-to-cancel so
+		// the response shape is honest about what didn't commit, but
+		// only count one operational error event for the cancellation
+		// rather than N (one per remaining subject).
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			for _, s := range subjects[i:] {
+				failedSubjects[s] = ctxErr.Error()
+			}
+			atomic.AddInt64(&c.errors, 1)
+			break
+		}
+		group := bySubject[subject]
+		casErr := c.entityBucket.UpdateWithRetry(ctx, subject, func(current []byte) ([]byte, error) {
+			var entity graph.EntityState
+
+			if len(current) > 0 {
+				if err := json.Unmarshal(current, &entity); err != nil {
+					return nil, err // Non-retryable
+				}
+			} else {
+				entity = graph.EntityState{
+					ID:        subject,
+					Version:   0,
+					UpdatedAt: time.Now(),
+				}
+			}
+
+			entity.Triples = append(entity.Triples, group...)
+			entity.Version++
+			entity.UpdatedAt = time.Now()
+
+			return json.Marshal(&entity)
+		})
+
+		if casErr != nil {
+			atomic.AddInt64(&c.errors, 1)
+			failedSubjects[subject] = casErr.Error()
+			continue
+		}
+		writtenCount += len(group)
+	}
+
+	if len(failedSubjects) == 0 {
+		return writtenCount, nil, nil
+	}
+
+	// Sort failed-subject names for stable error messages.
+	failed := make([]string, 0, len(failedSubjects))
+	for s := range failedSubjects {
+		failed = append(failed, s)
+	}
+	sort.Strings(failed)
+	return writtenCount, failedSubjects, errs.Wrap(
+		fmt.Errorf("CAS update failed for %d/%d subjects: %v", len(failedSubjects), len(subjects), failed),
+		"Component", "AddTriples", "batch CAS partial failure")
 }
 
 // RemoveTriple removes a triple from an entity using CAS for concurrency safety

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -13,6 +13,11 @@ import (
 const (
 	// SubjectTripleAdd is the NATS subject for add triple requests
 	SubjectTripleAdd = "graph.mutation.triple.add"
+	// SubjectTripleAddBatch is the NATS subject for batched add-triple
+	// requests. Optimised for tools that emit many triples in one call
+	// (write_todos per ADR-036): triples sharing a Subject collapse to
+	// one CAS round-trip on that entity.
+	SubjectTripleAddBatch = "graph.mutation.triple.add_batch"
 	// SubjectTripleRemove is the NATS subject for remove triple requests
 	SubjectTripleRemove = "graph.mutation.triple.remove"
 )
@@ -27,6 +32,12 @@ func (c *Component) setupMutationHandlers(ctx context.Context) error {
 	}
 	c.subscriptions = append(c.subscriptions, sub)
 
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectTripleAddBatch, c.handleTripleAddBatch)
+	if err != nil {
+		return fmt.Errorf("subscribe triple add_batch: %w", err)
+	}
+	c.subscriptions = append(c.subscriptions, sub)
+
 	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectTripleRemove, c.handleTripleRemove)
 	if err != nil {
 		return fmt.Errorf("subscribe triple remove: %w", err)
@@ -34,7 +45,7 @@ func (c *Component) setupMutationHandlers(ctx context.Context) error {
 	c.subscriptions = append(c.subscriptions, sub)
 
 	c.logger.Info("mutation handlers registered",
-		"subjects", []string{SubjectTripleAdd, SubjectTripleRemove})
+		"subjects", []string{SubjectTripleAdd, SubjectTripleAddBatch, SubjectTripleRemove})
 	return nil
 }
 
@@ -77,6 +88,62 @@ func (c *Component) handleTripleAdd(ctx context.Context, data []byte) ([]byte, e
 		},
 		Triple: &req.Triple,
 	})
+}
+
+// handleTripleAddBatch handles batched add-triple requests. The
+// implementation groups triples by Subject and issues one CAS per
+// entity, so a tool emitting many triples on the same loop entity
+// (write_todos, ADR-036) sees one round-trip to graph-ingest instead
+// of N. On partial failure across multiple entities, the response
+// surfaces FailedSubjects so the caller can decide whether to retry
+// the failed subset.
+func (c *Component) handleTripleAddBatch(ctx context.Context, data []byte) ([]byte, error) {
+	var req graph.AddTriplesBatchRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return json.Marshal(graph.AddTriplesBatchResponse{
+			MutationResponse: graph.MutationResponse{
+				Success:   false,
+				Error:     fmt.Sprintf("invalid request: %v", err),
+				Timestamp: time.Now().UnixNano(),
+			},
+		})
+	}
+
+	if len(req.Triples) == 0 {
+		return json.Marshal(graph.AddTriplesBatchResponse{
+			MutationResponse: graph.MutationResponse{
+				Success:   true,
+				Timestamp: time.Now().UnixNano(),
+			},
+			WrittenCount: 0,
+		})
+	}
+
+	written, failed, err := c.AddTriples(ctx, req.Triples)
+	if err != nil && len(failed) == 0 {
+		// Pre-CAS validation failure (e.g. empty subject/predicate).
+		// Whole batch rejected.
+		return json.Marshal(graph.AddTriplesBatchResponse{
+			MutationResponse: graph.MutationResponse{
+				Success:   false,
+				Error:     err.Error(),
+				Timestamp: time.Now().UnixNano(),
+			},
+		})
+	}
+
+	resp := graph.AddTriplesBatchResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   len(failed) == 0,
+			Timestamp: time.Now().UnixNano(),
+		},
+		WrittenCount:   written,
+		FailedSubjects: failed,
+	}
+	if err != nil {
+		resp.Error = err.Error()
+	}
+	return json.Marshal(resp)
 }
 
 // handleTripleRemove handles remove triple requests from rule processor and other components

--- a/processor/graph-query/pathrag.go
+++ b/processor/graph-query/pathrag.go
@@ -2,6 +2,7 @@
 package graphquery
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -193,12 +194,28 @@ func (p *PathSearcher) applyLimits(reqDepth, reqNodes int) (maxDepth, maxNodes i
 }
 
 // verifyEntityExists checks if an entity exists in the graph.
+//
+// Protocol note: graph-ingest's handleQueryEntityNATS returns a Go
+// error on missing-entity, but natsclient.SubscribeForRequests wraps
+// handler errors as a successful NATS response whose body starts with
+// "error: ". The previous implementation only branched on the Go err
+// return — which never fires on this protocol path — so a missing
+// entity silently passed verification. We detect the "error: " prefix
+// on the response payload to surface the not-found case correctly.
+// Same fix as ADR-036 Stage 4 H1 in processor/agentic-loop/todos.go.
 func (p *PathSearcher) verifyEntityExists(ctx context.Context, entityID string) error {
 	entityReq := map[string]string{"id": entityID}
 	entityReqData, _ := json.Marshal(entityReq)
-	_, err := p.nats.Request(ctx, "graph.ingest.query.entity", entityReqData, p.timeout)
+	respData, err := p.nats.Request(ctx, "graph.ingest.query.entity", entityReqData, p.timeout)
 	if err != nil {
-		return fmt.Errorf("entity not found: %w", err)
+		// Transport-layer failure (timeout, no responders).
+		return fmt.Errorf("query entity: %w", err)
+	}
+	// Handler-layer failure surfaces in the response body via
+	// natsclient's "error: <msg>" payload convention. The most
+	// common case is "error: not found: <id>" for missing entities.
+	if bytes.HasPrefix(respData, []byte("error: ")) {
+		return fmt.Errorf("entity not found: %s", string(respData))
 	}
 	return nil
 }

--- a/processor/graph-query/pathrag_test.go
+++ b/processor/graph-query/pathrag_test.go
@@ -1,0 +1,78 @@
+package graphquery
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestVerifyEntityExists_NotFoundProtocol pins ADR-036 Stage 4.1's
+// fix: graph-ingest's handleQueryEntityNATS returns a Go error on
+// missing-entity, but natsclient.SubscribeForRequests wraps that
+// into the response payload as "error: not found: <id>" with err=nil.
+// The previous implementation only branched on err and silently
+// passed verification when an entity was missing. Sister-bug to the
+// fix in processor/agentic-loop/todos.go.
+func TestVerifyEntityExists_NotFoundProtocol(t *testing.T) {
+	tests := []struct {
+		name        string
+		respData    []byte
+		respErr     error
+		wantErr     bool
+		wantMsgPart string
+	}{
+		{
+			name:     "entity exists — empty err, body is entity JSON",
+			respData: []byte(`{"id":"acme.test.foo.bar.baz.001","triples":[]}`),
+		},
+		{
+			name:        "missing entity — handler error wrapped as response payload",
+			respData:    []byte("error: not found: acme.test.foo.bar.baz.001"),
+			wantErr:     true,
+			wantMsgPart: "not found",
+		},
+		{
+			name:        "other handler error (e.g. internal) — surfaced too",
+			respData:    []byte("error: internal error: db down"),
+			wantErr:     true,
+			wantMsgPart: "internal error",
+		},
+		{
+			name:        "transport failure — propagated via Go err",
+			respErr:     errors.New("nats: timeout"),
+			wantErr:     true,
+			wantMsgPart: "query entity",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := newMockNATSClient()
+			mock.requestFunc = func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
+				if subject != "graph.ingest.query.entity" {
+					t.Errorf("unexpected subject %q", subject)
+				}
+				return tt.respData, tt.respErr
+			}
+
+			p := NewPathSearcher(mock, 1*time.Second, 5, slog.Default())
+			err := p.verifyEntityExists(context.Background(), "acme.test.foo.bar.baz.001")
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.wantMsgPart != "" && !strings.Contains(err.Error(), tt.wantMsgPart) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.wantMsgPart)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("expected nil error, got %v", err)
+			}
+		})
+	}
+}

--- a/processor/rule/config_validation.go
+++ b/processor/rule/config_validation.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/processor/rule/expression"
+	"github.com/c360studio/semstreams/vocabulary"
 )
 
 // ValidateConfigUpdate validates proposed configuration changes
@@ -167,6 +168,18 @@ func (rp *Processor) validateExpressionRule(ruleID string, ruleMap map[string]an
 			return errs.WrapInvalid(
 				fmt.Errorf("rule %s condition[%d] has invalid operator: %s", ruleID, i, operator),
 				"RuleProcessor", "validateExpressionRule", "check operator")
+		}
+
+		// Reject conditions that predicate on rule-opaque fields. Rule-opaque
+		// predicates carry free-form agent-private content (ADR-036); rules
+		// match structural facts only. Vocabulary marks the predicate
+		// rule-opaque via RuleOpaque metadata; unregistered predicates pass
+		// through (opacity is opt-in at registration time).
+		field, _ := condMap["field"].(string)
+		if field != "" && vocabulary.IsRuleOpaque(field) {
+			return errs.WrapInvalid(
+				fmt.Errorf("rule %s condition[%d] predicates on rule-opaque field %q; rule-opaque predicates carry agent-private content and cannot be matched in rule conditions (see ADR-036)", ruleID, i, field),
+				"RuleProcessor", "validateExpressionRule", "check rule-opaque field")
 		}
 	}
 

--- a/processor/rule/config_validation.go
+++ b/processor/rule/config_validation.go
@@ -220,13 +220,42 @@ func (rp *Processor) isValidOperator(operator string) bool {
 // ValidateDefinition validates a rule Definition for fields that are
 // processor-level concerns (not delegated to individual rule factories).
 // Call this before passing a Definition to CreateRuleFromDefinition.
+//
+// Both load paths converge here:
+//   - file-load → definitionFromMap → ValidateDefinition (this function)
+//   - hot-reload via KV → ValidateConfigUpdate → validateExpressionRule
+//
+// Discipline checks that apply to both paths (e.g. ADR-036's
+// rule-opaque field rejection) live here so a startup-time on-disk
+// rule cannot bypass what a hot-reload would catch.
 func ValidateDefinition(def Definition) error {
 	if def.FireEveryNEvents < 0 {
 		return errs.WrapInvalid(
 			fmt.Errorf("rule %s fire_every_n_events must be >= 0, got %d", def.ID, def.FireEveryNEvents),
 			"RuleProcessor", "ValidateDefinition", "validate fire_every_n_events")
 	}
+	if err := validateConditionFields(def); err != nil {
+		return err
+	}
 	return validateActionLists(def)
+}
+
+// validateConditionFields enforces ADR-036 Rule 1 on a parsed
+// Definition: no condition.field may name a vocabulary predicate
+// flagged RuleOpaque. Mirrors the check in validateExpressionRule's
+// hot-reload path so file-loaded rules see the same gate.
+func validateConditionFields(def Definition) error {
+	for i, c := range def.Conditions {
+		if c.Field == "" {
+			continue
+		}
+		if vocabulary.IsRuleOpaque(c.Field) {
+			return errs.WrapInvalid(
+				fmt.Errorf("rule %s condition[%d] predicates on rule-opaque field %q; rule-opaque predicates carry agent-private content and cannot be matched in rule conditions (see ADR-036)", def.ID, i, c.Field),
+				"RuleProcessor", "ValidateDefinition", "check rule-opaque field")
+		}
+	}
+	return nil
 }
 
 // validateActionLists walks every action slice on the Definition

--- a/processor/rule/config_validation_test.go
+++ b/processor/rule/config_validation_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/processor/rule/expression"
 	"github.com/c360studio/semstreams/vocabulary"
 )
 
@@ -178,6 +179,43 @@ func TestValidateExpressionRule_RejectsRuleOpaqueField(t *testing.T) {
 		})
 		if err != nil {
 			t.Errorf("structural field %q must remain rule-matchable: %v", structuralField, err)
+		}
+	})
+
+	t.Run("file-load path catches rule-opaque field via ValidateDefinition", func(t *testing.T) {
+		// Stage 1.5 — file-load (definitionFromMap → ValidateDefinition)
+		// must catch rule-opaque field references the same way the
+		// hot-reload path (ValidateConfigUpdate) does. ADR-036's
+		// discipline claim depends on both gates being equivalent.
+		def := Definition{
+			ID:   "file_load_opaque",
+			Type: "test_rule",
+			Conditions: []expression.ConditionExpression{
+				{Field: opaqueField, Operator: "eq", Value: "anything"},
+			},
+		}
+		err := ValidateDefinition(def)
+		if err == nil {
+			t.Fatal("expected ValidateDefinition to reject rule-opaque field on file-load path, got nil")
+		}
+		if !strings.Contains(err.Error(), "rule-opaque") {
+			t.Errorf("error %q should mention rule-opaque", err.Error())
+		}
+		if !errs.IsInvalid(err) {
+			t.Errorf("expected ErrorInvalid class, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("file-load path accepts structural sibling via ValidateDefinition", func(t *testing.T) {
+		def := Definition{
+			ID:   "file_load_structural",
+			Type: "test_rule",
+			Conditions: []expression.ConditionExpression{
+				{Field: structuralField, Operator: "eq", Value: "completed"},
+			},
+		}
+		if err := ValidateDefinition(def); err != nil {
+			t.Errorf("ValidateDefinition must accept structural field on file-load path: %v", err)
 		}
 	})
 

--- a/processor/rule/config_validation_test.go
+++ b/processor/rule/config_validation_test.go
@@ -1,7 +1,13 @@
 package rule
 
 import (
+	"log/slog"
+	"strings"
 	"testing"
+
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/vocabulary"
 )
 
 // definitionFromMap is the hot-reload wire-format → Definition decoder.
@@ -95,4 +101,103 @@ func TestDefinitionFromMap_AbsentCooldownIsEmptyString(t *testing.T) {
 	if def.Cooldown != "" {
 		t.Errorf("Cooldown = %q, want empty string for absent field", def.Cooldown)
 	}
+}
+
+// TestValidateExpressionRule_RejectsRuleOpaqueField pins ADR-036's Rule 1:
+// rules MUST NOT predicate on fields the vocabulary marks RuleOpaque.
+// The validator catches this at config-load so a misconfigured rule
+// never starts; structural fields (status, position) on the same
+// predicate family stay rule-matchable.
+func TestValidateExpressionRule_RejectsRuleOpaqueField(t *testing.T) {
+	// Snapshot the registry so test-registered predicates don't leak as
+	// stub entries to follow-on tests. SnapshotRegistry returns a closure
+	// that restores the pre-test state on defer.
+	defer vocabulary.SnapshotRegistry()()
+
+	const opaqueField = "test.todo.content"
+	const structuralField = "test.todo.status"
+
+	vocabulary.RegisterPredicate(vocabulary.PredicateMetadata{
+		Name:       opaqueField,
+		DataType:   "string",
+		RuleOpaque: true,
+	})
+	vocabulary.RegisterPredicate(vocabulary.PredicateMetadata{
+		Name:     structuralField,
+		DataType: "string",
+	})
+
+	processor := &Processor{
+		natsClient: &natsclient.Client{},
+		logger:     slog.Default(),
+		rules:      make(map[string]Rule),
+	}
+
+	t.Run("rejects condition on opaque field", func(t *testing.T) {
+		err := processor.ValidateConfigUpdate(map[string]any{
+			"rules": map[string]any{
+				"opaque_match": map[string]any{
+					"type": "test_rule",
+					"conditions": []any{
+						map[string]any{
+							"field":    opaqueField,
+							"operator": "eq",
+							"value":    "anything",
+						},
+					},
+				},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected error rejecting rule-opaque field, got nil")
+		}
+		if got := err.Error(); !strings.Contains(got, "rule-opaque") {
+			t.Errorf("error %q should mention rule-opaque (ADR-036 Rule 1)", got)
+		}
+		// Pin the WrapInvalid choice — a future refactor that switches to
+		// plain fmt.Errorf would silently break callers using errs.IsInvalid.
+		if !errs.IsInvalid(err) {
+			t.Errorf("expected ErrorInvalid class for rule-opaque rejection, got %T: %v", err, err)
+		}
+	})
+
+	t.Run("accepts condition on structural field of same family", func(t *testing.T) {
+		err := processor.ValidateConfigUpdate(map[string]any{
+			"rules": map[string]any{
+				"structural_match": map[string]any{
+					"type": "test_rule",
+					"conditions": []any{
+						map[string]any{
+							"field":    structuralField,
+							"operator": "eq",
+							"value":    "completed",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Errorf("structural field %q must remain rule-matchable: %v", structuralField, err)
+		}
+	})
+
+	t.Run("accepts condition on unregistered field (opacity is opt-in)", func(t *testing.T) {
+		err := processor.ValidateConfigUpdate(map[string]any{
+			"rules": map[string]any{
+				"unregistered_match": map[string]any{
+					"type": "test_rule",
+					"conditions": []any{
+						map[string]any{
+							"field":    "totally.new.field",
+							"operator": "eq",
+							"value":    "x",
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Errorf("unregistered fields must default to rule-matchable: %v", err)
+		}
+	})
 }

--- a/vocabulary/agentic/agentic_test.go
+++ b/vocabulary/agentic/agentic_test.go
@@ -255,8 +255,9 @@ func TestPredicateCount(t *testing.T) {
 	// Intent: 5, Capability: 7, Delegation: 7, Accountability: 6, Execution: 7, Action: 5, Task: 5
 	// Model: 8, Loop: 15 (core + LoopHasStep + LoopDescription)
 	// Step: 18 (15 core + tool_status + error_message + error_category), Identity: 6
-	// Total: 89 predicates
-	expectedMin := 89
+	// Todo: 5 (ADR-036 — id, content, status, position, updated_at)
+	// Total: 94 predicates
+	expectedMin := 94
 	if len(predicates) < expectedMin {
 		t.Errorf("expected at least %d predicates, got %d", expectedMin, len(predicates))
 	}
@@ -402,6 +403,41 @@ func TestIdentityPredicatesRegistered(t *testing.T) {
 		}
 		if meta.DataType != tt.dataType {
 			t.Errorf("%s: DataType = %q, want %q", tt.name, meta.DataType, tt.dataType)
+		}
+	}
+}
+
+func TestTodoPredicatesRegistered(t *testing.T) {
+	vocabulary.ClearRegistry()
+	defer vocabulary.ClearRegistry()
+
+	agentic.Register()
+
+	todoPredicates := []struct {
+		name       string
+		predicate  string
+		dataType   string
+		ruleOpaque bool
+	}{
+		{"TodoID", agentic.TodoID, "string", false},
+		{"TodoContent", agentic.TodoContent, "string", true},
+		{"TodoStatus", agentic.TodoStatus, "string", false},
+		{"TodoPosition", agentic.TodoPosition, "int", false},
+		{"TodoUpdatedAt", agentic.TodoUpdatedAt, "time.Time", false},
+	}
+
+	for _, tt := range todoPredicates {
+		meta := vocabulary.GetPredicateMetadata(tt.predicate)
+		if meta == nil {
+			t.Errorf("%s (%q): not registered", tt.name, tt.predicate)
+			continue
+		}
+		if meta.DataType != tt.dataType {
+			t.Errorf("%s: DataType = %q, want %q", tt.name, meta.DataType, tt.dataType)
+		}
+		if meta.RuleOpaque != tt.ruleOpaque {
+			t.Errorf("%s: RuleOpaque = %v, want %v (ADR-036 §Decision Rule 1: rules MUST NOT predicate on opaque content)",
+				tt.name, meta.RuleOpaque, tt.ruleOpaque)
 		}
 	}
 }

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -682,6 +682,59 @@ const (
 	OpsDiagnosisSeverity = "ops.diagnosis.severity"
 )
 
+// Todo Predicates (ADR-036 — Agent-Private Observable State)
+//
+// Written by the write_todos tool onto the owning agent's loop entity.
+// Each todo item produces five triples on the loop entity, keyed by the
+// todo's stable ID, so the prompt assembler can reconstruct the full
+// list across iterations even after context compaction.
+//
+// Discipline (ADR-036 §Decision):
+//   - The owning agent is the sole writer and sole interpreter of
+//     content. Other readers (rules, ops agent, debug UI) may match
+//     structural facts (status enums, counts, transitions) but MUST
+//     NOT predicate on TodoContent. The rule-validator enforces this
+//     via the RuleOpaque metadata flag on TodoContent.
+//   - Each call to write_todos replaces the prior list (full-list
+//     replace, not delta-merge). The executor removes triples for
+//     todos no longer present and writes the new set in a single
+//     batch.
+const (
+	// TodoID is the stable identifier the agent assigned to a todo
+	// item. Used to correlate the five triples that describe one item.
+	// Example: "1", "2", "task-a"
+	// DataType: string
+	TodoID = "agent.todo.id"
+
+	// TodoContent is the free-form description of the todo item.
+	// Owner-interpretable only. Rule-opaque — rules MUST NOT predicate
+	// on this field; the rule-validator rejects any rule whose
+	// condition.field names this predicate. See ADR-036 Rule 1.
+	// Example: "Survey existing rules"
+	// DataType: string
+	TodoContent = "agent.todo.content"
+
+	// TodoStatus is the structural state of the todo item. Rule-matchable.
+	// Values: "pending" | "in_progress" | "completed".
+	// Example: "in_progress"
+	// DataType: string
+	TodoStatus = "agent.todo.status"
+
+	// TodoPosition is the zero-based ordinal of the todo within the list.
+	// The prompt assembler sorts by this field when reconstructing the
+	// list for re-injection.
+	// Example: 0, 1, 2
+	// DataType: int
+	TodoPosition = "agent.todo.position"
+
+	// TodoUpdatedAt is the wall-clock timestamp of the last write to
+	// this todo. Rule-matchable for stuck-detector predicates
+	// ("status=in_progress AND updated_at < now-30m").
+	// Example: "2026-05-09T14:22:00Z"
+	// DataType: time.Time
+	TodoUpdatedAt = "agent.todo.updated_at"
+)
+
 // Ops Config Predicates (Phase 3, reserved)
 //
 // These predicates are declared now to lock the ops.config.* namespace but

--- a/vocabulary/agentic/register.go
+++ b/vocabulary/agentic/register.go
@@ -29,6 +29,33 @@ func Register() {
 	registerLoopPredicates()
 	registerStepPredicates()
 	registerIdentityPredicates()
+	registerTodoPredicates()
+}
+
+// registerTodoPredicates registers predicates for agent-private todo
+// state (ADR-036). TodoContent is flagged rule-opaque; the
+// rule-validator rejects any rule that predicates on it.
+func registerTodoPredicates() {
+	vocabulary.Register(TodoID,
+		vocabulary.WithDescription("Stable identifier for a todo item within an agent's loop"),
+		vocabulary.WithDataType("string"))
+
+	vocabulary.Register(TodoContent,
+		vocabulary.WithDescription("Free-form description of a todo item; owner-interpretable only"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithRuleOpaque(true))
+
+	vocabulary.Register(TodoStatus,
+		vocabulary.WithDescription("Status of a todo item (pending|in_progress|completed)"),
+		vocabulary.WithDataType("string"))
+
+	vocabulary.Register(TodoPosition,
+		vocabulary.WithDescription("Zero-based ordinal of a todo item within its list"),
+		vocabulary.WithDataType("int"))
+
+	vocabulary.Register(TodoUpdatedAt,
+		vocabulary.WithDescription("Wall-clock timestamp of the last write to a todo item"),
+		vocabulary.WithDataType("time.Time"))
 }
 
 // registerIntentPredicates registers predicates for agent intentions and goals.

--- a/vocabulary/predicates.go
+++ b/vocabulary/predicates.go
@@ -360,6 +360,19 @@ type PredicateMetadata struct {
 	//
 	// StandardIRI equivalent: owl:SymmetricProperty
 	IsSymmetric bool
+
+	// RuleOpaque marks the predicate as carrying free-form content that
+	// rules MUST NOT predicate on. The rule-validator rejects rule
+	// conditions whose `field` names a rule-opaque predicate at
+	// config-load time.
+	//
+	// Used for agent-private observable state (ADR-036): the owning
+	// agent is the sole writer and sole interpreter of content; rules
+	// may match structural facts (counts, status enums, transitions)
+	// but not the content itself. The asymmetric ownership pattern
+	// avoids LLM-on-LLM checklist Goodhart by keeping content out of
+	// the rule-engine's branching surface.
+	RuleOpaque bool
 }
 
 // IsValidPredicate checks if a predicate follows the three-level dotted notation

--- a/vocabulary/registry.go
+++ b/vocabulary/registry.go
@@ -186,6 +186,23 @@ func WithInverseOf(inversePredicate string) Option {
 	}
 }
 
+// WithRuleOpaque marks the predicate as carrying free-form content
+// that rules must not predicate on. The rule-validator rejects rule
+// conditions whose `field` names a rule-opaque predicate at
+// config-load time. See ADR-036 for the asymmetric-ownership rationale.
+//
+// Example:
+//
+//	Register("agent.todo.content",
+//	    WithDescription("Free-form todo description"),
+//	    WithDataType("string"),
+//	    WithRuleOpaque(true))
+func WithRuleOpaque(opaque bool) Option {
+	return func(m *PredicateMetadata) {
+		m.RuleOpaque = opaque
+	}
+}
+
 // WithSymmetric marks the predicate as symmetric (its own inverse).
 // Symmetric predicates imply bidirectional relationships: if A relates to B,
 // then B relates to A with the same predicate.
@@ -363,6 +380,21 @@ func GetInversePredicate(predicate string) string {
 	return meta.InverseOf
 }
 
+// IsRuleOpaque reports whether a predicate is marked rule-opaque.
+// Returns false for unregistered predicates so that vocabulary
+// registration is the only path to opacity — undeclared predicates
+// stay rule-matchable by default. See ADR-036.
+func IsRuleOpaque(predicate string) bool {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	meta, exists := predicateRegistry[predicate]
+	if !exists {
+		return false
+	}
+	return meta.RuleOpaque
+}
+
 // IsSymmetricPredicate checks if a predicate is symmetric.
 // Symmetric predicates represent bidirectional relationships where
 // if A relates to B, then B also relates to A with the same predicate.
@@ -429,4 +461,28 @@ func ClearRegistry() {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 	predicateRegistry = make(map[string]PredicateMetadata)
+}
+
+// SnapshotRegistry captures the current registry state and returns a
+// restore function. Intended for tests that register predicates
+// transiently and need to undo without leaving stub entries behind.
+//
+// Example:
+//
+//	defer vocabulary.SnapshotRegistry()()
+//	vocabulary.Register("test.foo.bar", ...)
+//	// test runs; deferred restore reverts the registry to its pre-test state.
+func SnapshotRegistry() func() {
+	registryMu.RLock()
+	saved := make(map[string]PredicateMetadata, len(predicateRegistry))
+	for k, v := range predicateRegistry {
+		saved[k] = v
+	}
+	registryMu.RUnlock()
+
+	return func() {
+		registryMu.Lock()
+		predicateRegistry = saved
+		registryMu.Unlock()
+	}
 }

--- a/vocabulary/registry_test.go
+++ b/vocabulary/registry_test.go
@@ -283,3 +283,46 @@ func TestSymmetricWithIRI(t *testing.T) {
 	// GetInversePredicate should return itself
 	assert.Equal(t, "test.rel.sibling", GetInversePredicate("test.rel.sibling"))
 }
+
+func TestRegisterWithRuleOpaque(t *testing.T) {
+	originalRegistry := make(map[string]PredicateMetadata)
+	registryMu.RLock()
+	for k, v := range predicateRegistry {
+		originalRegistry[k] = v
+	}
+	registryMu.RUnlock()
+	defer func() {
+		registryMu.Lock()
+		predicateRegistry = originalRegistry
+		registryMu.Unlock()
+	}()
+
+	ClearRegistry()
+
+	// Register an opaque predicate (free-form content, ADR-036)
+	Register("test.todo.content",
+		WithDescription("Free-form content"),
+		WithDataType("string"),
+		WithRuleOpaque(true))
+
+	// Register a structural predicate (rule-matchable)
+	Register("test.todo.status",
+		WithDescription("Status enum"),
+		WithDataType("string"))
+
+	meta := GetPredicateMetadata("test.todo.content")
+	require.NotNil(t, meta)
+	assert.True(t, meta.RuleOpaque)
+
+	meta2 := GetPredicateMetadata("test.todo.status")
+	require.NotNil(t, meta2)
+	assert.False(t, meta2.RuleOpaque)
+
+	// IsRuleOpaque convenience query
+	assert.True(t, IsRuleOpaque("test.todo.content"))
+	assert.False(t, IsRuleOpaque("test.todo.status"))
+
+	// Unregistered predicates default to non-opaque (opacity is opt-in
+	// at registration time per ADR-036)
+	assert.False(t, IsRuleOpaque("test.unknown.field"))
+}


### PR DESCRIPTION
## Summary

Implements [ADR-036](docs/adr/036-agent-private-observable-state.md) — agent-private observable state, with `write_todos` as the first concrete instance. Each loop carries a structured working list on its entity that survives context compaction; the prompt assembler re-injects it every iteration. Closes the same compaction-survival mechanism Claude Code's TodoWrite gives its agents, with semstreams's per-loop ownership discipline preventing the LLM-on-LLM checklist Goodhart pattern that bit semteams in alpha.

## What landed (9 commits, stage-by-stage with go-reviewer pass at each gate)

**Core ADR-036 work:**
- **Stage 1** (`fd28018`) — `RuleOpaque` metadata on `PredicateMetadata`, `agent.todo.*` predicates (`TodoContent` flagged opaque), rule-validator extension that rejects rule conditions matching on opaque fields.
- **Stage 2** (`1a8ba80`) — `graph.mutation.triple.add_batch` handler + `Component.AddTriples` that groups by Subject and collapses N triples to one CAS per entity. Single-subject CAS-collapse pinned by integration test (Version=1 not 5).
- **Stage 3** (`fc6b5b1`) — `write_todos` executor with full-list-replace semantics, Strict-mode tool definition, available to all roles (per-loop opacity, not per-role).
- **Stage 4** (`5995c8e`) — Prompt assembler reads todos and re-injects per iteration. The load-bearing compaction-survival mechanism. Reader fails open on transient errors.
- **Stage 5** (`3d3b04a`) — Operator guide (`docs/operations/15-agent-private-state.md`) + cross-component integration test that proves write→query→reconstruct end-to-end.

**Reviewer-flagged gap closures:**
- **Stage 1.5** (`0b47ade`) — File-load rule-validator gap. Pre-fix, the rule-opaque check fired only on hot-reload via KV; on-disk JSON rules at startup bypassed it. Moved into `ValidateDefinition` so both load paths converge.
- **Stage 3.7** (`1dd7d01`) — Clock injection on `WriteTodosExecutor`. Stage 3 shipped a doc-comment claiming testability that the code didn't deliver; wired `SetClock` so the contract matches.
- **Stage 4.1** (`4631e12`) — Sister-bug in `pathrag.go verifyEntityExists`: same protocol misunderstanding Stage 4 fixed (graph-ingest's "not found" Go error arrives as a successful NATS response with `error: not found:` payload, not in the `err` return). PathRAG silently passed verification on missing entities pre-fix.
- **Stage 3.8** (`965a557`) — Closed the `LoopExecutionEntityID` panic class (beta.36 precedent). Added `TryLoopExecutionEntityID` returning `(string, error)`; routed the three runtime tool executors (decide, emit_diagnosis, write_todos) through it so a malformed loop_id surfaces as `ToolErrorInternal` instead of crashing the dispatch goroutine.

## Three deliberately-did-NOT-do-X decisions

These are load-bearing for review-of-review and worth surfacing:

1. **No full agentic-loop boot in the Stage 5 integration test.** The cross-component contract Stage 5 proves is "triples written via Stage 2's batch path are reconstructible via Stage 4's reader." Booting the full agentic-loop adds dependency on mock-LLM machinery for a regression already covered by the prompt-assembler unit tests. The Stage 5 test exercises exactly the data path that ADR-036 makes a promise about.
2. **No atomic `update_entity_with_triples` handler (Stage 3.5).** The 5-remove + 1-batch-add sequence has a ~60ms read-during-write window where the loop entity has zero todo triples. Within an agent's own loop this is invisible (tool calls serialise; the assembler never reads mid-write). Cross-loop observers (ops agent post-completion, status-matching rules) see at most a sub-second transient empty state, and Stage 4's reader fails open on it. Filed as Stage 3.5; revisit when widespread adoption + cross-process consumers coincide.
3. **No new `dev-via-spec-with-todos.yaml` fixture.** `write_todos` is registered globally and personas opt in via fragment additions, not fixture changes. A new fixture would either duplicate `dev-via-spec.yaml` (if the only diff is a persona fragment) or imply a separate fixture per persona-permutation, which is the wrong scaling shape. Operator decision, not framework decision.

## Follow-ups filed (not blocking merge)

- **Stage 2.5** — Partial-CAS-failure integration test (speculative; no current multi-subject caller)
- **Stage 2.6** — Migrate multi-triple emitters in `graph_writer.go` to the batch path (perf-only)
- **Stage 3.5** — Atomic `update_entity_with_triples` handler (close the read-during-write window when adoption demands it)
- **Stage 3.6** — `MaxTodosPerWrite` ceiling (defensive)

## Test plan

- [x] `go build ./...` clean
- [x] `task lint` clean (vet, fmt, revive)
- [x] `go test ./...` green
- [x] `go test -race` on touched packages green
- [x] `go test -tags=integration` for the new graph-ingest batch tests + agentic-loop todo round-trip tests green
- [x] `go vet -tags=integration ./...` clean (per `feedback_pre_tag_sweep_includes_build_tags.md`)
- [x] `go vet -tags=live_llm ./...` clean
- [x] `task schema:generate` produces no diff
- [x] go-reviewer pass at every stage gate, all flagged items applied or filed

## Not breaking

Public API is fully additive:
- New `RuleOpaque` field on `PredicateMetadata` (zero value matches existing behaviour).
- New `WithRuleOpaque` option, `IsRuleOpaque` query, `SnapshotRegistry` test helper.
- New `agent.todo.*` predicates.
- New `graph.mutation.triple.add_batch` NATS subject + `AddTriplesBatchRequest/Response` types.
- New `Component.AddTriples` batch method on graph-ingest.
- New `write_todos` tool; existing tools unchanged.
- New `TodoReader` interface + `BuildTodoStateMessage` + `prependIterationContext` on agentic-loop; existing call sites preserved semantics exactly.
- New `TryLoopExecutionEntityID`; the original `LoopExecutionEntityID` keeps panic semantics for boot-time callers.

No registry singletons retired, no tags shipped, no operator-config breaking changes — the breaking-change-needs-e2e rule from CLAUDE.md does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)