### PR TITLE
feat: migrate decide/emit_diagnosis/scratchpad to AddTriplesBatch

### DIFF
--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -59,11 +59,33 @@ const decideMutationTimeout = 5 * time.Second
 // mutations at a glance in graph.
 const decideToolSource = "coordinator-decide"
 
-// TriplePublisher is the narrow surface DecideExecutor uses to write triples.
-// Production satisfies it with a natsclient.Client adapter; tests use an
-// in-memory recorder so they don't need a real NATS connection.
+// TriplePublisher is the narrow surface agent-private state tools use to
+// write triples. Production satisfies it with a natsclient.Client adapter;
+// tests use an in-memory recorder so they don't need a real NATS
+// connection.
+//
+// Two emission shapes:
+//
+//   - AddTriple — single-triple convenience. Used by callers that emit
+//     across multiple subjects per logical operation where per-subject
+//     atomicity is not required (web_search and http_request, where
+//     URL-entity triples and loop-back-link triples target distinct
+//     subjects and a partial write only loses the back-link
+//     observably).
+//
+//   - AddTriplesBatch — atomic per-Subject. The graph-ingest handler
+//     groups triples by Subject and CAS-applies them per entity, so a
+//     batch sharing one Subject is fully atomic. Used by decide /
+//     emit_diagnosis / scratchpad — each emits a co-emitted set on a
+//     single entity where partial-write orphans would corrupt the
+//     downstream rule-matching contract.
+//
+// See project_addtriplebatch_migration_followup memory for the
+// migration history; write_todos has used the batch path since
+// ADR-036 Stage 2 (2026-05-09).
 type TriplePublisher interface {
 	AddTriple(ctx context.Context, triple message.Triple) error
+	AddTriplesBatch(ctx context.Context, triples []message.Triple) error
 }
 
 // DecideExecutor is the coordinator's terminal tool. A coordinator agent
@@ -274,14 +296,18 @@ func (e *DecideExecutor) decide(ctx context.Context, call agentic.ToolCall) (age
 		})
 	}
 
-	for _, triple := range triples {
-		if err := e.publisher.AddTriple(ctx, triple); err != nil {
-			return agentic.ToolResult{
-				CallID:    call.ID,
-				Error:     fmt.Sprintf("publish %s triple: %v", triple.Predicate, err),
-				ErrorKind: agentic.ToolErrorNetwork,
-			}, errs.WrapTransient(err, "DecideExecutor", "decide", "publish triple")
-		}
+	// Atomic batch publish: all triples share loopEntityID, so the
+	// graph-ingest per-Subject CAS handler applies them as one unit.
+	// Pre-2026-05-13 this was a per-triple loop that could leave the
+	// loop entity with the next_action triple but no decision_reason
+	// on graph-ingest degradation — downstream rules would match an
+	// inconsistent snapshot. The atomic batch eliminates that window.
+	if err := e.publisher.AddTriplesBatch(ctx, triples); err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("publish decide triples: %v", err),
+			ErrorKind: agentic.ToolErrorNetwork,
+		}, errs.WrapTransient(err, "DecideExecutor", "decide", "publish triples batch")
 	}
 
 	// The tool's Content is the canonical decision payload. Downstream
@@ -487,14 +513,27 @@ func parseDecideArgs(raw map[string]any) (decideArgs, error) {
 	return args, nil
 }
 
-// natsTriplePublisher adapts natsclient.Client to TriplePublisher by
-// issuing a graph.mutation.triple.add request/reply per call. Kept local to
-// this file rather than shared because the only current caller is the
-// decide executor; other places that publish triples (rule actions, graph
-// writer) have their own adapters shaped to their needs.
+// natsTriplePublisher adapts natsclient.Client to TriplePublisher.
+// Routes single-triple writes through graph.mutation.triple.add and
+// batches through graph.mutation.triple.add_batch (the atomic per-
+// Subject CAS path landed in ADR-036 Stage 2). The two subjects
+// share the same retry policy — both mutation surfaces are
+// idempotent at graph-ingest (a triple is set-of, a batch is
+// deduplicated).
 type natsTriplePublisher struct {
 	client *natsclient.Client
 }
+
+// natsTriplesBatchSubject is the atomic per-Subject CAS path. Used
+// by AddTriplesBatch — co-located triples (all sharing one Subject)
+// land all-or-nothing, eliminating partial-write orphans on
+// graph-ingest degradation.
+const natsTriplesBatchSubject = "graph.mutation.triple.add_batch"
+
+// natsTriplesBatchTimeout is the round-trip budget for the batch
+// mutation. Matches write_todos's existing writeTodosTimeout (5s)
+// since both write through the same handler.
+const natsTriplesBatchTimeout = 5 * time.Second
 
 // NewNATSTriplePublisher builds a TriplePublisher backed by the shared
 // graph.mutation.triple.add NATS surface.
@@ -524,6 +563,38 @@ func (p *natsTriplePublisher) AddTriple(ctx context.Context, triple message.Trip
 	}
 	if !resp.Success {
 		return fmt.Errorf("graph-ingest rejected triple: %s", resp.Error)
+	}
+	return nil
+}
+
+// AddTriplesBatch routes through graph.mutation.triple.add_batch —
+// the atomic per-Subject CAS path. Callers that emit co-located
+// triples (all sharing one Subject — decide/emit_diagnosis/scratchpad)
+// rely on the all-or-nothing semantics to avoid partial-write
+// orphans when graph-ingest degrades. Same retry policy as AddTriple;
+// both mutation surfaces are idempotent at graph-ingest.
+func (p *natsTriplePublisher) AddTriplesBatch(ctx context.Context, triples []message.Triple) error {
+	if len(triples) == 0 {
+		// No-op: callers that conditionally accumulate triples may
+		// hand an empty slice rather than special-casing the gate.
+		return nil
+	}
+	req := graph.AddTriplesBatchRequest{Triples: triples}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal batch-add request: %w", err)
+	}
+	respData, err := p.client.RequestWithRetry(ctx, natsTriplesBatchSubject, reqData, natsTriplesBatchTimeout, natsclient.DefaultRetryConfig())
+	if err != nil {
+		return fmt.Errorf("request %s: %w", natsTriplesBatchSubject, err)
+	}
+	var resp graph.AddTriplesBatchResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return fmt.Errorf("unmarshal batch response: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("graph-ingest rejected batch (written=%d, failed=%v): %s",
+			resp.WrittenCount, resp.FailedSubjects, resp.Error)
 	}
 	return nil
 }

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -16,10 +16,21 @@ import (
 )
 
 // recordingPublisher implements TriplePublisher in-process so tests can
-// assert exactly what triples the decide tool emitted.
+// assert exactly what triples the agent-tool emitted.
+//
+// Records via both AddTriple (single) and AddTriplesBatch (atomic).
+// On error the single-add records nothing (preserves the original
+// pre-2026-05-13 behavior); the batch flattens the slice into the
+// triples log even on error so tests can assert which triples WOULD
+// have been emitted (atomic semantics — they would have landed
+// together if not for the error).
 type recordingPublisher struct {
 	triples []message.Triple
-	err     error
+	// batchCalls records the number of AddTriplesBatch invocations so
+	// migrated callers can assert they made the single atomic call
+	// rather than N per-triple calls.
+	batchCalls int
+	err        error
 }
 
 func (p *recordingPublisher) AddTriple(_ context.Context, triple message.Triple) error {
@@ -27,6 +38,15 @@ func (p *recordingPublisher) AddTriple(_ context.Context, triple message.Triple)
 		return p.err
 	}
 	p.triples = append(p.triples, triple)
+	return nil
+}
+
+func (p *recordingPublisher) AddTriplesBatch(_ context.Context, triples []message.Triple) error {
+	p.batchCalls++
+	if p.err != nil {
+		return p.err
+	}
+	p.triples = append(p.triples, triples...)
 	return nil
 }
 
@@ -53,6 +73,29 @@ func TestDecideExecutor_ListTools(t *testing.T) {
 	}
 	if len(want) > 0 {
 		t.Errorf("missing required fields: %v", want)
+	}
+}
+
+// TestDecideExecutor_UsesBatchPath confirms decide emits via
+// AddTriplesBatch (not the legacy per-triple loop). Atomicity matters
+// here because downstream rules match on coordinator.decision.next_action
+// AND coordinator.decision.reason being co-present on the loop entity;
+// pre-2026-05-13 per-triple emission could leave one without the other
+// on graph-ingest degradation, breaking deterministic rule routing.
+func TestDecideExecutor_UsesBatchPath(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutor(pub)
+	_, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "c",
+		Name:      DecideToolName,
+		LoopID:    "loop-batch",
+		Arguments: map[string]any{"action": "done", "reason": "test"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if pub.batchCalls != 1 {
+		t.Errorf("AddTriplesBatch call count = %d, want 1 (single atomic batch)", pub.batchCalls)
 	}
 }
 

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -19,11 +19,12 @@ import (
 // assert exactly what triples the agent-tool emitted.
 //
 // Records via both AddTriple (single) and AddTriplesBatch (atomic).
-// On error the single-add records nothing (preserves the original
-// pre-2026-05-13 behavior); the batch flattens the slice into the
-// triples log even on error so tests can assert which triples WOULD
-// have been emitted (atomic semantics — they would have landed
-// together if not for the error).
+// On error BOTH methods bail before recording — atomic-failure mirror
+// of the production graph-ingest CAS path, where a failed batch
+// commits nothing for the shared Subject. Tests that need to inspect
+// "what triples WOULD have been emitted" can read the migrated tool's
+// constructed slice via other means (the executors build the slice
+// before calling the publisher).
 type recordingPublisher struct {
 	triples []message.Triple
 	// batchCalls records the number of AddTriplesBatch invocations so

--- a/processor/agentic-tools/emit_diagnosis.go
+++ b/processor/agentic-tools/emit_diagnosis.go
@@ -188,21 +188,20 @@ func (e *EmitDiagnosisExecutor) emitDiagnosis(ctx context.Context, call agentic.
 
 	now := time.Now()
 
-	// Build the triple set in deterministic order. Fail-fast on the first
-	// publisher error — partial emission would leave an incomplete finding in
-	// the graph with no way for the consumer to distinguish "all triples
-	// landed" from "some triples landed". The ops agent sees the error in the
-	// next iteration and can retry the full call.
+	// Build the triple set in deterministic order. All triples share
+	// Subject=diagnosisEntityID (including the agent.action.executed_by
+	// back-link FROM the diagnosis TO the loop), so the atomic batch
+	// applies them as one unit. Pre-2026-05-13 this was a per-triple
+	// loop that could leave an incomplete finding visible to downstream
+	// consumers — the comment cited that explicitly. Migrating to
+	// AddTriplesBatch eliminates the partial-emission window entirely.
 	triples := buildEmitDiagnosisTriples(diagnosisEntityID, loopEntityID, args, now)
-
-	for _, triple := range triples {
-		if err := e.publisher.AddTriple(ctx, triple); err != nil {
-			return agentic.ToolResult{
-				CallID:    call.ID,
-				Error:     fmt.Sprintf("publish %s triple: %v", triple.Predicate, err),
-				ErrorKind: agentic.ToolErrorNetwork,
-			}, errs.WrapTransient(err, "EmitDiagnosisExecutor", "emitDiagnosis", "publish triple")
-		}
+	if err := e.publisher.AddTriplesBatch(ctx, triples); err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("publish diagnosis triples: %v", err),
+			ErrorKind: agentic.ToolErrorNetwork,
+		}, errs.WrapTransient(err, "EmitDiagnosisExecutor", "emitDiagnosis", "publish triples batch")
 	}
 
 	result := emitDiagnosisResult{

--- a/processor/agentic-tools/emit_diagnosis_test.go
+++ b/processor/agentic-tools/emit_diagnosis_test.go
@@ -22,6 +22,23 @@ func newEmitDiagnosisExecutor(publisher TriplePublisher) *EmitDiagnosisExecutor 
 	)
 }
 
+// TestEmitDiagnosisExecutor_UsesBatchPath confirms emit_diagnosis
+// emits via AddTriplesBatch (not the legacy per-triple loop).
+// Atomicity is the documented contract — partial emission would
+// leave an incomplete finding whose consumers (ops-agent, rule
+// engine) can't tell apart from a complete one.
+func TestEmitDiagnosisExecutor_UsesBatchPath(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newEmitDiagnosisExecutor(pub)
+	_, err := e.Execute(context.Background(), validEmitDiagnosisCall())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if pub.batchCalls != 1 {
+		t.Errorf("AddTriplesBatch call count = %d, want 1 (single atomic batch)", pub.batchCalls)
+	}
+}
+
 func validEmitDiagnosisCall() agentic.ToolCall {
 	return agentic.ToolCall{
 		ID:     "c1",

--- a/processor/agentic-tools/executors/web_emit_test.go
+++ b/processor/agentic-tools/executors/web_emit_test.go
@@ -16,7 +16,11 @@ import (
 
 // recordingPublisher captures every triple AddTriple is called with and
 // optionally fails on the Nth call so partial-failure tests can exercise
-// the log+continue path.
+// the log+continue path. web_search and http_request still use the
+// per-triple AddTriple path (NOT batch) because their emissions span
+// multiple Subjects per call — the per-Subject atomic batch surface
+// doesn't fit their cross-entity write pattern. See
+// project_addtriplebatch_migration_followup memory.
 type recordingPublisher struct {
 	triples  []message.Triple
 	failOn   int
@@ -29,6 +33,15 @@ func (p *recordingPublisher) AddTriple(_ context.Context, tr message.Triple) err
 		return p.failWith
 	}
 	return nil
+}
+
+// AddTriplesBatch satisfies the widened TriplePublisher interface but
+// web_search / http_request never call it (their emissions span
+// multiple Subjects per call so the atomic per-Subject batch doesn't
+// help). Present only for interface conformance — if a test hits it,
+// the migration model is broken.
+func (p *recordingPublisher) AddTriplesBatch(_ context.Context, _ []message.Triple) error {
+	panic("recordingPublisher: AddTriplesBatch unexpectedly called; web_search/http_request emit per-Subject via AddTriple")
 }
 
 func fixedClock(t time.Time) func() time.Time {

--- a/processor/agentic-tools/scratchpad.go
+++ b/processor/agentic-tools/scratchpad.go
@@ -204,9 +204,10 @@ func (e *ScratchpadExecutor) scratchpad(ctx context.Context, call agentic.ToolCa
 	// an orphan ScratchID + ScratchText pair (the first two writes) in
 	// the graph on graph-ingest degradation — the orphan was harmless
 	// (no duplication, the retry minted a fresh UUID), but the atomic
-	// batch eliminates the window entirely. See
-	// TestScratchpadExecutor_PartialWrite_LeavesOrphanID test history
-	// for the explicit before-vs-after assertion.
+	// batch eliminates the window entirely. The post-migration assertion
+	// lives in TestScratchpadExecutor_BatchFailure_LeavesNoOrphans; see
+	// git history for the pre-migration TestScratchpadExecutor_
+	// PartialWrite_LeavesOrphanID it replaced.
 	triples := []message.Triple{
 		{Subject: loopEntityID, Predicate: agvocab.ScratchID, Object: scratchID, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},
 		{Subject: loopEntityID, Predicate: agvocab.ScratchText, Object: args.Text, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},

--- a/processor/agentic-tools/scratchpad.go
+++ b/processor/agentic-tools/scratchpad.go
@@ -198,20 +198,27 @@ func (e *ScratchpadExecutor) scratchpad(ctx context.Context, call agentic.ToolCa
 	// matches decide/write_todos discipline, NOT the web-tools
 	// log+continue discipline, because the trajectory alone is not
 	// durable across compaction.
+	// Atomic batch publish: all four triples share Subject=loopEntityID,
+	// so the graph-ingest per-Subject CAS handler applies them as one
+	// unit. Pre-2026-05-13 this was a per-triple loop that could leave
+	// an orphan ScratchID + ScratchText pair (the first two writes) in
+	// the graph on graph-ingest degradation — the orphan was harmless
+	// (no duplication, the retry minted a fresh UUID), but the atomic
+	// batch eliminates the window entirely. See
+	// TestScratchpadExecutor_PartialWrite_LeavesOrphanID test history
+	// for the explicit before-vs-after assertion.
 	triples := []message.Triple{
 		{Subject: loopEntityID, Predicate: agvocab.ScratchID, Object: scratchID, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},
 		{Subject: loopEntityID, Predicate: agvocab.ScratchText, Object: args.Text, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},
 		{Subject: loopEntityID, Predicate: agvocab.ScratchCreatedAt, Object: createdAt, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},
 		{Subject: loopEntityID, Predicate: agvocab.ScratchChars, Object: chars, Source: scratchpadToolSource, Timestamp: now, Confidence: 1.0},
 	}
-	for _, tr := range triples {
-		if err := e.publisher.AddTriple(ctx, tr); err != nil {
-			return agentic.ToolResult{
-				CallID:    call.ID,
-				Error:     fmt.Sprintf("publish %s triple: %v", tr.Predicate, err),
-				ErrorKind: agentic.ToolErrorNetwork,
-			}, errs.WrapTransient(err, "ScratchpadExecutor", "scratchpad", "publish triple")
-		}
+	if err := e.publisher.AddTriplesBatch(ctx, triples); err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("publish scratchpad triples: %v", err),
+			ErrorKind: agentic.ToolErrorNetwork,
+		}, errs.WrapTransient(err, "ScratchpadExecutor", "scratchpad", "publish triples batch")
 	}
 
 	payload, err := json.Marshal(scratchpadResult{

--- a/processor/agentic-tools/scratchpad_test.go
+++ b/processor/agentic-tools/scratchpad_test.go
@@ -181,38 +181,66 @@ func TestScratchpadExecutor_AppendOnlyAcrossCalls(t *testing.T) {
 	}
 }
 
-// scratchpadPartialFailurePublisher returns success for the first N
-// AddTriple calls then surfaces an error on the (N+1)th. Records every
-// triple it sees so tests can assert exactly which writes landed.
-// Lives here (not next to recordingPublisher) because the existing
-// shared recorder bails BEFORE recording on error and the partial-write
-// invariant needs the opposite.
-type scratchpadPartialFailurePublisher struct {
-	failAfter int
-	calls     int
-	triples   []message.Triple
-	failWith  error
+// atomicBatchFailurePublisher fails the AddTriplesBatch call entirely
+// (records NOTHING on failure — atomic semantics). Models the post-
+// migration behavior where graph-ingest CAS rejects either all
+// triples or none. Pre-2026-05-13 this test used a per-triple
+// scratchpadPartialFailurePublisher that recorded the first N before
+// the failure; that mock and the orphan-leaving behavior it modeled
+// no longer apply.
+type atomicBatchFailurePublisher struct {
+	triples  []message.Triple
+	failWith error
 }
 
-func (p *scratchpadPartialFailurePublisher) AddTriple(_ context.Context, tr message.Triple) error {
-	p.calls++
-	if p.calls > p.failAfter {
+func (p *atomicBatchFailurePublisher) AddTriple(_ context.Context, _ message.Triple) error {
+	panic("atomicBatchFailurePublisher: AddTriple should not be called; scratchpad uses AddTriplesBatch")
+}
+
+func (p *atomicBatchFailurePublisher) AddTriplesBatch(_ context.Context, triples []message.Triple) error {
+	if p.failWith != nil {
+		// Atomic semantics: record nothing on failure. The graph-
+		// ingest CAS path either commits all of `triples` for the
+		// shared Subject or none of them.
 		return p.failWith
 	}
-	p.triples = append(p.triples, tr)
+	p.triples = append(p.triples, triples...)
 	return nil
 }
 
-// TestScratchpadExecutor_PartialWrite_LeavesOrphanID locks in the
-// documented partial-write behavior: a publish failure on triple 3
-// leaves the first 2 triples in the graph (orphan ScratchID +
-// ScratchText with no companions). The tool returns ToolErrorNetwork
-// so the LLM sees the failure and retries with a fresh UUID; the
-// orphan is harmless (no duplication). The eventual batch-publisher
-// migration (go-reviewer follow-up) eliminates orphans entirely —
-// this test makes that change a visible delta.
-func TestScratchpadExecutor_PartialWrite_LeavesOrphanID(t *testing.T) {
-	pub := &scratchpadPartialFailurePublisher{failAfter: 2, failWith: errors.New("nats degraded")}
+// TestScratchpadExecutor_UsesBatchPath confirms scratchpad emits via
+// AddTriplesBatch (not the legacy per-triple AddTriple path). Locks
+// the migration in — if a future refactor accidentally reverts to
+// per-triple emission, this test catches it before the orphan
+// behavior reappears.
+func TestScratchpadExecutor_UsesBatchPath(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newScratchpadExecutor(pub)
+	_, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "c", Name: ScratchpadToolName, LoopID: "loop", Arguments: map[string]any{"text": "x"},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if pub.batchCalls != 1 {
+		t.Errorf("AddTriplesBatch call count = %d, want 1 (single atomic batch)", pub.batchCalls)
+	}
+}
+
+// TestScratchpadExecutor_BatchFailure_LeavesNoOrphans is the inverted
+// assertion of the pre-batch TestScratchpadExecutor_PartialWrite_
+// LeavesOrphanID. Post-AddTriplesBatch-migration, a graph-ingest
+// failure rejects the entire batch atomically — no orphan ScratchID
+// + ScratchText pair, no orphan timestamp, nothing. The tool still
+// returns ToolErrorNetwork so the LLM retries with a fresh UUID; the
+// retry's batch either succeeds atomically or fails atomically.
+//
+// This test is the visible delta from the project memory
+// project_addtriplebatch_migration_followup. Before the migration it
+// asserted "first 2 triples land, third fails"; after the migration
+// it asserts "zero land, error surfaces."
+func TestScratchpadExecutor_BatchFailure_LeavesNoOrphans(t *testing.T) {
+	pub := &atomicBatchFailurePublisher{failWith: errors.New("nats degraded")}
 	e := NewScratchpadExecutor(pub, types.PlatformMeta{Org: "acme", Platform: "ops"})
 	e.SetIDGenerator(func() string { return "orphan-id" })
 
@@ -225,17 +253,8 @@ func TestScratchpadExecutor_PartialWrite_LeavesOrphanID(t *testing.T) {
 	if res.ErrorKind != agentic.ToolErrorNetwork {
 		t.Errorf("ErrorKind = %v, want network", res.ErrorKind)
 	}
-	if len(pub.triples) != 2 {
-		t.Errorf("recorded triples = %d, want 2 (first two land, third fails)", len(pub.triples))
-	}
-	// The first two predicates emitted are ScratchID and ScratchText
-	// (per scratchpad.go emission order). Locking that order in here
-	// makes any future reorder a visible test delta.
-	if pub.triples[0].Predicate != agvocab.ScratchID {
-		t.Errorf("first emitted predicate = %q, want %q", pub.triples[0].Predicate, agvocab.ScratchID)
-	}
-	if pub.triples[1].Predicate != agvocab.ScratchText {
-		t.Errorf("second emitted predicate = %q, want %q", pub.triples[1].Predicate, agvocab.ScratchText)
+	if len(pub.triples) != 0 {
+		t.Errorf("recorded triples = %d, want 0 (atomic batch: all-or-nothing)", len(pub.triples))
 	}
 }
 


### PR DESCRIPTION
Per `project_addtriplebatch_migration_followup` memory. Eliminates partial-write orphan triples in the three agent-private state tools that pre-date the batch primitive.

## Background

`AddTriplesBatch` (atomic per-Subject CAS via `graph.mutation.triple.add_batch`) landed in ADR-036 Stage 2 (2026-05-09). `write_todos` has used it since launch. The other three agent-private state tools — `decide`, `emit_diagnosis`, `scratchpad` — were grandfathered onto the older per-triple `AddTriple` loop because they shipped before the batch surface existed.

The per-triple loop could leave inconsistent state under graph-ingest degradation:

- **decide** could leave the coordinator's loop entity with `coordinator.decision.next_action` set but no `coordinator.decision.reason`, breaking deterministic rule routing
- **emit_diagnosis** could leave an incomplete finding visible to ops-agent (the explicit comment in the file called this out as a known limitation)
- **scratchpad** could leave orphan `ScratchID` + `ScratchText` triples without `ScratchCreatedAt` / `ScratchChars` (harmless but visible)

Each tool emits triples on a **single Subject** per call, so the per-Subject atomic batch applies them as one unit — all triples land or none do.

## What's in

- **Interface widening**: `TriplePublisher` gains `AddTriplesBatch(ctx, []message.Triple)` alongside `AddTriple`.
- **NATS adapter**: `natsTriplePublisher.AddTriplesBatch` routes through `graph.mutation.triple.add_batch` (same handler `write_todos` already uses).
- **Three executor migrations**: per-triple loop → single batch call. Same triples, same content, atomic emission.
- **AddTriple kept** for `web_search` / `http_request` — they emit across multiple Subjects per call (URL entity + loop back-link), so the per-Subject batch doesn't help them.

## Test deltas

- `recordingPublisher` (agentic-tools shared) gains `AddTriplesBatch` impl + `batchCalls` counter.
- `recordingPublisher` (executors web_emit_test) gains an `AddTriplesBatch` that **panics** — guards web_search/http_request from accidentally migrating to the wrong path.
- `scratchpadPartialFailurePublisher` (the per-triple-failure mock) replaced with `atomicBatchFailurePublisher` (all-or-nothing).
- **`TestScratchpadExecutor_PartialWrite_LeavesOrphanID` → `TestScratchpadExecutor_BatchFailure_LeavesNoOrphans`** — the visible delta from the project memory. Before: "first 2 triples land, third fails." After: "zero land, atomic batch rejected."
- New `Test*Executor_UsesBatchPath` for all three migrated tools — pins `batchCalls == 1` so a future regression to per-triple emission is caught immediately.

## Validated

- [x] `task lint` clean
- [x] `go test -race ./...` all green
- [x] `task schema:generate` no drift
- [x] Additive on the wire — no rule-config or predicate changes
- [x] e2e not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)