### PR TITLE
fix(config, rule): substitution bugs blocking ADR-039 governance consumers [BREAKING]

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -5,8 +5,19 @@ import (
 	"regexp"
 )
 
-// envVarRe matches ${VAR:-default}, ${VAR}, and $VAR patterns
-var envVarRe = regexp.MustCompile(`\$\{([^}:]+)(:-([^}]*))?\}|\$([a-zA-Z_][a-zA-Z0-9_]*)`)
+// envVarRe matches ${VAR:-default}, ${VAR}, and $VAR patterns.
+//
+// The bare-`$VAR` arm is intentionally uppercase-only (POSIX env-var
+// convention). Lowercase-prefixed `$word` tokens are reserved for the
+// rule engine's substitution namespaces (`$message.*`, `$entity.*`,
+// `$related.*`, `$state.*`, `$caller.*`, `$schedule.*` — see
+// `processor/rule/execution_context.go`). Operators commonly run this
+// helper on whole-file JSON configs that embed `inline_rules`; eating
+// those tokens at load time silently broke the rule templates and
+// produced garbage subjects/properties downstream (the beta.71 bug
+// from semspec `e2e-mock.json`). Operators with bare-lowercase env
+// refs must migrate to the braced `${var}` form.
+var envVarRe = regexp.MustCompile(`\$\{([^}:]+)(:-([^}]*))?\}|\$([A-Z_][A-Z0-9_]*)`)
 
 // ExpandEnvWithDefaults expands environment variables in a string,
 // supporting ${VAR:-default} syntax for default values.
@@ -14,7 +25,9 @@ var envVarRe = regexp.MustCompile(`\$\{([^}:]+)(:-([^}]*))?\}|\$([a-zA-Z_][a-zA-
 // Patterns:
 //   - ${VAR} - expands to value of VAR, or empty if unset
 //   - ${VAR:-default} - expands to value of VAR, or "default" if unset
-//   - $VAR - expands to value of VAR, or empty if unset
+//   - $VAR - expands to value of VAR (uppercase identifiers only;
+//     lowercase prefixes belong to the rule engine's substitution
+//     namespaces and pass through unchanged)
 func ExpandEnvWithDefaults(s string) string {
 	return envVarRe.ReplaceAllStringFunc(s, func(match string) string {
 		submatches := envVarRe.FindStringSubmatch(match)

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -126,6 +126,77 @@ func TestExpandEnvWithDefaults(t *testing.T) {
 			envVars:  map[string]string{"MY_VAR": ""},
 			expected: "default",
 		},
+		// Rule-engine substitution namespaces pass through unchanged.
+		// The bare-`$VAR` arm is uppercase-only by design — see envVarRe
+		// doc in env.go. Eating these tokens at load time silently
+		// broke rule templates and produced garbage subjects/properties
+		// downstream (semspec bug 2026-05-13).
+		{
+			name:     "rule namespace $message passes through",
+			input:    "$message.loop_id",
+			envVars:  nil,
+			expected: "$message.loop_id",
+		},
+		{
+			name:     "rule namespace $entity passes through",
+			input:    "$entity.id",
+			envVars:  nil,
+			expected: "$entity.id",
+		},
+		{
+			name:     "rule namespace $related passes through",
+			input:    "$related.id",
+			envVars:  nil,
+			expected: "$related.id",
+		},
+		{
+			name:     "rule namespace $state passes through",
+			input:    "$state.iteration",
+			envVars:  nil,
+			expected: "$state.iteration",
+		},
+		{
+			name:     "rule namespace $caller passes through",
+			input:    "$caller.role",
+			envVars:  nil,
+			expected: "$caller.role",
+		},
+		{
+			name:     "rule namespace $schedule passes through",
+			input:    "$schedule.spec",
+			envVars:  nil,
+			expected: "$schedule.spec",
+		},
+		{
+			name:     "ADR-039 publish subject template survives expansion",
+			input:    "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+			envVars:  nil,
+			expected: "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+		},
+		{
+			name:     "deep path $entity.triple.X survives",
+			input:    "$entity.triple.agent.loop.role",
+			envVars:  nil,
+			expected: "$entity.triple.agent.loop.role",
+		},
+		{
+			name:     "lowercase bare $var no longer expands (uppercase-only by design)",
+			input:    "$my_var",
+			envVars:  map[string]string{"my_var": "hello"},
+			expected: "$my_var",
+		},
+		{
+			name:     "mixed env + rule tokens: env expands, rule token survives",
+			input:    "${HOST:-localhost}/path.$message.call_id",
+			envVars:  map[string]string{"HOST": "example.com"},
+			expected: "example.com/path.$message.call_id",
+		},
+		{
+			name:     "braced lowercase still expands (explicit form)",
+			input:    "${my_var}",
+			envVars:  map[string]string{"my_var": "hello"},
+			expected: "hello",
+		},
 	}
 
 	for _, tt := range tests {
@@ -145,6 +216,7 @@ func TestExpandEnvWithDefaults(t *testing.T) {
 			os.Unsetenv("VAR")
 			os.Unsetenv("VAR1")
 			os.Unsetenv("VAR2")
+			os.Unsetenv("my_var")
 
 			for key, value := range tt.envVars {
 				os.Setenv(key, value)

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -489,6 +489,32 @@ func (e *ActionExecutor) ExecuteRemoveTriple(ctx context.Context, action Action,
 	return nil
 }
 
+// substituteStringProperties returns a shallow copy of props with any
+// top-level string value run through ec.SubstituteVariables. Non-string
+// values (numbers, bools, nested maps, arrays) pass through unchanged.
+//
+// The shallow-only contract matches the public docs at
+// `docs/operations/17-tool-call-governance.md` which describe
+// `properties` as a flat map. Deep-nested template strings (e.g.
+// `properties.foo.bar = "$message.x"`) are intentionally NOT recursed
+// — that's a separate behaviour contract and warrants its own
+// substitution-warning story. Returns nil unchanged so callers don't
+// have to special-case empty maps.
+func substituteStringProperties(props map[string]any, ec *ExecutionContext) map[string]any {
+	if props == nil {
+		return nil
+	}
+	out := make(map[string]any, len(props))
+	for k, v := range props {
+		if s, ok := v.(string); ok {
+			out[k] = ec.SubstituteVariables(s)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
 // executePublish executes a publish action, sending a message to a NATS subject.
 func (e *ActionExecutor) executePublish(ctx context.Context, action Action, ec *ExecutionContext) error {
 	entityID := ec.EntityID
@@ -499,6 +525,14 @@ func (e *ActionExecutor) executePublish(ctx context.Context, action Action, ec *
 	}
 
 	subject := ec.SubstituteVariables(action.Subject)
+	// Substitute $message.*/$entity.* etc. tokens in string property
+	// values before publish. ADR-039's canonical reject pattern relies
+	// on `properties.call_id = "$message.call_id"` resolving so the
+	// agentic-loop verdict dispatcher can demux via
+	// VerdictPayload.EffectiveCallID (falls back to Properties when
+	// top-level CallID is empty). Pre-fix, the literal template string
+	// reached the wire and broke enforce-mode routing.
+	properties := substituteStringProperties(action.Properties, ec)
 
 	// Build the message payload
 	payload := map[string]any{
@@ -506,7 +540,7 @@ func (e *ActionExecutor) executePublish(ctx context.Context, action Action, ec *
 		"subject":    subject,
 		"timestamp":  time.Now().Format(time.RFC3339Nano),
 		"source":     "rule_engine",
-		"properties": action.Properties,
+		"properties": properties,
 	}
 	if ec.RelatedID != "" {
 		payload["related_id"] = ec.RelatedID
@@ -517,7 +551,7 @@ func (e *ActionExecutor) executePublish(ctx context.Context, action Action, ec *
 			"subject", subject,
 			"entity_id", entityID,
 			"related_id", ec.RelatedID,
-			"properties", action.Properties)
+			"properties", properties)
 	}
 
 	// Publish via NATS if publisher is configured
@@ -964,11 +998,11 @@ func (e *ActionExecutor) executePublishBoidSignal(ctx context.Context, action Ac
 		signal["related_id"] = ec.RelatedID
 	}
 
-	// Include any custom properties
-	if action.Properties != nil {
-		for k, v := range action.Properties {
-			signal[k] = v
-		}
+	// Include any custom properties. Substitute string templates first
+	// for parity with executePublish — rule authors expect
+	// `$message.*`/`$entity.*` tokens in Properties to resolve.
+	for k, v := range substituteStringProperties(action.Properties, ec) {
+		signal[k] = v
 	}
 
 	if e.logger != nil {

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -532,6 +532,94 @@ func TestAction_Publish_PayloadFormat(t *testing.T) {
 	assert.Equal(t, float64(1), props["priority"]) // JSON numbers are float64
 }
 
+// TestExecutePublish_SubstitutesPropertyTemplates pins ADR-039's reject-shape
+// invariant: `properties.call_id = "$message.call_id"` (and similar
+// `$message.*` / `$entity.*` tokens) must resolve from ExecutionContext
+// before publish. Pre-fix, the literal template string reached the wire
+// and broke the agentic-loop verdict dispatcher's call-id demux for the
+// canonical ADR-039 reject pattern (`publish` action + `deny`). Non-string
+// property values (numbers, bools, nested maps) must pass through
+// unchanged — the shallow-only contract matches docs/operations/17.
+func TestExecutePublish_SubstitutesPropertyTemplates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+	ec := &ExecutionContext{
+		EntityID: "c360.platform.test.svc.entity.001",
+		MessageData: map[string]any{
+			"loop_id":   "loop-abc",
+			"call_id":   "call-001",
+			"tool_name": "bash",
+		},
+	}
+	action := Action{
+		Type:    ActionTypePublish,
+		Subject: "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+		Properties: map[string]any{
+			"decision":  "rejected",
+			"call_id":   "$message.call_id",
+			"loop_id":   "$message.loop_id",
+			"tool_name": "$message.tool_name",
+			"reason":    "writes outside worktree blocked",
+			"priority":  3,    // non-string survives unchanged
+			"sticky":    true, // non-string survives unchanged
+		},
+	}
+
+	require.NoError(t, executor.executePublish(ctx, action, ec))
+	require.Len(t, mock.published, 1, "publish must fire exactly once")
+
+	got := mock.published[0]
+	assert.Equal(t,
+		"agent.toolcall.rejected.loop-abc.call-001",
+		got.subject,
+		"subject $message.* tokens must substitute (existing behaviour)")
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(got.data, &payload))
+
+	props, ok := payload["properties"].(map[string]any)
+	require.True(t, ok, "properties must be a map")
+	assert.Equal(t, "rejected", props["decision"], "static string passes through unchanged")
+	assert.Equal(t, "call-001", props["call_id"],
+		"$message.call_id MUST resolve — VerdictPayload.EffectiveCallID falls back to this field for publish-action verdicts")
+	assert.Equal(t, "loop-abc", props["loop_id"], "$message.loop_id must resolve")
+	assert.Equal(t, "bash", props["tool_name"], "$message.tool_name must resolve")
+	assert.Equal(t, "writes outside worktree blocked", props["reason"], "static string passes through")
+	assert.Equal(t, float64(3), props["priority"], "non-string number survives unchanged (JSON unmarshals to float64)")
+	assert.Equal(t, true, props["sticky"], "non-string bool survives unchanged")
+}
+
+// TestExecutePublish_NilPropertiesNoOp pins that a publish action with no
+// Properties block doesn't panic and emits a nil/empty properties map
+// downstream. Guard against the substituteStringProperties helper
+// trying to range over a nil map after Bug 2's fix.
+func TestExecutePublish_NilPropertiesNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+	ec := &ExecutionContext{EntityID: "entity.001"}
+	action := Action{
+		Type:    ActionTypePublish,
+		Subject: "test.subject",
+	}
+
+	require.NoError(t, executor.executePublish(ctx, action, ec))
+	require.Len(t, mock.published, 1)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(mock.published[0].data, &payload))
+	// JSON null deserialises to nil interface; either nil or empty map is fine.
+	if v, ok := payload["properties"]; ok && v != nil {
+		_, isMap := v.(map[string]any)
+		assert.True(t, isMap, "properties when present must be a map, got %T", v)
+	}
+}
+
 // T043: Test Publish action without publisher (no-op)
 func TestAction_Publish_NoPublisher(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Two semspec-discovered bugs on beta.70 that silently break the documented ADR-039 tool-call governance pattern (inline rules in JSON config + the canonical `publish` + `deny` reject shape from `docs/operations/17-tool-call-governance.md`).

Bug report: `../semspec/.semspec/semstreams-substitution-bugs-2026-05-13.md`.

- **Bug 1 (BREAKING):** `config.ExpandEnvWithDefaults` ate `$message.*`, `$entity.*`, `$related.*`, `$state.*`, `$caller.*`, `$schedule.*` because the bare-`$VAR` regex matched any `[a-zA-Z_]...`. Tightened to uppercase-only (`\$([A-Z_][A-Z0-9_]*)`). semstreams internal flows aren't affected — the helper is exported and external consumers (semspec) wired it into their loaders.
- **Bug 2:** `executePublish` (and `executePublishBoidSignal`) passed `action.Properties` raw to the publish payload, so `$message.call_id` templates inside Property values reached the wire as literal strings. This breaks the agentic-loop's `VerdictPayload.EffectiveCallID()` fallback path → enforce-mode publish-shape rejects timed out fail-closed. Added `substituteStringProperties(props, ec)` (shallow, matches doc-17 flat-map contract).

Severity correction vs. semspec's report: Bug 2 is HIGH (breaks enforce-mode routing), not Medium. semspec's repro ran in audit mode, which masked the dispatcher impact.

## Why upstream e2e missed both

- `configs/agentic.json` uses the `approve` action (own payload-data path), not `publish` — immune to Bug 2.
- Config is loaded without env expansion — never triggers Bug 1.
- Test runs in audit mode — even if Bug 2 had fired, dispatcher impact would be invisible.

## BREAKING migration

Operators with bare-lowercase env-var refs in JSON configs must change:

```diff
-"url": "$my_endpoint/v1"
+"url": "${my_endpoint}/v1"
```

All-uppercase bare refs (`$MY_ENDPOINT`) and braced refs (`${anything}`) are unaffected. Inline rule templates (`$message.call_id` etc.) now work as documented in ADR-031, ADR-032, ADR-039, and doc 17.

## Test plan

- [x] `go test -race ./config/... ./processor/rule/...` — green
- [x] `go test -race ./...` — full unit + integration race-detected, green
- [x] `go test ./test/contract/...` — green
- [x] `task lint` — clean (no revive warnings)
- [x] `task schema:generate` + `git diff schemas/ specs/` — no drift
- [x] `go vet -tags=integration ./...` — clean
- [ ] sister-project (semspec) e2e against this tag with their workaround removed
- [ ] regression test idea (not in this PR): load `configs/agentic.json` through `ExpandEnvWithDefaults` first, then fire the rule, assert subject + properties resolved end-to-end

## Tests added

- `config/env_test.go`: 11 new cases — all six rule namespaces, deep paths (`$entity.triple.X`), the ADR-039 publish subject template, mixed env+rule strings, new lowercase-bare semantics.
- `processor/rule/actions_test.go`:
  - `TestExecutePublish_SubstitutesPropertyTemplates` — resolves `$message.call_id`/`loop_id`/`tool_name`, verifies non-string values (number, bool) survive unchanged.
  - `TestExecutePublish_NilPropertiesNoOp` — nil-Properties guard.

## Tag

Recommended: **beta.71 BREAKING**. The bare-lowercase env-ref change technically flips behavior even though the prior behavior was a footgun. Loud release-notes call-out preferred over silent fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)