### PR TITLE
feat(agentic,agentic-loop,agentic-tools): typed ResultHint + canonical pagination contract

### DIFF
--- a/agentic/result_hint_test.go
+++ b/agentic/result_hint_test.go
@@ -1,0 +1,163 @@
+package agentic_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// TestToolResult_ResultHint_JSONRoundTrip locks the wire shape of the
+// new ResultHint field on ToolResult. Per the JSON-roundtrip-test
+// discipline rule (feedback_polymorphic_config_needs_json_roundtrip_test.md),
+// any operator-reachable surface needs a JSON-load test.
+//
+// ResultHint is the typed counterpart to the legacy ApprovalRequiredPrefix
+// magic-string pattern — without this test, a future refactor that
+// changes the json tag (e.g. to "hint" or "result_hint_kind") would
+// silently break every consumer that already decodes ToolResults off
+// the wire.
+func TestToolResult_ResultHint_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		hint agentic.ToolResultHint
+	}{
+		{"too_large", agentic.HintTooLarge},
+		{"empty", agentic.HintEmpty},
+		{"syntax_error", agentic.HintSyntaxError},
+		{"empty hint (zero value)", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := agentic.ToolResult{
+				CallID:     "call-hint-test",
+				Content:    "irrelevant",
+				ResultHint: tt.hint,
+			}
+			data, err := json.Marshal(original)
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+
+			// Zero-value hint must omit from JSON (omitempty)
+			if tt.hint == "" && strings.Contains(string(data), "result_hint") {
+				t.Errorf("empty hint should be omitted from JSON, got: %s", data)
+			}
+			// Non-zero hint must be present
+			if tt.hint != "" && !strings.Contains(string(data), `"result_hint":"`+string(tt.hint)+`"`) {
+				t.Errorf("non-empty hint missing from JSON: %s", data)
+			}
+
+			var decoded agentic.ToolResult
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+			if decoded.ResultHint != tt.hint {
+				t.Errorf("ResultHint = %q, want %q", decoded.ResultHint, tt.hint)
+			}
+		})
+	}
+}
+
+// TestToolResult_ResultHint_ComposesWithError asserts ResultHint and
+// Error are NOT mutually exclusive on the wire. A tool that fails
+// partway through and returns partial data legitimately sets both
+// (Error documents the failure, ResultHint advises recovery).
+func TestToolResult_ResultHint_ComposesWithError(t *testing.T) {
+	original := agentic.ToolResult{
+		CallID:     "call-compose-test",
+		Content:    "partial results before failure",
+		Error:      "upstream returned 503 after 80 of 100 rows",
+		ErrorKind:  agentic.ToolErrorExternal,
+		ResultHint: agentic.HintTooLarge,
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded agentic.ToolResult
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded.Error != original.Error {
+		t.Errorf("Error lost in round-trip: got %q want %q", decoded.Error, original.Error)
+	}
+	if decoded.ResultHint != original.ResultHint {
+		t.Errorf("ResultHint lost in round-trip: got %q want %q", decoded.ResultHint, original.ResultHint)
+	}
+	if decoded.ErrorKind != original.ErrorKind {
+		t.Errorf("ErrorKind lost in round-trip: got %q want %q", decoded.ErrorKind, original.ErrorKind)
+	}
+}
+
+// TestToolDefinition_Paginated_JSONRoundTrip locks the wire shape of
+// the new Paginated bool flag on ToolDefinition.
+func TestToolDefinition_Paginated_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name       string
+		paginated  bool
+		wantInJSON bool
+	}{
+		{"paginated true serializes", true, true},
+		{"paginated false omits (omitempty zero value)", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := agentic.ToolDefinition{
+				Name:        "test_tool",
+				Description: "doc",
+				Parameters:  map[string]any{"type": "object"},
+				Paginated:   tt.paginated,
+			}
+			data, err := json.Marshal(original)
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+			hasField := strings.Contains(string(data), `"paginated"`)
+			if hasField != tt.wantInJSON {
+				t.Errorf("paginated in JSON = %v, want %v; data=%s", hasField, tt.wantInJSON, data)
+			}
+
+			var decoded agentic.ToolDefinition
+			if err := json.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+			if decoded.Paginated != tt.paginated {
+				t.Errorf("Paginated = %v, want %v", decoded.Paginated, tt.paginated)
+			}
+		})
+	}
+}
+
+// TestMetadataKeys_AreStableStrings is a guard against accidental
+// rename of the pagination metadata keys. Constants are wire-format —
+// changing the string value breaks every existing read_loop_result
+// consumer (semspec is integrated against these exact strings since
+// before they were lifted into constants).
+//
+// Update with care: changes to these values are BREAKING wire-format
+// changes and need e2e + downstream coordination.
+func TestMetadataKeys_AreStableStrings(t *testing.T) {
+	cases := map[string]string{
+		"MetadataKeyHasMore":    agentic.MetadataKeyHasMore,
+		"MetadataKeyNextOffset": agentic.MetadataKeyNextOffset,
+		"MetadataKeyNextCursor": agentic.MetadataKeyNextCursor,
+		"MetadataKeyTotalBytes": agentic.MetadataKeyTotalBytes,
+	}
+	wants := map[string]string{
+		"MetadataKeyHasMore":    "has_more",
+		"MetadataKeyNextOffset": "next_offset",
+		"MetadataKeyNextCursor": "next_cursor",
+		"MetadataKeyTotalBytes": "total_bytes",
+	}
+	for name, got := range cases {
+		if got != wants[name] {
+			t.Errorf("%s = %q, want %q (changing the constant value is a BREAKING wire change)", name, got, wants[name])
+		}
+	}
+}

--- a/agentic/tools.go
+++ b/agentic/tools.go
@@ -39,6 +39,23 @@ type ToolDefinition struct {
 	// non-conforming schema returns 400 from the upstream — caller bug,
 	// not a framework concern.
 	Strict bool `json:"strict,omitempty"`
+
+	// Paginated declares that this tool supports continuation paging via
+	// the agentic.MetadataKey{HasMore,NextOffset,NextCursor} contract.
+	// When true, the executor MUST set MetadataKeyHasMore on every
+	// successful result (bool false for last page, bool true with one
+	// of NextOffset or NextCursor for intermediate pages). The agent
+	// loop reads has_more in buildToolMessages and appends a canonical
+	// continuation hint to the model's next message — telling the
+	// model it can call the same tool again with the supplied
+	// continuation token instead of having to re-narrow blind.
+	//
+	// Informational at the wire level today: the loop branches on the
+	// actual has_more value in result metadata, not on this flag. Future
+	// uses include operator introspection ("which tools paginate?") and
+	// loop-side contract-violation warnings when has_more arrives from
+	// a tool that didn't declare Paginated.
+	Paginated bool `json:"paginated,omitempty"`
 }
 
 // Validate checks if the ToolDefinition is valid
@@ -229,17 +246,118 @@ const (
 	ToolErrorUnknown ToolErrorKind = "unknown"
 )
 
+// ToolResultHint classifies non-error conditions on a SUCCESSFUL tool
+// call where the agent should refine its approach before continuing.
+// It is the structured sibling of ToolErrorKind: ErrorKind classifies
+// errors (the tool failed), Hint classifies successes that returned
+// data the agent should treat as a signal to adjust.
+//
+// Distinct from ToolErrorKind because the call worked — there's
+// nothing to "retry" in the failure sense. The cases are advisory:
+// the model should narrow, broaden, or introspect on the next turn.
+// The agent loop reads Hint in buildToolMessages and prepends a
+// canonical hint line to the model's next message so small/mid-tier
+// models don't have to parse free-form English advice from a
+// successful result body.
+//
+// Pre-2026-05-11, the only in-band signaling pattern was
+// ApprovalRequiredPrefix — a stringly-typed magic-string sniffed off
+// the Error field. ResultHint replaces that pattern's spirit with a
+// typed enum: producers set it directly; consumers branch on the
+// typed value.
+type ToolResultHint string
+
+const (
+	// HintTooLarge means the call returned more data than the executor
+	// or framework permitted and the content was truncated (or the
+	// raw response would have exceeded an internal cap). Action: the
+	// model should narrow its query — add a filter, an entity_id, or
+	// a smaller limit. Composes with the pagination contract
+	// (MetadataKeyHasMore) when both are set: the model gets BOTH
+	// "narrow your query" AND "or continue with cursor=..." in one
+	// shot.
+	HintTooLarge ToolResultHint = "too_large"
+
+	// HintEmpty means the call succeeded with an empty result set
+	// (no entities matched the filter, search returned zero hits).
+	// Action: the model should try a broader filter, drop one of
+	// the predicates, or invoke a different tool to find candidate
+	// entities. Distinct from ToolErrorNotFound — empty results
+	// from a well-formed query is not an error.
+	HintEmpty ToolResultHint = "empty"
+
+	// HintSyntaxError means the tool's query-language parser
+	// rejected the request. Distinct from ToolErrorInvalidArgs —
+	// InvalidArgs is the AGENT's arguments failing JSON-schema
+	// validation at the framework boundary; SyntaxError is the
+	// TOOL's deeper parse of the argument content (e.g. the
+	// graph-query DSL itself rejecting a malformed expression).
+	// Action: the model should call an introspect/help facility
+	// on the tool before retrying with the same shape.
+	HintSyntaxError ToolResultHint = "syntax_error"
+)
+
+// MetadataKeyHasMore is the ToolResult.Metadata key set to a bool true
+// when more pages of results remain after the current call. Always set
+// when an executor opts into pagination (ToolDefinition.Paginated=true);
+// absence on a paginated tool's result is a contract violation worth
+// a Warn log. Mutually paired with either MetadataKeyNextOffset (for
+// byte/index-based paging) or MetadataKeyNextCursor (for opaque-keyset
+// paging) — never both.
+//
+// The agent loop reads this in buildToolMessages and appends a
+// canonical continuation hint to the model's next message so the
+// model knows it can call the same tool again with the supplied
+// continuation token, instead of having to re-narrow blind.
+//
+// Names are unprefixed because they're the canonical wire shape
+// read_loop_result has already shipped under (semspec is already
+// integrated against these strings). Lifting the existing names into
+// constants is the contract semspec asked for — promotion, not
+// rename.
+const MetadataKeyHasMore = "has_more"
+
+// MetadataKeyNextOffset is the ToolResult.Metadata key carrying the
+// byte/index offset to pass back on the next call to continue paging.
+// Use for offset-stable result sources where bytes-from-the-start
+// is meaningful (read_loop_result's byte-paging of a single string
+// is the canonical example). Mutually exclusive with NextCursor.
+const MetadataKeyNextOffset = "next_offset"
+
+// MetadataKeyNextCursor is the ToolResult.Metadata key carrying an
+// opaque server-format-controlled cursor token to pass back on the
+// next call. Use for keyset-paginated result SETS where there is no
+// natural byte offset (graph_search-style result iteration). The
+// agent must never inspect or modify the cursor — server owns the
+// format, so the backend can change encoding without breaking
+// in-flight pagination. Mutually exclusive with NextOffset.
+const MetadataKeyNextCursor = "next_cursor"
+
+// MetadataKeyTotalBytes is the OPTIONAL ToolResult.Metadata key
+// carrying the total result count, when the executor can compute it
+// cheaply (no expensive secondary round-trip). Useful for UIs that
+// want progress bars; not load-bearing for the agent. Absent when
+// the executor can't compute it without extra work.
+//
+// Named `total_bytes` rather than `total_available` to match the
+// existing read_loop_result wire — promotion of the shipped shape,
+// not rename. Executors with non-byte units can set their own
+// unit-specific key and document it; this one is reserved for
+// byte-paging consistency.
+const MetadataKeyTotalBytes = "total_bytes"
+
 // ToolResult represents the result of a tool call
 type ToolResult struct {
-	CallID    string         `json:"call_id"`
-	Name      string         `json:"name,omitempty"` // Tool function name (required by Gemini on tool result messages)
-	Content   string         `json:"content,omitempty"`
-	Error     string         `json:"error,omitempty"`
-	ErrorKind ToolErrorKind  `json:"error_kind,omitempty"` // Structured classification of the failure
-	Metadata  map[string]any `json:"metadata,omitempty"`
-	LoopID    string         `json:"loop_id,omitempty"`
-	TraceID   string         `json:"trace_id,omitempty"`
-	StopLoop  bool           `json:"stop_loop,omitempty"` // Signal loop termination; Content becomes the completion result
+	CallID     string         `json:"call_id"`
+	Name       string         `json:"name,omitempty"` // Tool function name (required by Gemini on tool result messages)
+	Content    string         `json:"content,omitempty"`
+	Error      string         `json:"error,omitempty"`
+	ErrorKind  ToolErrorKind  `json:"error_kind,omitempty"`  // Structured classification of the failure
+	ResultHint ToolResultHint `json:"result_hint,omitempty"` // Structured action recommendation when call worked but agent should refine
+	Metadata   map[string]any `json:"metadata,omitempty"`
+	LoopID     string         `json:"loop_id,omitempty"`
+	TraceID    string         `json:"trace_id,omitempty"`
+	StopLoop   bool           `json:"stop_loop,omitempty"` // Signal loop termination; Content becomes the completion result
 }
 
 // Validate checks if the ToolResult is valid

--- a/docs/concepts/24-tool-result-hints-and-pagination.md
+++ b/docs/concepts/24-tool-result-hints-and-pagination.md
@@ -1,0 +1,245 @@
+# Tool-Result Hints and Pagination
+
+Structured signaling on tool results — how SemStreams tells the agent
+*not just what happened* but *what to do next* when a successful call
+returns data the agent should treat as a refinement signal.
+
+Shipped in beta.63 to close the gap semspec hit on 2026-05-09:
+mid-tier models (qwen3.6-27b, llama-3.3-70b) retried the same
+102KB-overflowing graph query 3+ times because the "use more specific
+queries" advice was buried in a free-form error string the small model
+ignored. Lifting the signal to a typed field — and a documented
+pagination continuation token — gives the loop a structured cue to
+inject at the top of the model's next message, where it's harder to
+miss.
+
+## Two complementary contracts
+
+| Contract | Wire shape | Use when |
+|---|---|---|
+| **ResultHint** | `agentic.ToolResultHint` field on `ToolResult` | The call succeeded but the agent should refine its approach (too-large, empty, syntax-error). |
+| **Pagination** | `MetadataKey{HasMore,NextOffset,NextCursor}` in `ToolResult.Metadata` + `Paginated:true` on `ToolDefinition` | The call returned the first page of a larger result set and the agent can continue. |
+
+The two compose: a paginated tool whose first page exhausted the
+caller's byte budget can return BOTH `ResultHint=HintTooLarge` AND
+`Metadata[MetadataKeyHasMore]=true`. The framework renders both into
+the model's next message — "narrow your query OR continue with
+cursor=…" — and the model picks.
+
+## ResultHint — structured refinement signal
+
+The agent loop's `buildToolMessages` reads `ResultHint` and prepends a
+canonical advice line to the model's next tool-result message:
+
+```
+[hint: too_large] The result was truncated because the response
+exceeded the executor's size cap. Narrow your query — add a more
+specific filter, entity_id, or a smaller limit — before retrying.
+
+<original tool content>
+```
+
+The framework controls the advice text so the phrasing is consistent
+across every executor that signals the same hint. Executors pick the
+enum value, the framework renders the language.
+
+### Enum values
+
+- `HintTooLarge` — the call returned more data than the executor or
+  framework permitted; the content was truncated or rejected. **Action:**
+  narrow the query.
+- `HintEmpty` — the call succeeded with an empty result set (no
+  entities matched, search returned zero hits). **Action:** broaden
+  the filter or try a different tool. Distinct from
+  `ToolErrorNotFound` — empty results from a well-formed query is not
+  an error.
+- `HintSyntaxError` — the tool's query-language parser rejected the
+  request, distinct from `ToolErrorInvalidArgs` (which is the agent's
+  JSON arguments failing the framework's schema validation).
+  **Action:** introspect the tool's syntax before retrying.
+
+### Executor example
+
+```go
+func (e *MyExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agentic.ToolResult, error) {
+    rows, total, err := e.runQuery(ctx, call.Arguments)
+    if err != nil {
+        return agentic.ToolResult{
+            CallID:    call.ID,
+            Error:     err.Error(),
+            ErrorKind: agentic.ToolErrorExternal,
+        }, nil
+    }
+    if len(rows) == 0 {
+        return agentic.ToolResult{
+            CallID:     call.ID,
+            Content:    "[]",
+            ResultHint: agentic.HintEmpty,
+        }, nil
+    }
+    if serialized := serialize(rows); len(serialized) > capLimit {
+        return agentic.ToolResult{
+            CallID:     call.ID,
+            Content:    serialized[:capLimit],
+            ResultHint: agentic.HintTooLarge,
+        }, nil
+    }
+    // ... normal success path
+}
+```
+
+### Composition with `Error`
+
+`ResultHint` and `Error` are NOT mutually exclusive. A tool that fails
+*partway* through and returns partial data can set both — `Error`
+documents the failure, `ResultHint` advises the recovery. The
+framework renders both in order: hint preamble first, then content,
+then (if Content was empty) the error fallback.
+
+### Migration from `ApprovalRequiredPrefix`
+
+The legacy in-band signaling pattern (magic-string prefix on
+`ToolResult.Error` sniffed by `agentic.IsApprovalRequired`) is the
+shape `ResultHint` replaces. New executors should prefer the typed
+field. A future PR will migrate the approval flow itself onto
+`ResultHint=approval_required`, retiring the prefix sniffer.
+
+## Pagination — continuation tokens
+
+The canonical contract is **metadata-only**: a tool that supports
+pagination declares `Paginated:true` on its `ToolDefinition` and
+emits the continuation fields in every successful result's
+`Metadata` map. The agent loop reads `MetadataKeyHasMore` in
+`buildToolMessages` and appends a continuation hint to the model's
+next message when more pages remain:
+
+```
+<tool content>
+
+[pagination: more results available; pass cursor="abc123" to continue]
+```
+
+### Metadata keys
+
+```go
+const (
+    MetadataKeyHasMore       = "has_more"        // bool
+    MetadataKeyNextOffset    = "next_offset"     // int64 — byte/index paging
+    MetadataKeyNextCursor    = "next_cursor"     // string — opaque keyset paging
+    MetadataKeyTotalBytes    = "total_bytes"     // int64 — optional total
+)
+```
+
+`MetadataKeyHasMore` is always set on a paginated tool's result
+(`false` on the last page, `true` otherwise). Exactly one of
+`NextOffset` or `NextCursor` is set on intermediate pages — the choice
+depends on the tool's result-source shape:
+
+- **`NextOffset`** when the source is offset-stable: byte-paging
+  through a single string (`read_loop_result`), index-paging through a
+  list-of-known-length, etc. The agent reads the integer and passes it
+  back as an argument.
+- **`NextCursor`** when the source is a result SET with no natural
+  offset: a keyset-paginated search, a stream of entities by ID order.
+  The cursor is **opaque** — the server controls the format, the agent
+  must never inspect or modify it. Opacity is what allows the backend
+  to change encoding (or evict expired cursors) without breaking
+  in-flight pagination.
+
+### Choosing offset vs cursor
+
+| Property | Offset | Cursor |
+|---|---|---|
+| Source shape | Byte-stable / index-stable | Result set, possibly re-ranked |
+| Agent semantics | Numeric continuation | Opaque token |
+| Backend flexibility | Locked to byte/index ordering | Backend can change encoding |
+| Resumability across rebalances | Stable if source doesn't change | Server can invalidate |
+
+Reach for `NextOffset` when paginating a single piece of bytes;
+`NextCursor` when paginating a result set whose order or membership
+could shift between pages (BM25 ranking changes, new entities
+ingested, etc.).
+
+### Executor example
+
+```go
+func (e *MyExecutor) ListTools() []agentic.ToolDefinition {
+    return []agentic.ToolDefinition{
+        {
+            Name:        "my_search",
+            Description: "Search for entities by predicate.",
+            Paginated:   true,
+            Parameters: map[string]any{
+                "type": "object",
+                "properties": map[string]any{
+                    "predicate": map[string]any{"type": "string"},
+                    "cursor":    map[string]any{"type": "string", "description": "Pagination cursor from a previous call's metadata. Omit on first call."},
+                },
+                "required": []string{"predicate"},
+            },
+        },
+    }
+}
+
+func (e *MyExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agentic.ToolResult, error) {
+    cursor, _ := call.Arguments["cursor"].(string)
+    page, nextCursor, err := e.fetchPage(ctx, call.Arguments["predicate"].(string), cursor)
+    // ... handle err
+    meta := map[string]any{
+        agentic.MetadataKeyHasMore: nextCursor != "",
+    }
+    if nextCursor != "" {
+        meta[agentic.MetadataKeyNextCursor] = nextCursor
+    }
+    return agentic.ToolResult{
+        CallID:   call.ID,
+        Content:  serialize(page),
+        Metadata: meta,
+    }, nil
+}
+```
+
+### `Paginated:true` advertisement
+
+The flag is informational at the wire level today: the agent loop
+branches on the actual `has_more` value in result metadata, not on
+the flag. Future uses:
+
+1. **Operator introspection** — "which tools support pagination?"
+   answered without scraping per-executor source.
+2. **Contract-violation warnings** — the loop can log a Warn when
+   `has_more` arrives from a tool whose definition doesn't declare
+   `Paginated:true`, surfacing executor authors who set the metadata
+   without opting into the contract.
+
+Set the flag when your executor honors the contract; don't set it
+otherwise.
+
+## Reference
+
+- **Field definitions:** `agentic/tools.go` — `ToolResultHint`,
+  `ToolResult.ResultHint`, `ToolDefinition.Paginated`,
+  `MetadataKey{HasMore,NextOffset,NextCursor,TotalBytes}`.
+- **Loop rendering:** `processor/agentic-loop/result_hint.go` —
+  `decorateContentWithHint`, `decorateContentWithPagination`,
+  `hintMessages` text registry.
+- **First in-tree consumer:** `processor/agentic-tools/loop_result.go`
+  — `read_loop_result` declares `Paginated:true` and emits the metadata
+  keys.
+- **Migration target:** `agentic/approval.go` —
+  `ApprovalRequiredPrefix` will move to `ResultHint=approval_required`
+  in a follow-up.
+
+## Why this beats prompt-stanza fixes
+
+Every new failure mode that's handled by prompt engineering grows the
+system prompt by another sentence. Small models drown — prompts
+already crowd out task-specific reasoning, and a single new stanza
+displaces working examples on context-limited deployments. Structural
+signals compose: one hint preamble line works for every flow that
+generates the same `ResultHint`, the framework owns the phrasing, and
+small models pick it up from the top of the message instead of having
+to parse English advice buried in a free-form error string.
+
+The cost is a typed enum value per executor that signals — much
+cheaper than a per-model persona override.

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -1837,6 +1837,20 @@ func hasUserOrAssistantMessage(messages []agentic.ChatMessage) bool {
 // buildToolMessages converts tool results into ChatMessages for the conversation context.
 // Falls back to Error when Content is empty — Gemini rejects tool result messages
 // with no content (400 INVALID_ARGUMENT).
+//
+// Decoration order, when ResultHint and pagination metadata are present:
+//  1. base content (Content or formatted Error fallback or "(empty result)")
+//  2. hint preamble prepended (decorateContentWithHint) — top of message,
+//     so small/mid-tier models pick up the structured cue first
+//  3. pagination continuation appended (decorateContentWithPagination) —
+//     bottom of message, immediately before the next-turn boundary so
+//     the model has the continuation token in close proximity to its
+//     own response decision
+//
+// Composes with the ApprovalRequiredPrefix in-band signaling pattern
+// (which fires before this function via gateForApproval in
+// HandleToolResult). New executors should prefer ResultHint over
+// magic-string sniffing.
 func (h *MessageHandler) buildToolMessages(results []agentic.ToolResult) []agentic.ChatMessage {
 	messages := make([]agentic.ChatMessage, len(results))
 	for i, r := range results {
@@ -1848,6 +1862,8 @@ func (h *MessageHandler) buildToolMessages(results []agentic.ToolResult) []agent
 		if content == "" {
 			content = "(empty result)"
 		}
+		content = decorateContentWithHint(content, r.ResultHint)
+		content = decorateContentWithPagination(content, r.Metadata)
 		name := r.Name
 		if name == "" {
 			name = h.loopManager.GetToolName(r.CallID)

--- a/processor/agentic-loop/result_hint.go
+++ b/processor/agentic-loop/result_hint.go
@@ -1,0 +1,108 @@
+package agenticloop
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// hintMessages maps each ToolResultHint to the canonical English advice
+// the framework injects into the model's next message. Kept in the
+// framework (not the executor) so the phrasing is consistent across
+// every tool that signals the same hint — executors pick the right
+// enum value, the framework renders the text.
+//
+// The text is deliberately imperative and short so small/mid-tier
+// models pick it up at the top of the message. Empirical observation
+// (semspec 2026-05-09): qwen3.6-27b retries the same broad query 3+
+// times when the advice is buried in a free-form error string;
+// hoisting it to a structured preamble is the proposed mitigation.
+//
+// Update with care: changing phrasing changes how every existing flow
+// reacts. Add new hints as new map entries; don't rewrite existing
+// text without a downstream sweep.
+var hintMessages = map[agentic.ToolResultHint]string{
+	agentic.HintTooLarge:    "The result was truncated because the response exceeded the executor's size cap. Narrow your query — add a more specific filter, entity_id, or a smaller limit — before retrying.",
+	agentic.HintEmpty:       "The query succeeded but returned no results. Try a broader filter, drop one of the predicates, or use a different tool to find candidate entities.",
+	agentic.HintSyntaxError: "The tool's query parser rejected your request. Call the tool's introspect/help facility before retrying with the same shape.",
+}
+
+// decorateContentWithHint prepends a canonical hint preamble to the
+// model-facing content when ResultHint is set. Returns content
+// unchanged when no hint applies.
+//
+// Format: `[hint: <kind>] <canonical advice>\n\n<original content>`.
+// The bracketed kind tag is machine-parseable for downstream log
+// scraping or trajectory analytics; the canonical advice is what the
+// model actually reads.
+func decorateContentWithHint(content string, hint agentic.ToolResultHint) string {
+	if hint == "" {
+		return content
+	}
+	advice, ok := hintMessages[hint]
+	if !ok {
+		// Unknown hint kind — fall through to a generic preamble so the
+		// model still sees a structured cue, but log nothing here
+		// because this is the rendering path (any per-hint metrics or
+		// warns live at the consumer site in HandleToolResult).
+		advice = "The tool flagged this result with a non-canonical hint; refine your approach before retrying."
+	}
+	preamble := fmt.Sprintf("[hint: %s] %s", string(hint), advice)
+	if content == "" {
+		return preamble
+	}
+	return preamble + "\n\n" + content
+}
+
+// decorateContentWithPagination appends a canonical continuation hint
+// when the result metadata declares more pages remain. Composes with
+// decorateContentWithHint when both fire on the same ToolResult: the
+// hint preamble lands at the top of the message and the pagination
+// continuation at the bottom.
+//
+// Reads MetadataKeyHasMore (bool); when true, includes either
+// MetadataKeyNextCursor (opaque token, preferred when present) or
+// MetadataKeyNextOffset (byte/index offset). Tools choose ONE of the
+// continuation keys — the framework prefers cursor when both are set
+// (a contract violation, but recover gracefully).
+func decorateContentWithPagination(content string, metadata map[string]any) string {
+	if metadata == nil {
+		return content
+	}
+	hasMore, ok := metadata[agentic.MetadataKeyHasMore].(bool)
+	if !ok || !hasMore {
+		return content
+	}
+
+	var continuation strings.Builder
+	continuation.WriteString("\n\n[pagination: more results available")
+	if cursor, ok := metadata[agentic.MetadataKeyNextCursor].(string); ok && cursor != "" {
+		fmt.Fprintf(&continuation, "; pass cursor=%q to continue", cursor)
+	} else if offset, ok := metadataInt(metadata[agentic.MetadataKeyNextOffset]); ok {
+		fmt.Fprintf(&continuation, "; pass offset=%d to continue", offset)
+	} else {
+		continuation.WriteString("; pass the continuation token from this call's metadata to continue")
+	}
+	continuation.WriteString("]")
+	return content + continuation.String()
+}
+
+// metadataInt extracts an integer from a metadata value, handling the
+// json.Unmarshal-into-map[string]any case where numeric values land as
+// float64. Returns (value, true) on success, (0, false) on a missing
+// or unparseable value.
+func metadataInt(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case float64:
+		return int64(n), true
+	case nil:
+		return 0, false
+	default:
+		return 0, false
+	}
+}

--- a/processor/agentic-loop/result_hint_test.go
+++ b/processor/agentic-loop/result_hint_test.go
@@ -1,0 +1,210 @@
+package agenticloop
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// TestDecorateContentWithHint verifies that the framework prepends a
+// canonical hint preamble when ResultHint is set, and is a no-op
+// otherwise. The preamble must contain the bracketed kind tag so
+// downstream log scraping can match it, plus the canonical advice
+// text from the hintMessages registry.
+func TestDecorateContentWithHint(t *testing.T) {
+	tests := []struct {
+		name             string
+		hint             agentic.ToolResultHint
+		content          string
+		wantContainsKind string
+		wantOriginal     bool
+		wantUnchanged    bool
+	}{
+		{
+			name:          "no hint is a passthrough",
+			hint:          "",
+			content:       "raw tool output",
+			wantUnchanged: true,
+		},
+		{
+			name:             "too_large prepends canonical advice",
+			hint:             agentic.HintTooLarge,
+			content:          "[1, 2, 3]",
+			wantContainsKind: "[hint: too_large]",
+			wantOriginal:     true,
+		},
+		{
+			name:             "empty prepends canonical advice",
+			hint:             agentic.HintEmpty,
+			content:          "[]",
+			wantContainsKind: "[hint: empty]",
+			wantOriginal:     true,
+		},
+		{
+			name:             "syntax_error prepends canonical advice",
+			hint:             agentic.HintSyntaxError,
+			content:          "parse failed at pos 12",
+			wantContainsKind: "[hint: syntax_error]",
+			wantOriginal:     true,
+		},
+		{
+			name:             "unknown hint kind falls through to generic preamble",
+			hint:             agentic.ToolResultHint("not_a_real_hint"),
+			content:          "content",
+			wantContainsKind: "[hint: not_a_real_hint]",
+			wantOriginal:     true,
+		},
+		{
+			name:             "hint on empty content still emits preamble",
+			hint:             agentic.HintEmpty,
+			content:          "",
+			wantContainsKind: "[hint: empty]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decorateContentWithHint(tt.content, tt.hint)
+			if tt.wantUnchanged {
+				if got != tt.content {
+					t.Errorf("expected passthrough, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.wantContainsKind) {
+				t.Errorf("expected kind tag %q in output, got %q", tt.wantContainsKind, got)
+			}
+			if tt.wantOriginal && !strings.Contains(got, tt.content) {
+				t.Errorf("original content lost: %q not found in %q", tt.content, got)
+			}
+		})
+	}
+}
+
+// TestDecorateContentWithPagination verifies the continuation hint is
+// appended when has_more=true, with cursor preferred over offset and
+// graceful fallback when neither is present.
+func TestDecorateContentWithPagination(t *testing.T) {
+	tests := []struct {
+		name          string
+		metadata      map[string]any
+		content       string
+		wantContains  string
+		wantUnchanged bool
+	}{
+		{
+			name:          "nil metadata is passthrough",
+			metadata:      nil,
+			content:       "page content",
+			wantUnchanged: true,
+		},
+		{
+			name:          "empty metadata is passthrough",
+			metadata:      map[string]any{},
+			content:       "page content",
+			wantUnchanged: true,
+		},
+		{
+			name: "has_more=false is passthrough",
+			metadata: map[string]any{
+				agentic.MetadataKeyHasMore:    false,
+				agentic.MetadataKeyNextOffset: 100,
+			},
+			content:       "last page",
+			wantUnchanged: true,
+		},
+		{
+			name: "has_more with cursor renders cursor token",
+			metadata: map[string]any{
+				agentic.MetadataKeyHasMore:    true,
+				agentic.MetadataKeyNextCursor: "abc123",
+			},
+			content:      "page 1",
+			wantContains: `pass cursor="abc123"`,
+		},
+		{
+			name: "has_more with offset (int) renders offset",
+			metadata: map[string]any{
+				agentic.MetadataKeyHasMore:    true,
+				agentic.MetadataKeyNextOffset: 4096,
+			},
+			content:      "page 1",
+			wantContains: "pass offset=4096",
+		},
+		{
+			name: "has_more with offset (float64 from JSON decode) renders offset",
+			metadata: map[string]any{
+				agentic.MetadataKeyHasMore:    true,
+				agentic.MetadataKeyNextOffset: float64(4096),
+			},
+			content:      "page 1",
+			wantContains: "pass offset=4096",
+		},
+		{
+			name: "cursor preferred over offset when both set",
+			metadata: map[string]any{
+				agentic.MetadataKeyHasMore:    true,
+				agentic.MetadataKeyNextCursor: "tok",
+				agentic.MetadataKeyNextOffset: 100,
+			},
+			content:      "page 1",
+			wantContains: `pass cursor="tok"`,
+		},
+		{
+			name: "has_more without continuation token falls through to generic message",
+			metadata: map[string]any{
+				agentic.MetadataKeyHasMore: true,
+			},
+			content:      "page 1",
+			wantContains: "pass the continuation token from this call's metadata",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := decorateContentWithPagination(tt.content, tt.metadata)
+			if tt.wantUnchanged {
+				if got != tt.content {
+					t.Errorf("expected passthrough, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.wantContains) {
+				t.Errorf("expected %q in output, got %q", tt.wantContains, got)
+			}
+			if !strings.Contains(got, tt.content) {
+				t.Errorf("original content lost: %q not found in %q", tt.content, got)
+			}
+			if !strings.Contains(got, "[pagination:") {
+				t.Errorf("missing [pagination: ...] tag in output: %q", got)
+			}
+		})
+	}
+}
+
+// TestDecoration_ComposesHintAndPagination verifies the documented
+// integration shape: hint preamble at top, original content in the
+// middle, pagination continuation at the bottom. semspec's scenario
+// where TooLarge AND has_more both fire on the same result.
+func TestDecoration_ComposesHintAndPagination(t *testing.T) {
+	content := "some result body"
+	withHint := decorateContentWithHint(content, agentic.HintTooLarge)
+	final := decorateContentWithPagination(withHint, map[string]any{
+		agentic.MetadataKeyHasMore:    true,
+		agentic.MetadataKeyNextCursor: "next",
+	})
+
+	// Hint preamble must be at the start
+	if !strings.HasPrefix(final, "[hint: too_large]") {
+		t.Errorf("hint preamble not at start: %q", final)
+	}
+	// Pagination must be at the end
+	if !strings.HasSuffix(final, `[pagination: more results available; pass cursor="next" to continue]`) {
+		t.Errorf("pagination not at end: %q", final)
+	}
+	// Original content sandwiched between
+	if !strings.Contains(final, content) {
+		t.Errorf("original content lost: %q", final)
+	}
+}

--- a/processor/agentic-tools/loop_result.go
+++ b/processor/agentic-tools/loop_result.go
@@ -51,11 +51,18 @@ func NewReadLoopResultExecutor(kv LoopsKVReader) *ReadLoopResultExecutor {
 }
 
 // ListTools describes the read_loop_result tool.
+//
+// Paginated: true declares this tool follows the canonical pagination
+// contract (agentic.MetadataKeyHasMore + MetadataKeyNextOffset). The
+// agent loop reads has_more in buildToolMessages and appends a
+// continuation hint to the model's next message when more pages
+// remain; the executor sets the metadata fields in readLoopResult.
 func (e *ReadLoopResultExecutor) ListTools() []agentic.ToolDefinition {
 	return []agentic.ToolDefinition{
 		{
 			Name:        ReadLoopResultToolName,
 			Description: "Fetch the final Result text a previously completed agent loop produced, so this agent can react to or build on it without having the full content injected into its prompt. Returns a text slice plus role/outcome/completed_at metadata and total_bytes so the caller can page through long results by calling again with a different offset.",
+			Paginated:   true,
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
@@ -139,16 +146,16 @@ func (e *ReadLoopResultExecutor) readLoopResult(ctx context.Context, call agenti
 		CallID:  call.ID,
 		Content: slice,
 		Metadata: map[string]any{
-			"loop_id":        loopID,
-			"role":           event.Role,
-			"outcome":        event.Outcome,
-			"completed_at":   event.CompletedAt,
-			"total_bytes":    total,
-			"returned_bytes": len(slice),
-			"offset":         start,
-			"has_more":       end < total,
-			"next_offset":    end,
-			"task_id":        event.TaskID,
+			"loop_id":                     loopID,
+			"role":                        event.Role,
+			"outcome":                     event.Outcome,
+			"completed_at":                event.CompletedAt,
+			"returned_bytes":              len(slice),
+			"offset":                      start,
+			"task_id":                     event.TaskID,
+			agentic.MetadataKeyHasMore:    end < total,
+			agentic.MetadataKeyNextOffset: end,
+			agentic.MetadataKeyTotalBytes: total,
 		},
 	}, nil
 }


### PR DESCRIPTION
## Summary

Closes the structured-tool-result-signaling gap semspec hit on 2026-05-09. Ships both refined asks from the v2 research brief (`project_research_tool_paging_caps_2026_05_09_v2.md`).

## Ask 1 — ResultHint sibling to ErrorKind

New `agentic.ToolResultHint` typed enum (`too_large`, `empty`, `syntax_error`) + `ToolResult.ResultHint` field. Sibling to existing `ErrorKind`: ErrorKind classifies errors (tool failed), Hint classifies successes that returned data the agent should treat as a refinement signal.

The agent loop reads `ResultHint` in `buildToolMessages` and prepends a canonical advice line from a framework-controlled hintMessages registry:

```
[hint: too_large] The result was truncated because the response exceeded
the executor's size cap. Narrow your query — add a more specific filter,
entity_id, or a smaller limit — before retrying.

<original tool content>
```

The bracketed kind tag is machine-parseable for log scraping; the canonical advice is what the model reads. Framework owns the phrasing so it's consistent across every executor that signals the same hint.

Composes with `Error`: NOT mutually exclusive on the wire. A tool that fails partway through and returns partial data can set both.

## Ask 2 — canonical PaginatedMetadata contract

Four `MetadataKey*` constants lifting the existing `read_loop_result` wire shape into the documented contract:

```go
MetadataKeyHasMore    = "has_more"     // bool
MetadataKeyNextOffset = "next_offset"  // int — byte/index paging
MetadataKeyNextCursor = "next_cursor"  // string — opaque keyset paging
MetadataKeyTotalBytes = "total_bytes"  // int — optional total
```

Names are unprefixed because they're the canonical wire shape `read_loop_result` already shipped under (semspec is integrated against these exact strings). **Promotion of the shipped shape, not rename.**

New `ToolDefinition.Paginated bool` flag for executor self-declaration. Loop appends a continuation hint to the model's next message when `has_more=true`:

```
<tool content>

[pagination: more results available; pass cursor="abc123" to continue]
```

Cursor preferred over offset when both are set; graceful fallback to generic continuation message when neither is present.

## Composition

semspec's documented scenario where `HintTooLarge` AND `has_more` both fire on the same result: hint preamble at top, original content in the middle, pagination continuation at the bottom. The model gets BOTH "narrow your query" AND "or continue with cursor=…" in one shot. `TestDecoration_ComposesHintAndPagination` asserts the exact order.

## First in-tree consumer

`processor/agentic-tools/loop_result.go` migrates from string literals to the new constants and sets `Paginated:true` in `ListTools()`. Existing `read_loop_result_test.go` passes unchanged — wire-format strings are identical to what shipped.

## Behavior changes for downstreams

- **read_loop_result wire format**: unchanged. semspec's existing integration breaks nothing.
- **Every executor**: gains a typed slot for signaling refinement hints (ResultHint) and a typed flag for declaring pagination support (Paginated). Both opt-in.
- **Agent loop**: when ResultHint is set on any incoming tool result, the model sees a structured `[hint: kind]` preamble at top of its next message. When `has_more=true`, the model sees a `[pagination: ...]` continuation at the bottom. New observable output but no breaking semantic change.

**Behaviorally additive in every dimension; nothing previously working breaks.**

## Test plan

- [x] `task lint` clean (revive, vet, fmt)
- [x] `go test -race ./...` full suite green (incl. 19 new test cases — 4 JSON-roundtrip tests on agentic + 15 decoration tests on agentic-loop)
- [x] `go vet -tags=integration ./...` clean
- [x] `go vet -tags=live_llm ./...` clean
- [x] `task schema:generate` diff empty
- [x] `task e2e:agentic` green (15.83s, 3 loops, 2 tool executions, 14 graph_loop_triples + 5 graph_model_triples — same shape as beta.58 baseline, no observable latency hit from decoration helpers)
- [x] First in-tree consumer (`read_loop_result`) wired and validated by its existing test
- [ ] semspec to confirm `graph_search` integration against the new contract (their work)

## Doc

`docs/concepts/24-tool-result-hints-and-pagination.md` — both contracts with executor examples, offset-vs-cursor decision matrix, cursor-opacity invariant, ApprovalRequiredPrefix migration note.

## Follow-ups

- Migrate `ApprovalRequiredPrefix` magic-string sniffer to `ResultHint=approval_required` — retires the two-patterns-for-the-same-problem inconsistency.
- Operator introspection: surface `ToolDefinition.Paginated` in tool catalog UIs.
- Contract-violation warnings: log Warn when `has_more` arrives from a tool whose definition doesn't declare `Paginated:true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)