### PR TITLE
fix: audit cleanup (findings 4+5) + two CI flake root causes

### DIFF
--- a/component/port.go
+++ b/component/port.go
@@ -140,13 +140,24 @@ func (p *Port) UnmarshalJSON(data []byte) error {
 				return errs.Wrap(err, "Port", "UnmarshalJSON", "jetstream config unmarshaling")
 			}
 			p.Config = jsConfig
-		case "kvwatch":
+		// Accept both concatenated ("kvwatch") and dashed ("kv-watch")
+		// spellings to match PortDefinition.UnmarshalJSON
+		// (component/ports.go). Pre-2026-05-13 only the concatenated
+		// form parsed here while PortDefinition accepted both —
+		// operator configs that used the dashed spelling worked
+		// through the PortDefinition path but failed loudly if the
+		// same Port was round-tripped through Port.UnmarshalJSON
+		// (e.g. KV-stored Port descriptors or serialized flow
+		// definitions). Audit finding 2026-05-08 (Finding 5).
+		case "kvwatch", "kv-watch":
 			var kvConfig KVWatchPort
 			if err := json.Unmarshal(configWrapper.Data, &kvConfig); err != nil {
 				return errs.Wrap(err, "Port", "UnmarshalJSON", "kvwatch config unmarshaling")
 			}
 			p.Config = kvConfig
-		case "kvwrite":
+		case "kvwrite", "kv-write", "kv":
+			// "kv" is the shorthand PortDefinition.UnmarshalJSON
+			// accepts as well; keep parity.
 			var kvConfig KVWritePort
 			if err := json.Unmarshal(configWrapper.Data, &kvConfig); err != nil {
 				return errs.Wrap(err, "Port", "UnmarshalJSON", "kvwrite config unmarshaling")

--- a/component/port_test.go
+++ b/component/port_test.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -1560,6 +1561,74 @@ func TestPort_UnmarshalJSON_RoundTripsToTypedConfig(t *testing.T) {
 			// implementation, not a map[string]any. This is what catches
 			// drift in Port.UnmarshalJSON's type-discrimination switch.
 			tt.assert(t, decoded)
+		})
+	}
+}
+
+// TestPort_UnmarshalJSON_KVDashedAliases locks in audit-finding-5
+// (2026-05-08): Port.UnmarshalJSON must accept the dashed kv
+// spellings that PortDefinition.UnmarshalJSON already accepts.
+// Pre-fix, operator configs using "kv-watch" / "kv-write" / "kv"
+// parsed via the PortDefinition path but failed loudly if the same
+// Port struct was round-tripped through Port.UnmarshalJSON (e.g.
+// KV-stored Port descriptors or serialized flow definitions).
+//
+// Each case feeds a raw envelope-shaped Port JSON and asserts the
+// Config decodes to the expected typed Portable. Drift between this
+// switch and component/ports.go's PortDefinition.UnmarshalJSON
+// switch trips the test immediately.
+func TestPort_UnmarshalJSON_KVDashedAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeStr  string
+		wantImpl string // pretty-printed concrete type the Config should decode to
+	}{
+		{name: "kvwatch concatenated", typeStr: "kvwatch", wantImpl: "component.KVWatchPort"},
+		{name: "kv-watch dashed", typeStr: "kv-watch", wantImpl: "component.KVWatchPort"},
+		{name: "kvwrite concatenated", typeStr: "kvwrite", wantImpl: "component.KVWritePort"},
+		{name: "kv-write dashed", typeStr: "kv-write", wantImpl: "component.KVWritePort"},
+		{name: "kv shorthand", typeStr: "kv", wantImpl: "component.KVWritePort"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Wire-format mirror of how Port serializes: top-level
+			// name/direction/required/description, plus a config
+			// envelope with {type, data}.
+			var configData string
+			switch tt.wantImpl {
+			case "component.KVWatchPort":
+				configData = `{"bucket":"ENTITY_STATES"}`
+			case "component.KVWritePort":
+				configData = `{"bucket":"AGENT_LOOPS"}`
+			default:
+				t.Fatalf("test setup gap: no fixture for impl %q", tt.wantImpl)
+			}
+			raw := fmt.Sprintf(`{
+				"name": "test.port",
+				"direction": "output",
+				"required": false,
+				"description": "audit-finding-5 dashed-alias coverage",
+				"config": {"type": %q, "data": %s}
+			}`, tt.typeStr, configData)
+
+			var decoded Port
+			if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+				t.Fatalf("unmarshal %q: %v", tt.typeStr, err)
+			}
+
+			// Locate which typed Portable the Config decoded to.
+			var gotImpl string
+			switch decoded.Config.(type) {
+			case KVWatchPort:
+				gotImpl = "component.KVWatchPort"
+			case KVWritePort:
+				gotImpl = "component.KVWritePort"
+			default:
+				gotImpl = fmt.Sprintf("%T", decoded.Config)
+			}
+			if gotImpl != tt.wantImpl {
+				t.Errorf("Config = %s, want %s (spelling %q dropped to map or wrong type)", gotImpl, tt.wantImpl, tt.typeStr)
+			}
 		})
 	}
 }

--- a/processor/graph-clustering/integration_test.go
+++ b/processor/graph-clustering/integration_test.go
@@ -5,6 +5,7 @@ package graphclustering
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -543,9 +544,11 @@ func TestIntegration_ClusteringMinSize(t *testing.T) {
 	// min_community_size=3 prevents formation) flaked the test on
 	// CI. Local runs sometimes raced an unrelated entity-mapping
 	// write into the bucket before Keys was called, masking the
-	// bug. Audit-cleanup commit 2026-05-13.
+	// bug. Audit-cleanup commit 2026-05-13. errors.Is matches the
+	// canonical natsclient/kv.go:385 pattern in this codebase and
+	// also handles wrapped sentinels.
 	keys, err := communityBucket.Keys(ctx)
-	if err != nil && err != jetstream.ErrKeyNotFound && err != jetstream.ErrNoKeysFound {
+	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) && !errors.Is(err, jetstream.ErrNoKeysFound) {
 		require.NoError(t, err)
 	}
 
@@ -1137,10 +1140,14 @@ func TestIntegration_AnomalyDetectionEnabled(t *testing.T) {
 	// Note: Whether anomalies are detected depends on the graph structure
 	t.Log("Anomaly detection successfully initialized and ran")
 
-	// Verify we can access the bucket (it was created)
+	// Verify we can access the bucket (it was created).
+	// Sister sentinel-set to the community-bucket check above —
+	// Keys() on an empty bucket returns jetstream.ErrNoKeysFound,
+	// not ErrKeyNotFound. Pre-2026-05-13 only ErrKeyNotFound was
+	// accepted here too. errors.Is for wrapper resilience.
 	_, err = anomalyBucket.Keys(ctx)
-	if err != nil && err != jetstream.ErrKeyNotFound {
-		// Empty bucket is fine, but should be accessible
+	if err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) && !errors.Is(err, jetstream.ErrNoKeysFound) {
+		// Other errors mean the bucket is genuinely unreachable
 		t.Logf("ANOMALY_INDEX bucket accessible, keys error: %v", err)
 	}
 }

--- a/processor/graph-clustering/integration_test.go
+++ b/processor/graph-clustering/integration_test.go
@@ -531,13 +531,22 @@ func TestIntegration_ClusteringMinSize(t *testing.T) {
 	// Wait for detection cycles
 	time.Sleep(3 * time.Second)
 
-	// Verify no community was formed (below threshold)
+	// Verify no community was formed (below threshold).
+	// Two distinct empty-bucket sentinels are both acceptable here:
+	//   - jetstream.ErrKeyNotFound is for missing single keys, not
+	//     empty Keys() listings.
+	//   - jetstream.ErrNoKeysFound ("nats: no keys found") is what
+	//     Keys() actually returns when the bucket is empty.
+	//
+	// Pre-2026-05-13 only ErrKeyNotFound was accepted, so a fully
+	// empty community bucket (the expected state when
+	// min_community_size=3 prevents formation) flaked the test on
+	// CI. Local runs sometimes raced an unrelated entity-mapping
+	// write into the bucket before Keys was called, masking the
+	// bug. Audit-cleanup commit 2026-05-13.
 	keys, err := communityBucket.Keys(ctx)
-	if err != nil {
-		// Empty bucket is acceptable
-		if err != jetstream.ErrKeyNotFound {
-			require.NoError(t, err)
-		}
+	if err != nil && err != jetstream.ErrKeyNotFound && err != jetstream.ErrNoKeysFound {
+		require.NoError(t, err)
 	}
 
 	// Count community keys (excluding entity mappings)

--- a/processor/oasf-generator/entity_state_test.go
+++ b/processor/oasf-generator/entity_state_test.go
@@ -1,0 +1,73 @@
+package oasfgenerator
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+)
+
+// TestFetchEntityTriples_PreservesAllEntityStateFields locks in the
+// audit-finding-4 fix from 2026-05-08. The oasf-generator used to
+// declare a 3-field local `EntityState` shadow (ID, Triples,
+// UpdatedAt) which silently stripped StorageRef, MessageType, and
+// Version on json.Unmarshal — fine while the code only read Triples,
+// but a latent bug for any future logic that needs the other fields.
+//
+// This test round-trips a fully-populated graph.EntityState through
+// JSON and asserts every field survives. Future drift (e.g. someone
+// re-introducing a local shadow, or graph.EntityState growing a new
+// field that oasf-generator should also see) trips the test.
+func TestFetchEntityTriples_PreservesAllEntityStateFields(t *testing.T) {
+	original := graph.EntityState{
+		ID: "acme.platform.agent.web.observation.h1",
+		Triples: []message.Triple{
+			{Subject: "acme.platform.agent.web.observation.h1", Predicate: "agent.web.url", Object: "https://example.com"},
+		},
+		StorageRef: &message.StorageReference{
+			StorageInstance: "message-store-primary",
+			Key:             "msg-001",
+		},
+		MessageType: message.Type{Domain: "agent", Category: "web_observation", Version: "v1"},
+		Version:     7,
+		UpdatedAt:   time.Date(2026, 5, 13, 12, 0, 0, 0, time.UTC),
+	}
+
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// Mirror the decode path in fetchEntityTriples: unmarshal raw
+	// bucket bytes into graph.EntityState.
+	var decoded graph.EntityState
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded.ID != original.ID {
+		t.Errorf("ID drift: got %q, want %q", decoded.ID, original.ID)
+	}
+	if len(decoded.Triples) != 1 || decoded.Triples[0].Predicate != "agent.web.url" {
+		t.Errorf("Triples drift: got %+v", decoded.Triples)
+	}
+	// StorageRef, MessageType, Version are the three fields the
+	// pre-fix shadow silently stripped — confirm they survive.
+	if decoded.StorageRef == nil ||
+		decoded.StorageRef.StorageInstance != "message-store-primary" ||
+		decoded.StorageRef.Key != "msg-001" {
+		t.Errorf("StorageRef drift: got %+v", decoded.StorageRef)
+	}
+	if decoded.MessageType.Domain != "agent" ||
+		decoded.MessageType.Category != "web_observation" ||
+		decoded.MessageType.Version != "v1" {
+		t.Errorf("MessageType drift: got %+v", decoded.MessageType)
+	}
+	if decoded.Version != 7 {
+		t.Errorf("Version drift: got %d, want 7", decoded.Version)
+	}
+	if !decoded.UpdatedAt.Equal(original.UpdatedAt) {
+		t.Errorf("UpdatedAt drift: got %v, want %v", decoded.UpdatedAt, original.UpdatedAt)
+	}
+}

--- a/processor/oasf-generator/generator.go
+++ b/processor/oasf-generator/generator.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/cache"
@@ -181,20 +182,18 @@ func (g *Generator) fetchEntityTriples(ctx context.Context, entityID string) ([]
 		return nil, errs.Wrap(err, "Generator", "fetchEntityTriples", "get entity state")
 	}
 
-	// Parse entity state (expected to contain triples)
-	var entityState EntityState
+	// Parse entity state (expected to contain triples). Uses the
+	// canonical graph.EntityState rather than a local shadow so any
+	// future oasf logic that needs MessageType (filter by source),
+	// Version (optimistic-concurrency), or StorageRef sees real values
+	// rather than zero values from a silently-stripped JSON decode.
+	// Audit finding 2026-05-08 (Finding 4); closed in this commit.
+	var entityState graph.EntityState
 	if err := json.Unmarshal(entry.Value, &entityState); err != nil {
 		return nil, errs.Wrap(err, "Generator", "fetchEntityTriples", "unmarshal entity state")
 	}
 
 	return entityState.Triples, nil
-}
-
-// EntityState represents the stored state of an entity in KV.
-type EntityState struct {
-	ID        string           `json:"id"`
-	Triples   []message.Triple `json:"triples"`
-	UpdatedAt time.Time        `json:"updated_at"`
 }
 
 // storeAndPublish stores the OASF record and publishes a generation event.

--- a/service/flow_runtime_stream_integration_test.go
+++ b/service/flow_runtime_stream_integration_test.go
@@ -498,20 +498,25 @@ func collectEnvelopesOfType(t *testing.T, conn *websocket.Conn, msgType string, 
 
 		_, data, err := conn.ReadMessage()
 		if err != nil {
-			// Check for any kind of close or permanent error
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-				break
-			}
-			// Check if it's a network timeout (expected, continue trying)
+			// Timeout = no data yet, retry until deadline. This is
+			// the only safe continue path. Every other error class
+			// puts the gorilla/websocket connection into a state
+			// where a subsequent ReadMessage call panics with
+			// "repeated read on failed websocket connection" — the
+			// library considers retry after error a programmer bug.
+			// Pre-2026-05-13 the loop had a default "continue on
+			// transient error" path that hit exactly that panic on
+			// CI runners (network-shape sensitive); the defer
+			// recover() below caught it but left envelopes empty,
+			// flaking the downstream assertion. Audit-cleanup
+			// 2026-05-13.
 			if netErr, ok := err.(interface{ Timeout() bool }); ok && netErr.Timeout() {
 				continue
 			}
-			// Check for "use of closed network connection" type errors
-			if strings.Contains(err.Error(), "closed") || strings.Contains(err.Error(), "failed") {
-				break
-			}
-			// Other transient error, continue trying until deadline
-			continue
+			// Any non-timeout error (close, EOF, "use of closed
+			// network connection", abnormal close, etc.) is
+			// terminal for this connection. Stop reading.
+			break
 		}
 
 		var envelope StatusStreamEnvelope


### PR DESCRIPTION
Two threads bundled because they all came from the 2026-05-08 silent-failure audit baseline (`project_audit_findings_2026_05_08` memory) and from the failed CI run on main after PR #56 (both flakes turned out to be real bugs hiding behind intermittent triggers).

## Summary

**Audit cleanup — both LOW findings, latent today, fixed:**
- Finding 4: `processor/oasf-generator/generator.go` was using a 3-field local `EntityState` shadow that silently stripped `StorageRef` / `MessageType` / `Version` when unmarshaling the canonical 6-field `graph.EntityState`. Replaced with the canonical type. New `TestFetchEntityTriples_PreservesAllEntityStateFields` round-trip test pins the contract.
- Finding 5: `component/port.go`'s `Port.UnmarshalJSON` accepted only `"kvwatch"` / `"kvwrite"`, while `component/ports.go`'s `PortDefinition.UnmarshalJSON` accepts `"kvwatch"`/`"kv-watch"` AND `"kvwrite"`/`"kv-write"`/`"kv"`. Operator configs using dashed spellings parsed via the PortDefinition path but failed loudly when the same Port was round-tripped through Port.UnmarshalJSON (KV-stored Port descriptors, serialized flow definitions). Aligned the two switches. New `TestPort_UnmarshalJSON_KVDashedAliases` with one case per spelling variant.

**CI flake root causes — both real bugs, not pure environmental noise:**
- `processor/graph-clustering/integration_test.go:TestIntegration_ClusteringMinSize` only handled `jetstream.ErrKeyNotFound` (single-key missing) but `Keys()` on an empty bucket actually returns `jetstream.ErrNoKeysFound` (`"nats: no keys found"`). When the community bucket was genuinely empty — the **expected** state with `min_community_size=3` and only 2 entities — the test failed. Locally an unrelated entity-mapping write sometimes raced into the bucket before `Keys()` was called, masking the bug. Fix: accept both sentinels.
- `service/flow_runtime_stream_integration_test.go:collectEnvelopesOfType` had a "continue on any other transient error" default branch. gorilla/websocket panics with `"repeated read on failed websocket connection"` if `ReadMessage` is called after a previous read returned an error — the library treats retry-after-error as a programmer bug. The `defer recover()` caught the panic but left envelopes empty, flaking the downstream `assert.True(foundAllowed)`. Fix: only continue on timeout (no data yet); any other error is terminal for the connection.

## Test plan

- [x] `task lint` clean
- [x] `go test -race ./...` all green
- [x] `go test -tags=integration -race ./...` including both previously flaky tests
- [x] `task schema:generate` no drift

The failed main CI run from earlier today passed on rerun without code changes, confirming the intermittent nature. These fixes eliminate the intermittency rather than rely on retry.

## Memory updates

This PR closes out the 2026-05-08 audit (`project_audit_findings_2026_05_08`) — all 5 findings now resolved. I'll update the memory note post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)