### PR TITLE
chore: bump Go to 1.26.3 + race fix in test discovered by it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/c360studio/semstreams
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/agntcy/dir/api v1.3.0

--- a/processor/rule/message_substitution_test.go
+++ b/processor/rule/message_substitution_test.go
@@ -196,9 +196,14 @@ func TestSubstituteVariables_Message_VerdictSubject(t *testing.T) {
 // warning via the same path as missing $entity.triple.X. This is the
 // silent-pass guard the ADR specifically called out — catches new event
 // shapes that forgot to populate a field at publish time.
+//
+// Not t.Parallel(): slog.SetDefault mutates package-global state, and
+// any other parallel test that captures slog.Default() at setup races
+// against our SetDefault/Cleanup window. See the same discipline at
+// TestExecutionContext_SubstituteVariables_WarnsOnUnresolved in
+// actions_test.go. Caught on the beta.72 Go-bump CI run when scheduler
+// timing shifted enough to surface the latent race.
 func TestSubstituteVariables_Message_UnresolvedFieldWarns(t *testing.T) {
-	t.Parallel()
-
 	var buf bytes.Buffer
 	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
 	prev := slog.Default()


### PR DESCRIPTION
## Summary

Aligns `go.mod` (was `go 1.26.2`) with the patch version CI has been running (`GO_VERSION: "1.26"` resolves to `1.26.3` on the runners). Patch-level bump only; no API changes, no module changes.

## Test plan

- [x] `go mod tidy` — no-op
- [x] `go build ./...` — clean
- [x] `go test -race ./...` — 95 ok, 0 fail
- [ ] CI green on PR

## Bundle

Lands in the beta.72 release line alongside ADR-040 (boid retirement) and ADR-041 (evaluator unification) but is **itself non-BREAKING**. The BREAKING framing of beta.72 comes from the boid+evaluator changes already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)