### PR TITLE
test(agntcy): pin OASF schema, exercise A2A task lifecycle, parse OTLP structurally

### DIFF
--- a/processor/oasf-generator/oasf_contract_test.go
+++ b/processor/oasf-generator/oasf_contract_test.go
@@ -1,0 +1,152 @@
+package oasfgenerator
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/message"
+	agentic "github.com/c360studio/semstreams/vocabulary/agentic"
+	"github.com/google/go-cmp/cmp"
+)
+
+var update = flag.Bool("update", false, "rewrite testdata golden files")
+
+// TestOASFContract pins the OASF wire format that downstream AGNTCY consumers
+// rely on (directory registration body, A2A agent-card derivation). It exercises
+// every predicate the mapper handles and compares the marshalled record against
+// a checked-in golden file.
+//
+// If this test fails, either:
+//   - the upstream OASF schema has changed (update golden + CurrentSchemaVersion),
+//   - a SemStreams predicate has been renamed (update mapper + golden),
+//   - the mapper grew/lost a field (intentional changes need golden update).
+//
+// Update the golden by running: go test ./processor/oasf-generator/ -run TestOASFContract -update
+func TestOASFContract(t *testing.T) {
+	mapper := NewMapper("1.0.0", []string{"semstreams-test"}, true)
+	triples := contractTriples()
+
+	record, err := mapper.MapTriplesToOASF(contractAgentID, triples)
+	if err != nil {
+		t.Fatalf("MapTriplesToOASF: %v", err)
+	}
+
+	// Pin schema_version explicitly so a rename in oasf_types.go is caught here,
+	// not silently in production.
+	if record.SchemaVersion != CurrentSchemaVersion {
+		t.Errorf("SchemaVersion = %q, want %q", record.SchemaVersion, CurrentSchemaVersion)
+	}
+	if record.SchemaVersion != "1.0.0" {
+		t.Errorf("CurrentSchemaVersion drifted from documented 1.0.0: %q", record.SchemaVersion)
+	}
+
+	// CreatedAt is wallclock-derived; validate format then null it for comparison.
+	if record.CreatedAt == "" {
+		t.Error("CreatedAt is empty")
+	} else if _, err := time.Parse(time.RFC3339, record.CreatedAt); err != nil {
+		t.Errorf("CreatedAt %q is not RFC-3339: %v", record.CreatedAt, err)
+	}
+	record.CreatedAt = ""
+
+	// Map iteration order is non-deterministic for skills, domains, and
+	// extension lists; normalize before structural comparison.
+	normalizeForGolden(record)
+
+	got, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal record: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "oasf_record_golden.json")
+
+	if *update {
+		writeGolden(t, goldenPath, got)
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v (run with -update to create)", err)
+	}
+
+	// Compare structurally, not byte-for-byte, so trailing newline / indent
+	// differences don't trip the test.
+	var gotAny, wantAny any
+	if err := json.Unmarshal(got, &gotAny); err != nil {
+		t.Fatalf("unmarshal got: %v", err)
+	}
+	if err := json.Unmarshal(want, &wantAny); err != nil {
+		t.Fatalf("unmarshal golden: %v", err)
+	}
+
+	if diff := cmp.Diff(wantAny, gotAny); diff != "" {
+		t.Errorf("OASF record drift (-golden +got):\n%s\n\nFull got payload:\n%s",
+			diff, string(got))
+	}
+}
+
+const contractAgentID = "acme.ops.agentic.system.agent.contract-test"
+
+// contractTriples is the canonical input that exercises every predicate the
+// mapper handles. Keep this list aligned with PredicateMapping; if mapping
+// grows, add an entry here AND regenerate the golden.
+func contractTriples() []message.Triple {
+	ts := time.Unix(0, 0).UTC() // pinned timestamp; mapper doesn't read it but reviewers do
+	return []message.Triple{
+		// Skill 1: full surface
+		{Subject: contractAgentID, Predicate: agentic.CapabilityExpression, Object: "code-review", Context: "code-review", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.CapabilityName, Object: "Code Review", Context: "code-review", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.CapabilityDescription, Object: "Review code for quality and security issues", Context: "code-review", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.CapabilityConfidence, Object: 0.9, Context: "code-review", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.CapabilityPermission, Object: "file_read", Context: "code-review", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.CapabilityPermission, Object: "file_write", Context: "code-review", Timestamp: ts},
+
+		// Skill 2: minimal — exercises generateSkillID fallback when name only
+		{Subject: contractAgentID, Predicate: agentic.CapabilityExpression, Object: "documentation", Context: "documentation", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.CapabilityName, Object: "Documentation", Context: "documentation", Timestamp: ts},
+
+		// Intent → description + domains
+		{Subject: contractAgentID, Predicate: agentic.IntentGoal, Object: "Help developers review code and ship docs", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.IntentType, Object: "software-development", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.IntentType, Object: "documentation", Timestamp: ts},
+
+		// Action → extensions.action_types (deduped)
+		{Subject: contractAgentID, Predicate: agentic.ActionType, Object: "tool-call", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.ActionType, Object: "tool-call", Timestamp: ts},
+		{Subject: contractAgentID, Predicate: agentic.ActionType, Object: "model-call", Timestamp: ts},
+	}
+}
+
+// normalizeForGolden makes the record byte-stable by sorting collections whose
+// source-of-truth is a map.
+func normalizeForGolden(r *OASFRecord) {
+	sort.Slice(r.Skills, func(i, j int) bool { return r.Skills[i].ID < r.Skills[j].ID })
+	for i := range r.Skills {
+		sort.Strings(r.Skills[i].Permissions)
+	}
+	sort.Slice(r.Domains, func(i, j int) bool { return r.Domains[i].Name < r.Domains[j].Name })
+	if v, ok := r.Extensions["action_types"]; ok {
+		if list, ok := v.([]string); ok {
+			sort.Strings(list)
+			r.Extensions["action_types"] = list
+		}
+	}
+}
+
+func writeGolden(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir testdata: %v", err)
+	}
+	// Trailing newline so editors stop fighting us.
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write golden: %v", err)
+	}
+	t.Logf("updated golden %s", path)
+}

--- a/processor/oasf-generator/testdata/oasf_record_golden.json
+++ b/processor/oasf-generator/testdata/oasf_record_golden.json
@@ -1,0 +1,43 @@
+{
+  "name": "agent-contract-test",
+  "version": "1.0.0",
+  "schema_version": "1.0.0",
+  "authors": [
+    "semstreams-test"
+  ],
+  "created_at": "",
+  "description": "Help developers review code and ship docs",
+  "skills": [
+    {
+      "id": "code-review",
+      "name": "Code Review",
+      "description": "Review code for quality and security issues",
+      "confidence": 0.9,
+      "permissions": [
+        "file_read",
+        "file_write"
+      ]
+    },
+    {
+      "id": "documentation",
+      "name": "Documentation",
+      "confidence": 1
+    }
+  ],
+  "domains": [
+    {
+      "name": "documentation"
+    },
+    {
+      "name": "software-development"
+    }
+  ],
+  "extensions": {
+    "action_types": [
+      "model-call",
+      "tool-call"
+    ],
+    "semstreams_entity_id": "acme.ops.agentic.system.agent.contract-test",
+    "source": "semstreams"
+  }
+}

--- a/test/e2e/client/agntcy.go
+++ b/test/e2e/client/agntcy.go
@@ -2,11 +2,13 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -158,20 +160,32 @@ func NewA2AClient(baseURL string) *A2AClient {
 }
 
 // A2ATask represents an A2A task for testing.
+// Mirrors the server-side input/a2a.Task wire shape.
 type A2ATask struct {
-	ID     string `json:"id"`
-	Status struct {
-		State string `json:"state"`
-	} `json:"status"`
-	Messages []A2AMessage `json:"messages,omitempty"`
+	ID        string         `json:"id"`
+	SessionID string         `json:"sessionId,omitempty"`
+	Status    A2ATaskStatus  `json:"status"`
+	Message   A2AMessage     `json:"message,omitzero"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+// A2ATaskStatus mirrors input/a2a.TaskStatus.
+type A2ATaskStatus struct {
+	State     string `json:"state"`
+	Message   string `json:"message,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
 }
 
 // A2AMessage represents an A2A message.
 type A2AMessage struct {
-	Role  string `json:"role"`
-	Parts []struct {
-		Text string `json:"text,omitempty"`
-	} `json:"parts"`
+	Role  string           `json:"role"`
+	Parts []A2AMessagePart `json:"parts"`
+}
+
+// A2AMessagePart mirrors input/a2a.MessagePart for the text variant.
+type A2AMessagePart struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
 }
 
 // A2AAgentCard represents an A2A agent card response.
@@ -236,26 +250,28 @@ func (c *A2AClient) GetAgentCard(ctx context.Context) (*A2AAgentCard, error) {
 	return &card, nil
 }
 
-// SubmitTask submits a task to the A2A adapter.
+// SubmitTask submits a task to the A2A adapter via POST /tasks/send.
+// The adapter authenticates via X-Agent-DID; we pass a fixed test DID so the
+// stage works whether or not auth is enabled on the deployment.
 func (c *A2AClient) SubmitTask(ctx context.Context, taskID, prompt string) (*A2ATask, error) {
-	body := fmt.Sprintf(`{
-		"jsonrpc": "2.0",
-		"method": "tasks/send",
-		"params": {
-			"id": "%s",
-			"message": {
-				"role": "user",
-				"parts": [{"text": "%s"}]
-			}
+	task := A2ATask{
+		ID: taskID,
+		Message: A2AMessage{
+			Role:  "user",
+			Parts: []A2AMessagePart{{Type: "text", Text: prompt}},
 		},
-		"id": "1"
-	}`, taskID, prompt)
+	}
+	body, err := json.Marshal(task)
+	if err != nil {
+		return nil, fmt.Errorf("marshal task: %w", err)
+	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/", strings.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/tasks/send", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Agent-DID", "did:semstreams:e2e-test")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -263,43 +279,45 @@ func (c *A2AClient) SubmitTask(ctx context.Context, taskID, prompt string) (*A2A
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	// handleSendTask returns 202 Accepted on success.
+	if resp.StatusCode != http.StatusAccepted {
 		respBody, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("task submission failed: %s - %s", resp.Status, string(respBody))
 	}
 
-	var result struct {
-		Result *A2ATask `json:"result"`
-		Error  *struct {
-			Code    int    `json:"code"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
+	var result A2ATask
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
-
-	if result.Error != nil {
-		return nil, fmt.Errorf("A2A error %d: %s", result.Error.Code, result.Error.Message)
-	}
-
-	return result.Result, nil
+	return &result, nil
 }
 
-// GetTask retrieves task status from the A2A adapter.
-func (c *A2AClient) GetTask(ctx context.Context, taskID string) (*A2ATask, error) {
-	body := fmt.Sprintf(`{
-		"jsonrpc": "2.0",
-		"method": "tasks/get",
-		"params": {"id": "%s"},
-		"id": "1"
-	}`, taskID)
+// SubmitTaskRaw submits an arbitrary request body to /tasks/send. Used for
+// negative-path tests that need malformed payloads. Returns status code and body.
+func (c *A2AClient) SubmitTaskRaw(ctx context.Context, rawBody []byte) (int, []byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/tasks/send", bytes.NewReader(rawBody))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Agent-DID", "did:semstreams:e2e-test")
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/", strings.NewReader(body))
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, body, nil
+}
+
+// GetTask retrieves task status via GET /tasks/get?id=<id>.
+func (c *A2AClient) GetTask(ctx context.Context, taskID string) (*A2ATask, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		c.baseURL+"/tasks/get?id="+url.QueryEscape(taskID), nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -312,22 +330,42 @@ func (c *A2AClient) GetTask(ctx context.Context, taskID string) (*A2ATask, error
 		return nil, fmt.Errorf("get task failed: %s - %s", resp.Status, string(respBody))
 	}
 
-	var result struct {
-		Result *A2ATask `json:"result"`
-		Error  *struct {
-			Code    int    `json:"code"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
+	var result A2ATask
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
+	return &result, nil
+}
 
-	if result.Error != nil {
-		return nil, fmt.Errorf("A2A error %d: %s", result.Error.Code, result.Error.Message)
+// CancelTask cancels a task via POST /tasks/cancel.
+func (c *A2AClient) CancelTask(ctx context.Context, taskID string) (*A2ATask, error) {
+	body, err := json.Marshal(map[string]string{"id": taskID})
+	if err != nil {
+		return nil, fmt.Errorf("marshal cancel: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/tasks/cancel", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Agent-DID", "did:semstreams:e2e-test")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("cancel task failed: %s - %s", resp.Status, string(respBody))
 	}
 
-	return result.Result, nil
+	var result A2ATask
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &result, nil
 }
 
 // AGNTCYMockClient provides HTTP client for testing the AGNTCY mock server.
@@ -436,11 +474,25 @@ func (c *AGNTCYMockClient) WaitForRegistration(
 }
 
 // MockServerStats contains statistics from the AGNTCY mock server.
+// Structural fields (Spans*, MetricsDataPoints*, *Names) are populated by the
+// mock's OTLP-JSON parser and allow assertions beyond byte-count proof-of-life.
 type MockServerStats struct {
 	RequestCount    int64 `json:"request_count"`
 	Registrations   int   `json:"registrations"`
 	TracesReceived  int64 `json:"traces_received"`
 	MetricsReceived int64 `json:"metrics_received"`
+
+	// Structural trace aggregates parsed from OTLP JSON payloads.
+	TracesSpansTotal       int64    `json:"traces_spans_total"`
+	TracesStatusOK         int64    `json:"traces_status_ok"`
+	TracesStatusError      int64    `json:"traces_status_error"`
+	TracesParentChildLinks int      `json:"traces_parent_child_links"`
+	TracesSpanNames        []string `json:"traces_span_names"`
+	TracesLoopIDs          []string `json:"traces_loop_ids"`
+
+	// Structural metric aggregates.
+	MetricsDataPointsTotal int64    `json:"metrics_data_points_total"`
+	MetricsNames           []string `json:"metrics_names"`
 }
 
 // GetStats retrieves mock server statistics for e2e assertions.

--- a/test/e2e/mock/agntcy_server.go
+++ b/test/e2e/mock/agntcy_server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -24,10 +25,23 @@ type AGNTCYServer struct {
 	registrations   map[string]*AgentRegistration
 	registrationsMu sync.RWMutex
 
-	// OTEL tracking
-	tracesReceived   int64
-	metricsReceived  int64
-	lastTracePayload []byte
+	// OTEL trace tracking (POST counters + parsed-span aggregates)
+	tracesReceived    int64
+	tracesSpansTotal  int64
+	tracesStatusOK    int64
+	tracesStatusError int64
+	lastTracePayload  []byte
+	traceSpansMu      sync.RWMutex
+	spanNames         map[string]int
+	traceLoopIDs      map[string]struct{}
+	parentSpanIDs     map[string]struct{}
+	childSpanIDs      map[string]struct{}
+
+	// OTEL metric tracking
+	metricsReceived      int64
+	metricsDataPointsTot int64
+	metricsMu            sync.RWMutex
+	metricNames          map[string]int
 
 	// Stats
 	requestCount int64
@@ -47,6 +61,11 @@ func NewAGNTCYServer() *AGNTCYServer {
 	s := &AGNTCYServer{
 		mux:           http.NewServeMux(),
 		registrations: make(map[string]*AgentRegistration),
+		spanNames:     make(map[string]int),
+		traceLoopIDs:  make(map[string]struct{}),
+		parentSpanIDs: make(map[string]struct{}),
+		childSpanIDs:  make(map[string]struct{}),
+		metricNames:   make(map[string]int),
 	}
 	s.setupRoutes()
 	return s
@@ -69,19 +88,22 @@ func (s *AGNTCYServer) setupRoutes() {
 	s.mux.HandleFunc("/v1/metrics", s.handleOTELMetrics)
 }
 
-// Start starts the server on the given address.
+// Start starts the server on the given address. Pass ":0" to bind an
+// ephemeral port; the resolved address is available via Addr/URL.
 func (s *AGNTCYServer) Start(addr string) error {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
 	s.server = &http.Server{
-		Addr:    addr,
+		Addr:    listener.Addr().String(),
 		Handler: s.mux,
 	}
 	go func() {
-		if err := s.server.ListenAndServe(); err != http.ErrServerClosed {
+		if err := s.server.Serve(listener); err != http.ErrServerClosed {
 			log.Printf("AGNTCY mock server error: %v", err)
 		}
 	}()
-	// Give server time to start
-	time.Sleep(50 * time.Millisecond)
 	return nil
 }
 
@@ -98,7 +120,13 @@ func (s *AGNTCYServer) URL() string {
 	if s.server == nil {
 		return ""
 	}
-	return "http://localhost" + s.server.Addr
+	// server.Addr is "[::]:PORT" or "127.0.0.1:PORT" depending on bind.
+	// Always prefix the host explicitly for the ephemeral-port case so
+	// callers do not have to splice strings.
+	if _, port, err := net.SplitHostPort(s.server.Addr); err == nil {
+		return "http://127.0.0.1:" + port
+	}
+	return "http://" + s.server.Addr
 }
 
 // Health handlers
@@ -210,6 +238,63 @@ func (s *AGNTCYServer) handleListAgents(w http.ResponseWriter, _ *http.Request) 
 	})
 }
 
+// otlpTracePayload mirrors the JSON wire shape emitted by output/otel.OTLPExporter.
+// Only the fields the mock asserts on are decoded; unknown keys are ignored.
+type otlpTracePayload struct {
+	ResourceSpans []struct {
+		ScopeSpans []struct {
+			Spans []otlpSpan `json:"spans"`
+		} `json:"scopeSpans"`
+	} `json:"resourceSpans"`
+}
+
+type otlpSpan struct {
+	TraceID      string          `json:"traceId"`
+	SpanID       string          `json:"spanId"`
+	ParentSpanID string          `json:"parentSpanId"`
+	Name         string          `json:"name"`
+	Kind         int             `json:"kind"`
+	Status       otlpStatus      `json:"status"`
+	Attributes   []otlpAttribute `json:"attributes"`
+}
+
+type otlpStatus struct {
+	Code int `json:"code"` // 0=Unset, 1=Ok, 2=Error
+}
+
+type otlpAttribute struct {
+	Key   string `json:"key"`
+	Value struct {
+		StringValue *string  `json:"stringValue,omitempty"`
+		IntValue    *int64   `json:"intValue,omitempty"`
+		DoubleValue *float64 `json:"doubleValue,omitempty"`
+		BoolValue   *bool    `json:"boolValue,omitempty"`
+	} `json:"value"`
+}
+
+// otlpMetricPayload covers the subset of resourceMetrics this mock inspects.
+type otlpMetricPayload struct {
+	ResourceMetrics []struct {
+		ScopeMetrics []struct {
+			Metrics []struct {
+				Name string `json:"name"`
+				Sum  *struct {
+					DataPoints []json.RawMessage `json:"dataPoints"`
+				} `json:"sum,omitempty"`
+				Gauge *struct {
+					DataPoints []json.RawMessage `json:"dataPoints"`
+				} `json:"gauge,omitempty"`
+				Histogram *struct {
+					DataPoints []json.RawMessage `json:"dataPoints"`
+				} `json:"histogram,omitempty"`
+				Summary *struct {
+					DataPoints []json.RawMessage `json:"dataPoints"`
+				} `json:"summary,omitempty"`
+			} `json:"metrics"`
+		} `json:"scopeMetrics"`
+	} `json:"resourceMetrics"`
+}
+
 // OTEL handlers
 func (s *AGNTCYServer) handleOTELTraces(w http.ResponseWriter, r *http.Request) {
 	atomic.AddInt64(&s.requestCount, 1)
@@ -228,7 +313,14 @@ func (s *AGNTCYServer) handleOTELTraces(w http.ResponseWriter, r *http.Request) 
 	atomic.AddInt64(&s.tracesReceived, 1)
 	s.lastTracePayload = body
 
-	log.Printf("[AGNTCY Mock] Received OTEL traces: %d bytes", len(body))
+	if err := s.recordTracePayload(body); err != nil {
+		// Decode failures are flagged but the response still succeeds so the
+		// exporter does not retry; the e2e stage surfaces the parse error.
+		log.Printf("[AGNTCY Mock] OTEL trace parse error: %v (raw=%d bytes)", err, len(body))
+	} else {
+		log.Printf("[AGNTCY Mock] Received OTEL traces: %d bytes, %d spans cumulative",
+			len(body), atomic.LoadInt64(&s.tracesSpansTotal))
+	}
 
 	// Return OTLP HTTP response
 	w.Header().Set("Content-Type", "application/json")
@@ -236,6 +328,46 @@ func (s *AGNTCYServer) handleOTELTraces(w http.ResponseWriter, r *http.Request) 
 	json.NewEncoder(w).Encode(map[string]any{
 		"partialSuccess": map[string]any{},
 	})
+}
+
+// recordTracePayload decodes a single OTLP trace POST and updates the
+// structural aggregates the e2e harness inspects.
+func (s *AGNTCYServer) recordTracePayload(body []byte) error {
+	var payload otlpTracePayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return err
+	}
+
+	s.traceSpansMu.Lock()
+	defer s.traceSpansMu.Unlock()
+
+	for _, rs := range payload.ResourceSpans {
+		for _, ss := range rs.ScopeSpans {
+			for _, span := range ss.Spans {
+				atomic.AddInt64(&s.tracesSpansTotal, 1)
+				s.spanNames[span.Name]++
+
+				switch span.Status.Code {
+				case 1:
+					atomic.AddInt64(&s.tracesStatusOK, 1)
+				case 2:
+					atomic.AddInt64(&s.tracesStatusError, 1)
+				}
+
+				if span.ParentSpanID != "" {
+					s.parentSpanIDs[span.ParentSpanID] = struct{}{}
+					s.childSpanIDs[span.SpanID] = struct{}{}
+				}
+
+				for _, attr := range span.Attributes {
+					if attr.Key == "agent.loop_id" && attr.Value.StringValue != nil {
+						s.traceLoopIDs[*attr.Value.StringValue] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (s *AGNTCYServer) handleOTELMetrics(w http.ResponseWriter, r *http.Request) {
@@ -254,7 +386,12 @@ func (s *AGNTCYServer) handleOTELMetrics(w http.ResponseWriter, r *http.Request)
 
 	atomic.AddInt64(&s.metricsReceived, 1)
 
-	log.Printf("[AGNTCY Mock] Received OTEL metrics: %d bytes", len(body))
+	if err := s.recordMetricPayload(body); err != nil {
+		log.Printf("[AGNTCY Mock] OTEL metric parse error: %v (raw=%d bytes)", err, len(body))
+	} else {
+		log.Printf("[AGNTCY Mock] Received OTEL metrics: %d bytes, %d data points cumulative",
+			len(body), atomic.LoadInt64(&s.metricsDataPointsTot))
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -263,23 +400,81 @@ func (s *AGNTCYServer) handleOTELMetrics(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+func (s *AGNTCYServer) recordMetricPayload(body []byte) error {
+	var payload otlpMetricPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return err
+	}
+
+	s.metricsMu.Lock()
+	defer s.metricsMu.Unlock()
+
+	for _, rm := range payload.ResourceMetrics {
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				s.metricNames[m.Name]++
+				switch {
+				case m.Sum != nil:
+					atomic.AddInt64(&s.metricsDataPointsTot, int64(len(m.Sum.DataPoints)))
+				case m.Gauge != nil:
+					atomic.AddInt64(&s.metricsDataPointsTot, int64(len(m.Gauge.DataPoints)))
+				case m.Histogram != nil:
+					atomic.AddInt64(&s.metricsDataPointsTot, int64(len(m.Histogram.DataPoints)))
+				case m.Summary != nil:
+					atomic.AddInt64(&s.metricsDataPointsTot, int64(len(m.Summary.DataPoints)))
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // handleStats exposes server statistics as JSON for e2e test assertions.
 func (s *AGNTCYServer) handleStats(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(s.Stats())
 }
 
-// Stats returns server statistics.
+// Stats returns server statistics. Both byte-level counters (preserved for
+// backwards-compatibility with older e2e harnesses) and structural span/metric
+// aggregates are exposed.
 func (s *AGNTCYServer) Stats() map[string]any {
 	s.registrationsMu.RLock()
 	regCount := len(s.registrations)
 	s.registrationsMu.RUnlock()
 
+	s.traceSpansMu.RLock()
+	spanNames := make([]string, 0, len(s.spanNames))
+	for name := range s.spanNames {
+		spanNames = append(spanNames, name)
+	}
+	loopIDs := make([]string, 0, len(s.traceLoopIDs))
+	for id := range s.traceLoopIDs {
+		loopIDs = append(loopIDs, id)
+	}
+	parentLinks := len(s.childSpanIDs)
+	s.traceSpansMu.RUnlock()
+
+	s.metricsMu.RLock()
+	metricNames := make([]string, 0, len(s.metricNames))
+	for name := range s.metricNames {
+		metricNames = append(metricNames, name)
+	}
+	s.metricsMu.RUnlock()
+
 	return map[string]any{
-		"request_count":    atomic.LoadInt64(&s.requestCount),
-		"registrations":    regCount,
-		"traces_received":  atomic.LoadInt64(&s.tracesReceived),
-		"metrics_received": atomic.LoadInt64(&s.metricsReceived),
+		"request_count":             atomic.LoadInt64(&s.requestCount),
+		"registrations":             regCount,
+		"traces_received":           atomic.LoadInt64(&s.tracesReceived),
+		"traces_spans_total":        atomic.LoadInt64(&s.tracesSpansTotal),
+		"traces_status_ok":          atomic.LoadInt64(&s.tracesStatusOK),
+		"traces_status_error":       atomic.LoadInt64(&s.tracesStatusError),
+		"traces_parent_child_links": parentLinks,
+		"traces_span_names":         spanNames,
+		"traces_loop_ids":           loopIDs,
+		"metrics_received":          atomic.LoadInt64(&s.metricsReceived),
+		"metrics_data_points_total": atomic.LoadInt64(&s.metricsDataPointsTot),
+		"metrics_names":             metricNames,
 	}
 }
 

--- a/test/e2e/mock/agntcy_server_test.go
+++ b/test/e2e/mock/agntcy_server_test.go
@@ -1,0 +1,190 @@
+package mock
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"slices"
+	"testing"
+	"time"
+
+	otel "github.com/c360studio/semstreams/output/otel"
+)
+
+// TestAGNTCYServer_OTELTracesStructuralParse drives an end-to-end loop:
+// build a SpanData (the same shape semstreams's span collector produces) →
+// send it through the production OTLPExporter → assert the mock's parsed
+// aggregates pick up name, status, parent/child link, and the agent.loop_id
+// attribute. If the exporter's JSON wire format ever drifts, this fails before
+// the full e2e stack does.
+func TestAGNTCYServer_OTELTracesStructuralParse(t *testing.T) {
+	server := NewAGNTCYServer()
+	if err := server.Start(":0"); err != nil {
+		t.Fatalf("start mock server: %v", err)
+	}
+	defer server.Stop()
+
+	// Use the production exporter so we never hand-craft OTLP JSON in the test;
+	// any wire-format drift in the exporter is what we want this to catch.
+	exporter := otel.NewOTLPExporter(server.URL(), true, nil, slog.Default())
+	defer exporter.Shutdown(t.Context())
+
+	start := time.Now()
+	end := start.Add(50 * time.Millisecond)
+
+	spans := []*otel.SpanData{
+		{
+			TraceID:   "trace-0001",
+			SpanID:    "span-loop-1",
+			Name:      "agent.loop",
+			Kind:      "server",
+			StartTime: start,
+			EndTime:   end,
+			Status:    otel.SpanStatus{Code: "ok"},
+			Attributes: map[string]any{
+				"agent.loop_id": "loop-abc-123",
+				"agent.role":    "general",
+				"service.name":  "semstreams",
+			},
+		},
+		{
+			TraceID:      "trace-0001",
+			SpanID:       "span-tool-1",
+			ParentSpanID: "span-loop-1",
+			Name:         "agent.tool.read_loop_result",
+			Kind:         "internal",
+			StartTime:    start,
+			EndTime:      end,
+			Status:       otel.SpanStatus{Code: "error"},
+			Attributes: map[string]any{
+				"agent.loop_id": "loop-abc-123",
+				"agent.tool":    "read_loop_result",
+				"agent.error":   "kv miss",
+			},
+		},
+	}
+
+	if err := exporter.ExportSpans(t.Context(), spans); err != nil {
+		t.Fatalf("export spans: %v", err)
+	}
+
+	stats := server.Stats()
+
+	if got := stats["traces_received"].(int64); got != 1 {
+		t.Errorf("traces_received = %d, want 1", got)
+	}
+	if got := stats["traces_spans_total"].(int64); got != 2 {
+		t.Errorf("traces_spans_total = %d, want 2", got)
+	}
+	if got := stats["traces_status_ok"].(int64); got != 1 {
+		t.Errorf("traces_status_ok = %d, want 1", got)
+	}
+	if got := stats["traces_status_error"].(int64); got != 1 {
+		t.Errorf("traces_status_error = %d, want 1", got)
+	}
+	if got := stats["traces_parent_child_links"].(int); got != 1 {
+		t.Errorf("traces_parent_child_links = %d, want 1 (tool span → loop span)", got)
+	}
+
+	names := stats["traces_span_names"].([]string)
+	if !slices.Contains(names, "agent.loop") {
+		t.Errorf("span names missing agent.loop: %v", names)
+	}
+	if !slices.Contains(names, "agent.tool.read_loop_result") {
+		t.Errorf("span names missing agent.tool.*: %v", names)
+	}
+
+	loopIDs := stats["traces_loop_ids"].([]string)
+	if !slices.Contains(loopIDs, "loop-abc-123") {
+		t.Errorf("loop ids missing injected value: %v", loopIDs)
+	}
+}
+
+// TestAGNTCYServer_OTELMetricsStructuralParse validates the parallel metric
+// path: counter and histogram payloads emitted by the production exporter
+// surface in metrics_data_points_total and metrics_names.
+func TestAGNTCYServer_OTELMetricsStructuralParse(t *testing.T) {
+	server := NewAGNTCYServer()
+	if err := server.Start(":0"); err != nil {
+		t.Fatalf("start mock server: %v", err)
+	}
+	defer server.Stop()
+
+	exporter := otel.NewOTLPExporter(server.URL(), true, nil, slog.Default())
+	defer exporter.Shutdown(t.Context())
+
+	metrics := []*otel.MetricData{
+		{
+			Name: "semstreams.agentic.loop.loops_completed",
+			Type: otel.MetricTypeCounter,
+			DataPoints: []otel.DataPoint{
+				{Value: 3, Attributes: map[string]any{"role": "general"}},
+			},
+		},
+		{
+			Name: "semstreams.agentic.loop.iteration_duration",
+			Type: otel.MetricTypeHistogram,
+			DataPoints: []otel.DataPoint{
+				{Sum: 1.5, Count: 4, Attributes: map[string]any{"role": "general"}},
+				{Sum: 0.3, Count: 1, Attributes: map[string]any{"role": "architect"}},
+			},
+		},
+	}
+
+	if err := exporter.ExportMetrics(t.Context(), metrics); err != nil {
+		t.Fatalf("export metrics: %v", err)
+	}
+
+	stats := server.Stats()
+
+	if got := stats["metrics_received"].(int64); got != 1 {
+		t.Errorf("metrics_received = %d, want 1", got)
+	}
+	if got := stats["metrics_data_points_total"].(int64); got != 3 {
+		t.Errorf("metrics_data_points_total = %d, want 3 (1 counter + 2 histogram)", got)
+	}
+
+	names := stats["metrics_names"].([]string)
+	if !slices.Contains(names, "semstreams.agentic.loop.loops_completed") {
+		t.Errorf("metric names missing counter: %v", names)
+	}
+	if !slices.Contains(names, "semstreams.agentic.loop.iteration_duration") {
+		t.Errorf("metric names missing histogram: %v", names)
+	}
+}
+
+// TestAGNTCYServer_OTELMalformedPayloadDoesNotPanic ensures bad payloads are
+// logged but don't 5xx — the exporter retries on non-2xx, and we want the mock
+// to soak up garbage during fuzz / partial-write scenarios without breaking
+// the surrounding e2e run.
+func TestAGNTCYServer_OTELMalformedPayloadDoesNotPanic(t *testing.T) {
+	server := NewAGNTCYServer()
+	if err := server.Start(":0"); err != nil {
+		t.Fatalf("start mock server: %v", err)
+	}
+	defer server.Stop()
+
+	resp, err := http.Post(server.URL()+"/v1/traces", "application/json",
+		bytes.NewReader([]byte(`{"resourceSpans": "not-an-array"}`)))
+	if err != nil {
+		t.Fatalf("post malformed traces: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("malformed payload returned %d, want 200 (exporter retries on non-2xx)", resp.StatusCode)
+	}
+
+	stats := server.Stats()
+	if got := stats["traces_received"].(int64); got != 1 {
+		t.Errorf("traces_received = %d, want 1 (POST count is bytes-level, independent of parse)", got)
+	}
+	if got := stats["traces_spans_total"].(int64); got != 0 {
+		t.Errorf("traces_spans_total = %d, want 0 (parse rejected the body)", got)
+	}
+
+	// Sanity: stats response still serializable.
+	if _, err := json.Marshal(stats); err != nil {
+		t.Errorf("stats marshal: %v", err)
+	}
+}

--- a/test/e2e/scenarios/agentic/agntcy_stages.go
+++ b/test/e2e/scenarios/agentic/agntcy_stages.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"slices"
 	"time"
 
 	"github.com/c360studio/semstreams/test/e2e/client"
@@ -255,6 +257,89 @@ func (s *Scenario) verifyA2AAdapter(ctx context.Context, result *scenarios.Resul
 	return nil
 }
 
+// verifyA2ATaskLifecycle exercises the A2A adapter's task lifecycle endpoints
+// (POST /tasks/send → GET /tasks/get?id=… → POST /tasks/cancel) against the
+// running a2a-adapter component. This drives the production TaskMapper code path
+// — parsing the A2A wire format, extracting text from MessageParts, mapping into
+// agentic.TaskMessage — which the agent-card-only stage does not touch.
+//
+// The handler's get/cancel implementations are placeholders today (the TODO at
+// component.go:304 / :340), so this stage validates wire shape, not durable task
+// state. When persistence lands the assertions tighten to reflect real state.
+func (s *Scenario) verifyA2ATaskLifecycle(ctx context.Context, result *scenarios.Result) error {
+	agntcyConfig := s.getAGNTCYConfig()
+	if !agntcyConfig.Enabled {
+		result.Details["agntcy_a2a_lifecycle_skipped"] = "AGNTCY tests disabled"
+		return nil
+	}
+	if agntcyConfig.A2AURL == "" {
+		result.Details["agntcy_a2a_lifecycle_skipped"] = "A2A URL not configured"
+		return nil
+	}
+
+	a2aClient := client.NewA2AClient(agntcyConfig.A2AURL)
+	if err := a2aClient.Health(ctx); err != nil {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("A2A adapter not reachable for lifecycle stage: %v", err))
+		result.Details["agntcy_a2a_lifecycle_skipped"] = "adapter not reachable"
+		return nil
+	}
+
+	taskID := fmt.Sprintf("e2e-a2a-lifecycle-%d", time.Now().UnixNano())
+	const prompt = "Summarize the agent registry. Reply with one sentence."
+
+	// 1. SUBMIT — exercises TaskMapper.ToTaskMessage + handleSendTask happy path.
+	submitted, err := a2aClient.SubmitTask(ctx, taskID, prompt)
+	if err != nil {
+		return fmt.Errorf("submit task: %w", err)
+	}
+	if submitted.ID != taskID {
+		return fmt.Errorf("submit response task id = %q, want %q", submitted.ID, taskID)
+	}
+	if submitted.Status.State != "submitted" {
+		return fmt.Errorf("submit response state = %q, want \"submitted\"", submitted.Status.State)
+	}
+	result.Details["agntcy_a2a_lifecycle_submit_state"] = submitted.Status.State
+
+	// 2. NEGATIVE — empty parts should be rejected at the mapper boundary
+	// (task_mapper.go: "task message has no text content").
+	emptyTaskBody := []byte(`{"id":"e2e-a2a-empty","message":{"role":"user","parts":[]}}`)
+	status, body, err := a2aClient.SubmitTaskRaw(ctx, emptyTaskBody)
+	if err != nil {
+		return fmt.Errorf("submit empty-parts task: %w", err)
+	}
+	if status != http.StatusBadRequest {
+		return fmt.Errorf("empty-parts submit returned %d (body=%s), want 400", status, string(body))
+	}
+	result.Details["agntcy_a2a_lifecycle_negative_status"] = status
+
+	// 3. GET — placeholder handler returns "working".
+	fetched, err := a2aClient.GetTask(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("get task: %w", err)
+	}
+	if fetched.ID != taskID {
+		return fmt.Errorf("get response task id = %q, want %q", fetched.ID, taskID)
+	}
+	if fetched.Status.State == "" {
+		return fmt.Errorf("get response state empty")
+	}
+	result.Details["agntcy_a2a_lifecycle_get_state"] = fetched.Status.State
+
+	// 4. CANCEL — placeholder handler returns "canceled".
+	canceled, err := a2aClient.CancelTask(ctx, taskID)
+	if err != nil {
+		return fmt.Errorf("cancel task: %w", err)
+	}
+	if canceled.Status.State != "canceled" {
+		return fmt.Errorf("cancel response state = %q, want \"canceled\"", canceled.Status.State)
+	}
+	result.Details["agntcy_a2a_lifecycle_cancel_state"] = canceled.Status.State
+
+	result.Details["agntcy_a2a_lifecycle_verified"] = true
+	return nil
+}
+
 // verifyDirectoryBridge tests that the directory-bridge component registers agents.
 // This test verifies the directory-bridge component is watching OASF records and
 // registering them with the mock directory server.
@@ -327,16 +412,53 @@ func (s *Scenario) verifyOTELExport(ctx context.Context, result *scenarios.Resul
 
 	result.Metrics["otel_traces_received"] = int(stats.TracesReceived)
 	result.Metrics["otel_metrics_received"] = int(stats.MetricsReceived)
+	result.Metrics["otel_spans_total"] = int(stats.TracesSpansTotal)
+	result.Metrics["otel_status_ok"] = int(stats.TracesStatusOK)
+	result.Metrics["otel_status_error"] = int(stats.TracesStatusError)
+	result.Metrics["otel_metric_data_points"] = int(stats.MetricsDataPointsTotal)
+	result.Details["otel_span_names"] = stats.TracesSpanNames
+	result.Details["otel_metric_names"] = stats.MetricsNames
 
-	if stats.TracesReceived > 0 {
-		result.Details["otel_traces_exported"] = true
-	} else {
+	if stats.TracesReceived == 0 {
 		result.Warnings = append(result.Warnings,
 			"No OTEL traces received by mock server — exporter may not have flushed within the test window")
 		result.Details["otel_traces_exported"] = false
+		return nil
+	}
+	result.Details["otel_traces_exported"] = true
+
+	// Structural assertions on the parsed OTLP JSON. These catch:
+	//   - exporter emitting empty trace bodies (bytes > 0, spans == 0)
+	//   - the agent.loop_id attribute being dropped at the wire boundary
+	//   - the loop span being renamed or never published
+	if stats.TracesSpansTotal == 0 {
+		return fmt.Errorf("mock received %d trace POSTs but parsed 0 spans — exporter JSON shape likely drifted",
+			stats.TracesReceived)
 	}
 
+	if !containsString(stats.TracesSpanNames, "agent.loop") {
+		return fmt.Errorf("mock saw no agent.loop spans, only %v — span collector LoopCreated handler may be wired wrong",
+			stats.TracesSpanNames)
+	}
+
+	if injectedLoopID, ok := result.Details["loop_id"].(string); ok && injectedLoopID != "" {
+		if !containsString(stats.TracesLoopIDs, injectedLoopID) {
+			result.Warnings = append(result.Warnings, fmt.Sprintf(
+				"injected loop_id %q not present in span attrs (saw %v) — span may have flushed for a different loop, or attribute key changed",
+				injectedLoopID, stats.TracesLoopIDs))
+		} else {
+			result.Details["otel_injected_loop_id_found"] = true
+		}
+	}
+
+	result.Details["otel_structural_verified"] = true
 	return nil
+}
+
+// containsString reports whether s appears in xs. Tiny helper local to AGNTCY
+// stages — no general-purpose slice util in the e2e harness.
+func containsString(xs []string, s string) bool {
+	return slices.Contains(xs, s)
 }
 
 // cleanupAGNTCY cleans up test resources created by AGNTCY tests.

--- a/test/e2e/scenarios/agentic/scenario.go
+++ b/test/e2e/scenarios/agentic/scenario.go
@@ -164,6 +164,7 @@ func (s *Scenario) Execute(ctx context.Context) (*scenarios.Result, error) {
 		{"verify-oasf-generation", s.verifyOASFGeneration},
 		{"verify-directory-bridge", s.verifyDirectoryBridge},
 		{"verify-a2a-adapter", s.verifyA2AAdapter},
+		{"verify-a2a-task-lifecycle", s.verifyA2ATaskLifecycle},
 		{"verify-otel-export", s.verifyOTELExport},
 	}
 


### PR DESCRIPTION
## Summary

Closes three thin spots in our AGNTCY conformance coverage identified in an integration audit. Goal: wire-format drift fails in this repo, not in a downstream consumer's hands.

- **OASF contract test** pins `schema_version=1.0.0` and the full mapper output against a golden file across every predicate in `PredicateMapping`.
- **A2A task lifecycle e2e stage** drives `POST /tasks/send` → `GET /tasks/get` → `POST /tasks/cancel` against the running adapter, exercising the production `TaskMapper.ToTaskMessage` path. Required fixing the e2e `A2AClient`, which had been sending JSON-RPC to `/` while the component handles plain JSON at `/tasks/{send,get,cancel}` — the client was dead test code that no stage had hit yet.
- **OTLP structural parser in mock** replaces "did bytes arrive" with parsed-span aggregates: spans-total, OK/error split, parent/child links, distinct span names, distinct `agent.loop_id` values, metric data-point counts and names. `verify-otel-export` now hard-fails on zero parsed spans or a missing `agent.loop` span name.

Three new unit tests round-trip through the real `output/otel.OTLPExporter` so wire-format drift catches without Docker. Mock `Start(":0")` now binds an ephemeral port for those tests.

## Test plan

- [x] `go test -race ./processor/oasf-generator/ ./input/a2a/ ./test/e2e/client/ ./test/e2e/mock/ ./output/otel/` — all green
- [x] `go build ./...` — clean
- [x] `task lint` — clean (`go vet`, `go fmt`, `revive`)
- [ ] CI green
- [ ] Full agentic e2e tier (`task e2e:agentic`) when Docker is available — picks up the three new stages

## Notes

No behavior change to production binaries. All additions are test-tier or test-harness:
- `processor/oasf-generator/oasf_contract_test.go` + `testdata/`: new test only
- `test/e2e/mock/agntcy_server.go`: extends the in-test mock; binary path unchanged
- `test/e2e/scenarios/agentic/agntcy_stages.go` + `scenario.go`: new stage wired into the existing optional AGNTCY block
- `test/e2e/client/agntcy.go`: fixes dead client methods to match what the server actually serves

Regenerate the OASF golden via `go test ./processor/oasf-generator/ -run TestOASFContract -update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)