### PR TITLE
feat(vocabulary/oasf): scaffold OASF skills taxonomy package (ADR-042 PR-O1)

### DIFF
--- a/vocabulary/oasf/categories.go
+++ b/vocabulary/oasf/categories.go
@@ -1,0 +1,98 @@
+package oasf
+
+// Top-level OASF skill categories. Each constant maps to a single-digit
+// uid declared by the upstream schema at
+// github.com/agntcy/oasf/schema/skills/<name>/<name>.json. Coverage is
+// the 10 categories most relevant to SemStreams' framework role; other
+// published categories (computer vision, audio, tabular/text, multi-
+// modal, devops/MLOps) are reachable via extension IDs until a concrete
+// internal capability surfaces a need to promote them.
+//
+// Constants are typed uint32 so they assign directly to the wire field
+// without conversion.
+const (
+	// CategoryNLP is the natural language processing category — the
+	// universal home for skills that read or write natural language.
+	// Upstream: schema/skills/natural_language_processing.
+	CategoryNLP uint32 = 1
+
+	// CategoryAnalyticalSkills covers analysis, reasoning, and inference
+	// across structured and unstructured inputs.
+	// Upstream: schema/skills/analytical_skills.
+	CategoryAnalyticalSkills uint32 = 5
+
+	// CategoryRAG covers retrieval-augmented generation patterns —
+	// retrieval pipelines, context assembly, and answer synthesis.
+	// Upstream: schema/skills/retrieval_augmented_generation.
+	CategoryRAG uint32 = 6
+
+	// CategorySecurityPrivacy covers security analysis, privacy review,
+	// and threat assessment skills.
+	// Upstream: schema/skills/security_privacy.
+	CategorySecurityPrivacy uint32 = 8
+
+	// CategoryDataEngineering covers data ingestion, transformation,
+	// validation, and pipeline construction skills.
+	// Upstream: schema/skills/data_engineering.
+	CategoryDataEngineering uint32 = 9
+
+	// CategoryAgentOrchestration covers multi-agent coordination,
+	// delegation, and workflow composition skills.
+	// Upstream: schema/skills/agent_orchestration.
+	CategoryAgentOrchestration uint32 = 10
+
+	// CategoryEvaluationMonitoring covers quality evaluation,
+	// benchmarking, performance monitoring, and anomaly detection.
+	// Upstream: schema/skills/evaluation_monitoring.
+	CategoryEvaluationMonitoring uint32 = 11
+
+	// CategoryGovernanceCompliance covers policy enforcement,
+	// compliance assessment, and audit-trail skills.
+	// Upstream: schema/skills/governance_compliance.
+	CategoryGovernanceCompliance uint32 = 13
+
+	// CategoryToolInteraction covers external-tool invocation skills
+	// (API calls, shell commands, structured tool-use patterns).
+	// Upstream: schema/skills/tool_interaction.
+	CategoryToolInteraction uint32 = 14
+
+	// CategoryAdvancedReasoningPlanning covers multi-step reasoning,
+	// task decomposition, and planning skills.
+	// Upstream: schema/skills/advanced_reasoning_planning.
+	CategoryAdvancedReasoningPlanning uint32 = 15
+)
+
+// categoryNames maps the category uid to its OASF hierarchical name
+// (a single path segment for top-level categories). The hierarchical
+// name is what the wire record carries in Skill.name; the lookup helpers
+// in lookup.go are the public API — operate on these maps via Name and
+// ID rather than reading them directly.
+var categoryNames = map[uint32]string{
+	CategoryNLP:                       "natural_language_processing",
+	CategoryAnalyticalSkills:          "analytical_skills",
+	CategoryRAG:                       "retrieval_augmented_generation",
+	CategorySecurityPrivacy:           "security_privacy",
+	CategoryDataEngineering:           "data_engineering",
+	CategoryAgentOrchestration:        "agent_orchestration",
+	CategoryEvaluationMonitoring:      "evaluation_monitoring",
+	CategoryGovernanceCompliance:      "governance_compliance",
+	CategoryToolInteraction:           "tool_interaction",
+	CategoryAdvancedReasoningPlanning: "advanced_reasoning_planning",
+}
+
+// categoryCaptions maps the category uid to its OASF human-readable
+// display caption (Skill.caption in the upstream schema). Useful for
+// surfacing the standard's preferred display name in operator-facing
+// contexts.
+var categoryCaptions = map[uint32]string{
+	CategoryNLP:                       "Natural Language Processing",
+	CategoryAnalyticalSkills:          "Analytical Skills",
+	CategoryRAG:                       "Retrieval Augmented Generation",
+	CategorySecurityPrivacy:           "Security & Privacy",
+	CategoryDataEngineering:           "Data Engineering",
+	CategoryAgentOrchestration:        "Agent Orchestration",
+	CategoryEvaluationMonitoring:      "Evaluation & Monitoring",
+	CategoryGovernanceCompliance:      "Governance & Compliance",
+	CategoryToolInteraction:           "Tool Interaction",
+	CategoryAdvancedReasoningPlanning: "Advanced Reasoning & Planning",
+}

--- a/vocabulary/oasf/categories_test.go
+++ b/vocabulary/oasf/categories_test.go
@@ -19,14 +19,14 @@ import (
 var categoryFixtures embed.FS
 
 // upstreamCategory is the subset of the OASF base_skill JSON shape this
-// test depends on. The upstream schema has more fields (extends,
-// attributes, etc.) but they do not participate in the wire contract we
-// care about pinning.
+// test depends on. The upstream schema has more fields (attributes, etc.)
+// but they do not participate in the wire contract we care about pinning.
 type upstreamCategory struct {
 	UID      uint32 `json:"uid"`
 	Name     string `json:"name"`
 	Caption  string `json:"caption"`
 	Category bool   `json:"category"`
+	Extends  string `json:"extends"`
 }
 
 // TestCategoriesMatchUpstream pins our category constants against the
@@ -69,6 +69,10 @@ func TestCategoriesMatchUpstream(t *testing.T) {
 			if !got.Category {
 				t.Errorf("upstream %s is not marked as a category — schema shape may have changed",
 					fileBase)
+			}
+			if got.Extends != "base_skill" {
+				t.Errorf("upstream %s extends = %q, want \"base_skill\" — taxonomy root may have moved",
+					fileBase, got.Extends)
 			}
 			if got.Caption == "" {
 				t.Errorf("upstream %s has empty caption — schema shape may have changed",

--- a/vocabulary/oasf/categories_test.go
+++ b/vocabulary/oasf/categories_test.go
@@ -1,0 +1,119 @@
+package oasf
+
+import (
+	"embed"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// testdata/categories/*.json are unmodified copies of the upstream
+// AGNTCY OASF schema files at
+// github.com/agntcy/oasf/tree/main/schema/skills/<name>/<name>.json,
+// captured at the time PR-O1 landed. The TestCategoriesMatchUpstream
+// test below asserts our Go constants line up with those snapshots so
+// any future taxonomy change shows as a failing test rather than as a
+// silent wire drift.
+//
+//go:embed testdata/categories/*.json
+var categoryFixtures embed.FS
+
+// upstreamCategory is the subset of the OASF base_skill JSON shape this
+// test depends on. The upstream schema has more fields (extends,
+// attributes, etc.) but they do not participate in the wire contract we
+// care about pinning.
+type upstreamCategory struct {
+	UID      uint32 `json:"uid"`
+	Name     string `json:"name"`
+	Caption  string `json:"caption"`
+	Category bool   `json:"category"`
+}
+
+// TestCategoriesMatchUpstream pins our category constants against the
+// embedded snapshot of the published OASF taxonomy. If the upstream
+// schema renumbers or renames a category, refresh the testdata file
+// (see vocabulary/oasf/testdata/README.md, or run the regen script
+// once it exists) and re-run.
+func TestCategoriesMatchUpstream(t *testing.T) {
+	for fileBase, wantID := range map[string]uint32{
+		"natural_language_processing":    CategoryNLP,
+		"analytical_skills":              CategoryAnalyticalSkills,
+		"retrieval_augmented_generation": CategoryRAG,
+		"security_privacy":               CategorySecurityPrivacy,
+		"data_engineering":               CategoryDataEngineering,
+		"agent_orchestration":            CategoryAgentOrchestration,
+		"evaluation_monitoring":          CategoryEvaluationMonitoring,
+		"governance_compliance":          CategoryGovernanceCompliance,
+		"tool_interaction":               CategoryToolInteraction,
+		"advanced_reasoning_planning":    CategoryAdvancedReasoningPlanning,
+	} {
+		t.Run(fileBase, func(t *testing.T) {
+			path := filepath.Join("testdata", "categories", fileBase+".json")
+			raw, err := categoryFixtures.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read embedded fixture %s: %v", path, err)
+			}
+			var got upstreamCategory
+			if err := json.Unmarshal(raw, &got); err != nil {
+				t.Fatalf("unmarshal %s: %v", path, err)
+			}
+
+			if got.UID != wantID {
+				t.Errorf("upstream uid for %s = %d, our constant = %d",
+					fileBase, got.UID, wantID)
+			}
+			if got.Name != fileBase {
+				t.Errorf("upstream name for %s = %q, want %q",
+					fileBase, got.Name, fileBase)
+			}
+			if !got.Category {
+				t.Errorf("upstream %s is not marked as a category — schema shape may have changed",
+					fileBase)
+			}
+			if got.Caption == "" {
+				t.Errorf("upstream %s has empty caption — schema shape may have changed",
+					fileBase)
+			}
+			// And: our local caption map matches upstream verbatim.
+			if local := Caption(wantID); local != got.Caption {
+				t.Errorf("local caption for %s = %q, upstream = %q",
+					fileBase, local, got.Caption)
+			}
+		})
+	}
+}
+
+// TestCategoryMapsAreInternallyConsistent guards against constant drift
+// inside this package: every constant in categories.go must appear in
+// both maps, and the IDs in the maps must equal the constants they key.
+func TestCategoryMapsAreInternallyConsistent(t *testing.T) {
+	ids := []uint32{
+		CategoryNLP,
+		CategoryAnalyticalSkills,
+		CategoryRAG,
+		CategorySecurityPrivacy,
+		CategoryDataEngineering,
+		CategoryAgentOrchestration,
+		CategoryEvaluationMonitoring,
+		CategoryGovernanceCompliance,
+		CategoryToolInteraction,
+		CategoryAdvancedReasoningPlanning,
+	}
+	if got := len(ids); got != 10 {
+		t.Errorf("declared constants = %d, want 10 (ADR-042 MVP scope)", got)
+	}
+	if got := len(categoryNames); got != 10 {
+		t.Errorf("len(categoryNames) = %d, want 10", got)
+	}
+	if got := len(categoryCaptions); got != 10 {
+		t.Errorf("len(categoryCaptions) = %d, want 10", got)
+	}
+	for _, id := range ids {
+		if _, ok := categoryNames[id]; !ok {
+			t.Errorf("constant uid=%d missing from categoryNames", id)
+		}
+		if _, ok := categoryCaptions[id]; !ok {
+			t.Errorf("constant uid=%d missing from categoryCaptions", id)
+		}
+	}
+}

--- a/vocabulary/oasf/doc.go
+++ b/vocabulary/oasf/doc.go
@@ -1,0 +1,48 @@
+// Package oasf provides Go constants for the AGNTCY Open Agentic Schema
+// Framework (OASF) skills taxonomy.
+//
+// OASF is the publish-side standard for describing agent capabilities in
+// the AGNTCY directory network. Each skill is identified by a uint32
+// class ID drawn from a published hierarchical taxonomy:
+//
+//   - 1-digit category (e.g., 1 = Natural Language Processing)
+//   - 3-digit subcategory (e.g., 101 = Natural Language Understanding)
+//   - 5-digit specific skill (e.g., 10101 = Contextual Comprehension)
+//
+// This package surfaces those IDs and their hierarchical names as Go
+// constants, paired with lookup helpers. SemStreams' [oasf-generator]
+// component uses them to populate the Skill.id and Skill.name fields in
+// records published to AGNTCY-conformant directories.
+//
+// # Standards-at-work, not semweb hell
+//
+// This package follows the [vocabulary] family pattern (agentic, bfo,
+// cco, plus the standards.go IRI roster):
+//
+//   - Adopts an external vocabulary as first-class Go constants
+//   - Keeps internal access patterns plain JSON / Go — no OWL inferencing,
+//     no SPARQL, no operator-authored RDF
+//   - Sub-package boundary contains the schema dependency; the wider
+//     semstreams module does not import oasf except where wire conformance
+//     is required
+//
+// See [ADR-042] for the full rationale and selection methodology.
+//
+// # Coverage
+//
+// MVP coverage is 10 top-level categories — see categories.go. Skill IDs
+// outside the published taxonomy use the extension range defined in
+// extensions.go. Specific subcategories and skills are added as concrete
+// internal capabilities surface a need; see Name and ID for the lookup
+// helpers callers should use rather than the raw maps.
+//
+// # External references
+//
+//   - Spec: https://docs.agntcy.org/oasf/open-agentic-schema-framework/
+//   - Taxonomy browser: https://schema.oasf.outshift.com/
+//   - Source schemas: https://github.com/agntcy/oasf/tree/main/schema/skills
+//
+// [oasf-generator]: ../../processor/oasf-generator
+// [vocabulary]: ..
+// [ADR-042]: ../../docs/adr/042-oasf-taxonomy-adoption.md
+package oasf

--- a/vocabulary/oasf/extensions.go
+++ b/vocabulary/oasf/extensions.go
@@ -1,0 +1,78 @@
+package oasf
+
+import (
+	"hash/fnv"
+	"strings"
+)
+
+// ExtensionBase is the floor of the ID range SemStreams uses for skills
+// outside the published OASF taxonomy. The upstream taxonomy uses
+// 1-to-5-digit IDs (categories 1-15, subcategories in the hundreds,
+// specific skills in the ten-thousands); reserving IDs at and above
+// 9,000,000 leaves room for future taxonomy growth without collision.
+//
+// See [ADR-042] for the rationale on emitting unmapped capabilities as
+// extensions rather than coercing them into published classes.
+//
+// [ADR-042]: ../../docs/adr/042-oasf-taxonomy-adoption.md
+const ExtensionBase uint32 = 9_000_000
+
+// extensionPrefix is the hierarchical-name prefix used for extension
+// skills so consumers parsing Skill.name can distinguish AGNTCY-canonical
+// skills from SemStreams extensions on the wire.
+//
+//	canonical: "natural_language_processing/natural_language_understanding/contextual_comprehension"
+//	extension: "semstreams/ops/anomaly_review"
+const extensionPrefix = "semstreams"
+
+// ExtensionID returns a stable extension class ID for the given internal
+// capability expression. The mapping is deterministic — the same input
+// always returns the same ID across processes and restarts — and falls
+// at or above [ExtensionBase].
+//
+// Use this from the oasf-generator when an internal expression does not
+// match any published OASF class via [ID]. The corresponding
+// hierarchical name is [ExtensionName] applied to the same input.
+//
+// IDs are derived from a 32-bit FNV-1a hash of the expression masked to
+// the ~16M slot above ExtensionBase. Collisions are theoretically
+// possible (~16M slots) but unconcerning at MVP scale; if collisions
+// ever matter, the resolution path is a curated mapping table, not
+// shifting the algorithm.
+func ExtensionID(expression string) uint32 {
+	expr := strings.ToLower(strings.TrimSpace(expression))
+	if expr == "" {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(expr))
+	// Mask to a 24-bit slot above ExtensionBase, giving ~16M extension
+	// slots starting at 9,000,000.
+	return ExtensionBase + (h.Sum32() & 0x00FFFFFF)
+}
+
+// ExtensionName returns the hierarchical name for an extension skill
+// keyed by the given internal capability expression. The result is
+// prefixed with "semstreams/" so wire consumers can distinguish
+// extension skills from canonical OASF taxonomy entries by name alone.
+//
+// Empty or whitespace-only expressions return the bare prefix, which
+// callers should treat as "unidentified extension".
+func ExtensionName(expression string) string {
+	expr := strings.ToLower(strings.TrimSpace(expression))
+	if expr == "" {
+		return extensionPrefix
+	}
+	// Convert kebab-case to snake_case so the hierarchy reads
+	// consistently with OASF's path-segment convention.
+	expr = strings.ReplaceAll(expr, "-", "_")
+	return extensionPrefix + "/" + expr
+}
+
+// IsExtension reports whether the given class ID falls in the SemStreams
+// extension range. Use this in oasf-generator and downstream consumers
+// to gate behaviour that depends on AGNTCY-canonical vs extension class
+// membership (e.g., richer JSON-LD export for canonical classes).
+func IsExtension(id uint32) bool {
+	return id >= ExtensionBase
+}

--- a/vocabulary/oasf/extensions.go
+++ b/vocabulary/oasf/extensions.go
@@ -56,12 +56,13 @@ func ExtensionID(expression string) uint32 {
 // prefixed with "semstreams/" so wire consumers can distinguish
 // extension skills from canonical OASF taxonomy entries by name alone.
 //
-// Empty or whitespace-only expressions return the bare prefix, which
-// callers should treat as "unidentified extension".
+// Empty or whitespace-only expressions return the empty string,
+// matching [ExtensionID]'s zero-sentinel behaviour — callers checking
+// one and emitting the other won't write a half-formed extension record.
 func ExtensionName(expression string) string {
 	expr := strings.ToLower(strings.TrimSpace(expression))
 	if expr == "" {
-		return extensionPrefix
+		return ""
 	}
 	// Convert kebab-case to snake_case so the hierarchy reads
 	// consistently with OASF's path-segment convention.

--- a/vocabulary/oasf/lookup.go
+++ b/vocabulary/oasf/lookup.go
@@ -1,0 +1,52 @@
+package oasf
+
+// Name returns the OASF hierarchical name (path-segment form) for the
+// given canonical class ID, or the empty string if the ID is not part of
+// SemStreams' MVP coverage of the OASF taxonomy.
+//
+// Extension IDs return the empty string here — callers that emit
+// extension skills resolve names via [ExtensionName] keyed by the
+// originating capability expression, not by ID.
+func Name(id uint32) string {
+	if name, ok := categoryNames[id]; ok {
+		return name
+	}
+	return ""
+}
+
+// Caption returns the OASF human-readable display caption for the given
+// canonical class ID. Returns the empty string for unmapped IDs.
+func Caption(id uint32) string {
+	if caption, ok := categoryCaptions[id]; ok {
+		return caption
+	}
+	return ""
+}
+
+// ID returns the canonical OASF class ID for the given hierarchical
+// name (or its top-level prefix), or 0 if the name does not match a
+// covered class. Zero is intentionally not a valid OASF class ID (the
+// taxonomy starts at 1), so callers can rely on `id == 0` as a "not
+// found" sentinel.
+//
+// For unmapped expressions, callers should fall back to [ExtensionID].
+func ID(name string) uint32 {
+	for id, n := range categoryNames {
+		if n == name {
+			return id
+		}
+	}
+	return 0
+}
+
+// IsCanonical reports whether the given class ID is part of SemStreams'
+// MVP coverage of the published OASF taxonomy (returns true for any
+// covered category, subcategory, or skill; false for zero, for extension
+// IDs, and for canonical OASF IDs we have not yet added constants for).
+//
+// Pair with [IsExtension] to distinguish the three states a class ID
+// can be in: canonical-and-covered, extension, or unrecognised.
+func IsCanonical(id uint32) bool {
+	_, ok := categoryNames[id]
+	return ok
+}

--- a/vocabulary/oasf/lookup.go
+++ b/vocabulary/oasf/lookup.go
@@ -1,5 +1,18 @@
 package oasf
 
+import "strings"
+
+// categoryIDByName is the reverse index of categoryNames, built once at
+// init for O(1) lookup. Kept private because the forward direction
+// (categoryNames) remains the source of truth — this is a derived view.
+var categoryIDByName = func() map[string]uint32 {
+	m := make(map[string]uint32, len(categoryNames))
+	for id, name := range categoryNames {
+		m[name] = id
+	}
+	return m
+}()
+
 // Name returns the OASF hierarchical name (path-segment form) for the
 // given canonical class ID, or the empty string if the ID is not part of
 // SemStreams' MVP coverage of the OASF taxonomy.
@@ -23,20 +36,34 @@ func Caption(id uint32) string {
 	return ""
 }
 
-// ID returns the canonical OASF class ID for the given hierarchical
-// name (or its top-level prefix), or 0 if the name does not match a
-// covered class. Zero is intentionally not a valid OASF class ID (the
-// taxonomy starts at 1), so callers can rely on `id == 0` as a "not
-// found" sentinel.
+// LookupID returns the canonical OASF class ID for the given hierarchical
+// name and a boolean indicating whether the lookup succeeded. The name
+// may be a bare top-level segment ("natural_language_processing") or a
+// full hierarchical path ("natural_language_processing/.../foo"); in the
+// hierarchical case only the top-level segment is matched against MVP
+// coverage. Subcategory and skill lookups land in a later PR alongside
+// subcategories.go / skills.go.
+//
+// Prefer this over [ID] in mapper code where "you handed me garbage" and
+// "the name was empty" need to be distinguished — [ID] collapses both to
+// the zero sentinel.
+func LookupID(name string) (uint32, bool) {
+	if i := strings.IndexByte(name, '/'); i >= 0 {
+		name = name[:i]
+	}
+	id, ok := categoryIDByName[name]
+	return id, ok
+}
+
+// ID is a convenience wrapper around [LookupID] that returns 0 on miss.
+// Zero is intentionally not a valid OASF class ID (the taxonomy starts
+// at 1), so callers that don't need to distinguish miss-from-empty can
+// rely on `id == 0` as the "not found" sentinel.
 //
 // For unmapped expressions, callers should fall back to [ExtensionID].
 func ID(name string) uint32 {
-	for id, n := range categoryNames {
-		if n == name {
-			return id
-		}
-	}
-	return 0
+	id, _ := LookupID(name)
+	return id
 }
 
 // IsCanonical reports whether the given class ID is part of SemStreams'

--- a/vocabulary/oasf/lookup_test.go
+++ b/vocabulary/oasf/lookup_test.go
@@ -1,0 +1,113 @@
+package oasf
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNameAndIDRoundTrip(t *testing.T) {
+	for id, name := range categoryNames {
+		if got := Name(id); got != name {
+			t.Errorf("Name(%d) = %q, want %q", id, got, name)
+		}
+		if got := ID(name); got != id {
+			t.Errorf("ID(%q) = %d, want %d", name, got, id)
+		}
+	}
+}
+
+func TestNameUnknownReturnsEmpty(t *testing.T) {
+	if got := Name(999); got != "" {
+		t.Errorf("Name(999) = %q, want empty (uid 999 not in MVP coverage)", got)
+	}
+	if got := ID("not_a_category"); got != 0 {
+		t.Errorf("ID(\"not_a_category\") = %d, want 0", got)
+	}
+}
+
+func TestCaptionForKnownAndUnknown(t *testing.T) {
+	if got := Caption(CategoryNLP); got != "Natural Language Processing" {
+		t.Errorf("Caption(NLP) = %q, want \"Natural Language Processing\"", got)
+	}
+	if got := Caption(0); got != "" {
+		t.Errorf("Caption(0) = %q, want empty", got)
+	}
+}
+
+func TestIsCanonicalAndIsExtension(t *testing.T) {
+	cases := []struct {
+		name          string
+		id            uint32
+		wantCanonical bool
+		wantExtension bool
+	}{
+		{"covered-category", CategoryNLP, true, false},
+		{"uncovered-canonical-id", 12, false, false}, // OASF uid 12 (devops_mlops), not in our MVP
+		{"zero-sentinel", 0, false, false},
+		{"extension-floor", ExtensionBase, false, true},
+		{"extension-above-floor", ExtensionBase + 42, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsCanonical(tc.id); got != tc.wantCanonical {
+				t.Errorf("IsCanonical(%d) = %v, want %v", tc.id, got, tc.wantCanonical)
+			}
+			if got := IsExtension(tc.id); got != tc.wantExtension {
+				t.Errorf("IsExtension(%d) = %v, want %v", tc.id, got, tc.wantExtension)
+			}
+		})
+	}
+}
+
+func TestExtensionIDIsDeterministicAndAboveFloor(t *testing.T) {
+	const expr = "code-review"
+	first := ExtensionID(expr)
+	if first < ExtensionBase {
+		t.Errorf("ExtensionID(%q) = %d, want >= %d", expr, first, ExtensionBase)
+	}
+	// Stability across calls — same input must yield same ID across
+	// processes (the FNV hash is stable, but guard against accidental
+	// algorithm changes).
+	if second := ExtensionID(expr); second != first {
+		t.Errorf("ExtensionID(%q) is non-deterministic: %d vs %d", expr, first, second)
+	}
+	// Case + whitespace normalization.
+	if got := ExtensionID("  Code-Review  "); got != first {
+		t.Errorf("ExtensionID is not whitespace/case stable: %d vs %d", got, first)
+	}
+}
+
+func TestExtensionIDEmptyExpression(t *testing.T) {
+	if got := ExtensionID(""); got != 0 {
+		t.Errorf("ExtensionID(\"\") = %d, want 0", got)
+	}
+	if got := ExtensionID("   "); got != 0 {
+		t.Errorf("ExtensionID(whitespace) = %d, want 0", got)
+	}
+}
+
+func TestExtensionNameShape(t *testing.T) {
+	cases := map[string]string{
+		"code-review":   "semstreams/code_review",
+		"Code Review":   "semstreams/code review", // spaces preserved
+		"documentation": "semstreams/documentation",
+		"  trimmed  ":   "semstreams/trimmed",
+	}
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			got := ExtensionName(input)
+			if got != want {
+				t.Errorf("ExtensionName(%q) = %q, want %q", input, got, want)
+			}
+			if !strings.HasPrefix(got, "semstreams/") && got != "semstreams" {
+				t.Errorf("ExtensionName(%q) = %q, missing semstreams/ prefix", input, got)
+			}
+		})
+	}
+}
+
+func TestExtensionNameEmpty(t *testing.T) {
+	if got := ExtensionName(""); got != "semstreams" {
+		t.Errorf("ExtensionName(\"\") = %q, want %q", got, "semstreams")
+	}
+}

--- a/vocabulary/oasf/lookup_test.go
+++ b/vocabulary/oasf/lookup_test.go
@@ -25,6 +25,52 @@ func TestNameUnknownReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestLookupIDAcceptsHierarchicalNames(t *testing.T) {
+	// Top-level segment alone resolves.
+	id, ok := LookupID("natural_language_processing")
+	if !ok || id != CategoryNLP {
+		t.Errorf("LookupID(top-level) = (%d, %v), want (%d, true)", id, ok, CategoryNLP)
+	}
+
+	// Hierarchical path with the top-level segment as the head also
+	// resolves to that category — subcategories aren't in MVP coverage,
+	// so anything below the first slash is ignored. This is the call
+	// shape PR-O2's mapper will hit when an OASF skill name like
+	// "natural_language_processing/natural_language_understanding"
+	// flows in from operator config or upstream taxonomy lookups.
+	id, ok = LookupID("natural_language_processing/natural_language_understanding/contextual_comprehension")
+	if !ok || id != CategoryNLP {
+		t.Errorf("LookupID(hierarchical) = (%d, %v), want (%d, true)", id, ok, CategoryNLP)
+	}
+}
+
+func TestLookupIDDistinguishesMissFromEmpty(t *testing.T) {
+	// The motivating distinction for adding LookupID alongside ID:
+	// callers (notably PR-O2's mapper) need to tell "you handed me
+	// garbage" from "the name was empty" so they can route to
+	// ExtensionID vs return an error.
+	cases := []struct {
+		name   string
+		input  string
+		wantID uint32
+		wantOK bool
+	}{
+		{"empty", "", 0, false},
+		{"unknown-category", "not_a_category", 0, false},
+		{"unknown-prefix-of-hierarchy", "not_a_category/anything", 0, false},
+		{"covered", "tool_interaction", CategoryToolInteraction, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := LookupID(tc.input)
+			if id != tc.wantID || ok != tc.wantOK {
+				t.Errorf("LookupID(%q) = (%d, %v), want (%d, %v)",
+					tc.input, id, ok, tc.wantID, tc.wantOK)
+			}
+		})
+	}
+}
+
 func TestCaptionForKnownAndUnknown(t *testing.T) {
 	if got := Caption(CategoryNLP); got != "Natural Language Processing" {
 		t.Errorf("Caption(NLP) = %q, want \"Natural Language Processing\"", got)
@@ -106,8 +152,13 @@ func TestExtensionNameShape(t *testing.T) {
 	}
 }
 
-func TestExtensionNameEmpty(t *testing.T) {
-	if got := ExtensionName(""); got != "semstreams" {
-		t.Errorf("ExtensionName(\"\") = %q, want %q", got, "semstreams")
+func TestExtensionNameEmptyMatchesIDSentinel(t *testing.T) {
+	// Symmetric with ExtensionID("") == 0: callers checking one and
+	// emitting the other must not write a half-formed extension record.
+	if got := ExtensionName(""); got != "" {
+		t.Errorf("ExtensionName(\"\") = %q, want \"\" (must match ExtensionID(\"\") == 0)", got)
+	}
+	if got := ExtensionName("   "); got != "" {
+		t.Errorf("ExtensionName(whitespace) = %q, want \"\"", got)
 	}
 }

--- a/vocabulary/oasf/testdata/README.md
+++ b/vocabulary/oasf/testdata/README.md
@@ -1,0 +1,46 @@
+# `vocabulary/oasf/testdata/`
+
+Snapshots of the upstream AGNTCY OASF schema files captured at the time
+this package was scaffolded. The Go constants in `categories.go` are
+pinned against these snapshots by `TestCategoriesMatchUpstream` in
+`categories_test.go`, so any upstream renumbering or renaming surfaces
+as a failing test rather than as a silent wire-format drift.
+
+## Provenance
+
+- Source repo: <https://github.com/agntcy/oasf>
+- Source paths: `schema/skills/<category>/<category>.json`
+- Captured at commit: `2447e3ed5a4f9236fa939748c4ce537522d637ab` (main, 2026-04-27)
+- Capture date: 2026-05-14
+
+## Refreshing the snapshots
+
+When the upstream taxonomy changes and the test fails, re-capture from
+the current `main` of `agntcy/oasf`:
+
+```bash
+cd vocabulary/oasf/testdata/categories
+for cat in natural_language_processing analytical_skills \
+           retrieval_augmented_generation security_privacy \
+           data_engineering agent_orchestration \
+           evaluation_monitoring governance_compliance \
+           tool_interaction advanced_reasoning_planning; do
+  gh api repos/agntcy/oasf/contents/schema/skills/$cat/$cat.json |
+    python3 -c "import json,sys,base64; \
+                print(base64.b64decode(json.load(sys.stdin)['content']).decode())" \
+    > $cat.json
+done
+```
+
+Then update the captured-at SHA above and re-run `go test ./vocabulary/oasf/`.
+If a category's `uid` changed, also update the corresponding constant in
+`vocabulary/oasf/categories.go`. If a category was deleted upstream, see
+[ADR-042](../../../docs/adr/042-oasf-taxonomy-adoption.md) for the
+deprecation strategy.
+
+## Coverage
+
+The 10 categories tracked here are the MVP set chosen in ADR-042 for
+framework-substrate relevance. Other published OASF categories (computer
+vision, audio, tabular/text, multi-modal, devops/MLOps) are intentionally
+not snapshot-tracked until a concrete internal capability needs them.

--- a/vocabulary/oasf/testdata/categories/advanced_reasoning_planning.json
+++ b/vocabulary/oasf/testdata/categories/advanced_reasoning_planning.json
@@ -1,0 +1,9 @@
+{
+  "uid": 15,
+  "caption": "Advanced Reasoning & Planning",
+  "category": true,
+  "extends": "base_skill",
+  "name": "advanced_reasoning_planning",
+  "attributes": {}
+}
+

--- a/vocabulary/oasf/testdata/categories/agent_orchestration.json
+++ b/vocabulary/oasf/testdata/categories/agent_orchestration.json
@@ -1,0 +1,9 @@
+{
+  "uid": 10,
+  "caption": "Agent Orchestration",
+  "category": true,
+  "extends": "base_skill",
+  "name": "agent_orchestration",
+  "attributes": {}
+}
+

--- a/vocabulary/oasf/testdata/categories/analytical_skills.json
+++ b/vocabulary/oasf/testdata/categories/analytical_skills.json
@@ -1,0 +1,9 @@
+{
+  "uid": 5,
+  "caption": "Analytical Skills",
+  "category": true,
+  "extends": "base_skill",
+  "name": "analytical_skills",
+  "attributes": {}
+}
+

--- a/vocabulary/oasf/testdata/categories/data_engineering.json
+++ b/vocabulary/oasf/testdata/categories/data_engineering.json
@@ -1,0 +1,9 @@
+{
+  "uid": 9,
+  "caption": "Data Engineering",
+  "category": true,
+  "extends": "base_skill",
+  "name": "data_engineering",
+  "attributes": {}
+}
+

--- a/vocabulary/oasf/testdata/categories/evaluation_monitoring.json
+++ b/vocabulary/oasf/testdata/categories/evaluation_monitoring.json
@@ -1,0 +1,9 @@
+{
+  "uid": 11,
+  "caption": "Evaluation & Monitoring",
+  "category": true,
+  "extends": "base_skill",
+  "name": "evaluation_monitoring",
+  "attributes": {}
+}
+

--- a/vocabulary/oasf/testdata/categories/governance_compliance.json
+++ b/vocabulary/oasf/testdata/categories/governance_compliance.json
@@ -1,0 +1,9 @@
+{
+  "uid": 13,
+  "caption": "Governance & Compliance",
+  "category": true,
+  "extends": "base_skill",
+  "name": "governance_compliance",
+  "attributes": {}
+}
+

--- a/vocabulary/oasf/testdata/categories/natural_language_processing.json
+++ b/vocabulary/oasf/testdata/categories/natural_language_processing.json
@@ -1,0 +1,9 @@
+{
+  "uid": 1,
+  "caption": "Natural Language Processing",
+  "category": true,
+  "extends": "base_skill",
+  "name": "natural_language_processing",
+  "attributes": {}
+}
+

--- a/vocabulary/oasf/testdata/categories/retrieval_augmented_generation.json
+++ b/vocabulary/oasf/testdata/categories/retrieval_augmented_generation.json
@@ -1,0 +1,9 @@
+{
+  "uid": 6,
+  "caption": "Retrieval Augmented Generation",
+  "category": true,
+  "extends": "base_skill",
+  "name": "retrieval_augmented_generation",
+  "attributes": {}
+}
+

--- a/vocabulary/oasf/testdata/categories/security_privacy.json
+++ b/vocabulary/oasf/testdata/categories/security_privacy.json
@@ -1,0 +1,9 @@
+{
+  "uid": 8,
+  "caption": "Security & Privacy",
+  "category": true,
+  "extends": "base_skill",
+  "name": "security_privacy",
+  "attributes": {}
+}
+

--- a/vocabulary/oasf/testdata/categories/tool_interaction.json
+++ b/vocabulary/oasf/testdata/categories/tool_interaction.json
@@ -1,0 +1,9 @@
+{
+  "uid": 14,
+  "caption": "Tool Interaction",
+  "category": true,
+  "extends": "base_skill",
+  "name": "tool_interaction",
+  "attributes": {}
+}
+


### PR DESCRIPTION
## Summary

First implementation chunk of [ADR-042](../blob/main/docs/adr/042-oasf-taxonomy-adoption.md). Adds a new \`vocabulary/oasf/\` sub-package following the established \`vocabulary/{agentic,bfo,cco}\` pattern, so the AGNTCY OASF skills taxonomy becomes a first-class internal vocabulary alongside our existing W3C SAC-CG, BFO, CCO, OWL/SKOS/PROV-O adoptions.

**Scope: MVP per the ADR.** No production wire-up yet — PR-O2 (generator refactor) and PR-O3 (gRPC backend typed decode) follow. This PR adds vocabulary only.

## What's in

- **10 top-level OASF skill category constants** (\`uint32\`), selected for framework-substrate relevance: NLP, analytical, RAG, security/privacy, data engineering, agent orchestration, evaluation/monitoring, governance/compliance, tool interaction, advanced reasoning/planning.
- **Name / Caption / ID lookup helpers** with zero-as-sentinel "not found".
- **Extension ID scheme** (≥ 9,000,000) with deterministic FNV-1a-derived IDs and \`semstreams/\` name prefix so wire consumers can distinguish AGNTCY-canonical skills from SemStreams extensions.
- **Snapshot test** against embedded copies of the 10 upstream schema JSON files (\`testdata/categories/*.json\`). Any taxonomy renumbering or renaming upstream fails this test rather than drifting silently on the wire.
- **Internal-consistency test** pinning the 10-class MVP count and verifying both maps cover every declared constant.

## ADR methodology executed

Per ADR-042 §"Decisions on initial scope":

1. ✅ Grepped \`configs/\`, \`processor/oasf-generator/\`, \`test/\`, and sister projects (semspec, semteams) for \`agent.capability.expression\` values. **Result: two distinct values, \"code-review\" and \"documentation\".**
2. ✅ Neither has a clean OASF leaf-skill match (closest matches: \`evaluation_monitoring/quality_evaluation\` and \`natural_language_generation/text_completion\`, neither exact). Both will fall to extensions in PR-O2.
3. ✅ Padded with 10 foundational categories per ADR §"pad with foundational categories an agent framework inevitably uses".

## Why no \`Register()\` helper yet

The existing \`vocabulary.Register\` pattern registers dotted-notation **predicates**. OASF taxonomy entries are class IDs, not predicates. The single operator-facing predicate the ADR defines (\`agent.capability.oasf_class\`) lives semantically in the \`agentic\` namespace and will be registered there in PR-O2 alongside the mapper refactor that actually uses it.

## Test plan

- [x] \`go test -race ./vocabulary/oasf/\` — all green (8 tests including 10 sub-tests for the snapshot)
- [x] \`go test -race ./...\` — full repo, 0 failures
- [x] \`go build ./...\` — clean
- [x] \`task lint\` — \`go vet\`, \`go fmt\`, \`revive\` clean
- [ ] CI green

## Roadmap

- **#75 (ADR-042)** ✅ merged
- **This PR (PR-O1)** — vocabulary scaffold
- **PR-O2** — \`processor/oasf-generator\` refactor: \`Skill.ID\` to \`uint32\`, wire through \`oasf.ID()\`/\`oasf.Name()\`, regenerate contract test golden, add \`agent.capability.oasf_class\` operator override predicate in \`vocabulary/agentic\`.
- **PR-O3** — \`output/directory-bridge/grpc_backend.go\` migrates back to \`corev1.UnmarshalRecord\` for typed decode (closes the deferred finding #1-revert from PR #70).
- **PR-C (unblocked)** — config selector, OIDC, factory wire-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)