### PR TITLE
feat(agentic-tools): SkipBuiltins option on ToolDependencies (semteams ask)

### DIFF
--- a/processor/agentic-tools/executors/register.go
+++ b/processor/agentic-tools/executors/register.go
@@ -35,6 +35,7 @@ import (
 //     query_entity) are skipped
 //   - RuleManager nil → rule CRUD tools are skipped
 //   - ComponentRegistry nil → list_components skipped (Pattern-B step 5)
+//   - SkipBuiltins nil/empty → all builtins register (today's behaviour)
 //
 // Platform is a value type (not pointer) because PlatformMeta is a small
 // POD; the empty value is still safe for the decide tool to use.
@@ -53,6 +54,57 @@ type ToolDependencies struct {
 	// the name is frozen at RegisterBuiltins for the lifetime of the
 	// process.
 	LoopsBucket string
+	// SkipBuiltins is the list of builtin group keys to NOT register.
+	// Product shells set this when they want to register their own
+	// implementation under a canonical tool name (e.g., a chain-scoped
+	// `bash` wrapper for sandbox isolation).
+	//
+	// Valid group keys are defined in BuiltinGroupKeys. Unknown names
+	// cause RegisterBuiltins to return an error before any registration
+	// happens — typos surface loudly at boot, not silently as "wait,
+	// why isn't my replacement tool being called?".
+	//
+	// For single-tool registrations (e.g., bash, decide), the group key
+	// IS the tool name. For multi-tool registrations (e.g., graph_query
+	// advertises five query_* tools, rules advertises five rule_* CRUD
+	// tools), the group key is the register-function's domain label
+	// and skips all tools registered by that function as a unit. See
+	// BuiltinGroupKeys for the full mapping.
+	//
+	// Empty/nil = today's behaviour: every builtin registers.
+	SkipBuiltins []string
+}
+
+// BuiltinGroupKeys is the closed set of valid SkipBuiltins entries.
+// For single-tool register functions the key matches the tool name;
+// for multi-tool register functions the key is a domain label that
+// skips the whole group as a unit (the registry can't partially
+// register one executor's ListTools() output).
+//
+// The slice is exported so external callers (and tests) can iterate
+// for validation, documentation, or "skip everything except X"
+// derivation. Order is stable for golden-test reproducibility.
+var BuiltinGroupKeys = []string{
+	// Single-tool registrations: key == tool name
+	"bash",
+	"web_search",
+	"http_request",
+	"read_loop_result",
+	"decide",
+	"emit_diagnosis",
+	"write_todos",
+	"scratchpad",
+	"summarize_graph",
+	"search_graph",
+	"flow_monitor",
+	// Multi-tool registrations: key is the register-function's domain
+	"github",            // registerGitHub — github_* tools
+	"graph_query",       // registerGraphQuery — query_entity + 4 others
+	"rules",             // registerRules — rule CRUD tools
+	"flows",             // registerFlows — flow CRUD tools
+	"personas",          // registerPersonas — persona CRUD tools
+	"flow_templates",    // registerFlowTemplates — flow_template CRUD tools
+	"component_catalog", // registerComponentCatalog — list_components
 }
 
 // RegisterBuiltins wires every tool this package owns into the supplied
@@ -84,46 +136,89 @@ func RegisterBuiltins(ctx context.Context, reg *agentictools.ExecutorRegistry, d
 		loopsBucket = "AGENT_LOOPS"
 	}
 
+	skip, err := resolveSkipSet(deps.SkipBuiltins)
+	if err != nil {
+		return fmt.Errorf("RegisterBuiltins: %w", err)
+	}
+
 	var errs []error
 	track := func(err error) {
 		if err != nil {
 			errs = append(errs, err)
 		}
 	}
+	// gate runs fn() only when key is not in the skip set. Each
+	// register_* function is wrapped through this so the gating policy
+	// (skip vs register, log on skip) lives in one place and stays
+	// uniform across single-tool and multi-tool registrations.
+	gate := func(key string, fn func() error) {
+		if skip[key] {
+			logger.Debug("Skipping builtin tool group (SkipBuiltins)",
+				"group", key,
+				"hint", "product shell will register its own implementation under this name")
+			return
+		}
+		track(fn())
+	}
 
-	track(registerBash(reg, logger))
-	track(registerWebSearch(reg, deps.NATSClient, deps.Platform, logger))
-	track(registerHTTPRequest(reg, deps.NATSClient, deps.Platform, logger))
-	track(registerGitHub(reg, logger))
+	gate("bash", func() error { return registerBash(reg, logger) })
+	gate("web_search", func() error { return registerWebSearch(reg, deps.NATSClient, deps.Platform, logger) })
+	gate("http_request", func() error { return registerHTTPRequest(reg, deps.NATSClient, deps.Platform, logger) })
+	gate("github", func() error { return registerGitHub(reg, logger) })
 
 	if deps.NATSClient == nil {
 		logger.Warn("nats client not available; skipping stateful tool registration (read_loop_result, decide, emit_diagnosis, query_entity); web_search and http_request fall back to text-only return without graph emission")
 	} else {
-		track(registerReadLoopResult(ctx, reg, deps.NATSClient, logger, loopsBucket))
-		track(registerDecide(reg, deps.NATSClient, deps.Platform, logger))
-		track(registerEmitDiagnosis(reg, deps.NATSClient, deps.Platform, logger))
-		track(registerGraphQuery(ctx, reg, deps.NATSClient, logger))
-		track(registerWriteTodos(reg, deps.NATSClient, deps.Platform, logger))
-		track(registerScratchpad(reg, deps.NATSClient, deps.Platform, logger))
+		gate("read_loop_result", func() error { return registerReadLoopResult(ctx, reg, deps.NATSClient, logger, loopsBucket) })
+		gate("decide", func() error { return registerDecide(reg, deps.NATSClient, deps.Platform, logger) })
+		gate("emit_diagnosis", func() error { return registerEmitDiagnosis(reg, deps.NATSClient, deps.Platform, logger) })
+		gate("graph_query", func() error { return registerGraphQuery(ctx, reg, deps.NATSClient, logger) })
+		gate("write_todos", func() error { return registerWriteTodos(reg, deps.NATSClient, deps.Platform, logger) })
+		gate("scratchpad", func() error { return registerScratchpad(reg, deps.NATSClient, deps.Platform, logger) })
 		// Gateway-first discovery tools (PR #54 step 2): thin wrappers
 		// over the new graph.query.summary + graph.query.searchGraph
 		// server-side resolvers. Read-only, no platform identity
 		// required. See project_graph_tools_gateway_first_plan memory.
-		track(registerSummarizeGraph(reg, deps.NATSClient, logger))
-		track(registerSearchGraph(reg, deps.NATSClient, logger))
+		gate("summarize_graph", func() error { return registerSummarizeGraph(reg, deps.NATSClient, logger) })
+		gate("search_graph", func() error { return registerSearchGraph(reg, deps.NATSClient, logger) })
 	}
 
 	// Pattern-B registry-backed tools. A nil manager is a legal skip;
 	// duplicate-name failures propagate.
-	track(registerRules(reg, deps.RuleManager, logger))
-	track(registerFlows(reg, deps.FlowManager, logger))
-	track(registerPersonas(reg, deps.PersonaManager, logger))
-	track(registerFlowTemplates(reg, deps.FlowTemplateManager, logger))
-	track(registerComponentCatalog(reg, deps.ComponentRegistry, logger))
-	track(registerFlowMonitor(reg, deps.NATSClient, deps.FlowManager, logger, loopsBucket))
+	gate("rules", func() error { return registerRules(reg, deps.RuleManager, logger) })
+	gate("flows", func() error { return registerFlows(reg, deps.FlowManager, logger) })
+	gate("personas", func() error { return registerPersonas(reg, deps.PersonaManager, logger) })
+	gate("flow_templates", func() error { return registerFlowTemplates(reg, deps.FlowTemplateManager, logger) })
+	gate("component_catalog", func() error { return registerComponentCatalog(reg, deps.ComponentRegistry, logger) })
+	gate("flow_monitor", func() error { return registerFlowMonitor(reg, deps.NATSClient, deps.FlowManager, logger, loopsBucket) })
 
 	if len(errs) > 0 {
 		return fmt.Errorf("RegisterBuiltins: %w", errors.Join(errs...))
 	}
 	return nil
+}
+
+// resolveSkipSet validates the skip list against BuiltinGroupKeys and
+// returns a lookup map. An unknown name returns an error referencing
+// the full valid set so operators can self-correct without grepping
+// the source.
+//
+// Empty/nil input is the common case (today's behaviour); returns
+// (nil, nil) — the gate() helper treats nil maps as "skip nothing".
+func resolveSkipSet(skipBuiltins []string) (map[string]bool, error) {
+	if len(skipBuiltins) == 0 {
+		return nil, nil
+	}
+	valid := make(map[string]bool, len(BuiltinGroupKeys))
+	for _, k := range BuiltinGroupKeys {
+		valid[k] = true
+	}
+	skip := make(map[string]bool, len(skipBuiltins))
+	for _, name := range skipBuiltins {
+		if !valid[name] {
+			return nil, fmt.Errorf("unknown builtin group key %q in SkipBuiltins; valid keys: %v", name, BuiltinGroupKeys)
+		}
+		skip[name] = true
+	}
+	return skip, nil
 }

--- a/processor/agentic-tools/executors/register_test.go
+++ b/processor/agentic-tools/executors/register_test.go
@@ -177,3 +177,198 @@ func (m *recordingRuleManager) GetRule(_ context.Context, _ string) (*rule.Defin
 func (m *recordingRuleManager) ListRules(_ context.Context) (map[string]rule.Definition, error) {
 	return nil, nil
 }
+
+// TestRegisterBuiltins_SkipBuiltins_BashOmitted is the canonical
+// semteams use case: the product shell wants to register its own
+// chain-scoped `bash` implementation under the canonical name. Setting
+// SkipBuiltins=["bash"] omits the framework bash; the product shell's
+// subsequent RegisterTool("bash", custom) succeeds because the slot
+// is empty.
+func TestRegisterBuiltins_SkipBuiltins_BashOmitted(t *testing.T) {
+	t.Parallel()
+	reg := agentictools.NewExecutorRegistry()
+
+	err := RegisterBuiltins(context.Background(), reg, ToolDependencies{
+		Logger:       slog.Default(),
+		SkipBuiltins: []string{"bash"},
+	})
+	if err != nil {
+		t.Fatalf("RegisterBuiltins with SkipBuiltins=[bash]: %v", err)
+	}
+
+	tools := reg.ListTools()
+	if containsName(tools, "bash") {
+		t.Errorf("bash should be skipped, but is registered")
+	}
+	// Sanity-check: other builtins still register.
+	if !containsName(tools, "web_search") {
+		t.Errorf("web_search should still register when only bash is skipped")
+	}
+	if !containsName(tools, "http_request") {
+		t.Errorf("http_request should still register when only bash is skipped")
+	}
+
+	// Product-shell can now register a replacement under the canonical name.
+	stub := &registerTestStubExecutor{name: "bash"}
+	if err := reg.RegisterTool("bash", stub); err != nil {
+		t.Fatalf("product-shell bash replacement should succeed after SkipBuiltins[bash]: %v", err)
+	}
+}
+
+// TestRegisterBuiltins_SkipBuiltins_MultiToolGroup verifies that a
+// group-key skip (e.g., "graph_query") omits ALL tools the register
+// function would have advertised — necessary because RegisterExecutor
+// is atomic over an executor's full ListTools().
+func TestRegisterBuiltins_SkipBuiltins_MultiToolGroup(t *testing.T) {
+	t.Parallel()
+	// NATS-required tools skip when NATSClient is nil, so pass a non-nil
+	// path via the same skip mechanism: skip graph_query and verify that
+	// query_entity / query_relationships / etc. are absent. We test
+	// without NATSClient first to verify the skip semantics are
+	// orthogonal to the NATSClient-nil skip path.
+	t.Run("group_skip_with_nil_nats_no_op", func(t *testing.T) {
+		t.Parallel()
+		reg := agentictools.NewExecutorRegistry()
+		err := RegisterBuiltins(context.Background(), reg, ToolDependencies{
+			Logger:       slog.Default(),
+			SkipBuiltins: []string{"graph_query"},
+		})
+		if err != nil {
+			t.Fatalf("RegisterBuiltins: %v", err)
+		}
+		// With NATSClient=nil, graph_query wouldn't fire anyway; skip is a no-op.
+		// query_entity should be absent either way.
+		if containsName(reg.ListTools(), "query_entity") {
+			t.Errorf("query_entity should not register when NATSClient is nil regardless of skip")
+		}
+	})
+
+	t.Run("github_group_skip", func(t *testing.T) {
+		t.Parallel()
+		// github is a multi-tool group with no NATS dependency. Skipping
+		// it should leave bash registered while all github_* tools are
+		// absent.
+		reg := agentictools.NewExecutorRegistry()
+		err := RegisterBuiltins(context.Background(), reg, ToolDependencies{
+			Logger:       slog.Default(),
+			SkipBuiltins: []string{"github"},
+		})
+		if err != nil {
+			t.Fatalf("RegisterBuiltins: %v", err)
+		}
+		if !containsName(reg.ListTools(), "bash") {
+			t.Errorf("bash should still register when only github is skipped")
+		}
+		for _, name := range reg.ListTools() {
+			if strings.HasPrefix(name.Name, "github_") {
+				t.Errorf("github_* tool %q should be absent under SkipBuiltins=[github]", name.Name)
+			}
+		}
+	})
+}
+
+// TestRegisterBuiltins_SkipBuiltins_MultipleNames verifies that
+// multiple skip entries compose: all named groups are absent and
+// everything else registers as usual.
+func TestRegisterBuiltins_SkipBuiltins_MultipleNames(t *testing.T) {
+	t.Parallel()
+	reg := agentictools.NewExecutorRegistry()
+	err := RegisterBuiltins(context.Background(), reg, ToolDependencies{
+		Logger:       slog.Default(),
+		SkipBuiltins: []string{"bash", "web_search", "github"},
+	})
+	if err != nil {
+		t.Fatalf("RegisterBuiltins: %v", err)
+	}
+	tools := reg.ListTools()
+	for _, omitted := range []string{"bash", "web_search"} {
+		if containsName(tools, omitted) {
+			t.Errorf("%q should be skipped", omitted)
+		}
+	}
+	// http_request not in skip list — should register
+	if !containsName(tools, "http_request") {
+		t.Errorf("http_request should still register")
+	}
+}
+
+// TestRegisterBuiltins_SkipBuiltins_UnknownNameErrors is the
+// loud-typo-catching contract: an unknown group key must error before
+// any registration happens, with the valid set in the message so
+// operators can self-correct without grepping.
+func TestRegisterBuiltins_SkipBuiltins_UnknownNameErrors(t *testing.T) {
+	t.Parallel()
+	reg := agentictools.NewExecutorRegistry()
+	err := RegisterBuiltins(context.Background(), reg, ToolDependencies{
+		Logger:       slog.Default(),
+		SkipBuiltins: []string{"bahs"}, // typo for "bash"
+	})
+	if err == nil {
+		t.Fatalf("unknown SkipBuiltins entry must error, got nil")
+	}
+	if !strings.Contains(err.Error(), "bahs") {
+		t.Errorf("error must reference the unknown name, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "valid keys") {
+		t.Errorf("error must reference the valid-keys list, got: %v", err)
+	}
+	// No registration should have happened.
+	if len(reg.ListTools()) != 0 {
+		t.Errorf("registry must be empty on validation failure, got %d tools", len(reg.ListTools()))
+	}
+}
+
+// TestRegisterBuiltins_SkipBuiltins_EmptyNoOp pins backward-compat:
+// nil or empty SkipBuiltins must produce identical behaviour to the
+// pre-feature call (all builtins register).
+func TestRegisterBuiltins_SkipBuiltins_EmptyNoOp(t *testing.T) {
+	t.Parallel()
+	reg := agentictools.NewExecutorRegistry()
+	err := RegisterBuiltins(context.Background(), reg, ToolDependencies{
+		Logger:       slog.Default(),
+		SkipBuiltins: nil,
+	})
+	if err != nil {
+		t.Fatalf("nil SkipBuiltins: %v", err)
+	}
+	if !containsName(reg.ListTools(), "bash") {
+		t.Errorf("bash should register when SkipBuiltins is nil")
+	}
+
+	reg2 := agentictools.NewExecutorRegistry()
+	err = RegisterBuiltins(context.Background(), reg2, ToolDependencies{
+		Logger:       slog.Default(),
+		SkipBuiltins: []string{},
+	})
+	if err != nil {
+		t.Fatalf("empty SkipBuiltins: %v", err)
+	}
+	if !containsName(reg2.ListTools(), "bash") {
+		t.Errorf("bash should register when SkipBuiltins is empty")
+	}
+}
+
+// TestBuiltinGroupKeys_Stability locks the canonical set + ordering
+// of BuiltinGroupKeys. External callers iterate this slice for
+// validation/docs; reordering or renaming an entry is a BREAKING
+// change worth flagging at PR review.
+func TestBuiltinGroupKeys_Stability(t *testing.T) {
+	t.Parallel()
+	want := []string{
+		"bash", "web_search", "http_request",
+		"read_loop_result", "decide", "emit_diagnosis",
+		"write_todos", "scratchpad",
+		"summarize_graph", "search_graph", "flow_monitor",
+		"github", "graph_query",
+		"rules", "flows", "personas", "flow_templates",
+		"component_catalog",
+	}
+	if len(BuiltinGroupKeys) != len(want) {
+		t.Fatalf("BuiltinGroupKeys count = %d, want %d. Adding a builtin? Update this test AND consumer docs.", len(BuiltinGroupKeys), len(want))
+	}
+	for i, k := range want {
+		if BuiltinGroupKeys[i] != k {
+			t.Errorf("BuiltinGroupKeys[%d] = %q, want %q. Order matters for golden-test reproducibility.", i, BuiltinGroupKeys[i], k)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Lets product-shell callers opt out of specific builtin tool registrations so they can register their own implementation under the canonical name. Closes the semteams ask filed 2026-05-14 where they need to wrap `bash` for chain-scoped sandbox routing while keeping the canonical name (LLM training distribution; 3 real-LLM smokes burned ~\$3-5 surfacing the gap).

## API shape (one design refinement from the ask)

semteams proposed a separate `RegisterBuiltinsOptions` struct passed variadically. This PR adds the field directly on the existing `ToolDependencies` struct instead — same outcome, smaller surface, matches the project convention from `feedback_go_signatures` memory (\"4+ args → request struct, add fields rather than growing arg lists\").

\`\`\`go
type ToolDependencies struct {
    ...existing fields...
    SkipBuiltins []string  // NEW
}
\`\`\`

Backward-compat: zero value = today's behaviour (every builtin registers).

## Group keys

`BuiltinGroupKeys` (exported var) is the canonical list. Documented in field doc, locked by a stability test:

| Group type | Keys |
|---|---|
| Single-tool (key = tool name) | `bash`, `web_search`, `http_request`, `read_loop_result`, `decide`, `emit_diagnosis`, `write_todos`, `scratchpad`, `summarize_graph`, `search_graph`, `flow_monitor` |
| Multi-tool (key = domain label) | `github`, `graph_query`, `rules`, `flows`, `personas`, `flow_templates`, `component_catalog` |

For multi-tool: the executor registers under multiple names via `RegisterExecutor` (atomic); the group key skips all-or-nothing. If a future use case needs partial skip (\"keep `query_entity` but skip `query_relationships`\"), that's a separate refactor.

## Validation

Unknown skip name returns an error **before any registration happens** with the full valid set in the message — operators self-correct without grepping source:

\`\`\`
SkipBuiltins: []string{\"bahs\"} →
  RegisterBuiltins: unknown builtin group key \"bahs\" in SkipBuiltins;
  valid keys: [bash web_search http_request ...]
\`\`\`

## Usage (semteams)

\`\`\`go
if err := executors.RegisterBuiltins(ctx, reg, executors.ToolDependencies{
    NATSClient:   client,
    Platform:     plat,
    Logger:       logger,
    SkipBuiltins: []string{\"bash\"},  // we'll register our own
}); err != nil { ... }

// Now register the chain-scoped wrapper under the canonical name
if err := reg.RegisterTool(\"bash\", chainSandboxBash); err != nil { ... }
\`\`\`

## Test plan

- [x] 5 new test functions covering: canonical bash skip + replacement, multi-tool group skip, multiple skips compose, unknown name errors, empty/nil backward-compat, `BuiltinGroupKeys` stability lock
- [x] \`go test -race ./...\` — 96 ok, 0 fail
- [x] \`task lint\` clean
- [x] \`task schema:generate\` — no drift (internal Go API only)
- [x] \`go vet -tags=integration ./...\` clean
- [x] \`go vet -tags=live_llm ./...\` clean

## Bundle

Lands in beta.72 alongside:
- PR #68 — ADR-040 (boid retirement, merged)
- PR #71 — ADR-041 (evaluator unification, merged)
- PR #72 — boid code removal (merged)
- PR #73 — Go 1.26.3 bump + race fix (in CI)
- **This PR — SkipBuiltins**

Non-BREAKING addition. semteams + semspec both pin beta.72 to pick this up; semteams uses it immediately for the bash wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)