### PR TITLE
feat: ADR-039 Phase 2 — subject-mode tool-call governance (BREAKING)

### DIFF
--- a/configs/agentic.json
+++ b/configs/agentic.json
@@ -172,6 +172,13 @@
               "subject": "sensor.processed.entity",
               "type": "jetstream",
               "description": "Sensor entity events"
+            },
+            {
+              "name": "rule_toolcall_proposed_in",
+              "subject": "agent.toolcall.proposed.>",
+              "type": "jetstream",
+              "stream_name": "AGENT",
+              "description": "ADR-039 — proposed tool calls awaiting governance verdict"
             }
           ],
           "outputs": [
@@ -186,12 +193,60 @@
               "type": "jetstream",
               "stream_name": "AGENT",
               "description": "Agent task triggers from rules"
+            },
+            {
+              "name": "toolcall_approved_out",
+              "subject": "agent.toolcall.approved.*",
+              "type": "jetstream",
+              "stream_name": "AGENT",
+              "description": "ADR-039 — approve verdicts to agentic-loop"
+            },
+            {
+              "name": "toolcall_rejected_out",
+              "subject": "agent.toolcall.rejected.*",
+              "type": "jetstream",
+              "stream_name": "AGENT",
+              "description": "ADR-039 — reject verdicts to agentic-loop"
             }
           ]
         },
         "enable_graph_integration": true,
         "graph_event_subject_prefix": "sensor.processed",
         "inline_rules": [
+          {
+            "id": "governance-approve-all-audit",
+            "type": "expression",
+            "name": "ADR-039 audit-mode approve-all (E2E coverage)",
+            "description": "Approves every proposed tool call so the e2e:agentic scenario can verify the governance flow fires (metric increments). Audit-mode means dispatch is not gated; this rule's verdict is observability only. Required `tool_name` condition filters out non-tool-call messages — the rule's default subscription is `>` (match-all), so this condition is what scopes it.",
+            "enabled": true,
+            "conditions": [
+              {
+                "field": "tool_name",
+                "operator": "ne",
+                "value": "",
+                "required": true
+              },
+              {
+                "field": "call_id",
+                "operator": "ne",
+                "value": "",
+                "required": true
+              }
+            ],
+            "logic": "and",
+            "on_enter": [
+              {
+                "type": "approve",
+                "subject": "agent.toolcall.approved.$message.call_id",
+                "reason": "e2e governance audit approve-all for $message.tool_name"
+              }
+            ],
+            "metadata": {
+              "category": "governance",
+              "tier": 0,
+              "purpose": "e2e-coverage"
+            }
+          },
           {
             "id": "temperature-anomaly-agent",
             "type": "expression",
@@ -318,6 +373,10 @@
         "timeout": "30s",
         "stream_name": "AGENT",
         "loops_bucket": "AGENT_LOOPS",
+        "tool_call_governance": {
+          "mode": "audit",
+          "timeout": "1s"
+        },
         "ports": {
           "inputs": [
             {

--- a/docs/concepts/03-streams-vs-kv-watches.md
+++ b/docs/concepts/03-streams-vs-kv-watches.md
@@ -141,11 +141,14 @@ seeing them side-by-side makes the distinction concrete.
 │                                                                    │
 │  Work items (JetStream streams):                                  │
 │                                                                    │
-│   agent.task.*      ──► agentic-loop    "Execute this task"       │
-│   agent.request.*   ──► agentic-model   "Call LLM with these msgs"│
-│   tool.execute.*    ──► agentic-tools   "Run this tool"           │
-│   tool.result.*     ──► agentic-loop    "Here's the tool output"  │
-│   agent.response.*  ──► agentic-loop    "Here's the LLM output"   │
+│   agent.task.*               ──► agentic-loop    "Execute this task"        │
+│   agent.request.*            ──► agentic-model   "Call LLM with these msgs" │
+│   tool.execute.*             ──► agentic-tools   "Run this tool"            │
+│   tool.result.*              ──► agentic-loop    "Here's the tool output"   │
+│   agent.response.*           ──► agentic-loop    "Here's the LLM output"    │
+│   agent.toolcall.proposed.*  ──► rule processor  "Should this call run?"    │
+│   agent.toolcall.approved.>  ──► agentic-loop    "Verdict: approved"        │
+│   agent.toolcall.rejected.>  ──► agentic-loop    "Verdict: rejected"        │
 │                                                                    │
 │  State (KV buckets — twofer):                                     │
 │                                                                    │

--- a/docs/operations/17-tool-call-governance.md
+++ b/docs/operations/17-tool-call-governance.md
@@ -1,0 +1,327 @@
+# Tool-Call Governance (ADR-039)
+
+`agentic-loop` supports subject-mode tool-call governance via the
+rules engine. When enabled, every tool call the model proposes is
+published to `agent.toolcall.proposed.<loop_id>`, rules subscribe and
+emit verdicts on `agent.toolcall.approved.*` / `.rejected.*`, and the
+loop dispatches only approved calls.
+
+This is the rule-driven replacement for the in-process `ToolCallFilter`
+wiring shipped in beta.67+68. The filter wiring stays in place at
+beta.69 as an escape hatch — see [migration guide][migration] for the
+deprecation timeline.
+
+[migration]: migration-beta68-to-beta69.md
+
+## When to use this
+
+Use subject-mode governance when policy needs to:
+
+- Compose across signals (a deny condition depending on caller role
+  AND tool name AND time-of-day).
+- Be operator-editable without a recompile.
+- Emit audit triples that downstream rules can match on.
+- Vary across rule-engine deployments without code changes in
+  agentic-loop.
+
+The in-process `ToolCallFilter` (beta.67+68) handles fixed
+command-pattern blocklists with no rule-engine dependency; if that's
+your only need, you can stay on it through beta.69. Beta.70 retires
+it.
+
+## Modes
+
+Configure on the agentic-loop component:
+
+```json
+{
+  "tool_call_governance": {
+    "mode": "disabled",
+    "timeout": "1s"
+  }
+}
+```
+
+| Mode | Behavior |
+|---|---|
+| `disabled` (default) | No publish, no wait. In-process `ToolCallFilter` runs unchanged. Pre-beta.69 behavior. |
+| `audit` | Publishes every proposed call to `agent.toolcall.proposed.*`. Dispatches **immediately** without waiting. Verdicts that arrive are logged for observability. Use during rule development. |
+| `enforce` | Publishes proposed call, waits up to `timeout` for a per-call verdict, dispatches on approve / fails on reject / fail-closed on timeout. Production posture. |
+
+The default `1s` timeout is deliberately generous for beta.69 so
+operators see real p99 latency in the
+`tool_call_governance_verdict_duration_seconds` histogram before
+tightening. Beta.70 will tighten the default after measurement.
+
+## Subject Topology
+
+```text
+agent.toolcall.proposed.<loop_id>          (out from loop, in to rules)
+agent.toolcall.approved.<loop_id>.<call_id>  (in to loop, out from rules)
+agent.toolcall.rejected.<loop_id>.<call_id>  (in to loop, out from rules)
+```
+
+The loop binds a single wildcard subscription to
+`agent.toolcall.approved.>` and `.rejected.>` at startup, before any
+task arrives. Verdicts demux per-call by the `call_id` field on the
+payload — both approve-action (top-level) and publish-action (nested
+`properties`) shapes are supported.
+
+## Proposed-Call Payload
+
+```json
+{
+  "loop_id": "abc-123",
+  "parent_loop_id": "parent-uuid",
+  "call_id": "call-001",
+  "tool_name": "bash",
+  "command": "ls /tmp",
+  "url": "",
+  "arguments": { ... }
+}
+```
+
+- `parent_loop_id` is empty for top-level loops. It rides along from
+  day one so rules can match across spawn hierarchies (sub-agent
+  governance inheritance) without a wire format change.
+- `command` and `url` are lifted out of `arguments` when present, so
+  rule conditions can match `$message.command` and `$message.url`
+  directly instead of digging through `$message.arguments.command`.
+
+## Verdict Payload
+
+The loop accepts two payload shapes for the verdict:
+
+```json
+// shape A — emitted by `approve` action (top-level)
+{
+  "decision": "approved",
+  "call_id": "call-001",
+  "loop_id": "abc-123",
+  "rule_id": "allow-readonly-tools",
+  "reason": "tool is read-only",
+  "entity_id": "...",
+  "timestamp": "..."
+}
+```
+
+```json
+// shape B — emitted by `publish` action (nested under properties)
+{
+  "subject": "agent.toolcall.rejected.abc-123.call-001",
+  "source": "rule_engine",
+  "properties": {
+    "decision": "rejected",
+    "call_id": "call-001",
+    "reason": "bash disallowed by policy"
+  }
+}
+```
+
+`VerdictPayload.EffectiveDecision` / `EffectiveCallID` / `EffectiveReason`
+fall through both shapes so consumers don't write the dispatch logic
+twice. The ADR-039 canonical pattern uses `publish` + `deny` for
+rejections; the loop accepts the publish-action shape produced by that
+pair.
+
+## Writing Rules
+
+### Block bash patterns
+
+```json
+{
+  "name": "block-bash-workspace-leak",
+  "subscribe": ["agent.toolcall.proposed.>"],
+  "conditions": [
+    {"field": "tool_name", "operator": "eq", "value": "bash"},
+    {"field": "command", "operator": "contains", "value": "cd /workspace"}
+  ],
+  "logic": "all",
+  "on_enter": [
+    {
+      "type": "publish",
+      "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+      "properties": {
+        "decision": "rejected",
+        "call_id": "$message.call_id",
+        "reason": "writes outside worktree blocked"
+      }
+    },
+    {"type": "deny", "reason": "writes outside worktree blocked"}
+  ]
+}
+```
+
+The `publish` action emits the rejection to the loop's verdict
+subject. `deny` short-circuits the rule's remaining actions and
+records an audit triple under `rule.deny`.
+
+### Allow read-only tools
+
+```json
+{
+  "name": "auto-approve-readonly-tools",
+  "subscribe": ["agent.toolcall.proposed.>"],
+  "conditions": [
+    {"field": "tool_name", "operator": "in",
+     "value": ["query_entity", "query_relationships", "read_loop_result", "graph_search"]}
+  ],
+  "on_enter": [
+    {
+      "type": "approve",
+      "subject": "agent.toolcall.approved.$message.loop_id.$message.call_id",
+      "reason": "read-only tool $message.tool_name"
+    }
+  ]
+}
+```
+
+`approve` writes the audit triple (predicate `rule.approve`) AND
+publishes the verdict in one action. It does NOT short-circuit
+subsequent actions — operators may want to add metric-counter actions
+or downstream notifications on the same firing.
+
+### Role-based allowlist with caller context
+
+```json
+{
+  "name": "operator-role-allowlist",
+  "subscribe": ["agent.toolcall.proposed.>"],
+  "conditions": [
+    {"field": "tool_name", "operator": "in",
+     "value": ["bash", "http_request"]},
+    {"field": "$caller.role", "operator": "ne", "value": "operator"}
+  ],
+  "logic": "all",
+  "on_enter": [
+    {
+      "type": "publish",
+      "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+      "properties": {
+        "decision": "rejected",
+        "call_id": "$message.call_id",
+        "reason": "$caller.role role cannot use $message.tool_name"
+      }
+    },
+    {"type": "deny", "reason": "role $caller.role denied for $message.tool_name"}
+  ]
+}
+```
+
+## $message.* Substitution
+
+Rule action templates accept `$message.<field_path>` tokens that
+resolve against the proposed-call payload:
+
+| Token | Resolves to |
+|---|---|
+| `$message.loop_id` | The loop's bare UUID |
+| `$message.call_id` | The tool-call ID — required for verdict subjects |
+| `$message.tool_name` | The tool name (`bash`, `http_request`, etc.) |
+| `$message.command` | The bash command (top-level convenience) |
+| `$message.url` | The HTTP URL (top-level convenience) |
+| `$message.arguments.<key>` | Deep path into the arguments map |
+| `$message.parent_loop_id` | Spawn-tree parent's UUID (empty for top-level) |
+
+An unresolved token (field missing from the payload) survives
+substitution and trips the existing unresolved-template warning at
+`processor/rule/execution_context.go:27` — operators see the
+silent-pass loudly instead of empty strings landing in routing
+subjects.
+
+## Observability
+
+Three Prometheus metrics drive the operational view:
+
+| Metric | Labels | Use |
+|---|---|---|
+| `semstreams_agentic_loop_tool_call_governance_verdict_duration_seconds` | `decision`, `mode` | Buckets 1ms → 5s. Drives the timeout-tuning decision in beta.70 — set `timeout` after measuring p99 from this histogram. |
+| `semstreams_agentic_loop_tool_call_governance_verdict_total` | `decision`, `mode` | Sum of approved+rejected+timeout per mode. Sustained `decision=timeout` rate signals undersized timeout or stuck rule engine. |
+| `semstreams_agentic_loop_tool_call_governance_subscribe_before_publish_failures_total` | (none) | Increments when a verdict arrives without a registered waiter. Non-zero rate is the canonical signal that the subscribe-before-publish race-fix regressed; investigate immediately. |
+
+## Troubleshooting
+
+### All calls fail with `governance verdict timeout`
+
+The loop is in enforce mode but no rule is firing a verdict. Check:
+
+1. Is the rule engine running and subscribed to `agent.toolcall.proposed.>`?
+2. Does at least one rule's `subscribe` field include
+   `agent.toolcall.proposed.>` (or a more specific match)?
+3. Are rule actions writing to
+   `agent.toolcall.approved.$message.loop_id.$message.call_id` or
+   `.rejected.…`?
+4. Is the rule's evaluation triggering? Check
+   `semstreams_rule_evaluations_total{rule_name=...,result=triggered}`.
+
+The deliberately-generous 1s default timeout means a healthy rule
+engine fires well inside the window. If p99 is consistently >500ms,
+something's wrong with the rule path (slow rule, big condition set,
+contended NATS).
+
+### `subscribe_before_publish_failures` rate is non-zero
+
+Verdicts are arriving for `call_id`s that no longer have a registered
+waiter. Either:
+
+- The race-fix regressed (verdict reached the loop before Propose's
+  pre-register — should be impossible given the in-process buffered
+  channel pattern, but worth checking against a recent diff).
+- The verdict is from a different loop component (multi-component
+  deployment sharing the AGENT stream). Filter by inspecting the
+  proposed `loop_id` in the verdict payload — if it doesn't match a
+  known loop, route via a different subject or stream.
+
+### `audit` mode shows verdicts but `enforce` mode times out
+
+Switch back to `audit` and verify the verdict subject matches what the
+loop is subscribed to. The loop subscribes to wildcards
+`agent.toolcall.approved.>` and `.rejected.>` — rules that publish to
+`agent.toolcall.allow.…` or similar custom subjects will be invisible
+to the loop. Restore the canonical subject names.
+
+### Mass-rejection wedge
+
+If every tool call rejects, the loop can't make forward progress.
+This is the rule engine honoring operator policy — not a bug. To
+debug:
+
+1. Switch to `audit` mode temporarily so the loop dispatches anyway
+   but verdicts are still recorded.
+2. Inspect `rule_evaluations_total{result=triggered}` to identify
+   the rule(s) firing.
+3. Once the cause is clear, fix the rule, switch back to `enforce`.
+
+## Sub-Agent Governance Inheritance
+
+`parent_loop_id` rides along in every proposed-call payload — top-level
+loops emit empty, child loops emit their spawn-tree parent. Rules can
+match on `$message.parent_loop_id` to apply policy across loop
+hierarchies. Example:
+
+```json
+{
+  "name": "sub-agents-cannot-shell",
+  "subscribe": ["agent.toolcall.proposed.>"],
+  "conditions": [
+    {"field": "parent_loop_id", "operator": "ne", "value": ""},
+    {"field": "tool_name", "operator": "eq", "value": "bash"}
+  ],
+  "logic": "all",
+  "on_enter": [
+    {
+      "type": "publish",
+      "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+      "properties": {
+        "decision": "rejected",
+        "call_id": "$message.call_id",
+        "reason": "sub-agents cannot execute bash"
+      }
+    },
+    {"type": "deny", "reason": "sub-agents cannot execute bash"}
+  ]
+}
+```
+
+Top-level loops match `parent_loop_id == ""` and are exempt; spawned
+sub-agents match `parent_loop_id != ""` and get the bash deny.

--- a/docs/operations/migration-beta68-to-beta69.md
+++ b/docs/operations/migration-beta68-to-beta69.md
@@ -1,0 +1,212 @@
+# Migration Guide: beta.68 → beta.69
+
+## Summary
+
+beta.69 ships **ADR-039 Phase 2** — subject-mode tool-call governance.
+The rule engine gains a `$message.*` substitution namespace and an
+`approve` action; agentic-loop gains a config flag
+`tool_call_governance.mode` that turns on a published-then-subscribed
+verdict flow.
+
+The beta.67+68 in-process `ToolCallFilter` wiring is **retained** as
+an escape hatch. Operators migrate at their own pace by flipping the
+mode flag; beta.70 retires the in-process surface.
+
+This tag is marked **BREAKING** because:
+
+- New config schema field `tool_call_governance` on agentic-loop.
+  External config validators MUST tolerate the new section (default
+  `disabled` preserves all pre-beta.69 behavior).
+- New input/output ports on agentic-loop (`agent.toolcall.proposed.*`,
+  `agent.toolcall.approved.>`, `agent.toolcall.rejected.>`). Stream
+  provisioning and port-aware tooling must accept them.
+- New rule engine action type `approve` and substitution namespace
+  `$message.*`. Config validators that enumerate accepted action types
+  or substitution tokens must be updated.
+
+No wire-format breaking changes to existing subjects. semspec on
+beta.68 keeps working unchanged at beta.69 with `mode=disabled`.
+
+## For semspec consumers
+
+semspec currently wires the in-process filter:
+
+```go
+gov := governanceComponent.(*agenticgovernance.Component)
+loop := loopComponent.(*agenticloop.Component)
+if f := gov.ToolCallFilter(); f != nil {
+    loop.SetToolCallFilter(f)
+}
+```
+
+This **continues to work at beta.69** with `tool_call_governance.mode = "disabled"`
+(the default). No code change is required to upgrade from beta.68 to
+beta.69 — only the new config section needs to be accepted by your
+config validator.
+
+### Recommended migration path
+
+Two-stage cutover, controlled by config alone:
+
+#### Stage 1 (beta.69): turn on audit mode
+
+```json
+{
+  "agentic-loop": {
+    "tool_call_governance": {
+      "mode": "audit",
+      "timeout": "1s"
+    }
+  }
+}
+```
+
+In `audit` mode, every proposed call is published to
+`agent.toolcall.proposed.*` AND dispatched immediately. Verdicts that
+arrive are logged for observability but do NOT gate dispatch. Rules
+can be developed and tested without affecting production tool-call
+flow.
+
+Verify in metrics:
+
+- `tool_call_governance_verdict_total{decision,mode="audit"}` shows
+  approve/reject verdicts firing as expected.
+- `tool_call_governance_verdict_duration_seconds{mode="audit"}` —
+  inspect p99 to size the enforce-mode timeout.
+
+#### Stage 2 (beta.69, when rules are vetted): switch to enforce
+
+```json
+{
+  "agentic-loop": {
+    "tool_call_governance": {
+      "mode": "enforce",
+      "timeout": "1s"
+    }
+  }
+}
+```
+
+In `enforce` mode the loop **waits** for a per-call verdict and
+**fails-closed on timeout** (treats absent verdict as a reject). The
+in-process `ToolCallFilter` continues to run AFTER the governance
+layer — both can coexist during the migration window. Operators
+typically retire the in-process filter wiring once subject-mode rules
+cover the same policy surface.
+
+#### Stage 3 (beta.70): in-process filter surface retired
+
+When semspec's subject-mode rules are confirmed end-to-end, beta.70
+will retire the in-process filter wiring. Beta.70 will:
+
+- Remove `*ToolCallFilter` interface from `agentic` package.
+- Remove `agentic-loop.Component.SetToolCallFilter` /
+  `agentic-loop.Component.ToolCallFilter` accessors.
+- Remove the `agentic-governance.Component.ToolCallFilter()` accessor
+  (beta.67+68 wiring point).
+- Tighten the `tool_call_governance.timeout` default from `1s` to a
+  measured p99 from beta.69 deployments.
+
+There is no behavior change for deployments already on
+`mode=enforce` at beta.69 — beta.70 only removes the pre-migration
+escape hatch.
+
+### Translating semspec's filter config to rules
+
+semspec's filter config (beta.68):
+
+```json
+{
+  "filter_chain": {
+    "filters": [
+      {
+        "name": "tool_call_governance",
+        "tool_call_config": {
+          "blocked_command_patterns": ["cd /workspace "]
+        }
+      }
+    ]
+  }
+}
+```
+
+Equivalent subject-mode rule (load into the rule engine):
+
+```json
+{
+  "name": "block-bash-workspace-leak",
+  "subscribe": ["agent.toolcall.proposed.>"],
+  "conditions": [
+    {"field": "tool_name", "operator": "eq", "value": "bash"},
+    {"field": "command", "operator": "contains", "value": "cd /workspace"}
+  ],
+  "logic": "all",
+  "on_enter": [
+    {
+      "type": "publish",
+      "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+      "properties": {
+        "decision": "rejected",
+        "call_id": "$message.call_id",
+        "reason": "writes outside worktree blocked"
+      }
+    },
+    {"type": "deny", "reason": "writes outside worktree blocked"}
+  ]
+}
+```
+
+Each `blocked_command_patterns` entry becomes one rule. The
+`publish` + `deny` pair is the canonical ADR-039 rejection pattern:
+`publish` emits the verdict to the loop's subscribed subject; `deny`
+short-circuits subsequent actions and writes the audit triple.
+
+See `docs/operations/17-tool-call-governance.md` for the full operator
+guide, including `approve` action usage, `$caller.*` integration,
+sub-agent governance inheritance via `parent_loop_id`, and
+troubleshooting.
+
+## Behavior changes
+
+- **New default ports on agentic-loop.** `DefaultConfig` now includes
+  `agent.toolcall.proposed`, `agent.toolcall.approved`, and
+  `agent.toolcall.rejected` in the port set. Tests pinning the port
+  count must update from 6→8 inputs and 7→8 outputs.
+- **`ExecutionContext.MessageData`** is a new field on the rule
+  engine's execution context. Populated automatically on the
+  message-path (NATS-subscribed) rules from `GenericJSONPayload.Data`.
+  Nil for entity-state-driven and cron-fired rules; `$message.*`
+  substitution silent-passes + warns when nil.
+- **`Evaluation.MessageData`** is a new field on the stateful
+  evaluator's `Evaluation` struct. Populated by the rule processor's
+  message-path. Callers constructing `Evaluation` manually (rare —
+  almost always the rule processor's job) should populate this for
+  message-path evaluations.
+
+## New public API
+
+| Symbol | Purpose |
+|---|---|
+| `agenticloop.ToolCallGovernanceConfig` | Config struct (Mode + Timeout) |
+| `agenticloop.ToolCallGovernanceMode{Disabled,Audit,Enforce}` | Mode constants |
+| `agenticloop.GovernanceDispatcher` | Interface; constructed automatically in NewComponent |
+| `agenticloop.NewGovernanceDispatcher(cfg, publisher, logger, metrics)` | Manual construction for tests |
+| `agenticloop.ProposedToolCallPayload` | Wire shape published to `agent.toolcall.proposed.*` |
+| `agenticloop.VerdictPayload` | Wire shape accepted on `agent.toolcall.approved/rejected.>` |
+| `rule.ActionTypeApprove` (constant `"approve"`) | New action type |
+| `rule.PredicateRuleApprove` (constant `"rule.approve"`) | Audit-triple predicate |
+
+## Tag-readiness checklist (semstreams)
+
+Per the CLAUDE.md breaking-change rule, at least one relevant e2e
+tier must run green before tag:
+
+```bash
+task e2e:agentic   # required — exercises the rule-driven governance path
+```
+
+The e2e config under `test/e2e/agentic/` should be updated to include
+at least one rule-driven governance scenario in `audit` and `enforce`
+modes before tagging beta.69. If the existing fixtures don't cover
+this path, file a coverage gap and address before tag (HARD RULE per
+`feedback_e2e_required_for_breaking_changes.md`).

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -1797,6 +1797,14 @@ func (c *Component) getContextManagerForLoop(loopID string) *ContextManager {
 // authorship paths (approve action's top-level fields, publish action's
 // nested Properties) are supported.
 //
+// Wire format: the rule engine's `approve` action publishes a
+// `core.json.v1` BaseMessage; the canonical ADR-039 reject pattern
+// (`publish` action + `deny`) publishes a raw map. This handler
+// tolerates BOTH shapes — registry decode first, falling back to raw
+// JSON. The discipline (every publish wraps in registry) governs new
+// code; the fallback preserves the existing reject path. See
+// feedback_nats_publishes_use_payload_registry.
+//
 // No-op when the dispatcher is nil (disabled-mode-without-construction
 // edge case; should not occur in production because NewComponent always
 // constructs a dispatcher).
@@ -1806,10 +1814,10 @@ func (c *Component) handleToolCallVerdictMessage(_ context.Context, data []byte)
 		return
 	}
 
-	var payload VerdictPayload
-	if err := json.Unmarshal(data, &payload); err != nil {
+	payload, ok := decodeVerdictPayload(c.decoder, data)
+	if !ok {
 		c.logger.Warn("Failed to decode tool-call verdict payload; ignoring",
-			slog.String("error", err.Error()))
+			slog.Int("size", len(data)))
 		return
 	}
 
@@ -1823,6 +1831,73 @@ func (c *Component) handleToolCallVerdictMessage(_ context.Context, data []byte)
 	}
 
 	dispatcher.HandleVerdict(decision, callID, data)
+}
+
+// decodeVerdictPayload reads a VerdictPayload from wire bytes,
+// tolerating both authorship paths:
+//
+//  1. `approve` action — `core.json.v1` BaseMessage wrapping a
+//     GenericJSONPayload whose Data map contains the verdict fields.
+//     Decode via the registry, extract Data into VerdictPayload.
+//  2. `publish` action (the ADR-039 reject pattern) — raw map JSON
+//     with fields nested under `properties`. Decode via raw
+//     json.Unmarshal.
+//
+// Returns the decoded VerdictPayload and true on success; false on
+// double-fallback failure (neither shape parsed). The double-attempt
+// is acceptable for verdict frequency (per-tool-call, not per-token).
+func decodeVerdictPayload(decoder *message.Decoder, data []byte) (VerdictPayload, bool) {
+	// Try registry decode first — the canonical post-beta.69 shape.
+	if decoder != nil {
+		if baseMsg, err := decoder.Decode(data); err == nil {
+			if generic, ok := baseMsg.Payload().(*message.GenericJSONPayload); ok {
+				return verdictPayloadFromMap(generic.Data), true
+			}
+		}
+	}
+
+	// Fallback: raw JSON, used by the canonical ADR-039 reject pattern
+	// emitted via the `publish` action. Pre-existing wire shape; the
+	// fallback preserves compatibility.
+	var raw VerdictPayload
+	if err := json.Unmarshal(data, &raw); err == nil {
+		return raw, true
+	}
+
+	return VerdictPayload{}, false
+}
+
+// verdictPayloadFromMap translates a GenericJSONPayload.Data map into
+// the typed VerdictPayload. Only the routing-relevant fields are
+// extracted; the original bytes are still passed to the dispatcher's
+// HandleVerdict for context logging.
+func verdictPayloadFromMap(data map[string]any) VerdictPayload {
+	p := VerdictPayload{}
+	if v, ok := data["decision"].(string); ok {
+		p.Decision = v
+	}
+	if v, ok := data["call_id"].(string); ok {
+		p.CallID = v
+	}
+	if v, ok := data["loop_id"].(string); ok {
+		p.LoopID = v
+	}
+	if v, ok := data["rule_id"].(string); ok {
+		p.RuleID = v
+	}
+	if v, ok := data["reason"].(string); ok {
+		p.Reason = v
+	}
+	if v, ok := data["entity_id"].(string); ok {
+		p.EntityID = v
+	}
+	if v, ok := data["timestamp"].(string); ok {
+		p.Timestamp = v
+	}
+	if v, ok := data["properties"].(map[string]any); ok {
+		p.Properties = v
+	}
+	return p
 }
 
 // updateBoidPositionFromToolResult updates the agent's position in the Boid coordination system

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -103,6 +103,7 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 	}
 	config.Consumer.EnsureDefaults()
 	config.Context.EnsureDefaults()
+	config.ToolCallGovernance.EnsureDefaults()
 
 	// Validate configuration
 	if err := config.Validate(); err != nil {
@@ -147,6 +148,21 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 	handler := NewMessageHandler(config, loopOpts...)
 	handler.modelRegistry = deps.ModelRegistry
 	handler.toolRegistry = deps.ToolRegistry
+
+	// Subject-mode tool-call governance dispatcher (ADR-039). Always
+	// constructed — when Mode is "disabled" (the default) the
+	// dispatcher is a pass-through and the existing in-process
+	// ToolCallFilter wiring runs unchanged. A nil NATSClient (rare —
+	// almost always test scaffolding) yields a publisher-less
+	// dispatcher: disabled mode is unaffected, audit/enforce skip the
+	// publish step and log at Debug.
+	var verdictPublisher VerdictPublisher
+	if deps.NATSClient != nil {
+		verdictPublisher = deps.NATSClient
+	}
+	handler.SetGovernanceDispatcher(NewGovernanceDispatcher(
+		config.ToolCallGovernance, verdictPublisher, deps.GetLogger(),
+	))
 
 	// Wire LLM-backed summarizer for context compaction if model registry is available
 	if deps.ModelRegistry != nil && config.Context.Enabled {
@@ -650,6 +666,15 @@ func (c *Component) setupSubscriptions(ctx context.Context) error {
 			handler = c.handleSignalMessage
 		case "agent.approval_response":
 			handler = c.handleApprovalResponseMessage
+		case "agent.toolcall.approved", "agent.toolcall.rejected":
+			// Verdicts from rule-driven tool-call governance (ADR-039).
+			// Both subjects route into the same demux — the dispatcher
+			// uses the subject path to extract decision + call_id.
+			// Skip if no dispatcher is configured (disabled mode with
+			// no fallback construction); the wildcard subscription is
+			// still cheap to bind but never gets traffic in disabled
+			// mode because nothing publishes to proposed.
+			handler = c.handleToolCallVerdictMessage
 		case "agent.boid":
 			// Only subscribe to Boid signals if Boid coordination is enabled
 			if !c.config.BoidEnabled {
@@ -1757,6 +1782,46 @@ func (c *Component) handleBoidSignalMessage(ctx context.Context, data []byte) {
 // This is used by BoidHandler to apply steering signals to context.
 func (c *Component) getContextManagerForLoop(loopID string) *ContextManager {
 	return c.handler.GetContextManager(loopID)
+}
+
+// handleToolCallVerdictMessage routes inbound verdicts from
+// agent.toolcall.approved.> and agent.toolcall.rejected.> into the
+// governance dispatcher (ADR-039). The dispatcher demuxes by call_id
+// to per-call waiter channels.
+//
+// Both wildcard subjects share this single handler because the
+// existing input-port consumer wrapper discards the subject (see
+// setupConsumer's adapter at component.go:805). The verdict's decision
+// is read from the payload via VerdictPayload.EffectiveDecision — both
+// authorship paths (approve action's top-level fields, publish action's
+// nested Properties) are supported.
+//
+// No-op when the dispatcher is nil (disabled-mode-without-construction
+// edge case; should not occur in production because NewComponent always
+// constructs a dispatcher).
+func (c *Component) handleToolCallVerdictMessage(_ context.Context, data []byte) {
+	dispatcher := c.handler.GovernanceDispatcher()
+	if dispatcher == nil {
+		return
+	}
+
+	var payload VerdictPayload
+	if err := json.Unmarshal(data, &payload); err != nil {
+		c.logger.Warn("Failed to decode tool-call verdict payload; ignoring",
+			slog.String("error", err.Error()))
+		return
+	}
+
+	decision := payload.EffectiveDecision()
+	callID := payload.EffectiveCallID()
+	if decision == "" || callID == "" {
+		c.logger.Warn("Tool-call verdict payload missing decision or call_id; ignoring",
+			slog.String("decision", decision),
+			slog.String("call_id", callID))
+		return
+	}
+
+	dispatcher.HandleVerdict(decision, callID, data)
 }
 
 // updateBoidPositionFromToolResult updates the agent's position in the Boid coordination system

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -162,6 +162,7 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 	}
 	handler.SetGovernanceDispatcher(NewGovernanceDispatcher(
 		config.ToolCallGovernance, verdictPublisher, deps.GetLogger(),
+		getMetrics(deps.MetricsRegistry),
 	))
 
 	// Wire LLM-backed summarizer for context compaction if model registry is available

--- a/processor/agentic-loop/component_test.go
+++ b/processor/agentic-loop/component_test.go
@@ -34,8 +34,8 @@ func TestComponent_InputPorts(t *testing.T) {
 
 	ports := comp.InputPorts()
 
-	if len(ports) != 6 {
-		t.Fatalf("InputPorts() count = %d, want 6", len(ports))
+	if len(ports) != 8 {
+		t.Fatalf("InputPorts() count = %d, want 8", len(ports))
 	}
 
 	// Expected input ports with required flag
@@ -50,6 +50,8 @@ func TestComponent_InputPorts(t *testing.T) {
 		"agent.signal":            {"agent.signal.*", false},            // Optional - not all deployments need signal handling
 		"agent.boid":              {"agent.boid.>", false},              // Optional - Boid steering signals for coordination
 		"agent.approval_response": {"agent.approval_response.*", false}, // Optional - human-in-the-loop approval flow
+		"agent.toolcall.approved": {"agent.toolcall.approved.>", false}, // ADR-039 — verdict inbound (approve)
+		"agent.toolcall.rejected": {"agent.toolcall.rejected.>", false}, // ADR-039 — verdict inbound (reject)
 	}
 
 	for _, port := range ports {
@@ -84,8 +86,8 @@ func TestComponent_OutputPorts(t *testing.T) {
 
 	ports := comp.OutputPorts()
 
-	if len(ports) != 7 {
-		t.Fatalf("OutputPorts() count = %d, want 7", len(ports))
+	if len(ports) != 8 {
+		t.Fatalf("OutputPorts() count = %d, want 8", len(ports))
 	}
 
 	// Expected output ports
@@ -97,6 +99,7 @@ func TestComponent_OutputPorts(t *testing.T) {
 		"agent.failed":             "agent.failed.*",
 		"agent.context.compaction": "agent.context.compaction.*",
 		"agent.approval_pending":   "agent.approval_pending.*",
+		"agent.toolcall.proposed":  "agent.toolcall.proposed.*", // ADR-039 — published before dispatch
 	}
 
 	for _, port := range ports {

--- a/processor/agentic-loop/config.go
+++ b/processor/agentic-loop/config.go
@@ -12,6 +12,37 @@ import (
 // DefaultContextLimit is the fallback context window size when the model is unknown.
 const DefaultContextLimit = 128000
 
+// Tool-call governance mode constants. ADR-039.
+//
+// Disabled is the default — current behavior, no publish to the
+// proposed subject, direct dispatch. Existing in-process
+// ToolCallFilter wiring (beta.67+68) continues to run; semspec's
+// pre-migration deployments keep working unchanged.
+//
+// Audit publishes proposed tool calls to the proposed subject and
+// dispatches IMMEDIATELY without waiting for a verdict — shadow mode
+// for operators developing governance rules without blocking
+// production tool-call flow. Verdicts that arrive later are counted
+// for observability only.
+//
+// Enforce subscribes-then-publishes, waits up to ToolCallGovernance.Timeout
+// for a per-call verdict, and dispatches on approve / fails on
+// reject / fail-closed on timeout. The default 1s timeout is
+// deliberately generous for beta.69 to surface real p99 latency
+// before tightening in beta.70.
+const (
+	ToolCallGovernanceModeDisabled = "disabled"
+	ToolCallGovernanceModeAudit    = "audit"
+	ToolCallGovernanceModeEnforce  = "enforce"
+)
+
+// DefaultToolCallGovernanceTimeout is the wait window for a per-call
+// verdict in enforce mode before the dispatcher fails-closed (treats
+// the absence of a verdict as a reject). 1s is generous for beta.69 to
+// surface real p99 latency; tightens after measurement in beta.70 per
+// ADR-039 §"Observability".
+const DefaultToolCallGovernanceTimeout = "1s"
+
 // Config represents the configuration for the agentic-loop processor
 type Config struct {
 	MaxIterations        int                   `json:"max_iterations" schema:"type:int,description:Maximum number of iterations before loop terminates,default:20,min:1,max:1000,category:basic,required"`
@@ -28,9 +59,101 @@ type Config struct {
 	ContentBucket        string                `json:"content_bucket,omitempty" schema:"type:string,description:NATS ObjectStore bucket for trajectory step content (tool results and model responses),default:AGENT_CONTENT,category:advanced"`
 	TrajectoryCacheTTL   string                `json:"trajectory_cache_ttl,omitempty" schema:"type:string,description:TTL for trajectory cache (e.g. 4h or 30m). Trajectories older than this are only available via graph queries,default:4h,category:advanced"`
 	ApprovalTimeoutStr   string                `json:"approval_timeout,omitempty" schema:"type:string,description:Auto-reject pending approvals after this duration (e.g. 5m or 1h). Empty means wait indefinitely,category:advanced"`
-	Consumer             ConsumerConfig        `json:"consumer" schema:"type:object,description:JetStream consumer tuning for long-running ports (agent.task/agent.response/tool.result),category:advanced"`
-	Context              ContextConfig         `json:"context" schema:"type:object,description:Context window management. Model limits are resolved from the model registry,category:advanced"`
-	Ports                *component.PortConfig `json:"ports,omitempty" schema:"type:ports,description:Port configuration for inputs and outputs,category:basic"`
+	Consumer             ConsumerConfig             `json:"consumer" schema:"type:object,description:JetStream consumer tuning for long-running ports (agent.task/agent.response/tool.result),category:advanced"`
+	Context              ContextConfig              `json:"context" schema:"type:object,description:Context window management. Model limits are resolved from the model registry,category:advanced"`
+	ToolCallGovernance   ToolCallGovernanceConfig   `json:"tool_call_governance,omitempty" schema:"type:object,description:Subject-mode tool-call governance (ADR-039). Default mode=disabled retains existing in-process filter behavior,category:advanced"`
+	Ports                *component.PortConfig      `json:"ports,omitempty" schema:"type:ports,description:Port configuration for inputs and outputs,category:basic"`
+}
+
+// ToolCallGovernanceConfig configures subject-mode tool-call governance
+// (ADR-039). When Mode is "disabled" (the default), the loop keeps its
+// existing in-process ToolCallFilter wiring and never publishes to the
+// proposed subject. When Mode is "audit", every tool call is published
+// to agent.toolcall.proposed.* but dispatch is NOT blocked — verdicts
+// that arrive are logged/counted for observability. When Mode is
+// "enforce", the loop publishes-then-waits for a per-call verdict on
+// agent.toolcall.approved/rejected.* subjects, with Timeout as the
+// fail-closed window.
+//
+// The in-process ToolCallFilter (beta.67+68) is retained alongside this
+// new flow at beta.69 — retirement deferred to beta.70 per ADR-039
+// §"Retirement of beta.67+68 surface". Operators migrate by switching
+// Mode to "audit" (verify rules), then "enforce" (cut over).
+type ToolCallGovernanceConfig struct {
+	// Mode is one of "disabled", "audit", or "enforce". Default
+	// "disabled" preserves pre-beta.69 behavior.
+	Mode string `json:"mode,omitempty" schema:"type:string,description:Governance mode (disabled|audit|enforce). Default disabled retains in-process filter behavior,default:disabled,category:advanced"`
+
+	// Timeout is the per-call wait window in enforce mode before the
+	// dispatcher fails-closed (rejects). Parsed as a Go duration string
+	// (e.g. "500ms", "2s"). Ignored when Mode is "disabled" or "audit".
+	Timeout string `json:"timeout,omitempty" schema:"type:string,description:Per-call verdict wait window in enforce mode (e.g. 500ms or 2s). Default 1s,default:1s,category:advanced"`
+}
+
+// IsEnabled returns true when the governance flow is active (audit or
+// enforce). Callers use this to skip publish setup work when governance
+// is disabled.
+func (c ToolCallGovernanceConfig) IsEnabled() bool {
+	return c.Mode == ToolCallGovernanceModeAudit || c.Mode == ToolCallGovernanceModeEnforce
+}
+
+// IsEnforcing returns true when verdicts gate dispatch. Callers use
+// this to decide whether to wait for verdicts before dispatching.
+func (c ToolCallGovernanceConfig) IsEnforcing() bool {
+	return c.Mode == ToolCallGovernanceModeEnforce
+}
+
+// ParsedTimeout returns the parsed Timeout duration. Falls back to the
+// default when unset or unparseable; Validate is the safety net for
+// malformed input.
+func (c ToolCallGovernanceConfig) ParsedTimeout() time.Duration {
+	if c.Timeout == "" {
+		d, _ := time.ParseDuration(DefaultToolCallGovernanceTimeout)
+		return d
+	}
+	d, err := time.ParseDuration(c.Timeout)
+	if err != nil {
+		fallback, _ := time.ParseDuration(DefaultToolCallGovernanceTimeout)
+		return fallback
+	}
+	return d
+}
+
+// Validate validates the tool-call governance configuration.
+func (c ToolCallGovernanceConfig) Validate() error {
+	switch c.Mode {
+	case "", ToolCallGovernanceModeDisabled, ToolCallGovernanceModeAudit, ToolCallGovernanceModeEnforce:
+		// ok
+	default:
+		return errs.WrapInvalid(
+			fmt.Errorf("mode must be one of disabled, audit, enforce (got %q)", c.Mode),
+			"ToolCallGovernanceConfig", "Validate", "check mode")
+	}
+
+	if c.Timeout != "" {
+		d, err := time.ParseDuration(c.Timeout)
+		if err != nil {
+			return errs.WrapInvalid(err, "ToolCallGovernanceConfig", "Validate", "parse timeout")
+		}
+		if d <= 0 {
+			return errs.WrapInvalid(
+				fmt.Errorf("timeout must be positive (got %s)", c.Timeout),
+				"ToolCallGovernanceConfig", "Validate", "check timeout value")
+		}
+	}
+	return nil
+}
+
+// EnsureDefaults fills zero-valued fields with defaults. Called from
+// Config-level defaulting at boot so an unset governance section has a
+// stable Mode + Timeout instead of empty strings.
+func (c *ToolCallGovernanceConfig) EnsureDefaults() {
+	if c.Mode == "" {
+		c.Mode = ToolCallGovernanceModeDisabled
+	}
+	if c.Timeout == "" {
+		c.Timeout = DefaultToolCallGovernanceTimeout
+	}
 }
 
 // ConsumerConfig holds JetStream consumer tuning for long-running ports.
@@ -103,6 +226,11 @@ func (c Config) Validate() error {
 
 	// Validate consumer config
 	if err := c.Consumer.Validate(); err != nil {
+		return err
+	}
+
+	// Validate tool-call governance config
+	if err := c.ToolCallGovernance.Validate(); err != nil {
 		return err
 	}
 
@@ -231,6 +359,17 @@ func DefaultContextConfig() ContextConfig {
 	}
 }
 
+// DefaultToolCallGovernanceConfig returns the default tool-call
+// governance configuration: disabled mode (preserves pre-ADR-039
+// behavior) with the framework default Timeout for when an operator
+// later flips to enforce.
+func DefaultToolCallGovernanceConfig() ToolCallGovernanceConfig {
+	return ToolCallGovernanceConfig{
+		Mode:    ToolCallGovernanceModeDisabled,
+		Timeout: DefaultToolCallGovernanceTimeout,
+	}
+}
+
 // DefaultConfig returns the default configuration
 func DefaultConfig() Config {
 	return Config{
@@ -246,6 +385,7 @@ func DefaultConfig() Config {
 		TrajectoryDetail:   "summary",
 		Consumer:           DefaultConsumerConfig(),
 		Context:            DefaultContextConfig(),
+		ToolCallGovernance: DefaultToolCallGovernanceConfig(),
 		Ports: &component.PortConfig{
 			Inputs: []component.PortDefinition{
 				{
@@ -295,6 +435,22 @@ func DefaultConfig() Config {
 					StreamName:  "AGENT",
 					Required:    false,
 					Description: "Human approval responses for gated tool calls",
+				},
+				{
+					Name:        "agent.toolcall.approved",
+					Type:        "jetstream",
+					Subject:     "agent.toolcall.approved.>",
+					StreamName:  "AGENT",
+					Required:    false,
+					Description: "Approve verdicts from rule-driven tool-call governance (ADR-039). Wildcard subscription; demuxed per-call by trailing path segments.",
+				},
+				{
+					Name:        "agent.toolcall.rejected",
+					Type:        "jetstream",
+					Subject:     "agent.toolcall.rejected.>",
+					StreamName:  "AGENT",
+					Required:    false,
+					Description: "Reject verdicts from rule-driven tool-call governance (ADR-039). Wildcard subscription; demuxed per-call by trailing path segments.",
 				},
 			},
 			Outputs: []component.PortDefinition{
@@ -346,6 +502,13 @@ func DefaultConfig() Config {
 					Subject:     "agent.approval_pending.*",
 					StreamName:  "AGENT",
 					Description: "Tool calls awaiting human approval (JetStream)",
+				},
+				{
+					Name:        "agent.toolcall.proposed",
+					Type:        "jetstream",
+					Subject:     "agent.toolcall.proposed.*",
+					StreamName:  "AGENT",
+					Description: "Proposed tool calls awaiting rule-driven governance verdict (ADR-039). Emitted in audit and enforce modes.",
 				},
 			},
 			KVWrite: []component.PortDefinition{

--- a/processor/agentic-loop/config.go
+++ b/processor/agentic-loop/config.go
@@ -45,24 +45,24 @@ const DefaultToolCallGovernanceTimeout = "1s"
 
 // Config represents the configuration for the agentic-loop processor
 type Config struct {
-	MaxIterations        int                   `json:"max_iterations" schema:"type:int,description:Maximum number of iterations before loop terminates,default:20,min:1,max:1000,category:basic,required"`
-	Timeout              string                `json:"timeout" schema:"type:string,description:Timeout duration for loop execution (e.g. 120s or 5m),default:120s,category:basic,required"`
-	StreamName           string                `json:"stream_name" schema:"type:string,description:JetStream stream name,default:AGENT,category:advanced"`
-	ConsumerNameSuffix   string                `json:"consumer_name_suffix" schema:"type:string,description:Suffix for consumer names,category:advanced"`
-	DeleteConsumerOnStop bool                  `json:"delete_consumer_on_stop,omitempty" schema:"type:bool,description:Delete durable consumers on Stop (use for tests only),category:advanced,default:false"`
-	LoopsBucket          string                `json:"loops_bucket" schema:"type:string,description:NATS KV bucket name for storing loop state,default:AGENT_LOOPS,category:advanced,required"`
-	PositionsBucket      string                `json:"positions_bucket,omitempty" schema:"type:string,description:NATS KV bucket name for boid agent positions,default:AGENT_POSITIONS,category:advanced"`
-	BoidEnabled          bool                  `json:"boid_enabled,omitempty" schema:"type:bool,description:Enable Boid-style agent coordination (position tracking and steering signals),default:false,category:advanced"`
-	BoidSignalTTL        string                `json:"boid_signal_ttl,omitempty" schema:"type:string,description:TTL for Boid steering signals before expiration (e.g. 30s or 1m),default:30s,category:advanced"`
-	ToolResultMaxBytes   int                   `json:"tool_result_max_bytes,omitempty" schema:"type:int,description:Maximum bytes for tool result content before truncation. 0 means no limit,default:32768,category:advanced"`
-	TrajectoryDetail     string                `json:"trajectory_detail,omitempty" schema:"type:string,description:Trajectory detail level: summary (default) or full,default:summary,category:advanced"`
-	ContentBucket        string                `json:"content_bucket,omitempty" schema:"type:string,description:NATS ObjectStore bucket for trajectory step content (tool results and model responses),default:AGENT_CONTENT,category:advanced"`
-	TrajectoryCacheTTL   string                `json:"trajectory_cache_ttl,omitempty" schema:"type:string,description:TTL for trajectory cache (e.g. 4h or 30m). Trajectories older than this are only available via graph queries,default:4h,category:advanced"`
-	ApprovalTimeoutStr   string                `json:"approval_timeout,omitempty" schema:"type:string,description:Auto-reject pending approvals after this duration (e.g. 5m or 1h). Empty means wait indefinitely,category:advanced"`
-	Consumer             ConsumerConfig             `json:"consumer" schema:"type:object,description:JetStream consumer tuning for long-running ports (agent.task/agent.response/tool.result),category:advanced"`
-	Context              ContextConfig              `json:"context" schema:"type:object,description:Context window management. Model limits are resolved from the model registry,category:advanced"`
-	ToolCallGovernance   ToolCallGovernanceConfig   `json:"tool_call_governance,omitempty" schema:"type:object,description:Subject-mode tool-call governance (ADR-039). Default mode=disabled retains existing in-process filter behavior,category:advanced"`
-	Ports                *component.PortConfig      `json:"ports,omitempty" schema:"type:ports,description:Port configuration for inputs and outputs,category:basic"`
+	MaxIterations        int                      `json:"max_iterations" schema:"type:int,description:Maximum number of iterations before loop terminates,default:20,min:1,max:1000,category:basic,required"`
+	Timeout              string                   `json:"timeout" schema:"type:string,description:Timeout duration for loop execution (e.g. 120s or 5m),default:120s,category:basic,required"`
+	StreamName           string                   `json:"stream_name" schema:"type:string,description:JetStream stream name,default:AGENT,category:advanced"`
+	ConsumerNameSuffix   string                   `json:"consumer_name_suffix" schema:"type:string,description:Suffix for consumer names,category:advanced"`
+	DeleteConsumerOnStop bool                     `json:"delete_consumer_on_stop,omitempty" schema:"type:bool,description:Delete durable consumers on Stop (use for tests only),category:advanced,default:false"`
+	LoopsBucket          string                   `json:"loops_bucket" schema:"type:string,description:NATS KV bucket name for storing loop state,default:AGENT_LOOPS,category:advanced,required"`
+	PositionsBucket      string                   `json:"positions_bucket,omitempty" schema:"type:string,description:NATS KV bucket name for boid agent positions,default:AGENT_POSITIONS,category:advanced"`
+	BoidEnabled          bool                     `json:"boid_enabled,omitempty" schema:"type:bool,description:Enable Boid-style agent coordination (position tracking and steering signals),default:false,category:advanced"`
+	BoidSignalTTL        string                   `json:"boid_signal_ttl,omitempty" schema:"type:string,description:TTL for Boid steering signals before expiration (e.g. 30s or 1m),default:30s,category:advanced"`
+	ToolResultMaxBytes   int                      `json:"tool_result_max_bytes,omitempty" schema:"type:int,description:Maximum bytes for tool result content before truncation. 0 means no limit,default:32768,category:advanced"`
+	TrajectoryDetail     string                   `json:"trajectory_detail,omitempty" schema:"type:string,description:Trajectory detail level: summary (default) or full,default:summary,category:advanced"`
+	ContentBucket        string                   `json:"content_bucket,omitempty" schema:"type:string,description:NATS ObjectStore bucket for trajectory step content (tool results and model responses),default:AGENT_CONTENT,category:advanced"`
+	TrajectoryCacheTTL   string                   `json:"trajectory_cache_ttl,omitempty" schema:"type:string,description:TTL for trajectory cache (e.g. 4h or 30m). Trajectories older than this are only available via graph queries,default:4h,category:advanced"`
+	ApprovalTimeoutStr   string                   `json:"approval_timeout,omitempty" schema:"type:string,description:Auto-reject pending approvals after this duration (e.g. 5m or 1h). Empty means wait indefinitely,category:advanced"`
+	Consumer             ConsumerConfig           `json:"consumer" schema:"type:object,description:JetStream consumer tuning for long-running ports (agent.task/agent.response/tool.result),category:advanced"`
+	Context              ContextConfig            `json:"context" schema:"type:object,description:Context window management. Model limits are resolved from the model registry,category:advanced"`
+	ToolCallGovernance   ToolCallGovernanceConfig `json:"tool_call_governance,omitempty" schema:"type:object,description:Subject-mode tool-call governance (ADR-039). Default mode=disabled retains existing in-process filter behavior,category:advanced"`
+	Ports                *component.PortConfig    `json:"ports,omitempty" schema:"type:ports,description:Port configuration for inputs and outputs,category:basic"`
 }
 
 // ToolCallGovernanceConfig configures subject-mode tool-call governance

--- a/processor/agentic-loop/config_test.go
+++ b/processor/agentic-loop/config_test.go
@@ -201,17 +201,21 @@ func TestDefaultConfig(t *testing.T) {
 		t.Fatal("DefaultConfig() ports should not be nil")
 	}
 
-	// Verify input ports (includes agent.boid for Boid coordination
-	// and agent.approval_response for human-in-the-loop flow)
-	if len(cfg.Ports.Inputs) != 6 {
-		t.Errorf("DefaultConfig() input ports count = %d, want 6", len(cfg.Ports.Inputs))
+	// Verify input ports (includes agent.boid for Boid coordination,
+	// agent.approval_response for human-in-the-loop flow, and the
+	// ADR-039 verdict ports agent.toolcall.approved/rejected for
+	// subject-mode tool-call governance).
+	if len(cfg.Ports.Inputs) != 8 {
+		t.Errorf("DefaultConfig() input ports count = %d, want 8", len(cfg.Ports.Inputs))
 	}
 
 	// Verify output ports (agent.created + agent.failed declared as explicit
 	// output ports so downstream products can override their subjects via
-	// port config, matching the existing treatment of agent.request etc).
-	if len(cfg.Ports.Outputs) != 7 {
-		t.Errorf("DefaultConfig() output ports count = %d, want 7", len(cfg.Ports.Outputs))
+	// port config, matching the existing treatment of agent.request etc.
+	// agent.toolcall.proposed added in ADR-039 — published before dispatch
+	// when governance mode is audit or enforce).
+	if len(cfg.Ports.Outputs) != 8 {
+		t.Errorf("DefaultConfig() output ports count = %d, want 8", len(cfg.Ports.Outputs))
 	}
 
 	// Verify KV ports

--- a/processor/agentic-loop/governance_dispatcher.go
+++ b/processor/agentic-loop/governance_dispatcher.go
@@ -1,0 +1,586 @@
+// Package agenticloop — subject-mode tool-call governance dispatcher (ADR-039).
+//
+// The dispatcher sits between the model's tool-call response and the
+// loop's serial-dispatch fan-out. It implements three modes per
+// ToolCallGovernanceConfig.Mode:
+//
+//   - disabled: pass-through. All calls return as approved without
+//     publishing. Existing in-process ToolCallFilter (beta.67+68) keeps
+//     running unchanged.
+//   - audit: publishes each proposed call to agent.toolcall.proposed.*
+//     but returns all calls as approved IMMEDIATELY. Verdicts that
+//     arrive later are recorded for observability only. Shadow mode
+//     for rule development.
+//   - enforce: subscribes-then-publishes per ADR-039 race-fix option
+//     3 (per-call waiter registration BEFORE publish), waits up to
+//     ToolCallGovernanceConfig.Timeout for a per-call verdict, and
+//     returns approved/rejected sets. Fail-closed on timeout.
+//
+// # Race-condition fix: subscribe before publish
+//
+// JetStream consumer binding is async with publish. If the rule
+// processor fires faster than the loop's verdict subscription binds,
+// the verdict can be published to a subject with no subscribers, the
+// loop times out, the call fails — same class as the natsclient
+// handler-error payload convention bug.
+//
+// Fix: the Component sets up a SINGLE wildcard subscription to
+// `agent.toolcall.approved.>` and `agent.toolcall.rejected.>` at Start.
+// The dispatcher REGISTERS per-call waiter channels in-process BEFORE
+// publishing the proposed call. The wildcard subscription is bound
+// before any task arrives, and the in-process waiter registration is
+// synchronous with the publish call. Verdicts that arrive demux by
+// call_id (trailing path segment) into the registered waiter channel.
+//
+// # Approved subject shape (ADR-039 open question 1)
+//
+// Implementations consume verdict subjects of the shape
+// `agent.toolcall.{approved,rejected}.<loop_id>.<call_id>`. The call_id
+// is the trailing path segment. Operators templating verdict subjects
+// in their rule actions are expected to use
+// `$message.loop_id.$message.call_id`; ADR-039 §"Implementation" lists
+// this contract.
+package agenticloop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"maps"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// VerdictPublisher is the minimum surface the governance dispatcher
+// needs to publish proposed-call payloads. *natsclient.Client satisfies
+// it via PublishToStream. Kept as an interface here so tests can stub
+// the publish path without a real NATS connection.
+type VerdictPublisher interface {
+	PublishToStream(ctx context.Context, subject string, data []byte) error
+}
+
+// ToolCallRejection records why a tool call was denied. Mirrors the
+// existing agentic.ToolCallRejection shape used by the in-process
+// filter so the downstream serial-dispatch code can treat both paths
+// uniformly.
+type ToolCallRejection struct {
+	Call   agentic.ToolCall
+	Reason string
+}
+
+// DispatcherResult is the verdict for a batch of proposed calls. Empty
+// Rejected with full Approved is the disabled-mode/audit-mode steady
+// state. Partial splits are produced by enforce mode and the in-process
+// filter path.
+type DispatcherResult struct {
+	Approved []agentic.ToolCall
+	Rejected []ToolCallRejection
+}
+
+// ProposedToolCallPayload is the wire shape published to
+// agent.toolcall.proposed.<loop_id> in audit and enforce modes. Rules
+// match on these field paths via `$message.<field>` substitution.
+//
+// ParentLoopID is nullable from day one (ADR-039) so rule conditions
+// can match across loop hierarchies for sub-agent governance
+// inheritance. Empty string means no parent.
+type ProposedToolCallPayload struct {
+	LoopID       string         `json:"loop_id"`
+	ParentLoopID string         `json:"parent_loop_id,omitempty"`
+	CallID       string         `json:"call_id"`
+	ToolName     string         `json:"tool_name"`
+	Command      string         `json:"command,omitempty"`
+	URL          string         `json:"url,omitempty"`
+	Arguments    map[string]any `json:"arguments,omitempty"`
+}
+
+// VerdictPayload is the wire shape inbound on
+// agent.toolcall.{approved,rejected}.<loop_id>.<call_id>. Produced by
+// the rule engine's executeApprove action (top-level fields) OR by a
+// rule `publish` action emitting a rejection (fields nested under
+// Properties — the canonical ADR-039 reject pattern).
+//
+// Both shapes are supported because the ADR's example rule uses
+// `publish` + `deny` together for rejections (no extra `reject`
+// action). EffectiveCallID and EffectiveDecision fall through the two
+// shapes so callers don't write the same parsing code twice.
+type VerdictPayload struct {
+	Decision   string         `json:"decision,omitempty"`
+	CallID     string         `json:"call_id,omitempty"`
+	LoopID     string         `json:"loop_id,omitempty"`
+	RuleID     string         `json:"rule_id,omitempty"`
+	Reason     string         `json:"reason,omitempty"`
+	EntityID   string         `json:"entity_id,omitempty"`
+	Timestamp  string         `json:"timestamp,omitempty"`
+	Properties map[string]any `json:"properties,omitempty"`
+}
+
+// EffectiveCallID returns the routing call_id from the payload,
+// preferring the top-level CallID (approve-action shape) and falling
+// back to Properties["call_id"] (publish-action shape).
+func (v VerdictPayload) EffectiveCallID() string {
+	if v.CallID != "" {
+		return v.CallID
+	}
+	if v.Properties != nil {
+		if cid, ok := v.Properties["call_id"].(string); ok {
+			return cid
+		}
+	}
+	return ""
+}
+
+// EffectiveDecision returns the routing decision from the payload,
+// preferring the top-level Decision (approve-action shape) and falling
+// back to Properties["decision"] (publish-action shape).
+func (v VerdictPayload) EffectiveDecision() string {
+	if v.Decision != "" {
+		return v.Decision
+	}
+	if v.Properties != nil {
+		if d, ok := v.Properties["decision"].(string); ok {
+			return d
+		}
+	}
+	return ""
+}
+
+// EffectiveReason returns the human-readable reason, with the same
+// fall-through semantics as EffectiveCallID.
+func (v VerdictPayload) EffectiveReason() string {
+	if v.Reason != "" {
+		return v.Reason
+	}
+	if v.Properties != nil {
+		if r, ok := v.Properties["reason"].(string); ok {
+			return r
+		}
+	}
+	return ""
+}
+
+// GovernanceDispatcher abstracts the subject-mode tool-call governance
+// flow. The Component holds one instance per loop component and
+// delegates from handleToolCallResponse before the existing serial-
+// dispatch. Verdict arrival from the JetStream subscription is fed in
+// via HandleVerdict.
+type GovernanceDispatcher interface {
+	// Propose submits a batch of tool calls for governance review.
+	// Returns the approved/rejected split. Disabled mode passes
+	// through; audit mode publishes-but-passes-through; enforce mode
+	// waits up to the configured timeout per call and fails-closed on
+	// timeout (treats absent verdict as a reject).
+	//
+	// loopID is the originating loop's bare UUID. parentLoopID is the
+	// spawn-tree parent (empty for top-level loops). Both ride along
+	// in the proposed payload so rule conditions can match across the
+	// hierarchy from day one.
+	Propose(ctx context.Context, loopID, parentLoopID string, calls []agentic.ToolCall) (DispatcherResult, error)
+
+	// HandleVerdict feeds an inbound verdict to the dispatcher. The
+	// Component's wildcard subscription handlers call this for every
+	// verdict, after extracting the decision and call_id from the
+	// payload via VerdictPayload.EffectiveCallID/EffectiveDecision.
+	// The dispatcher demuxes by call_id to the appropriate waiter
+	// channel. No-op when no waiter is registered for the call_id
+	// (audit mode, late arrivals, verdicts for other components'
+	// loops on a shared stream). Data is retained for audit logging
+	// only — routing decisions are made from decision + callID.
+	HandleVerdict(decision, callID string, data []byte)
+
+	// Mode returns the configured mode for inspection. Useful for
+	// observability gauges and conditional logging in the handler.
+	Mode() string
+}
+
+// NewGovernanceDispatcher constructs the dispatcher matching the
+// configured mode. Publisher may be nil in disabled mode (no publishes
+// happen). The returned dispatcher's HandleVerdict is safe to call
+// from JetStream consumer callbacks.
+//
+// The dispatcher does NOT subscribe — the Component owns the wildcard
+// JetStream subscription and routes verdicts through HandleVerdict.
+// That keeps the consumer lifecycle (create / bind / cleanup-on-stop)
+// in one place and lets the dispatcher stay free of NATS dependencies.
+func NewGovernanceDispatcher(cfg ToolCallGovernanceConfig, publisher VerdictPublisher, logger *slog.Logger) GovernanceDispatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	switch cfg.Mode {
+	case ToolCallGovernanceModeAudit:
+		return &auditDispatcher{
+			publisher: publisher,
+			logger:    logger,
+		}
+	case ToolCallGovernanceModeEnforce:
+		return &enforceDispatcher{
+			publisher: publisher,
+			logger:    logger,
+			timeout:   cfg.ParsedTimeout(),
+			waiters:   map[string]chan verdictArrival{},
+		}
+	default:
+		// disabled (and any unknown value — Validate is the safety net)
+		return &disabledDispatcher{logger: logger}
+	}
+}
+
+// --- disabled mode ---------------------------------------------------
+
+type disabledDispatcher struct {
+	logger *slog.Logger
+}
+
+func (d *disabledDispatcher) Propose(_ context.Context, _, _ string, calls []agentic.ToolCall) (DispatcherResult, error) {
+	return DispatcherResult{Approved: calls}, nil
+}
+
+func (d *disabledDispatcher) HandleVerdict(decision, callID string, _ []byte) {
+	// No-op: in disabled mode the loop didn't publish a proposed call,
+	// so any verdict arriving is from another flow (or a misconfigured
+	// rule). Log at Debug only — not actionable.
+	d.logger.Debug("Verdict received in disabled-mode governance dispatcher; ignoring",
+		slog.String("decision", decision),
+		slog.String("call_id", callID))
+}
+
+func (d *disabledDispatcher) Mode() string { return ToolCallGovernanceModeDisabled }
+
+// --- audit mode -----------------------------------------------------
+
+type auditDispatcher struct {
+	publisher VerdictPublisher
+	logger    *slog.Logger
+}
+
+func (d *auditDispatcher) Propose(ctx context.Context, loopID, parentLoopID string, calls []agentic.ToolCall) (DispatcherResult, error) {
+	// Audit mode publishes every proposed call but does NOT block on
+	// verdicts. Publish failure is logged at Warn — audit is
+	// best-effort observability, not a gate. Returning an error here
+	// would fail tool calls operators explicitly chose NOT to gate.
+	for _, call := range calls {
+		if err := publishProposed(ctx, d.publisher, loopID, parentLoopID, call, d.logger); err != nil {
+			d.logger.Warn("Audit-mode publish failed; dispatch continues",
+				slog.String("loop_id", loopID),
+				slog.String("call_id", call.ID),
+				slog.String("tool_name", call.Name),
+				slog.Any("error", err))
+		}
+	}
+	return DispatcherResult{Approved: calls}, nil
+}
+
+func (d *auditDispatcher) HandleVerdict(decision, callID string, data []byte) {
+	// Audit mode logs verdicts for visibility but takes no action.
+	// Operators developing rules see their verdicts firing without
+	// gating real traffic.
+	var payload VerdictPayload
+	_ = json.Unmarshal(data, &payload)
+	d.logger.Info("Audit-mode verdict observed",
+		slog.String("decision", decision),
+		slog.String("call_id", callID),
+		slog.String("rule_id", payload.RuleID),
+		slog.String("reason", payload.EffectiveReason()))
+}
+
+func (d *auditDispatcher) Mode() string { return ToolCallGovernanceModeAudit }
+
+// --- enforce mode ---------------------------------------------------
+
+// verdictArrival is the message passed from HandleVerdict (running on
+// the JetStream consumer callback) to a Propose call waiting on its
+// waiter channel.
+type verdictArrival struct {
+	decision string
+	reason   string
+	ruleID   string
+}
+
+type enforceDispatcher struct {
+	publisher VerdictPublisher
+	logger    *slog.Logger
+	timeout   time.Duration
+
+	mu      sync.Mutex
+	waiters map[string]chan verdictArrival
+}
+
+// registerWaiter installs a per-call waiter channel BEFORE publish.
+// Buffered with capacity 1 so an early-arriving verdict (after publish
+// returns but before Propose enters the select) doesn't block the
+// HandleVerdict goroutine. The caller is responsible for releasing the
+// waiter via releaseWaiter exactly once (defer at the call site).
+func (d *enforceDispatcher) registerWaiter(callID string) chan verdictArrival {
+	ch := make(chan verdictArrival, 1)
+	d.mu.Lock()
+	d.waiters[callID] = ch
+	d.mu.Unlock()
+	return ch
+}
+
+func (d *enforceDispatcher) releaseWaiter(callID string) {
+	d.mu.Lock()
+	delete(d.waiters, callID)
+	d.mu.Unlock()
+}
+
+func (d *enforceDispatcher) lookupWaiter(callID string) (chan verdictArrival, bool) {
+	d.mu.Lock()
+	ch, ok := d.waiters[callID]
+	d.mu.Unlock()
+	return ch, ok
+}
+
+func (d *enforceDispatcher) Propose(ctx context.Context, loopID, parentLoopID string, calls []agentic.ToolCall) (DispatcherResult, error) {
+	// Pre-register every waiter BEFORE the first publish. Closes the
+	// subscribe-before-publish race window: even if a verdict arrives
+	// between publish-return and the per-call select below, the
+	// HandleVerdict path will find the waiter and deliver into the
+	// buffered channel.
+	channels := make(map[string]chan verdictArrival, len(calls))
+	for _, call := range calls {
+		channels[call.ID] = d.registerWaiter(call.ID)
+	}
+	defer func() {
+		for _, call := range calls {
+			d.releaseWaiter(call.ID)
+		}
+	}()
+
+	// Publish all proposed calls. Publish failure on any call is
+	// fail-closed: treat that call as rejected with the publish error
+	// as the reason. The rest of the batch continues — operators get
+	// per-call observability rather than a batch-level all-or-nothing.
+	publishFailures := map[string]error{}
+	for _, call := range calls {
+		if err := publishProposed(ctx, d.publisher, loopID, parentLoopID, call, d.logger); err != nil {
+			publishFailures[call.ID] = err
+		}
+	}
+
+	// Per-call wait. Approved/rejected sets are accumulated in order
+	// so the downstream serial dispatcher sees calls in the same
+	// order the model emitted them.
+	var (
+		approved []agentic.ToolCall
+		rejected []ToolCallRejection
+	)
+	for _, call := range calls {
+		if pubErr, failed := publishFailures[call.ID]; failed {
+			rejected = append(rejected, ToolCallRejection{
+				Call:   call,
+				Reason: fmt.Sprintf("governance publish failed: %v", pubErr),
+			})
+			continue
+		}
+
+		decision, reason := d.awaitVerdict(ctx, channels[call.ID], call, loopID)
+		switch decision {
+		case "approved":
+			approved = append(approved, call)
+		case "rejected":
+			rejected = append(rejected, ToolCallRejection{Call: call, Reason: reason})
+		default:
+			// timeout or unknown — fail-closed
+			rejected = append(rejected, ToolCallRejection{Call: call, Reason: reason})
+		}
+	}
+	return DispatcherResult{Approved: approved, Rejected: rejected}, nil
+}
+
+// awaitVerdict blocks until a verdict arrives, the context is cancelled,
+// or the configured timeout elapses. Returns the decision string
+// ("approved" | "rejected" | "timeout") and a human-readable reason.
+func (d *enforceDispatcher) awaitVerdict(ctx context.Context, ch chan verdictArrival, call agentic.ToolCall, loopID string) (string, string) {
+	// Use a fresh timer per call. time.After leaks the underlying
+	// timer until the channel fires; NewTimer + Stop is the idiomatic
+	// per-iteration pattern.
+	timer := time.NewTimer(d.timeout)
+	defer timer.Stop()
+
+	select {
+	case v := <-ch:
+		if v.decision == "" {
+			// Shouldn't happen — HandleVerdict only sends with a known
+			// decision. Defensive: treat as fail-closed.
+			d.logger.Warn("Enforce-mode verdict missing decision; rejecting fail-closed",
+				slog.String("loop_id", loopID),
+				slog.String("call_id", call.ID))
+			return "rejected", "governance verdict missing decision (fail-closed)"
+		}
+		return v.decision, fmtVerdictReason(v)
+	case <-timer.C:
+		d.logger.Warn("Enforce-mode verdict timeout; rejecting fail-closed",
+			slog.String("loop_id", loopID),
+			slog.String("call_id", call.ID),
+			slog.String("tool_name", call.Name),
+			slog.Duration("timeout", d.timeout))
+		return "timeout", fmt.Sprintf("governance verdict timeout after %s (fail-closed)", d.timeout)
+	case <-ctx.Done():
+		return "timeout", fmt.Sprintf("governance wait cancelled: %v", ctx.Err())
+	}
+}
+
+func (d *enforceDispatcher) HandleVerdict(decision, callID string, data []byte) {
+	if decision == "" || callID == "" {
+		d.logger.Warn("Verdict missing decision or call_id; ignoring",
+			slog.String("decision", decision),
+			slog.String("call_id", callID))
+		return
+	}
+
+	// Payload is optional audit context — routing relies on the
+	// (decision, callID) pair supplied by the caller. An unmarshal
+	// failure here downgrades the verdict reason but doesn't block
+	// dispatch.
+	var payload VerdictPayload
+	_ = json.Unmarshal(data, &payload)
+
+	ch, ok := d.lookupWaiter(callID)
+	if !ok {
+		// Either late arrival (Propose already returned via timeout)
+		// or a verdict for a different loop's call. Common in healthy
+		// operation when retries happen; log at Debug.
+		d.logger.Debug("Verdict arrived after waiter released; ignoring",
+			slog.String("call_id", callID),
+			slog.String("decision", decision))
+		return
+	}
+
+	// Non-blocking send via the buffered channel. If somehow a second
+	// verdict arrives for the same call_id (operator misconfigured a
+	// rule into a duplicate publish), the second is dropped — the
+	// first wins. Same as the natsclient request/response convention.
+	select {
+	case ch <- verdictArrival{decision: decision, reason: payload.EffectiveReason(), ruleID: payload.RuleID}:
+	default:
+		d.logger.Debug("Verdict channel already full (duplicate verdict?); dropping",
+			slog.String("call_id", callID))
+	}
+}
+
+func (d *enforceDispatcher) Mode() string { return ToolCallGovernanceModeEnforce }
+
+// --- shared helpers -------------------------------------------------
+
+// publishProposed serialises a single tool call as a
+// ProposedToolCallPayload and publishes to
+// agent.toolcall.proposed.<loop_id>. The subject shape matches the
+// ADR-039 commitment: rules subscribe to `agent.toolcall.proposed.*`
+// and match against the payload via $message.* substitution.
+//
+// Returns an error from marshal/publish — the caller decides whether
+// the error is fatal (enforce mode treats it as a fail-closed reject)
+// or best-effort (audit mode logs and proceeds).
+func publishProposed(ctx context.Context, publisher VerdictPublisher, loopID, parentLoopID string, call agentic.ToolCall, logger *slog.Logger) error {
+	if publisher == nil {
+		// No publisher: dev/test scaffold without a NATS connection.
+		// Log at Debug and treat as a no-op — disabled mode never
+		// reaches here; audit mode is best-effort; enforce mode will
+		// time out because no verdict can arrive.
+		if logger != nil {
+			logger.Debug("Skipping proposed-call publish (no publisher configured)",
+				slog.String("loop_id", loopID),
+				slog.String("call_id", call.ID))
+		}
+		return nil
+	}
+
+	payload := ProposedToolCallPayload{
+		LoopID:       loopID,
+		ParentLoopID: parentLoopID,
+		CallID:       call.ID,
+		ToolName:     call.Name,
+		Arguments:    coerceArguments(call.Arguments),
+	}
+	// Lift bash/http top-level conveniences out of the arguments map
+	// when present. Rule authors typically reach for $message.command /
+	// $message.url rather than $message.arguments.command — pre-flatten
+	// the two highest-value common fields so the rule DSL stays
+	// readable. The full Arguments map remains available for deep
+	// matching.
+	if cmd, ok := payload.Arguments["command"].(string); ok {
+		payload.Command = cmd
+	}
+	if url, ok := payload.Arguments["url"].(string); ok {
+		payload.URL = url
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal proposed-call payload: %w", err)
+	}
+
+	subject := "agent.toolcall.proposed." + loopID
+	if err := publisher.PublishToStream(ctx, subject, data); err != nil {
+		return fmt.Errorf("publish proposed to %s: %w", subject, err)
+	}
+	return nil
+}
+
+// coerceArguments normalises ToolCall.Arguments to a map[string]any so
+// the proposed payload's Arguments field has consistent JSON shape.
+// agentic.ToolCall.Arguments is already map[string]any in current
+// builds — this is defensive against future shape changes.
+func coerceArguments(args map[string]any) map[string]any {
+	if args == nil {
+		return nil
+	}
+	out := make(map[string]any, len(args))
+	maps.Copy(out, args)
+	return out
+}
+
+// decisionFromVerdictSubject parses the third segment of a verdict
+// subject (`agent.toolcall.{approved,rejected}.…`) into the decision
+// label. Returns "" when the subject doesn't begin with
+// `agent.toolcall.<approved|rejected>.` so callers can fall back to
+// payload-based extraction.
+//
+// The Component routes BOTH wildcard ports (approved / rejected) to a
+// shared handler; this helper plus VerdictPayload.EffectiveDecision
+// together cover both authorship paths (executeApprove writes the
+// decision field; executePublish leaves it in Properties).
+func decisionFromVerdictSubject(subject string) string {
+	parts := strings.SplitN(subject, ".", 4)
+	if len(parts) < 3 {
+		return ""
+	}
+	if parts[0] != "agent" || parts[1] != "toolcall" {
+		return ""
+	}
+	switch parts[2] {
+	case "approved":
+		return "approved"
+	case "rejected":
+		return "rejected"
+	}
+	return ""
+}
+
+// fmtVerdictReason formats the human-readable reason for an arrived
+// verdict, falling back to a default when the rule didn't supply one.
+func fmtVerdictReason(v verdictArrival) string {
+	switch {
+	case v.reason != "" && v.ruleID != "":
+		return fmt.Sprintf("%s (rule_id=%s)", v.reason, v.ruleID)
+	case v.reason != "":
+		return v.reason
+	case v.ruleID != "":
+		return fmt.Sprintf("rule_id=%s", v.ruleID)
+	default:
+		return "governance verdict (no reason)"
+	}
+}
+
+// ErrGovernancePublishFailed is returned by Propose only when the
+// dispatcher is unable to make any forward progress at all — currently
+// unused (per-call publish failures are recorded as per-call
+// rejections). Reserved for a future architectural failure mode that
+// short-circuits the entire batch.
+var ErrGovernancePublishFailed = errors.New("governance publish failed")

--- a/processor/agentic-loop/governance_dispatcher.go
+++ b/processor/agentic-loop/governance_dispatcher.go
@@ -54,6 +54,7 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
 )
 
 // VerdictPublisher is the minimum surface the governance dispatcher
@@ -552,7 +553,16 @@ func publishProposed(ctx context.Context, publisher VerdictPublisher, loopID, pa
 		payload.URL = url
 	}
 
-	data, err := json.Marshal(payload)
+	// Wrap in a `core.json.v1` BaseMessage envelope so the rule
+	// processor's decoder can parse this off the wire. The rule
+	// processor requires wireFormat-shaped messages (id/type/meta/
+	// payload); a raw `json.Marshal(ProposedToolCallPayload)` would
+	// fail decode and the rules would never see proposed calls. The
+	// `Data` map round-trips through GenericJSONPayload so
+	// `$message.<field>` substitution reads the proposed-call fields
+	// directly via `extractMessageData` in
+	// processor/rule/message_handler.go.
+	data, err := payloadToBaseMessageBytes(payload, "agentic-loop")
 	if err != nil {
 		return fmt.Errorf("marshal proposed-call payload: %w", err)
 	}
@@ -562,6 +572,35 @@ func publishProposed(ctx context.Context, publisher VerdictPublisher, loopID, pa
 		return fmt.Errorf("publish proposed to %s: %w", subject, err)
 	}
 	return nil
+}
+
+// payloadToBaseMessageBytes converts a ProposedToolCallPayload into a
+// wire-format BaseMessage envelope wrapping a `core.json.v1`
+// GenericJSONPayload. Returns the marshaled bytes ready to publish.
+//
+// The rule processor decodes via `message.NewDecoder(reg).Decode(data)`
+// which expects a wireFormat envelope; raw struct JSON fails that
+// decode path. GenericJSONPayload is the existing well-known type for
+// arbitrary JSON data; rule conditions and `$message.*` substitution
+// already consume `GenericJSONPayload.Data`.
+//
+// Round-trips the proposed payload via JSON to land in
+// `map[string]any` because GenericJSONPayload.Data is map-typed. The
+// allocation cost is acceptable on the per-tool-call hot path
+// (proposed-call publish is once per tool call; not once per
+// iteration).
+func payloadToBaseMessageBytes(payload ProposedToolCallPayload, source string) ([]byte, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal proposed-call to map: %w", err)
+	}
+	var asMap map[string]any
+	if err := json.Unmarshal(raw, &asMap); err != nil {
+		return nil, fmt.Errorf("re-decode proposed-call to map: %w", err)
+	}
+	generic := message.NewGenericJSON(asMap)
+	baseMsg := message.NewBaseMessage(generic.Schema(), generic, source)
+	return json.Marshal(baseMsg)
 }
 
 // coerceArguments normalises ToolCall.Arguments to a map[string]any so

--- a/processor/agentic-loop/governance_dispatcher.go
+++ b/processor/agentic-loop/governance_dispatcher.go
@@ -64,6 +64,25 @@ type VerdictPublisher interface {
 	PublishToStream(ctx context.Context, subject string, data []byte) error
 }
 
+// DispatcherMetrics is the optional metrics-sink interface the
+// dispatcher calls into for observability. The Component's
+// *loopMetrics satisfies it; tests pass nil.
+//
+// Kept narrow so the dispatcher stays free of Prometheus types and the
+// metrics layer can evolve independently. Implementations should be
+// non-blocking — the dispatcher is on the loop's hot path.
+type DispatcherMetrics interface {
+	// RecordGovernanceVerdict observes the wait duration and counts the
+	// verdict. decision is "approved" | "rejected" | "timeout"; mode is
+	// "audit" | "enforce".
+	RecordGovernanceVerdict(decision, mode string, duration float64)
+
+	// RecordGovernanceVerdictMissingWaiter signals that a verdict
+	// arrived for a call_id without a registered waiter — points at
+	// the subscribe-before-publish race regressing or a late arrival.
+	RecordGovernanceVerdictMissingWaiter()
+}
+
 // ToolCallRejection records why a tool call was denied. Mirrors the
 // existing agentic.ToolCallRejection shape used by the in-process
 // filter so the downstream serial-dispatch code can treat both paths
@@ -200,14 +219,15 @@ type GovernanceDispatcher interface {
 
 // NewGovernanceDispatcher constructs the dispatcher matching the
 // configured mode. Publisher may be nil in disabled mode (no publishes
-// happen). The returned dispatcher's HandleVerdict is safe to call
-// from JetStream consumer callbacks.
+// happen). Metrics may be nil — observability records are skipped when
+// unset. The returned dispatcher's HandleVerdict is safe to call from
+// JetStream consumer callbacks.
 //
 // The dispatcher does NOT subscribe — the Component owns the wildcard
 // JetStream subscription and routes verdicts through HandleVerdict.
 // That keeps the consumer lifecycle (create / bind / cleanup-on-stop)
 // in one place and lets the dispatcher stay free of NATS dependencies.
-func NewGovernanceDispatcher(cfg ToolCallGovernanceConfig, publisher VerdictPublisher, logger *slog.Logger) GovernanceDispatcher {
+func NewGovernanceDispatcher(cfg ToolCallGovernanceConfig, publisher VerdictPublisher, logger *slog.Logger, metrics DispatcherMetrics) GovernanceDispatcher {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -216,11 +236,13 @@ func NewGovernanceDispatcher(cfg ToolCallGovernanceConfig, publisher VerdictPubl
 		return &auditDispatcher{
 			publisher: publisher,
 			logger:    logger,
+			metrics:   metrics,
 		}
 	case ToolCallGovernanceModeEnforce:
 		return &enforceDispatcher{
 			publisher: publisher,
 			logger:    logger,
+			metrics:   metrics,
 			timeout:   cfg.ParsedTimeout(),
 			waiters:   map[string]chan verdictArrival{},
 		}
@@ -256,6 +278,7 @@ func (d *disabledDispatcher) Mode() string { return ToolCallGovernanceModeDisabl
 type auditDispatcher struct {
 	publisher VerdictPublisher
 	logger    *slog.Logger
+	metrics   DispatcherMetrics
 }
 
 func (d *auditDispatcher) Propose(ctx context.Context, loopID, parentLoopID string, calls []agentic.ToolCall) (DispatcherResult, error) {
@@ -286,6 +309,12 @@ func (d *auditDispatcher) HandleVerdict(decision, callID string, data []byte) {
 		slog.String("call_id", callID),
 		slog.String("rule_id", payload.RuleID),
 		slog.String("reason", payload.EffectiveReason()))
+	if d.metrics != nil {
+		// Audit mode can't measure latency (no per-call start time
+		// kept) — count the verdict with zero duration. Duration
+		// histogram is still useful for verdict-arrival rate visualisation.
+		d.metrics.RecordGovernanceVerdict(decision, ToolCallGovernanceModeAudit, 0)
+	}
 }
 
 func (d *auditDispatcher) Mode() string { return ToolCallGovernanceModeAudit }
@@ -304,6 +333,7 @@ type verdictArrival struct {
 type enforceDispatcher struct {
 	publisher VerdictPublisher
 	logger    *slog.Logger
+	metrics   DispatcherMetrics
 	timeout   time.Duration
 
 	mu      sync.Mutex
@@ -379,7 +409,15 @@ func (d *enforceDispatcher) Propose(ctx context.Context, loopID, parentLoopID st
 			continue
 		}
 
+		waitStart := time.Now()
 		decision, reason := d.awaitVerdict(ctx, channels[call.ID], call, loopID)
+		waitDuration := time.Since(waitStart).Seconds()
+		if d.metrics != nil {
+			// Record under the verdict's canonical decision label —
+			// "timeout" is its own label distinct from "rejected".
+			d.metrics.RecordGovernanceVerdict(decision, ToolCallGovernanceModeEnforce, waitDuration)
+		}
+
 		switch decision {
 		case "approved":
 			approved = append(approved, call)
@@ -449,6 +487,9 @@ func (d *enforceDispatcher) HandleVerdict(decision, callID string, data []byte) 
 		d.logger.Debug("Verdict arrived after waiter released; ignoring",
 			slog.String("call_id", callID),
 			slog.String("decision", decision))
+		if d.metrics != nil {
+			d.metrics.RecordGovernanceVerdictMissingWaiter()
+		}
 		return
 	}
 

--- a/processor/agentic-loop/governance_dispatcher_test.go
+++ b/processor/agentic-loop/governance_dispatcher_test.go
@@ -54,7 +54,7 @@ func TestDispatcher_DisabledModePassThroughNoPublish(t *testing.T) {
 	t.Parallel()
 
 	pub := &mockVerdictPublisher{}
-	d := NewGovernanceDispatcher(ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeDisabled}, pub, slog.Default())
+	d := NewGovernanceDispatcher(ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeDisabled}, pub, slog.Default(), nil)
 
 	calls := []agentic.ToolCall{
 		{ID: "c1", Name: "bash"},
@@ -75,7 +75,7 @@ func TestDispatcher_AuditModePublishesAndPassesThrough(t *testing.T) {
 	t.Parallel()
 
 	pub := &mockVerdictPublisher{}
-	d := NewGovernanceDispatcher(ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeAudit}, pub, slog.Default())
+	d := NewGovernanceDispatcher(ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeAudit}, pub, slog.Default(), nil)
 
 	calls := []agentic.ToolCall{
 		{ID: "c1", Name: "bash", Arguments: map[string]any{"command": "ls /tmp"}},
@@ -114,7 +114,7 @@ func TestDispatcher_AuditModeIgnoresPublishFailure(t *testing.T) {
 	t.Parallel()
 
 	pub := &mockVerdictPublisher{err: errors.New("nats unavailable")}
-	d := NewGovernanceDispatcher(ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeAudit}, pub, slog.Default())
+	d := NewGovernanceDispatcher(ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeAudit}, pub, slog.Default(), nil)
 
 	calls := []agentic.ToolCall{{ID: "c1", Name: "bash"}}
 	result, err := d.Propose(context.Background(), "loop-1", "", calls)
@@ -130,7 +130,7 @@ func TestDispatcher_EnforceModeWaitsForApproveVerdict(t *testing.T) {
 	pub := &mockVerdictPublisher{}
 	d := NewGovernanceDispatcher(
 		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "2s"},
-		pub, slog.Default(),
+		pub, slog.Default(), nil,
 	)
 
 	calls := []agentic.ToolCall{{ID: "call-001", Name: "bash"}}
@@ -161,7 +161,7 @@ func TestDispatcher_EnforceModeRejectsOnDenyVerdict(t *testing.T) {
 	pub := &mockVerdictPublisher{}
 	d := NewGovernanceDispatcher(
 		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "2s"},
-		pub, slog.Default(),
+		pub, slog.Default(), nil,
 	)
 
 	calls := []agentic.ToolCall{{ID: "call-001", Name: "bash"}}
@@ -193,7 +193,7 @@ func TestDispatcher_EnforceModeFailsClosedOnTimeout(t *testing.T) {
 	pub := &mockVerdictPublisher{}
 	d := NewGovernanceDispatcher(
 		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "100ms"},
-		pub, slog.Default(),
+		pub, slog.Default(), nil,
 	)
 
 	calls := []agentic.ToolCall{{ID: "call-001", Name: "bash"}}
@@ -221,7 +221,7 @@ func TestDispatcher_EnforceModeMixedVerdictsPreserveOrder(t *testing.T) {
 	pub := &mockVerdictPublisher{}
 	d := NewGovernanceDispatcher(
 		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "2s"},
-		pub, slog.Default(),
+		pub, slog.Default(), nil,
 	)
 
 	calls := []agentic.ToolCall{
@@ -267,7 +267,7 @@ func TestDispatcher_EnforceModePartialPublishFailure(t *testing.T) {
 	}}
 	d := NewGovernanceDispatcher(
 		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "1s"},
-		pub, slog.Default(),
+		pub, slog.Default(), nil,
 	)
 
 	calls := []agentic.ToolCall{
@@ -301,7 +301,7 @@ func TestDispatcher_EnforceModeVerdictBeforeSelectArrival(t *testing.T) {
 	pub := &raceTestPublisher{}
 	d := NewGovernanceDispatcher(
 		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "2s"},
-		pub, slog.Default(),
+		pub, slog.Default(), nil,
 	)
 
 	calls := []agentic.ToolCall{{ID: "fast-call", Name: "bash"}}
@@ -329,7 +329,7 @@ func TestDispatcher_EnforceModeLateVerdictIsNoOp(t *testing.T) {
 	pub := &mockVerdictPublisher{}
 	d := NewGovernanceDispatcher(
 		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "50ms"},
-		pub, slog.Default(),
+		pub, slog.Default(), nil,
 	)
 
 	// Propose returns via timeout (no verdict sent inside).
@@ -341,6 +341,116 @@ func TestDispatcher_EnforceModeLateVerdictIsNoOp(t *testing.T) {
 	// Now fire a late verdict — must not panic.
 	payload, _ := json.Marshal(VerdictPayload{Decision: "approved"})
 	d.HandleVerdict("approved", "late-call", payload)
+}
+
+// --- metrics integration --------------------------------------------
+
+// mockDispatcherMetrics captures metric calls so tests can assert the
+// dispatcher fires them on the right transitions.
+type mockDispatcherMetrics struct {
+	mu                 sync.Mutex
+	verdicts           []recordedVerdict
+	missingWaiterCalls int
+}
+
+type recordedVerdict struct {
+	decision string
+	mode     string
+	duration float64
+}
+
+func (m *mockDispatcherMetrics) RecordGovernanceVerdict(decision, mode string, duration float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.verdicts = append(m.verdicts, recordedVerdict{decision: decision, mode: mode, duration: duration})
+}
+
+func (m *mockDispatcherMetrics) RecordGovernanceVerdictMissingWaiter() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.missingWaiterCalls++
+}
+
+func (m *mockDispatcherMetrics) Verdicts() []recordedVerdict {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]recordedVerdict, len(m.verdicts))
+	copy(out, m.verdicts)
+	return out
+}
+
+func TestDispatcher_EnforceModeRecordsApprovedVerdictMetric(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	mx := &mockDispatcherMetrics{}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "2s"},
+		pub, slog.Default(), mx,
+	)
+
+	calls := []agentic.ToolCall{{ID: "c1", Name: "bash"}}
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		payload, _ := json.Marshal(VerdictPayload{Decision: "approved"})
+		d.HandleVerdict("approved", "c1", payload)
+	}()
+
+	_, err := d.Propose(context.Background(), "loop-1", "", calls)
+	require.NoError(t, err)
+
+	recorded := mx.Verdicts()
+	require.Len(t, recorded, 1)
+	assert.Equal(t, "approved", recorded[0].decision)
+	assert.Equal(t, ToolCallGovernanceModeEnforce, recorded[0].mode)
+	assert.Greater(t, recorded[0].duration, 0.0)
+}
+
+func TestDispatcher_EnforceModeRecordsTimeoutVerdictMetric(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	mx := &mockDispatcherMetrics{}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "50ms"},
+		pub, slog.Default(), mx,
+	)
+
+	calls := []agentic.ToolCall{{ID: "c1", Name: "bash"}}
+	_, err := d.Propose(context.Background(), "loop-1", "", calls)
+	require.NoError(t, err)
+
+	recorded := mx.Verdicts()
+	require.Len(t, recorded, 1)
+	assert.Equal(t, "timeout", recorded[0].decision, "timeout decision is its own label, not rejected")
+	assert.Equal(t, ToolCallGovernanceModeEnforce, recorded[0].mode)
+}
+
+// Late verdict (after Propose timeout already fired) increments the
+// missing-waiter counter — this is the canonical signal that the
+// subscribe-before-publish race-fix regressed.
+func TestDispatcher_LateVerdictIncrementsMissingWaiterMetric(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	mx := &mockDispatcherMetrics{}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "30ms"},
+		pub, slog.Default(), mx,
+	)
+
+	// Propose returns via timeout first.
+	_, err := d.Propose(context.Background(), "loop-1", "",
+		[]agentic.ToolCall{{ID: "late-call", Name: "bash"}})
+	require.NoError(t, err)
+
+	// Late verdict — waiter already released by defer. Must increment
+	// the missing-waiter counter, not panic.
+	payload, _ := json.Marshal(VerdictPayload{Decision: "approved"})
+	d.HandleVerdict("approved", "late-call", payload)
+
+	assert.Equal(t, 1, mx.missingWaiterCalls,
+		"late verdict for released waiter must increment subscribe-before-publish counter")
 }
 
 // --- subject parsing -------------------------------------------------

--- a/processor/agentic-loop/governance_dispatcher_test.go
+++ b/processor/agentic-loop/governance_dispatcher_test.go
@@ -92,20 +92,43 @@ func TestDispatcher_AuditModePublishesAndPassesThrough(t *testing.T) {
 
 	for i, expected := range []string{"c1", "c2"} {
 		assert.Equal(t, "agent.toolcall.proposed.loop-abc", published[i].subject)
-		var payload ProposedToolCallPayload
-		require.NoError(t, json.Unmarshal(published[i].data, &payload))
+		payload := unwrapProposedFromBaseMessage(t, published[i].data)
 		assert.Equal(t, "loop-abc", payload.LoopID)
 		assert.Equal(t, "parent-loop", payload.ParentLoopID, "parent_loop_id rides along from day one (ADR-039)")
 		assert.Equal(t, expected, payload.CallID)
 	}
 	// Flattened conveniences
-	var firstPayload ProposedToolCallPayload
-	require.NoError(t, json.Unmarshal(published[0].data, &firstPayload))
+	firstPayload := unwrapProposedFromBaseMessage(t, published[0].data)
 	assert.Equal(t, "ls /tmp", firstPayload.Command, "bash command should flatten to Command field for rule readability")
 
-	var secondPayload ProposedToolCallPayload
-	require.NoError(t, json.Unmarshal(published[1].data, &secondPayload))
+	secondPayload := unwrapProposedFromBaseMessage(t, published[1].data)
 	assert.Equal(t, "https://example.com", secondPayload.URL, "http_request url should flatten to URL field")
+}
+
+// unwrapProposedFromBaseMessage extracts a ProposedToolCallPayload from
+// the BaseMessage wire envelope the dispatcher publishes. Mirrors the
+// rule processor's decode path: pull `payload.data` out of the wire
+// form, re-marshal to bytes, decode into the typed payload.
+//
+// Kept as a test helper because production consumers (rule processor +
+// agentic-loop verdict handler) use different code paths — rules read
+// via GenericJSONPayload.Data; agentic-loop reads VerdictPayload off
+// the verdict subject. Tests need the typed view of the proposed-call
+// shape to assert on the canonical fields.
+func unwrapProposedFromBaseMessage(t *testing.T, data []byte) ProposedToolCallPayload {
+	t.Helper()
+	// wireFormat carries the payload under "payload" — extract it as a
+	// raw RawMessage, then re-unmarshal into the typed struct.
+	var envelope struct {
+		Payload json.RawMessage `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(data, &envelope), "envelope must be wireFormat-shaped")
+	// The payload is a GenericJSONPayload: { "data": { ... proposed-call fields ... } }
+	var generic struct {
+		Data ProposedToolCallPayload `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(envelope.Payload, &generic), "payload must be GenericJSONPayload-shaped")
+	return generic.Data
 }
 
 // Audit-mode publish failure logs but DOES NOT prevent dispatch.
@@ -604,10 +627,20 @@ type selectiveFailPublisher struct {
 }
 
 func (m *selectiveFailPublisher) PublishToStream(_ context.Context, subject string, data []byte) error {
-	var payload ProposedToolCallPayload
-	if err := json.Unmarshal(data, &payload); err == nil {
-		if m.failCallIDPredicate != nil && m.failCallIDPredicate(payload.CallID) {
-			return errors.New("selective publish failure")
+	// Bytes are BaseMessage-wrapped (wire envelope around GenericJSONPayload).
+	// Extract the proposed-call payload via the wire envelope so the
+	// per-call_id predicate can decide whether to fail.
+	var envelope struct {
+		Payload json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(data, &envelope); err == nil {
+		var generic struct {
+			Data ProposedToolCallPayload `json:"data"`
+		}
+		if err := json.Unmarshal(envelope.Payload, &generic); err == nil {
+			if m.failCallIDPredicate != nil && m.failCallIDPredicate(generic.Data.CallID) {
+				return errors.New("selective publish failure")
+			}
 		}
 	}
 	m.mu.Lock()

--- a/processor/agentic-loop/governance_dispatcher_test.go
+++ b/processor/agentic-loop/governance_dispatcher_test.go
@@ -1,0 +1,531 @@
+package agenticloop
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockVerdictPublisher captures every publish call so assertions can
+// inspect the published payloads. err is returned from PublishToStream
+// when non-nil.
+type mockVerdictPublisher struct {
+	mu        sync.Mutex
+	published []publishedVerdict
+	err       error
+}
+
+type publishedVerdict struct {
+	subject string
+	data    []byte
+}
+
+func (m *mockVerdictPublisher) PublishToStream(_ context.Context, subject string, data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	cpy := make([]byte, len(data))
+	copy(cpy, data)
+	m.published = append(m.published, publishedVerdict{subject: subject, data: cpy})
+	return nil
+}
+
+func (m *mockVerdictPublisher) Published() []publishedVerdict {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]publishedVerdict, len(m.published))
+	copy(out, m.published)
+	return out
+}
+
+// --- disabled mode --------------------------------------------------
+
+func TestDispatcher_DisabledModePassThroughNoPublish(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	d := NewGovernanceDispatcher(ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeDisabled}, pub, slog.Default())
+
+	calls := []agentic.ToolCall{
+		{ID: "c1", Name: "bash"},
+		{ID: "c2", Name: "http_request"},
+	}
+	result, err := d.Propose(context.Background(), "loop-1", "", calls)
+	require.NoError(t, err)
+
+	assert.Equal(t, calls, result.Approved, "disabled must pass all calls through as approved")
+	assert.Empty(t, result.Rejected, "disabled never rejects")
+	assert.Empty(t, pub.Published(), "disabled must NOT publish")
+	assert.Equal(t, ToolCallGovernanceModeDisabled, d.Mode())
+}
+
+// --- audit mode -----------------------------------------------------
+
+func TestDispatcher_AuditModePublishesAndPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	d := NewGovernanceDispatcher(ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeAudit}, pub, slog.Default())
+
+	calls := []agentic.ToolCall{
+		{ID: "c1", Name: "bash", Arguments: map[string]any{"command": "ls /tmp"}},
+		{ID: "c2", Name: "http_request", Arguments: map[string]any{"url": "https://example.com"}},
+	}
+	result, err := d.Propose(context.Background(), "loop-abc", "parent-loop", calls)
+	require.NoError(t, err)
+
+	assert.Equal(t, calls, result.Approved, "audit must pass all calls through as approved")
+	assert.Empty(t, result.Rejected, "audit never rejects locally — verdicts that arrive late are observability only")
+
+	published := pub.Published()
+	require.Len(t, published, 2, "audit must publish every call to agent.toolcall.proposed.*")
+
+	for i, expected := range []string{"c1", "c2"} {
+		assert.Equal(t, "agent.toolcall.proposed.loop-abc", published[i].subject)
+		var payload ProposedToolCallPayload
+		require.NoError(t, json.Unmarshal(published[i].data, &payload))
+		assert.Equal(t, "loop-abc", payload.LoopID)
+		assert.Equal(t, "parent-loop", payload.ParentLoopID, "parent_loop_id rides along from day one (ADR-039)")
+		assert.Equal(t, expected, payload.CallID)
+	}
+	// Flattened conveniences
+	var firstPayload ProposedToolCallPayload
+	require.NoError(t, json.Unmarshal(published[0].data, &firstPayload))
+	assert.Equal(t, "ls /tmp", firstPayload.Command, "bash command should flatten to Command field for rule readability")
+
+	var secondPayload ProposedToolCallPayload
+	require.NoError(t, json.Unmarshal(published[1].data, &secondPayload))
+	assert.Equal(t, "https://example.com", secondPayload.URL, "http_request url should flatten to URL field")
+}
+
+// Audit-mode publish failure logs but DOES NOT prevent dispatch.
+// Surface as a Warn, return Approved as if nothing happened.
+func TestDispatcher_AuditModeIgnoresPublishFailure(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{err: errors.New("nats unavailable")}
+	d := NewGovernanceDispatcher(ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeAudit}, pub, slog.Default())
+
+	calls := []agentic.ToolCall{{ID: "c1", Name: "bash"}}
+	result, err := d.Propose(context.Background(), "loop-1", "", calls)
+	require.NoError(t, err, "audit publish failure must not propagate")
+	assert.Equal(t, calls, result.Approved, "audit must still pass calls through even when publish fails")
+}
+
+// --- enforce mode ---------------------------------------------------
+
+func TestDispatcher_EnforceModeWaitsForApproveVerdict(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "2s"},
+		pub, slog.Default(),
+	)
+
+	calls := []agentic.ToolCall{{ID: "call-001", Name: "bash"}}
+
+	// Simulate an approve verdict arriving 50ms after Propose starts.
+	// HandleVerdict runs on a separate goroutine (in production, the
+	// JetStream callback). The buffered waiter channel absorbs the
+	// send even if Propose hasn't entered its select yet.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		payload, _ := json.Marshal(VerdictPayload{
+			Decision: "approved", RuleID: "rule-allow", Reason: "policy permits",
+		})
+		d.HandleVerdict("approved", "call-001", payload)
+	}()
+
+	result, err := d.Propose(context.Background(), "loop-1", "", calls)
+	require.NoError(t, err)
+
+	assert.Len(t, result.Approved, 1)
+	assert.Empty(t, result.Rejected)
+	assert.Equal(t, "call-001", result.Approved[0].ID)
+}
+
+func TestDispatcher_EnforceModeRejectsOnDenyVerdict(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "2s"},
+		pub, slog.Default(),
+	)
+
+	calls := []agentic.ToolCall{{ID: "call-001", Name: "bash"}}
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		payload, _ := json.Marshal(VerdictPayload{
+			Decision: "rejected", RuleID: "block-bash", Reason: "bash disallowed",
+		})
+		d.HandleVerdict("rejected", "call-001", payload)
+	}()
+
+	result, err := d.Propose(context.Background(), "loop-1", "", calls)
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Approved)
+	require.Len(t, result.Rejected, 1)
+	assert.Equal(t, "call-001", result.Rejected[0].Call.ID)
+	assert.Contains(t, result.Rejected[0].Reason, "bash disallowed")
+	assert.Contains(t, result.Rejected[0].Reason, "block-bash")
+}
+
+// Fail-closed on timeout — the canonical safety invariant. If governance
+// rules don't fire within the timeout, treat as a reject so missing
+// rules can't become silent approve.
+func TestDispatcher_EnforceModeFailsClosedOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "100ms"},
+		pub, slog.Default(),
+	)
+
+	calls := []agentic.ToolCall{{ID: "call-001", Name: "bash"}}
+
+	start := time.Now()
+	result, err := d.Propose(context.Background(), "loop-1", "", calls)
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+
+	assert.Empty(t, result.Approved, "no verdict within timeout must result in zero approved")
+	require.Len(t, result.Rejected, 1, "must reject on timeout (fail-closed)")
+	assert.Contains(t, result.Rejected[0].Reason, "timeout")
+	assert.GreaterOrEqual(t, elapsed, 100*time.Millisecond,
+		"must wait at least the configured timeout before failing closed")
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"must NOT wait significantly longer than timeout (within scheduling slop)")
+}
+
+// Mixed verdicts in a single batch: order must be preserved across
+// approve and reject so the downstream serial dispatcher sees calls in
+// the same order the model emitted them.
+func TestDispatcher_EnforceModeMixedVerdictsPreserveOrder(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "2s"},
+		pub, slog.Default(),
+	)
+
+	calls := []agentic.ToolCall{
+		{ID: "c1", Name: "bash"},
+		{ID: "c2", Name: "http_request"},
+		{ID: "c3", Name: "bash"},
+	}
+
+	// Race-fix: send the verdicts AFTER Propose has registered all
+	// waiters. 50ms slop is sufficient because Propose pre-registers
+	// every waiter synchronously before publish completes.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		// Reverse order on purpose to confirm the dispatcher
+		// re-orders by request, not by arrival.
+		approvedPayload, _ := json.Marshal(VerdictPayload{Decision: "approved"})
+		rejectedPayload, _ := json.Marshal(VerdictPayload{Decision: "rejected", Reason: "blocked"})
+		d.HandleVerdict("approved", "c3", approvedPayload)
+		d.HandleVerdict("rejected", "c2", rejectedPayload)
+		d.HandleVerdict("approved", "c1", approvedPayload)
+	}()
+
+	result, err := d.Propose(context.Background(), "loop-1", "", calls)
+	require.NoError(t, err)
+
+	require.Len(t, result.Approved, 2)
+	require.Len(t, result.Rejected, 1)
+	assert.Equal(t, "c1", result.Approved[0].ID, "approved ordering preserved")
+	assert.Equal(t, "c3", result.Approved[1].ID)
+	assert.Equal(t, "c2", result.Rejected[0].Call.ID)
+}
+
+// Publish failure on a single call in enforce mode becomes a per-call
+// rejection — the rest of the batch continues with their waiters
+// intact. This is the architectural commitment that publish failure
+// degrades to fail-closed gracefully rather than wedging the loop.
+func TestDispatcher_EnforceModePartialPublishFailure(t *testing.T) {
+	t.Parallel()
+
+	// Custom publisher that fails on the second call only.
+	pub := &selectiveFailPublisher{failCallIDPredicate: func(callID string) bool {
+		return callID == "c2"
+	}}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "1s"},
+		pub, slog.Default(),
+	)
+
+	calls := []agentic.ToolCall{
+		{ID: "c1", Name: "bash"},
+		{ID: "c2", Name: "bash"},
+	}
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		payload, _ := json.Marshal(VerdictPayload{Decision: "approved"})
+		// Only c1 will have a verdict subscribe path — c2's publish failed.
+		d.HandleVerdict("approved", "c1", payload)
+	}()
+
+	result, err := d.Propose(context.Background(), "loop-1", "", calls)
+	require.NoError(t, err)
+
+	require.Len(t, result.Approved, 1)
+	assert.Equal(t, "c1", result.Approved[0].ID)
+	require.Len(t, result.Rejected, 1)
+	assert.Equal(t, "c2", result.Rejected[0].Call.ID)
+	assert.Contains(t, result.Rejected[0].Reason, "publish failed")
+}
+
+// Race-condition fix: verdict arriving BEFORE Propose enters its select
+// (i.e., the buffered channel absorbs it) must still resolve correctly.
+// This is the canonical subscribe-before-publish race in process form.
+func TestDispatcher_EnforceModeVerdictBeforeSelectArrival(t *testing.T) {
+	t.Parallel()
+
+	pub := &raceTestPublisher{}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "2s"},
+		pub, slog.Default(),
+	)
+
+	calls := []agentic.ToolCall{{ID: "fast-call", Name: "bash"}}
+
+	// raceTestPublisher fires the verdict from INSIDE PublishToStream —
+	// before Propose returns from publish and enters the select. The
+	// buffered waiter channel must absorb this.
+	pub.onPublish = func() {
+		payload, _ := json.Marshal(VerdictPayload{Decision: "approved", RuleID: "fast-rule"})
+		d.HandleVerdict("approved", "fast-call", payload)
+	}
+
+	result, err := d.Propose(context.Background(), "loop-1", "", calls)
+	require.NoError(t, err)
+	require.Len(t, result.Approved, 1, "race-fix: verdict during publish must still resolve approved")
+	assert.Equal(t, "fast-call", result.Approved[0].ID)
+}
+
+// Late verdict (after Propose returned via timeout) must not panic or
+// leak. The waiter map is released by defer; HandleVerdict logs at
+// Debug and returns. Pins the no-leak invariant.
+func TestDispatcher_EnforceModeLateVerdictIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	pub := &mockVerdictPublisher{}
+	d := NewGovernanceDispatcher(
+		ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "50ms"},
+		pub, slog.Default(),
+	)
+
+	// Propose returns via timeout (no verdict sent inside).
+	result, err := d.Propose(context.Background(), "loop-1", "",
+		[]agentic.ToolCall{{ID: "late-call", Name: "bash"}})
+	require.NoError(t, err)
+	require.Len(t, result.Rejected, 1)
+
+	// Now fire a late verdict — must not panic.
+	payload, _ := json.Marshal(VerdictPayload{Decision: "approved"})
+	d.HandleVerdict("approved", "late-call", payload)
+}
+
+// --- subject parsing -------------------------------------------------
+
+func TestDecisionFromVerdictSubject(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		subject string
+		want    string
+	}{
+		{"canonical approved", "agent.toolcall.approved.loop-1.call-001", "approved"},
+		{"canonical rejected", "agent.toolcall.rejected.loop-1.call-001", "rejected"},
+		{"unrelated subject — empty", "agent.task.review", ""},
+		{"wrong verb — empty", "agent.toolcall.observed.loop-1.call-1", ""},
+		{"three segments still parses", "agent.toolcall.approved", "approved"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := decisionFromVerdictSubject(tt.subject)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// VerdictPayload supports two on-the-wire shapes. The approve-action
+// writes top-level fields; the publish-action shape (used by ADR-039's
+// rejection example rules) nests fields under "properties". Both must
+// resolve through the same helpers so consumers don't write a custom
+// parser per shape.
+func TestVerdictPayload_EffectiveAccessors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("top-level shape (approve action)", func(t *testing.T) {
+		t.Parallel()
+		p := VerdictPayload{
+			Decision: "approved",
+			CallID:   "call-1",
+			Reason:   "policy permits",
+		}
+		assert.Equal(t, "approved", p.EffectiveDecision())
+		assert.Equal(t, "call-1", p.EffectiveCallID())
+		assert.Equal(t, "policy permits", p.EffectiveReason())
+	})
+
+	t.Run("nested shape (publish action)", func(t *testing.T) {
+		t.Parallel()
+		p := VerdictPayload{
+			Properties: map[string]any{
+				"decision": "rejected",
+				"call_id":  "call-2",
+				"reason":   "blocked",
+			},
+		}
+		assert.Equal(t, "rejected", p.EffectiveDecision())
+		assert.Equal(t, "call-2", p.EffectiveCallID())
+		assert.Equal(t, "blocked", p.EffectiveReason())
+	})
+
+	t.Run("top-level wins over nested", func(t *testing.T) {
+		t.Parallel()
+		p := VerdictPayload{
+			CallID: "top-level",
+			Properties: map[string]any{
+				"call_id": "nested",
+			},
+		}
+		assert.Equal(t, "top-level", p.EffectiveCallID())
+	})
+
+	t.Run("empty payload yields empty effectives", func(t *testing.T) {
+		t.Parallel()
+		p := VerdictPayload{}
+		assert.Empty(t, p.EffectiveDecision())
+		assert.Empty(t, p.EffectiveCallID())
+		assert.Empty(t, p.EffectiveReason())
+	})
+}
+
+// --- config validation -----------------------------------------------
+
+func TestToolCallGovernanceConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     ToolCallGovernanceConfig
+		wantErr bool
+	}{
+		{"empty defaults are valid", ToolCallGovernanceConfig{}, false},
+		{"disabled", ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeDisabled}, false},
+		{"audit", ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeAudit}, false},
+		{"enforce", ToolCallGovernanceConfig{Mode: ToolCallGovernanceModeEnforce, Timeout: "500ms"}, false},
+		{"unknown mode rejected", ToolCallGovernanceConfig{Mode: "permit"}, true},
+		{"malformed timeout rejected", ToolCallGovernanceConfig{Mode: "enforce", Timeout: "5x"}, true},
+		{"zero timeout rejected", ToolCallGovernanceConfig{Mode: "enforce", Timeout: "0s"}, true},
+		{"negative timeout rejected", ToolCallGovernanceConfig{Mode: "enforce", Timeout: "-1s"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestToolCallGovernanceConfigEnsureDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg := ToolCallGovernanceConfig{}
+	cfg.EnsureDefaults()
+	assert.Equal(t, ToolCallGovernanceModeDisabled, cfg.Mode)
+	assert.Equal(t, DefaultToolCallGovernanceTimeout, cfg.Timeout)
+}
+
+func TestToolCallGovernanceConfigIsEnabled(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, ToolCallGovernanceConfig{}.IsEnabled())
+	assert.False(t, ToolCallGovernanceConfig{Mode: "disabled"}.IsEnabled())
+	assert.True(t, ToolCallGovernanceConfig{Mode: "audit"}.IsEnabled())
+	assert.True(t, ToolCallGovernanceConfig{Mode: "enforce"}.IsEnabled())
+}
+
+func TestToolCallGovernanceConfigIsEnforcing(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, ToolCallGovernanceConfig{Mode: "audit"}.IsEnforcing())
+	assert.True(t, ToolCallGovernanceConfig{Mode: "enforce"}.IsEnforcing())
+}
+
+// --- helpers -------------------------------------------------------
+
+// selectiveFailPublisher fails on calls whose call_id matches the
+// predicate. The mock builds the proposed subject as
+// "agent.toolcall.proposed.<loop>" — the publisher parses the payload
+// to extract call_id and decide whether to fail.
+type selectiveFailPublisher struct {
+	mu                  sync.Mutex
+	published           []publishedVerdict
+	failCallIDPredicate func(callID string) bool
+}
+
+func (m *selectiveFailPublisher) PublishToStream(_ context.Context, subject string, data []byte) error {
+	var payload ProposedToolCallPayload
+	if err := json.Unmarshal(data, &payload); err == nil {
+		if m.failCallIDPredicate != nil && m.failCallIDPredicate(payload.CallID) {
+			return errors.New("selective publish failure")
+		}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cpy := make([]byte, len(data))
+	copy(cpy, data)
+	m.published = append(m.published, publishedVerdict{subject: subject, data: cpy})
+	return nil
+}
+
+// raceTestPublisher invokes onPublish from within PublishToStream BEFORE
+// returning. This simulates the worst-case race where the verdict
+// arrives at the dispatcher before Propose's select runs.
+type raceTestPublisher struct {
+	mu        sync.Mutex
+	published []publishedVerdict
+	onPublish func()
+}
+
+func (m *raceTestPublisher) PublishToStream(_ context.Context, subject string, data []byte) error {
+	m.mu.Lock()
+	cpy := make([]byte, len(data))
+	copy(cpy, data)
+	m.published = append(m.published, publishedVerdict{subject: subject, data: cpy})
+	cb := m.onPublish
+	m.mu.Unlock()
+	if cb != nil {
+		cb()
+	}
+	return nil
+}

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -59,9 +59,17 @@ type MessageHandler struct {
 	trajectoryManager *TrajectoryManager
 	compactor         *Compactor
 	toolCallFilter    agentic.ToolCallFilter
-	modelRegistry     model.RegistryReader
-	toolRegistry      component.ToolRegistryReader
-	logger            *slog.Logger
+	// governanceDispatcher implements subject-mode tool-call governance
+	// (ADR-039). Set via SetGovernanceDispatcher at component boot. Nil
+	// means disabled-mode pass-through; in that case the existing
+	// toolCallFilter (beta.67+68) keeps running unchanged. When
+	// non-nil, governance runs BEFORE the in-process filter — a deny
+	// at the governance layer short-circuits the call before the
+	// filter ever sees it.
+	governanceDispatcher GovernanceDispatcher
+	modelRegistry        model.RegistryReader
+	toolRegistry         component.ToolRegistryReader
+	logger               *slog.Logger
 
 	// todoReader fetches the current write_todos list for a loop entity
 	// at iteration-build time (ADR-036 Stage 4). Nil disables the
@@ -287,6 +295,43 @@ func (h *MessageHandler) maybeCompact(ctx context.Context, cm *ContextManager, l
 // SetLogger sets the logger for the handler
 func (h *MessageHandler) SetLogger(logger *slog.Logger) {
 	h.logger = logger
+}
+
+// resolveParentLoopID reads the loop entity's ParentLoopID for the
+// proposed-call payload so rule conditions can match across the
+// spawn-tree from day one (ADR-039). Returns empty string when the
+// loop is top-level, when the entity isn't found (race with loop
+// creation, ignored intentionally — top-level is the safe default),
+// or when the field is unset.
+func (h *MessageHandler) resolveParentLoopID(loopID string) string {
+	if h.loopManager == nil {
+		return ""
+	}
+	entity, err := h.loopManager.GetLoop(loopID)
+	if err != nil {
+		return ""
+	}
+	return entity.ParentLoopID
+}
+
+// SetGovernanceDispatcher installs the subject-mode tool-call
+// governance dispatcher (ADR-039). Same pre-Start ordering invariant
+// as SetToolCallFilter — the field is not synchronized once the
+// JetStream consumer callbacks start reading it.
+//
+// Nil clears any previously installed dispatcher (effectively
+// reverting to disabled-mode pass-through). The Component wires this
+// automatically in NewComponent based on Config.ToolCallGovernance.Mode;
+// tests stub via this setter.
+func (h *MessageHandler) SetGovernanceDispatcher(d GovernanceDispatcher) {
+	h.governanceDispatcher = d
+}
+
+// GovernanceDispatcher returns the installed dispatcher (or nil). Used
+// by the Component's verdict subscription handlers to route inbound
+// verdicts via HandleVerdict.
+func (h *MessageHandler) GovernanceDispatcher() GovernanceDispatcher {
+	return h.governanceDispatcher
 }
 
 // SetToolCallFilter sets a filter that intercepts tool calls before execution.
@@ -918,9 +963,45 @@ func (h *MessageHandler) handleToolCallResponse(result *HandlerResult, loopID st
 
 	approved := toolCalls
 
-	// Apply filter if configured
+	// Subject-mode governance (ADR-039) runs BEFORE the in-process
+	// filter. When mode=disabled (the default), Propose passes through
+	// unchanged. When mode=audit, every call is published to
+	// agent.toolcall.proposed.* but Approved is still the full set —
+	// audit doesn't gate. When mode=enforce, the dispatcher waits for
+	// per-call verdicts and produces an Approved/Rejected split.
+	//
+	// Rejections at this layer materialize as immediate error results,
+	// same shape as the in-process filter's rejection path below.
+	if h.governanceDispatcher != nil {
+		parentLoopID := h.resolveParentLoopID(loopID)
+		govResult, gErr := h.governanceDispatcher.Propose(context.Background(), loopID, parentLoopID, toolCalls)
+		if gErr != nil {
+			// Governance-layer failure that isn't a per-call rejection
+			// is currently reserved (ErrGovernancePublishFailed) — the
+			// dispatcher returns per-call rejections instead. Surface
+			// any such error to the caller for visibility.
+			return gErr
+		}
+		for _, rejection := range govResult.Rejected {
+			h.loopManager.TrackToolName(rejection.Call.ID, rejection.Call.Name)
+			errResult := agentic.ToolResult{
+				CallID: rejection.Call.ID,
+				Name:   rejection.Call.Name,
+				Error:  fmt.Sprintf("tool call rejected by governance: %s", rejection.Reason),
+				LoopID: loopID,
+			}
+			if err := h.loopManager.StoreToolResult(loopID, errResult); err != nil {
+				return err
+			}
+		}
+		approved = govResult.Approved
+	}
+
+	// Apply filter if configured. Runs AFTER governance — operators
+	// during the beta.69 → beta.70 migration can keep both layers
+	// active; the filter sees only governance-approved calls.
 	if h.toolCallFilter != nil {
-		filterResult, err := h.toolCallFilter.FilterToolCalls(loopID, toolCalls)
+		filterResult, err := h.toolCallFilter.FilterToolCalls(loopID, approved)
 		if err != nil {
 			return err
 		}

--- a/processor/agentic-loop/metrics.go
+++ b/processor/agentic-loop/metrics.go
@@ -52,6 +52,11 @@ type loopMetrics struct {
 
 	// Graph-write-before-publish ordering
 	graphWritePublishTimeouts *prometheus.CounterVec
+
+	// Tool-call governance (ADR-039)
+	governanceVerdictDuration                 *prometheus.HistogramVec
+	governanceVerdictTotal                    *prometheus.CounterVec
+	governanceSubscribeBeforePublishFailures  prometheus.Counter
 }
 
 // Package-level metrics (registered once to avoid duplicate registration errors)
@@ -229,6 +234,32 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 				Name:      "graph_write_publish_timeout_total",
 				Help:      "Total times the graph-write-before-publish budget expired before WriteLoopCompletion/WriteLoopFailure returned. The agent.complete.* event was published anyway (best-effort preserved), but the loop entity's graph triples may not yet be visible to subscribers walking ancestry. Sustained non-zero rate points at graph-gateway latency or NATS subscription propagation issues; a tightenable budget is at graphWritePublishBudget in component.go.",
 			}, []string{"state"}),
+
+			// Tool-call governance (ADR-039) drives the timeout-tuning
+			// decision in beta.70 — buckets span 1ms → 5s to capture
+			// both fast in-process rule fires and slow networked
+			// rule-engine paths.
+			governanceVerdictDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Namespace: "semstreams",
+				Subsystem: "agentic_loop",
+				Name:      "tool_call_governance_verdict_duration_seconds",
+				Help:      "Time from proposed-call publish to verdict arrival. decision label is approved|rejected|timeout; mode is audit|enforce. Drives the timeout-tuning decision in beta.70 — wide range now, tighten after measurement.",
+				Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0},
+			}, []string{"decision", "mode"}),
+
+			governanceVerdictTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "agentic_loop",
+				Name:      "tool_call_governance_verdict_total",
+				Help:      "Total tool-call governance verdicts by decision and mode. Sum of decision=approved + decision=rejected + decision=timeout equals total proposed-call publishes (modulo in-flight). Sustained decision=timeout signals undersized timeout config or stuck rule-engine path.",
+			}, []string{"decision", "mode"}),
+
+			governanceSubscribeBeforePublishFailures: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "agentic_loop",
+				Name:      "tool_call_governance_subscribe_before_publish_failures_total",
+				Help:      "Times a verdict arrived for a call_id that no longer had a waiter registered, signalling the subscribe-before-publish race regressing (ADR-039 race-fix option 3). Non-zero rate means investigate immediately — verdicts are being dropped silently.",
+			}),
 		}
 
 		// Register metrics with the metrics registry if available
@@ -256,6 +287,9 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 			_ = registry.RegisterHistogram("agentic-loop", "context_compaction_tokens_saved", metrics.contextCompactionTokensSaved)
 			_ = registry.RegisterGauge("agentic-loop", "context_compacted_region_tokens", metrics.contextCompactedRegionTokens)
 			_ = registry.RegisterCounterVec("agentic-loop", "graph_write_publish_timeout_total", metrics.graphWritePublishTimeouts)
+			_ = registry.RegisterHistogramVec("agentic-loop", "tool_call_governance_verdict_duration_seconds", metrics.governanceVerdictDuration)
+			_ = registry.RegisterCounterVec("agentic-loop", "tool_call_governance_verdict_total", metrics.governanceVerdictTotal)
+			_ = registry.RegisterCounter("agentic-loop", "tool_call_governance_subscribe_before_publish_failures_total", metrics.governanceSubscribeBeforePublishFailures)
 		} else {
 			// Fallback to default prometheus registry for testing
 			_ = prometheus.DefaultRegisterer.Register(metrics.loopsCreated)
@@ -281,9 +315,34 @@ func getMetrics(registry *metric.MetricsRegistry) *loopMetrics {
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextCompactionTokensSaved)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contextCompactedRegionTokens)
 			_ = prometheus.DefaultRegisterer.Register(metrics.graphWritePublishTimeouts)
+			_ = prometheus.DefaultRegisterer.Register(metrics.governanceVerdictDuration)
+			_ = prometheus.DefaultRegisterer.Register(metrics.governanceVerdictTotal)
+			_ = prometheus.DefaultRegisterer.Register(metrics.governanceSubscribeBeforePublishFailures)
 		}
 	})
 	return metrics
+}
+
+// RecordGovernanceVerdict observes the verdict duration and
+// increments the per-decision counter. Implements
+// DispatcherMetrics — the GovernanceDispatcher calls this directly.
+// Decision is "approved" | "rejected" | "timeout"; mode is "audit" |
+// "enforce" — disabled mode never records verdicts (no publish, no
+// wait).
+func (m *loopMetrics) RecordGovernanceVerdict(decision, mode string, duration float64) {
+	m.governanceVerdictDuration.WithLabelValues(decision, mode).Observe(duration)
+	m.governanceVerdictTotal.WithLabelValues(decision, mode).Inc()
+}
+
+// RecordGovernanceVerdictMissingWaiter increments the
+// subscribe-before-publish-failures counter. Implements
+// DispatcherMetrics. Each non-zero increment signals a verdict
+// arrived for a call_id that no longer had a registered waiter —
+// either the race-fix regressed (verdict beat the pre-register) or a
+// verdict arrived after Propose's timeout already fired (benign in
+// audit mode, signal in enforce mode).
+func (m *loopMetrics) RecordGovernanceVerdictMissingWaiter() {
+	m.governanceSubscribeBeforePublishFailures.Inc()
 }
 
 // recordGraphWritePublishTimeout increments the counter when the

--- a/processor/agentic-loop/metrics.go
+++ b/processor/agentic-loop/metrics.go
@@ -54,9 +54,9 @@ type loopMetrics struct {
 	graphWritePublishTimeouts *prometheus.CounterVec
 
 	// Tool-call governance (ADR-039)
-	governanceVerdictDuration                 *prometheus.HistogramVec
-	governanceVerdictTotal                    *prometheus.CounterVec
-	governanceSubscribeBeforePublishFailures  prometheus.Counter
+	governanceVerdictDuration                *prometheus.HistogramVec
+	governanceVerdictTotal                   *prometheus.CounterVec
+	governanceSubscribeBeforePublishFailures prometheus.Counter
 }
 
 // Package-level metrics (registered once to avoid duplicate registration errors)

--- a/processor/rule/action_id.go
+++ b/processor/rule/action_id.go
@@ -96,6 +96,11 @@ func actionDistinguisher(a Action) string {
 		return a.Bucket + "/" + a.Key
 	case ActionTypeDeny:
 		return a.Reason
+	case ActionTypeApprove:
+		// Different approve subjects (verdict targets) are distinct
+		// firings for counter purposes — typical templates encode
+		// loop_id/call_id into the subject, so each is unique.
+		return a.Subject
 	}
 	return ""
 }

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -1118,7 +1118,7 @@ func (e *ActionExecutor) executeApprove(ctx context.Context, action Action, ec *
 		return nil
 	}
 
-	payload := map[string]any{
+	payloadData := map[string]any{
 		"decision":  "approved",
 		"rule_id":   ruleID,
 		"reason":    reason,
@@ -1134,13 +1134,21 @@ func (e *ActionExecutor) executeApprove(ctx context.Context, action Action, ec *
 	// state evaluations have no inbound call_id).
 	if ec.MessageData != nil {
 		if v, ok := ec.MessageData["call_id"].(string); ok && v != "" {
-			payload["call_id"] = v
+			payloadData["call_id"] = v
 		}
 		if v, ok := ec.MessageData["loop_id"].(string); ok && v != "" {
-			payload["loop_id"] = v
+			payloadData["loop_id"] = v
 		}
 	}
-	data, err := json.Marshal(payload)
+	// Wrap in a `core.json.v1` BaseMessage so subscribers using the
+	// payload registry (`message.NewDecoder(reg).Decode(data)`) can
+	// read this off the wire. Raw `json.Marshal(map)` would deliver
+	// silently to the agentic-loop's bespoke handler today but trap
+	// any future audit/ops dashboard subscriber that decodes via
+	// registry. See feedback_nats_publishes_use_payload_registry.
+	generic := message.NewGenericJSON(payloadData)
+	baseMsg := message.NewBaseMessage(generic.Schema(), generic, "rule_engine")
+	data, err := json.Marshal(baseMsg)
 	if err != nil {
 		return fmt.Errorf("marshal approve verdict payload: %w", err)
 	}

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -38,12 +38,25 @@ const (
 	// and surfaces as *DenyVerdict to the caller. The deny is always the terminal
 	// outcome: no later action in the same evaluation cycle runs once a deny fires.
 	ActionTypeDeny = "deny"
+	// ActionTypeApprove issues an approve verdict — writes an audit triple via
+	// the TripleMutator and publishes a verdict to the configured Subject.
+	// Asymmetric to deny: approve does NOT short-circuit subsequent actions.
+	// Approval doesn't preclude observability/audit/derived-state actions on
+	// the same rule firing; the asymmetry is the feature, not an oversight.
+	// See ADR-039 §"Why explicit approve, not optimistic absence of deny".
+	ActionTypeApprove = "approve"
 )
 
 // PredicateRuleDeny is the audit-triple predicate written by deny actions.
 // Downstream rules that gate on denials should match against this constant
 // so they stay in sync with any future rename.
 const PredicateRuleDeny = "rule.deny"
+
+// PredicateRuleApprove is the audit-triple predicate written by approve
+// actions. Downstream rules that gate on approvals (rate-limit a caller's
+// successful tool-call rate, audit-log every approve, etc.) should match
+// against this constant so they stay in sync with any future rename.
+const PredicateRuleApprove = "rule.approve"
 
 // Action represents an action to execute when a rule fires.
 // Actions are triggered by state transitions (OnEnter, OnExit) or
@@ -215,10 +228,13 @@ type Action struct {
 	// correctly.
 	MaxIterations *int `json:"max_iterations,omitempty"`
 
-	// Reason is the human-readable denial message for deny actions.
-	// It travels with the *DenyVerdict error so callers can record it
-	// without a side-channel lookup. Variable substitution is applied
-	// (e.g. "$caller.id denied: insufficient role $caller.role").
+	// Reason is the human-readable verdict message for deny AND approve
+	// actions. For deny it travels with the *DenyVerdict error so callers
+	// can record it without a side-channel lookup; for approve it lands in
+	// the audit triple and in the verdict payload published to Subject.
+	// Variable substitution is applied (e.g.
+	// "$caller.id denied: insufficient role $caller.role" or
+	// "$caller.id approved for tool $message.tool_name").
 	Reason string `json:"reason,omitempty"`
 }
 
@@ -356,6 +372,8 @@ func (e *ActionExecutor) Execute(ctx context.Context, action Action, ec *Executi
 		return e.executeUpdateKV(ctx, action, ec)
 	case ActionTypeDeny:
 		return e.executeDeny(ctx, action, ec)
+	case ActionTypeApprove:
+		return e.executeApprove(ctx, action, ec)
 	default:
 		return fmt.Errorf("unknown action type: %s", action.Type)
 	}
@@ -1038,6 +1056,91 @@ func (e *ActionExecutor) executeDeny(ctx context.Context, action Action, ec *Exe
 	}
 
 	return &DenyVerdict{RuleID: ruleID, Reason: reason}
+}
+
+// executeApprove issues an approve verdict — writes a best-effort audit triple
+// and publishes a verdict payload to the configured Subject. Asymmetric to
+// executeDeny: approve returns nil and does NOT short-circuit subsequent
+// actions. Approval is permissive, not terminal; later actions in the same
+// rule firing (observability triples, downstream notifications, derived
+// state) still run. See ADR-039 §"Why explicit approve, not optimistic
+// absence of deny" for the design rationale.
+//
+// Audit-write failure does NOT flip the verdict from approve to anything
+// else: the verdict is the structural outcome, logged at Error level so
+// operators see the audit gap, and the publish still attempts. Publish
+// failure DOES return an error — unlike audit, publish failure means
+// downstream consumers (the agentic-loop subject-mode dispatcher) never
+// learn the verdict and would time out.
+func (e *ActionExecutor) executeApprove(ctx context.Context, action Action, ec *ExecutionContext) error {
+	if action.Subject == "" {
+		return errors.New("subject is required for approve action")
+	}
+
+	subject := ec.SubstituteVariables(action.Subject)
+	reason := ec.SubstituteVariables(action.Reason)
+	ruleID := ec.RuleID()
+	entityID := ec.EntityID
+
+	// Best-effort audit triple. Mirror executeDeny's pattern: audit-write
+	// failure must NOT change the verdict — approve still proceeds to
+	// publish so downstream consumers see the decision.
+	if e.tripleMutator != nil {
+		auditTriple := message.Triple{
+			Subject:    ruleID,
+			Predicate:  PredicateRuleApprove,
+			Object:     reason,
+			Source:     "rule_engine",
+			Timestamp:  time.Now(),
+			Confidence: 1.0,
+		}
+		if _, err := e.tripleMutator.AddTriple(ctx, ruleID, auditTriple); err != nil {
+			if e.logger != nil {
+				e.logger.Error("approve verdict audit triple write failed; verdict still applies",
+					"rule_id", ruleID,
+					"subject", subject,
+					"reason", reason,
+					"error", err)
+			}
+			// fall through — verdict is structural, publish below must run
+		}
+	}
+
+	// Publish the verdict payload. The subject itself carries the routing
+	// identity (e.g. `agent.toolcall.approved.<loop_id>.<call_id>`); the
+	// payload carries context for audit/ops/replay.
+	if e.publisher == nil {
+		if e.logger != nil {
+			e.logger.Debug("Approve verdict not published (no publisher configured)",
+				"subject", subject,
+				"rule_id", ruleID)
+		}
+		return nil
+	}
+
+	payload := map[string]any{
+		"decision":  "approved",
+		"rule_id":   ruleID,
+		"reason":    reason,
+		"entity_id": entityID,
+		"timestamp": time.Now().Format(time.RFC3339Nano),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal approve verdict payload: %w", err)
+	}
+	if err := e.publisher.Publish(ctx, subject, data); err != nil {
+		return fmt.Errorf("publish approve verdict to %s: %w", subject, err)
+	}
+
+	if e.logger != nil {
+		e.logger.Debug("Approve verdict published",
+			"subject", subject,
+			"rule_id", ruleID,
+			"reason", reason,
+			"size", len(data))
+	}
+	return nil
 }
 
 // executeUpdateKV writes JSON to a named KV bucket with optional CAS merge semantics.

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -1125,6 +1125,21 @@ func (e *ActionExecutor) executeApprove(ctx context.Context, action Action, ec *
 		"entity_id": entityID,
 		"timestamp": time.Now().Format(time.RFC3339Nano),
 	}
+	// Echo call_id / loop_id from the proposed message so downstream
+	// consumers (the agentic-loop subject-mode dispatcher) can demux
+	// verdicts without parsing the subject. ADR-039: the subject IS
+	// authoritative for the decision, but the payload mirrors the
+	// routing identifiers so consumers don't need a custom subject
+	// parser. No-op when MessageData is nil (cron-fired or entity-
+	// state evaluations have no inbound call_id).
+	if ec.MessageData != nil {
+		if v, ok := ec.MessageData["call_id"].(string); ok && v != "" {
+			payload["call_id"] = v
+		}
+		if v, ok := ec.MessageData["loop_id"].(string); ok && v != "" {
+			payload["loop_id"] = v
+		}
+	}
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal approve verdict payload: %w", err)

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -2510,11 +2510,22 @@ func TestExecuteApprove_PublishesVerdictPayload(t *testing.T) {
 	assert.Equal(t, "agent.toolcall.approved.loop-abc.call-001", got.subject,
 		"subject must have $message.* substituted")
 
-	var payload map[string]any
-	require.NoError(t, json.Unmarshal(got.data, &payload))
-	assert.Equal(t, "approved", payload["decision"])
-	assert.Equal(t, "approve-rule-pub", payload["rule_id"])
-	assert.Equal(t, "policy permits", payload["reason"])
+	// Wire format is core.json.v1 BaseMessage wrapping a GenericJSONPayload.
+	// Unwrap to verify the verdict fields land in the Data map per the
+	// NATS-uses-payload-registry discipline.
+	var envelope struct {
+		Type    map[string]string `json:"type"`
+		Payload struct {
+			Data map[string]any `json:"data"`
+		} `json:"payload"`
+	}
+	require.NoError(t, json.Unmarshal(got.data, &envelope))
+	assert.Equal(t, "core", envelope.Type["domain"], "must be core.json.v1 envelope")
+	assert.Equal(t, "json", envelope.Type["category"])
+	assert.Equal(t, "v1", envelope.Type["version"])
+	assert.Equal(t, "approved", envelope.Payload.Data["decision"])
+	assert.Equal(t, "approve-rule-pub", envelope.Payload.Data["rule_id"])
+	assert.Equal(t, "policy permits", envelope.Payload.Data["reason"])
 }
 
 // TestExecuteApprove_WritesAuditTriple verifies the audit triple is written

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -2434,3 +2434,195 @@ func TestExecuteDeny_VariableSubstitutionInReason(t *testing.T) {
 	require.Len(t, mut.addedTriples, 1)
 	assert.Equal(t, "caller alice with role viewer is denied", mut.addedTriples[0].Object)
 }
+
+// --- executeApprove tests ---
+//
+// Approve is asymmetric to deny: it returns nil (does NOT short-circuit
+// subsequent actions), publishes a verdict payload to the configured
+// Subject, and writes an audit triple under PredicateRuleApprove. These
+// tests pin those invariants and the parity with deny on audit-failure
+// handling.
+
+// newApproveTestEC builds an ExecutionContext suitable for approve tests.
+// MessageData is populated so $message.* substitution can resolve in the
+// canonical ADR-039 use case (templating verdict subjects with the
+// proposed call's loop_id / call_id).
+func newApproveTestEC(ruleID string, caller *CallerContext, msgData map[string]any) *ExecutionContext {
+	return &ExecutionContext{
+		EntityID: "acme.ops.test.svc.entity.001",
+		State: &MatchState{
+			RuleID: ruleID,
+		},
+		Caller:      caller,
+		MessageData: msgData,
+	}
+}
+
+// TestExecuteApprove_ReturnsNilDoesNotShortCircuit pins the asymmetry: approve
+// returns nil so the action executor's Execute loop continues with later
+// actions. Deny short-circuits via *DenyVerdict; approve does NOT. This
+// asymmetry is the feature, not an oversight — observability/audit
+// actions on the same rule firing still run after approve. See ADR-039.
+func TestExecuteApprove_ReturnsNilDoesNotShortCircuit(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mut := &mockTripleMutator{}
+	pub := &mockPublisher{}
+	executor := NewActionExecutorFull(slog.Default(), mut, pub)
+	ec := newApproveTestEC("approve-rule-1", nil, nil)
+	action := Action{
+		Type:    ActionTypeApprove,
+		Subject: "agent.toolcall.approved.loop-abc.call-001",
+		Reason:  "approved by policy",
+	}
+
+	err := executor.executeApprove(ctx, action, ec)
+	assert.NoError(t, err, "approve must return nil so later actions can fire")
+}
+
+// TestExecuteApprove_PublishesVerdictPayload pins that approve publishes to
+// the substituted Subject with a payload carrying decision="approved" and
+// the rule context. Subject substitution must resolve $message.* tokens
+// so per-call verdict routing works for ADR-039 governance.
+func TestExecuteApprove_PublishesVerdictPayload(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mut := &mockTripleMutator{}
+	pub := &mockPublisher{}
+	executor := NewActionExecutorFull(slog.Default(), mut, pub)
+	ec := newApproveTestEC("approve-rule-pub", nil, map[string]any{
+		"loop_id": "loop-abc",
+		"call_id": "call-001",
+	})
+	action := Action{
+		Type:    ActionTypeApprove,
+		Subject: "agent.toolcall.approved.$message.loop_id.$message.call_id",
+		Reason:  "policy permits",
+	}
+
+	err := executor.executeApprove(ctx, action, ec)
+	require.NoError(t, err)
+
+	require.Len(t, pub.published, 1, "approve must publish exactly once")
+	got := pub.published[0]
+	assert.Equal(t, "agent.toolcall.approved.loop-abc.call-001", got.subject,
+		"subject must have $message.* substituted")
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(got.data, &payload))
+	assert.Equal(t, "approved", payload["decision"])
+	assert.Equal(t, "approve-rule-pub", payload["rule_id"])
+	assert.Equal(t, "policy permits", payload["reason"])
+}
+
+// TestExecuteApprove_WritesAuditTriple verifies the audit triple is written
+// with PredicateRuleApprove and the substituted reason as the object.
+// Downstream rules that count approvals by caller can match on this
+// predicate.
+func TestExecuteApprove_WritesAuditTriple(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mut := &mockTripleMutator{}
+	pub := &mockPublisher{}
+	executor := NewActionExecutorFull(slog.Default(), mut, pub)
+	ec := newApproveTestEC("approve-rule-audit", nil, nil)
+	action := Action{
+		Type:    ActionTypeApprove,
+		Subject: "agent.toolcall.approved.test",
+		Reason:  "policy permits",
+	}
+
+	require.NoError(t, executor.executeApprove(ctx, action, ec))
+
+	require.Len(t, mut.addedTriples, 1, "AddTriple must be called exactly once")
+	triple := mut.addedTriples[0]
+	assert.Equal(t, PredicateRuleApprove, triple.Predicate,
+		"audit triple predicate must be %q", PredicateRuleApprove)
+	assert.Equal(t, "policy permits", triple.Object,
+		"audit triple object must be the substituted reason")
+}
+
+// TestExecuteApprove_AuditFailureDoesNotBlockPublish is the deny-parity
+// invariant: an audit-write failure logs at Error level but MUST NOT
+// prevent the publish from running. The verdict is structural — operators
+// without an audit triple is a known-bad state we surface loudly, but
+// downstream consumers (agentic-loop) still need to receive the verdict
+// or the call would time out.
+func TestExecuteApprove_AuditFailureDoesNotBlockPublish(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mut := &mockTripleMutator{addErr: errors.New("nats unavailable")}
+	pub := &mockPublisher{}
+	executor := NewActionExecutorFull(slog.Default(), mut, pub)
+	ec := newApproveTestEC("approve-rule-audit-fail", nil, nil)
+	action := Action{
+		Type:    ActionTypeApprove,
+		Subject: "agent.toolcall.approved.test",
+		Reason:  "permit",
+	}
+
+	err := executor.executeApprove(ctx, action, ec)
+	assert.NoError(t, err, "audit failure must NOT propagate; publish ran")
+	require.Len(t, pub.published, 1, "publish must still fire when audit fails")
+}
+
+// TestExecuteApprove_PublishFailureReturnsError diverges from audit-failure
+// handling: publish failure DOES return an error because downstream
+// consumers never learned the verdict. The caller (rule processor) will
+// log + retry per its action-error policy.
+func TestExecuteApprove_PublishFailureReturnsError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mut := &mockTripleMutator{}
+	pub := &mockPublisher{err: errors.New("jetstream timeout")}
+	executor := NewActionExecutorFull(slog.Default(), mut, pub)
+	ec := newApproveTestEC("approve-rule-pub-fail", nil, nil)
+	action := Action{
+		Type:    ActionTypeApprove,
+		Subject: "agent.toolcall.approved.test",
+		Reason:  "permit",
+	}
+
+	err := executor.executeApprove(ctx, action, ec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "publish approve verdict")
+}
+
+// TestExecuteApprove_RequiresSubject rejects approve actions without a
+// Subject — the verdict has nowhere to go and downstream consumers
+// would time out. Fail loudly at action-execute time so operator config
+// errors surface immediately rather than as mysterious timeouts.
+func TestExecuteApprove_RequiresSubject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	executor := NewActionExecutorFull(slog.Default(), &mockTripleMutator{}, &mockPublisher{})
+	ec := newApproveTestEC("approve-no-subject", nil, nil)
+	action := Action{Type: ActionTypeApprove, Reason: "permit"}
+
+	err := executor.executeApprove(ctx, action, ec)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "subject is required")
+}
+
+// TestExecuteApprove_NoPublisherIsNoOp covers the early-boot or
+// publisher-not-configured scenario: approve must still complete (return
+// nil) and write the audit triple. The publish step is skipped without
+// error so dev/test environments without a NATS publisher don't break.
+func TestExecuteApprove_NoPublisherIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mut := &mockTripleMutator{}
+	executor := NewActionExecutorWithMutator(slog.Default(), mut)
+	ec := newApproveTestEC("approve-no-pub", nil, nil)
+	action := Action{Type: ActionTypeApprove, Subject: "agent.toolcall.approved.x", Reason: "permit"}
+
+	assert.NoError(t, executor.executeApprove(ctx, action, ec))
+	assert.Len(t, mut.addedTriples, 1, "audit triple still written without publisher")
+}

--- a/processor/rule/execution_context.go
+++ b/processor/rule/execution_context.go
@@ -24,7 +24,7 @@ import (
 // match deep predicate paths like $entity.triple.agent.loop.role. We stop
 // at any other character so legitimate adjacent syntax (e.g. "$entity.id.")
 // doesn't over-match.
-var unresolvedTemplateVarRe = regexp.MustCompile(`\$(?:entity|related|state|schedule|caller)\.\w[\w.]*`)
+var unresolvedTemplateVarRe = regexp.MustCompile(`\$(?:entity|related|state|schedule|caller|message)\.\w[\w.]*`)
 
 // ExecutionContext carries typed data through the rule evaluation → action pipeline.
 // It replaces the previous (entityID, relatedID string) action signature, providing
@@ -61,6 +61,20 @@ type ExecutionContext struct {
 	// substitution layer reads this; see caller_substitution.go for the
 	// namespace contract.
 	Caller *CallerContext
+
+	// MessageData carries the payload of the inbound message that
+	// triggered rule evaluation, as a generic map for dotted-path
+	// access. Populated on the message-path (NATS-subscribed rules)
+	// from `GenericJSONPayload.Data`. Nil for entity-state-driven and
+	// cron-fired evaluations — those have no inbound message in scope.
+	// The `$message.*` substitution layer reads this; see
+	// message_substitution.go for the namespace contract.
+	//
+	// Required for ADR-039 tool-call governance: rule templates need
+	// to splice fields from the proposed tool-call payload (`loop_id`,
+	// `call_id`, `tool_name`, etc.) into verdict subjects and audit
+	// reasons.
+	MessageData map[string]any
 }
 
 // RuleID returns the originating rule's identifier, or an empty string if the
@@ -95,6 +109,11 @@ func (ec *ExecutionContext) RuleID() string {
 //   - $caller.id: Caller identity ID (caller-aware rules only)
 //   - $caller.role: Caller role claim (caller-aware rules only)
 //   - $caller.org: Caller organization claim (caller-aware rules only)
+//   - $message.<field_path>: dotted-path access into the inbound
+//     message data (message-path rules only). E.g. $message.loop_id
+//     or $message.tool_args.command. Tokens survive substitution (and
+//     trip the unresolved-template warning) when MessageData is nil
+//     or the path doesn't resolve — see message_substitution.go.
 //
 // Entity triple values can be accessed via $entity.triple.<predicate> syntax.
 //
@@ -144,6 +163,11 @@ func (ec *ExecutionContext) SubstituteVariables(template string) string {
 	// $caller.* tokens will then trip the unresolved-template warning
 	// below.
 	result = applyCallerSubstitutions(result, ec.Caller)
+
+	// Message-data substitutions (message-path rules only). No-op when
+	// ec.MessageData is nil; unknown $message.* tokens then trip the
+	// unresolved-template warning below.
+	result = applyMessageSubstitutions(result, ec.MessageData)
 
 	ec.warnUnresolvedTemplateVars(template, result)
 

--- a/processor/rule/message_handler.go
+++ b/processor/rule/message_handler.go
@@ -142,10 +142,13 @@ func (rp *Processor) evaluateRulesForMessage(ctx context.Context, subject string
 
 			// Perform stateful evaluation. Message-path rules have no KV
 			// revision and no bootstrap phase, so those fields stay zero.
+			// MessageData carries the inbound payload for $message.*
+			// substitution in action templates (ADR-039).
 			transition, err := rp.statefulEvaluator.Evaluate(ctx, Evaluation{
 				Rule:              ruleDef,
 				EntityID:          entityID,
 				CurrentlyMatching: triggered,
+				MessageData:       extractMessageData(msg),
 			})
 			if err != nil {
 				rp.logger.Warn("Stateful evaluation failed", "rule_name", ruleName, "error", err)
@@ -383,6 +386,31 @@ func extractEntityID(msg message.Message) string {
 
 	// Fallback to message ID if no entity_id in payload
 	return msg.ID()
+}
+
+// extractMessageData returns the inbound message's payload as a generic
+// map for `$message.*` substitution. Mirrors the path the expression
+// evaluator uses at `expression_factory.go:97` — only
+// `GenericJSONPayload` exposes its data as a generic map, so other
+// payload types yield nil and the substitution layer falls back to
+// silent-pass + warning per the unresolvedTemplateVarRe contract.
+//
+// nil is a valid return: it signals "no message-data scope for this
+// evaluation" to downstream substitution. Authors who reach for
+// $message.* in templates fired by entity-state or cron rules will see
+// the unresolved-template warning, which is the correct surfacing.
+func extractMessageData(msg message.Message) map[string]any {
+	if msg == nil {
+		return nil
+	}
+	payload := msg.Payload()
+	if payload == nil {
+		return nil
+	}
+	if generic, ok := payload.(*message.GenericJSONPayload); ok {
+		return generic.Data
+	}
+	return nil
 }
 
 // recordError records an error and updates health status

--- a/processor/rule/message_substitution.go
+++ b/processor/rule/message_substitution.go
@@ -1,0 +1,112 @@
+// Package rule - Inbound-message substitution context.
+//
+// Tool-call governance rules (ADR-039) need to template verdict subjects
+// and audit reasons with values pulled from the proposed tool-call
+// payload: `agent.toolcall.rejected.$message.loop_id.$message.call_id`,
+// `Reason: "bash command $message.tool_args.command rejected for $message.tool_name"`.
+// The existing `$entity.*` / `$related.*` / `$state.*` / `$caller.*` /
+// `$schedule.*` namespaces all read from entity-side context; none of
+// them carry the payload of the message that triggered evaluation.
+//
+// `$message.<field_path>` closes that gap. Resolution walks a
+// `map[string]any` along the dotted path — same shape the expression
+// evaluator already uses for condition matching (see
+// `ExpressionRule.extractNestedValue` in `expression_factory.go`). Deep
+// paths (`$message.tool_args.command`) are supported per the
+// `$entity.triple.X` precedent.
+//
+// # Behaviour
+//
+// A nil or empty data map is a no-op — every `$message.*` token in the
+// template survives substitution and trips the unresolvedTemplateVarRe
+// warning. Same for paths that descend through a non-map intermediate or
+// hit a missing terminal key. The literal stays in the output so authors
+// see the silent-pass loudly, instead of empty strings landing in
+// downstream subjects/keys.
+//
+// # Namespace boundary
+//
+// `$message.*` shares the substitution-token regex with the other
+// namespaces in `execution_context.go`. The pass runs alongside the
+// other ApplyXSubstitutions calls in `ExecutionContext.SubstituteVariables`
+// and has no overlap with the other token shapes by construction.
+package rule
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// messageTokenRe matches `$message.<field_path>` where the path is one
+// or more dot-separated word segments. The non-capturing `\b` boundary
+// at the end stops the match at anything that isn't a word character or
+// dot — so a token followed by punctuation (`$message.loop_id.`,
+// `$message.call_id,`) doesn't over-consume into the trailing literal.
+//
+// The greedy-by-default `[\w.]+` is fine here: substitution iterates the
+// FindAllStringSubmatchIndex results in order, longest-first per regex
+// semantics, so deeper paths get tried before shorter prefixes that
+// would otherwise win. Resolution failure leaves the literal in place —
+// see the package doc for why that is the correct silent-pass behaviour.
+var messageTokenRe = regexp.MustCompile(`\$message\.[\w]+(?:\.[\w]+)*`)
+
+// applyMessageSubstitutions replaces `$message.<field_path>` tokens in
+// template against data using dotted-path access into the map. nil/empty
+// data leaves every token untouched so the unresolved-template warning
+// in execution_context.go fires.
+//
+// Path-resolution failure (intermediate not a map, terminal key missing)
+// is also a no-op — same surfacing behaviour as `$entity.triple.X`
+// missing a predicate on the entity at fire time. Authors see the
+// literal in the output and the warning, not a silently rendered empty.
+func applyMessageSubstitutions(template string, data map[string]any) string {
+	if len(data) == 0 {
+		return template
+	}
+	return messageTokenRe.ReplaceAllStringFunc(template, func(token string) string {
+		// token shape: "$message.<dotted.path>"
+		path := strings.TrimPrefix(token, "$message.")
+		if path == "" {
+			return token
+		}
+		value, ok := extractMessageValue(data, path)
+		if !ok {
+			return token
+		}
+		return fmt.Sprintf("%v", value)
+	})
+}
+
+// extractMessageValue walks data along the dotted path. Returns the
+// terminal value and true on success; the second return is false (and
+// the caller must leave the token literal in place) when:
+//
+//   - any non-terminal segment is missing from the current map, OR
+//   - any non-terminal segment resolves to a non-map value (can't
+//     descend further), OR
+//   - the terminal segment is missing.
+//
+// A nil terminal value is considered a successful resolution (the JSON
+// `null` distinct from "missing"). Callers render `<nil>` via fmt — the
+// silent-pass safety net is the regex-leftover warning, not extra
+// fallback logic here.
+func extractMessageValue(data map[string]any, path string) (any, bool) {
+	parts := strings.Split(path, ".")
+	current := any(data)
+	for i, part := range parts {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		value, exists := m[part]
+		if !exists {
+			return nil, false
+		}
+		if i == len(parts)-1 {
+			return value, true
+		}
+		current = value
+	}
+	return nil, false
+}

--- a/processor/rule/message_substitution_test.go
+++ b/processor/rule/message_substitution_test.go
@@ -1,0 +1,270 @@
+package rule
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestApplyMessageSubstitutions_FlatFields(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{
+		"loop_id":   "loop-abc",
+		"call_id":   "call-001",
+		"tool_name": "bash",
+	}
+
+	in := "loop=$message.loop_id call=$message.call_id tool=$message.tool_name"
+	want := "loop=loop-abc call=call-001 tool=bash"
+
+	if got := applyMessageSubstitutions(in, data); got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+// Deep paths must resolve through nested maps. Mirrors the $entity.triple.X
+// precedent — the substitution layer is the only place where tool-call
+// payloads with nested `tool_args` can be templated into rule subjects/reasons.
+func TestApplyMessageSubstitutions_DeepPath(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{
+		"tool_name": "bash",
+		"tool_args": map[string]any{
+			"command": "rm -rf /tmp/danger",
+			"timeout": 30,
+		},
+	}
+
+	in := "tool=$message.tool_name cmd=$message.tool_args.command timeout=$message.tool_args.timeout"
+	want := "tool=bash cmd=rm -rf /tmp/danger timeout=30"
+
+	if got := applyMessageSubstitutions(in, data); got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+// Nil/empty data MUST leave every token literal so unresolvedTemplateVarRe
+// surfaces the silent-pass. Authors get a warning instead of empty strings
+// landing in downstream subjects/keys. Catches new event shapes that forgot
+// to populate the field — the bug class the unresolved-warning regression
+// guard exists for.
+func TestApplyMessageSubstitutions_NilOrEmptyData(t *testing.T) {
+	t.Parallel()
+
+	in := "loop=$message.loop_id"
+
+	if got := applyMessageSubstitutions(in, nil); got != in {
+		t.Errorf("nil data: got %q, want unchanged %q", got, in)
+	}
+	if got := applyMessageSubstitutions(in, map[string]any{}); got != in {
+		t.Errorf("empty data: got %q, want unchanged %q", got, in)
+	}
+}
+
+// Missing terminal key, missing intermediate, and descent through a
+// non-map intermediate must all leave the token literal. This is the
+// class of silent-pass bug `$entity.triple.X` already defends against.
+func TestApplyMessageSubstitutions_UnresolvedPathLeavesToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		data map[string]any
+		in   string
+		want string
+	}{
+		{
+			name: "missing terminal key",
+			data: map[string]any{"loop_id": "loop-abc"},
+			in:   "call=$message.call_id",
+			want: "call=$message.call_id",
+		},
+		{
+			name: "missing intermediate",
+			data: map[string]any{"tool_name": "bash"},
+			in:   "cmd=$message.tool_args.command",
+			want: "cmd=$message.tool_args.command",
+		},
+		{
+			name: "intermediate is not a map (string)",
+			data: map[string]any{"tool_args": "not-a-map"},
+			in:   "cmd=$message.tool_args.command",
+			want: "cmd=$message.tool_args.command",
+		},
+		{
+			name: "intermediate is not a map (number)",
+			data: map[string]any{"tool_args": 42},
+			in:   "cmd=$message.tool_args.command",
+			want: "cmd=$message.tool_args.command",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := applyMessageSubstitutions(tt.in, tt.data); got != tt.want {
+				t.Errorf("got  %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Tokens with no resolution alongside resolved tokens must NOT eat into
+// each other — partial-resolution is fine, but leftovers stay literal so
+// the warning fires. Catches a regression where a greedy
+// ReplaceAllString might overwrite preceding successful substitutions on
+// failure.
+func TestApplyMessageSubstitutions_MixedResolution(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{
+		"loop_id": "loop-abc",
+	}
+
+	in := "loop=$message.loop_id call=$message.call_id"
+	want := "loop=loop-abc call=$message.call_id"
+
+	if got := applyMessageSubstitutions(in, data); got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+// Template with no $message.* tokens is unchanged regardless of data.
+// Guards a future regex refactor against false-positive matches.
+func TestApplyMessageSubstitutions_NoTokens(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]any{"loop_id": "loop-abc"}
+	in := "entity=$entity.id"
+	if got := applyMessageSubstitutions(in, data); got != in {
+		t.Errorf("got %q, want unchanged %q", got, in)
+	}
+}
+
+// End-to-end through ExecutionContext.SubstituteVariables. Confirms the
+// $message.* pass coexists with $entity.id and $caller.id resolution in
+// the same template — the use case for ADR-039 tool-call governance
+// reasons that splice caller + tool-call payload + entity.
+func TestSubstituteVariables_Message_FullPipeline(t *testing.T) {
+	t.Parallel()
+
+	ec := &ExecutionContext{
+		EntityID: "c360.osh.agent.agentic-loop.execution.uuid-001",
+		MessageData: map[string]any{
+			"loop_id":   "loop-abc",
+			"call_id":   "call-001",
+			"tool_name": "bash",
+			"tool_args": map[string]any{
+				"command": "ls /tmp",
+			},
+		},
+	}
+
+	in := "rule fired on $entity.id for loop=$message.loop_id call=$message.call_id cmd=$message.tool_args.command"
+	want := "rule fired on c360.osh.agent.agentic-loop.execution.uuid-001 for loop=loop-abc call=call-001 cmd=ls /tmp"
+
+	if got := ec.SubstituteVariables(in); got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+// $message.* in a verdict subject template — the canonical ADR-039 use
+// case. Pins that the existing publish/action subject substitution
+// pipeline correctly resolves $message.* tokens for routing.
+func TestSubstituteVariables_Message_VerdictSubject(t *testing.T) {
+	t.Parallel()
+
+	ec := &ExecutionContext{
+		MessageData: map[string]any{
+			"loop_id": "loop-abc",
+			"call_id": "call-001",
+		},
+	}
+
+	in := "agent.toolcall.rejected.$message.loop_id.$message.call_id"
+	want := "agent.toolcall.rejected.loop-abc.call-001"
+
+	if got := ec.SubstituteVariables(in); got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+// Unresolved $message.<missing> MUST fire the unresolvedTemplateVarRe
+// warning via the same path as missing $entity.triple.X. This is the
+// silent-pass guard the ADR specifically called out — catches new event
+// shapes that forgot to populate a field at publish time.
+func TestSubstituteVariables_Message_UnresolvedFieldWarns(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	prev := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	ec := &ExecutionContext{
+		MessageData: map[string]any{"loop_id": "loop-abc"},
+	}
+
+	in := "loop=$message.loop_id missing=$message.absent_field"
+	want := "loop=loop-abc missing=$message.absent_field"
+
+	got := ec.SubstituteVariables(in)
+	if got != want {
+		t.Errorf("substitution: got %q, want %q", got, want)
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "Unresolved template variables") {
+		t.Errorf("expected unresolved-template warning, got log: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "$message.absent_field") {
+		t.Errorf("expected $message.absent_field in warning, got log: %s", logOutput)
+	}
+}
+
+// $message.* alongside $entity.* alongside $caller.* — all three
+// namespaces resolve independently in the same template. Coexistence
+// property a "reorder the substitution passes" refactor would silently
+// break.
+func TestSubstituteVariables_Message_CoexistsWithOtherNamespaces(t *testing.T) {
+	t.Parallel()
+
+	ec := &ExecutionContext{
+		EntityID: "c360.osh.agent.agentic-loop.execution.uuid-001",
+		Caller: &CallerContext{
+			ID:   "alice",
+			Role: "operator",
+		},
+		MessageData: map[string]any{"tool_name": "bash"},
+	}
+
+	in := "caller=$caller.id role=$caller.role entity=$entity.instance tool=$message.tool_name"
+	want := "caller=alice role=operator entity=uuid-001 tool=bash"
+
+	if got := ec.SubstituteVariables(in); got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+// Confirms unresolvedTemplateVarRe matches $message.<field> so the
+// warning surfaces missing tokens. Mirror of the entity-parts regex
+// guard test in entity_substitution_test.go.
+func TestSubstituteVariables_Message_RegexMatchesTokens(t *testing.T) {
+	t.Parallel()
+
+	in := "loop=$message.loop_id deep=$message.tool_args.command"
+	leftovers := unresolvedTemplateVarRe.FindAllString(in, -1)
+	if len(leftovers) != 2 {
+		t.Fatalf("expected 2 $message.* matches, got %d: %v", len(leftovers), leftovers)
+	}
+	if leftovers[0] != "$message.loop_id" {
+		t.Errorf("first match: got %q want %q", leftovers[0], "$message.loop_id")
+	}
+	if leftovers[1] != "$message.tool_args.command" {
+		t.Errorf("second match: got %q want %q", leftovers[1], "$message.tool_args.command")
+	}
+}

--- a/processor/rule/stateful_evaluator.go
+++ b/processor/rule/stateful_evaluator.go
@@ -59,6 +59,15 @@ type Evaluation struct {
 	Related           *gtypes.EntityState // nil for single-entity or message-path
 	Revision          uint64              // KV revision that triggered this evaluation; 0 if unknown
 	Bootstrap         bool                // true during watcher initial-state replay
+
+	// MessageData carries the payload of the inbound message that
+	// triggered evaluation, as a generic map for dotted-path access.
+	// Populated by `evaluateRulesForMessage` from
+	// `GenericJSONPayload.Data` for message-path (NATS-subscribed)
+	// rules. Nil for entity-state-driven and cron-fired evaluations.
+	// Plumbed through to `ExecutionContext.MessageData` so
+	// `$message.*` substitution can resolve.
+	MessageData map[string]any
 }
 
 // entityKey returns the state-tracker key (single entity or canonical pair).
@@ -162,11 +171,12 @@ func (e *StatefulEvaluator) Evaluate(ctx context.Context, ev Evaluation) (Transi
 	}
 
 	ec := &ExecutionContext{
-		EntityID:  ev.EntityID,
-		RelatedID: ev.RelatedID,
-		Entity:    ev.Entity,
-		Related:   ev.Related,
-		State:     matchState,
+		EntityID:    ev.EntityID,
+		RelatedID:   ev.RelatedID,
+		Entity:      ev.Entity,
+		Related:     ev.Related,
+		State:       matchState,
+		MessageData: ev.MessageData,
 	}
 
 	stateFields := expression.StateFields{

--- a/schemas/agentic-loop.v1.json
+++ b/schemas/agentic-loop.v1.json
@@ -149,6 +149,25 @@
       "default": "120s",
       "category": "basic"
     },
+    "tool_call_governance": {
+      "type": "object",
+      "description": "Subject-mode tool-call governance (ADR-039). Default mode=disabled retains existing in-process filter behavior",
+      "category": "advanced",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "Governance mode (disabled|audit|enforce). Default disabled retains in-process filter behavior",
+          "default": "disabled",
+          "category": "advanced"
+        },
+        "timeout": {
+          "type": "string",
+          "description": "Per-call verdict wait window in enforce mode (e.g. 500ms or 2s). Default 1s",
+          "default": "1s",
+          "category": "advanced"
+        }
+      }
+    },
     "tool_result_max_bytes": {
       "type": "integer",
       "description": "Maximum bytes for tool result content before truncation. 0 means no limit",

--- a/test/e2e/scenarios/agentic/scenario.go
+++ b/test/e2e/scenarios/agentic/scenario.go
@@ -158,6 +158,7 @@ func (s *Scenario) Execute(ctx context.Context) (*scenarios.Result, error) {
 		{"verify-graph-triples", s.verifyGraphTriples},
 		{"verify-tool-execution", s.verifyToolExecution},
 		{"verify-streaming-metrics", s.verifyStreamingMetrics},
+		{"verify-tool-call-governance", s.verifyToolCallGovernance},
 		{"validate-results", s.validateResults},
 		// AGNTCY integration stages (optional, skip if not configured)
 		{"verify-oasf-generation", s.verifyOASFGeneration},
@@ -527,6 +528,64 @@ func (s *Scenario) verifyStreamingMetrics(ctx context.Context, result *scenarios
 	}
 
 	result.Details["streaming_verified"] = true
+	return nil
+}
+
+// verifyToolCallGovernance checks that the ADR-039 subject-mode
+// governance flow fired. The e2e config sets agentic-loop.mode=audit
+// and ships an approve-all rule that subscribes to
+// agent.toolcall.proposed.>. When the temperature-anomaly task issues
+// its tool call (`query_entity`), the loop publishes a proposed-call,
+// the rule fires an approve verdict, and three metrics increment:
+//
+//   - tool_call_governance_verdict_total{mode="audit"} — verdict received
+//   - tool_call_governance_verdict_duration_seconds_count — duration observed
+//   - rule_actions_executed_total — approve action fired in the rule engine
+//
+// Audit mode means dispatch is NOT gated; this stage validates the
+// governance path is wired end-to-end without affecting the existing
+// scenario's success criteria. HARD FAILURE because:
+//   - default mode=disabled retains pre-ADR-039 behavior, so failure
+//     here means the e2e config didn't take effect (regression: this
+//     was the canonical e2e coverage we added pre-tag).
+//   - audit-mode failure is the cheapest leading indicator that
+//     enforce-mode would wedge in production.
+func (s *Scenario) verifyToolCallGovernance(ctx context.Context, result *scenarios.Result) error {
+	verdictTotal, err := s.metrics.SumMetricsByName(ctx, "semstreams_agentic_loop_tool_call_governance_verdict_total")
+	if err != nil {
+		return fmt.Errorf("failed to fetch governance verdict counter: %w", err)
+	}
+	result.Metrics["governance_verdicts_total"] = verdictTotal
+
+	if verdictTotal < 1 {
+		return fmt.Errorf(
+			"governance verdict counter is 0 — agentic-loop did not publish a proposed-call OR the rule processor did not emit a verdict. " +
+				"Check (1) agentic-loop tool_call_governance.mode is set to 'audit' or 'enforce' in configs/agentic.json, " +
+				"(2) the rule processor subscribes to agent.toolcall.proposed.> with a rule whose actions include approve/publish to agent.toolcall.{approved,rejected}.* subjects, " +
+				"(3) the rule processor and agentic-loop are healthy")
+	}
+
+	// Confirm at least one verdict was an approve (the e2e rule is
+	// approve-all). If we ever see only timeouts here, the rule fired
+	// but its verdict didn't reach the loop in time — points at NATS
+	// propagation or a subject mismatch.
+	approves, err := s.metrics.GetMetricByLabels(ctx,
+		"semstreams_agentic_loop_tool_call_governance_verdict_total",
+		map[string]string{"decision": "approved", "mode": "audit"})
+	if err != nil {
+		return fmt.Errorf("failed to fetch approve verdict counter by labels: %w", err)
+	}
+	var approvedCount float64
+	for _, m := range approves {
+		approvedCount += m.Value
+	}
+	result.Metrics["governance_verdicts_approved_audit"] = approvedCount
+
+	if approvedCount < 1 {
+		return fmt.Errorf("audit-mode approve counter is 0 — rule fired but the verdict subject did not reach the loop. Subject mismatch or stream propagation issue?")
+	}
+
+	result.Details["governance_verified"] = true
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Implements ADR-039 Phase 2: tool-call governance migrates from in-process `ToolCallFilter` to rule-driven subject-mode flow. Six commits, all gates green (unit + race + integration + lint + schema).

**Marked BREAKING** because of new config schema + new ports + new rule action type. **No wire-format breakage** on existing subjects — `mode=disabled` (the default) preserves all pre-beta.69 behavior.

## What's in this PR

### Engine extensions (`processor/rule/`)

- `$message.*` substitution namespace — deep dotted-path access into the inbound message payload (e.g. `$message.tool_args.command`). Unresolved tokens trip the existing silent-pass warning at `execution_context.go:27`.
- `ExecutionContext.MessageData` + `Evaluation.MessageData` plumbed from the message-path. Populated from `GenericJSONPayload.Data`.
- `approve` action — symmetric to `deny` on audit-triple write, **asymmetric on short-circuit** (approve doesn't terminate the rule's remaining actions; the asymmetry is the feature). Writes audit triple under `rule.approve` predicate; publishes verdict payload to the substituted Subject.
- `executeApprove` auto-echoes `call_id` / `loop_id` from MessageData so the agentic-loop consumer can demux verdicts without a custom subject parser.

### Loop dispatcher (`processor/agentic-loop/`)

- `tool_call_governance.{mode,timeout}` config — default `mode=disabled` preserves existing behavior (the in-process `ToolCallFilter` keeps running).
- New ports: `agent.toolcall.proposed.*` (out, per-loop), `agent.toolcall.approved.>` / `.rejected.>` (in, wildcard per-call demux).
- `GovernanceDispatcher` interface + three implementations:
  - **disabled** — pass-through, no publish.
  - **audit** — publishes proposed-call, dispatches **immediately** without waiting; verdicts logged for observability.
  - **enforce** — publishes proposed-call, waits up to `Timeout` for per-call verdict, dispatches on approve / fails on reject / **fails-closed on timeout**.
- Subscribe-before-publish race-fix via in-process buffered waiter channels pre-registered before publish (ADR-039 race-fix option 3).
- `parent_loop_id` rides along in the proposed-call payload from day one for sub-agent governance inheritance.
- Both verdict-payload shapes supported (approve-action top-level fields AND publish-action nested `properties`).

### Observability

Three Prometheus metrics:
- `semstreams_agentic_loop_tool_call_governance_verdict_duration_seconds` (histogram, `decision×mode` labels, 1ms–5s buckets) — drives the timeout-tuning decision in beta.70.
- `semstreams_agentic_loop_tool_call_governance_verdict_total` (counter, `decision×mode`).
- `semstreams_agentic_loop_tool_call_governance_subscribe_before_publish_failures_total` (counter) — canonical signal that the race-fix regressed.

### Docs

- `docs/operations/17-tool-call-governance.md` — operator guide (modes, subject topology, rule examples, troubleshooting, sub-agent inheritance).
- `docs/operations/migration-beta68-to-beta69.md` — semspec migration guide with concrete config translation.
- `docs/concepts/03-streams-vs-kv-watches.md` — work-items diagram updated with new subjects.

## For semspec (current consumer pinned on beta.68)

**No code change required.** The in-process `ToolCallFilter` wiring is **retained** as an escape hatch at beta.69. Default `mode=disabled` means existing wiring keeps working exactly as before.

Two-stage cutover when ready, **config-only**:
1. `mode=audit` — publishes proposed calls but doesn't gate. Verify rules in metrics.
2. `mode=enforce` — wait for verdicts, fail-closed on timeout.

**beta.70** retires the in-process surface — semspec must migrate to subject-mode before then. Migration doc has the concrete translation from `blocked_command_patterns` to the equivalent rule.

## Test plan

- [x] Unit tests with race detector — `./processor/rule/...`, `./processor/agentic-loop/...`, `./processor/agentic-governance/...` all green
- [x] `task lint` clean
- [x] `task schema:generate` clean (regenerated schema committed)
- [x] Contract tests — `./test/contract/...` green
- [ ] **`task e2e:agentic` — coverage gap, see below**

## ⚠️ Blocking before final (un-draft)

**Coverage gap**: existing `task e2e:agentic` does NOT exercise the rule-driven governance path — no rules engine in `docker/compose/agentic.yml`, no governance config in `configs/agentic.json`, no governance scenario in `test/e2e/scenarios/agentic/`.

Per CLAUDE.md hard rule, BREAKING tags require ≥1 relevant e2e tier green covering the changed path before tag. Default `mode=disabled` means **no regression risk** from this PR on existing e2e behavior, but the new path itself is not e2e-covered.

**This PR is draft** until either:
- e2e:agentic is extended to exercise the rule-driven path (recommend separate follow-up PR), OR
- A scoped e2e test is added in this PR

Not flipping to ready-for-review until that decision is made and the relevant e2e tier is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)