### PR TITLE
feat: scratchpad tool — pre-commit reasoning channel for agents

### DIFF
--- a/processor/agentic-tools/executors/register.go
+++ b/processor/agentic-tools/executors/register.go
@@ -104,6 +104,7 @@ func RegisterBuiltins(ctx context.Context, reg *agentictools.ExecutorRegistry, d
 		track(registerEmitDiagnosis(reg, deps.NATSClient, deps.Platform, logger))
 		track(registerGraphQuery(ctx, reg, deps.NATSClient, logger))
 		track(registerWriteTodos(reg, deps.NATSClient, deps.Platform, logger))
+		track(registerScratchpad(reg, deps.NATSClient, deps.Platform, logger))
 	}
 
 	// Pattern-B registry-backed tools. A nil manager is a legal skip;

--- a/processor/agentic-tools/executors/register_scratchpad.go
+++ b/processor/agentic-tools/executors/register_scratchpad.go
@@ -1,0 +1,33 @@
+package executors
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/natsclient"
+	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
+)
+
+// registerScratchpad wires the scratchpad tool. The tool writes
+// agent.scratch.* triples on the calling loop's entity via the same
+// graph.mutation.triple.add NATS surface decide/write_todos use.
+//
+// semspec ask 2026-05-12, ADR-036 §Future candidates first
+// implementation. Available to any role; persona authors opt specific
+// roles out via tool allowlists for tiny-model deployments.
+//
+// A registry-level failure (duplicate name) returns the error so
+// RegisterBuiltins surfaces it at boot.
+func registerScratchpad(reg *agentictools.ExecutorRegistry, natsClient *natsclient.Client, platform component.PlatformMeta, logger *slog.Logger) error {
+	publisher := agentictools.NewNATSTriplePublisher(natsClient)
+	executor := agentictools.NewScratchpadExecutor(publisher, platform)
+	executor.SetLogger(logger)
+	if err := reg.RegisterTool(agentictools.ScratchpadToolName, executor); err != nil {
+		return fmt.Errorf("register scratchpad: %w", err)
+	}
+	logger.Info("Registered scratchpad tool",
+		slog.String("org", platform.Org),
+		slog.String("platform", platform.Platform))
+	return nil
+}

--- a/processor/agentic-tools/scratchpad.go
+++ b/processor/agentic-tools/scratchpad.go
@@ -68,14 +68,17 @@ func NewScratchpadExecutor(publisher TriplePublisher, platform types.PlatformMet
 	}
 }
 
-// SetLogger replaces the default logger. nil-safe.
+// SetLogger replaces the default logger. nil-safe. Boot-time wiring
+// only — NOT safe to call after Execute is in flight (no internal
+// locking; concurrent Execute readers would race the writer).
 func (e *ScratchpadExecutor) SetLogger(logger *slog.Logger) {
 	if logger != nil {
 		e.logger = logger
 	}
 }
 
-// SetClock replaces the time source. nil-safe. Tests use this for
+// SetClock replaces the time source. nil-safe. Boot-time wiring only —
+// NOT safe to call after Execute is in flight. Tests use this for
 // deterministic ScratchCreatedAt assertions; production should not.
 func (e *ScratchpadExecutor) SetClock(now func() time.Time) {
 	if now != nil {
@@ -83,8 +86,9 @@ func (e *ScratchpadExecutor) SetClock(now func() time.Time) {
 	}
 }
 
-// SetIDGenerator replaces the ID generator. nil-safe. Tests use this to
-// pin scratch IDs; production should not.
+// SetIDGenerator replaces the ID generator. nil-safe. Boot-time wiring
+// only — NOT safe to call after Execute is in flight. Tests use this
+// to pin scratch IDs; production should not.
 func (e *ScratchpadExecutor) SetIDGenerator(newID func() string) {
 	if newID != nil {
 		e.newID = newID

--- a/processor/agentic-tools/scratchpad.go
+++ b/processor/agentic-tools/scratchpad.go
@@ -1,0 +1,263 @@
+package agentictools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/types"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+// ScratchpadToolName is the name agents use to invoke the scratchpad
+// tool. semspec ask 2026-05-12, ADR-036 §Future candidates instance.
+const ScratchpadToolName = "scratchpad"
+
+// scratchpadToolSource is the Source field on triples this tool
+// publishes. Distinguishes scratchpad emissions from other agent-private
+// state writers (write_todos, decide, etc.) in graph queries.
+const scratchpadToolSource = "agent-scratchpad"
+
+// ScratchpadExecutor implements the scratchpad tool. The tool is a
+// free-form one-shot reasoning channel for agents that need a "think
+// before commit" runway — useful for weaker mid-tier models that
+// struggle under simultaneous strict response_format + strict tool-args
+// (qwen3-MoE on OpenRouter, mid-tier vLLM, llama-3.3-70b dense per the
+// semspec proposal).
+//
+// Per-call semantics (NOT cumulative or full-list-replace like
+// write_todos): every call mints a fresh scratch.id and appends four
+// triples to the loop entity (id, text, created_at, chars). Multiple
+// scratchpad calls within one loop simply accumulate; ordering is
+// recoverable via ScratchCreatedAt.
+//
+// Strict: false (per semspec 2026-05-12 decision) — the text field is
+// unconstrained anyway, so strict-mode response_format would impose
+// provider strictness on what is effectively a single-string envelope.
+// Re-evaluate if real-LLM testing shows drift.
+//
+// All public methods are safe for concurrent use across loops; the
+// executor holds no per-call mutable state.
+type ScratchpadExecutor struct {
+	publisher TriplePublisher
+	platform  types.PlatformMeta
+	logger    *slog.Logger
+	now       func() time.Time
+	newID     func() string
+}
+
+// NewScratchpadExecutor constructs the executor given a triple publisher
+// and the platform identity used to resolve the calling loop's entity
+// ID. The clock defaults to time.Now and the ID generator defaults to
+// uuid v4; tests inject deterministic alternatives via SetClock /
+// SetIDGenerator.
+func NewScratchpadExecutor(publisher TriplePublisher, platform types.PlatformMeta) *ScratchpadExecutor {
+	return &ScratchpadExecutor{
+		publisher: publisher,
+		platform:  platform,
+		logger:    slog.Default(),
+		now:       time.Now,
+		newID:     func() string { return uuid.New().String() },
+	}
+}
+
+// SetLogger replaces the default logger. nil-safe.
+func (e *ScratchpadExecutor) SetLogger(logger *slog.Logger) {
+	if logger != nil {
+		e.logger = logger
+	}
+}
+
+// SetClock replaces the time source. nil-safe. Tests use this for
+// deterministic ScratchCreatedAt assertions; production should not.
+func (e *ScratchpadExecutor) SetClock(now func() time.Time) {
+	if now != nil {
+		e.now = now
+	}
+}
+
+// SetIDGenerator replaces the ID generator. nil-safe. Tests use this to
+// pin scratch IDs; production should not.
+func (e *ScratchpadExecutor) SetIDGenerator(newID func() string) {
+	if newID != nil {
+		e.newID = newID
+	}
+}
+
+// ListTools returns the scratchpad tool definition. Single required
+// string argument, no length cap (trajectories already handle large
+// payloads — per the semspec proposal's open question, no tool-level
+// limit needed).
+func (e *ScratchpadExecutor) ListTools() []agentic.ToolDefinition {
+	return []agentic.ToolDefinition{{
+		Name: ScratchpadToolName,
+		Description: "Free-form reasoning space before committing structured output. " +
+			"Use this to think through decomposition, list constraints you must satisfy, " +
+			"or note edge cases you considered — content is recorded in the trajectory " +
+			"and graph but not interpreted by any rule or consumer. Call this BEFORE the strict " +
+			"commit tool when the task involves decomposition or multi-step planning.",
+		Parameters: map[string]any{
+			"type":                 "object",
+			"required":             []string{"text"},
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"text": map[string]any{
+					"type":        "string",
+					"description": "Your reasoning. Free-form prose; no schema, no length limit, no interpretation. Lands in the trajectory and on the loop entity for audit and recovery.",
+				},
+			},
+		},
+		// Strict: false per semspec 2026-05-12 decision — the text field
+		// is unconstrained anyway, so strict mode would impose provider
+		// strictness on what is effectively a single-string envelope.
+	}}
+}
+
+// scratchpadArgs is the parsed shape of the scratchpad tool arguments.
+type scratchpadArgs struct {
+	Text string `json:"text"`
+}
+
+// scratchpadResult is the JSON the executor returns in ToolResult.Content.
+// Compact, structured confirmation — gives the agent verifiable feedback
+// that the call landed (helps weaker models stay on the persona pattern)
+// and gives operators a Prometheus-able byte-count signal without
+// doubling trajectory size by echoing the text back.
+type scratchpadResult struct {
+	Status    string `json:"status"`
+	ScratchID string `json:"scratch_id"`
+	Chars     int    `json:"chars"`
+}
+
+// Execute routes the tool call. Any name other than scratchpad is a
+// routing bug at the dispatcher layer.
+func (e *ScratchpadExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agentic.ToolResult, error) {
+	if call.Name != ScratchpadToolName {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("unknown tool: %s", call.Name),
+			ErrorKind: agentic.ToolErrorNotFound,
+		}, errs.WrapInvalid(fmt.Errorf("unknown tool: %s", call.Name), "ScratchpadExecutor", "Execute", "route tool")
+	}
+	return e.scratchpad(ctx, call)
+}
+
+func (e *ScratchpadExecutor) scratchpad(ctx context.Context, call agentic.ToolCall) (agentic.ToolResult, error) {
+	args, err := parseScratchpadArgs(call.Arguments)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     err.Error(),
+			ErrorKind: agentic.ToolErrorInvalidArgs,
+		}, nil
+	}
+
+	if call.LoopID == "" {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     "scratchpad invoked without a loop_id; cannot resolve the loop entity",
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(fmt.Errorf("tool call missing loop_id"), "ScratchpadExecutor", "scratchpad", "resolve loop entity")
+	}
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(e.platform.Org, e.platform.Platform, call.LoopID)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("construct loop entity ID: %v", err),
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(err, "ScratchpadExecutor", "scratchpad", "construct loop entity ID")
+	}
+
+	scratchID := e.newID()
+	now := e.now()
+	createdAt := now.UTC().Format(time.RFC3339Nano)
+	chars := len(args.Text)
+
+	// Four triples on the loop entity, all keyed to the same scratch_id
+	// via co-emission. The graph is a set-of-triples; downstream
+	// consumers reconstruct each entry by grouping triples sharing the
+	// same scratch.id Object. Append-only — multiple scratchpad calls
+	// within one loop simply accumulate.
+	//
+	// Failures here ARE surfaced as ToolErrorNetwork because the graph
+	// emission is the audit/recovery contract of this tool (per the
+	// semspec proposal — "scratchpad calls appear in the trajectory
+	// alongside other tool calls" is supplemented by ADR-036-aligned
+	// triples so ops-agent and future recovery agents can query). This
+	// matches decide/write_todos discipline, NOT the web-tools
+	// log+continue discipline, because the trajectory alone is not
+	// durable across compaction.
+	triples := []message.Triple{
+		{Subject: loopEntityID, Predicate: agvocab.ScratchID, Object: scratchID, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},
+		{Subject: loopEntityID, Predicate: agvocab.ScratchText, Object: args.Text, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},
+		{Subject: loopEntityID, Predicate: agvocab.ScratchCreatedAt, Object: createdAt, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},
+		{Subject: loopEntityID, Predicate: agvocab.ScratchChars, Object: chars, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},
+	}
+	for _, tr := range triples {
+		if err := e.publisher.AddTriple(ctx, tr); err != nil {
+			return agentic.ToolResult{
+				CallID:    call.ID,
+				Error:     fmt.Sprintf("publish %s triple: %v", tr.Predicate, err),
+				ErrorKind: agentic.ToolErrorNetwork,
+			}, errs.WrapTransient(err, "ScratchpadExecutor", "scratchpad", "publish triple")
+		}
+	}
+
+	payload, err := json.Marshal(scratchpadResult{
+		Status:    "ok",
+		ScratchID: scratchID,
+		Chars:     chars,
+	})
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("marshal result: %v", err),
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(err, "ScratchpadExecutor", "scratchpad", "marshal result")
+	}
+
+	e.logger.Debug("scratchpad call recorded",
+		"loop_id", call.LoopID,
+		"loop_entity_id", loopEntityID,
+		"scratch_id", scratchID,
+		"chars", chars)
+
+	return agentic.ToolResult{
+		CallID:  call.ID,
+		Content: string(payload),
+		Metadata: map[string]any{
+			"scratch_id":     scratchID,
+			"chars":          chars,
+			"loop_entity_id": loopEntityID,
+		},
+	}, nil
+}
+
+// parseScratchpadArgs reads the untyped arguments and enforces the
+// required text field. Empty text is rejected so the agent gets
+// immediate feedback rather than a silent no-op emission (LLM-side
+// retry can correct).
+func parseScratchpadArgs(raw map[string]any) (scratchpadArgs, error) {
+	if raw == nil {
+		return scratchpadArgs{}, fmt.Errorf("missing required argument %q", "text")
+	}
+	rawText, ok := raw["text"]
+	if !ok {
+		return scratchpadArgs{}, fmt.Errorf("missing required argument %q", "text")
+	}
+	text, ok := rawText.(string)
+	if !ok {
+		return scratchpadArgs{}, fmt.Errorf("argument %q must be a string", "text")
+	}
+	if text == "" {
+		return scratchpadArgs{}, fmt.Errorf("argument %q must be a non-empty string", "text")
+	}
+	return scratchpadArgs{Text: text}, nil
+}

--- a/processor/agentic-tools/scratchpad_test.go
+++ b/processor/agentic-tools/scratchpad_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/types"
 	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
@@ -96,6 +97,19 @@ func TestScratchpadExecutor_HappyPath_EmitsFourTriples(t *testing.T) {
 		t.Errorf("ScratchChars = %v, want 38", byPredicate[agvocab.ScratchChars])
 	}
 
+	// Co-emission invariant: all four triples for one call share the
+	// same Timestamp so downstream consumers can group by timestamp
+	// (alternative to grouping by ScratchID) when reconstructing entries.
+	// The eventual batch-publisher migration (reviewer's class-of-bug
+	// note) preserves this property; pinning it in a test makes the
+	// future change a visible delta.
+	want := pub.triples[0].Timestamp
+	for i, tr := range pub.triples {
+		if !tr.Timestamp.Equal(want) {
+			t.Errorf("triple %d timestamp = %v, want %v (co-emission invariant)", i, tr.Timestamp, want)
+		}
+	}
+
 	// Confirmation payload — semspec asked for "short fixed confirmation"
 	// rather than echo. Asserts the contract surface.
 	var confirm scratchpadResult
@@ -127,6 +141,19 @@ func TestScratchpadExecutor_AppendOnlyAcrossCalls(t *testing.T) {
 		idx++
 		return out
 	})
+	// Drive the clock forward between calls so the test exercises the
+	// "ordering recoverable via ScratchCreatedAt" claim. A frozen clock
+	// would pass even if the implementation cached e.now() at boot.
+	clocks := []time.Time{
+		time.Date(2026, 5, 12, 9, 15, 0, 0, time.UTC),
+		time.Date(2026, 5, 12, 9, 16, 30, 0, time.UTC),
+	}
+	clockIdx := 0
+	e.SetClock(func() time.Time {
+		t := clocks[clockIdx]
+		clockIdx++
+		return t
+	})
 
 	for _, text := range []string{"first thought", "second thought"} {
 		if _, err := e.Execute(context.Background(), agentic.ToolCall{
@@ -139,13 +166,76 @@ func TestScratchpadExecutor_AppendOnlyAcrossCalls(t *testing.T) {
 		t.Errorf("triples after two calls = %d, want 8 (4 per call, append-only)", got)
 	}
 	scratchIDs := map[string]int{}
+	timestamps := map[time.Time]int{}
 	for _, tr := range pub.triples {
 		if tr.Predicate == agvocab.ScratchID {
 			scratchIDs[tr.Object.(string)]++
 		}
+		timestamps[tr.Timestamp]++
 	}
 	if len(scratchIDs) != 2 {
 		t.Errorf("distinct scratch IDs = %d, want 2", len(scratchIDs))
+	}
+	if len(timestamps) != 2 {
+		t.Errorf("distinct timestamps = %d, want 2 (each call advances the clock)", len(timestamps))
+	}
+}
+
+// scratchpadPartialFailurePublisher returns success for the first N
+// AddTriple calls then surfaces an error on the (N+1)th. Records every
+// triple it sees so tests can assert exactly which writes landed.
+// Lives here (not next to recordingPublisher) because the existing
+// shared recorder bails BEFORE recording on error and the partial-write
+// invariant needs the opposite.
+type scratchpadPartialFailurePublisher struct {
+	failAfter int
+	calls     int
+	triples   []message.Triple
+	failWith  error
+}
+
+func (p *scratchpadPartialFailurePublisher) AddTriple(_ context.Context, tr message.Triple) error {
+	p.calls++
+	if p.calls > p.failAfter {
+		return p.failWith
+	}
+	p.triples = append(p.triples, tr)
+	return nil
+}
+
+// TestScratchpadExecutor_PartialWrite_LeavesOrphanID locks in the
+// documented partial-write behavior: a publish failure on triple 3
+// leaves the first 2 triples in the graph (orphan ScratchID +
+// ScratchText with no companions). The tool returns ToolErrorNetwork
+// so the LLM sees the failure and retries with a fresh UUID; the
+// orphan is harmless (no duplication). The eventual batch-publisher
+// migration (go-reviewer follow-up) eliminates orphans entirely —
+// this test makes that change a visible delta.
+func TestScratchpadExecutor_PartialWrite_LeavesOrphanID(t *testing.T) {
+	pub := &scratchpadPartialFailurePublisher{failAfter: 2, failWith: errors.New("nats degraded")}
+	e := NewScratchpadExecutor(pub, types.PlatformMeta{Org: "acme", Platform: "ops"})
+	e.SetIDGenerator(func() string { return "orphan-id" })
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "c", Name: ScratchpadToolName, LoopID: "loop", Arguments: map[string]any{"text": "draft"},
+	})
+	if err == nil {
+		t.Fatalf("expected wrapped transient error")
+	}
+	if res.ErrorKind != agentic.ToolErrorNetwork {
+		t.Errorf("ErrorKind = %v, want network", res.ErrorKind)
+	}
+	if len(pub.triples) != 2 {
+		t.Errorf("recorded triples = %d, want 2 (first two land, third fails)", len(pub.triples))
+	}
+	// The first two predicates emitted are ScratchID and ScratchText
+	// (per scratchpad.go emission order). Locking that order in here
+	// makes any future reorder a visible test delta.
+	if pub.triples[0].Predicate != agvocab.ScratchID {
+		t.Errorf("first emitted predicate = %q, want %q", pub.triples[0].Predicate, agvocab.ScratchID)
+	}
+	if pub.triples[1].Predicate != agvocab.ScratchText {
+		t.Errorf("second emitted predicate = %q, want %q", pub.triples[1].Predicate, agvocab.ScratchText)
 	}
 }
 

--- a/processor/agentic-tools/scratchpad_test.go
+++ b/processor/agentic-tools/scratchpad_test.go
@@ -1,0 +1,236 @@
+package agentictools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/types"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+// newScratchpadExecutor builds a fully-mocked executor with a frozen
+// clock and pinned ID so tests can assert deterministic triples.
+func newScratchpadExecutor(pub TriplePublisher) *ScratchpadExecutor {
+	e := NewScratchpadExecutor(pub, types.PlatformMeta{Org: "acme", Platform: "ops"})
+	e.SetClock(func() time.Time { return time.Date(2026, 5, 12, 9, 15, 0, 0, time.UTC) })
+	e.SetIDGenerator(func() string { return "scratch-uuid-fixed" })
+	return e
+}
+
+func TestScratchpadExecutor_ListTools(t *testing.T) {
+	e := newScratchpadExecutor(&recordingPublisher{})
+	tools := e.ListTools()
+	if len(tools) != 1 {
+		t.Fatalf("ListTools = %d, want 1", len(tools))
+	}
+	tool := tools[0]
+	if tool.Name != ScratchpadToolName {
+		t.Errorf("name = %q, want %q", tool.Name, ScratchpadToolName)
+	}
+	// Strict:false per semspec 2026-05-12 decision — locked in here so
+	// a future drive-by toggle gets a flag from the test suite.
+	if tool.Strict {
+		t.Errorf("Strict = true, want false (per semspec design decision)")
+	}
+	// Required arg present and schema closed.
+	params := tool.Parameters
+	if params["additionalProperties"] != false {
+		t.Errorf("additionalProperties should be false")
+	}
+	required, ok := params["required"].([]string)
+	if !ok || len(required) != 1 || required[0] != "text" {
+		t.Errorf("required = %v, want [\"text\"]", required)
+	}
+}
+
+func TestScratchpadExecutor_HappyPath_EmitsFourTriples(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newScratchpadExecutor(pub)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "call-1",
+		Name:      ScratchpadToolName,
+		LoopID:    "loop-abc",
+		Arguments: map[string]any{"text": "Let me think: handle empty retry_hint."},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("result error: %q", res.Error)
+	}
+
+	// Four triples, all on the loop entity, all keyed to the fixed UUID
+	// via co-emission (graph is a set-of-triples; downstream readers
+	// group by timestamp / scratch_id to reconstruct one entry).
+	if got := len(pub.triples); got != 4 {
+		t.Fatalf("triples emitted = %d, want 4", got)
+	}
+
+	loopEntityID, err := agentic.TryLoopExecutionEntityID("acme", "ops", "loop-abc")
+	if err != nil {
+		t.Fatalf("loop entity id: %v", err)
+	}
+	byPredicate := map[string]any{}
+	for _, tr := range pub.triples {
+		if tr.Subject != loopEntityID {
+			t.Errorf("triple subject = %q, want loop entity %q", tr.Subject, loopEntityID)
+		}
+		if tr.Source != scratchpadToolSource {
+			t.Errorf("triple source = %q, want %q", tr.Source, scratchpadToolSource)
+		}
+		byPredicate[tr.Predicate] = tr.Object
+	}
+	if byPredicate[agvocab.ScratchID] != "scratch-uuid-fixed" {
+		t.Errorf("ScratchID = %v, want fixed uuid", byPredicate[agvocab.ScratchID])
+	}
+	if byPredicate[agvocab.ScratchText] != "Let me think: handle empty retry_hint." {
+		t.Errorf("ScratchText = %v, want literal", byPredicate[agvocab.ScratchText])
+	}
+	if byPredicate[agvocab.ScratchChars] != 38 {
+		t.Errorf("ScratchChars = %v, want 38", byPredicate[agvocab.ScratchChars])
+	}
+
+	// Confirmation payload — semspec asked for "short fixed confirmation"
+	// rather than echo. Asserts the contract surface.
+	var confirm scratchpadResult
+	if err := json.Unmarshal([]byte(res.Content), &confirm); err != nil {
+		t.Fatalf("unmarshal content: %v", err)
+	}
+	if confirm.Status != "ok" {
+		t.Errorf("status = %q, want ok", confirm.Status)
+	}
+	if confirm.ScratchID != "scratch-uuid-fixed" {
+		t.Errorf("scratch_id = %q, want fixed uuid", confirm.ScratchID)
+	}
+	if confirm.Chars != 38 {
+		t.Errorf("chars = %d, want 38", confirm.Chars)
+	}
+}
+
+// TestScratchpadExecutor_AppendOnlyAcrossCalls confirms multiple
+// scratchpad calls within one loop accumulate (NOT full-list-replace
+// like write_todos). Each call mints a fresh scratch.id; the graph
+// retains all four triples per call.
+func TestScratchpadExecutor_AppendOnlyAcrossCalls(t *testing.T) {
+	ids := []string{"id-1", "id-2"}
+	idx := 0
+	pub := &recordingPublisher{}
+	e := NewScratchpadExecutor(pub, types.PlatformMeta{Org: "acme", Platform: "ops"})
+	e.SetIDGenerator(func() string {
+		out := ids[idx]
+		idx++
+		return out
+	})
+
+	for _, text := range []string{"first thought", "second thought"} {
+		if _, err := e.Execute(context.Background(), agentic.ToolCall{
+			ID: "c", Name: ScratchpadToolName, LoopID: "loop", Arguments: map[string]any{"text": text},
+		}); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+	}
+	if got := len(pub.triples); got != 8 {
+		t.Errorf("triples after two calls = %d, want 8 (4 per call, append-only)", got)
+	}
+	scratchIDs := map[string]int{}
+	for _, tr := range pub.triples {
+		if tr.Predicate == agvocab.ScratchID {
+			scratchIDs[tr.Object.(string)]++
+		}
+	}
+	if len(scratchIDs) != 2 {
+		t.Errorf("distinct scratch IDs = %d, want 2", len(scratchIDs))
+	}
+}
+
+func TestScratchpadExecutor_RejectsEmptyText(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newScratchpadExecutor(pub)
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "c", Name: ScratchpadToolName, LoopID: "loop", Arguments: map[string]any{"text": ""},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("ErrorKind = %v, want invalid_args", res.ErrorKind)
+	}
+	if !strings.Contains(res.Error, "non-empty") {
+		t.Errorf("Error = %q, want substring 'non-empty'", res.Error)
+	}
+	if len(pub.triples) != 0 {
+		t.Errorf("rejected call should emit no triples, got %d", len(pub.triples))
+	}
+}
+
+func TestScratchpadExecutor_RejectsMissingText(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newScratchpadExecutor(pub)
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "c", Name: ScratchpadToolName, LoopID: "loop", Arguments: map[string]any{},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("ErrorKind = %v, want invalid_args", res.ErrorKind)
+	}
+}
+
+func TestScratchpadExecutor_RejectsNonStringText(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newScratchpadExecutor(pub)
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "c", Name: ScratchpadToolName, LoopID: "loop", Arguments: map[string]any{"text": 42},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("ErrorKind = %v, want invalid_args", res.ErrorKind)
+	}
+}
+
+func TestScratchpadExecutor_MissingLoopIDIsInternal(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newScratchpadExecutor(pub)
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "c", Name: ScratchpadToolName, Arguments: map[string]any{"text": "hi"},
+	})
+	if err == nil {
+		t.Errorf("expected wrapped Go error (dispatcher invariant violation)")
+	}
+	if res.ErrorKind != agentic.ToolErrorInternal {
+		t.Errorf("ErrorKind = %v, want internal", res.ErrorKind)
+	}
+}
+
+// TestScratchpadExecutor_PublishFailureSurfacesAsNetworkError confirms
+// scratchpad follows the decide/write_todos discipline (fail the tool
+// on publish error) rather than the web-tools log+continue discipline.
+// Rationale: the trajectory alone is not durable across compaction, so
+// the graph is the audit/recovery contract for this tool.
+func TestScratchpadExecutor_PublishFailureSurfacesAsNetworkError(t *testing.T) {
+	pub := &recordingPublisher{err: errors.New("nats degraded")}
+	e := newScratchpadExecutor(pub)
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "c", Name: ScratchpadToolName, LoopID: "loop", Arguments: map[string]any{"text": "draft"},
+	})
+	if err == nil {
+		t.Errorf("expected wrapped transient error")
+	}
+	if res.ErrorKind != agentic.ToolErrorNetwork {
+		t.Errorf("ErrorKind = %v, want network", res.ErrorKind)
+	}
+}
+
+func TestScratchpadExecutor_WrongNameIsRoutingBug(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newScratchpadExecutor(pub)
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "c", Name: "not_scratchpad", LoopID: "loop",
+	})
+	if err == nil {
+		t.Errorf("expected dispatcher routing error")
+	}
+	if res.ErrorKind != agentic.ToolErrorNotFound {
+		t.Errorf("ErrorKind = %v, want not_found", res.ErrorKind)
+	}
+}

--- a/vocabulary/agentic/agentic_test.go
+++ b/vocabulary/agentic/agentic_test.go
@@ -85,6 +85,11 @@ func TestPredicateFormat(t *testing.T) {
 		agentic.LoopUser,
 		agentic.LoopObservedWeb,
 		agentic.LoopFetchedWeb,
+		// Scratch
+		agentic.ScratchID,
+		agentic.ScratchText,
+		agentic.ScratchCreatedAt,
+		agentic.ScratchChars,
 		// Web
 		agentic.WebURL,
 		agentic.WebTitle,
@@ -271,10 +276,11 @@ func TestPredicateCount(t *testing.T) {
 	// Model: 8, Loop: 17 (15 core + LoopHasStep + LoopDescription + LoopObservedWeb + LoopFetchedWeb)
 	// Step: 18 (15 core + tool_status + error_message + error_category), Identity: 6
 	// Todo: 5 (ADR-036 — id, content, status, position, updated_at)
+	// Scratch: 4 (id, text, created_at, chars)
 	// Web: 12 (url, title, snippet, text, source_query, observed_at, fetched_at,
 	//   observed_by, fetched_by, content_type, status_code, truncated)
-	// Total: 108 predicates
-	expectedMin := 108
+	// Total: 112 predicates
+	expectedMin := 112
 	if len(predicates) < expectedMin {
 		t.Errorf("expected at least %d predicates, got %d", expectedMin, len(predicates))
 	}
@@ -456,6 +462,44 @@ func TestTodoPredicatesRegistered(t *testing.T) {
 		}
 		if meta.RuleOpaque != tt.ruleOpaque {
 			t.Errorf("%s: RuleOpaque = %v, want %v (ADR-036 §Decision Rule 1: rules MUST NOT predicate on opaque content)",
+				tt.name, meta.RuleOpaque, tt.ruleOpaque)
+		}
+	}
+}
+
+// TestScratchPredicatesRegistered asserts the 4 scratchpad predicates
+// land with the right data types and rule-opaque flags. ScratchText is
+// rule-opaque per the LLM-authored-content discipline; the other three
+// (id, created_at, chars) stay rule-matchable as structural facts.
+func TestScratchPredicatesRegistered(t *testing.T) {
+	vocabulary.ClearRegistry()
+	defer vocabulary.ClearRegistry()
+
+	agentic.Register()
+
+	scratchPredicates := []struct {
+		name       string
+		predicate  string
+		dataType   string
+		ruleOpaque bool
+	}{
+		{"ScratchID", agentic.ScratchID, "string", false},
+		{"ScratchText", agentic.ScratchText, "string", true},
+		{"ScratchCreatedAt", agentic.ScratchCreatedAt, "time.Time", false},
+		{"ScratchChars", agentic.ScratchChars, "int", false},
+	}
+
+	for _, tt := range scratchPredicates {
+		meta := vocabulary.GetPredicateMetadata(tt.predicate)
+		if meta == nil {
+			t.Errorf("%s (%q): not registered", tt.name, tt.predicate)
+			continue
+		}
+		if meta.DataType != tt.dataType {
+			t.Errorf("%s: DataType = %q, want %q", tt.name, meta.DataType, tt.dataType)
+		}
+		if meta.RuleOpaque != tt.ruleOpaque {
+			t.Errorf("%s: RuleOpaque = %v, want %v (LLM-authored content must not be rule-predicable — Goodhart feedback loop)",
 				tt.name, meta.RuleOpaque, tt.ruleOpaque)
 		}
 	}

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -751,6 +751,60 @@ const (
 	TodoUpdatedAt = "agent.todo.updated_at"
 )
 
+// Scratch Predicates (ADR-036 §Future candidates — agent.scratch.*)
+//
+// Emitted by the scratchpad tool on every call. Append-only on the
+// owning loop entity (NOT full-list-replace like write_todos): each
+// scratchpad call mints a stable scratch.id and lands four triples
+// keyed by it. The agent is the sole writer and sole interpreter of
+// content; rule-opaque flagging on agent.scratch.text mirrors the
+// ADR-036 discipline applied to TodoContent.
+//
+// The semspec ask (2026-05-12, scratchpad proposal) framed this as
+// pre-commit reasoning runway for mid-tier models that struggle under
+// simultaneous strict response_format + strict tool-args. Persona
+// pattern: instruct "scratchpad first, then your commit tool" plus
+// caller-side tool_choice=required on the first dispatch turn.
+//
+// Per-call audit / recovery: scratch entries are queryable via
+// query_relationships on the loop entity for any agent (recovery,
+// debug, ops diagnosis) reconstructing what the model drafted before
+// committing.
+const (
+	// ScratchID is the stable per-call identifier (UUID). Keyed onto
+	// the loop entity so the four triples for one call correlate.
+	// Rule-matchable.
+	// Example: "550e8400-e29b-41d4-a716-446655440000"
+	// DataType: string
+	ScratchID = "agent.scratch.id"
+
+	// ScratchText is the free-form prose the agent emitted. Owner-
+	// interpretable only. Rule-opaque — the rule-validator rejects any
+	// rule whose condition.field names this predicate (LLM-authored
+	// content; rules predicating on it would create Goodhart feedback
+	// loops where agents optimise drafts toward rule triggers).
+	// Example: "I need to handle the case where retry hint is empty…"
+	// DataType: string
+	ScratchText = "agent.scratch.text"
+
+	// ScratchCreatedAt is the wall-clock timestamp of the scratchpad
+	// call. Rule-matchable for ordering (no explicit position predicate
+	// needed; sort by created_at) and for age-based rules.
+	// Example: "2026-05-12T09:15:00Z"
+	// DataType: time.Time
+	ScratchCreatedAt = "agent.scratch.created_at"
+
+	// ScratchChars is the character count of ScratchText. Rule-matchable
+	// structural fact so operators / ops-agent can predicate on size
+	// (e.g. "agent called scratchpad with > 8000 chars" — signal of
+	// a model that's using the channel as a context dump rather than
+	// pre-commit reasoning). Lets dashboards surface size patterns
+	// without needing to read the rule-opaque body.
+	// Example: 245
+	// DataType: int
+	ScratchChars = "agent.scratch.chars"
+)
+
 // Web Predicates
 //
 // Emitted by the web_search and http_request tools when an operator has

--- a/vocabulary/agentic/register.go
+++ b/vocabulary/agentic/register.go
@@ -30,7 +30,31 @@ func Register() {
 	registerStepPredicates()
 	registerIdentityPredicates()
 	registerTodoPredicates()
+	registerScratchPredicates()
 	registerWebPredicates()
+}
+
+// registerScratchPredicates registers predicates for the scratchpad tool
+// (semspec ask 2026-05-12, ADR-036 §Future candidates). ScratchText is
+// rule-opaque per the LLM-authored content discipline; the three
+// structural predicates stay rule-matchable.
+func registerScratchPredicates() {
+	vocabulary.Register(ScratchID,
+		vocabulary.WithDescription("Stable per-call identifier (UUID) correlating the four triples written by one scratchpad call"),
+		vocabulary.WithDataType("string"))
+
+	vocabulary.Register(ScratchText,
+		vocabulary.WithDescription("Free-form pre-commit reasoning prose; owner-interpretable only, rule-opaque"),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithRuleOpaque(true))
+
+	vocabulary.Register(ScratchCreatedAt,
+		vocabulary.WithDescription("Wall-clock timestamp of the scratchpad call"),
+		vocabulary.WithDataType("time.Time"))
+
+	vocabulary.Register(ScratchChars,
+		vocabulary.WithDescription("Character count of ScratchText; structural fact for size-based dashboards/rules without reading the rule-opaque body"),
+		vocabulary.WithDataType("int"))
 }
 
 // registerTodoPredicates registers predicates for agent-private todo


### PR DESCRIPTION
Implements semspec's 2026-05-12 proposal at `../semspec/docs/proposals/semstreams-scratchpad-tool.md`. First instance of ADR-036 §Future candidates' `agent.scratch.*` primitive.

## Summary

New `scratchpad` tool: free-form one-shot reasoning channel for agents that need pre-commit thinking runway. Complements `write_todos` (cross-iteration list state) — different shape, different purpose. Mid-tier models in semspec's matrix (qwen3-MoE on OpenRouter, mid-tier vLLM, llama-3.3-70b dense) struggle with simultaneous strict `response_format` + strict tool-args; this gives them an explicit pre-commit reasoning channel.

## Design decisions (confirmed with semspec)

- **`Strict: false`** — text field is unconstrained; provider strict mode would only bracket a single-string envelope. Re-evaluate if real-LLM drift shows up.
- **Result is short fixed confirmation** `{status, scratch_id, chars}` rather than echo. Gives operators a byte-count signal without doubling trajectory size.
- **Emits triples** per ADR-036 alignment. The proposal's "no persistence required" line read more like "no persistence demanded" than "persistence forbidden" — and the project rule is "lean toward the triple for agent actions so we can graph it" (memory: `feedback_llm_authored_predicates_rule_opaque.md`).

## Vocabulary

4 new predicates on the loop entity:
- `agent.scratch.id` — UUID, rule-matchable
- `agent.scratch.text` — **rule-opaque** (LLM-authored prose)
- `agent.scratch.created_at` — timestamp, rule-matchable
- `agent.scratch.chars` — int, rule-matchable

Append-only across calls (NOT full-list-replace like write_todos): each call mints a fresh UUID-keyed `scratch_id` and writes 4 triples. Multiple scratchpad calls within a loop simply accumulate; ordering recoverable via `ScratchCreatedAt`.

## Error discipline

Publish failures surface as `ToolErrorNetwork` (decide/write_todos discipline, NOT web-tools log+continue) because the graph is the durable audit/recovery contract for this tool — the trajectory alone doesn't survive compaction.

## Test plan

- [x] `task lint` clean
- [x] `go test -race ./...` — all green (only pre-existing Ollama-timeout failures in `graph/query` integration tests, unrelated)
- [x] `task schema:generate` no drift
- [x] 7 scratchpad executor tests cover: list-tools schema (incl. `Strict:false` lock-in), happy path (4 triples + confirmation shape), append-only-across-calls, empty-text rejection, missing-text rejection, non-string-text rejection, missing-loop-id internal error, publish-failure surfacing, wrong-name routing-bug
- [x] Vocab test asserts rule-opaque flag on `ScratchText` only (3 structural predicates stay matchable)

E2E not required (additive feature, no rule-config wire format touched).

## Adoption plan (semspec post-merge)

1. Bump semstreams version
2. Wire `scratchpad` into the available-tool palette for `RoleRequirementGenerator` / `RoleScenarioGenerator` / `RoleArchitect` / `RolePlanner`
3. Update personas to instruct pre-commit draft + caller-side `tool_choice = {mode: "required", name: "scratchpad"}` on first dispatch turn
4. Measure generator failure rate on mid-tier providers vs current

🤖 Generated with [Claude Code](https://claude.com/claude-code)