### PR TITLE
feat(e2e): opt-in hosted-sandbox publish stage (ADR-042 PR-D)

### DIFF
--- a/test/e2e/scenarios/agentic/agntcy_hub_stages.go
+++ b/test/e2e/scenarios/agentic/agntcy_hub_stages.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	directorybridge "github.com/c360studio/semstreams/output/directory-bridge"
@@ -20,6 +21,11 @@ import (
 // (which is unexported) without taking a dependency on internals — the
 // stage runs outside the bridge's Component shell because it doesn't
 // need the KV-watch / heartbeat machinery, just the bare Backend.
+//
+// Duplication is intentional, not an accident — exporting the bridge's
+// helper would add a public API surface whose only consumer is this
+// test-binary stage. The mirror is shallow (TLS or insecure + optional
+// per-RPC creds) and drift risk is low. See PR #81 go-reviewer S4.
 func buildHubDialOptions(cfg *directorybridge.AgntcyGRPCConfig, auth directorybridge.AuthProvider) []grpc.DialOption {
 	opts := make([]grpc.DialOption, 0, 2)
 	if cfg.TLS {
@@ -45,8 +51,15 @@ func buildHubDialOptions(cfg *directorybridge.AgntcyGRPCConfig, auth directorybr
 //	AGNTCY_HUB_AUTH=1
 //	AGNTCY_HUB_ENDPOINT="prod.api.ads.outshift.io:443"   # optional override
 //	AGNTCY_HUB_OIDC_ISSUER="https://idp.example.com/oauth2/token"
-//	AGNTCY_HUB_CLIENT_ID="..."                            # or AGNTCY_HUB_CLIENT_ID_VALUE
+//	AGNTCY_HUB_CLIENT_ID="..."
 //	AGNTCY_HUB_CLIENT_SECRET="..."                        # required
+//	AGNTCY_HUB_TIMEOUT="30s"                              # optional, default 30s
+//
+// Gate semantics: AGNTCY_HUB_AUTH set to *any non-empty value* enables
+// the stage. The gate does NOT honor "0" / "false" / "no" — only empty
+// or unset skips. This is the safer default for a stage that publishes
+// to a production directory: opt-in must be deliberate, opt-out is the
+// default.
 //
 // Why opt-in: this stage talks to a real directory and would either
 // pollute it with CI-named records or fail without credentials. Default
@@ -66,6 +79,15 @@ func (s *Scenario) verifyAGNTCYHubPublish(ctx context.Context, result *scenarios
 		return fmt.Errorf("AGNTCY hub config: %w", err)
 	}
 
+	timeout := 30 * time.Second
+	if v := os.Getenv("AGNTCY_HUB_TIMEOUT"); v != "" {
+		parsed, perr := time.ParseDuration(v)
+		if perr != nil {
+			return fmt.Errorf("invalid AGNTCY_HUB_TIMEOUT %q: %w", v, perr)
+		}
+		timeout = parsed
+	}
+
 	auth, err := directorybridge.NewAuthProvider(cfg.Auth)
 	if err != nil {
 		return fmt.Errorf("build auth provider: %w", err)
@@ -80,11 +102,16 @@ func (s *Scenario) verifyAGNTCYHubPublish(ctx context.Context, result *scenarios
 	defer backend.Close()
 
 	record := buildHubTestRecord()
-	pubCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	entityID, ok := record.Extensions["semstreams_entity_id"].(string)
+	if !ok || entityID == "" {
+		return fmt.Errorf("internal: semstreams_entity_id extension missing or wrong type on test record")
+	}
+
+	pubCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	pub, err := backend.Publish(pubCtx, &directorybridge.PublishRequest{
-		EntityID: record.Extensions["semstreams_entity_id"].(string),
+		EntityID: entityID,
 		AgentDID: "did:semstreams:e2e-hub-publish-test",
 		Record:   record,
 		TTL:      0, // CID-anchored backend — TTL ignored
@@ -105,14 +132,17 @@ func (s *Scenario) verifyAGNTCYHubPublish(ctx context.Context, result *scenarios
 	// Cleanup: withdraw the test record so we don't leave CI artifacts
 	// in the hub's index. Errors here are logged-not-fatal — the
 	// publish succeeded, that's the assertion the stage is making.
-	withdrawCtx, cancelW := context.WithTimeout(ctx, 30*time.Second)
+	// Include the CID in the warning so operators have what they need
+	// to manually delete the record if our cleanup failed.
+	withdrawCtx, cancelW := context.WithTimeout(ctx, timeout)
 	defer cancelW()
 	if err := backend.Withdraw(withdrawCtx, &directorybridge.WithdrawRequest{
 		RecordID: pub.RecordID,
 		AgentDID: "did:semstreams:e2e-hub-publish-test",
 	}); err != nil {
 		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("hub withdraw failed (record left in directory): %v", err))
+			fmt.Sprintf("hub withdraw failed for CID %s (record left in directory; entity_id=%s): %v",
+				pub.RecordID, entityID, err))
 	} else {
 		result.Details["agntcy_hub_publish_cleanup"] = "withdrawn"
 	}
@@ -172,24 +202,15 @@ func buildHubConfigFromEnv() (*directorybridge.AgntcyGRPCConfig, error) {
 }
 
 // splitCSV splits a comma-separated env value into trimmed entries.
-// Empty entries are dropped.
+// Empty entries are dropped. Uses strings.TrimSpace so we correctly
+// handle CR/LF / NBSP / other Unicode whitespace that env values can
+// carry from Windows copy-paste etc.
 func splitCSV(s string) []string {
-	var out []string
-	start := 0
-	for i := 0; i <= len(s); i++ {
-		if i == len(s) || s[i] == ',' {
-			seg := s[start:i]
-			// Trim leading/trailing ASCII space without pulling strings.
-			for len(seg) > 0 && (seg[0] == ' ' || seg[0] == '\t') {
-				seg = seg[1:]
-			}
-			for len(seg) > 0 && (seg[len(seg)-1] == ' ' || seg[len(seg)-1] == '\t') {
-				seg = seg[:len(seg)-1]
-			}
-			if seg != "" {
-				out = append(out, seg)
-			}
-			start = i + 1
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
 		}
 	}
 	return out
@@ -197,11 +218,13 @@ func splitCSV(s string) []string {
 
 // buildHubTestRecord constructs a minimal OASF record for the hub-
 // publish smoke test. The entity ID encodes "this is a SemStreams CI
-// artifact" so AGNTCY operators reviewing the directory can identify
-// it as safe to delete if our withdraw cleanup ever fails.
+// artifact" in the 6-part SemStreams convention (org.platform.domain.
+// system.type.instance per CLAUDE.md) so AGNTCY operators reviewing
+// the directory can identify it as safe to delete if our withdraw
+// cleanup ever fails.
 func buildHubTestRecord() *oasfgenerator.OASFRecord {
 	now := time.Now().UTC()
-	entityID := fmt.Sprintf("semstreams.ci.publisher.test.%d", now.Unix())
+	entityID := fmt.Sprintf("semstreams.e2e.publisher.hub.smoke.%d", now.Unix())
 
 	rec := &oasfgenerator.OASFRecord{
 		Name:          "semstreams-ci-publisher-test",

--- a/test/e2e/scenarios/agentic/agntcy_hub_stages.go
+++ b/test/e2e/scenarios/agentic/agntcy_hub_stages.go
@@ -1,0 +1,225 @@
+package agentic
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	directorybridge "github.com/c360studio/semstreams/output/directory-bridge"
+	oasfgenerator "github.com/c360studio/semstreams/processor/oasf-generator"
+	"github.com/c360studio/semstreams/test/e2e/scenarios"
+	"github.com/c360studio/semstreams/vocabulary/oasf"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// buildHubDialOptions assembles transport and per-RPC credentials for
+// the hub publish stage. Mirrors directory-bridge.buildGRPCDialOptions
+// (which is unexported) without taking a dependency on internals — the
+// stage runs outside the bridge's Component shell because it doesn't
+// need the KV-watch / heartbeat machinery, just the bare Backend.
+func buildHubDialOptions(cfg *directorybridge.AgntcyGRPCConfig, auth directorybridge.AuthProvider) []grpc.DialOption {
+	opts := make([]grpc.DialOption, 0, 2)
+	if cfg.TLS {
+		opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(nil)))
+	} else {
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	if perRPC := auth.PerRPC(); perRPC != nil {
+		opts = append(opts, grpc.WithPerRPCCredentials(perRPC))
+	}
+	return opts
+}
+
+// verifyAGNTCYHubPublish is the opt-in PR-D stage from ADR-042. It
+// validates the agntcy_grpc backend wire path end-to-end against the
+// AGNTCY hosted hub (or any AGNTCY-conformant directory the operator
+// points at via env vars) by publishing a small OASF record, asserting
+// a CID is returned, then withdrawing the record for cleanup.
+//
+// Skips silently when AGNTCY_HUB_AUTH is unset — the default CI
+// behaviour. Opt in by setting:
+//
+//	AGNTCY_HUB_AUTH=1
+//	AGNTCY_HUB_ENDPOINT="prod.api.ads.outshift.io:443"   # optional override
+//	AGNTCY_HUB_OIDC_ISSUER="https://idp.example.com/oauth2/token"
+//	AGNTCY_HUB_CLIENT_ID="..."                            # or AGNTCY_HUB_CLIENT_ID_VALUE
+//	AGNTCY_HUB_CLIENT_SECRET="..."                        # required
+//
+// Why opt-in: this stage talks to a real directory and would either
+// pollute it with CI-named records or fail without credentials. Default
+// CI runs the mock-server stages instead (verifyDirectoryBridge etc.).
+//
+// What this exercises that no other test does: real TLS, real OIDC
+// client-credentials flow, real gRPC dial, real Push and Delete
+// streams against AGNTCY's typed schema validation.
+func (s *Scenario) verifyAGNTCYHubPublish(ctx context.Context, result *scenarios.Result) error {
+	if os.Getenv("AGNTCY_HUB_AUTH") == "" {
+		result.Details["agntcy_hub_publish_skipped"] = "AGNTCY_HUB_AUTH not set (opt-in stage)"
+		return nil
+	}
+
+	cfg, err := buildHubConfigFromEnv()
+	if err != nil {
+		return fmt.Errorf("AGNTCY hub config: %w", err)
+	}
+
+	auth, err := directorybridge.NewAuthProvider(cfg.Auth)
+	if err != nil {
+		return fmt.Errorf("build auth provider: %w", err)
+	}
+
+	dialOpts := buildHubDialOptions(cfg, auth)
+	backend, err := directorybridge.NewGRPCBackendWithAuth(cfg.Endpoint, auth, dialOpts...)
+	if err != nil {
+		_ = auth.Close()
+		return fmt.Errorf("dial hub %q: %w", cfg.Endpoint, err)
+	}
+	defer backend.Close()
+
+	record := buildHubTestRecord()
+	pubCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	pub, err := backend.Publish(pubCtx, &directorybridge.PublishRequest{
+		EntityID: record.Extensions["semstreams_entity_id"].(string),
+		AgentDID: "did:semstreams:e2e-hub-publish-test",
+		Record:   record,
+		TTL:      0, // CID-anchored backend — TTL ignored
+		Metadata: map[string]any{
+			"source":                  "semstreams-e2e",
+			"test_run_purpose":        "PR-D hub publish smoke",
+			"safe_to_garbage_collect": true,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("publish to hub: %w", err)
+	}
+	if pub.RecordID == "" {
+		return fmt.Errorf("hub returned empty CID")
+	}
+	result.Details["agntcy_hub_publish_cid"] = pub.RecordID
+
+	// Cleanup: withdraw the test record so we don't leave CI artifacts
+	// in the hub's index. Errors here are logged-not-fatal — the
+	// publish succeeded, that's the assertion the stage is making.
+	withdrawCtx, cancelW := context.WithTimeout(ctx, 30*time.Second)
+	defer cancelW()
+	if err := backend.Withdraw(withdrawCtx, &directorybridge.WithdrawRequest{
+		RecordID: pub.RecordID,
+		AgentDID: "did:semstreams:e2e-hub-publish-test",
+	}); err != nil {
+		result.Warnings = append(result.Warnings,
+			fmt.Sprintf("hub withdraw failed (record left in directory): %v", err))
+	} else {
+		result.Details["agntcy_hub_publish_cleanup"] = "withdrawn"
+	}
+
+	result.Details["agntcy_hub_publish_verified"] = true
+	return nil
+}
+
+// buildHubConfigFromEnv assembles an AgntcyGRPCConfig from the
+// AGNTCY_HUB_* env-var set. Returns an error if any required field is
+// missing. The full set, with defaults:
+//
+//	AGNTCY_HUB_ENDPOINT       (default "prod.api.ads.outshift.io:443")
+//	AGNTCY_HUB_TLS            (default "true"; set to "false" only for local mocks)
+//	AGNTCY_HUB_OIDC_ISSUER    (required when auth is on)
+//	AGNTCY_HUB_CLIENT_ID      (inline OIDC client_id)
+//	AGNTCY_HUB_CLIENT_SECRET  (the secret itself; the AuthConfig stores
+//	                           the env var *name* — for the stage we
+//	                           use a fixed name and read it here)
+//	AGNTCY_HUB_SCOPES         (comma-separated; optional)
+func buildHubConfigFromEnv() (*directorybridge.AgntcyGRPCConfig, error) {
+	endpoint := os.Getenv("AGNTCY_HUB_ENDPOINT")
+	if endpoint == "" {
+		endpoint = "prod.api.ads.outshift.io:443"
+	}
+
+	tls := true
+	if v := os.Getenv("AGNTCY_HUB_TLS"); v == "false" || v == "0" {
+		tls = false
+	}
+
+	issuer := os.Getenv("AGNTCY_HUB_OIDC_ISSUER")
+	clientID := os.Getenv("AGNTCY_HUB_CLIENT_ID")
+	if issuer == "" || clientID == "" {
+		return nil, fmt.Errorf("AGNTCY_HUB_OIDC_ISSUER and AGNTCY_HUB_CLIENT_ID required when AGNTCY_HUB_AUTH is set")
+	}
+	if os.Getenv("AGNTCY_HUB_CLIENT_SECRET") == "" {
+		return nil, fmt.Errorf("AGNTCY_HUB_CLIENT_SECRET env var is empty")
+	}
+
+	var scopes []string
+	if v := os.Getenv("AGNTCY_HUB_SCOPES"); v != "" {
+		scopes = splitCSV(v)
+	}
+
+	return &directorybridge.AgntcyGRPCConfig{
+		Endpoint: endpoint,
+		TLS:      tls,
+		Auth: &directorybridge.AuthConfig{
+			Type:            "oidc",
+			Issuer:          issuer,
+			ClientID:        clientID,
+			ClientSecretEnv: "AGNTCY_HUB_CLIENT_SECRET",
+			Scopes:          scopes,
+		},
+	}, nil
+}
+
+// splitCSV splits a comma-separated env value into trimmed entries.
+// Empty entries are dropped.
+func splitCSV(s string) []string {
+	var out []string
+	start := 0
+	for i := 0; i <= len(s); i++ {
+		if i == len(s) || s[i] == ',' {
+			seg := s[start:i]
+			// Trim leading/trailing ASCII space without pulling strings.
+			for len(seg) > 0 && (seg[0] == ' ' || seg[0] == '\t') {
+				seg = seg[1:]
+			}
+			for len(seg) > 0 && (seg[len(seg)-1] == ' ' || seg[len(seg)-1] == '\t') {
+				seg = seg[:len(seg)-1]
+			}
+			if seg != "" {
+				out = append(out, seg)
+			}
+			start = i + 1
+		}
+	}
+	return out
+}
+
+// buildHubTestRecord constructs a minimal OASF record for the hub-
+// publish smoke test. The entity ID encodes "this is a SemStreams CI
+// artifact" so AGNTCY operators reviewing the directory can identify
+// it as safe to delete if our withdraw cleanup ever fails.
+func buildHubTestRecord() *oasfgenerator.OASFRecord {
+	now := time.Now().UTC()
+	entityID := fmt.Sprintf("semstreams.ci.publisher.test.%d", now.Unix())
+
+	rec := &oasfgenerator.OASFRecord{
+		Name:          "semstreams-ci-publisher-test",
+		Version:       "1.0.0",
+		SchemaVersion: "1.0.0",
+		CreatedAt:     now.Format(time.RFC3339),
+		Description:   "SemStreams CI publisher-mode smoke test — safe to garbage-collect after 1h.",
+		Authors:       []string{"semstreams-ci"},
+		Skills: []oasfgenerator.OASFSkill{{
+			ID:         oasf.CategoryToolInteraction,
+			Name:       oasf.Name(oasf.CategoryToolInteraction),
+			Confidence: 1.0,
+		}},
+		Extensions: map[string]any{
+			"semstreams_entity_id":          entityID,
+			"source":                        "semstreams-e2e",
+			"safe_to_garbage_collect_after": now.Add(1 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	return rec
+}

--- a/test/e2e/scenarios/agentic/agntcy_hub_stages_test.go
+++ b/test/e2e/scenarios/agentic/agntcy_hub_stages_test.go
@@ -1,7 +1,10 @@
 package agentic
 
 import (
+	"strings"
 	"testing"
+
+	directorybridge "github.com/c360studio/semstreams/output/directory-bridge"
 )
 
 func TestBuildHubConfigFromEnv_DefaultsAndRequiredFields(t *testing.T) {
@@ -57,7 +60,7 @@ func TestBuildHubConfigFromEnv_DefaultsAndRequiredFields(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
 			}
-			if !contains(err.Error(), tc.wantErr) {
+			if !strings.Contains(err.Error(), tc.wantErr) {
 				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantErr)
 			}
 		})
@@ -162,12 +165,37 @@ func TestSplitCSV(t *testing.T) {
 	}
 }
 
-// contains is a tiny substring helper to keep test imports minimal.
-func contains(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
+// TestBuildHubDialOptions_InsecureNoAuth covers the local-mock-direction
+// shape — insecure transport, no per-RPC creds. Locks the option count
+// so a future refactor that drops WithPerRPCCredentials (or doubles up
+// transport credentials) fails fast here instead of in the live-hub
+// path that doesn't run in CI.
+func TestBuildHubDialOptions_InsecureNoAuth(t *testing.T) {
+	cfg := &directorybridge.AgntcyGRPCConfig{Endpoint: "h:1", TLS: false}
+	opts := buildHubDialOptions(cfg, directorybridge.NoOpAuthProvider{})
+	if got := len(opts); got != 1 {
+		t.Errorf("len(opts) = %d, want 1 (just insecure transport)", got)
 	}
-	return false
+}
+
+// TestBuildHubDialOptions_TLSWithAuth covers the hosted-hub-direction
+// shape — TLS transport + PerRPC OIDC.
+func TestBuildHubDialOptions_TLSWithAuth(t *testing.T) {
+	t.Setenv("AGNTCY_HUB_TEST_SECRET", "s")
+	auth, err := directorybridge.NewAuthProvider(&directorybridge.AuthConfig{
+		Type:            "oidc",
+		Issuer:          "https://idp.example.com/token",
+		ClientID:        "c",
+		ClientSecretEnv: "AGNTCY_HUB_TEST_SECRET",
+	})
+	if err != nil {
+		t.Fatalf("NewAuthProvider: %v", err)
+	}
+	defer auth.Close()
+
+	cfg := &directorybridge.AgntcyGRPCConfig{Endpoint: "h:1", TLS: true}
+	opts := buildHubDialOptions(cfg, auth)
+	if got := len(opts); got != 2 {
+		t.Errorf("len(opts) = %d, want 2 (TLS transport + PerRPC OIDC)", got)
+	}
 }

--- a/test/e2e/scenarios/agentic/agntcy_hub_stages_test.go
+++ b/test/e2e/scenarios/agentic/agntcy_hub_stages_test.go
@@ -1,0 +1,173 @@
+package agentic
+
+import (
+	"testing"
+)
+
+func TestBuildHubConfigFromEnv_DefaultsAndRequiredFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     map[string]string
+		wantErr string
+	}{
+		{
+			name: "missing issuer",
+			env: map[string]string{
+				"AGNTCY_HUB_AUTH":          "1",
+				"AGNTCY_HUB_CLIENT_ID":     "ci-client",
+				"AGNTCY_HUB_CLIENT_SECRET": "s",
+			},
+			wantErr: "OIDC_ISSUER",
+		},
+		{
+			name: "missing client id",
+			env: map[string]string{
+				"AGNTCY_HUB_AUTH":          "1",
+				"AGNTCY_HUB_OIDC_ISSUER":   "https://idp/token",
+				"AGNTCY_HUB_CLIENT_SECRET": "s",
+			},
+			wantErr: "CLIENT_ID",
+		},
+		{
+			name: "missing client secret",
+			env: map[string]string{
+				"AGNTCY_HUB_AUTH":        "1",
+				"AGNTCY_HUB_OIDC_ISSUER": "https://idp/token",
+				"AGNTCY_HUB_CLIENT_ID":   "ci-client",
+			},
+			wantErr: "CLIENT_SECRET",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear potential leakage from the host env first; t.Setenv
+			// only sets the named keys.
+			t.Setenv("AGNTCY_HUB_AUTH", "")
+			t.Setenv("AGNTCY_HUB_OIDC_ISSUER", "")
+			t.Setenv("AGNTCY_HUB_CLIENT_ID", "")
+			t.Setenv("AGNTCY_HUB_CLIENT_SECRET", "")
+			t.Setenv("AGNTCY_HUB_ENDPOINT", "")
+			t.Setenv("AGNTCY_HUB_TLS", "")
+			t.Setenv("AGNTCY_HUB_SCOPES", "")
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+
+			_, err := buildHubConfigFromEnv()
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildHubConfigFromEnv_AllFieldsPopulated(t *testing.T) {
+	t.Setenv("AGNTCY_HUB_AUTH", "1")
+	t.Setenv("AGNTCY_HUB_ENDPOINT", "custom.example.com:9443")
+	t.Setenv("AGNTCY_HUB_TLS", "true")
+	t.Setenv("AGNTCY_HUB_OIDC_ISSUER", "https://idp.example.com/token")
+	t.Setenv("AGNTCY_HUB_CLIENT_ID", "ci-client")
+	t.Setenv("AGNTCY_HUB_CLIENT_SECRET", "the-secret")
+	t.Setenv("AGNTCY_HUB_SCOPES", "agntcy.publish, agntcy.read")
+
+	cfg, err := buildHubConfigFromEnv()
+	if err != nil {
+		t.Fatalf("buildHubConfigFromEnv: %v", err)
+	}
+	if cfg.Endpoint != "custom.example.com:9443" {
+		t.Errorf("Endpoint = %q, want override", cfg.Endpoint)
+	}
+	if !cfg.TLS {
+		t.Error("TLS = false, want true (env=\"true\")")
+	}
+	if cfg.Auth == nil {
+		t.Fatal("Auth is nil")
+	}
+	if cfg.Auth.Type != "oidc" {
+		t.Errorf("Auth.Type = %q, want \"oidc\"", cfg.Auth.Type)
+	}
+	if cfg.Auth.Issuer != "https://idp.example.com/token" {
+		t.Errorf("Auth.Issuer = %q", cfg.Auth.Issuer)
+	}
+	if cfg.Auth.ClientID != "ci-client" {
+		t.Errorf("Auth.ClientID = %q", cfg.Auth.ClientID)
+	}
+	if cfg.Auth.ClientSecretEnv != "AGNTCY_HUB_CLIENT_SECRET" {
+		t.Errorf("Auth.ClientSecretEnv = %q, want fixed name", cfg.Auth.ClientSecretEnv)
+	}
+	if len(cfg.Auth.Scopes) != 2 || cfg.Auth.Scopes[0] != "agntcy.publish" || cfg.Auth.Scopes[1] != "agntcy.read" {
+		t.Errorf("Auth.Scopes = %v, want [agntcy.publish agntcy.read]", cfg.Auth.Scopes)
+	}
+}
+
+func TestBuildHubConfigFromEnv_DefaultEndpoint(t *testing.T) {
+	t.Setenv("AGNTCY_HUB_AUTH", "1")
+	t.Setenv("AGNTCY_HUB_ENDPOINT", "") // empty triggers default
+	t.Setenv("AGNTCY_HUB_OIDC_ISSUER", "https://idp/token")
+	t.Setenv("AGNTCY_HUB_CLIENT_ID", "c")
+	t.Setenv("AGNTCY_HUB_CLIENT_SECRET", "s")
+
+	cfg, err := buildHubConfigFromEnv()
+	if err != nil {
+		t.Fatalf("buildHubConfigFromEnv: %v", err)
+	}
+	if cfg.Endpoint != "prod.api.ads.outshift.io:443" {
+		t.Errorf("default endpoint = %q, want prod.api.ads.outshift.io:443", cfg.Endpoint)
+	}
+}
+
+func TestBuildHubConfigFromEnv_TLSFalse(t *testing.T) {
+	t.Setenv("AGNTCY_HUB_AUTH", "1")
+	t.Setenv("AGNTCY_HUB_TLS", "false")
+	t.Setenv("AGNTCY_HUB_OIDC_ISSUER", "https://idp/token")
+	t.Setenv("AGNTCY_HUB_CLIENT_ID", "c")
+	t.Setenv("AGNTCY_HUB_CLIENT_SECRET", "s")
+
+	cfg, err := buildHubConfigFromEnv()
+	if err != nil {
+		t.Fatalf("buildHubConfigFromEnv: %v", err)
+	}
+	if cfg.TLS {
+		t.Error("TLS = true, want false (env=\"false\")")
+	}
+}
+
+func TestSplitCSV(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"a", []string{"a"}},
+		{"a,b,c", []string{"a", "b", "c"}},
+		{"a, b , c", []string{"a", "b", "c"}},
+		{"a,,b", []string{"a", "b"}}, // empty entries dropped
+		{",a,", []string{"a"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := splitCSV(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("splitCSV(%q) len = %d, want %d (got %v)", tc.in, len(got), len(tc.want), got)
+			}
+			for i, w := range tc.want {
+				if got[i] != w {
+					t.Errorf("splitCSV(%q)[%d] = %q, want %q", tc.in, i, got[i], w)
+				}
+			}
+		})
+	}
+}
+
+// contains is a tiny substring helper to keep test imports minimal.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/scenarios/agentic/scenario.go
+++ b/test/e2e/scenarios/agentic/scenario.go
@@ -166,6 +166,11 @@ func (s *Scenario) Execute(ctx context.Context) (*scenarios.Result, error) {
 		{"verify-a2a-adapter", s.verifyA2AAdapter},
 		{"verify-a2a-task-lifecycle", s.verifyA2ATaskLifecycle},
 		{"verify-otel-export", s.verifyOTELExport},
+		// Opt-in: only runs when AGNTCY_HUB_AUTH env is set. Publishes
+		// to a real AGNTCY-conformant directory (default
+		// prod.api.ads.outshift.io:443). Default CI skips cleanly.
+		// See verifyAGNTCYHubPublish godoc for required env vars.
+		{"verify-agntcy-hub-publish", s.verifyAGNTCYHubPublish},
 	}
 
 	for _, stage := range stages {


### PR DESCRIPTION
## Summary

Final chunk of the ADR-042 AGNTCY publisher-mode rollout. Adds the \`verifyAGNTCYHubPublish\` stage to the agentic e2e scenario. The stage opt-in-gates on \`AGNTCY_HUB_AUTH\` env (skip cleanly when unset — the default CI behaviour), and when enabled exercises the full \`agntcy_grpc\` backend wire path end-to-end against the AGNTCY hosted hub or any AGNTCY-conformant directory the operator points at.

## What it does

- Reads endpoint + OIDC issuer + client_id + client_secret from the \`AGNTCY_HUB_*\` env-var set
- Builds a \`GRPCBackend\` via \`NewGRPCBackendWithAuth\` (TLS + per-RPC OIDC client-credentials)
- Publishes a small OASF record (extension class \`CategoryToolInteraction\`, \`semstreams-ci-publisher-test\` name, entity ID embeds an "ok to garbage-collect" marker for AGNTCY operators)
- Asserts a CID is returned
- Withdraws the record for cleanup (errors logged-not-fatal — the publish succeeded, which is the assertion)
- Closes the backend (releases conn + auth provider per the lifecycle binding from PR-C)

## What it exercises that no other test does

- Real TLS handshake against the live hub endpoint
- Real OIDC client-credentials token fetch + refresh
- Real gRPC dial against AGNTCY's typed proto schema validation
- Real Push and Delete streaming RPC round-trip

## Default skip

\`AGNTCY_HUB_AUTH\` unset → stage logs \`"AGNTCY_HUB_AUTH not set (opt-in stage)"\` and returns. **No CI churn without explicit opt-in.** No CI machinery is configured to set the gate; this is intentional — operators opt in deliberately when they have credentials and want to verify the wire path against a real directory.

## Required env when opting in

\`\`\`bash
AGNTCY_HUB_AUTH=1                                                # gate
AGNTCY_HUB_ENDPOINT="prod.api.ads.outshift.io:443"               # optional, default shown
AGNTCY_HUB_OIDC_ISSUER="https://idp.example.com/oauth2/token"
AGNTCY_HUB_CLIENT_ID="..."
AGNTCY_HUB_CLIENT_SECRET="..."
AGNTCY_HUB_TLS="true"                                            # optional, default
AGNTCY_HUB_SCOPES="agntcy.publish,agntcy.read"                   # optional
\`\`\`

## Tests

4 new unit tests covering env parsing — defaults, required-field errors, override propagation, CSV scope split. The live-hub path itself only runs when an operator sets the gate; CI exercises the parser only.

- [x] \`go test -race ./test/e2e/scenarios/agentic/\` — all green
- [x] \`go build ./...\` — clean
- [x] \`task lint\` — clean
- [ ] CI green
- [ ] go-reviewer pass (running concurrently with this PR)

## ADR-042 rollout — complete

| PR | Title | Status |
|----|-------|--------|
| #75 | ADR-042 design | ✅ merged |
| #76 (PR-O1) | \`vocabulary/oasf\` scaffold | ✅ merged |
| #78 (PR-O2) | generator refactor | ✅ merged |
| #79 (PR-O3) | typed Decode at marshal boundary | ✅ merged |
| #80 (PR-C) | config + OIDC + factory | ✅ merged |
| **this PR (PR-D)** | **hosted-sandbox e2e** | **open** |

Two PR #70 review findings remain open as independent hygiene PRs and don't block anything:
- #6 — sendHeartbeats \`*Registration\` field race
- #7 — double-Close idempotency test

🤖 Generated with [Claude Code](https://claude.com/claude-code)