### PR TITLE
Web tools observable graph state + 3-segment coordinator predicates

### DIFF
--- a/agentic/web_observation_entity.go
+++ b/agentic/web_observation_entity.go
@@ -95,6 +95,13 @@ func canonicalizeURL(rawURL string) (string, error) {
 	// strings.ToLower on host:port still works).
 	u.Host = strings.ToLower(u.Host)
 
+	// Strip userinfo. Credentials in a canonical URL would leak into the
+	// entity hash AND into agent.web.url; the same URL with vs without
+	// credentials would also diverge across loops, breaking dedup. The
+	// agent's original (credentialed) URL stays in the trajectory for
+	// audit if anyone needs it.
+	u.User = nil
+
 	// Strip default port.
 	if (u.Scheme == "http" && strings.HasSuffix(u.Host, ":80")) ||
 		(u.Scheme == "https" && strings.HasSuffix(u.Host, ":443")) {

--- a/agentic/web_observation_entity.go
+++ b/agentic/web_observation_entity.go
@@ -1,0 +1,116 @@
+package agentic
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// webObservationInstanceLen is the number of sha256 hex characters used
+// as the instance segment. 16 hex chars = 64 bits of entropy. Long
+// enough to make collisions vanishingly unlikely at any realistic graph
+// scale; short enough to keep entity IDs and NATS subjects compact.
+const webObservationInstanceLen = 16
+
+// TryWebObservationEntityID returns the canonical 6-part entity ID for a
+// URL observed by an agent (web_search) or fetched by an agent
+// (http_request), along with the canonical URL the entity represents.
+// Same URL across loops → same entity ID, so observations naturally
+// dedup: rule queries against agent.web.observation entities see one
+// vertex per URL with whatever predicates the system has so far
+// accumulated.
+//
+// Format: {org}.{platform}.agent.web.observation.{sha256-hex-16}
+//
+// Returns ("", "", error) when org/platform are empty or contain dots,
+// when rawURL fails to parse, or when the constructed ID fails
+// IsValidEntityID. The Try-variant naming follows the beta.36 precedent
+// for runtime tool executors: a panic in a tool handler silently kills
+// the dispatch goroutine, so runtime code MUST use this error-returning
+// form.
+//
+// Canonicalisation (V1, conservative — easily extended in a follow-up
+// without changing the entity hash for URLs that didn't hit the new
+// rules):
+//   - lowercase scheme and host
+//   - strip default port (:80 for http, :443 for https)
+//   - strip fragment (#section)
+//   - strip trailing slash on bare-host URLs (preserve internal slashes)
+//   - preserve query string as-is (tracking-param stripping and
+//     query-param sorting are V2 candidates; query-param semantics are
+//     too domain-specific to canonicalise generically)
+//
+// Note that canonicalisation is one-way: callers who need to display
+// the agent's original input URL should keep it from the tool call, not
+// try to reverse the hash.
+func TryWebObservationEntityID(org, platform, rawURL string) (entityID, canonicalURL string, err error) {
+	if err := validatePart("org", org); err != nil {
+		return "", "", fmt.Errorf("WebObservationEntityID: %w", err)
+	}
+	if err := validatePart("platform", platform); err != nil {
+		return "", "", fmt.Errorf("WebObservationEntityID: %w", err)
+	}
+	if rawURL == "" {
+		return "", "", fmt.Errorf("WebObservationEntityID: rawURL must not be empty")
+	}
+
+	canonicalURL, err = canonicalizeURL(rawURL)
+	if err != nil {
+		return "", "", fmt.Errorf("WebObservationEntityID: %w", err)
+	}
+
+	sum := sha256.Sum256([]byte(canonicalURL))
+	instance := hex.EncodeToString(sum[:])[:webObservationInstanceLen]
+
+	id := fmt.Sprintf("%s.%s.agent.web.observation.%s", org, platform, instance)
+	if !message.IsValidEntityID(id) {
+		return "", "", fmt.Errorf("WebObservationEntityID: constructed id %q failed IsValidEntityID — check input values", id)
+	}
+	return id, canonicalURL, nil
+}
+
+// canonicalizeURL applies the V1 canonicalisation rules. Returns an
+// error when rawURL is unparseable, has no scheme, or has no host —
+// these are caller bugs (the http_request executor already rejects
+// non-http(s) URLs before reaching this point; web_search inherits the
+// provider's URL validity).
+func canonicalizeURL(rawURL string) (string, error) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil {
+		return "", fmt.Errorf("parse url: %w", err)
+	}
+	if u.Scheme == "" {
+		return "", fmt.Errorf("url %q has no scheme", rawURL)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("url %q has no host", rawURL)
+	}
+
+	u.Scheme = strings.ToLower(u.Scheme)
+	// Lowercase host but preserve port (port is numeric so case-irrelevant;
+	// strings.ToLower on host:port still works).
+	u.Host = strings.ToLower(u.Host)
+
+	// Strip default port.
+	if (u.Scheme == "http" && strings.HasSuffix(u.Host, ":80")) ||
+		(u.Scheme == "https" && strings.HasSuffix(u.Host, ":443")) {
+		u.Host = u.Hostname()
+	}
+
+	// Strip fragment.
+	u.Fragment = ""
+	u.RawFragment = ""
+
+	// Strip trailing slash on bare-host URLs ("https://example.com/" →
+	// "https://example.com"). Preserve internal slashes; "/foo/" stays
+	// "/foo/" because that's a meaningful distinction in many APIs.
+	if u.Path == "/" {
+		u.Path = ""
+	}
+
+	return u.String(), nil
+}

--- a/agentic/web_observation_entity_test.go
+++ b/agentic/web_observation_entity_test.go
@@ -106,6 +106,28 @@ func TestTryWebObservationEntityID_QueryStringPreserved(t *testing.T) {
 	}
 }
 
+// TestTryWebObservationEntityID_StripsUserinfo confirms credentials in
+// the raw URL never reach the canonical form (or the entity hash). A
+// URL with userinfo and the same URL without must converge to one
+// entity, and the canonical URL stored on agent.web.url must not leak
+// the credentials downstream.
+func TestTryWebObservationEntityID_StripsUserinfo(t *testing.T) {
+	plain, _, err := TryWebObservationEntityID("acme", "ops", "https://example.com/path")
+	if err != nil {
+		t.Fatalf("plain: %v", err)
+	}
+	credentialed, canon, err := TryWebObservationEntityID("acme", "ops", "https://user:secret@example.com/path")
+	if err != nil {
+		t.Fatalf("credentialed: %v", err)
+	}
+	if plain != credentialed {
+		t.Errorf("credentials in URL produced a different entity: plain=%q credentialed=%q", plain, credentialed)
+	}
+	if strings.Contains(canon, "user") || strings.Contains(canon, "secret") {
+		t.Errorf("canonical URL leaked credentials: %q", canon)
+	}
+}
+
 // TestTryWebObservationEntityID_Rejections covers the input-validation
 // failure modes: empty/dotted org/platform/url, malformed url, missing scheme/host.
 func TestTryWebObservationEntityID_Rejections(t *testing.T) {

--- a/agentic/web_observation_entity_test.go
+++ b/agentic/web_observation_entity_test.go
@@ -1,0 +1,138 @@
+package agentic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+func TestTryWebObservationEntityID_HappyPath(t *testing.T) {
+	id, canon, err := TryWebObservationEntityID("acme", "ops", "https://pkg.go.dev/net/http")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !message.IsValidEntityID(id) {
+		t.Errorf("id %q is not a valid 6-part entity ID", id)
+	}
+	parts := strings.Split(id, ".")
+	if len(parts) != 6 {
+		t.Fatalf("id %q does not split into 6 parts", id)
+	}
+	if parts[0] != "acme" || parts[1] != "ops" {
+		t.Errorf("org/platform parts = %q/%q, want acme/ops", parts[0], parts[1])
+	}
+	if parts[2] != "agent" || parts[3] != "web" || parts[4] != "observation" {
+		t.Errorf("domain.system.type = %q.%q.%q, want agent.web.observation", parts[2], parts[3], parts[4])
+	}
+	if len(parts[5]) != webObservationInstanceLen {
+		t.Errorf("instance segment %q has length %d, want %d", parts[5], len(parts[5]), webObservationInstanceLen)
+	}
+	if canon != "https://pkg.go.dev/net/http" {
+		t.Errorf("canonical URL = %q, want https://pkg.go.dev/net/http", canon)
+	}
+}
+
+// TestTryWebObservationEntityID_DedupsAcrossInputs proves the
+// canonicalisation rules collapse common URL variants into one entity:
+// scheme/host case, default port, trailing-slash, fragment.
+func TestTryWebObservationEntityID_DedupsAcrossInputs(t *testing.T) {
+	canonicalInput := "https://example.com/foo"
+	wantID, wantCanon, err := TryWebObservationEntityID("acme", "ops", canonicalInput)
+	if err != nil {
+		t.Fatalf("canonical input failed: %v", err)
+	}
+
+	variants := []string{
+		"https://EXAMPLE.com/foo",
+		"HTTPS://example.com/foo",
+		"https://example.com:443/foo",
+		"https://example.com/foo#section",
+		"  https://example.com/foo  ",
+	}
+	for _, v := range variants {
+		gotID, gotCanon, err := TryWebObservationEntityID("acme", "ops", v)
+		if err != nil {
+			t.Errorf("variant %q: unexpected error: %v", v, err)
+			continue
+		}
+		if gotID != wantID {
+			t.Errorf("variant %q: id = %q, want %q (canonical=%q vs %q)", v, gotID, wantID, gotCanon, wantCanon)
+		}
+	}
+}
+
+// TestTryWebObservationEntityID_BareHostTrailingSlash documents that
+// "/" gets stripped but internal trailing slashes don't — that distinction
+// is meaningful for many APIs.
+func TestTryWebObservationEntityID_BareHostTrailingSlash(t *testing.T) {
+	idA, _, err := TryWebObservationEntityID("acme", "ops", "https://example.com")
+	if err != nil {
+		t.Fatalf("no-slash: %v", err)
+	}
+	idB, _, err := TryWebObservationEntityID("acme", "ops", "https://example.com/")
+	if err != nil {
+		t.Fatalf("trailing-slash: %v", err)
+	}
+	if idA != idB {
+		t.Errorf("bare-host trailing slash not collapsed: %q vs %q", idA, idB)
+	}
+
+	idC, _, err := TryWebObservationEntityID("acme", "ops", "https://example.com/foo/")
+	if err != nil {
+		t.Fatalf("internal-trailing-slash: %v", err)
+	}
+	idD, _, err := TryWebObservationEntityID("acme", "ops", "https://example.com/foo")
+	if err != nil {
+		t.Fatalf("no-internal-trailing-slash: %v", err)
+	}
+	if idC == idD {
+		t.Errorf("internal trailing slash should not collapse: /foo/ and /foo produced the same id %q", idC)
+	}
+}
+
+// TestTryWebObservationEntityID_QueryStringPreserved ensures different
+// query strings produce different observation entities. Tracking-param
+// stripping and query-param sorting are intentionally out of scope for V1.
+func TestTryWebObservationEntityID_QueryStringPreserved(t *testing.T) {
+	idA, _, _ := TryWebObservationEntityID("acme", "ops", "https://example.com/foo?a=1")
+	idB, _, _ := TryWebObservationEntityID("acme", "ops", "https://example.com/foo?a=2")
+	idC, _, _ := TryWebObservationEntityID("acme", "ops", "https://example.com/foo?b=1&a=1")
+	if idA == idB {
+		t.Errorf("different query values collapsed to one entity: %q", idA)
+	}
+	if idA == idC {
+		t.Errorf("different query orderings collapsed (V1 preserves order, V2 may sort): %q", idA)
+	}
+}
+
+// TestTryWebObservationEntityID_Rejections covers the input-validation
+// failure modes: empty/dotted org/platform/url, malformed url, missing scheme/host.
+func TestTryWebObservationEntityID_Rejections(t *testing.T) {
+	cases := []struct {
+		name    string
+		org     string
+		plat    string
+		url     string
+		wantSub string
+	}{
+		{"empty org", "", "ops", "https://example.com", "org must not be empty"},
+		{"dotted org", "ac.me", "ops", "https://example.com", "must not contain dots"},
+		{"empty platform", "acme", "", "https://example.com", "platform must not be empty"},
+		{"dotted platform", "acme", "o.ps", "https://example.com", "must not contain dots"},
+		{"empty url", "acme", "ops", "", "rawURL must not be empty"},
+		{"no scheme", "acme", "ops", "example.com/foo", "no scheme"},
+		{"no host", "acme", "ops", "https://", "no host"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			id, canon, err := TryWebObservationEntityID(c.org, c.plat, c.url)
+			if err == nil {
+				t.Fatalf("expected error, got id=%q canon=%q", id, canon)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("error %q does not contain %q", err.Error(), c.wantSub)
+			}
+		})
+	}
+}

--- a/configs/rules/deep-research/03-fan-out-subtopics.json
+++ b/configs/rules/deep-research/03-fan-out-subtopics.json
@@ -11,7 +11,7 @@
       "value": "research-coordinator"
     },
     {
-      "field": "coordinator.next_action",
+      "field": "coordinator.decision.next_action",
       "operator": "eq",
       "value": "fan_out"
     }

--- a/configs/rules/deep-research/04-synthesize-evidence.json
+++ b/configs/rules/deep-research/04-synthesize-evidence.json
@@ -11,7 +11,7 @@
       "value": "research-coordinator"
     },
     {
-      "field": "coordinator.next_action",
+      "field": "coordinator.decision.next_action",
       "operator": "eq",
       "value": "synthesize"
     }

--- a/configs/rules/deep-research/07-spawn-coordinator.json
+++ b/configs/rules/deep-research/07-spawn-coordinator.json
@@ -2,7 +2,7 @@
   "id": "spawn_research_coordinator",
   "type": "expression",
   "name": "Spawn Research Coordinator on Researcher Complete",
-  "description": "When a researcher completes successfully, spawn a research-coordinator to judge what should happen next (fan_out, synthesize, retry, done). The coordinator reads the researcher's output via read_loop_result and returns a structured decision via the decide tool, which emits a coordinator.next_action triple that downstream rules (03, 04, 05) match on. max_iterations bounds the fan-out recursion. See ADR-026 + ADR-028.",
+  "description": "When a researcher completes successfully, spawn a research-coordinator to judge what should happen next (fan_out, synthesize, retry, done). The coordinator reads the researcher's output via read_loop_result and returns a structured decision via the decide tool, which emits a coordinator.decision.next_action triple that downstream rules (03, 04, 05) match on. max_iterations bounds the fan-out recursion. See ADR-026 + ADR-028.",
   "enabled": true,
   "conditions": [
     {

--- a/docs/adr/026-coordinator-agent-dynamic-flow-composition.md
+++ b/docs/adr/026-coordinator-agent-dynamic-flow-composition.md
@@ -22,7 +22,7 @@ Semstreams commits to rule skeleton + coordinator agent + ops agent (ADR-028). T
 
 - **Invoked by rules**, not continuously running. Rules fire at decision points where metadata isn't enough to choose the next action (e.g. "did the researcher produce fan-out-worthy subtopics, or is it done?"). Those rules spawn the coordinator as a normal agent loop with the coordinator role persona.
 - **Reads agent output on demand** via `read_loop_result(loop_id)`. The upstream agent's prose is never injected into the coordinator's prompt — the coordinator fetches only what fits its context.
-- **Returns a structured terminal decision** via a `decide()` tool whose schema enumerates the valid next actions (e.g. `fan_out`, `synthesize`, `retry`, `done`). Rules downstream match on `coordinator.next_action` triples and route accordingly.
+- **Returns a structured terminal decision** via a `decide()` tool whose schema enumerates the valid next actions (e.g. `fan_out`, `synthesize`, `retry`, `done`). Rules downstream match on `coordinator.decision.next_action` triples and route accordingly.
 - **Contains schema discipline to one role.** Researcher, coder, synthesizer, reviewer agents produce free text. Only the coordinator needs structured output — which means ADR-028's per-tool retry policy gets invoked at the coordinator's `decide` tool, not at every role's submit boundary.
 - **Can manipulate flows and rules at runtime** via the six tool executors defined below. That's how the coordinator adapts the pipeline when its judgment reveals a gap.
 
@@ -89,7 +89,7 @@ Seven tool executors in total: one terminal `decide` tool that is the coordinato
 ```
 
 On successful decide, the tool emits a triple on the coordinator's loop entity:
-`coordinator.next_action = <action>`. The rule engine matches downstream rules on that triple and routes mechanically. The reason + action-specific fields land in the loop's result text so they're inspectable via `read_loop_result` without any tool parsing.
+`coordinator.decision.next_action = <action>`. The rule engine matches downstream rules on that triple and routes mechanically. The reason + action-specific fields land in the loop's result text so they're inspectable via `read_loop_result` without any tool parsing.
 
 Because `decide` is where schema discipline is concentrated, it's also the first real consumer of the opt-in `tool_retries` policy (ADR-028 Layer 1). Stock coordinator configs declare:
 
@@ -297,11 +297,11 @@ external network call to manage its own infrastructure.
 
 Before a first coordinator ships, in order:
 
-1. `decide` terminal tool — simplest, most important. Defined per flow, emits the `coordinator.next_action` triple. No flow-composition capability yet; just judgment.
+1. `decide` terminal tool — simplest, most important. Defined per flow, emits the `coordinator.decision.next_action` triple. No flow-composition capability yet; just judgment.
 2. `read_loop_result` is already built (ADR-028 Layer 1).
 3. Opt-in retry policy is already built (ADR-028 Layer 1) — the coordinator's stock config opts in for `decide`.
 4. Stock research coordinator persona + `configs/flows/coordinator-research.json`.
-5. Re-enable rule 03 (subtopic fan-out) in the deep-research flow, this time matching on `coordinator.next_action = fan_out`.
+5. Re-enable rule 03 (subtopic fan-out) in the deep-research flow, this time matching on `coordinator.decision.next_action = fan_out`.
 6. End-to-end coordinator exercise on the deep-research flow.
 7. Six flow-composition executors — after the judgment-only coordinator is proved out.
 

--- a/docs/adr/028-orchestration-architecture.md
+++ b/docs/adr/028-orchestration-architecture.md
@@ -121,7 +121,7 @@ Commit to a three-layer agentic orchestration architecture:
   branch on the content of a result ("did the researcher find
   subtopics?"), that's a judgment call. The rule should trigger a
   coordinator; the coordinator's terminal tool result emits a triple
-  (e.g., `coordinator.next_action = fan_out`) that a subsequent rule
+  (e.g., `coordinator.decision.next_action = fan_out`) that a subsequent rule
   can match on deterministically.
 - **Tool retries live in config.** For tools where transient failures
   (timeout, external 5xx) are worth auto-retrying at the framework
@@ -152,7 +152,7 @@ Commit to a three-layer agentic orchestration architecture:
   read_loop_result handles single-result retrieval; artifact store
   generalises it to multi-file dev outputs.
 - **Rule 03 re-enable** — depends on coordinator emitting a
-  `coordinator.next_action = fan_out` triple for rule 03 to match on.
+  `coordinator.decision.next_action = fan_out` triple for rule 03 to match on.
 
 ## Consequences
 

--- a/docs/adr/033-operating-curve-based-observability.md
+++ b/docs/adr/033-operating-curve-based-observability.md
@@ -233,7 +233,7 @@ cut. SemStreams ships **opinion-free machinery**. Products ship
 | `OperatingCurve`, `RegimeAnnotation`, `SentinelRun` data shapes | SemStreams (framework) | Mechanical observability infrastructure. Storage layout for the operating-curve library. |
 | Sentinel-run scheduler | SemStreams (framework, reusing ADR-031 cron rule) | A sentinel run is a cron rule with a fixture-controlled prompt set and a regime-tagged result write-back. No new scheduler. |
 | Stationarity-check primitive (variance comparison vs. established curve) | SemStreams (framework) | Mechanical, no LLM judgment. Pure function over `OperatingCurve` + new sample. |
-| Signal taxonomy as agvocab predicates: `ops.curve_departure.*`, `ops.threshold_crossed.*`, `ops.regime_expired.*` | SemStreams (framework) | Vocabulary, not opinion. Same shape as `coordinator.next_action`. |
+| Signal taxonomy as agvocab predicates: `ops.curve_departure.*`, `ops.threshold_crossed.*`, `ops.regime_expired.*` | SemStreams (framework) | Vocabulary, not opinion. Same shape as `coordinator.decision.next_action`. |
 | Ops-agent state machine (read predicate stream → mechanical detect → emit signal) | SemStreams (framework) | Generic orchestration loop. Reuses `agentic-loop`. |
 | The axis catalog itself (Q1–Q5, G1–G10, future axes) | Product (semteams, semspec) | Curated against this product's failure modes. Different products care about different axes. |
 | Detector implementations (`ThinkingSpiral`, `RapidShallowToolCalls`, `EmptyStopAfterToolCalls`, terminal-artifact validators, etc.) | Product | Each detects a failure mode specific to product flows. |

--- a/docs/operations/migration-beta43-to-beta44.md
+++ b/docs/operations/migration-beta43-to-beta44.md
@@ -251,8 +251,10 @@ actionable before the next retry budget review.
   exact + SAP allowlist resolver
 - `processor/agentic-tools/decide.go:normaliseActionForSAP` — V1
   normalisation rules
-- `vocabulary/agentic/predicates.go:CoordinatorDecideSAPCoerced` —
-  audit triple predicate
+- `vocabulary/agentic/predicates.go:CoordinatorDecisionSAPCoerced` —
+  audit triple predicate (renamed from `CoordinatorDecideSAPCoerced`
+  alongside the 3-segment predicate convention sweep; same underlying
+  audit semantics)
 - `processor/rule/action_id_test.go` —
   fingerprint stability + cap resolution tests
 - `processor/rule/action_maxiterations_test.go` — end-to-end cap

--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -108,7 +108,7 @@ func (e *DecideExecutor) SetLogger(logger *slog.Logger) {
 // prose. When the description named a handful of example actions,
 // models biased their terminal choice toward those examples,
 // overriding the persona's enumerated value and wedging chains at an
-// unhandled coordinator.next_action triple. The action vocabulary
+// unhandled coordinator.decision.next_action triple. The action vocabulary
 // lives strictly in the role's system prompt; flows that want
 // structural enforcement use the per-spawn allowlist threaded through
 // TaskMessage.Metadata under MetadataKeyDecideActionAllowlist (see
@@ -120,7 +120,7 @@ func (e *DecideExecutor) ListTools() []agentic.ToolDefinition {
 	return []agentic.ToolDefinition{
 		{
 			Name:        DecideToolName,
-			Description: "Terminal decision tool for coordinator agents. Call exactly once with the action your role's system prompt enumerates. Emits a coordinator.next_action triple on this loop's entity so downstream rules can route; the full args stay in the loop's Result for any agent that needs supporting data.",
+			Description: "Terminal decision tool for coordinator agents. Call exactly once with the action your role's system prompt enumerates. Emits a coordinator.decision.next_action triple on this loop's entity so downstream rules can route; the full args stay in the loop's Result for any agent that needs supporting data.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -266,7 +266,7 @@ func (e *DecideExecutor) decide(ctx context.Context, call agentic.ToolCall) (age
 	if sapCoerced {
 		triples = append(triples, message.Triple{
 			Subject:    loopEntityID,
-			Predicate:  agvocab.CoordinatorDecideSAPCoerced,
+			Predicate:  agvocab.CoordinatorDecisionSAPCoerced,
 			Object:     allowlist.rawAction + "|" + allowlist.canonicalAction,
 			Source:     decideToolSource,
 			Timestamp:  now,

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -333,8 +333,8 @@ func TestDecideExecutor_SAP_CoercesAndSignalsLoudly(t *testing.T) {
 	if got := byPredicate[agvocab.CoordinatorNextAction]; got != "fan_out" {
 		t.Errorf("CoordinatorNextAction = %v, want canonical %q", got, "fan_out")
 	}
-	if got := byPredicate[agvocab.CoordinatorDecideSAPCoerced]; got != "fan-out|fan_out" {
-		t.Errorf("CoordinatorDecideSAPCoerced = %v, want %q", got, "fan-out|fan_out")
+	if got := byPredicate[agvocab.CoordinatorDecisionSAPCoerced]; got != "fan-out|fan_out" {
+		t.Errorf("CoordinatorDecisionSAPCoerced = %v, want %q", got, "fan-out|fan_out")
 	}
 }
 

--- a/processor/agentic-tools/executors/httprequest.go
+++ b/processor/agentic-tools/executors/httprequest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -11,17 +12,39 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
+	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
 
 const (
 	httpMaxResponseSize = 100 * 1024 // 100KB
 	httpMaxTextSize     = 20000      // chars
 	httpRequestTimeout  = 30 * time.Second
+
+	// httpRequestTripleSource is the Source field on triples this tool
+	// publishes; mirrors agent-web-search / coordinator-decide.
+	httpRequestTripleSource = "agent-http-request"
 )
 
 // HTTPRequestExecutor handles http_request tool calls.
+//
+// Triple emission is optional (mirrors WebSearchExecutor): when a non-nil
+// TriplePublisher is supplied via WithHTTPTriplePublisher, each
+// successful 2xx/3xx fetch additionally emits a fixed set of predicates
+// onto an agent.web.observation entity plus a back-link triple onto the
+// calling loop entity. Non-2xx responses (≥400) do not emit — the
+// graph claim is "we observed this URL's content" and a 4xx/5xx isn't
+// that observation. Per-triple failures log + counter + continue
+// (semstreams.agentic_tool_web.emit_failures_total).
 type HTTPRequestExecutor struct {
 	timeout time.Duration
+
+	publisher agentictools.TriplePublisher
+	platform  component.PlatformMeta
+	logger    *slog.Logger
+	now       func() time.Time
 }
 
 // HTTPRequestOption configures the executor.
@@ -32,9 +55,44 @@ func WithHTTPTimeout(d time.Duration) HTTPRequestOption {
 	return func(e *HTTPRequestExecutor) { e.timeout = d }
 }
 
+// WithHTTPTriplePublisher enables graph emission. nil disables emission
+// (default).
+func WithHTTPTriplePublisher(p agentictools.TriplePublisher) HTTPRequestOption {
+	return func(e *HTTPRequestExecutor) { e.publisher = p }
+}
+
+// WithHTTPPlatform supplies the platform identity used to build
+// observation entity IDs and resolve the calling loop's entity ID.
+// Required when publisher is non-nil; ignored otherwise.
+func WithHTTPPlatform(p component.PlatformMeta) HTTPRequestOption {
+	return func(e *HTTPRequestExecutor) { e.platform = p }
+}
+
+// WithHTTPLogger replaces the default logger (slog.Default()). nil-safe.
+func WithHTTPLogger(l *slog.Logger) HTTPRequestOption {
+	return func(e *HTTPRequestExecutor) {
+		if l != nil {
+			e.logger = l
+		}
+	}
+}
+
+// WithHTTPClock replaces the time source the executor stamps onto
+// fetched_at / triple timestamps. nil-safe.
+func WithHTTPClock(now func() time.Time) HTTPRequestOption {
+	return func(e *HTTPRequestExecutor) {
+		if now != nil {
+			e.now = now
+		}
+	}
+}
+
 // NewHTTPRequestExecutor creates an HTTP request executor.
 func NewHTTPRequestExecutor(opts ...HTTPRequestOption) *HTTPRequestExecutor {
-	e := &HTTPRequestExecutor{}
+	e := &HTTPRequestExecutor{
+		logger: slog.Default(),
+		now:    time.Now,
+	}
 	for _, opt := range opts {
 		opt(e)
 	}
@@ -143,14 +201,69 @@ func (e *HTTPRequestExecutor) Execute(ctx context.Context, call agentic.ToolCall
 	}
 
 	content := string(body)
+	truncated := false
 	if len(content) > httpMaxTextSize {
 		content = content[:httpMaxTextSize] + "\n[content truncated]"
+		truncated = true
+	}
+
+	if e.publisher != nil {
+		e.emitObservation(reqCtx, call, rawURL, resp, content, truncated)
 	}
 
 	return agentic.ToolResult{
 		CallID:  call.ID,
 		Content: fmt.Sprintf("HTTP %d\n\n%s", resp.StatusCode, content),
 	}, nil
+}
+
+// emitObservation writes the URL-side observation entity plus a
+// LoopFetchedWeb back-link onto the calling loop. Per-triple publish
+// failures log + counter + continue; emission is additive observation,
+// not the LLM-facing contract. Non-2xx responses never reach this code
+// path — the executor returned earlier with an Error result and the
+// graph claim ("we observed this URL's content") doesn't apply.
+func (e *HTTPRequestExecutor) emitObservation(ctx context.Context, call agentic.ToolCall, rawURL string, resp *http.Response, body string, truncated bool) {
+	if call.LoopID == "" {
+		e.logger.Warn("http_request emission skipped: tool call missing loop_id",
+			"call_id", call.ID, "url", rawURL)
+		return
+	}
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+	if err != nil {
+		e.logger.Warn("http_request emission skipped: cannot resolve loop entity",
+			"call_id", call.ID, "loop_id", call.LoopID, "error", err)
+		return
+	}
+	urlEntity, canon, err := agentic.TryWebObservationEntityID(e.platform.Org, e.platform.Platform, rawURL)
+	if err != nil {
+		webEmitFailuresTotal.WithLabelValues("http_request", "entity_id").Inc()
+		e.logger.Warn("http_request emission skipped: cannot build observation entity",
+			"call_id", call.ID, "url", rawURL, "error", err)
+		return
+	}
+
+	now := e.now()
+	fetchedAt := now.UTC().Format(time.RFC3339Nano)
+	contentType := resp.Header.Get("Content-Type")
+
+	triples := []message.Triple{
+		{Subject: urlEntity, Predicate: agvocab.WebURL, Object: canon, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
+		{Subject: urlEntity, Predicate: agvocab.WebFetchedAt, Object: fetchedAt, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
+		{Subject: urlEntity, Predicate: agvocab.WebFetchedBy, Object: loopEntityID, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
+		{Subject: urlEntity, Predicate: agvocab.WebContentType, Object: contentType, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
+		{Subject: urlEntity, Predicate: agvocab.WebStatusCode, Object: resp.StatusCode, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
+		{Subject: urlEntity, Predicate: agvocab.WebText, Object: body, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
+		{Subject: urlEntity, Predicate: agvocab.WebTruncated, Object: truncated, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
+		{Subject: loopEntityID, Predicate: agvocab.LoopFetchedWeb, Object: urlEntity, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
+	}
+	for _, tr := range triples {
+		if err := e.publisher.AddTriple(ctx, tr); err != nil {
+			webEmitFailuresTotal.WithLabelValues("http_request", "publish").Inc()
+			e.logger.Warn("http_request emission failed for triple",
+				"call_id", call.ID, "url", canon, "predicate", tr.Predicate, "error", err)
+		}
+	}
 }
 
 // httpResolveAndValidate performs DNS resolution and SSRF validation in a single

--- a/processor/agentic-tools/executors/httprequest.go
+++ b/processor/agentic-tools/executors/httprequest.go
@@ -207,8 +207,15 @@ func (e *HTTPRequestExecutor) Execute(ctx context.Context, call agentic.ToolCall
 		truncated = true
 	}
 
+	// Opportunistic graph emission. Detach from the caller's ctx so an
+	// upstream cancellation doesn't half-write the batch, and so the
+	// reqCtx's deferred cancel() doesn't kill the emission path the
+	// moment Execute returns. Bounded timeout prevents a wedged
+	// graph-ingest from leaking the goroutine.
 	if e.publisher != nil {
-		e.emitObservation(reqCtx, call, rawURL, resp, content, truncated)
+		emitCtx, emitCancel := context.WithTimeout(context.WithoutCancel(ctx), webEmitTimeout)
+		defer emitCancel()
+		e.emitObservation(emitCtx, call, rawURL, resp, content, truncated)
 	}
 
 	return agentic.ToolResult{
@@ -247,7 +254,10 @@ func (e *HTTPRequestExecutor) emitObservation(ctx context.Context, call agentic.
 	fetchedAt := now.UTC().Format(time.RFC3339Nano)
 	contentType := resp.Header.Get("Content-Type")
 
+	// Loop back-link first so partial-writes under graph-ingest
+	// degradation still leave a discoverable pointer from the loop.
 	triples := []message.Triple{
+		{Subject: loopEntityID, Predicate: agvocab.LoopFetchedWeb, Object: urlEntity, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
 		{Subject: urlEntity, Predicate: agvocab.WebURL, Object: canon, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
 		{Subject: urlEntity, Predicate: agvocab.WebFetchedAt, Object: fetchedAt, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
 		{Subject: urlEntity, Predicate: agvocab.WebFetchedBy, Object: loopEntityID, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
@@ -255,7 +265,6 @@ func (e *HTTPRequestExecutor) emitObservation(ctx context.Context, call agentic.
 		{Subject: urlEntity, Predicate: agvocab.WebStatusCode, Object: resp.StatusCode, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
 		{Subject: urlEntity, Predicate: agvocab.WebText, Object: body, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
 		{Subject: urlEntity, Predicate: agvocab.WebTruncated, Object: truncated, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
-		{Subject: loopEntityID, Predicate: agvocab.LoopFetchedWeb, Object: urlEntity, Source: httpRequestTripleSource, Timestamp: now, Confidence: 1.0},
 	}
 	for _, tr := range triples {
 		if err := e.publisher.AddTriple(ctx, tr); err != nil {

--- a/processor/agentic-tools/executors/register.go
+++ b/processor/agentic-tools/executors/register.go
@@ -92,12 +92,12 @@ func RegisterBuiltins(ctx context.Context, reg *agentictools.ExecutorRegistry, d
 	}
 
 	track(registerBash(reg, logger))
-	track(registerWebSearch(reg, logger))
-	track(registerHTTPRequest(reg, logger))
+	track(registerWebSearch(reg, deps.NATSClient, deps.Platform, logger))
+	track(registerHTTPRequest(reg, deps.NATSClient, deps.Platform, logger))
 	track(registerGitHub(reg, logger))
 
 	if deps.NATSClient == nil {
-		logger.Warn("nats client not available; skipping stateful tool registration (read_loop_result, decide, emit_diagnosis, query_entity)")
+		logger.Warn("nats client not available; skipping stateful tool registration (read_loop_result, decide, emit_diagnosis, query_entity); web_search and http_request fall back to text-only return without graph emission")
 	} else {
 		track(registerReadLoopResult(ctx, reg, deps.NATSClient, logger, loopsBucket))
 		track(registerDecide(reg, deps.NATSClient, deps.Platform, logger))

--- a/processor/agentic-tools/executors/register_http_request.go
+++ b/processor/agentic-tools/executors/register_http_request.go
@@ -4,17 +4,36 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/natsclient"
 	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
 )
 
 // registerHTTPRequest registers the http_request executor. Always
-// available; no external deps. A registry-level failure (duplicate name)
-// returns the error so RegisterBuiltins can surface it at boot.
-func registerHTTPRequest(tools *agentictools.ExecutorRegistry, logger *slog.Logger) error {
-	httpExec := NewHTTPRequestExecutor()
+// available; no external deps.
+//
+// When natsClient is non-nil, each successful 2xx/3xx fetch additionally
+// emits agent.web.observation triples so downstream rules / queries /
+// ops diagnosis can see what URLs the loop pulled. Per-triple failures
+// log + counter + continue.
+//
+// A registry-level failure (duplicate name) returns the error so
+// RegisterBuiltins can surface it at boot.
+func registerHTTPRequest(tools *agentictools.ExecutorRegistry, natsClient *natsclient.Client, platform component.PlatformMeta, logger *slog.Logger) error {
+	opts := []HTTPRequestOption{
+		WithHTTPLogger(logger),
+		WithHTTPPlatform(platform),
+	}
+	emitting := "false"
+	if natsClient != nil {
+		opts = append(opts, WithHTTPTriplePublisher(agentictools.NewNATSTriplePublisher(natsClient)))
+		emitting = "true"
+	}
+	httpExec := NewHTTPRequestExecutor(opts...)
 	if err := tools.RegisterTool("http_request", httpExec); err != nil {
 		return fmt.Errorf("register http_request: %w", err)
 	}
-	logger.Info("Registered http_request tool")
+	logger.Info("Registered http_request tool",
+		slog.String("graph_emission", emitting))
 	return nil
 }

--- a/processor/agentic-tools/executors/register_web_search.go
+++ b/processor/agentic-tools/executors/register_web_search.go
@@ -5,27 +5,49 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/natsclient"
 	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
 )
 
 // registerWebSearch registers the web_search executor: real Brave-backed
 // one when BRAVE_SEARCH_API_KEY is set, stub otherwise. The stub keeps
 // web_search advertised for researcher-role agents and e2e fixtures that
-// don't want to hit an external API. A registry-level failure (duplicate
-// name) returns the error so RegisterBuiltins can surface it at boot.
-func registerWebSearch(tools *agentictools.ExecutorRegistry, logger *slog.Logger) error {
-	if apiKey := os.Getenv("BRAVE_SEARCH_API_KEY"); apiKey != "" {
-		ws := NewWebSearchExecutor(apiKey)
-		if err := tools.RegisterTool("web_search", ws); err != nil {
-			return fmt.Errorf("register web_search (brave): %w", err)
+// don't want to hit an external API.
+//
+// When natsClient is non-nil, the Brave-backed executor additionally
+// emits agent.web.observation triples per result so downstream rules /
+// queries / ops diagnosis can see what URLs the loop has seen. The stub
+// intentionally does NOT emit — canned data shouldn't pollute the graph.
+//
+// A registry-level failure (duplicate name) returns the error so
+// RegisterBuiltins can surface it at boot.
+func registerWebSearch(tools *agentictools.ExecutorRegistry, natsClient *natsclient.Client, platform component.PlatformMeta, logger *slog.Logger) error {
+	apiKey := os.Getenv("BRAVE_SEARCH_API_KEY")
+	if apiKey == "" {
+		stub := NewStubWebSearchExecutor()
+		if err := tools.RegisterTool("web_search", stub); err != nil {
+			return fmt.Errorf("register web_search (stub): %w", err)
 		}
-		logger.Info("Registered web_search tool", slog.String("provider", "brave"))
+		logger.Info("Registered web_search tool", slog.String("provider", "stub"))
 		return nil
 	}
-	stub := NewStubWebSearchExecutor()
-	if err := tools.RegisterTool("web_search", stub); err != nil {
-		return fmt.Errorf("register web_search (stub): %w", err)
+
+	opts := []WebSearchOption{
+		WithWebSearchLogger(logger),
+		WithWebSearchPlatform(platform),
 	}
-	logger.Info("Registered web_search tool", slog.String("provider", "stub"))
+	emitting := "false"
+	if natsClient != nil {
+		opts = append(opts, WithWebSearchTriplePublisher(agentictools.NewNATSTriplePublisher(natsClient)))
+		emitting = "true"
+	}
+	ws := NewWebSearchExecutor(apiKey, opts...)
+	if err := tools.RegisterTool("web_search", ws); err != nil {
+		return fmt.Errorf("register web_search (brave): %w", err)
+	}
+	logger.Info("Registered web_search tool",
+		slog.String("provider", "brave"),
+		slog.String("graph_emission", emitting))
 	return nil
 }

--- a/processor/agentic-tools/executors/web_emit.go
+++ b/processor/agentic-tools/executors/web_emit.go
@@ -1,9 +1,20 @@
 package executors
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
+
+// webEmitTimeout bounds how long the per-tool emission path will wait
+// for graph-ingest before giving up. The emission ctx is detached from
+// the caller's ctx (context.WithoutCancel) so an upstream agent-loop
+// cancellation doesn't half-write batches; this timeout prevents a
+// wedged graph-ingest from leaking the goroutine. Per the 2026-05-11
+// design decision: emission is opportunistic substrate observation,
+// not the LLM-facing contract.
+const webEmitTimeout = 5 * time.Second
 
 // webEmitFailuresTotal counts per-result triple emission failures from
 // the web_search and http_request executors, labelled by tool and

--- a/processor/agentic-tools/executors/web_emit.go
+++ b/processor/agentic-tools/executors/web_emit.go
@@ -1,0 +1,29 @@
+package executors
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// webEmitFailuresTotal counts per-result triple emission failures from
+// the web_search and http_request executors, labelled by tool and
+// failure class. Operators alert on rate-of-change here: a non-zero
+// entity_id rate signals malformed URLs the LLM is producing (worth
+// surfacing to persona tuning); a non-zero publish rate signals
+// graph-ingest / NATS infrastructure trouble (worth paging).
+//
+// Reasons are a closed set:
+//   - "entity_id" — TryWebObservationEntityID rejected the URL
+//   - "publish"   — TriplePublisher.AddTriple returned an error
+//
+// Per the 2026-05-11 design decision, both tools log+counter+continue
+// rather than failing the tool — graph emission is additive observation,
+// not the primary contract.
+var webEmitFailuresTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "agentic_tool_web",
+		Name:      "emit_failures_total",
+		Help:      "Number of per-result triple emission failures from web_search/http_request, labelled by tool and reason. Non-zero entity_id rate suggests malformed URLs (persona tuning); non-zero publish rate suggests graph-ingest infra (page).",
+	},
+	[]string{"tool", "reason"},
+)

--- a/processor/agentic-tools/executors/web_emit_test.go
+++ b/processor/agentic-tools/executors/web_emit_test.go
@@ -1,0 +1,345 @@
+package executors
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+// recordingPublisher captures every triple AddTriple is called with and
+// optionally fails on the Nth call so partial-failure tests can exercise
+// the log+continue path.
+type recordingPublisher struct {
+	triples  []message.Triple
+	failOn   int
+	failWith error
+}
+
+func (p *recordingPublisher) AddTriple(_ context.Context, tr message.Triple) error {
+	p.triples = append(p.triples, tr)
+	if p.failWith != nil && len(p.triples) == p.failOn {
+		return p.failWith
+	}
+	return nil
+}
+
+func fixedClock(t time.Time) func() time.Time {
+	return func() time.Time { return t }
+}
+
+func testPlatform() component.PlatformMeta {
+	return component.PlatformMeta{Org: "acme", Platform: "ops"}
+}
+
+// TestWebSearchExecutor_NilPublisher_NoEmission confirms the executor
+// behaves exactly as pre-emission code when no publisher is wired —
+// the canonical "additive, opt-in" guarantee.
+func TestWebSearchExecutor_NilPublisher_NoEmission(t *testing.T) {
+	e := NewWebSearchExecutor("test-key") // no options
+	if e.publisher != nil {
+		t.Fatalf("publisher should default to nil")
+	}
+	// emitObservations is the side-effect surface; with publisher==nil
+	// the wider Execute path skips calling it. Confirm the field default
+	// is nil and the executor stays zero-impact.
+}
+
+// TestWebSearchExecutor_EmitObservations_HappyPath drives the emission
+// helper directly with two synthetic results. Verifies the full triple
+// set lands: 6 per URL entity + 1 loop back-link per result.
+func TestWebSearchExecutor_EmitObservations_HappyPath(t *testing.T) {
+	clock := time.Date(2026, 5, 11, 14, 22, 0, 0, time.UTC)
+	pub := &recordingPublisher{}
+	e := NewWebSearchExecutor("test-key",
+		WithWebSearchTriplePublisher(pub),
+		WithWebSearchPlatform(testPlatform()),
+		WithWebSearchClock(fixedClock(clock)),
+	)
+
+	results := []searchResult{
+		{title: "Go net/http docs", url: "https://pkg.go.dev/net/http", description: "Package http provides HTTP client and server implementations."},
+		{title: "Go json docs", url: "https://pkg.go.dev/encoding/json", description: "Package json implements encoding and decoding of JSON."},
+	}
+	call := agentic.ToolCall{ID: "call-1", Name: "web_search", LoopID: "loop-abc"}
+
+	e.emitObservations(context.Background(), call, "go stdlib http and json", results)
+
+	// 2 results × (6 URL triples + 1 loop back-link) = 14 triples.
+	if got := len(pub.triples); got != 14 {
+		t.Fatalf("triples published = %d, want 14", got)
+	}
+
+	loopEntityID, err := agentic.TryLoopExecutionEntityID("acme", "ops", "loop-abc")
+	if err != nil {
+		t.Fatalf("loop entity id: %v", err)
+	}
+
+	// Per-result invariants: each result produces an agent.web.observation
+	// entity referenced by exactly one LoopObservedWeb back-link.
+	loopBacklinks := map[string]int{}
+	urlByEntity := map[string]string{}
+	for _, tr := range pub.triples {
+		if tr.Subject == loopEntityID && tr.Predicate == agvocab.LoopObservedWeb {
+			loopBacklinks[tr.Object.(string)]++
+		}
+		if tr.Predicate == agvocab.WebURL {
+			urlByEntity[tr.Subject] = tr.Object.(string)
+		}
+		// Source field must distinguish web_search emissions for operator
+		// graph queries.
+		if tr.Source != "agent-web-search" {
+			t.Errorf("triple Source = %q, want %q", tr.Source, "agent-web-search")
+		}
+	}
+	if len(loopBacklinks) != 2 {
+		t.Errorf("expected 2 distinct observation entities back-linked from loop, got %d", len(loopBacklinks))
+	}
+	for entity, count := range loopBacklinks {
+		if count != 1 {
+			t.Errorf("observation entity %q referenced %d times in back-links, want 1", entity, count)
+		}
+	}
+
+	// Canonical URLs land verbatim on agent.web.url.
+	wantURLs := map[string]bool{
+		"https://pkg.go.dev/net/http":      true,
+		"https://pkg.go.dev/encoding/json": true,
+	}
+	for _, u := range urlByEntity {
+		if !wantURLs[u] {
+			t.Errorf("unexpected canonical url %q", u)
+		}
+	}
+
+	// The source query lands on every observation. Rule-opaque per
+	// vocabulary metadata; verified-rule-opaque is a separate test in
+	// the vocab package.
+	queryCount := 0
+	for _, tr := range pub.triples {
+		if tr.Predicate == agvocab.WebSourceQuery {
+			queryCount++
+			if tr.Object.(string) != "go stdlib http and json" {
+				t.Errorf("source_query = %v, want literal", tr.Object)
+			}
+		}
+	}
+	if queryCount != 2 {
+		t.Errorf("source_query triple count = %d, want 2 (one per observation entity)", queryCount)
+	}
+}
+
+// TestWebSearchExecutor_EmitObservations_PublishFailure_ContinuesBatch
+// confirms a per-triple publish failure does not abort the rest of the
+// batch — graph emission is additive substrate, not the LLM-facing
+// contract.
+func TestWebSearchExecutor_EmitObservations_PublishFailure_ContinuesBatch(t *testing.T) {
+	pub := &recordingPublisher{failOn: 2, failWith: errors.New("nats degraded")}
+	e := NewWebSearchExecutor("test-key",
+		WithWebSearchTriplePublisher(pub),
+		WithWebSearchPlatform(testPlatform()),
+	)
+
+	results := []searchResult{
+		{title: "A", url: "https://example.com/a", description: ""},
+		{title: "B", url: "https://example.com/b", description: ""},
+	}
+	call := agentic.ToolCall{ID: "call-2", Name: "web_search", LoopID: "loop-xyz"}
+
+	// Must not panic, must not return an error (executor caller would never
+	// see one — emitObservations is fire-and-forget by design).
+	e.emitObservations(context.Background(), call, "q", results)
+
+	if len(pub.triples) != 14 {
+		t.Errorf("AddTriple call count = %d, want 14 (continue-on-failure semantics)", len(pub.triples))
+	}
+}
+
+// TestWebSearchExecutor_EmitObservations_MissingLoopID_Skips ensures the
+// emission path declines cleanly when the tool call lacks a loop_id —
+// the URL-side entities have nothing to back-link to.
+func TestWebSearchExecutor_EmitObservations_MissingLoopID_Skips(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := NewWebSearchExecutor("test-key",
+		WithWebSearchTriplePublisher(pub),
+		WithWebSearchPlatform(testPlatform()),
+	)
+	results := []searchResult{{title: "A", url: "https://example.com/a"}}
+	call := agentic.ToolCall{ID: "no-loop", Name: "web_search"} // LoopID empty
+
+	e.emitObservations(context.Background(), call, "q", results)
+
+	if len(pub.triples) != 0 {
+		t.Errorf("expected 0 triples when loop_id missing, got %d", len(pub.triples))
+	}
+}
+
+// --- HTTPRequestExecutor emission tests ---
+
+// TestHTTPRequestExecutor_NilPublisher_NoEmission confirms the
+// pre-emission behavior is preserved when no publisher is wired.
+func TestHTTPRequestExecutor_NilPublisher_NoEmission(t *testing.T) {
+	e := NewHTTPRequestExecutor() // no options
+	if e.publisher != nil {
+		t.Errorf("publisher should default to nil")
+	}
+}
+
+// TestHTTPRequestExecutor_EmitObservation_HappyPath drives the emission
+// helper with a synthetic http.Response. Verifies all 8 triples land
+// (7 URL-side + 1 loop back-link) and the truncated flag rides through.
+func TestHTTPRequestExecutor_EmitObservation_HappyPath(t *testing.T) {
+	clock := time.Date(2026, 5, 11, 14, 22, 0, 0, time.UTC)
+	pub := &recordingPublisher{}
+	e := NewHTTPRequestExecutor(
+		WithHTTPTriplePublisher(pub),
+		WithHTTPPlatform(testPlatform()),
+		WithHTTPClock(fixedClock(clock)),
+	)
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
+	}
+	call := agentic.ToolCall{ID: "call-1", Name: "http_request", LoopID: "loop-abc"}
+
+	e.emitObservation(context.Background(), call, "https://example.com/docs", resp, "<html>body</html>", false)
+
+	if got := len(pub.triples); got != 8 {
+		t.Fatalf("triples published = %d, want 8 (7 URL-side + 1 loop back-link)", got)
+	}
+
+	byPredicate := map[string]any{}
+	loopBacklinkCount := 0
+	for _, tr := range pub.triples {
+		if tr.Source != "agent-http-request" {
+			t.Errorf("Source = %q, want agent-http-request", tr.Source)
+		}
+		if tr.Predicate == agvocab.LoopFetchedWeb {
+			loopBacklinkCount++
+			continue
+		}
+		byPredicate[tr.Predicate] = tr.Object
+	}
+	if loopBacklinkCount != 1 {
+		t.Errorf("LoopFetchedWeb back-link count = %d, want 1", loopBacklinkCount)
+	}
+
+	checks := map[string]any{
+		agvocab.WebURL:         "https://example.com/docs",
+		agvocab.WebContentType: "text/html; charset=utf-8",
+		agvocab.WebStatusCode:  200,
+		agvocab.WebText:        "<html>body</html>",
+		agvocab.WebTruncated:   false,
+	}
+	for pred, want := range checks {
+		if got := byPredicate[pred]; got != want {
+			t.Errorf("predicate %q = %v, want %v", pred, got, want)
+		}
+	}
+}
+
+// TestHTTPRequestExecutor_EmitObservation_TruncatedFlag confirms the
+// truncated bool reflects what was passed in — operators can rely on
+// the structural fact even though WebText is rule-opaque.
+func TestHTTPRequestExecutor_EmitObservation_TruncatedFlag(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := NewHTTPRequestExecutor(
+		WithHTTPTriplePublisher(pub),
+		WithHTTPPlatform(testPlatform()),
+	)
+	resp := &http.Response{StatusCode: 200, Header: http.Header{}}
+
+	e.emitObservation(context.Background(), agentic.ToolCall{ID: "c", LoopID: "l"}, "https://example.com/big", resp, "(big body)", true)
+
+	found := false
+	for _, tr := range pub.triples {
+		if tr.Predicate == agvocab.WebTruncated {
+			if tr.Object != true {
+				t.Errorf("truncated = %v, want true", tr.Object)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no WebTruncated triple emitted")
+	}
+}
+
+// TestHTTPRequestExecutor_EmitObservation_PublishFailure_ContinuesBatch
+// confirms log+continue when a per-triple publish fails.
+func TestHTTPRequestExecutor_EmitObservation_PublishFailure_ContinuesBatch(t *testing.T) {
+	pub := &recordingPublisher{failOn: 3, failWith: errors.New("nats degraded")}
+	e := NewHTTPRequestExecutor(
+		WithHTTPTriplePublisher(pub),
+		WithHTTPPlatform(testPlatform()),
+	)
+	resp := &http.Response{StatusCode: 200, Header: http.Header{}}
+
+	e.emitObservation(context.Background(), agentic.ToolCall{ID: "c", LoopID: "l"}, "https://example.com/x", resp, "body", false)
+
+	// All 8 AddTriple calls should have been issued, even though the
+	// 3rd one returned an error — the helper logs and continues.
+	if got := len(pub.triples); got != 8 {
+		t.Errorf("AddTriple call count = %d, want 8 (continue-on-failure)", got)
+	}
+}
+
+// TestHTTPRequestExecutor_EmitObservation_MissingLoopID_Skips
+// confirms the helper bails when no loop_id is available; emitting
+// dangling URL entities with no back-link to the consuming agent
+// loses the audit trail.
+func TestHTTPRequestExecutor_EmitObservation_MissingLoopID_Skips(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := NewHTTPRequestExecutor(
+		WithHTTPTriplePublisher(pub),
+		WithHTTPPlatform(testPlatform()),
+	)
+	resp := &http.Response{StatusCode: 200, Header: http.Header{}}
+	call := agentic.ToolCall{ID: "no-loop"} // empty LoopID
+
+	e.emitObservation(context.Background(), call, "https://example.com/x", resp, "body", false)
+
+	if len(pub.triples) != 0 {
+		t.Errorf("expected 0 triples when loop_id missing, got %d", len(pub.triples))
+	}
+}
+
+// TestWebSearchExecutor_EmitObservations_MalformedURL_Skips_Result
+// confirms a per-result entity-ID failure doesn't abort the batch.
+// Different results can have different validity (search providers
+// occasionally return relative URLs); the bad one is skipped, the rest
+// land.
+func TestWebSearchExecutor_EmitObservations_MalformedURL_Skips_Result(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := NewWebSearchExecutor("test-key",
+		WithWebSearchTriplePublisher(pub),
+		WithWebSearchPlatform(testPlatform()),
+	)
+	results := []searchResult{
+		{title: "bad", url: "not-a-url", description: ""},
+		{title: "good", url: "https://example.com/x", description: ""},
+	}
+	call := agentic.ToolCall{ID: "call-3", Name: "web_search", LoopID: "loop-1"}
+
+	e.emitObservations(context.Background(), call, "q", results)
+
+	// Only the good result emits its 7 triples; the bad one contributes 0.
+	if len(pub.triples) != 7 {
+		t.Fatalf("expected 7 triples (good result only), got %d", len(pub.triples))
+	}
+	for _, tr := range pub.triples {
+		if tr.Predicate == agvocab.WebURL {
+			if got := tr.Object.(string); !strings.Contains(got, "example.com/x") {
+				t.Errorf("good result url = %q, want host example.com/x", got)
+			}
+		}
+	}
+}

--- a/processor/agentic-tools/executors/web_emit_test.go
+++ b/processor/agentic-tools/executors/web_emit_test.go
@@ -312,6 +312,107 @@ func TestHTTPRequestExecutor_EmitObservation_MissingLoopID_Skips(t *testing.T) {
 	}
 }
 
+// TestWebSearchExecutor_EmitObservations_CancelledCtx_StillEmits is
+// the regression for go-reviewer B1: caller-side ctx cancellation must
+// NOT half-write batches, because graph emission is opportunistic
+// substrate observation, not the LLM-facing contract. The Execute path
+// wraps the emission ctx via context.WithoutCancel + bounded timeout;
+// driving emitObservations directly with a pre-cancelled ctx exercises
+// the inner path (publishes still flow because recordingPublisher
+// ignores ctx). For full E2E coverage of the Execute-level detach, the
+// integration-tier mock publisher inspects ctx.Err().
+func TestWebSearchExecutor_EmitObservations_CancelledCtx_StillEmits(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := NewWebSearchExecutor("test-key",
+		WithWebSearchTriplePublisher(pub),
+		WithWebSearchPlatform(testPlatform()),
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel; the emission helper does not gate on ctx.Err()
+	e.emitObservations(ctx, agentic.ToolCall{ID: "c", LoopID: "l"}, "q", []searchResult{{title: "A", url: "https://example.com/a"}})
+	// 1 result × 7 triples = 7. If the emission helper short-circuited
+	// on a dead ctx, only the loop back-link (or zero) would land.
+	if got := len(pub.triples); got != 7 {
+		t.Errorf("AddTriple call count = %d, want 7 (helper must not short-circuit on ctx)", got)
+	}
+}
+
+// TestWebSearchExecutor_EmitObservations_DedupsAcrossCalls asserts the
+// hashed entity ID converges across two emission batches with the same
+// URL. The reviewer flagged this invariant as stated in three places in
+// docstrings but never property-tested. This locks it in.
+func TestWebSearchExecutor_EmitObservations_DedupsAcrossCalls(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := NewWebSearchExecutor("test-key",
+		WithWebSearchTriplePublisher(pub),
+		WithWebSearchPlatform(testPlatform()),
+	)
+	results := []searchResult{{title: "T", url: "https://example.com/x", description: "d"}}
+
+	e.emitObservations(context.Background(), agentic.ToolCall{ID: "c1", LoopID: "loop-a"}, "q", results)
+	firstCallTripleCount := len(pub.triples)
+
+	e.emitObservations(context.Background(), agentic.ToolCall{ID: "c2", LoopID: "loop-b"}, "q", results)
+
+	// Find the WebURL subjects from both batches.
+	var subjects []string
+	for _, tr := range pub.triples {
+		if tr.Predicate == agvocab.WebURL {
+			subjects = append(subjects, tr.Subject)
+		}
+	}
+	if len(subjects) != 2 {
+		t.Fatalf("WebURL triple count = %d, want 2 (one per emission call)", len(subjects))
+	}
+	if subjects[0] != subjects[1] {
+		t.Errorf("observation entity diverged across calls: %q vs %q (dedup property broken)", subjects[0], subjects[1])
+	}
+	if len(pub.triples) != firstCallTripleCount*2 {
+		t.Errorf("second call did not produce equal triple count: total=%d first=%d", len(pub.triples), firstCallTripleCount)
+	}
+}
+
+// TestWebSearchExecutor_EmitObservations_LoopBacklinkFirst asserts the
+// reordering from go-reviewer N2: the LoopObservedWeb back-link is the
+// first triple in each per-result batch so partial-writes under
+// graph-ingest degradation leave a discoverable pointer.
+func TestWebSearchExecutor_EmitObservations_LoopBacklinkFirst(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := NewWebSearchExecutor("test-key",
+		WithWebSearchTriplePublisher(pub),
+		WithWebSearchPlatform(testPlatform()),
+	)
+	results := []searchResult{{title: "A", url: "https://example.com/a"}}
+	e.emitObservations(context.Background(), agentic.ToolCall{ID: "c", LoopID: "l"}, "q", results)
+
+	if len(pub.triples) == 0 {
+		t.Fatalf("no triples emitted")
+	}
+	if pub.triples[0].Predicate != agvocab.LoopObservedWeb {
+		t.Errorf("first triple predicate = %q, want %q (back-link must precede URL-side triples for partial-write resilience)",
+			pub.triples[0].Predicate, agvocab.LoopObservedWeb)
+	}
+}
+
+// TestHTTPRequestExecutor_EmitObservation_LoopBacklinkFirst is the
+// http_request counterpart to the websearch reordering check.
+func TestHTTPRequestExecutor_EmitObservation_LoopBacklinkFirst(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := NewHTTPRequestExecutor(
+		WithHTTPTriplePublisher(pub),
+		WithHTTPPlatform(testPlatform()),
+	)
+	resp := &http.Response{StatusCode: 200, Header: http.Header{}}
+	e.emitObservation(context.Background(), agentic.ToolCall{ID: "c", LoopID: "l"}, "https://example.com/x", resp, "body", false)
+
+	if len(pub.triples) == 0 {
+		t.Fatalf("no triples emitted")
+	}
+	if pub.triples[0].Predicate != agvocab.LoopFetchedWeb {
+		t.Errorf("first triple predicate = %q, want %q", pub.triples[0].Predicate, agvocab.LoopFetchedWeb)
+	}
+}
+
 // TestWebSearchExecutor_EmitObservations_MalformedURL_Skips_Result
 // confirms a per-result entity-ID failure doesn't abort the batch.
 // Different results can have different validity (search providers

--- a/processor/agentic-tools/executors/websearch.go
+++ b/processor/agentic-tools/executors/websearch.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -12,6 +13,10 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
+	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
 
 const (
@@ -19,22 +24,95 @@ const (
 	braveMaxResults        = 10
 	braveResponseBodyLimit = 100 * 1024 // 100KB
 	webSearchDefaultMax    = 5
+
+	// webSearchTripleSource is the Source field on triples this tool
+	// publishes. Mirrors decide.go / emit_diagnosis / write_todos so
+	// operators can distinguish web_search emissions in graph queries.
+	webSearchTripleSource = "agent-web-search"
 )
 
 // WebSearchExecutor implements the web_search agentic tool.
+//
+// Triple emission is optional: when a non-nil TriplePublisher is supplied
+// via WithWebSearchTriplePublisher, each successful search additionally
+// emits 6 triples per result onto an agent.web.observation entity plus a
+// back-link triple onto the calling loop entity. When the publisher is
+// nil the executor behaves exactly as it did pre-emission — text-only
+// return, no graph writes. Per-result emission errors are logged and
+// counted (semstreams.agentic_tool_web.emit_failures_total) but never
+// fail the tool, because graph emission is opportunistic substrate
+// observation, not the tool's primary LLM-facing contract. This diverges
+// from decide / write_todos where the triples ARE the contract.
 type WebSearchExecutor struct {
 	apiKey     string
 	httpClient *http.Client
+
+	// Optional triple-emission machinery. publisher == nil means emission
+	// is fully disabled; the three companion fields default to package
+	// defaults so a partially-configured executor stays safe.
+	publisher agentictools.TriplePublisher
+	platform  component.PlatformMeta
+	logger    *slog.Logger
+	now       func() time.Time
 }
 
-// NewWebSearchExecutor creates a web search executor backed by the Brave Search API.
-func NewWebSearchExecutor(apiKey string) *WebSearchExecutor {
-	return &WebSearchExecutor{
+// WebSearchOption configures a WebSearchExecutor. All options are
+// optional; the executor works with just an apiKey.
+type WebSearchOption func(*WebSearchExecutor)
+
+// WithWebSearchTriplePublisher enables graph emission. When the
+// publisher is non-nil, each successful search result mints an
+// agent.web.observation entity and writes the per-URL predicates plus a
+// back-link from the calling loop. nil disables emission (default).
+func WithWebSearchTriplePublisher(p agentictools.TriplePublisher) WebSearchOption {
+	return func(e *WebSearchExecutor) { e.publisher = p }
+}
+
+// WithWebSearchPlatform supplies the platform identity used to build
+// observation entity IDs and resolve the calling loop's entity ID.
+// Required when publisher is non-nil; ignored otherwise.
+func WithWebSearchPlatform(p component.PlatformMeta) WebSearchOption {
+	return func(e *WebSearchExecutor) { e.platform = p }
+}
+
+// WithWebSearchLogger replaces the default logger (slog.Default()).
+// nil-safe.
+func WithWebSearchLogger(l *slog.Logger) WebSearchOption {
+	return func(e *WebSearchExecutor) {
+		if l != nil {
+			e.logger = l
+		}
+	}
+}
+
+// WithWebSearchClock replaces the time source the executor stamps onto
+// observed_at / triple timestamps. nil-safe. Tests use this for
+// deterministic timestamp assertions; production should not.
+func WithWebSearchClock(now func() time.Time) WebSearchOption {
+	return func(e *WebSearchExecutor) {
+		if now != nil {
+			e.now = now
+		}
+	}
+}
+
+// NewWebSearchExecutor creates a web search executor backed by the
+// Brave Search API. The variadic options enable opt-in features
+// (triple emission, custom logger/clock) without disturbing legacy
+// call sites that pass only the API key.
+func NewWebSearchExecutor(apiKey string, opts ...WebSearchOption) *WebSearchExecutor {
+	e := &WebSearchExecutor{
 		apiKey: apiKey,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
+		logger: slog.Default(),
+		now:    time.Now,
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // ListTools returns the web_search tool definition.
@@ -113,10 +191,72 @@ func (e *WebSearchExecutor) Execute(ctx context.Context, call agentic.ToolCall) 
 		}
 	}
 
+	// Opportunistic graph emission. Failures here never affect the
+	// LLM-facing return — log + counter + continue per the 2026-05-11
+	// design decision.
+	if e.publisher != nil {
+		e.emitObservations(ctx, call, query, results)
+	}
+
 	return agentic.ToolResult{
 		CallID:  call.ID,
 		Content: sb.String(),
 	}, nil
+}
+
+// emitObservations writes per-result observation triples plus loop
+// back-links. Each result is handled independently: an entity-ID
+// failure on result N (malformed URL from the search provider) does
+// not skip N+1. Publish failures likewise log + counter + continue.
+func (e *WebSearchExecutor) emitObservations(ctx context.Context, call agentic.ToolCall, query string, results []searchResult) {
+	if call.LoopID == "" {
+		// Without a loop_id we can't build the back-link triple; rather
+		// than emit dangling URL entities, skip the whole batch and log
+		// once. The LLM-side result is unaffected.
+		e.logger.Warn("web_search emission skipped: tool call missing loop_id",
+			"call_id", call.ID, "result_count", len(results))
+		return
+	}
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+	if err != nil {
+		e.logger.Warn("web_search emission skipped: cannot resolve loop entity",
+			"call_id", call.ID, "loop_id", call.LoopID, "error", err)
+		return
+	}
+
+	now := e.now()
+	observedAt := now.UTC().Format(time.RFC3339Nano)
+
+	for _, r := range results {
+		urlEntity, canon, err := agentic.TryWebObservationEntityID(e.platform.Org, e.platform.Platform, r.url)
+		if err != nil {
+			webEmitFailuresTotal.WithLabelValues("web_search", "entity_id").Inc()
+			e.logger.Warn("web_search emission skipped result: cannot build observation entity",
+				"call_id", call.ID, "url", r.url, "error", err)
+			continue
+		}
+
+		triples := []message.Triple{
+			{Subject: urlEntity, Predicate: agvocab.WebURL, Object: canon, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
+			{Subject: urlEntity, Predicate: agvocab.WebTitle, Object: r.title, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
+			{Subject: urlEntity, Predicate: agvocab.WebSnippet, Object: r.description, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
+			{Subject: urlEntity, Predicate: agvocab.WebSourceQuery, Object: query, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
+			{Subject: urlEntity, Predicate: agvocab.WebObservedAt, Object: observedAt, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
+			{Subject: urlEntity, Predicate: agvocab.WebObservedBy, Object: loopEntityID, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
+			{Subject: loopEntityID, Predicate: agvocab.LoopObservedWeb, Object: urlEntity, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
+		}
+		for _, tr := range triples {
+			if err := e.publisher.AddTriple(ctx, tr); err != nil {
+				webEmitFailuresTotal.WithLabelValues("web_search", "publish").Inc()
+				e.logger.Warn("web_search emission failed for triple",
+					"call_id", call.ID, "url", canon, "predicate", tr.Predicate, "error", err)
+				// Don't abort the batch — other triples (including the
+				// loop back-link) may still land, and the next result is
+				// independent. The graph is a set-of-triples; partial
+				// writes are correct, not corrupt.
+			}
+		}
+	}
 }
 
 type searchResult struct {

--- a/processor/agentic-tools/executors/websearch.go
+++ b/processor/agentic-tools/executors/websearch.go
@@ -193,9 +193,13 @@ func (e *WebSearchExecutor) Execute(ctx context.Context, call agentic.ToolCall) 
 
 	// Opportunistic graph emission. Failures here never affect the
 	// LLM-facing return — log + counter + continue per the 2026-05-11
-	// design decision.
+	// design decision. Detach from the caller's ctx so a cancellation
+	// mid-emission doesn't leave half-written batches; bounded timeout
+	// prevents a wedged graph-ingest from leaking goroutines.
 	if e.publisher != nil {
-		e.emitObservations(ctx, call, query, results)
+		emitCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), webEmitTimeout)
+		defer cancel()
+		e.emitObservations(emitCtx, call, query, results)
 	}
 
 	return agentic.ToolResult{
@@ -236,14 +240,20 @@ func (e *WebSearchExecutor) emitObservations(ctx context.Context, call agentic.T
 			continue
 		}
 
+		// Loop back-link is emitted first so a partial-write under
+		// graph-ingest degradation still leaves a discoverable pointer
+		// from the loop to the (possibly under-populated) observation
+		// entity. The URL-side predicates can be re-populated by any
+		// later observation of the same URL; the back-link is the
+		// rule-matchable fact that drives downstream query patterns.
 		triples := []message.Triple{
+			{Subject: loopEntityID, Predicate: agvocab.LoopObservedWeb, Object: urlEntity, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
 			{Subject: urlEntity, Predicate: agvocab.WebURL, Object: canon, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
 			{Subject: urlEntity, Predicate: agvocab.WebTitle, Object: r.title, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
 			{Subject: urlEntity, Predicate: agvocab.WebSnippet, Object: r.description, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
 			{Subject: urlEntity, Predicate: agvocab.WebSourceQuery, Object: query, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
 			{Subject: urlEntity, Predicate: agvocab.WebObservedAt, Object: observedAt, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
 			{Subject: urlEntity, Predicate: agvocab.WebObservedBy, Object: loopEntityID, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
-			{Subject: loopEntityID, Predicate: agvocab.LoopObservedWeb, Object: urlEntity, Source: webSearchTripleSource, Timestamp: now, Confidence: 1.0},
 		}
 		for _, tr := range triples {
 			if err := e.publisher.AddTriple(ctx, tr); err != nil {

--- a/test/e2e/scenarios/deep-research/scenario.go
+++ b/test/e2e/scenarios/deep-research/scenario.go
@@ -282,7 +282,7 @@ func (s *Scenario) verifyEvidenceCollected(ctx context.Context, result *scenario
 }
 
 // verifyCoordinatorFired scans ENTITY_STATES for a research-coordinator
-// loop whose decide() call landed a coordinator.next_action=fan_out
+// loop whose decide() call landed a coordinator.decision.next_action=fan_out
 // triple. This is the canary for the judgment layer: if absent, either
 // rule 07 (spawn-coordinator) didn't fire, the mock didn't trigger the
 // decide tool, or the decide tool's triple publication failed. Any of
@@ -308,7 +308,7 @@ func (s *Scenario) verifyCoordinatorFired(ctx context.Context, result *scenarios
 				if s, ok := t.Object.(string); ok {
 					role = s
 				}
-			case "coordinator.next_action":
+			case "coordinator.decision.next_action":
 				if s, ok := t.Object.(string); ok {
 					nextAction = s
 				}
@@ -332,7 +332,7 @@ func (s *Scenario) verifyCoordinatorFired(ctx context.Context, result *scenarios
 		return fmt.Errorf("no research-coordinator loop found in ENTITY_STATES — rule 07 (spawn-coordinator) did not fire or the coordinator loop never completed")
 	}
 	if len(fanOutIDs) == 0 {
-		return fmt.Errorf("research-coordinator completed but no coordinator.next_action=fan_out triple appeared — decide tool likely did not publish (check mock LLM WithRoleToolCallSequence or agentic-tools decide registration)")
+		return fmt.Errorf("research-coordinator completed but no coordinator.decision.next_action=fan_out triple appeared — decide tool likely did not publish (check mock LLM WithRoleToolCallSequence or agentic-tools decide registration)")
 	}
 	return nil
 }

--- a/vocabulary/agentic/agentic_test.go
+++ b/vocabulary/agentic/agentic_test.go
@@ -83,6 +83,21 @@ func TestPredicateFormat(t *testing.T) {
 		agentic.LoopWorkflowStep,
 		agentic.LoopEndedAt,
 		agentic.LoopUser,
+		agentic.LoopObservedWeb,
+		agentic.LoopFetchedWeb,
+		// Web
+		agentic.WebURL,
+		agentic.WebTitle,
+		agentic.WebSnippet,
+		agentic.WebText,
+		agentic.WebSourceQuery,
+		agentic.WebObservedAt,
+		agentic.WebFetchedAt,
+		agentic.WebObservedBy,
+		agentic.WebFetchedBy,
+		agentic.WebContentType,
+		agentic.WebStatusCode,
+		agentic.WebTruncated,
 	}
 
 	for _, p := range predicates {
@@ -253,11 +268,13 @@ func TestPredicateCount(t *testing.T) {
 
 	// Expected predicates by category:
 	// Intent: 5, Capability: 7, Delegation: 7, Accountability: 6, Execution: 7, Action: 5, Task: 5
-	// Model: 8, Loop: 15 (core + LoopHasStep + LoopDescription)
+	// Model: 8, Loop: 17 (15 core + LoopHasStep + LoopDescription + LoopObservedWeb + LoopFetchedWeb)
 	// Step: 18 (15 core + tool_status + error_message + error_category), Identity: 6
 	// Todo: 5 (ADR-036 — id, content, status, position, updated_at)
-	// Total: 94 predicates
-	expectedMin := 94
+	// Web: 12 (url, title, snippet, text, source_query, observed_at, fetched_at,
+	//   observed_by, fetched_by, content_type, status_code, truncated)
+	// Total: 108 predicates
+	expectedMin := 108
 	if len(predicates) < expectedMin {
 		t.Errorf("expected at least %d predicates, got %d", expectedMin, len(predicates))
 	}
@@ -322,6 +339,8 @@ func TestLoopPredicatesRegistered(t *testing.T) {
 		{"LoopUser", agentic.LoopUser, "string"},
 		{"LoopHasStep", agentic.LoopHasStep, "string"},
 		{"LoopDescription", agentic.LoopDescription, "string"},
+		{"LoopObservedWeb", agentic.LoopObservedWeb, "string"},
+		{"LoopFetchedWeb", agentic.LoopFetchedWeb, "string"},
 	}
 
 	for _, tt := range loopPredicates {
@@ -439,5 +458,66 @@ func TestTodoPredicatesRegistered(t *testing.T) {
 			t.Errorf("%s: RuleOpaque = %v, want %v (ADR-036 §Decision Rule 1: rules MUST NOT predicate on opaque content)",
 				tt.name, meta.RuleOpaque, tt.ruleOpaque)
 		}
+	}
+}
+
+// TestWebPredicatesRegistered asserts the 12 web predicates land with the
+// right data types and rule-opaque flags. Title, snippet, text, and
+// source_query are rule-opaque per the LLM-authored content discipline
+// (rules predicating on LLM-sampled values create Goodhart feedback loops).
+func TestWebPredicatesRegistered(t *testing.T) {
+	vocabulary.ClearRegistry()
+	defer vocabulary.ClearRegistry()
+
+	agentic.Register()
+
+	webPredicates := []struct {
+		name       string
+		predicate  string
+		dataType   string
+		ruleOpaque bool
+	}{
+		{"WebURL", agentic.WebURL, "string", false},
+		{"WebTitle", agentic.WebTitle, "string", true},
+		{"WebSnippet", agentic.WebSnippet, "string", true},
+		{"WebText", agentic.WebText, "string", true},
+		{"WebSourceQuery", agentic.WebSourceQuery, "string", true},
+		{"WebObservedAt", agentic.WebObservedAt, "time.Time", false},
+		{"WebFetchedAt", agentic.WebFetchedAt, "time.Time", false},
+		{"WebObservedBy", agentic.WebObservedBy, "string", false},
+		{"WebFetchedBy", agentic.WebFetchedBy, "string", false},
+		{"WebContentType", agentic.WebContentType, "string", false},
+		{"WebStatusCode", agentic.WebStatusCode, "int", false},
+		{"WebTruncated", agentic.WebTruncated, "bool", false},
+	}
+
+	opaqueCount := 0
+	matchableCount := 0
+	for _, tt := range webPredicates {
+		meta := vocabulary.GetPredicateMetadata(tt.predicate)
+		if meta == nil {
+			t.Errorf("%s (%q): not registered", tt.name, tt.predicate)
+			continue
+		}
+		if meta.DataType != tt.dataType {
+			t.Errorf("%s: DataType = %q, want %q", tt.name, meta.DataType, tt.dataType)
+		}
+		if meta.RuleOpaque != tt.ruleOpaque {
+			t.Errorf("%s: RuleOpaque = %v, want %v (LLM-authored content must not be rule-predicable — Goodhart feedback loop)",
+				tt.name, meta.RuleOpaque, tt.ruleOpaque)
+		}
+		if tt.ruleOpaque {
+			opaqueCount++
+		} else {
+			matchableCount++
+		}
+	}
+
+	// Aligns with the semteams 2026-05-11 review: 4 rule-opaque + 8 rule-matchable.
+	if opaqueCount != 4 {
+		t.Errorf("rule-opaque count = %d, want 4 (title, snippet, text, source_query)", opaqueCount)
+	}
+	if matchableCount != 8 {
+		t.Errorf("rule-matchable count = %d, want 8 (url, observed_at, fetched_at, observed_by, fetched_by, content_type, status_code, truncated)", matchableCount)
 	}
 }

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -470,6 +470,22 @@ const (
 	// Example: "Investigate MQTT retained-message behavior"
 	// DataType: string
 	LoopDescription = "agent.loop.description"
+
+	// LoopObservedWeb is an entity reference to a web observation entity
+	// (agent.web.observation) the loop saw in a web_search result.
+	// Multi-valued: one triple per result. Paired with the URL entity's
+	// agent.web.observed_by back-link. See the Web Predicates block.
+	// Example: entity ID of a web.observation entity
+	// DataType: string (entity ID)
+	LoopObservedWeb = "agent.loop.observed_web"
+
+	// LoopFetchedWeb is an entity reference to a web observation entity
+	// (agent.web.observation) the loop pulled via http_request. Multi-valued:
+	// one triple per successful 2xx/3xx fetch. Paired with the URL entity's
+	// agent.web.fetched_by back-link. See the Web Predicates block.
+	// Example: entity ID of a web.observation entity
+	// DataType: string (entity ID)
+	LoopFetchedWeb = "agent.loop.fetched_web"
 )
 
 // Step Predicates
@@ -733,6 +749,116 @@ const (
 	// Example: "2026-05-09T14:22:00Z"
 	// DataType: time.Time
 	TodoUpdatedAt = "agent.todo.updated_at"
+)
+
+// Web Predicates
+//
+// Emitted by the web_search and http_request tools when an operator has
+// wired an optional TriplePublisher into their registration. The URL-side
+// predicates land on a per-URL agent.web.observation entity whose instance
+// segment is sha256-hex(canonical URL) so the same URL converges across
+// loops (natural dedup). The loop-side back-link predicates
+// (agent.loop.observed_web and agent.loop.fetched_web) live in the Loop
+// Predicates block above.
+//
+// Discipline: title, snippet, text, and source_query are flagged rule-opaque
+// per the LLM-authored-content principle. The first three are external prose
+// the tool's primary contract returns; the LLM-authored source_query is opaque
+// so rules don't predicate on its content (which would teach agents to optimise
+// queries toward rule triggers — Goodhart). Rules match on the structural
+// fields (url, content_type, status_code, observed_at, fetched_at, truncated)
+// or follow the entity-ID back-links.
+const (
+	// WebURL is the canonical URL the observation entity represents.
+	// The canonicalisation rules are documented in
+	// agentic/entity_ids.go:TryWebObservationEntityID (lowercase scheme+host,
+	// strip default port, strip fragment, strip trailing slash on bare host,
+	// preserve query string). Rule-matchable for allow/deny prefix matching
+	// and host-routing rules.
+	// Example: "https://pkg.go.dev/net/http"
+	// DataType: string
+	WebURL = "agent.web.url"
+
+	// WebTitle is the search-result title returned by the search provider.
+	// Free-form external prose. Rule-opaque — the rule-validator rejects
+	// any rule whose condition.field names this predicate.
+	// Example: "net/http package - Go Documentation"
+	// DataType: string
+	WebTitle = "agent.web.title"
+
+	// WebSnippet is the search-result description returned by the search
+	// provider. Free-form external prose. Rule-opaque.
+	// Example: "Package http provides HTTP client and server implementations…"
+	// DataType: string
+	WebSnippet = "agent.web.snippet"
+
+	// WebText is the fetched body of an http_request, after HTML→text
+	// extraction, truncated at the executor's httpMaxTextSize cap. Free-form
+	// external prose. Rule-opaque. WebTruncated reflects whether the cap was
+	// hit so rules can branch on completeness without reading the body.
+	// Example: "Package http provides HTTP client and server …"
+	// DataType: string
+	WebText = "agent.web.text"
+
+	// WebSourceQuery is the search query string passed to the web_search
+	// tool. LLM-authored content; rule-opaque so rules don't condition on
+	// query text (which would create a feedback loop where agents optimise
+	// queries toward rule triggers). Rules wanting to react to specific
+	// search activity should match on the observation entity's WebURL or
+	// the loop's role/workflow instead.
+	// Example: "NATS JetStream KV bucket history retention"
+	// DataType: string
+	WebSourceQuery = "agent.web.source_query"
+
+	// WebObservedAt is the wall-clock timestamp the web_search call saw
+	// this URL. Rule-matchable for age-based predicates.
+	// Example: "2026-05-11T14:22:00Z"
+	// DataType: time.Time
+	WebObservedAt = "agent.web.observed_at"
+
+	// WebFetchedAt is the wall-clock timestamp the http_request call pulled
+	// this URL's body. Rule-matchable.
+	// Example: "2026-05-11T14:22:30Z"
+	// DataType: time.Time
+	WebFetchedAt = "agent.web.fetched_at"
+
+	// WebObservedBy is the loop entity ID that observed this URL via
+	// web_search. Multi-valued across loops (different loops can converge
+	// on the same observation entity). Rule-matchable for relationship
+	// walks.
+	// Example: entity ID of the observing loop
+	// DataType: string (entity ID)
+	WebObservedBy = "agent.web.observed_by"
+
+	// WebFetchedBy is the loop entity ID that pulled this URL via
+	// http_request. Multi-valued across loops. Rule-matchable.
+	// Example: entity ID of the fetching loop
+	// DataType: string (entity ID)
+	WebFetchedBy = "agent.web.fetched_by"
+
+	// WebContentType is the HTTP Content-Type header value from an
+	// http_request fetch. Effectively an enum for rule purposes (route
+	// HTML vs JSON vs binary), so rule-matchable.
+	// Example: "text/html; charset=utf-8"
+	// DataType: string
+	WebContentType = "agent.web.content_type"
+
+	// WebStatusCode is the HTTP response status code from an http_request
+	// fetch. Only emitted for 2xx/3xx (the tool surfaces ≥400 as an error
+	// and does not write to the graph). Rule-matchable for retry-on-redirect
+	// style rules.
+	// Example: 200
+	// DataType: int
+	WebStatusCode = "agent.web.status_code"
+
+	// WebTruncated indicates whether the http_request body exceeded the
+	// executor's httpMaxTextSize cap and was truncated when written to
+	// WebText. Rule-matchable so a future "re-fetch when truncated" rule
+	// can act on completeness without reading the body. WebText itself
+	// remains rule-opaque.
+	// Example: false
+	// DataType: bool
+	WebTruncated = "agent.web.truncated"
 )
 
 // Ops Config Predicates (Phase 3, reserved)

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -597,7 +597,7 @@ const (
 	// "fan_out", "synthesize", "retry", "done".
 	// Example: "fan_out"
 	// DataType: string
-	CoordinatorNextAction = "coordinator.next_action"
+	CoordinatorNextAction = "coordinator.decision.next_action"
 
 	// CoordinatorDecisionReason is a short natural-language justification
 	// the coordinator supplied alongside its action choice. Small enough
@@ -606,9 +606,9 @@ const (
 	// Example: "researcher produced three distinct subtopics worth
 	// separate investigation"
 	// DataType: string
-	CoordinatorDecisionReason = "coordinator.decision_reason"
+	CoordinatorDecisionReason = "coordinator.decision.reason"
 
-	// CoordinatorDecideSAPCoerced is an audit triple emitted by the
+	// CoordinatorDecisionSAPCoerced is an audit triple emitted by the
 	// decide tool's SAP (schema-aligned-parsing) layer when it normalises
 	// an LLM-emitted action_allowlist drift to the allowlist's canonical
 	// form. Object is "{raw}|{canonical}" so a single predicate captures
@@ -623,7 +623,7 @@ const (
 	// can act on the signal rather than raise MaxIterations.
 	// Example: "fan-out|fan_out"
 	// DataType: string
-	CoordinatorDecideSAPCoerced = "coordinator.decide_sap_coerced"
+	CoordinatorDecisionSAPCoerced = "coordinator.decision.sap_coerced"
 )
 
 // Ops Predicates

--- a/vocabulary/agentic/register.go
+++ b/vocabulary/agentic/register.go
@@ -30,6 +30,7 @@ func Register() {
 	registerStepPredicates()
 	registerIdentityPredicates()
 	registerTodoPredicates()
+	registerWebPredicates()
 }
 
 // registerTodoPredicates registers predicates for agent-private todo
@@ -375,6 +376,73 @@ func registerLoopPredicates() {
 	vocabulary.Register(LoopDescription,
 		vocabulary.WithDescription("User task prompt that initiated this loop; indexed for NL/BM25 search"),
 		vocabulary.WithDataType("string"))
+
+	vocabulary.Register(LoopObservedWeb,
+		vocabulary.WithDescription("Entity reference to a web observation seen by this loop via web_search (multi-valued)"),
+		vocabulary.WithDataType("string"))
+
+	vocabulary.Register(LoopFetchedWeb,
+		vocabulary.WithDescription("Entity reference to a web observation pulled by this loop via http_request (multi-valued)"),
+		vocabulary.WithDataType("string"))
+}
+
+// registerWebPredicates registers predicates for web observation entities
+// emitted by the web_search and http_request tools. Title, snippet, text,
+// and source_query are flagged rule-opaque per the LLM-authored content
+// discipline (rules predicating on LLM-authored content create Goodhart
+// feedback loops). Structural fields stay rule-matchable.
+func registerWebPredicates() {
+	vocabulary.Register(WebURL,
+		vocabulary.WithDescription("Canonical URL this observation entity represents"),
+		vocabulary.WithDataType("string"))
+
+	vocabulary.Register(WebTitle,
+		vocabulary.WithDescription("Search-result title returned by the provider; rule-opaque external prose"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithRuleOpaque(true))
+
+	vocabulary.Register(WebSnippet,
+		vocabulary.WithDescription("Search-result description returned by the provider; rule-opaque external prose"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithRuleOpaque(true))
+
+	vocabulary.Register(WebText,
+		vocabulary.WithDescription("Fetched body of an http_request (HTML→text, truncated); rule-opaque external prose"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithRuleOpaque(true))
+
+	vocabulary.Register(WebSourceQuery,
+		vocabulary.WithDescription("LLM-authored search query string; rule-opaque to prevent agents optimising queries toward rule triggers"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithRuleOpaque(true))
+
+	vocabulary.Register(WebObservedAt,
+		vocabulary.WithDescription("Wall-clock timestamp the web_search call saw this URL"),
+		vocabulary.WithDataType("time.Time"))
+
+	vocabulary.Register(WebFetchedAt,
+		vocabulary.WithDescription("Wall-clock timestamp the http_request call pulled this URL's body"),
+		vocabulary.WithDataType("time.Time"))
+
+	vocabulary.Register(WebObservedBy,
+		vocabulary.WithDescription("Loop entity ID that observed this URL via web_search"),
+		vocabulary.WithDataType("string"))
+
+	vocabulary.Register(WebFetchedBy,
+		vocabulary.WithDescription("Loop entity ID that pulled this URL via http_request"),
+		vocabulary.WithDataType("string"))
+
+	vocabulary.Register(WebContentType,
+		vocabulary.WithDescription("HTTP Content-Type header value from an http_request fetch"),
+		vocabulary.WithDataType("string"))
+
+	vocabulary.Register(WebStatusCode,
+		vocabulary.WithDescription("HTTP response status code from an http_request fetch (2xx/3xx only)"),
+		vocabulary.WithDataType("int"))
+
+	vocabulary.Register(WebTruncated,
+		vocabulary.WithDescription("Whether the http_request body was truncated; rule-matchable structural flag"),
+		vocabulary.WithDataType("bool"))
 }
 
 // registerStepPredicates registers predicates for trajectory step entities.


### PR DESCRIPTION
Two related changes bundled because both touch `vocabulary/agentic/predicates.go`. Reviewable as two commits.

## Summary

- **BREAKING** `coordinator.*` predicates renamed to 3-segment form (`coordinator.decision.{next_action,reason,sap_coerced}`). The 2-segment shape was the only violator of the three-level dotted convention in the whole vocab. Rule configs in `configs/rules/deep-research/{03,04}*.json` updated; operator rule configs matching on the old names must update too.
- **Additive** `web_search` and `http_request` emit `agent.web.observation` entities when operators wire NATS into agentic-tools registration. Pattern mirrors `decide` / `emit_diagnosis` / `write_todos`. Pre-emission behavior preserved exactly when no publisher is wired. Stub web_search never emits.

## Design alignment

Spec confirmed with semteams 2026-05-11. Final predicate set: 4 rule-opaque (`title`, `snippet`, `text`, `source_query`) + 8 rule-matchable structural (`url`, `observed_at`, `fetched_at`, `observed_by`, `fetched_by`, `content_type`, `status_code`, `truncated`) + 2 loop-side back-links (`agent.loop.observed_web`, `agent.loop.fetched_web`).

`source_query` is rule-opaque because rules predicating on LLM-authored values create Goodhart feedback loops (agents learn to optimise queries toward rule triggers). Same principle generalises to future agent-private content predicates per ADR-036 §Future candidates.

Entity ID: `{org}.{platform}.agent.web.observation.{sha256-hex-16}` of the canonical URL — same URL across loops converges on the same entity. V1 canonicalization: lowercase scheme+host, strip default port, strip fragment, strip bare-host trailing slash, preserve query string.

Per-result emission failures log + Prometheus counter + continue, diverging from `decide` / `write_todos` (which fail the tool on publish error). Justified inline: graph emission here is opportunistic substrate observation, not the LLM-facing contract — failing a `web_search` because graph-ingest is restarting would be hostile to the calling agent.

## Test plan

- [x] `task lint` — clean (vet, fmt, revive)
- [x] `go test -race ./...` — all green
- [x] `go test -tags=integration -race ./...` — green (only pre-existing Ollama-dependent failures in `graph/query` integration tests, confirmed identical on `main`)
- [x] `task schema:generate` — no drift
- [x] **`task e2e:deep-research`** — green; `coordinator_fan_out_decisions:1` confirms rule 03 matches on the renamed predicate end-to-end (satisfies the BREAKING-needs-e2e HARD RULE from `CLAUDE.md`)
- [x] `task e2e:agentic` — green; executor wiring change (registration sites now thread NATSClient+Platform) doesn't regress agent loop + tool execution

## Migration

Operators with rule configs matching on `coordinator.next_action` etc. must rename to `coordinator.decision.next_action`. Reference rule configs at `configs/rules/deep-research/{03,04}*.json` show the new form. Web tools emission is opt-in via NATS availability — no operator action required, fall-through to text-only return when NATS is absent (logged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)