### PR TITLE
feat(rule): unify condition evaluator [BREAKING, ADR-041]

### DIFF
--- a/docs/adr/041-unified-condition-evaluator.md
+++ b/docs/adr/041-unified-condition-evaluator.md
@@ -1,0 +1,300 @@
+# ADR-041: Unified Condition Evaluator — Rule-Level + Action-When Share Field Resolution
+
+## Status
+
+**Proposed — 2026-05-14.** Tag scope: beta.72 BREAKING (bundled with the
+ADR-040 boid retirement so semspec migrates once).
+
+Forcing function: semspec filed an ask
+(`.semspec/semstreams-ask-action-when-message-payload.md`, 2026-05-13)
+to extend `Action.When` to see message payloads. Investigation found
+that the underlying cause is a structural debt — two condition
+evaluators with different field-resolution semantics — that semspec's
+governance use case is the visible symptom of, not the root.
+
+This ADR records the **full unification** rather than the surgical
+patch semspec requested. Rationale below; bundle of one BREAKING tag
+is the cost saver.
+
+## Context
+
+### Two evaluators today
+
+| | Rule-level (message-path) | Action-When |
+|---|---|---|
+| Path | `ExpressionRule.evaluateConditions(data)` (`expression_factory.go`, pre-unification) | `evaluateWhen → EvaluateWithStateFields` (`stateful_evaluator.go`) |
+| Field source | Walks message data map via own `extractNestedValue` | Entity triples + `$state.*`, nothing else |
+| `$state.*` | Not supported | Supported |
+| `$message.*` (explicit) | Not supported | Not supported |
+| Bare name | Message payload (with deep-walk) | Entity triples |
+| Operators | Inline switch in `expression_factory.go` (`eq/ne/lt/...`) | Registered `OperatorFunc` map in `expression/evaluator.go` |
+| Numeric coerce | `toNumeric`/`compareNumeric`/`compareValues` (rule package) | `toFloat64`/`compareValuesWithError` (expression package) |
+
+Same author writing one rule that uses both rule-level `conditions` and
+action-level `when` had to learn **two different field-resolution
+models**, two different operator coverage matrices, and two different
+numeric-coercion edge case sets. The split was historical: the
+expression package was added later for entity-state rules; the original
+`ExpressionRule.evaluateConditions` predated it and was never migrated.
+
+### How the asymmetry blocked semspec
+
+ADR-039 introduced subject-mode tool-call governance with the canonical
+reject pattern `publish` + `deny`. In enforce mode every call needs an
+explicit verdict within `timeout` or the dispatcher fails closed. The
+race-free shape for "block N patterns, approve everything else" is a
+single rule with `when`-guarded publish/deny pairs followed by an
+unconditional approve fallback. semspec hit "take-20 of hybrid @hard
+2026-05-13" wedged on this because `when` couldn't see `$message.*` —
+the planner's `submit_work` call matched no rule, got no verdict,
+timed out fail-closed.
+
+Their workaround: three separate rules with three separate publish/deny
+pairs, racing each other on enforce-mode firing order. That works only
+in audit mode (where verdicts don't gate dispatch). Not viable for
+production governance.
+
+### The surgical fix vs. the structural fix
+
+semspec's filing proposed extending `evaluateWhen` to receive
+`messageFields` and adding `EvaluateWithStateAndMessage` — a targeted
+~150-300 LOC patch that closes the When-clause asymmetry while leaving
+the rule-level evaluator's separate code path intact. This works.
+
+The structural alternative: route both paths through one evaluator,
+delete the duplicate. Adds ~50-100 LOC but **deletes ~200 LOC** of
+duplicate (rule-package `compareValues`/`compareNumeric`/`toNumeric` +
+`ExpressionRule.evaluateConditions`/`extractNestedValue`/`evaluateCondition`
++ `TestRule` equivalents). Net smaller. Fixes the cognitive split for
+rule authors. Forecloses a class of "rule-level vs when-level
+behaviour drift" bugs that would otherwise accumulate over time.
+
+We are greenfield (beta tag train, ≤2 external consumers — semspec and
+semteams), already shipping at least one BREAKING change (ADR-040 boid
+retirement + Go version bump). The marginal cost of bundling the
+structural fix is near zero; the carrying cost of leaving the duplicate
+evaluators in place compounds every time the framework gains a new
+substitution namespace or operator.
+
+## Decision
+
+**Unify rule-level and action-When evaluation behind a single
+`Evaluator.EvaluateWithStateAndMessage(entity, stateFields, messageFields, expr)`
+method.** All callers (message-path rule evaluation, entity-path rule
+evaluation, action-When guards, transition re-evaluation) route through
+this method. Delete the duplicate evaluators in `expression_factory.go`
+and `test_rule_factory.go`.
+
+### Field-resolution precedence (single rule)
+
+Applied uniformly by `evaluateConditionWithStateAndMessage`:
+
+1. **`$state.<field>` / `$prev.<field>`** → resolves from `stateFields`
+2. **`$message.<dotted.path>`** → resolves from `messageFields` via
+   deep-walk (shared `expression.ExtractMessageValue` helper, also
+   used by `$message.*` substitution in
+   `processor/rule/message_substitution.go`)
+3. **`OpTransition` operator** → uses `$prev.<field>` from stateFields
+   against current entity triple (entity-state-only by design)
+4. **Bare field name** → entity triples first (when entity is non-nil),
+   falls through to `messageFields` if not present on the entity. When
+   entity is nil (message-path rules), bare names resolve from
+   `messageFields` directly.
+
+### Documentation guidance
+
+**`$message.<field>` is the recommended form** when the resolution
+source matters — matches the `$message.*` substitution namespace used
+in `subject`, `properties`, and `reason` strings, and avoids the "wait,
+which `command` did this resolve to?" debugging path.
+
+Bare names remain valid for terse authoring; resolution source depends
+on rule type (entity-path resolves entity-first, message-path resolves
+message-only). Acceptable when the author is writing rules for one rule
+type and knows the context.
+
+## What ships in beta.72
+
+| File | Net change |
+|---|---|
+| `processor/rule/expression/types.go` | +`MessageFields` type alias |
+| `processor/rule/expression/message_path.go` | New file: `ExtractMessageValue` helper (shared with substitution layer) |
+| `processor/rule/expression/evaluator.go` | New `EvaluateWithStateAndMessage` (now single resolution entry point); `Evaluate` delegates; `EvaluateWithStateFields` deleted; `evaluateCondition` deleted; new `applyOperator` helper |
+| `processor/rule/stateful_evaluator.go` | `runActions`/`evaluateWhen` gain `messageFields` parameter, threaded from `ec.MessageData`; transition re-eval uses `EvaluateWithStateAndMessage` with nil messageFields |
+| `processor/rule/expression_factory.go` | `ExpressionRule.evaluateConditions`, `extractNestedValue`, `evaluateCondition` deleted; package-level `compareValues`/`compareNumeric`/`toNumeric` deleted; `Evaluate` routes through unified evaluator |
+| `processor/rule/test_rule_factory.go` | Same migration as ExpressionRule |
+| `processor/rule/message_substitution.go` | Local `extractMessageValue` removed; delegates to `expression.ExtractMessageValue` |
+| `processor/rule/expression/evaluator_test.go` | New test matrix: explicit `$message.*`, deep paths, bare-name message-path fallback, entity-path backward compat, precedence ordering, state+message composition |
+| `processor/rule/stateful_evaluator_test.go` | `TestStatefulEvaluator_WhenMessagePayloadAccess` (ADR-041 acceptance), `TestStatefulEvaluator_WhenConsolidatedGovernancePattern` (semspec's canonical use case) |
+| `processor/rule/actions.go` | `Action.When` doc comment rewritten for new precedence |
+| `docs/operations/17-tool-call-governance.md` | New "Consolidated blocklist with fallback approve" example showing the canonical race-free pattern |
+
+**Net LOC:** approximately +400 / -250 → +150 net (test matrix dominates).
+
+## BREAKING surface
+
+1. **`Evaluator.EvaluateWithStateFields` removed.** Was previously a
+   deprecated shim; all callers updated to `EvaluateWithStateAndMessage`.
+   External callers (none identified outside semstreams) must rename.
+
+2. **Bare-name field resolution semantics widened.** On message-path
+   rules, bare names now resolve from message payload (was: silently
+   skipped because entity was nil). On entity-path rules, bare names
+   now fall through to message payload after checking entity triples
+   (was: only entity triples). The fall-through is additive — no
+   existing test or production config relies on the old "field not
+   found" behaviour for bare names that match a message field, because
+   no existing path had access to message data at the When-clause level
+   anyway.
+
+3. **Operator behaviour merged.** `ExpressionRule.evaluateCondition`'s
+   inline operator implementations had subtle differences from the
+   expression package's operators (e.g., `compareValues` numeric-then-
+   string fallback vs `compareValuesWithError`). Diff'd line-by-line;
+   the expression package's behaviour was kept where they diverged
+   because (a) it has better error returns, (b) it matches the
+   `OperatorFunc` registry used by entity-state evaluation, (c) edge
+   cases are documented in test cases. Behaviour delta is invisible
+   for any input both implementations agreed on; only edge cases like
+   "compare string to nil" potentially differ.
+
+4. **Bundle with ADR-040 + Go version bump in beta.72.** Single
+   BREAKING tag; release notes call out the unification, the boid
+   retirement, and the Go bump together. semspec migrates once.
+
+## Migration
+
+**For semspec:**
+
+```diff
+-"on_enter": [
+-  {"type": "publish", "subject": "...rejected...", "properties": {...}},
+-  {"type": "deny", "reason": "..."}
+-]
++"on_enter": [
++  {
++    "type": "publish",
++    "when": [{"field": "$message.command", "operator": "contains", "value": "cd /workspace"}],
++    "subject": "...rejected...",
++    "properties": {...}
++  },
++  {
++    "type": "deny",
++    "when": [{"field": "$message.command", "operator": "contains", "value": "cd /workspace"}],
++    "reason": "..."
++  },
++  {"type": "publish", "subject": "...approved...", "properties": {...}}  // unconditional fallback
++]
+```
+
+Collapse three rules into one. Drops the multi-rule firing race in
+enforce mode.
+
+**For framework consumers calling the evaluator directly:**
+
+```diff
+-result, err := evaluator.EvaluateWithStateFields(entity, stateFields, expr)
++result, err := evaluator.EvaluateWithStateAndMessage(entity, stateFields, nil, expr)
+```
+
+Or pass `messageFields` if you have an inbound payload in scope.
+
+## Why not just the surgical patch
+
+semspec's filing proposed the surgical patch and explicitly offered to
+accept the secondary "`default_decision_on_timeout`" knob as a fallback.
+Both work for the immediate use case. We picked the structural fix
+because:
+
+1. **Cognitive surface for rule authors.** Two evaluators with
+   different field-resolution rules means authors must remember which
+   path they're on when reading a rule. Unification removes that.
+
+2. **Future namespace additions get one home.** When (not if) the
+   framework adds `$caller.*` to condition evaluation (currently it's
+   only substitution-side), `$schedule.*` to non-cron rules, or any
+   future namespace — the surgical patch would require duplicating the
+   addition into both evaluators. Unification means one place.
+
+3. **Duplicate operators were a latent divergence risk.** Subtle
+   differences in `compareValues` numeric handling, missing operators
+   in `ExpressionRule.evaluateCondition` (no `in`/`not_in`/`between`/
+   `regex` — only `eq/ne/lt/lte/gt/gte/contains/starts_with/ends_with`)
+   meant rule-level and When-level rules **already had different
+   operator coverage** before this change. Unification gives both paths
+   the full operator set.
+
+4. **Cost asymmetry.** Surgical patch: ~+200 LOC. Structural fix:
+   ~+150 LOC net (more new code, more deleted). The structural fix is
+   strictly smaller and strictly more general.
+
+5. **We control both consumers.** semspec is willing to migrate;
+   semteams pinning track is close behind. Greenfield bias is the right
+   default for any change that's correct-but-breaking.
+
+## Alternative considered: `default_decision_on_timeout` knob
+
+semspec proposed this as a secondary ask: a config knob on
+`tool_call_governance` that flips enforce semantics from implicit-deny
+to implicit-allow. Rejected:
+
+- One-purpose patch — only fixes the governance dispatcher; nothing
+  else benefits
+- Encodes a policy that real security gates would disagree with
+  (implicit-allow on a security path is a footgun)
+- Doesn't fix the underlying evaluator asymmetry — same class of bug
+  resurfaces wherever per-action gating wants payload context
+
+Not shipping. The unified evaluator is strictly more general.
+
+## Operator coverage parity
+
+Pre-unification, the two evaluators had different operator sets:
+
+| Operator | Rule-level | Action-When |
+|---|---|---|
+| eq, ne | ✓ | ✓ |
+| lt, lte, gt, gte | ✓ | ✓ |
+| contains, starts_with, ends_with | ✓ | ✓ |
+| in, not_in | ✗ (rule-level had no support) | ✓ |
+| between | ✗ | ✓ |
+| regex | ✗ | ✓ |
+| transition | ✗ | ✓ (entity-state only) |
+| array length_eq/gt/lt | ✗ | ✓ |
+| array_contains | ✗ | ✓ |
+
+Post-unification both paths get the full set. semspec's existing
+rule-level conditions (using `in` and other ops via separate code paths)
+keep working; their new When clauses gain access to the same set.
+
+## Related ADRs
+
+- [ADR-028 Orchestration Architecture](028-orchestration-architecture.md)
+  — rules vs workflows; the basis for "rules engine is the evaluation
+  primitive"
+- [ADR-031 Time-Trigger Primitive](031-time-trigger-primitive.md) —
+  `$schedule.*` namespace; precedent for namespace-scoped resolution
+- [ADR-032 Policy/Tenancy/Cluster](032-policy-tenancy-cluster.md) —
+  `$caller.*` namespace + `deny` action
+- [ADR-039 Tool-Call Governance Rule-Driven](039-tool-call-governance-rule-driven.md)
+  — the consumer that surfaced the asymmetry; this ADR completes
+  ADR-039's vision of "rules engine is the policy DSL" by making the
+  policy DSL composable on action-level guards
+- [ADR-040 Retire Boid Subsystem](040-retire-boid-subsystem.md) —
+  bundled in the same beta.72 BREAKING tag
+
+## Open questions deferred
+
+- **Whether to expose `$caller.*` in condition `Field` paths** (not
+  just in substitution strings). Today `$caller.*` works in `subject`,
+  `reason`, etc. via substitution but not as a `Field` in a condition.
+  Could be added under the new evaluator with a small extension to the
+  precedence rule. Defer to a future ADR if a use case appears.
+- **Whether to add a `$entity.<part>` form for condition `Field`** —
+  per-segment entity ID access (`$entity.org`, `$entity.platform`,
+  etc.) currently works in substitution but not condition. Same
+  pattern; defer until needed.
+- **Operator chaining / nested logic expressions** — the current
+  `LogicalExpression` has flat `Conditions` with one `Logic` op.
+  Nested AND/OR/NOT trees would need a different shape. Out of scope
+  here.

--- a/docs/operations/17-tool-call-governance.md
+++ b/docs/operations/17-tool-call-governance.md
@@ -181,6 +181,80 @@ publishes the verdict in one action. It does NOT short-circuit
 subsequent actions — operators may want to add metric-counter actions
 or downstream notifications on the same firing.
 
+### Consolidated blocklist with fallback approve (recommended)
+
+The canonical race-free shape for enforce-mode governance: one rule
+that pairs `publish` + `deny` for each bad pattern, then a trailing
+unconditional approve. Exactly one verdict per call, no multi-rule
+race condition. Requires action-`when` clauses with `$message.*`
+access (ADR-041, beta.72+).
+
+```json
+{
+  "name": "bash-workspace-guard",
+  "subscribe": ["agent.toolcall.proposed.>"],
+  "conditions": [
+    {"field": "$message.tool_name", "operator": "eq", "value": "bash"}
+  ],
+  "on_enter": [
+    {
+      "type": "publish",
+      "when": [{"field": "$message.command", "operator": "contains", "value": "cd /workspace"}],
+      "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+      "properties": {
+        "decision": "rejected",
+        "call_id": "$message.call_id",
+        "reason": "bash 'cd /workspace' blocked — stay in worktree"
+      }
+    },
+    {
+      "type": "deny",
+      "when": [{"field": "$message.command", "operator": "contains", "value": "cd /workspace"}],
+      "reason": "bash 'cd /workspace' blocked"
+    },
+    {
+      "type": "publish",
+      "when": [{"field": "$message.command", "operator": "contains", "value": "> /workspace/"}],
+      "subject": "agent.toolcall.rejected.$message.loop_id.$message.call_id",
+      "properties": {
+        "decision": "rejected",
+        "call_id": "$message.call_id",
+        "reason": "bash redirect into /workspace blocked"
+      }
+    },
+    {
+      "type": "deny",
+      "when": [{"field": "$message.command", "operator": "contains", "value": "> /workspace/"}],
+      "reason": "bash redirect into /workspace blocked"
+    },
+    {
+      "type": "publish",
+      "subject": "agent.toolcall.approved.$message.loop_id.$message.call_id",
+      "properties": {
+        "decision": "approved",
+        "call_id": "$message.call_id",
+        "reason": "bash command passed blocklist"
+      }
+    }
+  ]
+}
+```
+
+Sequencing invariants this pattern relies on:
+
+- Actions inside a rule run sequentially in declared order
+- `deny` short-circuits remaining actions in the same firing (returns
+  `*DenyVerdict`, which the executor handles by breaking the loop —
+  see `processor/rule/stateful_evaluator.go:357-366`)
+- Actions without a `when` clause always run if reached
+- Therefore the trailing unconditional `publish approved` only fires
+  when **no earlier `deny` matched** → exactly one verdict per call
+
+Without the `when` clause's access to `$message.*`, this pattern is
+impossible to express in a single rule. Pre-ADR-041 the only option
+was N separate rules (one per bad pattern), which introduced a
+multi-rule firing race in enforce mode.
+
 ### Role-based allowlist with caller context
 
 ```json

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -175,8 +175,20 @@ type Action struct {
 	WorkflowStep string `json:"workflow_step,omitempty"`
 
 	// When is an optional guard clause for conditional action execution.
-	// If present, all conditions must match (AND logic) against the entity's current
-	// state and $state.* fields for the action to execute. Actions without When always execute.
+	// All conditions must match (AND logic) for the action to execute.
+	// Actions without When always execute.
+	//
+	// Field resolution follows the same precedence as rule-level
+	// conditions (see ADR-041):
+	//
+	//   - `$state.<field>` / `$prev.<field>` → rule match state
+	//   - `$message.<dotted.path>` → inbound message payload (recommended)
+	//   - bare name → entity triples first (when entity is non-nil),
+	//     falls through to message payload if not on the entity
+	//
+	// Use `$message.<field>` for unambiguous access in new rules. Bare
+	// names work but their resolution source depends on whether the rule
+	// fires on an entity-state event or a message-path event.
 	When []expression.ConditionExpression `json:"when,omitempty"`
 
 	// Bucket is the KV bucket name for update_kv actions (e.g., "PLAN_STATES").

--- a/processor/rule/expression/evaluator.go
+++ b/processor/rule/expression/evaluator.go
@@ -30,7 +30,7 @@ func NewExpressionEvaluator() *Evaluator {
 	evaluator.operators[OpNotIn] = operatorNotIn
 	evaluator.operators[OpBetween] = operatorBetween
 
-	// Note: OpTransition is handled specially in evaluateConditionWithState
+	// Note: OpTransition is handled specially in evaluateConditionWithStateAndMessage
 	// because it needs access to $prev.* state fields, not just fieldValue/compareValue.
 
 	// Register string operators
@@ -42,16 +42,35 @@ func NewExpressionEvaluator() *Evaluator {
 	return evaluator
 }
 
-// Evaluate evaluates a logical expression against an entity state
+// Evaluate evaluates a logical expression against an entity state.
+// Equivalent to EvaluateWithStateAndMessage with nil stateFields and nil
+// messageFields — entity triples are the only resolution source.
 func (e *Evaluator) Evaluate(entityState *gtypes.EntityState, expr LogicalExpression) (bool, error) {
-	return e.EvaluateWithStateFields(entityState, nil, expr)
+	return e.EvaluateWithStateAndMessage(entityState, nil, nil, expr)
 }
 
-// EvaluateWithStateFields evaluates a logical expression against entity state and optional
-// match state fields. The stateFields parameter provides $state.* pseudo-field values
-// (e.g., "$state.iteration", "$state.max_iterations") for conditions that reference
-// rule execution state rather than entity triples.
-func (e *Evaluator) EvaluateWithStateFields(entityState *gtypes.EntityState, stateFields StateFields, expr LogicalExpression) (bool, error) {
+// EvaluateWithStateAndMessage evaluates a logical expression against the
+// full field-resolution surface: entity triples, rule match-state
+// (`$state.*`/`$prev.*`), and the inbound message payload (`$message.*`).
+//
+// Field resolution precedence per condition:
+//
+//  1. `$state.*` / `$prev.*` → stateFields map
+//  2. `$message.<dotted.path>` → messageFields via deep-walk
+//  3. Bare field name → entity triples first (when entity is non-nil);
+//     falls through to messageFields if not present on the entity.
+//     When entity is nil (message-path rules), bare names resolve from
+//     messageFields directly.
+//
+// This is the single condition evaluator for both rule-level conditions
+// (where the rule fires on message-path or entity-state events) and
+// action-level `when` guards. See ADR-041 for the unification rationale.
+//
+// `$message.command` is the recommended form when both rule-level and
+// when-clause use the same field, because it makes the resolution source
+// explicit. Bare `command` works equivalently on message-path rules but
+// implicitly prefers entity triples on entity-path rules.
+func (e *Evaluator) EvaluateWithStateAndMessage(entityState *gtypes.EntityState, stateFields StateFields, messageFields MessageFields, expr LogicalExpression) (bool, error) {
 	if len(expr.Conditions) == 0 {
 		return true, nil // Empty condition list passes
 	}
@@ -60,7 +79,7 @@ func (e *Evaluator) EvaluateWithStateFields(entityState *gtypes.EntityState, sta
 
 	// Evaluate each condition
 	for i, condition := range expr.Conditions {
-		result, err := e.evaluateConditionWithState(entityState, stateFields, condition)
+		result, err := e.evaluateConditionWithStateAndMessage(entityState, stateFields, messageFields, condition)
 		if err != nil {
 			return false, err
 		}
@@ -92,11 +111,12 @@ func (e *Evaluator) EvaluateWithStateFields(entityState *gtypes.EntityState, sta
 	}
 }
 
-// evaluateConditionWithState evaluates a single condition, resolving $state.* fields
-// from stateFields before falling through to entity triple evaluation.
-func (e *Evaluator) evaluateConditionWithState(entityState *gtypes.EntityState, stateFields StateFields, condition ConditionExpression) (bool, error) {
-	// Check for $state.* pseudo-fields first
-	if strings.HasPrefix(condition.Field, "$state.") {
+// evaluateConditionWithStateAndMessage resolves a single condition against
+// the layered sources (stateFields, messageFields, entity triples) per
+// the precedence rule documented on EvaluateWithStateAndMessage.
+func (e *Evaluator) evaluateConditionWithStateAndMessage(entityState *gtypes.EntityState, stateFields StateFields, messageFields MessageFields, condition ConditionExpression) (bool, error) {
+	// 1. `$state.*` / `$prev.*` — pseudo-fields from rule match state.
+	if strings.HasPrefix(condition.Field, "$state.") || strings.HasPrefix(condition.Field, "$prev.") {
 		fieldValue, exists := stateFields[condition.Field]
 		if !exists {
 			if condition.Required {
@@ -107,84 +127,84 @@ func (e *Evaluator) evaluateConditionWithState(entityState *gtypes.EntityState, 
 			}
 			return false, nil
 		}
-
-		// Get operator function
-		opFunc, opExists := e.operators[condition.Operator]
-		if !opExists {
-			return false, &EvaluationError{
-				Field:    condition.Field,
-				Operator: condition.Operator,
-				Message:  "unsupported operator",
-			}
-		}
-
-		result, err := opFunc(fieldValue, condition.Value)
-		if err != nil {
-			return false, &EvaluationError{
-				Field:    condition.Field,
-				Operator: condition.Operator,
-				Message:  "operator execution failed",
-				Err:      err,
-			}
-		}
-		return result, nil
+		return e.applyOperator(condition, fieldValue)
 	}
 
-	// Handle transition operator (needs previous value from state)
+	// 2. `$message.<path>` — explicit message payload access.
+	if strings.HasPrefix(condition.Field, "$message.") {
+		path := strings.TrimPrefix(condition.Field, "$message.")
+		fieldValue, exists := ExtractMessageValue(messageFields, path)
+		if !exists {
+			if condition.Required {
+				return false, &EvaluationError{
+					Field:   condition.Field,
+					Message: "required message field not found",
+				}
+			}
+			return false, nil
+		}
+		return e.applyOperator(condition, fieldValue)
+	}
+
+	// 3. Transition operator — entity-state-only (uses $prev.* from
+	//    stateFields against the current entity triple value).
 	if condition.Operator == OpTransition {
 		return e.evaluateTransition(entityState, stateFields, condition)
 	}
 
-	// If entityState is nil (message-path rules), non-$state fields are treated as missing
-	if entityState == nil {
-		if condition.Required {
+	// 4. Bare field name resolution.
+	//    Entity-path (entity non-nil): triples first, fall through to
+	//    messageFields if not present.
+	//    Message-path (entity nil): messageFields only.
+	if entityState != nil {
+		fieldValue, exists, err := e.typeDetector.GetFieldValue(entityState, condition.Field)
+		if err != nil {
 			return false, &EvaluationError{
 				Field:   condition.Field,
-				Message: "entity state is nil, field not available",
+				Message: "failed to get field value",
+				Err:     err,
 			}
 		}
-		return false, nil
+		if exists {
+			return e.applyOperator(condition, fieldValue)
+		}
+		// Fall through to messageFields below.
 	}
 
-	return e.evaluateCondition(entityState, condition)
-}
+	if messageFields != nil {
+		if fieldValue, ok := ExtractMessageValue(messageFields, condition.Field); ok {
+			return e.applyOperator(condition, fieldValue)
+		}
+	}
 
-// evaluateCondition evaluates a single condition against entity state
-func (e *Evaluator) evaluateCondition(entityState *gtypes.EntityState, condition ConditionExpression) (bool, error) {
-	// Get field value from entity state
-	fieldValue, exists, err := e.typeDetector.GetFieldValue(entityState, condition.Field)
-	if err != nil {
+	if condition.Required {
+		if entityState == nil && messageFields == nil {
+			return false, &EvaluationError{
+				Field:   condition.Field,
+				Message: "no entity state or message fields available",
+			}
+		}
 		return false, &EvaluationError{
 			Field:   condition.Field,
-			Message: "failed to get field value",
-			Err:     err,
+			Message: "required field not found",
 		}
 	}
+	return false, nil
+}
 
-	// Handle missing fields based on Required flag
-	if !exists {
-		if condition.Required {
-			// Required field missing - fail fast as requested
-			return false, &EvaluationError{
-				Field:   condition.Field,
-				Message: "required field not found",
-			}
-		}
-		// Optional field missing - condition fails (conservative approach)
-		return false, nil
-	}
-
-	// Get operator function
-	opFunc, exists := e.operators[condition.Operator]
-	if !exists {
+// applyOperator runs the registered operator function for the condition
+// against fieldValue and returns the boolean result. Used by every field
+// resolution branch in evaluateConditionWithStateAndMessage so error
+// shapes stay uniform.
+func (e *Evaluator) applyOperator(condition ConditionExpression, fieldValue any) (bool, error) {
+	opFunc, ok := e.operators[condition.Operator]
+	if !ok {
 		return false, &EvaluationError{
 			Field:    condition.Field,
 			Operator: condition.Operator,
 			Message:  "unsupported operator",
 		}
 	}
-
-	// Execute operator
 	result, err := opFunc(fieldValue, condition.Value)
 	if err != nil {
 		return false, &EvaluationError{
@@ -194,7 +214,6 @@ func (e *Evaluator) evaluateCondition(entityState *gtypes.EntityState, condition
 			Err:      err,
 		}
 	}
-
 	return result, nil
 }
 

--- a/processor/rule/expression/evaluator_test.go
+++ b/processor/rule/expression/evaluator_test.go
@@ -1113,7 +1113,7 @@ func TestExpressionEvaluator_TransitionOperator(t *testing.T) {
 				Logic:      LogicAnd,
 			}
 
-			result, err := evaluator.EvaluateWithStateFields(testEntity, tt.stateFields, expr)
+			result, err := evaluator.EvaluateWithStateAndMessage(testEntity, tt.stateFields, nil, expr)
 			if tt.shouldErr {
 				require.Error(t, err)
 				return
@@ -1132,4 +1132,278 @@ func createTestEntity(entityID string, triples []message.Triple) *gtypes.EntityS
 		Version:   1,
 		UpdatedAt: time.Now(),
 	}
+}
+
+// TestEvaluateWithStateAndMessage_MessageFieldExplicit pins that explicit
+// $message.<path> tokens resolve from MessageFields and walk deep paths.
+// This is the recommended form (ADR-041) — operators writing rules should
+// reach for the explicit prefix when the resolution source matters.
+func TestEvaluateWithStateAndMessage_MessageFieldExplicit(t *testing.T) {
+	evaluator := NewExpressionEvaluator()
+
+	tests := []struct {
+		name      string
+		condition ConditionExpression
+		message   MessageFields
+		expected  bool
+		shouldErr bool
+	}{
+		{
+			name: "$message.command resolves top-level field",
+			condition: ConditionExpression{
+				Field:    "$message.command",
+				Operator: OpContains,
+				Value:    "cd /workspace",
+			},
+			message:  MessageFields{"command": "cd /workspace && ls", "tool_name": "bash"},
+			expected: true,
+		},
+		{
+			name: "$message.deep.path walks nested maps",
+			condition: ConditionExpression{
+				Field:    "$message.tool_args.command",
+				Operator: OpEqual,
+				Value:    "echo hello",
+			},
+			message: MessageFields{
+				"tool_args": map[string]any{"command": "echo hello"},
+			},
+			expected: true,
+		},
+		{
+			name: "missing $message field with Required errors",
+			condition: ConditionExpression{
+				Field:    "$message.absent",
+				Operator: OpEqual,
+				Value:    "x",
+				Required: true,
+			},
+			message:   MessageFields{"command": "x"},
+			shouldErr: true,
+		},
+		{
+			name: "missing $message field without Required returns false",
+			condition: ConditionExpression{
+				Field:    "$message.absent",
+				Operator: OpEqual,
+				Value:    "x",
+			},
+			message:  MessageFields{"command": "x"},
+			expected: false,
+		},
+		{
+			name: "$message field with nil messageFields returns false",
+			condition: ConditionExpression{
+				Field:    "$message.command",
+				Operator: OpEqual,
+				Value:    "x",
+			},
+			message:  nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := LogicalExpression{Conditions: []ConditionExpression{tt.condition}, Logic: LogicAnd}
+			result, err := evaluator.EvaluateWithStateAndMessage(nil, nil, tt.message, expr)
+			if tt.shouldErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestEvaluateWithStateAndMessage_BareNameMessagePath pins that on message-path
+// rules (entity nil), bare field names resolve from MessageFields. This is
+// the asymmetry semspec hit on beta.71: action-When clauses on message-path
+// rules previously couldn't see the payload because the evaluator skipped
+// non-$state fields when entity was nil. ADR-041 closes this.
+func TestEvaluateWithStateAndMessage_BareNameMessagePath(t *testing.T) {
+	evaluator := NewExpressionEvaluator()
+
+	tests := []struct {
+		name      string
+		condition ConditionExpression
+		message   MessageFields
+		expected  bool
+	}{
+		{
+			name: "bare command resolves from messageFields when entity is nil",
+			condition: ConditionExpression{
+				Field:    "command",
+				Operator: OpContains,
+				Value:    "cd /workspace",
+			},
+			message:  MessageFields{"command": "cd /workspace && ls"},
+			expected: true,
+		},
+		{
+			name: "bare tool_name eq matches",
+			condition: ConditionExpression{
+				Field:    "tool_name",
+				Operator: OpEqual,
+				Value:    "bash",
+			},
+			message:  MessageFields{"tool_name": "bash"},
+			expected: true,
+		},
+		{
+			name: "bare deep.path walks into nested maps",
+			condition: ConditionExpression{
+				Field:    "tool_args.command",
+				Operator: OpEqual,
+				Value:    "echo hi",
+			},
+			message:  MessageFields{"tool_args": map[string]any{"command": "echo hi"}},
+			expected: true,
+		},
+		{
+			name: "missing bare field returns false without Required",
+			condition: ConditionExpression{
+				Field:    "absent",
+				Operator: OpEqual,
+				Value:    "x",
+			},
+			message:  MessageFields{"command": "x"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := LogicalExpression{Conditions: []ConditionExpression{tt.condition}, Logic: LogicAnd}
+			result, err := evaluator.EvaluateWithStateAndMessage(nil, nil, tt.message, expr)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestEvaluateWithStateAndMessage_EntityPathBareNameUnchanged pins the
+// backward-compat guarantee: entity-path rules with bare field names
+// resolve from entity triples, unchanged from the pre-ADR-041 behaviour.
+// This is the critical regression class — any existing rule that matches
+// on `field: "battery.level"` against entity state must keep working.
+func TestEvaluateWithStateAndMessage_EntityPathBareNameUnchanged(t *testing.T) {
+	evaluator := NewExpressionEvaluator()
+	entity := createTestEntity("test.entity.001", []message.Triple{
+		{Predicate: "battery.level", Object: 15.0},
+		{Predicate: "status", Object: "active"},
+	})
+
+	tests := []struct {
+		name      string
+		condition ConditionExpression
+		expected  bool
+	}{
+		{
+			name: "bare predicate resolves from entity triple",
+			condition: ConditionExpression{
+				Field:    "battery.level",
+				Operator: OpLessThan,
+				Value:    20.0,
+			},
+			expected: true,
+		},
+		{
+			name: "bare predicate string operator",
+			condition: ConditionExpression{
+				Field:    "status",
+				Operator: OpEqual,
+				Value:    "active",
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := LogicalExpression{Conditions: []ConditionExpression{tt.condition}, Logic: LogicAnd}
+			result, err := evaluator.EvaluateWithStateAndMessage(entity, nil, nil, expr)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestEvaluateWithStateAndMessage_EntityFallsThroughToMessage pins the
+// precedence rule: when entity is non-nil but the bare field isn't on
+// the entity, resolution falls through to messageFields. This is the
+// "mixed source" case — a rule on an entity-state event that wants to
+// match on the inbound event's metadata.
+func TestEvaluateWithStateAndMessage_EntityFallsThroughToMessage(t *testing.T) {
+	evaluator := NewExpressionEvaluator()
+	entity := createTestEntity("test.entity.001", []message.Triple{
+		{Predicate: "battery.level", Object: 15.0},
+	})
+
+	expr := LogicalExpression{
+		Conditions: []ConditionExpression{
+			{Field: "battery.level", Operator: OpLessThan, Value: 20.0},
+			{Field: "command", Operator: OpContains, Value: "danger"}, // from messageFields
+		},
+		Logic: LogicAnd,
+	}
+	result, err := evaluator.EvaluateWithStateAndMessage(entity, nil, MessageFields{"command": "danger zone"}, expr)
+	require.NoError(t, err)
+	assert.True(t, result, "entity-resolved AND message-fallback should both match")
+}
+
+// TestEvaluateWithStateAndMessage_PrecedenceOrder pins the explicit
+// precedence: $state.* > $message.* > entity triples > bare-from-message.
+// Even when keys overlap across sources, the explicit namespace wins.
+func TestEvaluateWithStateAndMessage_PrecedenceOrder(t *testing.T) {
+	evaluator := NewExpressionEvaluator()
+	entity := createTestEntity("test.entity.001", []message.Triple{
+		{Predicate: "shared_key", Object: "entity_value"},
+	})
+
+	// $message.shared_key explicit beats entity triple of same name.
+	expr := LogicalExpression{
+		Conditions: []ConditionExpression{
+			{Field: "$message.shared_key", Operator: OpEqual, Value: "message_value"},
+		},
+		Logic: LogicAnd,
+	}
+	result, err := evaluator.EvaluateWithStateAndMessage(entity, nil, MessageFields{"shared_key": "message_value"}, expr)
+	require.NoError(t, err)
+	assert.True(t, result, "$message.* explicit must resolve from messageFields, not entity triple")
+
+	// Bare shared_key with entity present resolves from entity, NOT
+	// messageFields (entity wins for bare names on entity-path rules).
+	expr2 := LogicalExpression{
+		Conditions: []ConditionExpression{
+			{Field: "shared_key", Operator: OpEqual, Value: "entity_value"},
+		},
+		Logic: LogicAnd,
+	}
+	result2, err := evaluator.EvaluateWithStateAndMessage(entity, nil, MessageFields{"shared_key": "message_value"}, expr2)
+	require.NoError(t, err)
+	assert.True(t, result2, "bare name with entity present must resolve from entity triple")
+}
+
+// TestEvaluateWithStateAndMessage_StatePlusMessage exercises the
+// canonical ADR-039 use case: action-When clauses that combine
+// $state.iteration with $message.command. semspec's consolidated-rule
+// pattern depends on this composition.
+func TestEvaluateWithStateAndMessage_StatePlusMessage(t *testing.T) {
+	evaluator := NewExpressionEvaluator()
+
+	expr := LogicalExpression{
+		Conditions: []ConditionExpression{
+			{Field: "$state.iteration", Operator: OpLessThan, Value: 5},
+			{Field: "$message.command", Operator: OpContains, Value: "cd /workspace"},
+		},
+		Logic: LogicAnd,
+	}
+	stateFields := StateFields{"$state.iteration": 2}
+	messageFields := MessageFields{"command": "cd /workspace && rm -rf"}
+
+	result, err := evaluator.EvaluateWithStateAndMessage(nil, stateFields, messageFields, expr)
+	require.NoError(t, err)
+	assert.True(t, result, "$state.* AND $message.* must compose in a single When clause")
 }

--- a/processor/rule/expression/message_path.go
+++ b/processor/rule/expression/message_path.go
@@ -1,0 +1,49 @@
+// Package expression — Dotted-path access into MessageFields payloads.
+//
+// Both `$message.*` substitution (in processor/rule/message_substitution.go)
+// and `$message.*` condition evaluation (Evaluator.EvaluateWithStateAndMessage)
+// walk the same map shape via the same dotted-path rules. This helper is
+// the single source of truth — shared via the expression package so the
+// rule package can import it without introducing a cycle.
+package expression
+
+import "strings"
+
+// ExtractMessageValue walks data along a dotted path. Returns the
+// terminal value and true on success; the second return is false (and
+// the caller must treat the result as "field not present") when:
+//
+//   - any non-terminal segment is missing from the current map, OR
+//   - any non-terminal segment resolves to a non-map value (can't
+//     descend further), OR
+//   - the terminal segment is missing.
+//
+// A nil terminal value is considered a successful resolution (the JSON
+// `null` distinct from "missing"). Callers can render `<nil>` via fmt;
+// the surfacing safety net is the regex-leftover warning at the
+// substitution layer, or the `Required` flag at the condition layer.
+//
+// The path is the bare dotted form (no `$message.` prefix). Callers
+// trim the prefix before calling.
+func ExtractMessageValue(data MessageFields, path string) (any, bool) {
+	if len(data) == 0 || path == "" {
+		return nil, false
+	}
+	parts := strings.Split(path, ".")
+	var current any = map[string]any(data)
+	for i, part := range parts {
+		m, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		value, exists := m[part]
+		if !exists {
+			return nil, false
+		}
+		if i == len(parts)-1 {
+			return value, true
+		}
+		current = value
+	}
+	return nil, false
+}

--- a/processor/rule/expression/types.go
+++ b/processor/rule/expression/types.go
@@ -130,3 +130,19 @@ const (
 // in condition expressions. Keys are the full field names (e.g., "$state.iteration").
 // This avoids circular dependencies between the expression and rule packages.
 type StateFields map[string]interface{}
+
+// MessageFields carries the inbound NATS message payload for `$message.*`
+// pseudo-field resolution in condition expressions. The map shape is
+// `map[string]any` (matching `GenericJSONPayload.Data` and what
+// `ExecutionContext.MessageData` carries through the rule pipeline).
+//
+// Deep-path access is supported: `$message.tool_args.command` walks the
+// map along the dotted path. Bare field names (e.g. `command`) also
+// resolve here when entity state is nil or when the field isn't present
+// as an entity triple — see Evaluator.EvaluateWithStateAndMessage for the
+// full precedence rule.
+//
+// Empty or nil maps cause `$message.*` and bare-name message lookups to
+// return "not found" — same surfacing behaviour as missing entity triples
+// (condition fails when Required=false, errors when Required=true).
+type MessageFields map[string]any

--- a/processor/rule/expression_factory.go
+++ b/processor/rule/expression_factory.go
@@ -4,7 +4,6 @@ package rule
 import (
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	gtypes "github.com/c360studio/semstreams/graph"
@@ -76,7 +75,14 @@ func (r *ExpressionRule) Subscribe() []string {
 	return r.subscribed
 }
 
-// Evaluate evaluates the rule against messages
+// Evaluate evaluates the rule against messages.
+//
+// Routes through the unified expression.Evaluator with `messageFields`
+// populated from the payload's GenericJSONPayload data. Bare field names
+// resolve via the same precedence rule documented on
+// `Evaluator.EvaluateWithStateAndMessage`. ADR-041 unified this with the
+// action-When path so rule-level conditions and action guards share the
+// same field-resolution semantics — no more two-evaluator split.
 func (r *ExpressionRule) Evaluate(messages []message.Message) bool {
 	if !r.enabled || len(messages) == 0 {
 		return false
@@ -90,11 +96,10 @@ func (r *ExpressionRule) Evaluate(messages []message.Message) bool {
 	// For expression rules, evaluate the last message
 	msg := messages[len(messages)-1]
 
-	// Get payload data - try multiple approaches
+	// Get payload data — only GenericJSONPayload is supported for
+	// expression matching because conditions are field-keyed maps.
 	payload := msg.Payload()
-	var data map[string]interface{}
-
-	// GenericJSONPayload with nested data structure (for NATS message-based rules)
+	var data map[string]any
 	if genericPayload, ok := payload.(*message.GenericJSONPayload); ok {
 		data = genericPayload.Data
 	}
@@ -103,13 +108,19 @@ func (r *ExpressionRule) Evaluate(messages []message.Message) bool {
 		return false
 	}
 
-	// Evaluate conditions
-	if len(r.conditions) > 0 {
-		r.shouldTrigger = r.evaluateConditions(data)
-		return r.shouldTrigger
+	if len(r.conditions) == 0 {
+		return false
 	}
 
-	return false
+	result, err := r.evaluator.EvaluateWithStateAndMessage(nil, nil, expression.MessageFields(data), r.buildLogicalExpression())
+	if err != nil {
+		slog.Debug("ExpressionRule: message-path evaluation error",
+			"rule", r.name,
+			"error", err)
+		return false
+	}
+	r.shouldTrigger = result
+	return result
 }
 
 // EvaluateEntityState evaluates the rule directly against EntityState triples.
@@ -151,153 +162,6 @@ func (r *ExpressionRule) buildLogicalExpression() expression.LogicalExpression {
 	return expression.LogicalExpression{
 		Conditions: r.conditions,
 		Logic:      r.logic,
-	}
-}
-
-// evaluateConditions checks if message data matches rule conditions
-func (r *ExpressionRule) evaluateConditions(data map[string]interface{}) bool {
-	results := make([]bool, len(r.conditions))
-
-	for i, cond := range r.conditions {
-		// Extract nested field value (e.g., "battery.level")
-		value := r.extractNestedValue(data, cond.Field)
-
-		// Handle missing fields based on Required flag
-		if value == nil {
-			if cond.Required {
-				return false // Required field missing - fail immediately
-			}
-			results[i] = false
-			continue
-		}
-
-		// Evaluate condition
-		results[i] = r.evaluateCondition(value, cond.Operator, cond.Value)
-	}
-
-	// Apply logic operator
-	switch r.logic {
-	case "or":
-		for _, result := range results {
-			if result {
-				return true
-			}
-		}
-		return false
-	case "and":
-		fallthrough
-	default:
-		for _, result := range results {
-			if !result {
-				return false
-			}
-		}
-		return true
-	}
-}
-
-// extractNestedValue extracts a value from nested map using dot notation
-func (r *ExpressionRule) extractNestedValue(data map[string]interface{}, field string) interface{} {
-	parts := strings.Split(field, ".")
-	current := data
-
-	for i, part := range parts {
-		if i == len(parts)-1 {
-			return current[part]
-		}
-
-		next, ok := current[part].(map[string]interface{})
-		if !ok {
-			return nil
-		}
-		current = next
-	}
-
-	return nil
-}
-
-// evaluateCondition evaluates a single condition
-func (r *ExpressionRule) evaluateCondition(value interface{}, operator string, expected interface{}) bool {
-	switch operator {
-	case "eq":
-		return compareValues(value, expected) == 0
-	case "ne":
-		return compareValues(value, expected) != 0
-	case "lt":
-		return compareNumeric(value, expected) < 0
-	case "lte":
-		return compareNumeric(value, expected) <= 0
-	case "gt":
-		return compareNumeric(value, expected) > 0
-	case "gte":
-		return compareNumeric(value, expected) >= 0
-	case "contains":
-		return strings.Contains(fmt.Sprintf("%v", value), fmt.Sprintf("%v", expected))
-	case "starts_with":
-		return strings.HasPrefix(fmt.Sprintf("%v", value), fmt.Sprintf("%v", expected))
-	case "ends_with":
-		return strings.HasSuffix(fmt.Sprintf("%v", value), fmt.Sprintf("%v", expected))
-	default:
-		return false
-	}
-}
-
-// compareValues compares two values for equality
-func compareValues(a, b interface{}) int {
-	// Try numeric comparison first
-	_, aIsNum := toNumeric(a)
-	_, bIsNum := toNumeric(b)
-
-	if aIsNum && bIsNum {
-		return compareNumeric(a, b)
-	}
-
-	// Fallback to string comparison
-	aStr := fmt.Sprintf("%v", a)
-	bStr := fmt.Sprintf("%v", b)
-
-	if aStr < bStr {
-		return -1
-	} else if aStr > bStr {
-		return 1
-	}
-	return 0
-}
-
-// compareNumeric compares two values as numbers
-func compareNumeric(a, b interface{}) int {
-	aFloat, _ := toNumeric(a)
-	bFloat, _ := toNumeric(b)
-
-	if aFloat < bFloat {
-		return -1
-	} else if aFloat > bFloat {
-		return 1
-	}
-	return 0
-}
-
-// toNumeric converts a value to float64
-func toNumeric(v interface{}) (float64, bool) {
-	switch val := v.(type) {
-	case float64:
-		return val, true
-	case float32:
-		return float64(val), true
-	case int:
-		return float64(val), true
-	case int64:
-		return float64(val), true
-	case int32:
-		return float64(val), true
-	case uint:
-		return float64(val), true
-	case uint64:
-		return float64(val), true
-	case uint32:
-		return float64(val), true
-	default:
-		return 0, false
 	}
 }
 

--- a/processor/rule/message_substitution.go
+++ b/processor/rule/message_substitution.go
@@ -36,6 +36,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/c360studio/semstreams/processor/rule/expression"
 )
 
 // messageTokenRe matches `$message.<field_path>` where the path is one
@@ -70,43 +72,10 @@ func applyMessageSubstitutions(template string, data map[string]any) string {
 		if path == "" {
 			return token
 		}
-		value, ok := extractMessageValue(data, path)
+		value, ok := expression.ExtractMessageValue(expression.MessageFields(data), path)
 		if !ok {
 			return token
 		}
 		return fmt.Sprintf("%v", value)
 	})
-}
-
-// extractMessageValue walks data along the dotted path. Returns the
-// terminal value and true on success; the second return is false (and
-// the caller must leave the token literal in place) when:
-//
-//   - any non-terminal segment is missing from the current map, OR
-//   - any non-terminal segment resolves to a non-map value (can't
-//     descend further), OR
-//   - the terminal segment is missing.
-//
-// A nil terminal value is considered a successful resolution (the JSON
-// `null` distinct from "missing"). Callers render `<nil>` via fmt — the
-// silent-pass safety net is the regex-leftover warning, not extra
-// fallback logic here.
-func extractMessageValue(data map[string]any, path string) (any, bool) {
-	parts := strings.Split(path, ".")
-	current := any(data)
-	for i, part := range parts {
-		m, ok := current.(map[string]any)
-		if !ok {
-			return nil, false
-		}
-		value, exists := m[part]
-		if !exists {
-			return nil, false
-		}
-		if i == len(parts)-1 {
-			return value, true
-		}
-		current = value
-	}
-	return nil, false
 }

--- a/processor/rule/stateful_evaluator.go
+++ b/processor/rule/stateful_evaluator.go
@@ -189,7 +189,7 @@ func (e *StatefulEvaluator) Evaluate(ctx context.Context, ev Evaluation) (Transi
 	}
 
 	actions := e.selectActions(ev.Rule, transition, currentlyMatching, recovering, ev.EntityID, ev.RelatedID, iteration)
-	e.runActions(ctx, ev.Rule, ec, actions, ev.Entity, stateFields, ev.EntityID, ev.RelatedID)
+	e.runActions(ctx, ev.Rule, ec, actions, ev.Entity, stateFields, expression.MessageFields(ev.MessageData), ev.EntityID, ev.RelatedID)
 
 	matchState.FieldValues = captureTransitionFields(ev.Rule, ev.Entity)
 
@@ -231,7 +231,7 @@ func (e *StatefulEvaluator) reEvaluateTransitions(
 	if expr.Logic == "" {
 		expr.Logic = expression.LogicAnd
 	}
-	match, err := e.exprEvaluator.EvaluateWithStateFields(entity, prevFields, expr)
+	match, err := e.exprEvaluator.EvaluateWithStateAndMessage(entity, prevFields, nil, expr)
 	if err != nil {
 		e.logger.Warn("Failed to re-evaluate transition conditions",
 			"rule_id", ruleDef.ID,
@@ -297,6 +297,11 @@ func (e *StatefulEvaluator) selectActions(
 // clause does not match. Action errors are logged and do not stop subsequent
 // actions — the rule engine prefers best-effort execution so one failing
 // side effect does not block the rest of a transition.
+//
+// messageFields carries the inbound message payload (nil on entity-state
+// evaluations) so When clauses can match against `$message.<field>`
+// tokens or bare names that resolve from the payload — see
+// EvaluateWithStateAndMessage for the precedence rule.
 func (e *StatefulEvaluator) runActions(
 	ctx context.Context,
 	ruleDef Definition,
@@ -304,11 +309,12 @@ func (e *StatefulEvaluator) runActions(
 	actions []Action,
 	entity *gtypes.EntityState,
 	stateFields expression.StateFields,
+	messageFields expression.MessageFields,
 	entityID, relatedID string,
 ) {
 	for _, action := range actions {
 		if len(action.When) > 0 {
-			match, whenErr := e.evaluateWhen(action.When, entity, stateFields)
+			match, whenErr := e.evaluateWhen(action.When, entity, stateFields, messageFields)
 			if whenErr != nil {
 				e.logger.Warn("When clause evaluation failed, skipping action",
 					"rule_id", ruleDef.ID,
@@ -450,18 +456,21 @@ func captureTransitionFields(ruleDef Definition, entity *gtypes.EntityState) map
 }
 
 // evaluateWhen evaluates a When clause (action-level guard conditions).
-// When clauses use AND logic by default — all conditions must match for the action to execute.
-// If entity is nil (message-path rules), the When clause is skipped and returns true.
+// When clauses use AND logic by default — all conditions must match for
+// the action to execute. Field resolution mirrors rule-level conditions:
+// `$state.*` from stateFields, `$message.<path>` from messageFields,
+// bare names from entity triples (when present) then messageFields. See
+// `Evaluator.EvaluateWithStateAndMessage` for the full precedence rule
+// and ADR-041 for the unification rationale.
 func (e *StatefulEvaluator) evaluateWhen(
 	conditions []expression.ConditionExpression,
 	entity *gtypes.EntityState,
 	stateFields expression.StateFields,
+	messageFields expression.MessageFields,
 ) (bool, error) {
-	// For message-path rules without entity state, skip When evaluation
-	// unless all conditions reference $state.* fields
 	expr := expression.LogicalExpression{
 		Conditions: conditions,
 		Logic:      expression.LogicAnd,
 	}
-	return e.exprEvaluator.EvaluateWithStateFields(entity, stateFields, expr)
+	return e.exprEvaluator.EvaluateWithStateAndMessage(entity, stateFields, messageFields, expr)
 }

--- a/processor/rule/stateful_evaluator_test.go
+++ b/processor/rule/stateful_evaluator_test.go
@@ -514,6 +514,152 @@ func (m *mockActionExecutor) Execute(_ context.Context, action Action, _ *Execut
 	return nil
 }
 
+// TestStatefulEvaluator_WhenMessagePayloadAccess is the ADR-041
+// acceptance test: action-When clauses on message-path rules can match
+// against the inbound message payload via `$message.<field>` tokens AND
+// via bare field names (entity-is-nil resolution falls through to
+// messageFields). This is what unlocks semspec's consolidated-rule
+// governance pattern.
+func TestStatefulEvaluator_WhenMessagePayloadAccess(t *testing.T) {
+	ctx := context.Background()
+	bucket := newMockKVBucket()
+	logger := slog.Default()
+	stateTracker := NewStateTracker(bucket, logger)
+	actionExecutor := &mockActionExecutor{}
+	evaluator := NewStatefulEvaluator(stateTracker, actionExecutor, logger)
+
+	ruleDef := Definition{
+		ID:   "message-when-rule",
+		Type: "expression",
+		Name: "Message-Path When Rule",
+		OnEnter: []Action{
+			{
+				Type:    ActionTypePublish,
+				Subject: "test.explicit-message",
+				When: []expression.ConditionExpression{
+					// Explicit $message.<field> form (recommended per ADR-041).
+					{Field: "$message.command", Operator: "contains", Value: "cd /workspace"},
+				},
+			},
+			{
+				Type:    ActionTypePublish,
+				Subject: "test.bare-name-message",
+				When: []expression.ConditionExpression{
+					// Bare name; entity is nil so resolves from messageFields.
+					{Field: "tool_name", Operator: "eq", Value: "bash"},
+				},
+			},
+			{
+				Type:    ActionTypePublish,
+				Subject: "test.deep-path",
+				When: []expression.ConditionExpression{
+					// Deep-path access into nested payload.
+					{Field: "$message.tool_args.command", Operator: "starts_with", Value: "rm"},
+				},
+			},
+			{
+				Type:    ActionTypePublish,
+				Subject: "test.no-match",
+				When: []expression.ConditionExpression{
+					{Field: "$message.command", Operator: "contains", Value: "safe"},
+				},
+			},
+		},
+	}
+
+	_, err := evaluator.Evaluate(ctx, Evaluation{
+		Rule:              ruleDef,
+		EntityID:          "entity-msg-path",
+		CurrentlyMatching: true,
+		MessageData: map[string]any{
+			"command":   "cd /workspace && something",
+			"tool_name": "bash",
+			"tool_args": map[string]any{
+				"command": "rm -rf /tmp/x",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+
+	// Three matches (explicit, bare, deep-path); the "safe" one doesn't.
+	if actionExecutor.executeCallCount != 3 {
+		t.Errorf("Expected 3 actions executed (explicit + bare + deep-path matched; safe didn't), got %d", actionExecutor.executeCallCount)
+	}
+}
+
+// TestStatefulEvaluator_WhenConsolidatedGovernancePattern exercises
+// semspec's exact governance use case from
+// `.semspec/semstreams-ask-action-when-message-payload.md`: one rule
+// with publish+deny pairs guarded by $message.command patterns, plus a
+// trailing unconditional approve fallback. With ADR-041, exactly one
+// verdict per call by construction — no multi-rule race, no enforce-
+// mode timeout false positives.
+func TestStatefulEvaluator_WhenConsolidatedGovernancePattern(t *testing.T) {
+	ctx := context.Background()
+	bucket := newMockKVBucket()
+	logger := slog.Default()
+	stateTracker := NewStateTracker(bucket, logger)
+	actionExecutor := &mockActionExecutor{}
+	evaluator := NewStatefulEvaluator(stateTracker, actionExecutor, logger)
+
+	ruleDef := Definition{
+		ID:   "governance-bash-blocklist",
+		Type: "expression",
+		Name: "ADR-039 governance with consolidated blocklist",
+		OnEnter: []Action{
+			// Block "cd /workspace" pattern.
+			{
+				Type:    ActionTypePublish,
+				Subject: "agent.toolcall.rejected.cd",
+				When: []expression.ConditionExpression{
+					{Field: "$message.command", Operator: "contains", Value: "cd /workspace"},
+				},
+			},
+			// Trailing unconditional approve — only fires if no earlier
+			// guarded action matched. With $message access in When, this
+			// becomes a real composable fallback.
+			{
+				Type:    ActionTypePublish,
+				Subject: "agent.toolcall.approved.fallback",
+			},
+		},
+	}
+
+	// Case 1: command matches blocklist → rejected fires + fallback also
+	// fires (no deny short-circuit in this test since we're just
+	// exercising the When-clause field-resolution path).
+	actionExecutor.executeCallCount = 0
+	_, err := evaluator.Evaluate(ctx, Evaluation{
+		Rule:              ruleDef,
+		EntityID:          "entity-1",
+		CurrentlyMatching: true,
+		MessageData:       map[string]any{"command": "cd /workspace && ls", "tool_name": "bash"},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if actionExecutor.executeCallCount != 2 {
+		t.Errorf("Case 1: expected 2 actions (rejected + fallback approve), got %d", actionExecutor.executeCallCount)
+	}
+
+	// Case 2: command doesn't match → rejected skipped, only fallback fires.
+	actionExecutor.executeCallCount = 0
+	_, err = evaluator.Evaluate(ctx, Evaluation{
+		Rule:              ruleDef,
+		EntityID:          "entity-2",
+		CurrentlyMatching: true,
+		MessageData:       map[string]any{"command": "ls /tmp", "tool_name": "bash"},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate() error = %v", err)
+	}
+	if actionExecutor.executeCallCount != 1 {
+		t.Errorf("Case 2: expected 1 action (fallback only), got %d", actionExecutor.executeCallCount)
+	}
+}
+
 // TestStatefulEvaluator_TransitionFieldTracking verifies that FieldValues are
 // persisted across evaluations and used by the transition operator.
 func TestStatefulEvaluator_TransitionFieldTracking(t *testing.T) {

--- a/processor/rule/test_rule_factory.go
+++ b/processor/rule/test_rule_factory.go
@@ -3,7 +3,6 @@ package rule
 
 import (
 	"fmt"
-	"strings"
 
 	gtypes "github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
@@ -17,6 +16,8 @@ type TestRule struct {
 	subscribed    []string
 	enabled       bool
 	conditions    []expression.ConditionExpression
+	logic         string
+	evaluator     *expression.Evaluator
 	shouldTrigger bool // Set to true when conditions match
 }
 
@@ -28,6 +29,8 @@ func NewTestRule(id, name string, subjects []string, conditions []expression.Con
 		subscribed: subjects,
 		enabled:    true,
 		conditions: conditions,
+		logic:      expression.LogicAnd,
+		evaluator:  expression.NewExpressionEvaluator(),
 	}
 }
 
@@ -41,7 +44,9 @@ func (r *TestRule) Subscribe() []string {
 	return r.subscribed
 }
 
-// Evaluate evaluates the rule against messages
+// Evaluate evaluates the rule against messages.
+// Routes through the unified expression.Evaluator — same field
+// resolution semantics as production rules. See ADR-041.
 func (r *TestRule) Evaluate(messages []message.Message) bool {
 	if !r.enabled || len(messages) == 0 {
 		return false
@@ -50,7 +55,7 @@ func (r *TestRule) Evaluate(messages []message.Message) bool {
 	// For test purposes, evaluate the last message
 	msg := messages[len(messages)-1]
 
-	// Get payload data - try to cast to GenericJSONPayload
+	// Get payload data — only GenericJSONPayload supports field-keyed matching.
 	payload := msg.Payload()
 	genericPayload, ok := payload.(*message.GenericJSONPayload)
 	if !ok {
@@ -62,37 +67,27 @@ func (r *TestRule) Evaluate(messages []message.Message) bool {
 		return false
 	}
 
-	// Evaluate conditions if present
-	if len(r.conditions) > 0 {
-		return r.evaluateConditions(data)
+	if len(r.conditions) == 0 {
+		// No conditions - trigger if we have data
+		r.shouldTrigger = len(data) > 0
+		return r.shouldTrigger
 	}
 
-	// Default: trigger if we have data
-	r.shouldTrigger = len(data) > 0
-	return r.shouldTrigger
-}
-
-// evaluateConditions checks if message data matches rule conditions
-func (r *TestRule) evaluateConditions(data map[string]interface{}) bool {
-	for _, cond := range r.conditions {
-		// Extract nested field value (e.g., "battery.level")
-		value := extractNestedValue(data, cond.Field)
-		if value == nil {
-			return false
-		}
-
-		// Evaluate condition
-		if !evaluateCondition(value, cond.Operator, cond.Value) {
-			return false
-		}
+	expr := expression.LogicalExpression{
+		Conditions: r.conditions,
+		Logic:      r.logic,
 	}
-
-	r.shouldTrigger = true
-	return true
+	result, err := r.evaluator.EvaluateWithStateAndMessage(nil, nil, expression.MessageFields(data), expr)
+	if err != nil {
+		return false
+	}
+	r.shouldTrigger = result
+	return result
 }
 
-// EvaluateEntityState evaluates the rule directly against EntityState triples.
-// This implements the EntityStateEvaluator interface for KV watch-based evaluation.
+// EvaluateEntityState evaluates the rule against entity triples via the
+// unified evaluator. Implements the EntityStateEvaluator interface for
+// KV watch-based evaluation.
 func (r *TestRule) EvaluateEntityState(entityState *gtypes.EntityState) bool {
 	if !r.enabled || entityState == nil {
 		return false
@@ -104,32 +99,16 @@ func (r *TestRule) EvaluateEntityState(entityState *gtypes.EntityState) bool {
 		return true
 	}
 
-	// Evaluate conditions against triples
-	for _, cond := range r.conditions {
-		// Find triple with matching predicate
-		var value interface{}
-		found := false
-		for _, triple := range entityState.Triples {
-			if triple.Predicate == cond.Field {
-				value = triple.Object
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			// Required field not found
-			return false
-		}
-
-		// Evaluate condition
-		if !evaluateCondition(value, cond.Operator, cond.Value) {
-			return false
-		}
+	expr := expression.LogicalExpression{
+		Conditions: r.conditions,
+		Logic:      r.logic,
 	}
-
-	r.shouldTrigger = true
-	return true
+	result, err := r.evaluator.Evaluate(entityState, expr)
+	if err != nil {
+		return false
+	}
+	r.shouldTrigger = result
+	return result
 }
 
 // ExecuteEvents generates events when rule triggers
@@ -144,7 +123,7 @@ func (r *TestRule) ExecuteEvents(messages []message.Message) ([]Event, error) {
 	event := gtypes.Event{
 		Type:     gtypes.EventEntityUpdate, // Using a standard event type
 		EntityID: "test.entity." + r.id,
-		Properties: map[string]interface{}{
+		Properties: map[string]any{
 			"rule_id":    r.id,
 			"rule_name":  r.name,
 			"message_id": msg.ID(),
@@ -162,79 +141,6 @@ func (r *TestRule) ExecuteEvents(messages []message.Message) ([]Event, error) {
 
 	r.shouldTrigger = false // Reset trigger state
 	return []Event{&event}, nil
-}
-
-// extractNestedValue extracts a value from nested map using dot notation
-func extractNestedValue(data map[string]interface{}, field string) interface{} {
-	parts := strings.Split(field, ".")
-	current := data
-
-	for i, part := range parts {
-		if i == len(parts)-1 {
-			// Last part - return the value
-			return current[part]
-		}
-
-		// Navigate deeper
-		next, ok := current[part].(map[string]interface{})
-		if !ok {
-			return nil
-		}
-		current = next
-	}
-
-	return nil
-}
-
-// evaluateCondition evaluates a single condition
-func evaluateCondition(value interface{}, operator string, expected interface{}) bool {
-	switch operator {
-	case "eq":
-		return value == expected
-	case "ne":
-		return value != expected
-	case "lt":
-		return compareNumbers(value, expected) < 0
-	case "lte":
-		return compareNumbers(value, expected) <= 0
-	case "gt":
-		return compareNumbers(value, expected) > 0
-	case "gte":
-		return compareNumbers(value, expected) >= 0
-	default:
-		return false
-	}
-}
-
-// compareNumbers compares two values as numbers
-func compareNumbers(a, b interface{}) int {
-	aFloat := toFloat64(a)
-	bFloat := toFloat64(b)
-
-	if aFloat < bFloat {
-		return -1
-	} else if aFloat > bFloat {
-		return 1
-	}
-	return 0
-}
-
-// toFloat64 converts a value to float64
-func toFloat64(v interface{}) float64 {
-	switch val := v.(type) {
-	case float64:
-		return val
-	case float32:
-		return float64(val)
-	case int:
-		return float64(val)
-	case int64:
-		return float64(val)
-	case int32:
-		return float64(val)
-	default:
-		return 0
-	}
 }
 
 // TestRuleFactory creates test rules for integration testing


### PR DESCRIPTION
## Summary

Unifies rule-level conditions and action-When guards behind a single `Evaluator.EvaluateWithStateAndMessage` with one precedence rule. Closes the structural debt that surfaced as semspec's beta.71 "action-When can't see message payload" bug, but goes further than the surgical patch they requested — bundling the cleanup into the same BREAKING tag while we control both consumers (semspec, semteams).

semspec's ask: `../semspec/.semspec/semstreams-ask-action-when-message-payload.md`. They proposed `EvaluateWithStateAndMessage` as a side path; we made it the only path and deleted the duplicates.

## Why structural over surgical

| | Pre-ADR-041 |
|---|---|
| Rule-level (`ExpressionRule.evaluateConditions`) | Own `extractNestedValue`, no `$state.*`, limited operator set (eq/ne/lt/lte/gt/gte/contains/starts_with/ends_with) |
| Action-When (`Evaluator.EvaluateWithStateFields`) | Entity triples + `$state.*`, no message access, full operator set |

Same author writing one rule that used both surfaces had to learn two field-resolution models AND two operator coverage matrices. Surgical fix would have entrenched that split.

We are greenfield; ≤2 external consumers; already shipping BREAKING in beta.72 (ADR-040 + Go bump). Marginal cost of structural fix ≈ surgical; carrying cost of duplicate evaluators compounds at every namespace/operator addition.

## Field resolution precedence (single rule)

1. `$state.<field>` / `$prev.<field>` → `stateFields`
2. `$message.<dotted.path>` → `messageFields` via deep-walk (shared `expression.ExtractMessageValue`)
3. `OpTransition` → entity-state-only (uses `$prev.<field>`)
4. Bare name → entity triples first when entity non-nil, falls through to `messageFields`; when entity nil, `messageFields` only

`$message.<field>` is the documented form. Bare names work but the resolution source depends on rule type — operators reach for the explicit prefix when source matters.

## Deletions

- `Evaluator.EvaluateWithStateFields` (deprecated shim)
- `Evaluator.evaluateCondition` (subsumed)
- `ExpressionRule.evaluateConditions` / `extractNestedValue` / `evaluateCondition`
- Package-level `compareValues` / `compareNumeric` / `toNumeric` (rule package)
- `TestRule` equivalents
- `rule.extractMessageValue` (delegates to `expression.ExtractMessageValue`)

Net: +400 LOC / -250 LOC ≈ +150 LOC net (test matrix dominates the additions).

## BREAKING

1. `Evaluator.EvaluateWithStateFields` removed — callers rename to `EvaluateWithStateAndMessage(entity, stateFields, nil, expr)`
2. Bare-name field resolution on message-path rules now resolves from payload (was: skipped). Additive — no pre-ADR-041 path had message access at When-clause level
3. Operator coverage merged — rule-level conditions gain `in`/`not_in`/`between`/`regex`/`array_*`/`transition` operators that previously worked only at action-When level

## Migration for semspec

Three governance rules collapse into one with `when`-guarded `publish`+`deny` pairs and a trailing unconditional `approve`:

```diff
-on_enter: [
-  {type:"publish", subject:"...rejected...", properties:{...}},
-  {type:"deny", reason:"..."}
-]
+on_enter: [
+  {
+    "type": "publish",
+    "when": [{"field": "$message.command", "operator": "contains", "value": "cd /workspace"}],
+    "subject": "...rejected...",
+    "properties": {...}
+  },
+  {
+    "type": "deny",
+    "when": [{"field": "$message.command", "operator": "contains", "value": "cd /workspace"}],
+    "reason": "..."
+  },
+  {"type": "publish", "subject": "...approved...", "properties": {...}}  // unconditional fallback
+]
```

Race-free by construction; exactly one verdict per call in enforce mode. Pattern documented in `docs/operations/17-tool-call-governance.md`.

## Test plan

- [x] `go test -race ./...` — 97 ok, 0 fail
- [x] `task lint` — clean
- [x] `go vet -tags=integration ./...` — clean
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `task schema:generate` — no drift
- [x] `go test ./test/contract/...` — clean
- [x] `task e2e:agentic` — green (`governance_verdicts_approved_audit:3`, `verify-tool-call-governance` OK)
- [ ] semspec migrates rules to consolidated pattern on this tag

## Test matrix added

- `processor/rule/expression/evaluator_test.go`:
  - `TestEvaluateWithStateAndMessage_MessageFieldExplicit` (explicit `$message.*`, deep paths, Required behaviour)
  - `TestEvaluateWithStateAndMessage_BareNameMessagePath` (bare-name fallback on message-path)
  - `TestEvaluateWithStateAndMessage_EntityPathBareNameUnchanged` (backward-compat regression class)
  - `TestEvaluateWithStateAndMessage_EntityFallsThroughToMessage` (mixed-source case)
  - `TestEvaluateWithStateAndMessage_PrecedenceOrder` (explicit beats entity for shared keys)
  - `TestEvaluateWithStateAndMessage_StatePlusMessage` (composition)
- `processor/rule/stateful_evaluator_test.go`:
  - `TestStatefulEvaluator_WhenMessagePayloadAccess` (ADR-041 acceptance)
  - `TestStatefulEvaluator_WhenConsolidatedGovernancePattern` (semspec's canonical use case)

## Bundle

beta.72 BREAKING. Bundle with:
- ADR-040 (boid retirement — PR #68)
- Go version bump (per user direction)

semspec/semteams migrate once.

## References

- ADR-041 (`docs/adr/041-unified-condition-evaluator.md`)
- ADR-039 (precedent for rules-engine migration)
- semspec ask: `.semspec/semstreams-ask-action-when-message-payload.md`
- semspec beta.71 bug filing: `.semspec/semstreams-substitution-bugs-2026-05-13.md` (same evaluator surface, narrower symptom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)