### PR TITLE
feat(directory-bridge): typed Decode at marshal boundary (ADR-042 PR-O3)

### DIFF
--- a/output/directory-bridge/grpc_backend.go
+++ b/output/directory-bridge/grpc_backend.go
@@ -10,7 +10,6 @@ import (
 	corev1 "github.com/agntcy/dir/api/core/v1"
 	storev1 "github.com/agntcy/dir/api/store/v1"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // GRPCBackend implements Backend by talking to an AGNTCY-compatible
@@ -178,21 +177,27 @@ func (b *GRPCBackend) Close() error {
 }
 
 // oasfToProtoRecord converts our domain OASFRecord into the wire-level
-// core.v1.Record. The proto carries the record as an opaque
-// google.protobuf.Struct, so we hand-roll JSON → structpb instead of
-// using corev1.UnmarshalRecord — that helper enforces the AGNTCY typed
-// proto OASF schema (which has numeric Skill.id as uint32), but our
-// oasf-generator emits string Skill.id values per our internal OASF
-// shape. Aligning the two schemas is out of scope for PR-B; see the
-// pr70-deferred-review-findings memory for the schema-alignment task.
+// core.v1.Record using the AGNTCY SDK's corev1.UnmarshalRecord helper.
+// The helper performs the JSON → structpb conversion AND runs the
+// typed-proto Decode against the schema_version discriminator (1.x → v1,
+// 0.8.x → v1alpha2, 0.7.x → v1alpha1) — so malformed records fail here
+// at the publisher's marshalling boundary instead of as an opaque
+// stream error 50ms later at the directory.
+//
+// Routing through UnmarshalRecord became viable in PR-O2 once the
+// oasf-generator switched from string Skill.IDs to uint32 (per ADR-042).
+// Pre-PR-O2 records would have failed Decode with
+// "json: cannot unmarshal string into Go struct field Skill.skills.id
+// of type uint32"; the typed validation here is exactly the kind of
+// pre-flight check the original go-reviewer pass on PR-B recommended.
 func oasfToProtoRecord(rec any) (*corev1.Record, error) {
 	jsonBytes, err := json.Marshal(rec)
 	if err != nil {
 		return nil, fmt.Errorf("marshal record to JSON: %w", err)
 	}
-	data := &structpb.Struct{}
-	if err := data.UnmarshalJSON(jsonBytes); err != nil {
-		return nil, fmt.Errorf("unmarshal record to structpb: %w", err)
+	record, err := corev1.UnmarshalRecord(jsonBytes)
+	if err != nil {
+		return nil, fmt.Errorf("decode OASF record: %w", err)
 	}
-	return &corev1.Record{Data: data}, nil
+	return record, nil
 }

--- a/output/directory-bridge/grpc_backend_test.go
+++ b/output/directory-bridge/grpc_backend_test.go
@@ -329,5 +329,41 @@ func TestGRPCBackend_NilRequests(t *testing.T) {
 	}
 }
 
+// TestGRPCBackend_PublishRejectsMalformedRecordBeforeStream verifies
+// that the AGNTCY typed-decode validation in oasfToProtoRecord runs at
+// the marshalling boundary, *before* the bidirectional Push stream is
+// opened. A record with an unrecognised schema_version discriminator
+// must fail at the publisher — not as an opaque server-side stream
+// error 50ms later. This is the pre-flight check go-reviewer flagged
+// on PR #70 (finding #1-revert), now closed.
+//
+// We assert on the failure mode (the publish errors AND the server's
+// Push handler was never invoked) rather than on the specific error
+// string — the SDK's error wording may evolve.
+func TestGRPCBackend_PublishRejectsMalformedRecordBeforeStream(t *testing.T) {
+	fake, backend, teardown := startTestServer(t)
+	defer teardown()
+
+	bad := &oasfgenerator.OASFRecord{
+		Name:          "broken-agent",
+		Version:       "1.0.0",
+		SchemaVersion: "999.0.0", // not a registered OASF schema version
+		Skills:        []oasfgenerator.OASFSkill{{ID: 9_100_001, Name: "semstreams/x"}},
+	}
+
+	_, err := backend.Publish(context.Background(), &PublishRequest{
+		EntityID: "acme.ops.agentic.system.agent.bad",
+		AgentDID: "did:semstreams:bad",
+		Record:   bad,
+		TTL:      time.Minute,
+	})
+	if err == nil {
+		t.Fatal("expected typed-decode rejection at marshal boundary")
+	}
+	if fake.pushCalls != 0 {
+		t.Errorf("server's Push handler invoked %d times; expected 0 (validation must run before stream open)", fake.pushCalls)
+	}
+}
+
 // Compile-time assertion that GRPCBackend implements Backend.
 var _ Backend = (*GRPCBackend)(nil)


### PR DESCRIPTION
## Summary

Third and final foundational chunk of [ADR-042](../blob/main/docs/adr/042-oasf-taxonomy-adoption.md) before PR-C unblocks. Migrates \`oasfToProtoRecord\` in \`output/directory-bridge/grpc_backend.go\` from the hand-rolled JSON→structpb path (workaround I shipped in PR-B pending the schema-alignment work) to \`corev1.UnmarshalRecord\`, which runs the AGNTCY SDK's typed Decode against the \`schema_version\` discriminator (1.x → v1, 0.8.x → v1alpha2, 0.7.x → v1alpha1) at the marshalling boundary.

## Why now

PR-O2 (#78) landed the \`uint32\` ID flip that aligns our \`OASFRecord\` shape with AGNTCY's typed proto schema. Pre-PR-O2 records would have failed Decode with \`json: cannot unmarshal string into Go struct field Skill.skills.id of type uint32\` — the original go-reviewer finding on PR #70 (\`#1-revert\`). Post-PR-O2 they pass cleanly, so typed-decode validation is now safe to enable on the wire path.

## Benefits beyond closing the deferred finding

- **Malformed records fail at the publisher's marshalling boundary** instead of as an opaque server-side stream error 50ms later.
- **The error site is the construction call** — not somewhere downstream after \`Push\` has been opened and bytes sent.
- **Future OASF schema version bumps** (1.1, 2.0) are discovered at Decode time, not by hand-debugging server rejections.

## New test

\`TestGRPCBackend_PublishRejectsMalformedRecordBeforeStream\` crafts a record with an unrecognised \`schema_version\`, asserts the publish errors AND the bufconn server's Push handler is never invoked. Locks the pre-flight ordering — typed validation must run *before* stream open.

## What this unblocks

**PR-C** — config selector for backend selection, OIDC token provider, factory wire-up. The wire path is now clean end-to-end against AGNTCY-conformant directories.

## Test plan

- [x] \`go test -race ./output/directory-bridge/\` — all green (5 GRPCBackend tests including the new typed-decode rejection)
- [x] \`go build ./...\` — clean
- [x] \`task lint\` — \`go vet\`, \`go fmt\`, \`revive\` clean
- [x] PR #70 reviewer finding #1-revert closed in full (memory updated)
- [ ] CI green

## Roadmap

- **#75 (ADR-042)** ✅ merged
- **#76 (PR-O1)** ✅ merged — \`vocabulary/oasf\` scaffold
- **#78 (PR-O2)** ✅ merged — generator refactor
- **This PR (PR-O3)** — typed Decode at marshal boundary
- **PR-C (unblocked)** — config selector, OIDC, factory wire-up
- **PR-D** — opt-in hosted-sandbox e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)