### PR TITLE
feat(agentic-governance, agentic-loop): wiring accessors for semspec integration

### DIFF
--- a/processor/agentic-governance/component.go
+++ b/processor/agentic-governance/component.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/errs"
@@ -598,4 +599,32 @@ func (c *Component) outputPortDefs() []component.PortDefinition {
 // ProcessMessage is a convenience method for testing filter chain processing
 func (c *Component) ProcessMessage(ctx context.Context, msg *Message) (*ChainResult, error) {
 	return c.chain.Process(ctx, msg)
+}
+
+// ToolCallFilter returns the chain's *ToolCallFilter as an agentic.ToolCallFilter,
+// or nil when neither EnableToolGovernance: true nor a "tool_call_governance"
+// entry in FilterChain.Filters was configured. Returns the FIRST matching
+// filter when multiple are present (today the legacy-add guard prevents
+// duplicates; future slice-based wiring should add a ToolCallFilters()
+// accessor rather than redefining this one).
+//
+// The returned filter is safe to share — pass directly to
+// agentic-loop's Component.SetToolCallFilter so the same instance
+// enforces pre-execution tool-call governance there as well. The
+// filter is read-only after construction (BlockedCommandPatterns,
+// BlockedURLPatterns, piiFilter); both Process and FilterToolCalls
+// surfaces can run concurrently on the shared instance. Note the
+// receiver's pre-Start ordering invariant when wiring downstream:
+// the agentic-loop side's SetToolCallFilter must be called before
+// its Component.Start.
+func (c *Component) ToolCallFilter() agentic.ToolCallFilter {
+	if c == nil || c.chain == nil {
+		return nil
+	}
+	for _, f := range c.chain.Filters {
+		if tcf, ok := f.(*ToolCallFilter); ok {
+			return tcf
+		}
+	}
+	return nil
 }

--- a/processor/agentic-governance/component_test.go
+++ b/processor/agentic-governance/component_test.go
@@ -354,6 +354,123 @@ func TestComponent_EnableToolGovernance_Legacy_WithConfigDeclared(t *testing.T) 
 		"safety default must still be present (append-not-replace)")
 }
 
+// TestComponent_ToolCallFilter_Accessor_NotConfigured verifies the
+// accessor returns nil when neither EnableToolGovernance: true nor a
+// config-declared tool_call_governance filter is present (the
+// default config in DefaultConfig()).
+func TestComponent_ToolCallFilter_Accessor_NotConfigured(t *testing.T) {
+	config := DefaultConfig()
+	rawConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := NewComponent(rawConfig, component.Dependencies{})
+	require.NoError(t, err)
+	c := comp.(*Component)
+
+	assert.Nil(t, c.ToolCallFilter(),
+		"default config (no governance enabled either way) returns nil accessor")
+}
+
+// TestComponent_ToolCallFilter_Accessor_LegacyFlag verifies the
+// accessor returns the legacy-appended filter when
+// EnableToolGovernance: true is set without a config-declared filter.
+func TestComponent_ToolCallFilter_Accessor_LegacyFlag(t *testing.T) {
+	config := DefaultConfig()
+	config.EnableToolGovernance = true
+	rawConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := NewComponent(rawConfig, component.Dependencies{})
+	require.NoError(t, err)
+	c := comp.(*Component)
+
+	got := c.ToolCallFilter()
+	require.NotNil(t, got, "legacy flag should expose ToolCallFilter via accessor")
+
+	// Confirm it's the same instance the chain holds.
+	chainTCF := findToolCallFilter(c)
+	require.NotNil(t, chainTCF)
+	assert.Same(t, chainTCF, got,
+		"accessor must return the SAME instance held in the chain (not a copy)")
+}
+
+// TestComponent_ToolCallFilter_Accessor_ConfigDeclared verifies the
+// accessor returns the config-declared filter when tool_call_governance
+// is in FilterChain.Filters. Custom patterns must be present on the
+// returned filter, proving the accessor returns the chain's instance.
+func TestComponent_ToolCallFilter_Accessor_ConfigDeclared(t *testing.T) {
+	config := DefaultConfig()
+	config.FilterChain.Filters = append(config.FilterChain.Filters, FilterConfig{
+		Name:    "tool_call_governance",
+		Enabled: true,
+		ToolCallConfig: &ToolCallFilterConfig{
+			BlockedCommandPatterns: []string{"cd /workspace "},
+		},
+	})
+
+	rawConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := NewComponent(rawConfig, component.Dependencies{})
+	require.NoError(t, err)
+	c := comp.(*Component)
+
+	got := c.ToolCallFilter()
+	require.NotNil(t, got)
+
+	tcf, ok := got.(*ToolCallFilter)
+	require.True(t, ok, "accessor must return a *ToolCallFilter behind the interface")
+	assert.Contains(t, tcf.BlockedCommandPatterns, "cd /workspace ",
+		"accessor returned filter must carry operator's custom patterns")
+	// Regression guard for the post-build PIIFilter patch loop in
+	// component.go (~108-124). If a future refactor moves piiFilter
+	// wiring outside NewComponent's return path, this assertion fires
+	// before any operator deployment sees a silent PII-scan gap.
+	assert.NotNil(t, tcf.piiFilter,
+		"accessor returned filter must have PIIFilter sibling patched in")
+}
+
+// TestComponent_ToolCallFilter_Accessor_BothPaths verifies the accessor
+// still returns exactly one filter when both EnableToolGovernance: true
+// and a config-declared tool_call_governance are set — the
+// !hasToolGovernance guard prevents duplicates, and the accessor must
+// return the config-declared instance (carrying the operator's custom
+// patterns).
+func TestComponent_ToolCallFilter_Accessor_BothPaths(t *testing.T) {
+	config := DefaultConfig()
+	config.EnableToolGovernance = true
+	config.FilterChain.Filters = append(config.FilterChain.Filters, FilterConfig{
+		Name:    "tool_call_governance",
+		Enabled: true,
+		ToolCallConfig: &ToolCallFilterConfig{
+			BlockedCommandPatterns: []string{"cd /workspace "},
+		},
+	})
+
+	rawConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := NewComponent(rawConfig, component.Dependencies{})
+	require.NoError(t, err)
+	c := comp.(*Component)
+
+	assert.Equal(t, 1, countToolCallFilters(c),
+		"both paths must not produce two ToolCallFilters (legacy guard)")
+
+	got := c.ToolCallFilter()
+	require.NotNil(t, got)
+	tcf := got.(*ToolCallFilter)
+	assert.Contains(t, tcf.BlockedCommandPatterns, "cd /workspace ",
+		"accessor must return the config-declared instance (not a legacy-added one with only defaults)")
+}
+
+// TestComponent_ToolCallFilter_Accessor_NilReceiver guards a passing
+// caller from panicking on a possibly-nil Component pointer.
+func TestComponent_ToolCallFilter_Accessor_NilReceiver(t *testing.T) {
+	var c *Component
+	assert.Nil(t, c.ToolCallFilter())
+}
+
 // TestComponent_ConfigDeclaredToolGovernance_NoLegacyFlag verifies the
 // happy path: operator declares tool_call_governance in Filters,
 // EnableToolGovernance stays false (default). One filter, custom

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -286,6 +286,31 @@ func (c *Component) Initialize() error {
 	return nil
 }
 
+// SetToolCallFilter installs a filter that intercepts tool calls before
+// execution on this component's MessageHandler. Pass-through to
+// MessageHandler.SetToolCallFilter.
+//
+// **Ordering invariant:** must be called between NewComponent and Start.
+// The underlying field on MessageHandler is not synchronized — once
+// Start spawns the JetStream consumer callback goroutines, reads of
+// the filter slot race with any further writes. Pass nil to clear a
+// previously installed filter (still bound by the pre-Start
+// ordering). Runtime hot-swap requires either (a) stopping the
+// component first, or (b) promoting the underlying field to
+// atomic.Pointer — neither is wired today.
+//
+// Typical wiring: hold a reference to an agentic-governance.Component,
+// call its ToolCallFilter() accessor to obtain the configured filter,
+// then call SetToolCallFilter here to install it on the loop side.
+// The same governance filter instance enforces inbound governance
+// in the chain AND pre-execution tool-call governance in the loop.
+func (c *Component) SetToolCallFilter(filter agentic.ToolCallFilter) {
+	if c == nil || c.handler == nil {
+		return
+	}
+	c.handler.SetToolCallFilter(filter)
+}
+
 // Start starts the component.
 // The context is used for cancellation during startup operations.
 func (c *Component) Start(ctx context.Context) error {

--- a/processor/agentic-loop/component_setter_internal_test.go
+++ b/processor/agentic-loop/component_setter_internal_test.go
@@ -1,0 +1,61 @@
+package agenticloop
+
+// Internal tests for Component setter pass-throughs that need to read
+// private fields on MessageHandler. Public-API tests for the underlying
+// SetToolCallFilter behaviour live in handlers_test.go.
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/component"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// internalMockFilter is the smallest possible agentic.ToolCallFilter for
+// pass-through verification — we never invoke it, we just confirm the
+// Component's SetToolCallFilter wired it into the handler.
+type internalMockFilter struct{}
+
+func (f *internalMockFilter) FilterToolCalls(_ string, calls []agentic.ToolCall) (agentic.ToolCallFilterResult, error) {
+	return agentic.ToolCallFilterResult{Approved: calls}, nil
+}
+
+// TestComponent_SetToolCallFilter_PassThrough verifies that
+// Component.SetToolCallFilter installs the filter on the underlying
+// MessageHandler (and that passing nil clears it). The Component
+// method is a thin shim over MessageHandler.SetToolCallFilter — the
+// filter's behavioral semantics are tested in handlers_test.go.
+func TestComponent_SetToolCallFilter_PassThrough(t *testing.T) {
+	config := DefaultConfig()
+	rawConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := NewComponent(rawConfig, component.Dependencies{})
+	require.NoError(t, err)
+	c := comp.(*Component)
+
+	require.NotNil(t, c.handler, "handler should be constructed by NewComponent")
+	assert.Nil(t, c.handler.toolCallFilter, "handler starts with nil tool-call filter")
+
+	filter := &internalMockFilter{}
+	c.SetToolCallFilter(filter)
+	assert.Same(t, filter, c.handler.toolCallFilter,
+		"SetToolCallFilter must pass filter through to the handler")
+
+	c.SetToolCallFilter(nil)
+	assert.Nil(t, c.handler.toolCallFilter,
+		"SetToolCallFilter(nil) must clear the handler's filter")
+}
+
+// TestComponent_SetToolCallFilter_NilReceiver_Noop guards the nil-safety
+// branch on the setter. Callers passing through a possibly-nil Component
+// (e.g. configuration paths that may skip the agentic-loop component)
+// shouldn't panic.
+func TestComponent_SetToolCallFilter_NilReceiver_Noop(t *testing.T) {
+	var c *Component
+	assert.NotPanics(t, func() { c.SetToolCallFilter(&internalMockFilter{}) })
+	assert.NotPanics(t, func() { c.SetToolCallFilter(nil) })
+}


### PR DESCRIPTION
## Summary

Closes the integration wiring gap semspec caught after beta.67 (PR #58 / tag `v1.0.0-beta.67`). Beta.67 shipped the *mechanics* for tool-call governance but the consumer-side accessors needed to wire `SetToolCallFilter` from a downstream `main.go` weren't exposed:

- `agentic-governance.Component` held the chain (and the configured `*ToolCallFilter`) in a private `chain` field, with no exported accessor.
- `agentic-loop.Component` held the handler in a private `handler` field; `MessageHandler.SetToolCallFilter` exists but a caller with only a `Component` reference couldn't reach it.

Two thin accessors close the gap. semspec wiring is now:

```go
gov := governanceComponent.(*agenticgovernance.Component)
loop := loopComponent.(*agenticloop.Component)
if f := gov.ToolCallFilter(); f != nil {
    loop.SetToolCallFilter(f)
}
```

## What changed

- `agentic-governance.Component.ToolCallFilter() agentic.ToolCallFilter` — scans `chain.Filters` for the first `*ToolCallFilter`, returns it as the public interface. Returns nil when neither `EnableToolGovernance: true` nor a config-declared `tool_call_governance` filter exists. Returns the **same instance** the chain holds (filter is read-only post-construction; sharing avoids operator-side reconfiguration drift, which is the whole point).
- `agentic-loop.Component.SetToolCallFilter(agentic.ToolCallFilter)` — pass-through to `c.handler.SetToolCallFilter`. **Pre-Start ordering invariant** documented explicitly: must be called between `NewComponent` and `Start` (the underlying field is unsynchronized; runtime hot-swap requires either stop+rewire or a future `atomic.Pointer` upgrade, neither wired today).
- 5 governance accessor tests (not-configured / legacy-flag / config-declared / both-paths-no-duplicate / nil-receiver) + 2 loop setter pass-through tests via new internal `_test.go` file (reads private `handler.toolCallFilter` to verify the wire).

## Review

go-reviewer pass (Opus 4.7). One important issue fixed before request:

- **I1**: doc-comment originally said "safe to call any time after `NewComponent`" — overstated the concurrency contract because `MessageHandler.toolCallFilter` is an unsynchronized field. Reads happen from JetStream consumer goroutines spawned in `Start`, so post-Start setters race. Doc rewritten to specify the pre-Start ordering invariant explicitly; matches the actual safety contract of every other handler setter (`SetSummarizer`, `SetTodoReader`, etc.).
- **N2**: added regression-guard comment to `TestComponent_ToolCallFilter_Accessor_ConfigDeclared` so the next maintainer touching the PIIFilter patch loop understands what's catching the regression.
- **N5**: docstring on `Component.ToolCallFilter()` now disambiguates "first match" semantics for forward-compat with Ask 4.

Verdict was approved-with-fixes; all fixes applied.

## Test plan

- [x] `task lint` clean
- [x] `go vet -tags=integration ./...` clean
- [x] `go vet -tags=live_llm ./...` clean
- [x] `go test -race ./...` full suite green
- [x] 7 new tests pass under `-race`
- [x] `task schema:generate` produces zero diff (no schema-relevant changes)
- [ ] semspec to integrate against `e2e:watch:llm` rig once tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)