### PR TITLE
graphSummary + searchGraph GraphQL resolvers (gateway-first step 1/4)

### DIFF
--- a/gateway/graph-gateway/component.go
+++ b/gateway/graph-gateway/component.go
@@ -850,6 +850,19 @@ func (c *Component) mapGraphQLQueryToNATSSubject(query string) string {
 		return "graph.query.capabilities"
 	}
 
+	// Composite resolvers — match before their lower-level primitives
+	// so the dedicated subject wins. Convention: most specific first
+	// (mirrors the localsearch-before-globalsearch ordering below).
+	// graphSummary is a composite over predicates + prefix; searchGraph
+	// is a composite over globalSearch + semantic fallback. Both must
+	// match before the generic terms further down.
+	if strings.Contains(query, "graphsummary") {
+		return "graph.query.summary"
+	}
+	if strings.Contains(query, "searchgraph") {
+		return "graph.query.searchGraph"
+	}
+
 	// GraphRAG search patterns - must come before generic "entity" check
 	if strings.Contains(query, "localsearch") {
 		return "graph.query.localSearch"
@@ -909,6 +922,10 @@ func (c *Component) subjectToGraphQLField(subject string) string {
 		return "localSearch"
 	case "graph.query.globalSearch":
 		return "globalSearch"
+	case "graph.query.summary":
+		return "graphSummary"
+	case "graph.query.searchGraph":
+		return "searchGraph"
 	case "graph.index.query.predicate":
 		return "entitiesByPredicate"
 	case "graph.index.query.predicateList":
@@ -950,6 +967,13 @@ func (c *Component) transformVariablesToNATSPayload(variables map[string]interfa
 	case "graph.query.localSearch":
 		return c.transformLocalSearchVars(variables)
 	case "graph.query.globalSearch":
+		return c.transformGlobalSearchVars(variables)
+	case "graph.query.summary":
+		return extractVars(variables, "include_predicates", "entity_sample_limit", "examples_per_type")
+	case "graph.query.searchGraph":
+		// Same arg shape as globalSearch — searchGraph is a server-side
+		// composite over it. Reuse the existing transformer to keep the
+		// arg surface in sync without code duplication.
 		return c.transformGlobalSearchVars(variables)
 	case "graph.index.query.predicate":
 		return extractVars(variables, "predicate", "value", "limit")
@@ -1508,6 +1532,10 @@ func buildIntrospectionSchema() map[string]interface{} {
 					fieldDef("predicates", "PredicateListResult"),
 					fieldDef("predicateStats", "PredicateStatsResult", argDef("predicate", "String!"), argDef("sampleLimit", "Int")),
 					fieldDef("compoundPredicateQuery", "CompoundPredicateResult", argDef("predicates", "[String!]!"), argDef("operator", "String!"), argDef("limit", "Int")),
+					// Composite discovery resolver — entity-type distribution + predicate counts + example IDs.
+					fieldDef("graphSummary", "GraphSummaryResult", argDef("include_predicates", "Boolean"), argDef("entity_sample_limit", "Int"), argDef("examples_per_type", "Int")),
+					// searchGraph — wraps globalSearch with a server-side semantic fallback when GraphRAG returns empty.
+					fieldDef("searchGraph", "GlobalSearchResult", argDef("query", "String!"), argDef("level", "Int"), argDef("maxCommunities", "Int"), argDef("summarizeThreshold", "Int"), argDef("includeSummaries", "Boolean"), argDef("includeRelationships", "Boolean"), argDef("includeSources", "Boolean")),
 				},
 			},
 			typeDef("OBJECT", "Entity", "id", "triples"),
@@ -1527,6 +1555,9 @@ func buildIntrospectionSchema() map[string]interface{} {
 			typeDef("OBJECT", "PredicateListResult", "predicates", "total"),
 			typeDef("OBJECT", "PredicateStatsResult", "predicate", "entityCount", "sampleEntities"),
 			typeDef("OBJECT", "CompoundPredicateResult", "entities", "operator", "matched"),
+			// Graph summary types
+			typeDef("OBJECT", "GraphSummaryResult", "total_entities", "entity_sample_truncated", "entity_types", "predicates", "predicate_total"),
+			typeDef("OBJECT", "EntityTypeSummary", "type", "count", "examples"),
 			// Agentic types
 			typeDef("OBJECT", "Trajectory", "loopId", "startTime", "endTime", "steps", "outcome", "totalTokensIn", "totalTokensOut", "duration"),
 			typeDef("OBJECT", "TrajectoryStep", "timestamp", "stepType", "requestId", "prompt", "response", "tokensIn", "tokensOut", "toolName", "toolResult", "duration"),

--- a/gateway/graph-gateway/query_test.go
+++ b/gateway/graph-gateway/query_test.go
@@ -197,6 +197,126 @@ func TestGateway_MapGraphQLToNATSSubject_Unknown(t *testing.T) {
 	}
 }
 
+// TestGateway_MapGraphQLToNATSSubject_GraphSummary covers the composite
+// discovery resolver added 2026-05-12. The mapping uses a "graphsummary"
+// substring match positioned BEFORE the generic "entity" / "predicates"
+// fallbacks so the dedicated subject wins.
+func TestGateway_MapGraphQLToNATSSubject_GraphSummary(t *testing.T) {
+	comp := createTestGateway(t)
+
+	tests := []struct {
+		name            string
+		query           string
+		expectedSubject string
+	}{
+		{
+			name:            "graphSummary no-args",
+			query:           `query { graphSummary { total_entities entity_types { type count } } }`,
+			expectedSubject: "graph.query.summary",
+		},
+		{
+			name:            "graphSummary with include_predicates arg",
+			query:           `query { graphSummary(include_predicates: false) { total_entities } }`,
+			expectedSubject: "graph.query.summary",
+		},
+		{
+			name:            "graphSummary lowercase variant",
+			query:           `{ graphsummary { total_entities } }`,
+			expectedSubject: "graph.query.summary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subject := comp.mapGraphQLQueryToNATSSubject(tt.query)
+			assert.Equal(t, tt.expectedSubject, subject)
+		})
+	}
+}
+
+// TestGateway_SubjectToGraphQLField_GraphSummary confirms the inverse
+// mapping — when graph-query responds to graph.query.summary, the
+// gateway wraps the payload under the "graphSummary" GraphQL field.
+func TestGateway_SubjectToGraphQLField_GraphSummary(t *testing.T) {
+	comp := createTestGateway(t)
+	assert.Equal(t, "graphSummary", comp.subjectToGraphQLField("graph.query.summary"))
+}
+
+// TestGateway_TransformVariables_GraphSummary verifies the three V1
+// fields land in the NATS payload (and unrelated variables are dropped
+// per the extractVars convention).
+func TestGateway_TransformVariables_GraphSummary(t *testing.T) {
+	comp := createTestGateway(t)
+	vars := map[string]any{
+		"include_predicates":  false,
+		"entity_sample_limit": 500,
+		"examples_per_type":   3,
+		"unrelated":           "ignored",
+	}
+	payload := comp.transformVariablesToNATSPayload(vars, "graph.query.summary")
+	assert.Equal(t, false, payload["include_predicates"])
+	assert.Equal(t, 500, payload["entity_sample_limit"])
+	assert.Equal(t, 3, payload["examples_per_type"])
+	_, hasUnrelated := payload["unrelated"]
+	assert.False(t, hasUnrelated, "extractVars should drop variables not in the allowlist")
+}
+
+// TestGateway_MapGraphQLToNATSSubject_SearchGraph covers the searchGraph
+// keyword routing. Important corner: "searchgraph" must match BEFORE
+// "globalsearch" so the dedicated subject wins when an agent's query
+// references both terms.
+func TestGateway_MapGraphQLToNATSSubject_SearchGraph(t *testing.T) {
+	comp := createTestGateway(t)
+	tests := []struct {
+		name            string
+		query           string
+		expectedSubject string
+	}{
+		{
+			name:            "searchGraph simple call",
+			query:           `query { searchGraph(query: "auth flow") { count entity_digests { id } } }`,
+			expectedSubject: "graph.query.searchGraph",
+		},
+		{
+			name:            "searchGraph alongside word globalsearch in comment",
+			query:           `# also try globalsearch later` + "\n" + `{ searchGraph(query: "x") { count } }`,
+			expectedSubject: "graph.query.searchGraph",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subject := comp.mapGraphQLQueryToNATSSubject(tt.query)
+			assert.Equal(t, tt.expectedSubject, subject)
+		})
+	}
+}
+
+// TestGateway_SubjectToGraphQLField_SearchGraph confirms the response
+// wraps under the GraphQL "searchGraph" field.
+func TestGateway_SubjectToGraphQLField_SearchGraph(t *testing.T) {
+	comp := createTestGateway(t)
+	assert.Equal(t, "searchGraph", comp.subjectToGraphQLField("graph.query.searchGraph"))
+}
+
+// TestGateway_TransformVariables_SearchGraph confirms searchGraph
+// reuses the globalSearch variable transformer so the arg surface
+// stays in sync — the server-side handler is a composite over
+// globalSearch and expects identical request shape.
+func TestGateway_TransformVariables_SearchGraph(t *testing.T) {
+	comp := createTestGateway(t)
+	vars := map[string]any{
+		"query":          "auth flow",
+		"level":          float64(2),
+		"maxCommunities": float64(5),
+	}
+	payload := comp.transformVariablesToNATSPayload(vars, "graph.query.searchGraph")
+	assert.Equal(t, "auth flow", payload["query"])
+	// Should match transformGlobalSearchVars output for the same input —
+	// any divergence indicates the searchGraph case stopped delegating.
+	expected := comp.transformVariablesToNATSPayload(vars, "graph.query.globalSearch")
+	assert.Equal(t, expected, payload)
+}
+
 // ====================================================================================
 // Request Forwarding Tests
 // ====================================================================================

--- a/graph/query_summary_types.go
+++ b/graph/query_summary_types.go
@@ -1,0 +1,101 @@
+// Package graph provides graph summary query data types.
+package graph
+
+// --- Graph Summary Query Types ---
+//
+// GraphSummary is the composite "what's in this graph" overview a
+// caller (LLM agent or external dashboard) gets without knowing any
+// entity IDs up-front. Solves the discovery chicken-and-egg problem:
+// query_entity / query_relationships all need known IDs to start;
+// graphSummary tells the caller which IDs and predicates are worth
+// knowing.
+//
+// Composed server-side from existing primitives (entity prefix scan
+// for type distribution, predicate-list index for predicate counts).
+// Source distribution (Triple.Source aggregation) is deliberately
+// deferred to V2 — computing it requires a write-time index or a
+// full triple walk, neither of which fits a V1 budget; see the
+// project_graph_tools_gateway_first_plan memory.
+
+// SummaryRequest is the request shape for the graph summary
+// query. Both fields are optional with sensible V1 defaults.
+type SummaryRequest struct {
+	// IncludePredicates toggles the predicate counts section.
+	// Defaults to true. Setting false is useful when the caller
+	// already has the predicate list cached or when the response
+	// would otherwise exceed the gateway's body budget at large
+	// scales.
+	IncludePredicates bool `json:"include_predicates"`
+
+	// EntitySampleLimit caps how many entity IDs the type-distribution
+	// aggregation walks. Defaults to 2000. The resulting type counts
+	// are approximate when the scan is truncated; the response sets
+	// EntitySampleTruncated=true and TotalEntities reflects what was
+	// scanned, not what the graph holds. V2 candidates: write-time
+	// type-count index for exact counts.
+	EntitySampleLimit int `json:"entity_sample_limit"`
+
+	// ExamplesPerType caps how many sample entity IDs to retain per
+	// type bucket in the response. Defaults to 2. Example IDs are
+	// load-bearing for the discovery use case (semspec's bug log
+	// confirms models invent IDs when no examples are provided);
+	// keep this >= 1.
+	ExamplesPerType int `json:"examples_per_type"`
+}
+
+// EntityTypeSummary represents one entity-type bucket — entities
+// grouped by their 6-part ID's domain.system.type segments (parts
+// 3.4.5 in 1-indexed terms; parts 2-4 in 0-indexed slice terms).
+//
+// Examples in this codebase:
+//
+//	acme.platform1.agent.agentic-loop.execution.<loopID>
+//	→ type "agent.agentic-loop.execution"
+//
+//	acme.platform1.agent.web.observation.<hash>
+//	→ type "agent.web.observation"
+type EntityTypeSummary struct {
+	// Type is the domain.system.type triple — the bucket name.
+	Type string `json:"type"`
+
+	// Count is how many entities in the scanned sample fall in this
+	// bucket. Approximate when EntitySampleTruncated is set on the
+	// parent SummaryData.
+	Count int `json:"count"`
+
+	// Examples is up to ExamplesPerType real entity IDs from this
+	// bucket. The caller uses these as starting points for
+	// query_entity / query_relationships without having to invent IDs.
+	Examples []string `json:"examples"`
+}
+
+// SummaryData is the composite response. Caller-friendly text
+// formatting happens at the tool-wrapper layer (agent tools / future
+// MCP); this shape stays structured for non-LLM consumers (dashboards,
+// audit, programmatic clients).
+type SummaryData struct {
+	// TotalEntities is the count of entities actually scanned (= sum
+	// of EntityTypes counts). When EntitySampleTruncated is true,
+	// the underlying graph holds more than this.
+	TotalEntities int `json:"total_entities"`
+
+	// EntitySampleTruncated is true when the entity scan hit
+	// EntitySampleLimit before draining the bucket. The TotalEntities
+	// and per-type counts are then approximate.
+	EntitySampleTruncated bool `json:"entity_sample_truncated"`
+
+	// EntityTypes is the sorted (highest-count-first) list of type
+	// buckets discovered in the scanned sample.
+	EntityTypes []EntityTypeSummary `json:"entity_types"`
+
+	// Predicates is populated when IncludePredicates is true (default).
+	// Each entry mirrors PredicateSummary — predicate name + the
+	// entity count from the predicate index. Counts here are exact
+	// (the predicate index maintains them at write time); they do
+	// NOT inherit the entity-scan truncation.
+	Predicates []PredicateSummary `json:"predicates,omitempty"`
+
+	// PredicateTotal is len(Predicates). Convenience for callers
+	// formatting "N predicates registered" lines.
+	PredicateTotal int `json:"predicate_total,omitempty"`
+}

--- a/processor/graph-query/query.go
+++ b/processor/graph-query/query.go
@@ -15,85 +15,47 @@ import (
 
 // setupQueryHandlers subscribes to all query request subjects
 func (c *Component) setupQueryHandlers(ctx context.Context) error {
-	// Subscribe to entity query passthrough
-	sub, err := c.natsClient.SubscribeForRequests(ctx, "graph.query.entity", c.handleQueryEntity)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to entity query")
+	// Table-driven registration: each row is a NATS subject + its
+	// handler. Keeping this as a table rather than 12 inline blocks
+	// lets the function stay under the revive function-length cap
+	// AND makes the "what subjects this component owns" surface
+	// scannable at a glance. Order is preserved across iterations so
+	// the slog.Info call below reports subjects in declaration order.
+	type subRegistration struct {
+		subject string
+		handler func(ctx context.Context, data []byte) ([]byte, error)
 	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
-
-	// Subscribe to entity by alias query (resolves alias then fetches entity)
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.entityByAlias", c.handleQueryEntityByAlias)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to entityByAlias query")
+	registrations := []subRegistration{
+		{"graph.query.entity", c.handleQueryEntity},
+		{"graph.query.entityByAlias", c.handleQueryEntityByAlias},
+		{"graph.query.relationships", c.handleQueryRelationships},
+		{"graph.query.pathSearch", c.handlePathSearch},
+		{"graph.query.hierarchyStats", c.handleQueryHierarchyStats},
+		{"graph.query.prefix", c.handleQueryPrefix},
+		{"graph.query.spatial", c.handleQuerySpatial},
+		{"graph.query.temporal", c.handleQueryTemporal},
+		{"graph.query.semantic", c.handleQuerySemantic},
+		{"graph.query.similar", c.handleQuerySimilar},
+		{"graph.query.globalSearch", c.handleGlobalSearch},
+		// graphSummary — composite discovery resolver (fans out to
+		// graph.ingest.query.prefix + graph.index.query.predicateList).
+		{"graph.query.summary", c.handleQueryGraphSummary},
+		// searchGraph — wraps globalSearch with a semantic fallback
+		// when GraphRAG strategies return empty.
+		{"graph.query.searchGraph", c.handleSearchGraph},
 	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
 
-	// Subscribe to relationships query passthrough
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.relationships", c.handleQueryRelationships)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to relationships query")
+	subjects := make([]string, 0, len(registrations))
+	for _, r := range registrations {
+		sub, err := c.natsClient.SubscribeForRequests(ctx, r.subject, r.handler)
+		if err != nil {
+			return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to "+r.subject)
+		}
+		c.querySubscriptions = append(c.querySubscriptions, sub)
+		subjects = append(subjects, r.subject)
 	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
 
-	// Subscribe to path search orchestration
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.pathSearch", c.handlePathSearch)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to path search")
-	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
-
-	// Subscribe to hierarchy stats (orchestrates prefix query to graph-ingest)
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.hierarchyStats", c.handleQueryHierarchyStats)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to hierarchy stats")
-	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
-
-	// Subscribe to prefix query (passthrough to graph-ingest)
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.prefix", c.handleQueryPrefix)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to prefix query")
-	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
-
-	// Subscribe to spatial query passthrough
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.spatial", c.handleQuerySpatial)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to spatial query")
-	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
-
-	// Subscribe to temporal query passthrough
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.temporal", c.handleQueryTemporal)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to temporal query")
-	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
-
-	// Subscribe to semantic search (passthrough to graph-embedding)
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.semantic", c.handleQuerySemantic)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to semantic query")
-	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
-
-	// Subscribe to similar entity search (passthrough to graph-embedding)
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.similar", c.handleQuerySimilar)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to similar query")
-	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
-
-	// Subscribe to globalSearch - the main NL query handler with classifier routing
-	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.query.globalSearch", c.handleGlobalSearch)
-	if err != nil {
-		return errs.WrapTransient(err, "GraphQuery", "setupQueryHandlers", "subscribe to globalSearch query")
-	}
-	c.querySubscriptions = append(c.querySubscriptions, sub)
-
-	c.logger.Info("query handlers registered",
-		"subjects", []string{"graph.query.entity", "graph.query.entityByAlias", "graph.query.relationships", "graph.query.pathSearch", "graph.query.hierarchyStats", "graph.query.prefix", "graph.query.spatial", "graph.query.temporal", "graph.query.semantic", "graph.query.similar", "graph.query.globalSearch"})
+	c.logger.Info("query handlers registered", "subjects", subjects)
 
 	return nil
 }

--- a/processor/graph-query/searchgraph.go
+++ b/processor/graph-query/searchgraph.go
@@ -4,7 +4,6 @@ package graphquery
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"github.com/c360studio/semstreams/pkg/errs"
 )
@@ -96,7 +95,7 @@ func (c *Component) handleSearchGraph(ctx context.Context, data []byte) ([]byte,
 	// per the existing graph-embedding contract; we map entries to
 	// EntityDigest so existing callers reading the digest list keep
 	// working.
-	out := adaptSemanticToGlobalSearchResponse(semanticResp, origReq.Query, time.Since(time.Now()))
+	out := adaptSemanticToGlobalSearchResponse(semanticResp)
 	if out == nil || len(out.EntityDigests) == 0 {
 		// Fallback found nothing either — return the original empty
 		// globalSearch payload so the caller has uniform structure.
@@ -159,7 +158,11 @@ type semanticEnvelope struct {
 // markers indicating the fallback fired. Returns nil if the input
 // is unparseable or empty (callers fall back to the original empty
 // globalSearch payload).
-func adaptSemanticToGlobalSearchResponse(data []byte, query string, _ time.Duration) *GlobalSearchResponse {
+//
+// The Answer field is intentionally omitted: the fallback is a
+// last-resort discovery surface, not a synthesis path. Downstream
+// callers that want narrative output answer-synthesize on their own.
+func adaptSemanticToGlobalSearchResponse(data []byte) *GlobalSearchResponse {
 	var env semanticEnvelope
 	if err := json.Unmarshal(data, &env); err != nil || len(env.SimilaritySearch.Results) == 0 {
 		return nil
@@ -177,16 +180,11 @@ func adaptSemanticToGlobalSearchResponse(data []byte, query string, _ time.Durat
 	if len(digests) == 0 {
 		return nil
 	}
-	reason := "global_search_empty_semantic_fallback"
-	// Answer omitted on the fallback path — the fallback is a
-	// last-resort discovery surface; downstream callers can
-	// answer-synthesize on their own if they want narrative output.
-	_ = query // arg reserved for future per-query annotation; kept named for godoc clarity
 	return &GlobalSearchResponse{
 		Strategy:       searchGraphStrategySemanticFallback,
 		EntityDigests:  digests,
 		Count:          len(digests),
 		Degraded:       true,
-		DegradedReason: reason,
+		DegradedReason: "global_search_empty_semantic_fallback",
 	}
 }

--- a/processor/graph-query/searchgraph.go
+++ b/processor/graph-query/searchgraph.go
@@ -1,0 +1,192 @@
+// Package graphquery — searchGraph handler.
+package graphquery
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+const (
+	// searchGraphSemanticFallbackLimit caps the semantic fallback's
+	// result count. Matches semspec's empirical V1 value (semspec's
+	// tools/workflow/graph.go:semanticSearchFallback hardcoded 8 —
+	// "enough for the agent to choose a few good entities to graph_query
+	// into without flooding the response").
+	searchGraphSemanticFallbackLimit = 8
+
+	// searchGraphStrategySemanticFallback is the Strategy field value
+	// on the synthesized response when the semantic fallback fires.
+	// Distinct from globalSearch's existing strategy names so callers
+	// can filter dashboards on it and operators see "fallback fired N
+	// times" in graph telemetry.
+	searchGraphStrategySemanticFallback = "semantic_fallback"
+)
+
+// handleSearchGraph is the canonical "find me stuff" entry point for
+// agents and external callers. It composes:
+//
+//  1. handleGlobalSearch (GraphRAG path: classifier → strategy → tier-1
+//     semantic → tier-2 text-based community).
+//  2. When that returns an empty response (no entities, no digests,
+//     no community summaries, no count), fall back to a direct
+//     semantic similarity search.
+//
+// The fallback closes the gap semspec discovered empirically (their
+// tools/workflow/graph.go:semanticSearchFallback): some classifier-
+// routed strategies (entity_lookup, pathrag, spatial, temporal) can
+// return empty even when a direct semantic search would find on-topic
+// matches. Moving the fallback server-side means every caller —
+// agent tools, MCP, external apps — gets the same degraded-but-useful
+// behavior without re-implementing the logic.
+//
+// Response shape is always GlobalSearchResponse so callers don't need
+// to special-case the fallback path. When the fallback fires:
+//
+//   - Strategy = "semantic_fallback"
+//   - Degraded = true
+//   - DegradedReason = "global_search_empty_semantic_fallback"
+//
+// Callers can drive UI/persona behavior off Strategy or simply read
+// the entity_digests as usual.
+func (c *Component) handleSearchGraph(ctx context.Context, data []byte) ([]byte, error) {
+	// 1) Always try globalSearch first. It owns query classification
+	// and strategy routing; we don't second-guess.
+	globalResp, err := c.handleGlobalSearch(ctx, data)
+	if err != nil {
+		// Hard transport / parse errors propagate. The fallback is
+		// for empty-but-successful responses, not for failures.
+		return nil, err
+	}
+
+	if !searchGraphResponseEmpty(globalResp) {
+		return globalResp, nil
+	}
+
+	// 2) Empty result — synthesize a fallback request and call the
+	// semantic search path directly.
+	var origReq GlobalSearchRequest
+	if err := json.Unmarshal(data, &origReq); err != nil {
+		// If we can't parse the original request we can't fall back;
+		// return the empty-but-valid globalSearch response so the
+		// caller at least sees the structured zero result.
+		return globalResp, nil
+	}
+
+	semanticPayload, marshalErr := json.Marshal(map[string]any{
+		"query": origReq.Query,
+		"limit": searchGraphSemanticFallbackLimit,
+	})
+	if marshalErr != nil {
+		// Same defensive posture: prefer returning the empty
+		// globalSearch payload over failing the whole call.
+		return globalResp, nil
+	}
+
+	semanticResp, semanticErr := c.handleQuerySemantic(ctx, semanticPayload)
+	if semanticErr != nil {
+		c.recordError(semanticErr)
+		return globalResp, nil
+	}
+
+	// 3) Adapt the semantic response into a GlobalSearchResponse shape.
+	// The semantic backend returns {"results": [{"entity_id", "similarity"}], ...}
+	// per the existing graph-embedding contract; we map entries to
+	// EntityDigest so existing callers reading the digest list keep
+	// working.
+	out := adaptSemanticToGlobalSearchResponse(semanticResp, origReq.Query, time.Since(time.Now()))
+	if out == nil || len(out.EntityDigests) == 0 {
+		// Fallback found nothing either — return the original empty
+		// globalSearch payload so the caller has uniform structure.
+		return globalResp, nil
+	}
+
+	respBytes, err := json.Marshal(out)
+	if err != nil {
+		// Marshal failure is genuinely exceptional — surface it.
+		return nil, errs.Wrap(err, "GraphQuery", "handleSearchGraph", "marshal fallback response")
+	}
+	return respBytes, nil
+}
+
+// searchGraphResponseEmpty mirrors semspec's globalSearchEmpty
+// detection: a GlobalSearchResponse is "empty" when no facet has
+// content. Defensive against missing/malformed JSON — treats any
+// parse failure as non-empty so a half-decoded response doesn't
+// trigger a redundant fallback call.
+func searchGraphResponseEmpty(data []byte) bool {
+	var resp GlobalSearchResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return false
+	}
+	if resp.Count > 0 {
+		return false
+	}
+	if len(resp.Entities) > 0 {
+		return false
+	}
+	if len(resp.EntityDigests) > 0 {
+		return false
+	}
+	if len(resp.CommunitySummaries) > 0 {
+		return false
+	}
+	return true
+}
+
+// semanticHit is the per-result row from the graph-embedding
+// similaritySearch envelope. Kept local because the envelope is
+// internal to the embedding contract; lifting it would entangle
+// packages.
+type semanticHit struct {
+	EntityID   string  `json:"entity_id"`
+	Similarity float64 `json:"similarity"`
+}
+
+// semanticEnvelope is the response shape graph-embedding returns from
+// the semantic search path. Same wire shape semspec's client-side
+// fallback parsed (tools/workflow/graph.go:semanticSearchFallback).
+type semanticEnvelope struct {
+	SimilaritySearch struct {
+		Results []semanticHit `json:"results"`
+	} `json:"similaritySearch"`
+}
+
+// adaptSemanticToGlobalSearchResponse turns a raw semantic-search
+// response into a GlobalSearchResponse with Strategy and Degraded
+// markers indicating the fallback fired. Returns nil if the input
+// is unparseable or empty (callers fall back to the original empty
+// globalSearch payload).
+func adaptSemanticToGlobalSearchResponse(data []byte, query string, _ time.Duration) *GlobalSearchResponse {
+	var env semanticEnvelope
+	if err := json.Unmarshal(data, &env); err != nil || len(env.SimilaritySearch.Results) == 0 {
+		return nil
+	}
+	digests := make([]EntityDigest, 0, len(env.SimilaritySearch.Results))
+	for _, hit := range env.SimilaritySearch.Results {
+		if hit.EntityID == "" {
+			continue
+		}
+		digests = append(digests, EntityDigest{
+			ID:        hit.EntityID,
+			Relevance: hit.Similarity,
+		})
+	}
+	if len(digests) == 0 {
+		return nil
+	}
+	reason := "global_search_empty_semantic_fallback"
+	// Answer omitted on the fallback path — the fallback is a
+	// last-resort discovery surface; downstream callers can
+	// answer-synthesize on their own if they want narrative output.
+	_ = query // arg reserved for future per-query annotation; kept named for godoc clarity
+	return &GlobalSearchResponse{
+		Strategy:       searchGraphStrategySemanticFallback,
+		EntityDigests:  digests,
+		Count:          len(digests),
+		Degraded:       true,
+		DegradedReason: reason,
+	}
+}

--- a/processor/graph-query/searchgraph_test.go
+++ b/processor/graph-query/searchgraph_test.go
@@ -1,8 +1,11 @@
 package graphquery
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"testing"
+	"time"
 )
 
 // TestSearchGraphResponseEmpty covers the empty-detection predicate
@@ -69,7 +72,7 @@ func TestAdaptSemanticToGlobalSearchResponse_HappyPath(t *testing.T) {
 		{"entity_id":"acme.x.agent.web.observation.h2","similarity":0.71}
 	]}}`)
 
-	got := adaptSemanticToGlobalSearchResponse(semanticPayload, "what do we know", 0)
+	got := adaptSemanticToGlobalSearchResponse(semanticPayload)
 	if got == nil {
 		t.Fatalf("expected non-nil adapted response")
 	}
@@ -108,9 +111,36 @@ func TestAdaptSemanticToGlobalSearchResponse_EmptyReturnsNil(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := adaptSemanticToGlobalSearchResponse([]byte(tt.body), "q", 0); got != nil {
+			if got := adaptSemanticToGlobalSearchResponse([]byte(tt.body)); got != nil {
 				t.Errorf("expected nil, got %+v", got)
 			}
 		})
+	}
+}
+
+// TestHandleSearchGraph_InvalidRequestPropagates confirms invalid-
+// input errors from handleGlobalSearch (unmarshal failure, empty
+// query) propagate through handleSearchGraph unchanged. The fallback
+// path is for empty-but-successful responses, not for caller bugs;
+// surfacing the error lets the caller fix the request rather than
+// silently triggering a redundant semantic search.
+//
+// A full end-to-end test of the empty→fallback path requires
+// distinguishing globalSearch's INTERNAL semantic call (graphrag
+// Tier 1) from the OUTER semantic fallback — both hit the same NATS
+// subject so they're indistinguishable at the mock layer. The
+// fallback logic is covered as unit tests against the helpers
+// (searchGraphResponseEmpty + adaptSemanticToGlobalSearchResponse)
+// instead; live integration coverage will land with the e2e tier
+// that exercises a real graph-embedding deployment.
+func TestHandleSearchGraph_InvalidRequestPropagates(t *testing.T) {
+	c := newSummaryTestComponent(func(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+		return nil, errors.New("should not be called: handleGlobalSearch should fail at unmarshal")
+	})
+	// Unparseable JSON — handleGlobalSearch fails at json.Unmarshal
+	// before any NATS subordinate call. handleSearchGraph propagates
+	// the error.
+	if _, err := c.handleSearchGraph(context.Background(), []byte(`{bad json`)); err == nil {
+		t.Errorf("expected error to propagate for unparseable request; got nil")
 	}
 }

--- a/processor/graph-query/searchgraph_test.go
+++ b/processor/graph-query/searchgraph_test.go
@@ -1,0 +1,116 @@
+package graphquery
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestSearchGraphResponseEmpty covers the empty-detection predicate
+// used to decide whether to fire the semantic fallback. Mirrors
+// semspec's globalSearchEmpty contract from tools/workflow/graph.go.
+func TestSearchGraphResponseEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		response GlobalSearchResponse
+		want     bool
+	}{
+		{
+			name:     "zero-valued response is empty",
+			response: GlobalSearchResponse{},
+			want:     true,
+		},
+		{
+			name:     "non-zero count is non-empty",
+			response: GlobalSearchResponse{Count: 1},
+			want:     false,
+		},
+		{
+			name:     "entity digest present is non-empty",
+			response: GlobalSearchResponse{EntityDigests: []EntityDigest{{ID: "x"}}},
+			want:     false,
+		},
+		{
+			name:     "community summary present is non-empty",
+			response: GlobalSearchResponse{CommunitySummaries: []CommunitySummary{{}}},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.response)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got := searchGraphResponseEmpty(data)
+			if got != tt.want {
+				t.Errorf("searchGraphResponseEmpty = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSearchGraphResponseEmpty_MalformedJSONIsNonEmpty documents the
+// defensive posture: an unparseable response does NOT trigger the
+// fallback (treated as non-empty so we don't spend an extra NATS hop
+// chasing a payload we couldn't decode).
+func TestSearchGraphResponseEmpty_MalformedJSONIsNonEmpty(t *testing.T) {
+	if searchGraphResponseEmpty([]byte(`not-json`)) {
+		t.Errorf("malformed response should NOT count as empty (would trigger redundant fallback)")
+	}
+}
+
+// TestAdaptSemanticToGlobalSearchResponse_HappyPath confirms semantic
+// results map onto EntityDigests with similarity → Relevance and the
+// fallback-marker fields are set.
+func TestAdaptSemanticToGlobalSearchResponse_HappyPath(t *testing.T) {
+	semanticPayload := []byte(`{"similaritySearch":{"results":[
+		{"entity_id":"acme.x.agent.web.observation.h1","similarity":0.82},
+		{"entity_id":"acme.x.agent.web.observation.h2","similarity":0.71}
+	]}}`)
+
+	got := adaptSemanticToGlobalSearchResponse(semanticPayload, "what do we know", 0)
+	if got == nil {
+		t.Fatalf("expected non-nil adapted response")
+	}
+	if got.Strategy != searchGraphStrategySemanticFallback {
+		t.Errorf("Strategy = %q, want %q", got.Strategy, searchGraphStrategySemanticFallback)
+	}
+	if !got.Degraded {
+		t.Errorf("Degraded = false, want true (fallback path always marks degraded)")
+	}
+	if got.DegradedReason == "" {
+		t.Errorf("DegradedReason should be set on the fallback path")
+	}
+	if got.Count != 2 {
+		t.Errorf("Count = %d, want 2", got.Count)
+	}
+	if len(got.EntityDigests) != 2 {
+		t.Fatalf("EntityDigests len = %d, want 2", len(got.EntityDigests))
+	}
+	if got.EntityDigests[0].ID != "acme.x.agent.web.observation.h1" {
+		t.Errorf("first digest ID = %q", got.EntityDigests[0].ID)
+	}
+	if got.EntityDigests[0].Relevance != 0.82 {
+		t.Errorf("first digest Relevance = %v, want 0.82", got.EntityDigests[0].Relevance)
+	}
+}
+
+// TestAdaptSemanticToGlobalSearchResponse_EmptyReturnsNil — the
+// adapter signals "nothing useful here" so the caller can fall back
+// to the original empty globalSearch payload (uniform shape).
+func TestAdaptSemanticToGlobalSearchResponse_EmptyReturnsNil(t *testing.T) {
+	tests := []struct{ name, body string }{
+		{"unparseable", "not-json"},
+		{"no results key", `{}`},
+		{"empty results", `{"similaritySearch":{"results":[]}}`},
+		{"all rows missing entity_id", `{"similaritySearch":{"results":[{"similarity":0.9}]}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := adaptSemanticToGlobalSearchResponse([]byte(tt.body), "q", 0); got != nil {
+				t.Errorf("expected nil, got %+v", got)
+			}
+		})
+	}
+}

--- a/processor/graph-query/summary.go
+++ b/processor/graph-query/summary.go
@@ -1,0 +1,257 @@
+// Package graphquery — graph summary handler.
+package graphquery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+const (
+	// graphSummaryDefaultSampleLimit is the V1 cap on entity IDs the
+	// type-distribution scan pulls from graph-ingest. Picked at 2000
+	// because: (a) one NATS message of that many short strings is
+	// comfortably under the gateway's 100KB body budget, (b) at
+	// typical scales (~10k-100k entities) this is large enough to
+	// surface the major type buckets, (c) tight enough to keep the
+	// per-call latency bounded. Operators tuning for larger graphs
+	// override via GraphSummaryRequest.EntitySampleLimit.
+	graphSummaryDefaultSampleLimit = 2000
+
+	// graphSummaryDefaultExamplesPerType caps example IDs per type
+	// bucket. 2 is the V1 sweet spot: enough that the caller sees
+	// the ID shape (helps prevent ID hallucination per the semspec
+	// bug-log precedent at docs/bugs/gemini-duplicate-graph-summary.md)
+	// while keeping the response compact.
+	graphSummaryDefaultExamplesPerType = 2
+
+	// graphSummaryMinEntityIDSegments is the minimum number of
+	// dot-separated parts in a canonical entity ID per
+	// message.IsValidEntityID. Below this we skip the entity from
+	// the type-distribution aggregation (it isn't a real entity ID).
+	graphSummaryMinEntityIDSegments = 6
+)
+
+// handleQueryGraphSummary composes a graph overview by fanning out to:
+//
+//   - graph.ingest.query.prefix (prefix="" limit=sample) for the
+//     entity-type distribution and per-type example IDs.
+//   - graph.index.query.predicateList for predicate counts.
+//
+// Either subordinate can fail independently; partial responses are
+// still useful (a graph with no predicate index should still surface
+// entity types). The handler returns the best result it can build
+// from whichever subordinates succeeded, with the failing facet
+// simply omitted (Predicates nil, EntityTypes empty). Hard transport
+// errors propagate so the caller sees the gateway/NATS issue rather
+// than an empty response.
+//
+// Deliberate V1 scope: NO Source distribution (Triple.Source
+// aggregation). That facet requires a write-time index over triple
+// sources or a full triple walk; both are V2 candidates documented
+// in graph/query_summary_types.go.
+func (c *Component) handleQueryGraphSummary(ctx context.Context, data []byte) ([]byte, error) {
+	req := parseSummaryRequest(data)
+
+	summary := graph.SummaryData{}
+
+	// Entity-type aggregation via the prefix-query orchestration the
+	// hierarchyStats handler already uses. Empty prefix scans all
+	// entities up to the limit; downstream is responsible for the
+	// envelope shape.
+	prefixPayload, err := json.Marshal(map[string]any{
+		"prefix": "",
+		"limit":  req.EntitySampleLimit,
+	})
+	if err != nil {
+		return nil, errs.Wrap(err, "GraphQuery", "handleQueryGraphSummary", "marshal prefix request")
+	}
+	prefixSubject := c.router.Route("entityPrefix")
+	if prefixSubject == "" {
+		return nil, errs.WrapTransient(errors.New("entityPrefix query routing not available"), "GraphQuery", "handleQueryGraphSummary", "route prefix query")
+	}
+
+	prefixResp, prefixErr := c.natsClient.Request(ctx, prefixSubject, prefixPayload, c.config.QueryTimeout)
+	if prefixErr != nil {
+		c.recordError(prefixErr)
+		if errors.Is(prefixErr, nats.ErrTimeout) {
+			return nil, errs.WrapTransient(prefixErr, "GraphQuery", "handleQueryGraphSummary", "prefix request timeout")
+		}
+		// Non-timeout transport errors from graph-ingest also bubble:
+		// they indicate the data plane is unavailable, not a partial-
+		// data shape worth returning.
+		return nil, errs.WrapTransient(prefixErr, "GraphQuery", "handleQueryGraphSummary", "prefix request")
+	}
+
+	entityIDs := extractEntityIDsFromPrefixResponse(prefixResp)
+	summary.TotalEntities = len(entityIDs)
+	summary.EntitySampleTruncated = len(entityIDs) >= req.EntitySampleLimit
+	summary.EntityTypes = aggregateEntityTypes(entityIDs, req.ExamplesPerType)
+
+	// Predicate counts via the existing index. This call is OPTIONAL
+	// (caller can suppress with IncludePredicates=false) and the
+	// failure mode is non-fatal — if graph-index is degraded, return
+	// the entity facet and let the caller note the gap.
+	if req.IncludePredicates {
+		predicateResp, predErr := c.natsClient.Request(ctx, "graph.index.query.predicateList", []byte("{}"), c.config.QueryTimeout)
+		if predErr != nil {
+			// Log via the metric path; don't propagate. The caller
+			// gets a partial-but-useful response.
+			c.recordError(predErr)
+		} else {
+			predicates := extractPredicates(predicateResp)
+			summary.Predicates = predicates
+			summary.PredicateTotal = len(predicates)
+		}
+	}
+
+	responseData, err := json.Marshal(graph.NewQueryResponse(summary))
+	if err != nil {
+		c.recordError(err)
+		return nil, errs.Wrap(err, "GraphQuery", "handleQueryGraphSummary", "marshal response")
+	}
+	c.recordSuccess(len(data), len(responseData))
+	return responseData, nil
+}
+
+// parseSummaryRequest decodes the request bytes and applies V1
+// defaults. Robust to empty/malformed input — the gateway sometimes
+// passes "{}" for variable-less queries.
+func parseSummaryRequest(data []byte) graph.SummaryRequest {
+	req := graph.SummaryRequest{
+		IncludePredicates: true,
+		EntitySampleLimit: graphSummaryDefaultSampleLimit,
+		ExamplesPerType:   graphSummaryDefaultExamplesPerType,
+	}
+	if len(data) == 0 {
+		return req
+	}
+	// Parse into a partial struct so a missing field uses the default,
+	// not the zero value.
+	var partial struct {
+		IncludePredicates *bool `json:"include_predicates,omitempty"`
+		EntitySampleLimit *int  `json:"entity_sample_limit,omitempty"`
+		ExamplesPerType   *int  `json:"examples_per_type,omitempty"`
+	}
+	if err := json.Unmarshal(data, &partial); err != nil {
+		return req
+	}
+	if partial.IncludePredicates != nil {
+		req.IncludePredicates = *partial.IncludePredicates
+	}
+	if partial.EntitySampleLimit != nil && *partial.EntitySampleLimit > 0 {
+		req.EntitySampleLimit = *partial.EntitySampleLimit
+	}
+	if partial.ExamplesPerType != nil && *partial.ExamplesPerType > 0 {
+		req.ExamplesPerType = *partial.ExamplesPerType
+	}
+	return req
+}
+
+// extractEntityIDsFromPrefixResponse pulls the IDs out of the
+// graph-ingest prefix response envelope. graph-ingest returns
+// {"entities": [{"id": "..."}, ...]} per the existing
+// handleQueryPrefixNATS shape. Returns an empty slice on any parse
+// failure; callers treat that as "no entities discoverable" rather
+// than a hard error so a partial summary still ships.
+func extractEntityIDsFromPrefixResponse(data []byte) []string {
+	var envelope struct {
+		Entities []struct {
+			ID string `json:"id"`
+		} `json:"entities"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(envelope.Entities))
+	for _, e := range envelope.Entities {
+		if e.ID != "" {
+			out = append(out, e.ID)
+		}
+	}
+	return out
+}
+
+// aggregateEntityTypes groups entity IDs into domain.system.type
+// buckets (segments 2.3.4 of the 6-part ID) and selects up to
+// examplesPerType sample IDs per bucket. Returns the buckets sorted
+// by count descending (highest-count types first), with ties broken
+// alphabetically on the type name so the response is stable across
+// calls — load-bearing for prompt-caching downstream.
+func aggregateEntityTypes(entityIDs []string, examplesPerType int) []EntityTypeSummary {
+	if examplesPerType <= 0 {
+		examplesPerType = graphSummaryDefaultExamplesPerType
+	}
+	type bucket struct {
+		count    int
+		examples []string
+	}
+	buckets := make(map[string]*bucket)
+	for _, id := range entityIDs {
+		segs := strings.Split(id, ".")
+		if len(segs) < graphSummaryMinEntityIDSegments {
+			continue
+		}
+		typeKey := segs[2] + "." + segs[3] + "." + segs[4]
+		b, ok := buckets[typeKey]
+		if !ok {
+			b = &bucket{}
+			buckets[typeKey] = b
+		}
+		b.count++
+		if len(b.examples) < examplesPerType {
+			b.examples = append(b.examples, id)
+		}
+	}
+	out := make([]EntityTypeSummary, 0, len(buckets))
+	for t, b := range buckets {
+		out = append(out, EntityTypeSummary{Type: t, Count: b.count, Examples: b.examples})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Type < out[j].Type
+	})
+	return out
+}
+
+// extractPredicates pulls the predicate list out of the
+// graph.index.query.predicateList response. Returns an empty slice
+// when the response is malformed or carries an error — the summary
+// caller treats predicate facet as best-effort.
+func extractPredicates(data []byte) []graph.PredicateSummary {
+	// Response shape per graph.NewQueryResponse[PredicateListData]:
+	// { "data": {"predicates": [...], "total": N}, "error": "" }
+	// Error is non-empty on the failure branch (NewQueryError); we
+	// treat that as "no predicates" rather than failing the summary.
+	var resp graph.QueryResponse[graph.PredicateListData]
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil
+	}
+	if resp.Error != "" {
+		return nil
+	}
+	return resp.Data.Predicates
+}
+
+// EntityTypeSummary is re-exported here as a type alias of the graph
+// package definition so handler code reads cleanly without the
+// `graph.` prefix on every line. Declared as a local alias rather
+// than an import-side rename so the public-facing types stay in
+// graph/.
+type EntityTypeSummary = graph.EntityTypeSummary
+
+// IsKVNotFoundError is unused inside this file but kept as an
+// import-pin so the natsclient package stays imported (handler files
+// share an import set; subtractive edits elsewhere should not drop
+// it). Lifted from query.go's existing import list.
+var _ = natsclient.IsKVNotFoundError

--- a/processor/graph-query/summary.go
+++ b/processor/graph-query/summary.go
@@ -11,7 +11,6 @@ import (
 	"github.com/nats-io/nats.go"
 
 	"github.com/c360studio/semstreams/graph"
-	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/errs"
 )
 
@@ -186,7 +185,7 @@ func extractEntityIDsFromPrefixResponse(data []byte) []string {
 // by count descending (highest-count types first), with ties broken
 // alphabetically on the type name so the response is stable across
 // calls — load-bearing for prompt-caching downstream.
-func aggregateEntityTypes(entityIDs []string, examplesPerType int) []EntityTypeSummary {
+func aggregateEntityTypes(entityIDs []string, examplesPerType int) []graph.EntityTypeSummary {
 	if examplesPerType <= 0 {
 		examplesPerType = graphSummaryDefaultExamplesPerType
 	}
@@ -211,9 +210,9 @@ func aggregateEntityTypes(entityIDs []string, examplesPerType int) []EntityTypeS
 			b.examples = append(b.examples, id)
 		}
 	}
-	out := make([]EntityTypeSummary, 0, len(buckets))
+	out := make([]graph.EntityTypeSummary, 0, len(buckets))
 	for t, b := range buckets {
-		out = append(out, EntityTypeSummary{Type: t, Count: b.count, Examples: b.examples})
+		out = append(out, graph.EntityTypeSummary{Type: t, Count: b.count, Examples: b.examples})
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Count != out[j].Count {
@@ -242,16 +241,3 @@ func extractPredicates(data []byte) []graph.PredicateSummary {
 	}
 	return resp.Data.Predicates
 }
-
-// EntityTypeSummary is re-exported here as a type alias of the graph
-// package definition so handler code reads cleanly without the
-// `graph.` prefix on every line. Declared as a local alias rather
-// than an import-side rename so the public-facing types stay in
-// graph/.
-type EntityTypeSummary = graph.EntityTypeSummary
-
-// IsKVNotFoundError is unused inside this file but kept as an
-// import-pin so the natsclient package stays imported (handler files
-// share an import set; subtractive edits elsewhere should not drop
-// it). Lifted from query.go's existing import list.
-var _ = natsclient.IsKVNotFoundError

--- a/processor/graph-query/summary_test.go
+++ b/processor/graph-query/summary_test.go
@@ -290,3 +290,31 @@ func TestParseGraphSummaryRequest_ExplicitFalseOverrides(t *testing.T) {
 		t.Errorf("explicit include_predicates=false ignored")
 	}
 }
+
+// TestParseSummaryRequest_RoundTrip locks in the JSON tag contract
+// per the project's polymorphic-config rule (memory:
+// feedback_polymorphic_config_needs_json_roundtrip_test.md). The
+// request struct IS operator-visible via GraphQL variables → NATS
+// payload, so a stealth rename of a snake_case tag would silently
+// break operators without surfacing here. This test catches that.
+func TestParseSummaryRequest_RoundTrip(t *testing.T) {
+	original := graph.SummaryRequest{
+		IncludePredicates: false,
+		EntitySampleLimit: 500,
+		ExamplesPerType:   3,
+	}
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	decoded := parseSummaryRequest(encoded)
+	if decoded.IncludePredicates != original.IncludePredicates {
+		t.Errorf("IncludePredicates round-trip: got %v, want %v", decoded.IncludePredicates, original.IncludePredicates)
+	}
+	if decoded.EntitySampleLimit != original.EntitySampleLimit {
+		t.Errorf("EntitySampleLimit round-trip: got %d, want %d", decoded.EntitySampleLimit, original.EntitySampleLimit)
+	}
+	if decoded.ExamplesPerType != original.ExamplesPerType {
+		t.Errorf("ExamplesPerType round-trip: got %d, want %d", decoded.ExamplesPerType, original.ExamplesPerType)
+	}
+}

--- a/processor/graph-query/summary_test.go
+++ b/processor/graph-query/summary_test.go
@@ -1,0 +1,292 @@
+package graphquery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+)
+
+// newSummaryTestComponent builds a Component wired only with what
+// handleQueryGraphSummary touches: a mock natsClient, the static
+// router, a logger, and the config's QueryTimeout.
+func newSummaryTestComponent(req func(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)) *Component {
+	mock := newMockNATSClient()
+	mock.requestFunc = req
+	c := &Component{
+		natsClient: mock,
+		router:     NewStaticRouter(slog.Default()),
+		logger:     slog.Default(),
+		config: Config{
+			QueryTimeout: 5 * time.Second,
+		},
+	}
+	return c
+}
+
+// prefixEnvelope marshals the {"entities": [...]} shape graph-ingest
+// returns from handleQueryPrefixNATS.
+func prefixEnvelope(ids ...string) []byte {
+	type ent struct {
+		ID string `json:"id"`
+	}
+	entities := make([]ent, len(ids))
+	for i, id := range ids {
+		entities[i] = ent{ID: id}
+	}
+	out, _ := json.Marshal(map[string]any{"entities": entities})
+	return out
+}
+
+// predicateListResponse marshals a successful predicate-list response
+// from graph.index.query.predicateList.
+func predicateListResponse(preds ...graph.PredicateSummary) []byte {
+	resp := graph.NewQueryResponse(graph.PredicateListData{
+		Predicates: preds,
+		Total:      len(preds),
+	})
+	out, _ := json.Marshal(resp)
+	return out
+}
+
+// TestHandleQueryGraphSummary_HappyPath exercises the full composite:
+// prefix returns entities, predicates return three predicates, the
+// handler aggregates by domain.system.type and returns both facets.
+func TestHandleQueryGraphSummary_HappyPath(t *testing.T) {
+	c := newSummaryTestComponent(func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
+		switch subject {
+		case "graph.ingest.query.prefix":
+			return prefixEnvelope(
+				"acme.platform.agent.web.observation.h1",
+				"acme.platform.agent.web.observation.h2",
+				"acme.platform.agent.web.observation.h3",
+				"acme.platform.agent.agentic-loop.execution.l1",
+				"acme.platform.agent.agentic-loop.execution.l2",
+				"acme.platform.semsource.golang.workspace.f1",
+			), nil
+		case "graph.index.query.predicateList":
+			return predicateListResponse(
+				graph.PredicateSummary{Predicate: "agent.web.url", EntityCount: 3},
+				graph.PredicateSummary{Predicate: "agent.loop.outcome", EntityCount: 2},
+				graph.PredicateSummary{Predicate: "source.code.symbol_name", EntityCount: 1},
+			), nil
+		}
+		return nil, errors.New("unexpected subject: " + subject)
+	})
+
+	respBytes, err := c.handleQueryGraphSummary(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resp graph.QueryResponse[graph.SummaryData]
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("response error: %q", resp.Error)
+	}
+
+	summary := resp.Data
+	if summary.TotalEntities != 6 {
+		t.Errorf("TotalEntities = %d, want 6", summary.TotalEntities)
+	}
+	if summary.EntitySampleTruncated {
+		t.Errorf("EntitySampleTruncated = true, want false (6 < default sample limit)")
+	}
+	if got := len(summary.EntityTypes); got != 3 {
+		t.Fatalf("EntityTypes = %d, want 3 buckets", got)
+	}
+	// Buckets must be sorted by Count desc; first is the 3-entity web.observation.
+	if summary.EntityTypes[0].Type != "agent.web.observation" {
+		t.Errorf("top bucket = %q, want agent.web.observation", summary.EntityTypes[0].Type)
+	}
+	if summary.EntityTypes[0].Count != 3 {
+		t.Errorf("top bucket Count = %d, want 3", summary.EntityTypes[0].Count)
+	}
+	// Example IDs default to 2 per bucket — verify cap respected on the
+	// 3-entity bucket.
+	if got := len(summary.EntityTypes[0].Examples); got != 2 {
+		t.Errorf("top bucket Examples = %d, want 2 (default examples_per_type cap)", got)
+	}
+	// Predicates pass through with exact counts.
+	if summary.PredicateTotal != 3 {
+		t.Errorf("PredicateTotal = %d, want 3", summary.PredicateTotal)
+	}
+	if got := len(summary.Predicates); got != 3 {
+		t.Errorf("Predicates length = %d, want 3", got)
+	}
+}
+
+// TestHandleQueryGraphSummary_IncludePredicatesFalse confirms the
+// predicate facet can be opted out — useful when callers cache it or
+// when response size matters.
+func TestHandleQueryGraphSummary_IncludePredicatesFalse(t *testing.T) {
+	predicateCalled := false
+	c := newSummaryTestComponent(func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
+		switch subject {
+		case "graph.ingest.query.prefix":
+			return prefixEnvelope("acme.platform.agent.web.observation.h1"), nil
+		case "graph.index.query.predicateList":
+			predicateCalled = true
+			return predicateListResponse(graph.PredicateSummary{Predicate: "x", EntityCount: 1}), nil
+		}
+		return nil, errors.New("unexpected subject: " + subject)
+	})
+
+	respBytes, err := c.handleQueryGraphSummary(context.Background(), []byte(`{"include_predicates": false}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if predicateCalled {
+		t.Errorf("predicate subject should NOT be requested when include_predicates=false")
+	}
+
+	var resp graph.QueryResponse[graph.SummaryData]
+	if err := json.Unmarshal(respBytes, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Data.Predicates != nil {
+		t.Errorf("Predicates should be nil when include_predicates=false")
+	}
+	if resp.Data.PredicateTotal != 0 {
+		t.Errorf("PredicateTotal = %d, want 0", resp.Data.PredicateTotal)
+	}
+}
+
+// TestHandleQueryGraphSummary_PredicateFailure_StillReturnsEntityFacet
+// confirms the predicate facet failing is non-fatal — the caller gets
+// the entity overview anyway. This is the "best-effort composite"
+// invariant documented on handleQueryGraphSummary.
+func TestHandleQueryGraphSummary_PredicateFailure_StillReturnsEntityFacet(t *testing.T) {
+	c := newSummaryTestComponent(func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
+		switch subject {
+		case "graph.ingest.query.prefix":
+			return prefixEnvelope("acme.platform.agent.web.observation.h1"), nil
+		case "graph.index.query.predicateList":
+			return nil, errors.New("graph-index degraded")
+		}
+		return nil, errors.New("unexpected subject: " + subject)
+	})
+
+	respBytes, err := c.handleQueryGraphSummary(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("composite should not fail just because predicate facet failed: %v", err)
+	}
+	var resp graph.QueryResponse[graph.SummaryData]
+	_ = json.Unmarshal(respBytes, &resp)
+	if resp.Data.TotalEntities != 1 {
+		t.Errorf("TotalEntities = %d, want 1 (entity facet should land)", resp.Data.TotalEntities)
+	}
+	if resp.Data.Predicates != nil {
+		t.Errorf("Predicates should be nil on predicate-facet failure (partial response)")
+	}
+}
+
+// TestHandleQueryGraphSummary_PrefixFailure_Propagates confirms that
+// the entity-facet failure DOES propagate — without entities there
+// is nothing useful to return.
+func TestHandleQueryGraphSummary_PrefixFailure_Propagates(t *testing.T) {
+	c := newSummaryTestComponent(func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
+		if subject == "graph.ingest.query.prefix" {
+			return nil, errors.New("graph-ingest down")
+		}
+		return predicateListResponse(), nil
+	})
+	if _, err := c.handleQueryGraphSummary(context.Background(), nil); err == nil {
+		t.Errorf("expected error when entity facet fails; got nil")
+	}
+}
+
+// TestHandleQueryGraphSummary_TruncationFlag confirms the
+// EntitySampleTruncated flag is set when the prefix scan saturates
+// the limit. Callers use this to know counts are approximate.
+func TestHandleQueryGraphSummary_TruncationFlag(t *testing.T) {
+	c := newSummaryTestComponent(func(_ context.Context, subject string, _ []byte, _ time.Duration) ([]byte, error) {
+		if subject == "graph.ingest.query.prefix" {
+			// Return exactly the limit we asked for — simulates a full sample.
+			return prefixEnvelope(
+				"acme.platform.agent.web.observation.h1",
+				"acme.platform.agent.web.observation.h2",
+				"acme.platform.agent.web.observation.h3",
+			), nil
+		}
+		return predicateListResponse(), nil
+	})
+	respBytes, err := c.handleQueryGraphSummary(context.Background(), []byte(`{"entity_sample_limit": 3, "include_predicates": false}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var resp graph.QueryResponse[graph.SummaryData]
+	_ = json.Unmarshal(respBytes, &resp)
+	if !resp.Data.EntitySampleTruncated {
+		t.Errorf("EntitySampleTruncated = false, want true when scan saturates limit")
+	}
+}
+
+// TestAggregateEntityTypes_SkipsMalformedIDs documents that the
+// aggregation only counts entities with the canonical 6-part shape;
+// shorter IDs (legacy tests, junk) are silently skipped rather than
+// failing the whole summary.
+func TestAggregateEntityTypes_SkipsMalformedIDs(t *testing.T) {
+	ids := []string{
+		"acme.platform.agent.web.observation.h1", // valid
+		"too.short",                              // 2 parts, skip
+		"acme.platform.agent.web.observation.h2", // valid
+		"three.part.thing",                       // 3 parts, skip
+	}
+	got := aggregateEntityTypes(ids, 2)
+	if len(got) != 1 {
+		t.Fatalf("buckets = %d, want 1 (only valid IDs grouped)", len(got))
+	}
+	if got[0].Count != 2 {
+		t.Errorf("Count = %d, want 2", got[0].Count)
+	}
+}
+
+// TestAggregateEntityTypes_StableTieBreak — equal-count buckets sort
+// alphabetically so prompt-caching downstream stays stable across
+// repeat summary calls on the same graph.
+func TestAggregateEntityTypes_StableTieBreak(t *testing.T) {
+	ids := []string{
+		"acme.platform.zeta.system.type.e1",
+		"acme.platform.alpha.system.type.e1",
+	}
+	got := aggregateEntityTypes(ids, 1)
+	if len(got) != 2 {
+		t.Fatalf("buckets = %d, want 2", len(got))
+	}
+	if got[0].Type != "alpha.system.type" {
+		t.Errorf("first bucket = %q, want alpha.system.type (ties break alphabetically)", got[0].Type)
+	}
+}
+
+// TestParseGraphSummaryRequest_Defaults confirms missing fields fall
+// back to V1 defaults rather than zero values (which would silently
+// disable the scan).
+func TestParseGraphSummaryRequest_Defaults(t *testing.T) {
+	req := parseSummaryRequest([]byte(`{}`))
+	if !req.IncludePredicates {
+		t.Errorf("IncludePredicates default = false, want true")
+	}
+	if req.EntitySampleLimit != graphSummaryDefaultSampleLimit {
+		t.Errorf("EntitySampleLimit default = %d, want %d", req.EntitySampleLimit, graphSummaryDefaultSampleLimit)
+	}
+	if req.ExamplesPerType != graphSummaryDefaultExamplesPerType {
+		t.Errorf("ExamplesPerType default = %d, want %d", req.ExamplesPerType, graphSummaryDefaultExamplesPerType)
+	}
+}
+
+// TestParseGraphSummaryRequest_ExplicitFalseOverrides confirms that
+// passing include_predicates=false actually disables predicates
+// (the default-bool footgun: distinguishing "unset" from "false").
+func TestParseGraphSummaryRequest_ExplicitFalseOverrides(t *testing.T) {
+	req := parseSummaryRequest([]byte(`{"include_predicates": false}`))
+	if req.IncludePredicates {
+		t.Errorf("explicit include_predicates=false ignored")
+	}
+}


### PR DESCRIPTION
Step 1 of the gateway-first migration plan in `project_graph_tools_gateway_first_plan` (memory). Adds server-side primitives so future agent-tool wrappers, the upcoming MCP gateway, and external apps all share one implementation. No agent tools land in this PR — they're step 2.

## What's in

**`graphSummary`** — composite discovery resolver that solves the chicken-and-egg problem in the existing `query_*` family (all need known IDs to start). Fans out to `graph.ingest.query.prefix` (sample entity IDs for type distribution + example IDs per type) and `graph.index.query.predicateList` (predicate counts).

Returns structured `SummaryData { total_entities, entity_sample_truncated, entity_types[{type, count, examples}], predicates[], predicate_total }`. Best-effort composite: predicate facet failure is non-fatal; entity facet failure propagates.

V1 deliberately defers **Source distribution** (`Triple.Source` aggregation) to V2 — needs a write-time index or expensive triple walk per call. Documented inline in `graph/query_summary_types.go`.

**`searchGraph`** — wraps `globalSearch` GraphRAG path with a semantic-search fallback. Moves semspec's client-side `semanticSearchFallback` (from `semspec/tools/workflow/graph.go`) server-side so every consumer (agent tools, MCP, external apps) gets the same degraded-but-useful behavior. When fallback fires, response is annotated with `Strategy="semantic_fallback"`, `Degraded=true`, and a structured reason — uniform `GlobalSearchResponse` shape so callers don't special-case.

**Gateway wiring**: both resolvers added to `mapGraphQLQueryToNATSSubject`, `subjectToGraphQLField`, `transformVariablesToNATSPayload`, and the GraphQL introspection schema. `searchGraph` reuses `transformGlobalSearchVars` (same arg surface). Specific-first ordering means `graphsummary` and `searchgraph` keywords beat their lower-level primitives, mirroring the existing `localsearch`-before-`globalsearch` precedent.

**Refactor**: `setupQueryHandlers` converted to table-driven registration. Two new subscriptions would have pushed past revive's 50-statement cap; the table form is cleaner and makes the "what subjects this component owns" surface scannable.

## Why now

semteams + semspec both need a graph summary tool and (per @cglusky's review at the previous PR) require agents to call search before query to avoid guessing. semspec already shipped local versions. semstreams gateway-first means write the capability once; the agent-tool / MCP / HTTP layers are thin wrappers.

## Test plan

- [x] `task lint` clean (resolved 2 exported-stutter + 1 function-length warnings during dev)
- [x] `go test -race ./...` all green
- [x] `go vet -tags=integration ./...` and `go vet -tags=live_llm ./...` clean
- [x] `task schema:generate` no drift
- [x] New tests:
  - `processor/graph-query/summary_test.go` — happy path, predicate opt-out, predicate facet failure non-fatal, prefix failure propagates, truncation flag, malformed ID skipping, stable tie-break, default parsing
  - `processor/graph-query/searchgraph_test.go` — empty detection across all four facets, malformed-response defensive posture, semantic-to-globalSearch adapter, empty-fallback returns nil
  - `gateway/graph-gateway/query_test.go` — subject mapping + reverse mapping + variable transformation for both new resolvers

E2E not required: additive feature, no wire-format break, no rule-config changes.

## Sequencing

Per the 4-step plan in `project_graph_tools_gateway_first_plan`:

1. **This PR** — server-side primitives (graphSummary + searchGraph resolvers).
2. Agent-tool wrappers (`summarize_graph` + `search_graph` in `processor/agentic-tools/executors/`) — thin (~30-50 LOC each) wrappers calling the new GraphQL fields. Future PR.
3. Migrate the 5 KV-direct `query_*` agent tools onto the gateway path. Future PR.
4. MCP exposure deferred until MCP gateway lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)