### PR TITLE
feat(directory-bridge): config selector + OIDC auth + factory wire-up (ADR-042 PR-C)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/net v0.53.0
+	golang.org/x/oauth2 v0.34.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1

--- a/output/directory-bridge/auth.go
+++ b/output/directory-bridge/auth.go
@@ -1,0 +1,162 @@
+package directorybridge
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// AuthProvider supplies per-RPC credentials for the agntcy_grpc backend.
+// Implementations either source a bearer token (OIDC) or signal that no
+// authentication should be attached to outgoing RPCs (NoOp).
+//
+// The provider lifecycle parallels the Backend's: the bridge constructs
+// one provider per Component.Initialize and closes it via Close at
+// Component.Stop. Token caching / refresh lives inside the provider —
+// callers see only the wrapped credentials.PerRPCCredentials.
+type AuthProvider interface {
+	// PerRPC returns the per-RPC credentials to attach to gRPC calls, or
+	// nil for "no auth". The bridge feeds the result into
+	// grpc.WithPerRPCCredentials at dial time; a nil return is the
+	// signal to omit that DialOption.
+	PerRPC() credentials.PerRPCCredentials
+
+	// Close releases any provider-held resources (token caches, HTTP
+	// clients). Providers without resources to release implement this
+	// as a no-op.
+	Close() error
+}
+
+// NewAuthProvider constructs an AuthProvider from the given config.
+// A nil config or Type "" / "none" returns the NoOp provider.
+// "oidc" reads the client_id and client_secret from the configured env
+// vars (or inline field) and returns an OIDC client-credentials
+// provider that auto-refreshes tokens.
+func NewAuthProvider(cfg *AuthConfig) (AuthProvider, error) {
+	if cfg == nil {
+		return NoOpAuthProvider{}, nil
+	}
+	switch cfg.Type {
+	case "", "none":
+		return NoOpAuthProvider{}, nil
+	case "oidc":
+		return newOIDCAuthProvider(cfg)
+	default:
+		return nil, fmt.Errorf("unsupported auth type %q", cfg.Type)
+	}
+}
+
+// NoOpAuthProvider attaches no credentials. Suitable for local dev,
+// bufconn tests, and privately hosted directories that don't gate on
+// auth. The hosted hub at prod.api.ads.outshift.io generally does, so
+// production deployments swap this for OIDCAuthProvider.
+type NoOpAuthProvider struct{}
+
+// PerRPC returns nil — the bridge skips grpc.WithPerRPCCredentials.
+func (NoOpAuthProvider) PerRPC() credentials.PerRPCCredentials { return nil }
+
+// Close is a no-op for NoOpAuthProvider.
+func (NoOpAuthProvider) Close() error { return nil }
+
+// OIDCAuthProvider sources per-RPC bearer tokens from an OIDC issuer
+// via the client-credentials flow. Tokens are cached and auto-refreshed
+// by the underlying clientcredentials.Config.TokenSource, so callers
+// don't need to manage lifetimes — each PerRPC().GetRequestMetadata
+// call returns whatever the cached source hands out.
+type OIDCAuthProvider struct {
+	source oauth2.TokenSource
+}
+
+func newOIDCAuthProvider(cfg *AuthConfig) (*OIDCAuthProvider, error) {
+	clientID := cfg.ClientID
+	if cfg.ClientIDEnv != "" {
+		if v := os.Getenv(cfg.ClientIDEnv); v != "" {
+			clientID = v
+		}
+	}
+	if clientID == "" {
+		return nil, fmt.Errorf("oidc: client_id is empty (set client_id or %s env)", cfg.ClientIDEnv)
+	}
+
+	clientSecret := os.Getenv(cfg.ClientSecretEnv)
+	if clientSecret == "" {
+		return nil, fmt.Errorf("oidc: client secret not set in env var %q", cfg.ClientSecretEnv)
+	}
+
+	ccCfg := &clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TokenURL:     cfg.Issuer,
+		Scopes:       cfg.Scopes,
+	}
+	return &OIDCAuthProvider{
+		source: ccCfg.TokenSource(context.Background()),
+	}, nil
+}
+
+// PerRPC wraps the OAuth2 token source as gRPC PerRPCCredentials.
+func (p *OIDCAuthProvider) PerRPC() credentials.PerRPCCredentials {
+	return &oauthTokenSource{src: p.source}
+}
+
+// Close is a no-op — clientcredentials.Config.TokenSource uses
+// net/http's default transport, which is reclaimed by GC.
+func (p *OIDCAuthProvider) Close() error { return nil }
+
+// oauthTokenSource adapts an oauth2.TokenSource to gRPC's
+// PerRPCCredentials interface. We hand-roll the adapter (instead of
+// importing google.golang.org/grpc/credentials/oauth) to keep the
+// dependency surface small — that package pulls in google.golang.org/api
+// transitively.
+type oauthTokenSource struct {
+	src oauth2.TokenSource
+}
+
+// GetRequestMetadata returns the Authorization header for one RPC.
+func (o *oauthTokenSource) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	tok, err := o.src.Token()
+	if err != nil {
+		return nil, fmt.Errorf("fetch OIDC token: %w", err)
+	}
+	return map[string]string{
+		"authorization": tok.Type() + " " + tok.AccessToken,
+	}, nil
+}
+
+// RequireTransportSecurity reports whether the credentials require
+// transport security. Bearer tokens must travel over TLS, so we return
+// true — gRPC refuses to attach these credentials over an insecure
+// connection unless the caller explicitly overrides. For local dev with
+// bufconn, use NoOpAuthProvider instead.
+func (o *oauthTokenSource) RequireTransportSecurity() bool { return true }
+
+// buildGRPCDialOptions assembles the grpc.DialOption set for the
+// agntcy_grpc backend. TLS is chosen via AgntcyGRPCConfig.TLS (real TLS
+// for production hubs, insecure for local dev / bufconn). Per-RPC OIDC
+// credentials are attached when the auth provider supplies them; the
+// NoOp provider returns nil from PerRPC and we skip the
+// WithPerRPCCredentials option entirely.
+func buildGRPCDialOptions(cfg *AgntcyGRPCConfig, auth AuthProvider) []grpc.DialOption {
+	opts := make([]grpc.DialOption, 0, 2)
+
+	if cfg.TLS {
+		// Default OS cert pool + ALPN; sufficient for the hosted hub.
+		// Operators needing custom roots or mTLS can extend this when
+		// the use case actually shows up.
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(nil)))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+
+	if perRPC := auth.PerRPC(); perRPC != nil {
+		opts = append(opts, grpc.WithPerRPCCredentials(perRPC))
+	}
+
+	return opts
+}

--- a/output/directory-bridge/auth.go
+++ b/output/directory-bridge/auth.go
@@ -114,11 +114,21 @@ func (p *OIDCAuthProvider) Close() error { return nil }
 // importing google.golang.org/grpc/credentials/oauth) to keep the
 // dependency surface small — that package pulls in google.golang.org/api
 // transitively.
+//
+// Known limitation: the gRPC PerRPCCredentials context is intentionally
+// dropped — oauth2.TokenSource.Token() pre-dates context plumbing and
+// doesn't accept one. If a gRPC RPC deadline trips while a token
+// refresh is in-flight, the refresh continues on its own HTTP client
+// timeout (90s by net/http default). The window is small but nonzero;
+// operators sensitive to it should set tight client timeouts on the
+// HTTP client passed via oauth2.HTTPClient context value before
+// constructing the provider. Acceptable v1 limitation per ADR-042.
 type oauthTokenSource struct {
 	src oauth2.TokenSource
 }
 
 // GetRequestMetadata returns the Authorization header for one RPC.
+// See the type comment for context-handling caveats.
 func (o *oauthTokenSource) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
 	tok, err := o.src.Token()
 	if err != nil {

--- a/output/directory-bridge/auth_test.go
+++ b/output/directory-bridge/auth_test.go
@@ -1,6 +1,11 @@
 package directorybridge
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -61,13 +66,50 @@ func TestNewAuthProvider_OIDC_MissingClientSecret(t *testing.T) {
 	}
 }
 
+// TestNewAuthProvider_OIDC_Success exercises the full token-fetch path
+// (not just construction) against an httptest.Server that mints a fake
+// access token. Construction alone, as the prior version of this test
+// did, doesn't catch a misnamed oauth2 import or a broken adapter —
+// only an end-to-end GetRequestMetadata call does.
 func TestNewAuthProvider_OIDC_Success(t *testing.T) {
-	t.Setenv("PR_C_OIDC_TEST_CLIENT_SECRET", "the-secret")
-	t.Setenv("PR_C_OIDC_TEST_CLIENT_ID", "env-client")
+	// Fake issuer that satisfies the OAuth2 client-credentials flow.
+	// Asserts the client_id / client_secret made it through, then mints
+	// a bearer token the provider should surface in Authorization.
+	const wantClientID = "env-client"
+	const wantSecret = "the-secret"
+	const issuedToken = "fake-access-token"
+
+	issuer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// clientcredentials sends client_id/secret either in Basic auth
+		// or as form params; check both.
+		gotID, gotSecret, hasBasic := r.BasicAuth()
+		if !hasBasic {
+			gotID = r.Form.Get("client_id")
+			gotSecret = r.Form.Get("client_secret")
+		}
+		if gotID != wantClientID || gotSecret != wantSecret {
+			http.Error(w, "bad credentials", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": issuedToken,
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer issuer.Close()
+
+	t.Setenv("PR_C_OIDC_TEST_CLIENT_SECRET", wantSecret)
+	t.Setenv("PR_C_OIDC_TEST_CLIENT_ID", wantClientID)
 
 	p, err := NewAuthProvider(&AuthConfig{
 		Type:            "oidc",
-		Issuer:          "https://issuer.example.com/token",
+		Issuer:          issuer.URL,
 		ClientIDEnv:     "PR_C_OIDC_TEST_CLIENT_ID",
 		ClientSecretEnv: "PR_C_OIDC_TEST_CLIENT_SECRET",
 		Scopes:          []string{"a", "b"},
@@ -75,16 +117,33 @@ func TestNewAuthProvider_OIDC_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewAuthProvider: %v", err)
 	}
+	defer p.Close()
+
 	if _, ok := p.(*OIDCAuthProvider); !ok {
 		t.Errorf("got %T, want *OIDCAuthProvider", p)
 	}
-	if perRPC := p.PerRPC(); perRPC == nil {
-		t.Error("OIDCAuthProvider.PerRPC() = nil, want PerRPCCredentials")
-	} else if !perRPC.RequireTransportSecurity() {
+
+	perRPC := p.PerRPC()
+	if perRPC == nil {
+		t.Fatal("OIDCAuthProvider.PerRPC() = nil, want PerRPCCredentials")
+	}
+	if !perRPC.RequireTransportSecurity() {
 		t.Error("OIDC PerRPC must require transport security (bearer tokens over TLS)")
 	}
-	if err := p.Close(); err != nil {
-		t.Errorf("Close: %v", err)
+
+	md, err := perRPC.GetRequestMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("GetRequestMetadata: %v", err)
+	}
+	authz, ok := md["authorization"]
+	if !ok {
+		t.Fatalf("metadata missing authorization header: %v", md)
+	}
+	if want := "Bearer " + issuedToken; authz != want {
+		t.Errorf("authorization = %q, want %q", authz, want)
+	}
+	if !strings.HasPrefix(authz, "Bearer ") {
+		t.Errorf("authorization must start with \"Bearer \", got %q", authz)
 	}
 }
 

--- a/output/directory-bridge/auth_test.go
+++ b/output/directory-bridge/auth_test.go
@@ -1,0 +1,122 @@
+package directorybridge
+
+import (
+	"testing"
+)
+
+func TestNewAuthProvider_NilConfig(t *testing.T) {
+	p, err := NewAuthProvider(nil)
+	if err != nil {
+		t.Fatalf("NewAuthProvider(nil): %v", err)
+	}
+	if _, ok := p.(NoOpAuthProvider); !ok {
+		t.Errorf("got %T, want NoOpAuthProvider for nil config", p)
+	}
+}
+
+func TestNewAuthProvider_None(t *testing.T) {
+	for _, typ := range []string{"", "none"} {
+		t.Run("type="+typ, func(t *testing.T) {
+			p, err := NewAuthProvider(&AuthConfig{Type: typ})
+			if err != nil {
+				t.Fatalf("NewAuthProvider(%q): %v", typ, err)
+			}
+			if _, ok := p.(NoOpAuthProvider); !ok {
+				t.Errorf("got %T, want NoOpAuthProvider", p)
+			}
+			if perRPC := p.PerRPC(); perRPC != nil {
+				t.Errorf("NoOpAuthProvider.PerRPC() = %v, want nil", perRPC)
+			}
+			if err := p.Close(); err != nil {
+				t.Errorf("Close: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewAuthProvider_OIDC_MissingClientID(t *testing.T) {
+	// Neither inline client_id nor env-var set — must error at construction.
+	_, err := NewAuthProvider(&AuthConfig{
+		Type:            "oidc",
+		Issuer:          "https://issuer.example.com/token",
+		ClientIDEnv:     "PR_C_UNSET_CLIENT_ID_VAR",
+		ClientSecretEnv: "PR_C_UNSET_CLIENT_SECRET_VAR",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing client_id")
+	}
+}
+
+func TestNewAuthProvider_OIDC_MissingClientSecret(t *testing.T) {
+	// ClientID inline is fine; secret env var is unset → construction error.
+	t.Setenv("PR_C_UNSET_CLIENT_SECRET_VAR", "") // ensure not set
+	_, err := NewAuthProvider(&AuthConfig{
+		Type:            "oidc",
+		Issuer:          "https://issuer.example.com/token",
+		ClientID:        "test-client",
+		ClientSecretEnv: "PR_C_UNSET_CLIENT_SECRET_VAR",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing client_secret env var")
+	}
+}
+
+func TestNewAuthProvider_OIDC_Success(t *testing.T) {
+	t.Setenv("PR_C_OIDC_TEST_CLIENT_SECRET", "the-secret")
+	t.Setenv("PR_C_OIDC_TEST_CLIENT_ID", "env-client")
+
+	p, err := NewAuthProvider(&AuthConfig{
+		Type:            "oidc",
+		Issuer:          "https://issuer.example.com/token",
+		ClientIDEnv:     "PR_C_OIDC_TEST_CLIENT_ID",
+		ClientSecretEnv: "PR_C_OIDC_TEST_CLIENT_SECRET",
+		Scopes:          []string{"a", "b"},
+	})
+	if err != nil {
+		t.Fatalf("NewAuthProvider: %v", err)
+	}
+	if _, ok := p.(*OIDCAuthProvider); !ok {
+		t.Errorf("got %T, want *OIDCAuthProvider", p)
+	}
+	if perRPC := p.PerRPC(); perRPC == nil {
+		t.Error("OIDCAuthProvider.PerRPC() = nil, want PerRPCCredentials")
+	} else if !perRPC.RequireTransportSecurity() {
+		t.Error("OIDC PerRPC must require transport security (bearer tokens over TLS)")
+	}
+	if err := p.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func TestNewAuthProvider_UnsupportedType(t *testing.T) {
+	_, err := NewAuthProvider(&AuthConfig{Type: "kerberos"})
+	if err == nil {
+		t.Fatal("expected error for unsupported auth type")
+	}
+}
+
+func TestBuildGRPCDialOptions_InsecureNoAuth(t *testing.T) {
+	opts := buildGRPCDialOptions(&AgntcyGRPCConfig{Endpoint: "h:1", TLS: false}, NoOpAuthProvider{})
+	if len(opts) != 1 {
+		t.Errorf("len(opts) = %d, want 1 (just insecure transport)", len(opts))
+	}
+}
+
+func TestBuildGRPCDialOptions_TLSWithAuth(t *testing.T) {
+	t.Setenv("PR_C_DIAL_OPTS_SECRET", "s")
+	auth, err := NewAuthProvider(&AuthConfig{
+		Type:            "oidc",
+		Issuer:          "https://issuer.example.com/token",
+		ClientID:        "c",
+		ClientSecretEnv: "PR_C_DIAL_OPTS_SECRET",
+	})
+	if err != nil {
+		t.Fatalf("NewAuthProvider: %v", err)
+	}
+	defer auth.Close()
+
+	opts := buildGRPCDialOptions(&AgntcyGRPCConfig{Endpoint: "h:1", TLS: true}, auth)
+	if len(opts) != 2 {
+		t.Errorf("len(opts) = %d, want 2 (TLS transport + PerRPC OIDC)", len(opts))
+	}
+}

--- a/output/directory-bridge/component.go
+++ b/output/directory-bridge/component.go
@@ -3,6 +3,7 @@ package directorybridge
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"reflect"
 	"sync"
@@ -87,14 +88,18 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 	}, nil
 }
 
-// Initialize prepares the component.
+// Initialize prepares the component, selecting a Backend implementation
+// based on config.Backend. Empty / "http" selects the legacy HTTP wire
+// format; "agntcy_grpc" selects the AGNTCY gRPC StoreService wire
+// format with optional per-RPC OIDC auth.
 func (c *Component) Initialize() error {
-	// Select backend. PR-A wires the HTTP backend exclusively; backend
-	// selection from config lands in a follow-up PR.
-	c.backend = NewHTTPBackend(c.config.DirectoryURL)
+	backend, err := c.buildBackend()
+	if err != nil {
+		return errs.Wrap(err, "Component", "Initialize", "build backend")
+	}
+	c.backend = backend
 
 	// Create identity provider
-	var err error
 	c.idProvider, err = identity.DefaultProviderFactory(identity.ProviderConfig{
 		ProviderType: c.config.IdentityProvider,
 	})
@@ -106,6 +111,34 @@ func (c *Component) Initialize() error {
 	c.regManager = NewRegistrationManager(c.backend, c.idProvider, c.config, c.logger)
 
 	return nil
+}
+
+// buildBackend constructs the wire-level Backend implementation selected
+// by config.Backend. The auth provider's lifetime is owned by the
+// backend (returned wrapped via NewGRPCBackend), so callers do not need
+// to hold a separate reference for shutdown.
+func (c *Component) buildBackend() (Backend, error) {
+	switch c.config.Backend {
+	case "", BackendHTTP:
+		return NewHTTPBackend(c.config.DirectoryURL), nil
+	case BackendAgntcyGRPC:
+		if c.config.AgntcyGRPC == nil {
+			return nil, fmt.Errorf("backend %q requires agntcy_grpc block (validation should have caught this)", BackendAgntcyGRPC)
+		}
+		auth, err := NewAuthProvider(c.config.AgntcyGRPC.Auth)
+		if err != nil {
+			return nil, fmt.Errorf("build auth provider: %w", err)
+		}
+		dialOpts := buildGRPCDialOptions(c.config.AgntcyGRPC, auth)
+		backend, err := NewGRPCBackendWithAuth(c.config.AgntcyGRPC.Endpoint, auth, dialOpts...)
+		if err != nil {
+			_ = auth.Close()
+			return nil, fmt.Errorf("dial agntcy_grpc backend: %w", err)
+		}
+		return backend, nil
+	default:
+		return nil, fmt.Errorf("unsupported backend %q", c.config.Backend)
+	}
 }
 
 // Start begins watching for OASF records and registering agents.

--- a/output/directory-bridge/component.go
+++ b/output/directory-bridge/component.go
@@ -335,6 +335,18 @@ func (c *Component) Stop(timeout time.Duration) error {
 		}
 	}
 
+	// Release backend resources: gRPC client connection, OIDC token-
+	// refresh state, etc. Backend.Close() is the only seam that lets
+	// the AuthProvider lifetime bound to NewGRPCBackendWithAuth actually
+	// release. Without this call every Initialize/Stop cycle leaks a
+	// *grpc.ClientConn (caught in PR #80 go-reviewer pass).
+	if c.backend != nil {
+		if err := c.backend.Close(); err != nil {
+			c.logger.Warn("Failed to close backend", slog.Any("error", err))
+		}
+		c.backend = nil
+	}
+
 	c.running = false
 	c.logger.Info("Directory bridge stopped")
 

--- a/output/directory-bridge/config.go
+++ b/output/directory-bridge/config.go
@@ -12,8 +12,24 @@ type Config struct {
 	// Ports defines the input/output port configuration.
 	Ports *component.PortConfig `json:"ports" schema:"type:ports,description:Port configuration,category:basic"`
 
-	// DirectoryURL is the AGNTCY directory service URL.
-	DirectoryURL string `json:"directory_url" schema:"type:string,description:AGNTCY directory service URL,category:basic"`
+	// Backend selects the directory wire format. One of:
+	//   - "http" (default) — POST /v1/agents JSON to DirectoryURL.
+	//     The legacy SemStreams-defined HTTP protocol that the in-tree
+	//     mock and any privately hosted HTTP directory speak.
+	//   - "agntcy_grpc" — AGNTCY agntcy/dir StoreService over gRPC.
+	//     Use this for the hosted hub at prod.api.ads.outshift.io and
+	//     for any AGNTCY-conformant directory.
+	// Empty defaults to "http" for backwards compatibility with
+	// pre-PR-C configs.
+	Backend string `json:"backend,omitempty" schema:"type:string,description:Wire-format backend (http or agntcy_grpc),category:basic,default:http"`
+
+	// DirectoryURL is the HTTP backend's directory service URL.
+	// Ignored when Backend == "agntcy_grpc" — that path uses AgntcyGRPC.Endpoint.
+	DirectoryURL string `json:"directory_url" schema:"type:string,description:AGNTCY directory service URL (HTTP backend only),category:basic"`
+
+	// AgntcyGRPC carries the agntcy_grpc backend's settings. Ignored
+	// when Backend is not "agntcy_grpc".
+	AgntcyGRPC *AgntcyGRPCConfig `json:"agntcy_grpc,omitempty" schema:"type:object,description:agntcy_grpc backend settings,category:basic"`
 
 	// HeartbeatInterval is how often to send heartbeats to the directory.
 	HeartbeatInterval string `json:"heartbeat_interval" schema:"type:string,description:Heartbeat interval,category:basic,default:30s"`
@@ -39,6 +55,64 @@ type Config struct {
 
 	// DeleteConsumerOnStop enables consumer cleanup on stop (for testing).
 	DeleteConsumerOnStop bool `json:"delete_consumer_on_stop,omitempty" schema:"type:bool,description:Delete consumers on Stop,category:advanced,default:false"`
+}
+
+// Backend constants accepted by Config.Backend.
+const (
+	// BackendHTTP is the default — POST JSON to a SemStreams HTTP directory.
+	BackendHTTP = "http"
+	// BackendAgntcyGRPC is the AGNTCY agntcy/dir StoreService over gRPC.
+	BackendAgntcyGRPC = "agntcy_grpc"
+)
+
+// AgntcyGRPCConfig carries settings for the agntcy_grpc backend.
+type AgntcyGRPCConfig struct {
+	// Endpoint is the host:port the gRPC client dials.
+	// Example: "prod.api.ads.outshift.io:443".
+	Endpoint string `json:"endpoint"`
+
+	// TLS controls whether the client establishes TLS on dial. The
+	// hosted hub requires TLS (true); local dev / bufconn tests use
+	// false. When false the client uses insecure transport credentials
+	// (grpc.WithTransportCredentials(insecure.NewCredentials())) —
+	// suitable only for trusted networks and local development.
+	TLS bool `json:"tls"`
+
+	// Auth carries optional per-RPC OIDC authentication. nil or
+	// Type=="none" disables auth (suitable for local dev / private
+	// deployments). The hosted hub generally requires Type=="oidc".
+	Auth *AuthConfig `json:"auth,omitempty"`
+}
+
+// AuthConfig configures per-RPC authentication for the agntcy_grpc
+// backend. The only auth flow supported today is OIDC client
+// credentials (the deployment pattern AGNTCY's hosted hub uses).
+type AuthConfig struct {
+	// Type selects the auth flow. One of "none" or "oidc". Empty
+	// defaults to "none".
+	Type string `json:"type"`
+
+	// Issuer is the OIDC token endpoint URL (the `token_endpoint` from
+	// the issuer's OIDC discovery document). Required when Type=="oidc".
+	Issuer string `json:"issuer,omitempty"`
+
+	// ClientID is the OIDC client identifier. Prefer ClientIDEnv for
+	// secret management hygiene. Required when Type=="oidc" if
+	// ClientIDEnv is not set.
+	ClientID string `json:"client_id,omitempty"`
+
+	// ClientIDEnv names an environment variable to read the OIDC
+	// client_id from at runtime. Wins over ClientID when both set.
+	ClientIDEnv string `json:"client_id_env,omitempty"`
+
+	// ClientSecretEnv names an environment variable to read the OIDC
+	// client_secret from at runtime. Required when Type=="oidc".
+	// No inline client_secret field — secrets do not live in JSON
+	// config on disk; this is intentional.
+	ClientSecretEnv string `json:"client_secret_env,omitempty"`
+
+	// Scopes is the OIDC scope list requested at token-endpoint time.
+	Scopes []string `json:"scopes,omitempty"`
 }
 
 // DefaultConfig returns the default configuration.
@@ -85,6 +159,21 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("oasf_kv_bucket is required")
 	}
 
+	// Backend selector — empty is valid (defaults to http).
+	switch c.Backend {
+	case "", BackendHTTP:
+		// OK; agntcy_grpc block ignored on this path.
+	case BackendAgntcyGRPC:
+		if c.AgntcyGRPC == nil {
+			return fmt.Errorf("backend=%q requires agntcy_grpc block", BackendAgntcyGRPC)
+		}
+		if err := c.AgntcyGRPC.Validate(); err != nil {
+			return fmt.Errorf("agntcy_grpc: %w", err)
+		}
+	default:
+		return fmt.Errorf("backend must be %q or %q, got %q", BackendHTTP, BackendAgntcyGRPC, c.Backend)
+	}
+
 	// Validate heartbeat interval if set
 	if c.HeartbeatInterval != "" {
 		if _, err := time.ParseDuration(c.HeartbeatInterval); err != nil {
@@ -107,6 +196,40 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+// Validate validates an AgntcyGRPCConfig.
+func (g *AgntcyGRPCConfig) Validate() error {
+	if g.Endpoint == "" {
+		return fmt.Errorf("endpoint is required")
+	}
+	if g.Auth != nil {
+		if err := g.Auth.Validate(); err != nil {
+			return fmt.Errorf("auth: %w", err)
+		}
+	}
+	return nil
+}
+
+// Validate validates an AuthConfig.
+func (a *AuthConfig) Validate() error {
+	switch a.Type {
+	case "", "none":
+		return nil
+	case "oidc":
+		if a.Issuer == "" {
+			return fmt.Errorf("issuer is required for oidc auth")
+		}
+		if a.ClientID == "" && a.ClientIDEnv == "" {
+			return fmt.Errorf("either client_id or client_id_env is required for oidc auth")
+		}
+		if a.ClientSecretEnv == "" {
+			return fmt.Errorf("client_secret_env is required for oidc auth (secrets must not live in config)")
+		}
+		return nil
+	default:
+		return fmt.Errorf("auth.type must be %q or %q, got %q", "none", "oidc", a.Type)
+	}
 }
 
 // GetHeartbeatInterval returns the heartbeat interval.

--- a/output/directory-bridge/config.go
+++ b/output/directory-bridge/config.go
@@ -69,19 +69,19 @@ const (
 type AgntcyGRPCConfig struct {
 	// Endpoint is the host:port the gRPC client dials.
 	// Example: "prod.api.ads.outshift.io:443".
-	Endpoint string `json:"endpoint"`
+	Endpoint string `json:"endpoint" schema:"type:string,description:gRPC endpoint host:port,category:basic"`
 
 	// TLS controls whether the client establishes TLS on dial. The
 	// hosted hub requires TLS (true); local dev / bufconn tests use
 	// false. When false the client uses insecure transport credentials
 	// (grpc.WithTransportCredentials(insecure.NewCredentials())) —
 	// suitable only for trusted networks and local development.
-	TLS bool `json:"tls"`
+	TLS bool `json:"tls" schema:"type:bool,description:Establish TLS on dial (required for the hosted hub),category:basic"`
 
 	// Auth carries optional per-RPC OIDC authentication. nil or
 	// Type=="none" disables auth (suitable for local dev / private
 	// deployments). The hosted hub generally requires Type=="oidc".
-	Auth *AuthConfig `json:"auth,omitempty"`
+	Auth *AuthConfig `json:"auth,omitempty" schema:"type:object,description:Per-RPC OIDC auth (omit for unauthenticated),category:basic"`
 }
 
 // AuthConfig configures per-RPC authentication for the agntcy_grpc
@@ -90,29 +90,29 @@ type AgntcyGRPCConfig struct {
 type AuthConfig struct {
 	// Type selects the auth flow. One of "none" or "oidc". Empty
 	// defaults to "none".
-	Type string `json:"type"`
+	Type string `json:"type" schema:"type:string,description:Auth flow (none or oidc),category:basic,default:none"`
 
 	// Issuer is the OIDC token endpoint URL (the `token_endpoint` from
 	// the issuer's OIDC discovery document). Required when Type=="oidc".
-	Issuer string `json:"issuer,omitempty"`
+	Issuer string `json:"issuer,omitempty" schema:"type:string,description:OIDC token endpoint URL,category:basic"`
 
 	// ClientID is the OIDC client identifier. Prefer ClientIDEnv for
 	// secret management hygiene. Required when Type=="oidc" if
 	// ClientIDEnv is not set.
-	ClientID string `json:"client_id,omitempty"`
+	ClientID string `json:"client_id,omitempty" schema:"type:string,description:OIDC client identifier (inline; prefer client_id_env),category:basic"`
 
 	// ClientIDEnv names an environment variable to read the OIDC
 	// client_id from at runtime. Wins over ClientID when both set.
-	ClientIDEnv string `json:"client_id_env,omitempty"`
+	ClientIDEnv string `json:"client_id_env,omitempty" schema:"type:string,description:Env var name for OIDC client_id (wins over inline),category:basic"`
 
 	// ClientSecretEnv names an environment variable to read the OIDC
 	// client_secret from at runtime. Required when Type=="oidc".
 	// No inline client_secret field — secrets do not live in JSON
 	// config on disk; this is intentional.
-	ClientSecretEnv string `json:"client_secret_env,omitempty"`
+	ClientSecretEnv string `json:"client_secret_env,omitempty" schema:"type:string,description:Env var name for OIDC client_secret (secrets must not live in config),category:basic"`
 
 	// Scopes is the OIDC scope list requested at token-endpoint time.
-	Scopes []string `json:"scopes,omitempty"`
+	Scopes []string `json:"scopes,omitempty" schema:"type:array,description:OIDC scope list,category:basic"`
 }
 
 // DefaultConfig returns the default configuration.
@@ -138,6 +138,7 @@ func DefaultConfig() Config {
 				},
 			},
 		},
+		Backend:           BackendHTTP,
 		HeartbeatInterval: "30s",
 		RegistrationTTL:   "5m",
 		IdentityProvider:  "local",

--- a/output/directory-bridge/config_test.go
+++ b/output/directory-bridge/config_test.go
@@ -326,6 +326,16 @@ func TestConfig_JSONRoundTrip(t *testing.T) {
 	if len(decoded.AgntcyGRPC.Auth.Scopes) != len(original.AgntcyGRPC.Auth.Scopes) {
 		t.Errorf("Auth.Scopes len = %d, want %d", len(decoded.AgntcyGRPC.Auth.Scopes), len(original.AgntcyGRPC.Auth.Scopes))
 	}
+	// Element-wise compare — length parity alone wouldn't catch a slice
+	// that round-tripped with swapped/dropped/renamed entries.
+	for i, want := range original.AgntcyGRPC.Auth.Scopes {
+		if i >= len(decoded.AgntcyGRPC.Auth.Scopes) {
+			break
+		}
+		if got := decoded.AgntcyGRPC.Auth.Scopes[i]; got != want {
+			t.Errorf("Auth.Scopes[%d] = %q, want %q", i, got, want)
+		}
+	}
 
 	// Confirm the decoded config validates (covers the V (validate) leg
 	// of the round-trip-and-validate contract).

--- a/output/directory-bridge/config_test.go
+++ b/output/directory-bridge/config_test.go
@@ -1,9 +1,12 @@
 package directorybridge
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/c360studio/semstreams/component"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -233,6 +236,207 @@ func TestConfigGetRetryDelay(t *testing.T) {
 			got := cfg.GetRetryDelay()
 			if got != tt.want {
 				t.Errorf("GetRetryDelay() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestConfig_JSONRoundTrip covers the polymorphic-config discipline:
+// every operator-reachable field (including the new Backend selector,
+// the AgntcyGRPC block, and its nested AuthConfig) must survive a
+// JSON marshal/unmarshal round-trip without silent dropping. See the
+// feedback memory feedback_polymorphic_config_needs_json_roundtrip_test.
+func TestConfig_JSONRoundTrip(t *testing.T) {
+	original := Config{
+		Ports: &component.PortConfig{
+			Inputs:  []component.PortDefinition{{Name: "i", Subject: "a", Type: "kv-watch"}},
+			Outputs: []component.PortDefinition{{Name: "o", Subject: "b", Type: "jetstream"}},
+		},
+		Backend:      BackendAgntcyGRPC,
+		DirectoryURL: "http://legacy-http",
+		AgntcyGRPC: &AgntcyGRPCConfig{
+			Endpoint: "prod.api.ads.outshift.io:443",
+			TLS:      true,
+			Auth: &AuthConfig{
+				Type:            "oidc",
+				Issuer:          "https://issuer.example.com/token",
+				ClientID:        "inline-client",
+				ClientIDEnv:     "EXAMPLE_CLIENT_ID",
+				ClientSecretEnv: "EXAMPLE_CLIENT_SECRET",
+				Scopes:          []string{"agntcy.publish", "agntcy.read"},
+			},
+		},
+		HeartbeatInterval:    "30s",
+		RegistrationTTL:      "5m",
+		IdentityProvider:     "local",
+		OASFKVBucket:         "OASF_RECORDS",
+		RetryCount:           3,
+		RetryDelay:           "1s",
+		ConsumerNameSuffix:   "test-suffix",
+		DeleteConsumerOnStop: true,
+	}
+
+	raw, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded Config
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Spot-check every field that wasn't already in the existing
+	// TestConfigValidate / TestDefaultConfig coverage. Catches the
+	// "shadow struct" / "field silently dropped" failure mode the
+	// polymorphic-config rule exists to prevent.
+	if decoded.Backend != original.Backend {
+		t.Errorf("Backend = %q, want %q", decoded.Backend, original.Backend)
+	}
+	if decoded.DirectoryURL != original.DirectoryURL {
+		t.Errorf("DirectoryURL = %q, want %q", decoded.DirectoryURL, original.DirectoryURL)
+	}
+	if decoded.AgntcyGRPC == nil {
+		t.Fatal("AgntcyGRPC dropped during round-trip")
+	}
+	if decoded.AgntcyGRPC.Endpoint != original.AgntcyGRPC.Endpoint {
+		t.Errorf("AgntcyGRPC.Endpoint = %q, want %q", decoded.AgntcyGRPC.Endpoint, original.AgntcyGRPC.Endpoint)
+	}
+	if decoded.AgntcyGRPC.TLS != original.AgntcyGRPC.TLS {
+		t.Errorf("AgntcyGRPC.TLS = %v, want %v", decoded.AgntcyGRPC.TLS, original.AgntcyGRPC.TLS)
+	}
+	if decoded.AgntcyGRPC.Auth == nil {
+		t.Fatal("AgntcyGRPC.Auth dropped during round-trip")
+	}
+	if decoded.AgntcyGRPC.Auth.Type != original.AgntcyGRPC.Auth.Type {
+		t.Errorf("Auth.Type = %q, want %q", decoded.AgntcyGRPC.Auth.Type, original.AgntcyGRPC.Auth.Type)
+	}
+	if decoded.AgntcyGRPC.Auth.Issuer != original.AgntcyGRPC.Auth.Issuer {
+		t.Errorf("Auth.Issuer = %q, want %q", decoded.AgntcyGRPC.Auth.Issuer, original.AgntcyGRPC.Auth.Issuer)
+	}
+	if decoded.AgntcyGRPC.Auth.ClientID != original.AgntcyGRPC.Auth.ClientID {
+		t.Errorf("Auth.ClientID = %q, want %q", decoded.AgntcyGRPC.Auth.ClientID, original.AgntcyGRPC.Auth.ClientID)
+	}
+	if decoded.AgntcyGRPC.Auth.ClientIDEnv != original.AgntcyGRPC.Auth.ClientIDEnv {
+		t.Errorf("Auth.ClientIDEnv = %q, want %q", decoded.AgntcyGRPC.Auth.ClientIDEnv, original.AgntcyGRPC.Auth.ClientIDEnv)
+	}
+	if decoded.AgntcyGRPC.Auth.ClientSecretEnv != original.AgntcyGRPC.Auth.ClientSecretEnv {
+		t.Errorf("Auth.ClientSecretEnv = %q, want %q", decoded.AgntcyGRPC.Auth.ClientSecretEnv, original.AgntcyGRPC.Auth.ClientSecretEnv)
+	}
+	if len(decoded.AgntcyGRPC.Auth.Scopes) != len(original.AgntcyGRPC.Auth.Scopes) {
+		t.Errorf("Auth.Scopes len = %d, want %d", len(decoded.AgntcyGRPC.Auth.Scopes), len(original.AgntcyGRPC.Auth.Scopes))
+	}
+
+	// Confirm the decoded config validates (covers the V (validate) leg
+	// of the round-trip-and-validate contract).
+	if err := decoded.Validate(); err != nil {
+		t.Errorf("decoded config failed validate: %v", err)
+	}
+}
+
+// TestConfigValidate_BackendVariants exercises the new selector and
+// per-backend validation branches.
+func TestConfigValidate_BackendVariants(t *testing.T) {
+	base := DefaultConfig()
+	cases := []struct {
+		name    string
+		mutate  func(*Config)
+		wantErr string
+	}{
+		{
+			name:   "empty backend defaults to http",
+			mutate: func(c *Config) { c.Backend = "" },
+		},
+		{
+			name:   "explicit http",
+			mutate: func(c *Config) { c.Backend = BackendHTTP },
+		},
+		{
+			name: "agntcy_grpc requires block",
+			mutate: func(c *Config) {
+				c.Backend = BackendAgntcyGRPC
+				c.AgntcyGRPC = nil
+			},
+			wantErr: "requires agntcy_grpc block",
+		},
+		{
+			name: "agntcy_grpc requires endpoint",
+			mutate: func(c *Config) {
+				c.Backend = BackendAgntcyGRPC
+				c.AgntcyGRPC = &AgntcyGRPCConfig{Endpoint: ""}
+			},
+			wantErr: "endpoint is required",
+		},
+		{
+			name: "agntcy_grpc with none auth ok",
+			mutate: func(c *Config) {
+				c.Backend = BackendAgntcyGRPC
+				c.AgntcyGRPC = &AgntcyGRPCConfig{Endpoint: "h:1", Auth: &AuthConfig{Type: "none"}}
+			},
+		},
+		{
+			name: "oidc auth requires issuer",
+			mutate: func(c *Config) {
+				c.Backend = BackendAgntcyGRPC
+				c.AgntcyGRPC = &AgntcyGRPCConfig{
+					Endpoint: "h:1",
+					Auth:     &AuthConfig{Type: "oidc", ClientID: "x", ClientSecretEnv: "S"},
+				}
+			},
+			wantErr: "issuer is required",
+		},
+		{
+			name: "oidc auth requires client_id",
+			mutate: func(c *Config) {
+				c.Backend = BackendAgntcyGRPC
+				c.AgntcyGRPC = &AgntcyGRPCConfig{
+					Endpoint: "h:1",
+					Auth:     &AuthConfig{Type: "oidc", Issuer: "iss", ClientSecretEnv: "S"},
+				}
+			},
+			wantErr: "client_id or client_id_env",
+		},
+		{
+			name: "oidc auth requires client_secret_env",
+			mutate: func(c *Config) {
+				c.Backend = BackendAgntcyGRPC
+				c.AgntcyGRPC = &AgntcyGRPCConfig{
+					Endpoint: "h:1",
+					Auth:     &AuthConfig{Type: "oidc", Issuer: "iss", ClientID: "x"},
+				}
+			},
+			wantErr: "client_secret_env",
+		},
+		{
+			name:    "unknown backend",
+			mutate:  func(c *Config) { c.Backend = "nonsense" },
+			wantErr: "backend must be",
+		},
+		{
+			name: "unknown auth type",
+			mutate: func(c *Config) {
+				c.Backend = BackendAgntcyGRPC
+				c.AgntcyGRPC = &AgntcyGRPCConfig{Endpoint: "h:1", Auth: &AuthConfig{Type: "kerberos"}}
+			},
+			wantErr: "auth.type must be",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			tc.mutate(&cfg)
+			err := cfg.Validate()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("Validate() error = %q, want substring %q", err.Error(), tc.wantErr)
 			}
 		})
 	}

--- a/output/directory-bridge/grpc_backend.go
+++ b/output/directory-bridge/grpc_backend.go
@@ -94,6 +94,13 @@ func NewGRPCBackendFromClient(conn *grpc.ClientConn) *GRPCBackend {
 // The dialOpts slice is expected to already include transport credentials
 // (TLS or insecure) and any grpc.WithPerRPCCredentials needed for auth;
 // see buildGRPCDialOptions in auth.go for the canonical construction.
+//
+// Note on error semantics: grpc.NewClient is non-blocking — it only
+// validates dial arguments and returns. Connection establishment
+// happens lazily on the first RPC. As a result, unreachable hosts /
+// DNS failures / TLS handshake errors will not surface here; the first
+// Publish or Withdraw call returns them instead. The error returned by
+// this constructor reflects argument-validation failures only.
 func NewGRPCBackendWithAuth(target string, auth AuthProvider, dialOpts ...grpc.DialOption) (*GRPCBackend, error) {
 	conn, err := grpc.NewClient(target, dialOpts...)
 	if err != nil {

--- a/output/directory-bridge/grpc_backend.go
+++ b/output/directory-bridge/grpc_backend.go
@@ -3,6 +3,7 @@ package directorybridge
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -11,6 +12,15 @@ import (
 	storev1 "github.com/agntcy/dir/api/store/v1"
 	"google.golang.org/grpc"
 )
+
+// ErrRefreshNotSupported is returned by GRPCBackend.Refresh — the
+// agntcy/dir StoreService stores content-addressed records (CIDs) that
+// do not expire on the publisher side, so heartbeat-style refresh has
+// no wire counterpart. The bridge's RegistrationManager already skips
+// the Refresh path when ExpiresAt.IsZero() (set by Publish for this
+// backend), so this sentinel only surfaces if a caller bypasses the
+// manager and invokes Refresh directly. Use errors.Is to test for it.
+var ErrRefreshNotSupported = errors.New("agntcy_grpc backend: refresh has no wire counterpart (records are CID-anchored)")
 
 // GRPCBackend implements Backend by talking to an AGNTCY-compatible
 // directory over the agntcy/dir gRPC StoreService.
@@ -34,14 +44,25 @@ import (
 type GRPCBackend struct {
 	conn   *grpc.ClientConn
 	client storev1.StoreServiceClient
+	// auth is optionally retained when the backend constructed an auth
+	// provider — needed so Close() can release the provider's resources
+	// (token caches, HTTP clients). nil when the caller used
+	// NewGRPCBackend / NewGRPCBackendFromClient (caller owns lifetime).
+	auth AuthProvider
 }
 
 // NewGRPCBackend dials the directory at target and returns a backend ready
 // to Publish/Withdraw. Caller is responsible for closing it via Close().
 //
 // Pass grpc.WithTransportCredentials(...) for TLS; for the hosted hub at
-// prod.api.ads.outshift.io that means real cert validation. For local
-// dev / bufconn tests, pass grpc.WithTransportCredentials(insecure.NewCredentials()).
+// prod.api.ads.outshift.io that means real cert validation
+// (credentials.NewTLS(nil) covers the default OS root pool case). For
+// local dev / bufconn tests, pass
+// grpc.WithTransportCredentials(insecure.NewCredentials()) — from
+// google.golang.org/grpc/credentials/insecure. Production wire-up uses
+// the [NewGRPCBackendWithAuth] constructor and the buildGRPCDialOptions
+// helper in auth.go to assemble both transport credentials and per-RPC
+// OIDC auth in one shot.
 func NewGRPCBackend(target string, opts ...grpc.DialOption) (*GRPCBackend, error) {
 	conn, err := grpc.NewClient(target, opts...)
 	if err != nil {
@@ -62,6 +83,27 @@ func NewGRPCBackendFromClient(conn *grpc.ClientConn) *GRPCBackend {
 		conn:   conn,
 		client: storev1.NewStoreServiceClient(conn),
 	}
+}
+
+// NewGRPCBackendWithAuth is the production constructor used by
+// Component.Initialize. It dials target with the supplied DialOptions
+// and binds the AuthProvider to the backend's lifecycle so Close()
+// releases both the gRPC connection and any provider-held resources
+// (OIDC token cache HTTP clients, etc.).
+//
+// The dialOpts slice is expected to already include transport credentials
+// (TLS or insecure) and any grpc.WithPerRPCCredentials needed for auth;
+// see buildGRPCDialOptions in auth.go for the canonical construction.
+func NewGRPCBackendWithAuth(target string, auth AuthProvider, dialOpts ...grpc.DialOption) (*GRPCBackend, error) {
+	conn, err := grpc.NewClient(target, dialOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("dial directory %q: %w", target, err)
+	}
+	return &GRPCBackend{
+		conn:   conn,
+		client: storev1.NewStoreServiceClient(conn),
+		auth:   auth,
+	}, nil
 }
 
 // Publish marshals the OASF record into a structpb.Struct, drives one
@@ -122,9 +164,13 @@ func (b *GRPCBackend) Publish(ctx context.Context, req *PublishRequest) (*Publis
 	}, nil
 }
 
-// Refresh is a no-op for CID-anchored records. The bridge skips heartbeats
-// when ExpiresAt.IsZero(), so this should not be called in practice; if it
-// is (e.g. operator manually triggers), echo the RecordID back.
+// Refresh returns [ErrRefreshNotSupported]. The bridge's
+// RegistrationManager skips this code path for CID-anchored backends
+// (Publish returns zero ExpiresAt, and sendHeartbeats short-circuits on
+// IsZero), so this method only fires when a caller bypasses the
+// manager and invokes Refresh directly. Pre-PR-C behaviour was to echo
+// the RecordID back silently — the typed sentinel surfaces the misuse
+// loudly, per the go-reviewer pass on PR #70.
 func (b *GRPCBackend) Refresh(_ context.Context, req *RefreshRequest) (*PublishResult, error) {
 	if req == nil {
 		return nil, fmt.Errorf("refresh request is nil")
@@ -132,10 +178,7 @@ func (b *GRPCBackend) Refresh(_ context.Context, req *RefreshRequest) (*PublishR
 	if req.RecordID == "" {
 		return nil, fmt.Errorf("refresh request RecordID is empty")
 	}
-	return &PublishResult{
-		RecordID:  req.RecordID,
-		ExpiresAt: time.Time{},
-	}, nil
+	return nil, ErrRefreshNotSupported
 }
 
 // Withdraw drives the StoreService.Delete client-streaming RPC for one
@@ -166,14 +209,23 @@ func (b *GRPCBackend) Withdraw(ctx context.Context, req *WithdrawRequest) error 
 	return nil
 }
 
-// Close tears down the underlying gRPC client connection. Safe to call
-// once; subsequent calls return whatever grpc.ClientConn.Close returns
-// (typically nil even when already closed).
+// Close tears down the underlying gRPC client connection and releases
+// any bound AuthProvider resources. Safe to call once; subsequent calls
+// return whatever grpc.ClientConn.Close returns (typically nil even
+// when already closed).
 func (b *GRPCBackend) Close() error {
-	if b.conn == nil {
-		return nil
+	var firstErr error
+	if b.auth != nil {
+		if err := b.auth.Close(); err != nil {
+			firstErr = err
+		}
 	}
-	return b.conn.Close()
+	if b.conn != nil {
+		if err := b.conn.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 // oasfToProtoRecord converts our domain OASFRecord into the wire-level

--- a/output/directory-bridge/grpc_backend_test.go
+++ b/output/directory-bridge/grpc_backend_test.go
@@ -250,26 +250,22 @@ func TestGRPCBackend_PublishWithdrawRoundTrip(t *testing.T) {
 	}
 }
 
-// TestGRPCBackend_RefreshIsNoop documents the CID-anchored contract:
-// Refresh never hits the wire (fake.pushCalls stays at 0) and returns
-// the same RecordID with ExpiresAt zero so the bridge keeps skipping
-// heartbeats for this registration.
-func TestGRPCBackend_RefreshIsNoop(t *testing.T) {
+// TestGRPCBackend_RefreshReturnsNotSupported documents the
+// CID-anchored contract: Refresh never hits the wire AND surfaces a
+// typed [ErrRefreshNotSupported] sentinel. The bridge's
+// RegistrationManager skips Refresh when ExpiresAt.IsZero() (set by
+// Publish for this backend), so direct callers — only seen on
+// operator-triggered re-publish or debug tools — get a clear signal.
+func TestGRPCBackend_RefreshReturnsNotSupported(t *testing.T) {
 	fake, backend, teardown := startTestServer(t)
 	defer teardown()
 
-	res, err := backend.Refresh(context.Background(), &RefreshRequest{
+	_, err := backend.Refresh(context.Background(), &RefreshRequest{
 		RecordID: "test:abcdef",
 		AgentDID: "did:test",
 	})
-	if err != nil {
-		t.Fatalf("Refresh: %v", err)
-	}
-	if res.RecordID != "test:abcdef" {
-		t.Errorf("RecordID = %q, want echo of input", res.RecordID)
-	}
-	if !res.ExpiresAt.IsZero() {
-		t.Errorf("ExpiresAt = %v, want zero", res.ExpiresAt)
+	if !errors.Is(err, ErrRefreshNotSupported) {
+		t.Errorf("Refresh err = %v, want %v", err, ErrRefreshNotSupported)
 	}
 	if fake.pushCalls != 0 || fake.deleteCalls != 0 {
 		t.Errorf("Refresh hit the wire: push=%d delete=%d, want 0/0", fake.pushCalls, fake.deleteCalls)

--- a/output/directory-bridge/registration.go
+++ b/output/directory-bridge/registration.go
@@ -2,6 +2,7 @@ package directorybridge
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -315,6 +316,20 @@ func (rm *RegistrationManager) sendHeartbeats(ctx context.Context) {
 			AgentDID: reg.AgentDID,
 		})
 		if err != nil {
+			// Self-healing path for CID-anchored backends: a non-zero
+			// ExpiresAt got into the map (operator forge, future bug),
+			// the backend's Refresh returns ErrRefreshNotSupported, and
+			// without intervention we'd log "Heartbeat failed" forever
+			// at every interval. Zero out ExpiresAt so the IsZero guard
+			// above starts skipping this registration cleanly.
+			if errors.Is(err, ErrRefreshNotSupported) {
+				rm.logger.Warn("Backend does not support refresh; clearing expiry to stop further heartbeat attempts",
+					slog.String("entity_id", reg.EntityID))
+				rm.mu.Lock()
+				reg.ExpiresAt = time.Time{}
+				rm.mu.Unlock()
+				continue
+			}
 			rm.logger.Warn("Heartbeat failed",
 				slog.String("entity_id", reg.EntityID),
 				slog.Any("error", err))

--- a/schemas/directory-bridge.v1.json
+++ b/schemas/directory-bridge.v1.json
@@ -5,6 +5,60 @@
   "title": "directory-bridge Configuration",
   "description": "Registers agents with AGNTCY directories using OASF records",
   "properties": {
+    "agntcy_grpc": {
+      "type": "object",
+      "description": "agntcy_grpc backend settings",
+      "category": "basic",
+      "properties": {
+        "auth": {
+          "type": "object",
+          "description": "auth",
+          "properties": {
+            "client_id": {
+              "type": "string",
+              "description": "client_id"
+            },
+            "client_id_env": {
+              "type": "string",
+              "description": "client_id_env"
+            },
+            "client_secret_env": {
+              "type": "string",
+              "description": "client_secret_env"
+            },
+            "issuer": {
+              "type": "string",
+              "description": "issuer"
+            },
+            "scopes": {
+              "type": "array",
+              "description": "scopes",
+              "items": {
+                "type": "string"
+              }
+            },
+            "type": {
+              "type": "string",
+              "description": "type"
+            }
+          }
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "endpoint"
+        },
+        "tls": {
+          "type": "boolean",
+          "description": "tls"
+        }
+      }
+    },
+    "backend": {
+      "type": "string",
+      "description": "Wire-format backend (http or agntcy_grpc)",
+      "default": "http",
+      "category": "basic"
+    },
     "consumer_name_suffix": {
       "type": "string",
       "description": "Suffix for consumer names",
@@ -18,7 +72,7 @@
     },
     "directory_url": {
       "type": "string",
-      "description": "AGNTCY directory service URL",
+      "description": "AGNTCY directory service URL (HTTP backend only)",
       "category": "basic"
     },
     "heartbeat_interval": {

--- a/schemas/directory-bridge.v1.json
+++ b/schemas/directory-bridge.v1.json
@@ -12,44 +12,54 @@
       "properties": {
         "auth": {
           "type": "object",
-          "description": "auth",
+          "description": "Per-RPC OIDC auth (omit for unauthenticated)",
+          "category": "basic",
           "properties": {
             "client_id": {
               "type": "string",
-              "description": "client_id"
+              "description": "OIDC client identifier (inline; prefer client_id_env)",
+              "category": "basic"
             },
             "client_id_env": {
               "type": "string",
-              "description": "client_id_env"
+              "description": "Env var name for OIDC client_id (wins over inline)",
+              "category": "basic"
             },
             "client_secret_env": {
               "type": "string",
-              "description": "client_secret_env"
+              "description": "Env var name for OIDC client_secret (secrets must not live in config)",
+              "category": "basic"
             },
             "issuer": {
               "type": "string",
-              "description": "issuer"
+              "description": "OIDC token endpoint URL",
+              "category": "basic"
             },
             "scopes": {
               "type": "array",
-              "description": "scopes",
+              "description": "OIDC scope list",
               "items": {
                 "type": "string"
-              }
+              },
+              "category": "basic"
             },
             "type": {
               "type": "string",
-              "description": "type"
+              "description": "Auth flow (none or oidc)",
+              "default": "none",
+              "category": "basic"
             }
           }
         },
         "endpoint": {
           "type": "string",
-          "description": "endpoint"
+          "description": "gRPC endpoint host:port",
+          "category": "basic"
         },
         "tls": {
           "type": "boolean",
-          "description": "tls"
+          "description": "Establish TLS on dial (required for the hosted hub)",
+          "category": "basic"
         }
       }
     },


### PR DESCRIPTION
## Summary

Completes the AGNTCY publisher-mode rollout from ADR-042. \`Component.Initialize\` now selects between \`HTTPBackend\` and \`GRPCBackend\` based on \`config.Backend\`; the gRPC path threads OIDC client-credentials auth into per-RPC credentials when configured. After this PR the wire path is operator-configurable end-to-end against AGNTCY-conformant directories, including the hosted hub at \`prod.api.ads.outshift.io\`.

## What's in

### Config (\`config.go\`)
- New \`Backend\` selector field: \`"http"\` (default, backwards-compatible) or \`"agntcy_grpc"\`. Empty defaults to http.
- New \`AgntcyGRPCConfig\` block (endpoint, TLS, auth).
- New \`AuthConfig\` type with \`"none"\` or \`"oidc"\` flows. OIDC reads \`client_id\` from inline or env var; \`client_secret\` **strictly from env** — no inline field, secrets do not live in JSON config on disk.
- \`Validate()\` covers all branches with explicit error messages naming the missing field.
- **JSON round-trip test** pinned per the \`feedback_polymorphic_config_needs_json_roundtrip_test\` discipline.

### Auth (\`auth.go\`)
- \`AuthProvider\` interface (\`PerRPC\` + \`Close\`).
- \`NoOpAuthProvider\` for local dev / bufconn / unauthenticated private hubs.
- \`OIDCAuthProvider\` via \`golang.org/x/oauth2/clientcredentials\` (already a transitive dep; promoted to direct in go.mod).
- Hand-rolled \`oauthTokenSource\` adapter wrapping \`oauth2.TokenSource\` as gRPC \`PerRPCCredentials\` — avoids pulling \`google.golang.org/grpc/credentials/oauth\` which transitively depends on \`google.golang.org/api\`.
- \`buildGRPCDialOptions\` assembles TLS + per-RPC auth in one shot; used by \`Component.buildBackend\`.

### Component (\`component.go\`)
- New \`buildBackend()\` helper switches on \`config.Backend\`.
- The \`agntcy_grpc\` path constructs \`AuthProvider\` via \`NewAuthProvider\`, builds DialOptions via \`buildGRPCDialOptions\`, and dials via \`NewGRPCBackendWithAuth\` (new constructor that binds \`AuthProvider\` to the backend's lifecycle so \`Close()\` releases both conn + provider).

## Deferred findings closed in-PR

While the surface was open:

- **#5** — \`GRPCBackend.Refresh\` returns the typed \`ErrRefreshNotSupported\` sentinel instead of silently echoing the RecordID. \`errors.Is\`-friendly. Direct callers (operator-triggered re-publish, debug tools) now get a clear signal.
- **#8** — \`NewGRPCBackend\` doc-string references the correct \`google.golang.org/grpc/credentials/insecure\` import path and points at \`NewGRPCBackendWithAuth\` + \`buildGRPCDialOptions\` as the production wire-up path.

Memory \`project_pr70_deferred_review_findings.md\` updated. Only #6 (sendHeartbeats \`*Registration\` field race) and #7 (double-Close idempotency test) remain; neither blocks PR-D.

## Example config

\`\`\`jsonc
{
  "directory-bridge": {
    "backend": "agntcy_grpc",
    "agntcy_grpc": {
      "endpoint": "prod.api.ads.outshift.io:443",
      "tls": true,
      "auth": {
        "type": "oidc",
        "issuer": "https://idp.example.com/oauth2/token",
        "client_id": "semstreams-publisher",
        "client_secret_env": "AGNTCY_CLIENT_SECRET",
        "scopes": ["agntcy.publish"]
      }
    },
    "heartbeat_interval": "5m",
    "registration_ttl": "30m",
    "oasf_kv_bucket": "OASF_RECORDS"
  }
}
\`\`\`

## Test plan

- [x] \`go test -race ./output/directory-bridge/\` — all green (existing suite + 9 new config/auth tests)
- [x] \`go build ./...\` — clean
- [x] \`task lint\` — \`go vet\`, \`go fmt\`, \`revive\` clean
- [x] \`task schema:generate\` clean (schemas/directory-bridge.v1.json regenerated)
- [x] Full repo \`go test\` green modulo known-flaky integration tests in natsclient/websocket/graph-index (pass on rerun; unrelated to this PR)
- [ ] CI green
- [ ] go-reviewer pass (will request before requesting human review)

## Roadmap

- **#75 (ADR-042)** ✅ merged
- **#76 (PR-O1)** ✅ merged — \`vocabulary/oasf\` scaffold
- **#78 (PR-O2)** ✅ merged — generator refactor
- **#79 (PR-O3)** ✅ merged — typed Decode at marshal boundary
- **This PR (PR-C)** — config + OIDC + factory wire-up
- **PR-D** — opt-in hosted-sandbox e2e stage gated on \`AGNTCY_HUB_AUTH\` env

🤖 Generated with [Claude Code](https://claude.com/claude-code)