### PR TITLE
chore: bump Go toolchain 1.25 → 1.26.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, develop]
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
 
       - name: Get version

--- a/.github/workflows/semspec-validation.yml
+++ b/.github/workflows/semspec-validation.yml
@@ -9,7 +9,7 @@ on:
         default: 'main'
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
 
 jobs:
   semspec-e2e:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@
 #     -t semstreams:latest .
 
 # Build arguments
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 ARG VERSION=dev
 ARG COMMIT_SHA=unknown
 ARG BUILD_DATE=unknown

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/c360studio/semstreams
 
-go 1.25.3
+go 1.26.2
 
 require (
 	github.com/go-acme/lego/v4 v4.20.4

--- a/test/e2e/mock/Dockerfile
+++ b/test/e2e/mock/Dockerfile
@@ -6,7 +6,7 @@
 # Build from repository root:
 #   docker build -t mock-openai:latest -f test/e2e/mock/Dockerfile .
 
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 
 # Build stage
 FROM golang:${GO_VERSION}-alpine AS builder


### PR DESCRIPTION
## Summary

Bumps the Go toolchain minimum from **1.25.3 → 1.26.2** to unblock the `agntcy/dir/api` dependency that PR-B (gRPC directory backend) will add. That module declares `go 1.26.2` in its go.mod, which becomes a transitive minimum once added — so this PR lands the toolchain shift cleanly *before* PR-B, rather than coupling them.

## ⚠️ BREAKING for downstream consumers

Sister projects (semspec, semteams) import this module and run their own go.mod. **They must bump their toolchains to ≥1.26 once this lands.**

### Downstream migration steps

In each sister-project repo:

\`\`\`bash
# Edit go.mod: bump the go directive
sed -i.bak 's/^go 1\\.25.*/go 1.26.2/' go.mod && rm go.mod.bak

# Pull the new semstreams
go get github.com/c360studio/semstreams@<commit-after-this-merges>
go mod tidy

# Verify
go build ./...
go test ./...
\`\`\`

Also bump any local CI / Docker pins to \`1.26\` (mirror the changes in this PR).

No source-level migration required — Go 1.26 is fully backwards-compatible with Go 1.25 code in this repo.

## Why now?

\`agntcy/dir/api\` (the lean SDK subpackage we'll use for AGNTCY directory publishing — *not* the heavy \`agntcy/dir/client\` with sigstore/k8s/docker) declares Go 1.26.2 as its minimum. Once PR-B adds it as a direct dep, the toolchain bump becomes inescapable for downstream consumers. Doing the bump as a standalone chore PR keeps the review focused and gives sister-project owners a clean checkpoint to coordinate around.

## Files changed

- \`go.mod\` — \`go 1.25.3\` → \`go 1.26.2\`
- \`docker/Dockerfile\` — \`ARG GO_VERSION=1.25\` → \`1.26\`
- \`test/e2e/mock/Dockerfile\` — same
- \`.github/workflows/ci.yml\` — \`GO_VERSION: \"1.25\"\` → \`\"1.26\"\` (env var feeds 4 jobs)
- \`.github/workflows/semspec-validation.yml\` — same
- \`.github/workflows/release.yml\` — hardcoded \`go-version: \"1.25\"\` → \`\"1.26\"\`

## Test plan

- [x] \`go mod tidy\` — no diff beyond the directive bump
- [x] \`go build ./...\` — clean under 1.26.2
- [x] \`go test ./... -race -count=1\` — full repo, 0 failures
- [x] \`task lint\` — \`go vet\`, \`go fmt\`, \`revive\` clean
- [ ] CI green on this PR
- [ ] semspec / semteams owners ack the heads-up

## Sequencing

1. **This PR (PR-Z)** — toolchain bump.
2. **PR #67 (PR-A)** — directory-bridge Backend interface refactor. Independent of this; can merge either order.
3. **PR-B** — gRPC GRPCBackend implementation, depends on both above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)