### PR TITLE
feat(adr044): phase 2 — vocabulary/{sosa,swe,oms} + export Register()

### DIFF
--- a/vocabulary/export/phase2_smoke_test.go
+++ b/vocabulary/export/phase2_smoke_test.go
@@ -1,0 +1,138 @@
+package export_test
+
+// Phase 2 smoke test for ADR-044 — confirms that importing the
+// new vocabulary/{sosa,swe,oms} sub-packages registers their
+// prefixes via init() and that an end-to-end Turtle export of
+// app-level predicates bound to SOSA / SSN / SWE / OMS IRIs
+// produces compacted output with all four expected prefixes.
+//
+// This is the "first user" of the new packages that satisfies the
+// PR-scope rule: the three packages plus a proximate exporter
+// consumer ship together, so no dead code accumulates between the
+// framework merge and the first sister-repo consumer.
+//
+// The pattern exercised here is the established one: app-level
+// dotted predicates registered with vocabulary.Register(...,
+// WithIRI(sosa.Observes)). The IRI constants in vocabulary/sosa,
+// vocabulary/swe, and vocabulary/oms are designed to be passed
+// through WithIRI; the exporter's prefix table (extended via
+// each package's Register() init) handles the compaction.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/vocabulary"
+	"github.com/c360studio/semstreams/vocabulary/export"
+
+	// Blank-import to trigger init() prefix registration.
+	_ "github.com/c360studio/semstreams/vocabulary/oms"
+	_ "github.com/c360studio/semstreams/vocabulary/sosa"
+	_ "github.com/c360studio/semstreams/vocabulary/swe"
+
+	"github.com/c360studio/semstreams/vocabulary/oms"
+	"github.com/c360studio/semstreams/vocabulary/sosa"
+	"github.com/c360studio/semstreams/vocabulary/swe"
+)
+
+// registerPhase2SmokePredicates wires app-level dotted predicates
+// to the SOSA/SSN/SWE/OMS IRIs exposed by the new packages. In
+// production code this binding lives in each consumer's
+// domain-specific vocabulary file (per the existing pattern); the
+// test inlines it because the binding IS the demonstration.
+func registerPhase2SmokePredicates() {
+	vocabulary.Register("smoke.platform.hasDeployment", vocabulary.WithIRI(sosa.SSNHasDeployment))
+	vocabulary.Register("smoke.platform.hosts", vocabulary.WithIRI(sosa.Hosts))
+	vocabulary.Register("smoke.sensor.madeObservation", vocabulary.WithIRI(sosa.MadeObservation))
+	vocabulary.Register("smoke.observation.resultTime", vocabulary.WithIRI(sosa.ResultTime))
+	vocabulary.Register("smoke.observation.uom", vocabulary.WithIRI(swe.UoM))
+	vocabulary.Register("smoke.observation.observedProperty", vocabulary.WithIRI(oms.ObservedProperty))
+}
+
+func TestPhase2_SensorObservationExportsAllFourPrefixes(t *testing.T) {
+	defer vocabulary.SnapshotRegistry()()
+	registerPhase2SmokePredicates()
+
+	const (
+		platform    = "acme.ops.robotics.gcs.drone.001"
+		sensor      = "acme.ops.robotics.gcs.drone.001/sensor/battery"
+		observation = "acme.ops.robotics.gcs.drone.001/obs/123"
+		deployment  = "acme.ops.robotics.gcs.drone.001/deployment/mission-7"
+	)
+	triples := []message.Triple{
+		{Subject: platform, Predicate: "smoke.platform.hasDeployment", Object: deployment},
+		{Subject: platform, Predicate: "smoke.platform.hosts", Object: sensor},
+		{Subject: sensor, Predicate: "smoke.sensor.madeObservation", Object: observation},
+		{Subject: observation, Predicate: "smoke.observation.resultTime", Object: "2026-05-15T12:00:00Z"},
+		{Subject: observation, Predicate: "smoke.observation.uom", Object: "%"},
+		{Subject: observation, Predicate: "smoke.observation.observedProperty", Object: "http://example.org/battery-level"},
+	}
+
+	out, err := export.SerializeToString(triples, export.Turtle)
+	if err != nil {
+		t.Fatalf("SerializeToString: %v", err)
+	}
+
+	// Prefix declarations should appear for every namespace touched.
+	for _, want := range []string{
+		"@prefix sosa: <http://www.w3.org/ns/sosa/>",
+		"@prefix ssn: <http://www.w3.org/ns/ssn/>",
+		"@prefix swe: <http://www.opengis.net/swe/2.0/>",
+		"@prefix oms: <http://www.opengis.net/oms/3.0/>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+
+	// And the compacted predicates themselves should appear.
+	for _, want := range []string{
+		"ssn:hasDeployment",
+		"sosa:hosts",
+		"sosa:madeObservation",
+		"sosa:resultTime",
+		"swe:uom",
+		"oms:observedProperty",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain compacted predicate %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPhase2_RegisteredPrefixesSurviveExporterReuse(t *testing.T) {
+	defer vocabulary.SnapshotRegistry()()
+	registerPhase2SmokePredicates()
+
+	triples := []message.Triple{
+		{Subject: "acme.ops.robotics.gcs.drone.001", Predicate: "smoke.platform.hosts", Object: "sensor"},
+	}
+
+	first, err := export.SerializeToString(triples, export.Turtle)
+	if err != nil {
+		t.Fatalf("first export: %v", err)
+	}
+	if !strings.Contains(first, "sosa:hosts") {
+		t.Errorf("first export missing sosa:hosts:\n%s", first)
+	}
+
+	// A custom base IRI overrides only the ss: prefix; sosa: should still resolve.
+	second, err := export.SerializeToString(triples, export.Turtle, export.WithBaseIRI("https://example.org"))
+	if err != nil {
+		t.Fatalf("second export: %v", err)
+	}
+	if !strings.Contains(second, "sosa:hosts") {
+		t.Errorf("second export missing sosa:hosts:\n%s", second)
+	}
+	// The override should also re-base subject IRIs under the custom
+	// base, proving the snapshot-and-override interaction works
+	// together rather than the prefix snapshot silently shadowing it.
+	// (The @prefix ss: declaration only appears when an IRI actually
+	// compacts through ss: — entity-shaped subjects have slashes in
+	// their local part and bypass CURIE compaction, so we verify the
+	// effect on the subject IRI directly.)
+	if !strings.Contains(second, "<https://example.org/entities/") {
+		t.Errorf("second export expected subject IRI under custom base, got:\n%s", second)
+	}
+}

--- a/vocabulary/export/prefix.go
+++ b/vocabulary/export/prefix.go
@@ -1,27 +1,81 @@
 package export
 
 import (
+	"fmt"
+	"maps"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/c360studio/semstreams/vocabulary"
 )
 
 // defaultPrefixes maps short prefix names to their namespace IRIs.
 // Only prefixes that are actually used in output are emitted.
-var defaultPrefixes = map[string]string{
-	"rdf":    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-	"owl":    "http://www.w3.org/2002/07/owl#",
-	"skos":   "http://www.w3.org/2004/02/skos/core#",
-	"rdfs":   "http://www.w3.org/2000/01/rdf-schema#",
-	"dc":     "http://purl.org/dc/terms/",
-	"schema": "https://schema.org/",
-	"foaf":   "http://xmlns.com/foaf/0.1/",
-	"prov":   "http://www.w3.org/ns/prov#",
-	"ssn":    "http://www.w3.org/ns/ssn/",
-	"sosa":   "http://www.w3.org/ns/sosa/",
-	"xsd":    "http://www.w3.org/2001/XMLSchema#",
-	"ss":     vocabulary.SemStreamsBase + "/",
+//
+// The baseline set ships with the package; vocabulary sub-packages
+// (e.g. vocabulary/sosa, vocabulary/swe, vocabulary/oms) extend it
+// from init() via Register. Read access is mutex-guarded because
+// downstream code may register additional namespaces from init in
+// any package import order, and exporters snapshot the map at
+// newPrefixMap time.
+var (
+	defaultPrefixesMu sync.RWMutex
+	defaultPrefixes   = map[string]string{
+		"rdf":    "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+		"owl":    "http://www.w3.org/2002/07/owl#",
+		"skos":   "http://www.w3.org/2004/02/skos/core#",
+		"rdfs":   "http://www.w3.org/2000/01/rdf-schema#",
+		"dc":     "http://purl.org/dc/terms/",
+		"schema": "https://schema.org/",
+		"foaf":   "http://xmlns.com/foaf/0.1/",
+		"prov":   "http://www.w3.org/ns/prov#",
+		"ssn":    "http://www.w3.org/ns/ssn/",
+		"sosa":   "http://www.w3.org/ns/sosa/",
+		"xsd":    "http://www.w3.org/2001/XMLSchema#",
+		"ss":     vocabulary.SemStreamsBase + "/",
+	}
+)
+
+// Register adds a prefix → namespace binding to the export prefix
+// table. It is idempotent: registering the same prefix with the same
+// namespace twice is a no-op. Registering the same prefix with a
+// different namespace returns an error so collisions surface loudly
+// rather than silently shadowing.
+//
+// Intended use is from a package init() in a vocabulary sub-package
+// (e.g. vocabulary/sosa), so registrations land before any exporter
+// runs. The function is safe to call at runtime as well, but mid-
+// export registrations will only affect prefix maps constructed
+// after the call returns.
+func Register(prefix, namespace string) error {
+	if prefix == "" {
+		return fmt.Errorf("vocabulary/export: prefix must not be empty")
+	}
+	if namespace == "" {
+		return fmt.Errorf("vocabulary/export: namespace must not be empty for prefix %q", prefix)
+	}
+	defaultPrefixesMu.Lock()
+	defer defaultPrefixesMu.Unlock()
+	if existing, ok := defaultPrefixes[prefix]; ok {
+		if existing == namespace {
+			return nil
+		}
+		return fmt.Errorf("vocabulary/export: prefix %q already bound to %q, cannot rebind to %q", prefix, existing, namespace)
+	}
+	defaultPrefixes[prefix] = namespace
+	return nil
+}
+
+// snapshotDefaults returns a copy of the current prefix table under
+// the read lock. Callers iterate the returned map without holding
+// any lock.
+func snapshotDefaults() map[string]string {
+	defaultPrefixesMu.RLock()
+	defer defaultPrefixesMu.RUnlock()
+	out := make(map[string]string, len(defaultPrefixes))
+	maps.Copy(out, defaultPrefixes)
+	return out
 }
 
 // prefixMap tracks namespaces and which prefixes are actually used.
@@ -33,12 +87,10 @@ type prefixMap struct {
 // newPrefixMap creates a prefix map initialized with defaults, optionally
 // overriding the ss: prefix if a custom base IRI is provided.
 func newPrefixMap(base string) *prefixMap {
+	defaults := snapshotDefaults()
 	pm := &prefixMap{
-		prefixes: make(map[string]string, len(defaultPrefixes)),
-		used:     make(map[string]bool, len(defaultPrefixes)),
-	}
-	for k, v := range defaultPrefixes {
-		pm.prefixes[k] = v
+		prefixes: defaults,
+		used:     make(map[string]bool, len(defaults)),
 	}
 	// Override ss: if custom base
 	if base != "" && base != vocabulary.SemStreamsBase {

--- a/vocabulary/export/prefix_test.go
+++ b/vocabulary/export/prefix_test.go
@@ -93,6 +93,50 @@ func TestPrefixMap_UsedPrefixMap(t *testing.T) {
 	}
 }
 
+func TestRegister_IdempotentSameNamespace(t *testing.T) {
+	// Re-registering an existing default with the same namespace is a no-op.
+	if err := Register("sosa", "http://www.w3.org/ns/sosa/"); err != nil {
+		t.Fatalf("Register sosa same namespace: %v", err)
+	}
+}
+
+func TestRegister_RejectsCollision(t *testing.T) {
+	err := Register("sosa", "https://example.org/different/")
+	if err == nil {
+		t.Fatalf("expected error rebinding sosa to a different namespace")
+	}
+}
+
+func TestRegister_RejectsEmpty(t *testing.T) {
+	if err := Register("", "http://example.org/"); err == nil {
+		t.Fatalf("expected error for empty prefix")
+	}
+	if err := Register("foo", ""); err == nil {
+		t.Fatalf("expected error for empty namespace")
+	}
+}
+
+func TestRegister_NewPrefixAppearsInSnapshot(t *testing.T) {
+	// Pick a prefix unlikely to collide with the defaults or sub-packages.
+	const probe = "test-register-probe"
+	const ns = "https://example.org/test-register-probe/"
+	if err := Register(probe, ns); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// Cleanup is intentional: this is a registry of test fixtures and
+	// the next test run would see the leftover. We have no Unregister
+	// to keep the API surface narrow; reach into the private map.
+	t.Cleanup(func() {
+		defaultPrefixesMu.Lock()
+		delete(defaultPrefixes, probe)
+		defaultPrefixesMu.Unlock()
+	})
+	pm := newPrefixMap("")
+	if got := pm.namespaceFor(probe); got != ns {
+		t.Errorf("namespaceFor(%q) = %q, want %q", probe, got, ns)
+	}
+}
+
 func TestEnsureTrailingSlash(t *testing.T) {
 	tests := []struct {
 		input string

--- a/vocabulary/oms/doc.go
+++ b/vocabulary/oms/doc.go
@@ -1,0 +1,48 @@
+// Package oms provides Go constants for the OGC Observations,
+// Measurements, and Samples (OMS) v3.0 vocabulary — the umbrella
+// standard (OGC 20-082r4) that the OGC API Connected Systems v1.0
+// observation document encoding builds on.
+//
+// OMS v3.0 supersedes the historical O&M 2.0 model and ships
+// alongside CS API v1.0 with a JSON encoding. SemStreams uses OMS
+// IRIs to type the Observation entities emitted by sensor
+// pipelines and to wire the BaseMessage ↔ OMS document mapper
+// scheduled for Phase 6 (message/oms).
+//
+// # Namespace pinning
+//
+// The Namespace constant pins to "http://www.opengis.net/oms/3.0/"
+// — matching the package name for readability of compact output
+// ("oms:Observation"). If a future OMS revision changes the
+// namespace stem, this package gets a major-version change rather
+// than a silent rebinding; callers can detect the move via the
+// contract test that compares every constant against the declared
+// Namespace.
+//
+// # Coverage
+//
+// MVP coverage is the load-bearing subset required by Phase 6's
+// observation document mapper: Observation, ObservableProperty,
+// Procedure, FeatureOfInterest, Result and the time-stamp
+// predicates ResultTime / PhenomenonTime. Less-common OMS terms
+// (Process, Specimen, samplingDistance, …) are added when a
+// concrete capability surfaces a need.
+//
+// # Standards-at-work, not semweb hell
+//
+// This package follows the [vocabulary] family pattern. Constants
+// are exported strings; no OWL inferencing, no SPARQL, no
+// operator-authored RDF. Prefix registration is automatic on
+// import.
+//
+// See [ADR-044] for the framework/sister-repo split rationale.
+//
+// # External references
+//
+//   - Spec: https://www.ogc.org/standards/om/ (OGC 20-082r4)
+//   - JSON encoding bundled with CS API v1.0:
+//     https://docs.ogc.org/DRAFTS/23-002r0.html
+//
+// [vocabulary]: ..
+// [ADR-044]: ../../docs/adr/044-ogc-connected-systems-framework-split.md
+package oms

--- a/vocabulary/oms/iris.go
+++ b/vocabulary/oms/iris.go
@@ -1,0 +1,66 @@
+package oms
+
+// OMS namespace identifiers. Pinned to the namespace used by the
+// CS API v1.0 OMS bundle.
+const (
+	// Prefix is the OMS short token used when compacting IRIs.
+	Prefix = "oms"
+
+	// Namespace is the OMS v3.0 IRI stem.
+	Namespace = "http://www.opengis.net/oms/3.0/"
+)
+
+// OMS class IRIs. Use these as the object of an rdf:type triple,
+// or anywhere an Observation document references one of the
+// core OMS concepts. SOSA defines parallel terms in sosa:; OMS
+// preserves them for backward compatibility with O&M 2.0 consumers
+// and bundles a small set of OMS-specific extensions.
+const (
+	// Observation — an act associating a result with a procedure,
+	// feature of interest, and observable property. Parallel to
+	// sosa:Observation; downstream encoders pick the IRI that
+	// matches the consuming endpoint's content negotiation.
+	Observation = Namespace + "Observation"
+
+	// ObservableProperty — the quality the observation measured.
+	// Parallel to sosa:ObservableProperty.
+	ObservableProperty = Namespace + "ObservableProperty"
+
+	// Procedure — the workflow / algorithm / instrument that
+	// produced the result.
+	Procedure = Namespace + "Procedure"
+
+	// FeatureOfInterest — the real-world thing the observation is
+	// about.
+	FeatureOfInterest = Namespace + "FeatureOfInterest"
+
+	// Result — the structured value produced by an Observation.
+	Result = Namespace + "Result"
+)
+
+// OMS predicate IRIs.
+const (
+	// ResultTime is the time the observation result was produced
+	// (clock time of the measurement, not the phenomenon).
+	ResultTime = Namespace + "resultTime"
+
+	// PhenomenonTime is the time the observed phenomenon occurred
+	// — may differ from ResultTime for processed or back-dated
+	// observations.
+	PhenomenonTime = Namespace + "phenomenonTime"
+
+	// HasResult attaches a structured Result entity to an
+	// Observation.
+	HasResult = Namespace + "hasResult"
+
+	// HasFeatureOfInterest binds an Observation to the
+	// FeatureOfInterest it is about.
+	HasFeatureOfInterest = Namespace + "hasFeatureOfInterest"
+
+	// ObservedProperty binds an Observation to the
+	// ObservableProperty it measured.
+	ObservedProperty = Namespace + "observedProperty"
+
+	// UsedProcedure binds an Observation to the Procedure used.
+	UsedProcedure = Namespace + "usedProcedure"
+)

--- a/vocabulary/oms/iris_test.go
+++ b/vocabulary/oms/iris_test.go
@@ -1,0 +1,83 @@
+package oms
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIRIsCoverConstants(t *testing.T) {
+	wantPairs := map[string]string{
+		Prefix + ":Observation":        Observation,
+		Prefix + ":ObservableProperty": ObservableProperty,
+		Prefix + ":Procedure":          Procedure,
+		Prefix + ":FeatureOfInterest":  FeatureOfInterest,
+		Prefix + ":Result":             Result,
+
+		Prefix + ":resultTime":           ResultTime,
+		Prefix + ":phenomenonTime":       PhenomenonTime,
+		Prefix + ":hasResult":            HasResult,
+		Prefix + ":hasFeatureOfInterest": HasFeatureOfInterest,
+		Prefix + ":observedProperty":     ObservedProperty,
+		Prefix + ":usedProcedure":        UsedProcedure,
+	}
+	got := IRIs()
+	if len(got) != len(wantPairs) {
+		t.Fatalf("IRIs(): want %d entries, got %d", len(wantPairs), len(got))
+	}
+	for compact, iri := range wantPairs {
+		if gotIRI, ok := got[compact]; !ok {
+			t.Errorf("IRIs() missing %q", compact)
+		} else if gotIRI != iri {
+			t.Errorf("IRIs()[%q] = %q, want %q", compact, gotIRI, iri)
+		}
+	}
+}
+
+func TestConstantsLiveInDeclaredNamespace(t *testing.T) {
+	all := []string{
+		Observation, ObservableProperty, Procedure, FeatureOfInterest, Result,
+		ResultTime, PhenomenonTime, HasResult, HasFeatureOfInterest,
+		ObservedProperty, UsedProcedure,
+	}
+	for _, c := range all {
+		if !strings.HasPrefix(c, Namespace) {
+			t.Errorf("%q does not start with OMS namespace %q", c, Namespace)
+		}
+	}
+}
+
+func TestIsKnown(t *testing.T) {
+	cases := []struct {
+		iri  string
+		want bool
+	}{
+		{Observation, true},
+		{ResultTime, true},
+		{Namespace + "unmappedButValidOMS", false},
+		{"http://example.org/not-oms", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsKnown(c.iri); got != c.want {
+			t.Errorf("IsKnown(%q) = %v, want %v", c.iri, got, c.want)
+		}
+	}
+}
+
+func TestLocalName(t *testing.T) {
+	cases := []struct {
+		iri  string
+		want string
+	}{
+		{Observation, "Observation"},
+		{ResultTime, "resultTime"},
+		{Namespace + "unmappedButValidOMS", "unmappedButValidOMS"},
+		{"http://example.org/not-oms", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := LocalName(c.iri); got != c.want {
+			t.Errorf("LocalName(%q) = %q, want %q", c.iri, got, c.want)
+		}
+	}
+}

--- a/vocabulary/oms/predicates.go
+++ b/vocabulary/oms/predicates.go
@@ -1,0 +1,59 @@
+package oms
+
+import (
+	"maps"
+	"strings"
+)
+
+// iris is the canonical set of IRIs this package surfaces, indexed
+// by their compact form. Adding a constant in iris.go requires
+// adding it here too; the contract test in iris_test.go fails loud
+// if these drift apart.
+var iris = map[string]string{
+	// Classes
+	Prefix + ":Observation":        Observation,
+	Prefix + ":ObservableProperty": ObservableProperty,
+	Prefix + ":Procedure":          Procedure,
+	Prefix + ":FeatureOfInterest":  FeatureOfInterest,
+	Prefix + ":Result":             Result,
+
+	// Predicates
+	Prefix + ":resultTime":           ResultTime,
+	Prefix + ":phenomenonTime":       PhenomenonTime,
+	Prefix + ":hasResult":            HasResult,
+	Prefix + ":hasFeatureOfInterest": HasFeatureOfInterest,
+	Prefix + ":observedProperty":     ObservedProperty,
+	Prefix + ":usedProcedure":        UsedProcedure,
+}
+
+var reverseIRIs = func() map[string]string {
+	m := make(map[string]string, len(iris))
+	for compact, iri := range iris {
+		m[iri] = compact
+	}
+	return m
+}()
+
+// IRIs returns a copy of the full set of compact → IRI mappings
+// covered by this package.
+func IRIs() map[string]string {
+	out := make(map[string]string, len(iris))
+	maps.Copy(out, iris)
+	return out
+}
+
+// IsKnown reports whether the given IRI is part of this package's
+// coverage.
+func IsKnown(iri string) bool {
+	_, ok := reverseIRIs[iri]
+	return ok
+}
+
+// LocalName returns the local part of an OMS IRI, or the empty
+// string if the IRI is not in the OMS namespace.
+func LocalName(iri string) string {
+	if strings.HasPrefix(iri, Namespace) {
+		return iri[len(Namespace):]
+	}
+	return ""
+}

--- a/vocabulary/oms/register.go
+++ b/vocabulary/oms/register.go
@@ -1,0 +1,22 @@
+package oms
+
+import (
+	"fmt"
+
+	"github.com/c360studio/semstreams/vocabulary/export"
+)
+
+// Register binds the oms: prefix into the export prefix table.
+// Importing the package triggers this from init(); idempotent.
+func Register() error {
+	if err := export.Register(Prefix, Namespace); err != nil {
+		return fmt.Errorf("vocabulary/oms: register oms prefix: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	if err := Register(); err != nil {
+		panic(err)
+	}
+}

--- a/vocabulary/oms/register_test.go
+++ b/vocabulary/oms/register_test.go
@@ -1,0 +1,15 @@
+package oms
+
+import "testing"
+
+// End-to-end integration with vocabulary/export's prefix
+// compaction is covered by the Phase 2 smoke test in
+// vocabulary/export/phase2_smoke_test.go.
+func TestRegisterIsIdempotent(t *testing.T) {
+	if err := Register(); err != nil {
+		t.Fatalf("Register() after init: %v", err)
+	}
+	if err := Register(); err != nil {
+		t.Fatalf("Register() second call: %v", err)
+	}
+}

--- a/vocabulary/sosa/doc.go
+++ b/vocabulary/sosa/doc.go
@@ -1,0 +1,64 @@
+// Package sosa provides Go constants for the W3C SOSA/SSN vocabulary
+// (Sensor, Observation, Sample, and Actuator ontology + Semantic
+// Sensor Network ontology), the semantic-sensor backbone of the OGC
+// API Connected Systems standard.
+//
+// SOSA is the lightweight core; SSN is the systems/deployment
+// overlay published in the same W3C 2017 TR. SemStreams co-locates
+// both in this package — the namespaces are distinct (sosa: and
+// ssn:) but the upstream is one document and the consumers always
+// import them together. SOSA constants are bare ([Sensor],
+// [Observes]); the (small) SSN companion set uses an SSN prefix
+// ([SSNSystem], [SSNHasDeployment]) so the namespace switch is
+// explicit at call sites — per the ADR-044 guidance to default to
+// SOSA and surface SSN deviations.
+//
+// Convention at a call site:
+//
+//	triples := []message.Triple{
+//	    // SOSA core — observation provenance:
+//	    {Subject: platform, Predicate: sosa.Hosts, Object: sensor},
+//	    {Subject: sensor, Predicate: sosa.MadeObservation, Object: obs},
+//	    // SSN overlay — system / deployment topology:
+//	    {Subject: platform, Predicate: sosa.SSNHasDeployment, Object: deployment},
+//	}
+//
+// # Standards-at-work, not semweb hell
+//
+// This package follows the [vocabulary] family pattern (agentic,
+// bfo, cco, oasf, plus the standards.go IRI roster):
+//
+//   - Adopts an external vocabulary as first-class Go constants
+//   - Keeps internal access patterns plain JSON / Go — no OWL
+//     inferencing, no SPARQL, no operator-authored RDF
+//   - Sub-package boundary contains the schema dependency; the
+//     wider semstreams module does not import sosa except where
+//     the IRIs themselves are needed in [Graphable.Triples] output
+//
+// See [ADR-044] for the framework/sister-repo split rationale and
+// the dependency chain that places this package in Phase 2.
+//
+// # Coverage
+//
+// MVP coverage is the load-bearing subset required by Phase 5
+// (parser/sensorml), Phase 6 (message/oms), and the sister-repo
+// CS-API gateway: twelve SOSA classes, twelve SOSA predicates,
+// two SSN classes, five SSN predicates. Additional constants are
+// added as concrete capabilities surface a need; the [IsKnown]
+// and [IRIs] helpers report the current coverage.
+//
+// Prefix registration is automatic — importing this package runs
+// an init() that registers sosa: and ssn: with
+// [github.com/c360studio/semstreams/vocabulary/export]. Callers
+// emitting RDF/Turtle or JSON-LD via that package therefore get
+// the compact prefixes without further wiring.
+//
+// # External references
+//
+//   - Spec: https://www.w3.org/TR/vocab-ssn/
+//   - OGC CS API binding: https://www.ogc.org/standards/ogc-api-connected-systems/
+//
+// [vocabulary]: ..
+// [ADR-044]: ../../docs/adr/044-ogc-connected-systems-framework-split.md
+// [Graphable.Triples]: ../../message
+package sosa

--- a/vocabulary/sosa/iris.go
+++ b/vocabulary/sosa/iris.go
@@ -1,0 +1,158 @@
+package sosa
+
+// SOSA namespace identifiers. The Namespace constant is the IRI
+// stem; Prefix is the short token used in compact RDF/Turtle and
+// JSON-LD output. Both are registered into vocabulary/export at
+// package init — see register.go.
+const (
+	// Prefix is the SOSA short token used when compacting IRIs in
+	// RDF/Turtle and JSON-LD output (e.g. "sosa:observes").
+	Prefix = "sosa"
+
+	// Namespace is the SOSA IRI stem.
+	Namespace = "http://www.w3.org/ns/sosa/"
+)
+
+// SOSA class IRIs. Use these as the object of an rdf:type triple,
+// or wherever a Graphable needs to declare its SOSA-aligned kind.
+const (
+	// Sensor — a device or simulator that produces observations.
+	Sensor = Namespace + "Sensor"
+
+	// Observation — an act associating a Result with a Procedure,
+	// FeatureOfInterest, ObservableProperty, and time stamps.
+	Observation = Namespace + "Observation"
+
+	// FeatureOfInterest — the real-world thing the observation is
+	// about (a river, a robot joint, a building zone).
+	FeatureOfInterest = Namespace + "FeatureOfInterest"
+
+	// ObservableProperty — the quality being observed (temperature,
+	// flow rate, vibration amplitude).
+	ObservableProperty = Namespace + "ObservableProperty"
+
+	// Platform — the thing hosting one or more sensors / samplers
+	// / actuators (a drone airframe, a buoy, a robot chassis).
+	Platform = Namespace + "Platform"
+
+	// Procedure — the workflow, protocol, or algorithm a sensor or
+	// actuator follows.
+	Procedure = Namespace + "Procedure"
+
+	// Sample — material taken from a FeatureOfInterest for
+	// downstream observation.
+	Sample = Namespace + "Sample"
+
+	// Sampler — the device or method that produces a Sample.
+	Sampler = Namespace + "Sampler"
+
+	// Result — the value produced by an Observation. SOSA permits
+	// either a structured Result entity or a simple inline value
+	// via [HasSimpleResult].
+	Result = Namespace + "Result"
+
+	// Actuator — a device that effects change in the world by
+	// executing an Actuation on an ActuatableProperty.
+	Actuator = Namespace + "Actuator"
+
+	// Actuation — an act of effecting change, dual to Observation.
+	Actuation = Namespace + "Actuation"
+
+	// ActuatableProperty — a property an Actuator can affect.
+	ActuatableProperty = Namespace + "ActuatableProperty"
+)
+
+// SOSA predicate IRIs. Use these as the predicate of a Triple.
+const (
+	// Observes binds a Sensor to the ObservableProperty it senses.
+	Observes = Namespace + "observes"
+
+	// HasFeatureOfInterest binds an Observation to the
+	// FeatureOfInterest it is about.
+	HasFeatureOfInterest = Namespace + "hasFeatureOfInterest"
+
+	// MadeBySensor binds an Observation to the Sensor that made
+	// it. Inverse of [MadeObservation].
+	MadeBySensor = Namespace + "madeBySensor"
+
+	// MadeObservation binds a Sensor to an Observation it
+	// produced. Inverse of [MadeBySensor].
+	MadeObservation = Namespace + "madeObservation"
+
+	// UsedProcedure binds an Observation or Actuation to the
+	// Procedure used.
+	UsedProcedure = Namespace + "usedProcedure"
+
+	// HasSimpleResult attaches a literal result value (number,
+	// string, boolean) directly to an Observation, bypassing a
+	// structured Result entity.
+	HasSimpleResult = Namespace + "hasSimpleResult"
+
+	// HasResult attaches a structured Result entity to an
+	// Observation.
+	HasResult = Namespace + "hasResult"
+
+	// ResultTime is the time the result was produced.
+	ResultTime = Namespace + "resultTime"
+
+	// PhenomenonTime is the time the observed phenomenon occurred
+	// (may differ from ResultTime, e.g. for processed observations).
+	PhenomenonTime = Namespace + "phenomenonTime"
+
+	// Hosts binds a Platform to a Sensor / Sampler / Actuator it
+	// carries. Inverse of [IsHostedBy].
+	Hosts = Namespace + "hosts"
+
+	// IsHostedBy binds a Sensor / Sampler / Actuator to the
+	// Platform that carries it. Inverse of [Hosts].
+	IsHostedBy = Namespace + "isHostedBy"
+
+	// ObservedProperty binds an Observation to the
+	// ObservableProperty it measured.
+	ObservedProperty = Namespace + "observedProperty"
+)
+
+// SSN namespace identifiers. SSN is the systems/deployment overlay
+// to SOSA, published in the same W3C 2017 TR but at a distinct
+// namespace. The constants below use an SSN prefix to make the
+// namespace switch explicit at call sites — per ADR-044's
+// "default to SOSA" guidance.
+const (
+	// SSNPrefix is the SSN short token used when compacting IRIs.
+	SSNPrefix = "ssn"
+
+	// SSNNamespace is the SSN IRI stem.
+	SSNNamespace = "http://www.w3.org/ns/ssn/"
+)
+
+// SSN class IRIs.
+const (
+	// SSNSystem — a unit of abstraction for pieces of infrastructure
+	// (sensor networks, robots, observatories) that implements
+	// some Procedure. Aligns with the "system" segment of a
+	// SemStreams 6-part Entity ID.
+	SSNSystem = SSNNamespace + "System"
+
+	// SSNDeployment — a placement of a System for some Purpose
+	// over some period in some location.
+	SSNDeployment = SSNNamespace + "Deployment"
+)
+
+// SSN predicate IRIs.
+const (
+	// SSNHasDeployment binds a System to a Deployment.
+	SSNHasDeployment = SSNNamespace + "hasDeployment"
+
+	// SSNDeployedSystem binds a Deployment back to its System.
+	SSNDeployedSystem = SSNNamespace + "deployedSystem"
+
+	// SSNHasSubSystem binds a System to its sub-Systems
+	// (a fleet to its drones, a robot to its joint controllers).
+	SSNHasSubSystem = SSNNamespace + "hasSubSystem"
+
+	// SSNHasInput binds a Procedure to one of its inputs.
+	SSNHasInput = SSNNamespace + "hasInput"
+
+	// SSNHasOutput binds a Procedure to one of its outputs.
+	SSNHasOutput = SSNNamespace + "hasOutput"
+)

--- a/vocabulary/sosa/iris_test.go
+++ b/vocabulary/sosa/iris_test.go
@@ -1,0 +1,126 @@
+package sosa
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIRIsCoverConstants is the contract test that catches drift
+// between the package-level constants and the iris map. If a new
+// constant is added in iris.go without a matching entry in
+// predicates.go, this test fails loud.
+func TestIRIsCoverConstants(t *testing.T) {
+	wantPairs := map[string]string{
+		Prefix + ":Sensor":             Sensor,
+		Prefix + ":Observation":        Observation,
+		Prefix + ":FeatureOfInterest":  FeatureOfInterest,
+		Prefix + ":ObservableProperty": ObservableProperty,
+		Prefix + ":Platform":           Platform,
+		Prefix + ":Procedure":          Procedure,
+		Prefix + ":Sample":             Sample,
+		Prefix + ":Sampler":            Sampler,
+		Prefix + ":Result":             Result,
+		Prefix + ":Actuator":           Actuator,
+		Prefix + ":Actuation":          Actuation,
+		Prefix + ":ActuatableProperty": ActuatableProperty,
+
+		Prefix + ":observes":             Observes,
+		Prefix + ":hasFeatureOfInterest": HasFeatureOfInterest,
+		Prefix + ":madeBySensor":         MadeBySensor,
+		Prefix + ":madeObservation":      MadeObservation,
+		Prefix + ":usedProcedure":        UsedProcedure,
+		Prefix + ":hasSimpleResult":      HasSimpleResult,
+		Prefix + ":hasResult":            HasResult,
+		Prefix + ":resultTime":           ResultTime,
+		Prefix + ":phenomenonTime":       PhenomenonTime,
+		Prefix + ":hosts":                Hosts,
+		Prefix + ":isHostedBy":           IsHostedBy,
+		Prefix + ":observedProperty":     ObservedProperty,
+
+		SSNPrefix + ":System":         SSNSystem,
+		SSNPrefix + ":Deployment":     SSNDeployment,
+		SSNPrefix + ":hasDeployment":  SSNHasDeployment,
+		SSNPrefix + ":deployedSystem": SSNDeployedSystem,
+		SSNPrefix + ":hasSubSystem":   SSNHasSubSystem,
+		SSNPrefix + ":hasInput":       SSNHasInput,
+		SSNPrefix + ":hasOutput":      SSNHasOutput,
+	}
+	got := IRIs()
+	if len(got) != len(wantPairs) {
+		t.Fatalf("IRIs(): want %d entries, got %d", len(wantPairs), len(got))
+	}
+	for compact, iri := range wantPairs {
+		if gotIRI, ok := got[compact]; !ok {
+			t.Errorf("IRIs() missing %q", compact)
+		} else if gotIRI != iri {
+			t.Errorf("IRIs()[%q] = %q, want %q", compact, gotIRI, iri)
+		}
+	}
+}
+
+// TestConstantsLiveInDeclaredNamespace catches typos: every SOSA
+// constant must start with Namespace; every SSN constant with
+// SSNNamespace.
+func TestConstantsLiveInDeclaredNamespace(t *testing.T) {
+	sosaConsts := []string{
+		Sensor, Observation, FeatureOfInterest, ObservableProperty,
+		Platform, Procedure, Sample, Sampler, Result, Actuator,
+		Actuation, ActuatableProperty,
+		Observes, HasFeatureOfInterest, MadeBySensor, MadeObservation,
+		UsedProcedure, HasSimpleResult, HasResult, ResultTime,
+		PhenomenonTime, Hosts, IsHostedBy, ObservedProperty,
+	}
+	for _, c := range sosaConsts {
+		if !strings.HasPrefix(c, Namespace) {
+			t.Errorf("%q does not start with SOSA namespace %q", c, Namespace)
+		}
+	}
+	ssnConsts := []string{
+		SSNSystem, SSNDeployment,
+		SSNHasDeployment, SSNDeployedSystem, SSNHasSubSystem,
+		SSNHasInput, SSNHasOutput,
+	}
+	for _, c := range ssnConsts {
+		if !strings.HasPrefix(c, SSNNamespace) {
+			t.Errorf("%q does not start with SSN namespace %q", c, SSNNamespace)
+		}
+	}
+}
+
+func TestIsKnown(t *testing.T) {
+	cases := []struct {
+		iri  string
+		want bool
+	}{
+		{Observes, true},
+		{SSNHasDeployment, true},
+		{Namespace + "unmappedButValidSosa", false},
+		{"http://example.org/not-sosa", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsKnown(c.iri); got != c.want {
+			t.Errorf("IsKnown(%q) = %v, want %v", c.iri, got, c.want)
+		}
+	}
+}
+
+func TestLocalName(t *testing.T) {
+	cases := []struct {
+		iri  string
+		want string
+	}{
+		{Observes, "observes"},
+		{Sensor, "Sensor"},
+		{SSNHasDeployment, "hasDeployment"},
+		{SSNSystem, "System"},
+		{Namespace + "unmappedButValidSosa", "unmappedButValidSosa"},
+		{"http://example.org/not-sosa", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := LocalName(c.iri); got != c.want {
+			t.Errorf("LocalName(%q) = %q, want %q", c.iri, got, c.want)
+		}
+	}
+}

--- a/vocabulary/sosa/predicates.go
+++ b/vocabulary/sosa/predicates.go
@@ -1,0 +1,100 @@
+package sosa
+
+import (
+	"maps"
+	"strings"
+)
+
+// iris is the canonical set of IRIs this package surfaces, indexed
+// by their compact form ("sosa:observes", "ssn:hasDeployment"). The
+// map is the source of truth for IsKnown / IRIs / LocalName lookups
+// and for the contract test that verifies round-trip compaction.
+//
+// Adding a new constant in iris.go requires adding it here too; the
+// contract test fails loud if these drift apart.
+var iris = map[string]string{
+	// SOSA classes
+	Prefix + ":Sensor":             Sensor,
+	Prefix + ":Observation":        Observation,
+	Prefix + ":FeatureOfInterest":  FeatureOfInterest,
+	Prefix + ":ObservableProperty": ObservableProperty,
+	Prefix + ":Platform":           Platform,
+	Prefix + ":Procedure":          Procedure,
+	Prefix + ":Sample":             Sample,
+	Prefix + ":Sampler":            Sampler,
+	Prefix + ":Result":             Result,
+	Prefix + ":Actuator":           Actuator,
+	Prefix + ":Actuation":          Actuation,
+	Prefix + ":ActuatableProperty": ActuatableProperty,
+
+	// SOSA predicates
+	Prefix + ":observes":             Observes,
+	Prefix + ":hasFeatureOfInterest": HasFeatureOfInterest,
+	Prefix + ":madeBySensor":         MadeBySensor,
+	Prefix + ":madeObservation":      MadeObservation,
+	Prefix + ":usedProcedure":        UsedProcedure,
+	Prefix + ":hasSimpleResult":      HasSimpleResult,
+	Prefix + ":hasResult":            HasResult,
+	Prefix + ":resultTime":           ResultTime,
+	Prefix + ":phenomenonTime":       PhenomenonTime,
+	Prefix + ":hosts":                Hosts,
+	Prefix + ":isHostedBy":           IsHostedBy,
+	Prefix + ":observedProperty":     ObservedProperty,
+
+	// SSN classes
+	SSNPrefix + ":System":     SSNSystem,
+	SSNPrefix + ":Deployment": SSNDeployment,
+
+	// SSN predicates
+	SSNPrefix + ":hasDeployment":  SSNHasDeployment,
+	SSNPrefix + ":deployedSystem": SSNDeployedSystem,
+	SSNPrefix + ":hasSubSystem":   SSNHasSubSystem,
+	SSNPrefix + ":hasInput":       SSNHasInput,
+	SSNPrefix + ":hasOutput":      SSNHasOutput,
+}
+
+// reverseIRIs maps full IRI back to compact form, built once at init.
+var reverseIRIs = func() map[string]string {
+	m := make(map[string]string, len(iris))
+	for compact, iri := range iris {
+		m[iri] = compact
+	}
+	return m
+}()
+
+// IRIs returns a copy of the full set of compact → IRI mappings
+// covered by this package. The returned map is safe for the caller
+// to mutate without affecting the package state.
+func IRIs() map[string]string {
+	out := make(map[string]string, len(iris))
+	maps.Copy(out, iris)
+	return out
+}
+
+// IsKnown reports whether the given IRI is part of this package's
+// coverage. Returns false for IRIs in the sosa: or ssn: namespace
+// that we have not yet added a constant for — callers that need
+// to accept any well-formed SOSA/SSN IRI should pair this with a
+// namespace check.
+func IsKnown(iri string) bool {
+	_, ok := reverseIRIs[iri]
+	return ok
+}
+
+// LocalName returns the local part of a SOSA or SSN IRI (the segment
+// after the namespace stem), or the empty string if the IRI is not
+// in either namespace.
+//
+// Distinct from IsKnown: an IRI in the SOSA namespace that this
+// package has not promoted to a constant still returns a non-empty
+// local name from this function, because the split is purely
+// lexical.
+func LocalName(iri string) string {
+	if strings.HasPrefix(iri, Namespace) {
+		return iri[len(Namespace):]
+	}
+	if strings.HasPrefix(iri, SSNNamespace) {
+		return iri[len(SSNNamespace):]
+	}
+	return ""
+}

--- a/vocabulary/sosa/register.go
+++ b/vocabulary/sosa/register.go
@@ -1,0 +1,39 @@
+package sosa
+
+import (
+	"fmt"
+
+	"github.com/c360studio/semstreams/vocabulary/export"
+)
+
+// Register binds the sosa: and ssn: prefixes into the export
+// prefix table. Importing the package triggers this from init();
+// downstream callers normally do not need to invoke it directly,
+// but it is exported so consumers that build a custom export
+// pipeline (skipping the package's init) can still wire the
+// prefixes deterministically.
+//
+// Registration is idempotent: calling Register a second time with
+// the same namespaces is a no-op. The function returns an error
+// only if vocabulary/export rejects the binding — which today only
+// happens if a different namespace was already bound to the same
+// prefix (collision).
+func Register() error {
+	if err := export.Register(Prefix, Namespace); err != nil {
+		return fmt.Errorf("vocabulary/sosa: register sosa prefix: %w", err)
+	}
+	if err := export.Register(SSNPrefix, SSNNamespace); err != nil {
+		return fmt.Errorf("vocabulary/sosa: register ssn prefix: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	if err := Register(); err != nil {
+		// Hard panic: this can only happen if a downstream package
+		// rebound sosa: or ssn: to a foreign namespace before our
+		// init ran, which is a build-time integration bug, not a
+		// runtime condition we can recover from.
+		panic(err)
+	}
+}

--- a/vocabulary/sosa/register_test.go
+++ b/vocabulary/sosa/register_test.go
@@ -1,0 +1,20 @@
+package sosa
+
+import "testing"
+
+// TestRegisterIsIdempotent confirms calling Register again after
+// the init-time call is a no-op rather than a collision. This
+// protects callers that defensively wire the prefix table from
+// scratch without skipping our init.
+//
+// End-to-end integration with vocabulary/export's prefix
+// compaction is covered by the Phase 2 smoke test in
+// vocabulary/export/phase2_smoke_test.go.
+func TestRegisterIsIdempotent(t *testing.T) {
+	if err := Register(); err != nil {
+		t.Fatalf("Register() after init: %v", err)
+	}
+	if err := Register(); err != nil {
+		t.Fatalf("Register() second call: %v", err)
+	}
+}

--- a/vocabulary/standards.go
+++ b/vocabulary/standards.go
@@ -458,15 +458,9 @@ const (
 	FoafAccountName = "http://xmlns.com/foaf/0.1/accountName"
 )
 
-// SSN (Semantic Sensor Network Ontology) Standard IRIs
-// Useful for IoT and robotics applications
-const (
-	// SsnHasDeployment indicates where/when a system is deployed
-	SsnHasDeployment = "http://www.w3.org/ns/ssn/hasDeployment"
-
-	// SosaObserves indicates what property a sensor observes
-	SosaObserves = "http://www.w3.org/ns/sosa/observes"
-
-	// SosaHasSimpleResult provides the simple result value
-	SosaHasSimpleResult = "http://www.w3.org/ns/sosa/hasSimpleResult"
-)
+// SOSA / SSN constants formerly defined here were promoted to the
+// vocabulary/sosa sub-package on 2026-05-15 as part of ADR-044
+// Phase 2. Import github.com/c360studio/semstreams/vocabulary/sosa
+// and use sosa.Observes, sosa.HasSimpleResult, sosa.SSNHasDeployment
+// directly. The sub-package also registers the sosa:/ssn: prefixes
+// with vocabulary/export automatically on import.

--- a/vocabulary/swe/doc.go
+++ b/vocabulary/swe/doc.go
@@ -1,0 +1,52 @@
+// Package swe provides Go constants for the OGC SWE Common Data
+// Model v2.1 vocabulary — the typed-data-primitive layer used by
+// SOSA observations to declare what kind of value a Result carries
+// (Quantity, Category, Time, Count, Boolean, Text, …) and the
+// structural roles (label, definition, uom, value, nilValue) that
+// describe each typed slot.
+//
+// SWE Common is part of the bundle published alongside the OGC
+// API Connected Systems v1.0 standard. This package's coverage is
+// the load-bearing subset that downstream Phase 5 (parser/sensorml)
+// and Phase 6 (message/oms) work needs to wire observation results.
+// Less-common SWE types (DataChoice, Matrix, encoded streams) are
+// added when a concrete capability surfaces a need.
+//
+// # Namespace pinning
+//
+// The Namespace constant pins to "http://www.opengis.net/swe/2.0/"
+// — the namespace that the CS API v1.0 bundle uses. The trailing
+// slash is a SemStreams convention required for CURIE local-name
+// concatenation; the canonical OGC XSD targetNamespace is the
+// slashless form "http://www.opengis.net/swe/2.0". Both forms
+// resolve to the same vocabulary; only the slash form composes
+// with local names ("Quantity", "uom", …) for IRI compaction.
+//
+// SWE Common 3.0 (OGC 24-014) exists and uses
+// "http://www.opengis.net/spec/SWE/3.0" as its normative base —
+// not this stem. The CS API v1.0 bundle is v2.0, so this package
+// pins to v2.0 for now; a future Phase will introduce a
+// vocabulary/swe3 sibling rather than rebinding this stem.
+// Callers can detect any stem change via the contract test that
+// compares every constant against the declared Namespace.
+//
+// # Standards-at-work, not semweb hell
+//
+// This package follows the [vocabulary] family pattern. Constants
+// are exported strings; no OWL inferencing, no SPARQL, no
+// operator-authored RDF. Prefix registration is automatic on
+// import — the package's init() registers swe: with
+// [github.com/c360studio/semstreams/vocabulary/export].
+//
+// See [ADR-044] for the framework/sister-repo split rationale and
+// the dependency chain that places this package in Phase 2.
+//
+// # External references
+//
+//   - Spec: https://www.ogc.org/standards/swecommon/
+//   - JSON encoding bundled with CS API v1.0:
+//     https://docs.ogc.org/DRAFTS/23-001r0.html
+//
+// [vocabulary]: ..
+// [ADR-044]: ../../docs/adr/044-ogc-connected-systems-framework-split.md
+package swe

--- a/vocabulary/swe/iris.go
+++ b/vocabulary/swe/iris.go
@@ -1,0 +1,74 @@
+package swe
+
+// SWE namespace identifiers. Pinned to the namespace used by the
+// CS API v1.0 bundle.
+const (
+	// Prefix is the SWE short token used when compacting IRIs.
+	Prefix = "swe"
+
+	// Namespace is the SWE Common v2.1 IRI stem.
+	Namespace = "http://www.opengis.net/swe/2.0/"
+)
+
+// Typed-data primitives. Each is the IRI of an rdf:type that a SWE
+// field declares; SOSA observations whose Result is a typed value
+// carry one of these as their type IRI.
+const (
+	// Quantity — a numeric value with a unit of measure.
+	Quantity = Namespace + "Quantity"
+
+	// Category — a labelled discrete value drawn from a code list.
+	Category = Namespace + "Category"
+
+	// Time — a temporal instant or duration.
+	Time = Namespace + "Time"
+
+	// Count — a discrete numeric count (no unit of measure).
+	Count = Namespace + "Count"
+
+	// Boolean — a true/false value.
+	Boolean = Namespace + "Boolean"
+
+	// Text — a free-text string value.
+	Text = Namespace + "Text"
+
+	// QuantityRange — a [min, max] pair, both with the same UoM.
+	QuantityRange = Namespace + "QuantityRange"
+
+	// DataRecord — a heterogeneous record of named typed fields.
+	DataRecord = Namespace + "DataRecord"
+
+	// DataArray — an array of homogeneous typed elements.
+	DataArray = Namespace + "DataArray"
+
+	// DataChoice — a discriminated union of typed alternatives.
+	DataChoice = Namespace + "DataChoice"
+
+	// Vector — a 1-D set of values referencing the same axis frame.
+	Vector = Namespace + "Vector"
+)
+
+// Structural role predicates. Use these as the predicate of a
+// Triple when describing a SWE-shaped Result.
+const (
+	// Label is the human-readable name of a SWE field.
+	Label = Namespace + "label"
+
+	// Definition is the IRI of the controlled term defining the
+	// field's semantic meaning (e.g. a QUDT or SWEET concept).
+	Definition = Namespace + "definition"
+
+	// UoM is the unit of measure (UCUM symbol or QUDT IRI).
+	UoM = Namespace + "uom"
+
+	// Value is the literal value of a SWE field.
+	Value = Namespace + "value"
+
+	// NilValue is the literal stand-in declared for "no reading"
+	// — paired with a reason IRI in SWE-shaped Results.
+	NilValue = Namespace + "nilValue"
+
+	// ReferenceFrame is the IRI of the coordinate / temporal frame
+	// the value is expressed in.
+	ReferenceFrame = Namespace + "referenceFrame"
+)

--- a/vocabulary/swe/iris_test.go
+++ b/vocabulary/swe/iris_test.go
@@ -1,0 +1,91 @@
+package swe
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIRIsCoverConstants catches drift between the iris.go
+// constants and the predicates.go lookup map.
+func TestIRIsCoverConstants(t *testing.T) {
+	wantPairs := map[string]string{
+		Prefix + ":Quantity":      Quantity,
+		Prefix + ":Category":      Category,
+		Prefix + ":Time":          Time,
+		Prefix + ":Count":         Count,
+		Prefix + ":Boolean":       Boolean,
+		Prefix + ":Text":          Text,
+		Prefix + ":QuantityRange": QuantityRange,
+		Prefix + ":DataRecord":    DataRecord,
+		Prefix + ":DataArray":     DataArray,
+		Prefix + ":DataChoice":    DataChoice,
+		Prefix + ":Vector":        Vector,
+
+		Prefix + ":label":          Label,
+		Prefix + ":definition":     Definition,
+		Prefix + ":uom":            UoM,
+		Prefix + ":value":          Value,
+		Prefix + ":nilValue":       NilValue,
+		Prefix + ":referenceFrame": ReferenceFrame,
+	}
+	got := IRIs()
+	if len(got) != len(wantPairs) {
+		t.Fatalf("IRIs(): want %d entries, got %d", len(wantPairs), len(got))
+	}
+	for compact, iri := range wantPairs {
+		if gotIRI, ok := got[compact]; !ok {
+			t.Errorf("IRIs() missing %q", compact)
+		} else if gotIRI != iri {
+			t.Errorf("IRIs()[%q] = %q, want %q", compact, gotIRI, iri)
+		}
+	}
+}
+
+func TestConstantsLiveInDeclaredNamespace(t *testing.T) {
+	all := []string{
+		Quantity, Category, Time, Count, Boolean, Text, QuantityRange,
+		DataRecord, DataArray, DataChoice, Vector,
+		Label, Definition, UoM, Value, NilValue, ReferenceFrame,
+	}
+	for _, c := range all {
+		if !strings.HasPrefix(c, Namespace) {
+			t.Errorf("%q does not start with SWE namespace %q", c, Namespace)
+		}
+	}
+}
+
+func TestIsKnown(t *testing.T) {
+	cases := []struct {
+		iri  string
+		want bool
+	}{
+		{Quantity, true},
+		{Label, true},
+		{Namespace + "unmappedButValidSWE", false},
+		{"http://example.org/not-swe", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsKnown(c.iri); got != c.want {
+			t.Errorf("IsKnown(%q) = %v, want %v", c.iri, got, c.want)
+		}
+	}
+}
+
+func TestLocalName(t *testing.T) {
+	cases := []struct {
+		iri  string
+		want string
+	}{
+		{Quantity, "Quantity"},
+		{UoM, "uom"},
+		{Namespace + "unmappedButValidSWE", "unmappedButValidSWE"},
+		{"http://example.org/not-swe", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := LocalName(c.iri); got != c.want {
+			t.Errorf("LocalName(%q) = %q, want %q", c.iri, got, c.want)
+		}
+	}
+}

--- a/vocabulary/swe/predicates.go
+++ b/vocabulary/swe/predicates.go
@@ -1,0 +1,68 @@
+package swe
+
+import (
+	"maps"
+	"strings"
+)
+
+// iris is the canonical set of IRIs this package surfaces, indexed
+// by their compact form. Adding a constant in iris.go requires
+// adding it here too; the contract test in iris_test.go fails loud
+// if these drift apart.
+var iris = map[string]string{
+	// Types
+	Prefix + ":Quantity":      Quantity,
+	Prefix + ":Category":      Category,
+	Prefix + ":Time":          Time,
+	Prefix + ":Count":         Count,
+	Prefix + ":Boolean":       Boolean,
+	Prefix + ":Text":          Text,
+	Prefix + ":QuantityRange": QuantityRange,
+	Prefix + ":DataRecord":    DataRecord,
+	Prefix + ":DataArray":     DataArray,
+	Prefix + ":DataChoice":    DataChoice,
+	Prefix + ":Vector":        Vector,
+
+	// Structural roles
+	Prefix + ":label":          Label,
+	Prefix + ":definition":     Definition,
+	Prefix + ":uom":            UoM,
+	Prefix + ":value":          Value,
+	Prefix + ":nilValue":       NilValue,
+	Prefix + ":referenceFrame": ReferenceFrame,
+}
+
+var reverseIRIs = func() map[string]string {
+	m := make(map[string]string, len(iris))
+	for compact, iri := range iris {
+		m[iri] = compact
+	}
+	return m
+}()
+
+// IRIs returns a copy of the full set of compact → IRI mappings
+// covered by this package. The returned map is safe for the caller
+// to mutate without affecting the package state.
+func IRIs() map[string]string {
+	out := make(map[string]string, len(iris))
+	maps.Copy(out, iris)
+	return out
+}
+
+// IsKnown reports whether the given IRI is part of this package's
+// coverage. Returns false for swe: IRIs that have not been promoted
+// to constants yet.
+func IsKnown(iri string) bool {
+	_, ok := reverseIRIs[iri]
+	return ok
+}
+
+// LocalName returns the local part of a SWE IRI (the segment after
+// the namespace stem), or the empty string if the IRI is not in
+// the SWE namespace.
+func LocalName(iri string) string {
+	if strings.HasPrefix(iri, Namespace) {
+		return iri[len(Namespace):]
+	}
+	return ""
+}

--- a/vocabulary/swe/register.go
+++ b/vocabulary/swe/register.go
@@ -1,0 +1,28 @@
+package swe
+
+import (
+	"fmt"
+
+	"github.com/c360studio/semstreams/vocabulary/export"
+)
+
+// Register binds the swe: prefix into the export prefix table.
+// Importing the package triggers this from init(); downstream
+// callers normally do not need to invoke it directly, but it is
+// exported so consumers building a custom export pipeline can
+// wire the prefix deterministically.
+//
+// Idempotent: calling Register a second time with the same
+// namespace is a no-op.
+func Register() error {
+	if err := export.Register(Prefix, Namespace); err != nil {
+		return fmt.Errorf("vocabulary/swe: register swe prefix: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	if err := Register(); err != nil {
+		panic(err)
+	}
+}

--- a/vocabulary/swe/register_test.go
+++ b/vocabulary/swe/register_test.go
@@ -1,0 +1,15 @@
+package swe
+
+import "testing"
+
+// End-to-end integration with vocabulary/export's prefix
+// compaction is covered by the Phase 2 smoke test in
+// vocabulary/export/phase2_smoke_test.go.
+func TestRegisterIsIdempotent(t *testing.T) {
+	if err := Register(); err != nil {
+		t.Fatalf("Register() after init: %v", err)
+	}
+	if err := Register(); err != nil {
+		t.Fatalf("Register() second call: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

ADR-044 Phase 2 lands the Tier A vocabulary sub-packages for the OGC API Connected Systems framework/sister-repo split:

- `vocabulary/sosa` — W3C SOSA core + SSN systems/deployment overlay (co-located per W3C 2017 TR; SSN companions use `SSN*` Go identifier prefix per ADR-044 line 252 "default to SOSA")
- `vocabulary/swe` — OGC SWE Common v2.1 typed-data primitives + structural roles (pinned to CS API v1.0 bundle namespace; SWE 3.0 migration is a future bounded event, not a rebind)
- `vocabulary/oms` — OGC OMS v3.0 observation document IRIs

Each package follows the `vocabulary/oasf` template: `doc.go` + `iris.go` (typed string constants) + `predicates.go` (`IRIs()`, `IsKnown()`, `LocalName()` helpers) + `register.go` (idempotent `Register()` called from `init()`) + contract tests catching coverage drift and namespace adherence.

`vocabulary/export/prefix.go` gains a public `Register(prefix, namespace) error` API guarded by `sync.RWMutex` with a `snapshotDefaults()` helper that `newPrefixMap` calls. Idempotent on same-namespace re-register; errors loud on collision with a foreign namespace. The three sub-packages feed it from their own `init()`, so importing them is sufficient.

The three orphan SOSA/SSN constants in `vocabulary/standards.go:461-472` (zero internal call sites) are promoted into `vocabulary/sosa` and the source location carries a tombstone comment pointing to the new home.

The Phase 2 smoke test in `vocabulary/export/phase2_smoke_test.go` is the PR-scope "first user". It exercises the established consumption pattern — app-level dotted predicate registered via `vocabulary.Register(name, WithIRI(sosa.Hosts))` — and asserts that all four prefixes (sosa/ssn/swe/oms) appear in compacted Turtle output. Uses `vocabulary.SnapshotRegistry()` to isolate the predicate-registry mutation from the surrounding test surface.

Non-breaking: no API removals beyond the three unused constants, no signature changes to existing exporter entry points.

## Notable

- The exporter pipeline (`vocabulary/export/export.go:196`) expects `Triple.Predicate` to be a dotted name resolved through the predicate registry. The IRI constants here are designed for the right-hand side of `WithIRI()`, matching how the deleted `standards.go` SOSA constants were meant to be used. Phase 5 (parser/sensorml) may add a raw-IRI escape hatch to the exporter if SensorML's natural IRI-shaped output makes the registration ceremony onerous.
- go-reviewer signed off APPROVED; four nice-to-haves applied in the same branch (registry-snapshot in smoke test, dead-code dup tests deleted, doc.go usage example for SOSA/SSN convention, SWE namespace pinning comment).

## Test plan

- [x] `task lint` — clean (`go vet`, `go fmt`, `revive`)
- [x] `go test -race ./vocabulary/...` — all green
- [x] `go vet -tags=integration ./...` and `go vet -tags=live_llm ./...` — clean (per pre-tag-sweep discipline)
- [x] `task schema:generate` — no uncommitted diff
- [x] Phase 2 smoke test (`vocabulary/export/phase2_smoke_test.go`) asserts compacted output for sosa/ssn/swe/oms prefixes end-to-end
- [ ] CI must pass before merge

Phase 3 (`graph/geo/geojson` + polygon-containment extension to `graph-index-spatial`) starts next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)