### PR TITLE
feat(adr044): phase 4 — input/http REST polling component

### DIFF
--- a/input/http/config.go
+++ b/input/http/config.go
@@ -1,0 +1,326 @@
+package http
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// Auth types. Strings rather than typed enums so the JSON wire
+// shape stays human-editable; Validate coerces and rejects.
+const (
+	AuthNone   = "none"
+	AuthBearer = "bearer"
+	AuthBasic  = "basic"
+)
+
+// Decoder modes.
+const (
+	DecoderJSON  = "json"
+	DecoderJSONL = "jsonl"
+)
+
+// HTTP methods supported by this component. POST is included so
+// callers can hit query-shaped APIs that require a request body;
+// streaming POST (chunked uploads) is out of scope.
+const (
+	MethodGET  = "GET"
+	MethodPOST = "POST"
+)
+
+// Config holds the operator-facing configuration for the http
+// input component.
+type Config struct {
+	// URL is the endpoint to poll. Required. Must be absolute and
+	// use the http or https scheme.
+	URL string `json:"url" schema:"type:string,description:Endpoint URL to poll,required:true,category:basic"`
+
+	// Method is the HTTP method (GET or POST). Default GET.
+	Method string `json:"method,omitempty" schema:"type:string,description:HTTP method (GET or POST),default:GET,category:basic"`
+
+	// Body is the optional request body sent with POST requests.
+	// Ignored for GET.
+	Body string `json:"body,omitempty" schema:"type:string,description:Request body (POST only),category:basic"`
+
+	// Interval is the duration between consecutive polls.
+	// Default 30s. Minimum 100ms to prevent runaway clients.
+	Interval string `json:"interval,omitempty" schema:"type:string,description:Delay between polls,default:30s,category:basic"`
+
+	// Timeout is the per-attempt HTTP request timeout. Retries get
+	// a fresh clock — total cycle time is bounded by
+	// MaxAttempts * (Timeout + MaxBackoff). Default 10s.
+	Timeout string `json:"timeout,omitempty" schema:"type:string,description:Per-attempt HTTP timeout (retries get a fresh clock),default:10s,category:basic"`
+
+	// Headers is a map of additional headers to send with every
+	// request. Overrides any default headers but does not override
+	// the Authorization header set by Auth.
+	Headers map[string]string `json:"headers,omitempty" schema:"type:object,description:Additional request headers,category:advanced"`
+
+	// Auth configures the Authorization header.
+	Auth *AuthConfig `json:"auth,omitempty" schema:"type:object,description:Authentication configuration,category:security"`
+
+	// Retry configures retry/backoff behavior.
+	Retry *RetryConfig `json:"retry,omitempty" schema:"type:object,description:Retry / backoff configuration,category:reliability"`
+
+	// Decoder configures how response bodies are interpreted.
+	Decoder *DecoderConfig `json:"decoder,omitempty" schema:"type:object,description:Response decoder configuration,category:basic"`
+
+	// Ports configures input / output ports. Required: at least
+	// one NATS or JetStream output port.
+	Ports *component.PortConfig `json:"ports" schema:"type:ports,description:Port configuration,category:basic"`
+}
+
+// AuthConfig is the Authorization-header configuration.
+type AuthConfig struct {
+	Type     string `json:"type" schema:"type:string,description:Auth type (none, bearer, basic),default:none"`
+	Token    string `json:"token,omitempty" schema:"type:string,description:Bearer token,category:security"`
+	Username string `json:"username,omitempty" schema:"type:string,description:Basic auth username,category:security"`
+	Password string `json:"password,omitempty" schema:"type:string,description:Basic auth password,category:security"`
+}
+
+// RetryConfig is the retry / backoff configuration.
+type RetryConfig struct {
+	// MaxAttempts is the total number of attempts (1 = no retry).
+	// Default 3.
+	MaxAttempts int `json:"max_attempts,omitempty" schema:"type:int,description:Total attempts (1 = no retry),default:3"`
+
+	// InitialBackoff is the first delay before retry. Default 1s.
+	InitialBackoff string `json:"initial_backoff,omitempty" schema:"type:string,description:First retry delay,default:1s"`
+
+	// MaxBackoff caps the exponential growth. Default 30s.
+	MaxBackoff string `json:"max_backoff,omitempty" schema:"type:string,description:Max retry delay,default:30s"`
+
+	// Multiplier grows the backoff exponentially. Default 2.0.
+	Multiplier float64 `json:"multiplier,omitempty" schema:"type:float,description:Backoff multiplier,default:2.0"`
+}
+
+// DecoderConfig is the response-body decoding configuration.
+type DecoderConfig struct {
+	// Mode selects the decoder: "json" (single object per poll) or
+	// "jsonl" (line-delimited; one publish per line). Default
+	// "json".
+	Mode string `json:"mode,omitempty" schema:"type:string,description:Decoder mode (json or jsonl),default:json"`
+}
+
+// DefaultConfig returns a Config with field defaults filled in.
+// The URL and Ports fields remain zero — callers must supply
+// them.
+func DefaultConfig() Config {
+	return Config{
+		Method:   MethodGET,
+		Interval: "30s",
+		Timeout:  "10s",
+		Auth: &AuthConfig{
+			Type: AuthNone,
+		},
+		Retry: &RetryConfig{
+			MaxAttempts:    3,
+			InitialBackoff: "1s",
+			MaxBackoff:     "30s",
+			Multiplier:     2.0,
+		},
+		Decoder: &DecoderConfig{
+			Mode: DecoderJSON,
+		},
+	}
+}
+
+// Validate enforces config invariants. Called by the registry
+// before the component is constructed.
+func (c *Config) Validate() error {
+	if c.URL == "" {
+		return errs.WrapInvalid(errs.ErrMissingConfig, "Config", "Validate", "url is required")
+	}
+	u, err := url.Parse(c.URL)
+	if err != nil {
+		return errs.WrapInvalid(err, "Config", "Validate", "invalid url")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, "Config", "Validate",
+			fmt.Sprintf("url scheme must be http or https, got %q", u.Scheme))
+	}
+	if u.Host == "" {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, "Config", "Validate", "url must include a host")
+	}
+
+	method := strings.ToUpper(c.Method)
+	if method != "" && method != MethodGET && method != MethodPOST {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, "Config", "Validate",
+			fmt.Sprintf("method must be GET or POST, got %q", c.Method))
+	}
+
+	if c.Interval != "" {
+		d, err := time.ParseDuration(c.Interval)
+		if err != nil {
+			return errs.WrapInvalid(err, "Config", "Validate", "invalid interval")
+		}
+		if d < 100*time.Millisecond {
+			return errs.WrapInvalid(errs.ErrInvalidConfig, "Config", "Validate",
+				"interval must be at least 100ms to prevent runaway polling")
+		}
+	}
+
+	if c.Timeout != "" {
+		if _, err := time.ParseDuration(c.Timeout); err != nil {
+			return errs.WrapInvalid(err, "Config", "Validate", "invalid timeout")
+		}
+	}
+
+	if c.Auth != nil {
+		switch strings.ToLower(c.Auth.Type) {
+		case "", AuthNone:
+		case AuthBearer:
+			if c.Auth.Token == "" {
+				return errs.WrapInvalid(errs.ErrMissingConfig, "Config", "Validate",
+					"auth.token is required when auth.type is bearer")
+			}
+		case AuthBasic:
+			if c.Auth.Username == "" {
+				return errs.WrapInvalid(errs.ErrMissingConfig, "Config", "Validate",
+					"auth.username is required when auth.type is basic")
+			}
+		default:
+			return errs.WrapInvalid(errs.ErrInvalidConfig, "Config", "Validate",
+				fmt.Sprintf("auth.type must be none, bearer, or basic, got %q", c.Auth.Type))
+		}
+	}
+
+	if c.Retry != nil {
+		if c.Retry.MaxAttempts < 1 {
+			return errs.WrapInvalid(errs.ErrInvalidConfig, "Config", "Validate",
+				"retry.max_attempts must be >= 1")
+		}
+		if c.Retry.InitialBackoff != "" {
+			if _, err := time.ParseDuration(c.Retry.InitialBackoff); err != nil {
+				return errs.WrapInvalid(err, "Config", "Validate", "invalid retry.initial_backoff")
+			}
+		}
+		if c.Retry.MaxBackoff != "" {
+			if _, err := time.ParseDuration(c.Retry.MaxBackoff); err != nil {
+				return errs.WrapInvalid(err, "Config", "Validate", "invalid retry.max_backoff")
+			}
+		}
+		if c.Retry.Multiplier != 0 && c.Retry.Multiplier < 1.0 {
+			return errs.WrapInvalid(errs.ErrInvalidConfig, "Config", "Validate",
+				"retry.multiplier must be >= 1.0")
+		}
+	}
+
+	if c.Decoder != nil {
+		switch strings.ToLower(c.Decoder.Mode) {
+		case "", DecoderJSON, DecoderJSONL:
+		default:
+			return errs.WrapInvalid(errs.ErrInvalidConfig, "Config", "Validate",
+				fmt.Sprintf("decoder.mode must be json or jsonl, got %q", c.Decoder.Mode))
+		}
+	}
+
+	if c.Ports == nil || len(c.Ports.Outputs) == 0 {
+		return errs.WrapInvalid(errs.ErrMissingConfig, "Config", "Validate",
+			"at least one output port is required")
+	}
+	for _, output := range c.Ports.Outputs {
+		if (output.Type == "nats" || output.Type == "jetstream") && output.Subject == "" {
+			return errs.WrapInvalid(errs.ErrMissingConfig, "Config", "Validate",
+				"NATS output subject is required")
+		}
+	}
+
+	return nil
+}
+
+// resolved holds the parsed / coerced runtime view of a Config.
+type resolved struct {
+	url            string
+	method         string
+	body           []byte
+	interval       time.Duration
+	timeout        time.Duration
+	headers        map[string]string
+	auth           AuthConfig
+	maxAttempts    int
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+	multiplier     float64
+	decoderMode    string
+	subject        string
+	useJetStream   bool
+}
+
+// resolve produces a runtime view of the config, applying
+// defaults. Assumes Validate has already succeeded; out-of-range
+// values fall back to defaults rather than re-erroring here.
+func (c *Config) resolve() resolved {
+	r := resolved{
+		url:            c.URL,
+		method:         strings.ToUpper(c.Method),
+		interval:       30 * time.Second,
+		timeout:        10 * time.Second,
+		headers:        c.Headers,
+		maxAttempts:    3,
+		initialBackoff: 1 * time.Second,
+		maxBackoff:     30 * time.Second,
+		multiplier:     2.0,
+		decoderMode:    DecoderJSON,
+	}
+	if r.method == "" {
+		r.method = MethodGET
+	}
+	if c.Body != "" {
+		r.body = []byte(c.Body)
+	}
+	if c.Interval != "" {
+		if d, err := time.ParseDuration(c.Interval); err == nil {
+			r.interval = d
+		}
+	}
+	if c.Timeout != "" {
+		if d, err := time.ParseDuration(c.Timeout); err == nil {
+			r.timeout = d
+		}
+	}
+	if c.Auth != nil {
+		r.auth = *c.Auth
+		r.auth.Type = strings.ToLower(r.auth.Type)
+		if r.auth.Type == "" {
+			r.auth.Type = AuthNone
+		}
+	} else {
+		r.auth = AuthConfig{Type: AuthNone}
+	}
+	if c.Retry != nil {
+		if c.Retry.MaxAttempts > 0 {
+			r.maxAttempts = c.Retry.MaxAttempts
+		}
+		if c.Retry.InitialBackoff != "" {
+			if d, err := time.ParseDuration(c.Retry.InitialBackoff); err == nil {
+				r.initialBackoff = d
+			}
+		}
+		if c.Retry.MaxBackoff != "" {
+			if d, err := time.ParseDuration(c.Retry.MaxBackoff); err == nil {
+				r.maxBackoff = d
+			}
+		}
+		if c.Retry.Multiplier >= 1.0 {
+			r.multiplier = c.Retry.Multiplier
+		}
+	}
+	if c.Decoder != nil && c.Decoder.Mode != "" {
+		r.decoderMode = strings.ToLower(c.Decoder.Mode)
+	}
+	if c.Ports != nil {
+		for _, output := range c.Ports.Outputs {
+			if (output.Type == "nats" || output.Type == "jetstream") && output.Subject != "" {
+				r.subject = output.Subject
+				r.useJetStream = output.Type == "jetstream"
+				break
+			}
+		}
+	}
+	return r
+}

--- a/input/http/doc.go
+++ b/input/http/doc.go
@@ -1,0 +1,86 @@
+// Package http provides a REST polling input component for
+// ingesting data from HTTP endpoints into SemStreams.
+//
+// # Overview
+//
+// The http input polls a configurable REST endpoint on a fixed
+// schedule, decodes the response body, and publishes each decoded
+// record as a BaseMessage envelope to a NATS subject. It is the
+// generic counterpart to the typed-input components (UDP,
+// WebSocket, GitHub webhook, …) — anything reachable over HTTP
+// that emits JSON, JSON Lines, or a single JSON object is in
+// scope.
+//
+// Authentication via bearer token or HTTP Basic, custom request
+// headers, configurable timeout, and exponential-backoff retry on
+// transient failures are first-class config options.
+//
+// # Quick start
+//
+//	config := http.Config{
+//	    URL:      "https://api.example.org/sensors/telemetry",
+//	    Interval: "30s",
+//	    Auth: &http.AuthConfig{
+//	        Type:  "bearer",
+//	        Token: "<token>",
+//	    },
+//	    Decoder: &http.DecoderConfig{Mode: "json"},
+//	    Ports: &component.PortConfig{
+//	        Outputs: []component.PortDefinition{
+//	            {Name: "out", Type: "jetstream", Subject: "sensors.telemetry"},
+//	        },
+//	    },
+//	}
+//	rawConfig, _ := json.Marshal(config)
+//	input, err := http.CreateInput(rawConfig, deps)
+//
+// # Decoder modes
+//
+//   - "json"  — parse the response body as a single JSON object;
+//     publish one BaseMessage per poll cycle.
+//   - "jsonl" — parse the response body as JSON Lines; publish
+//     one BaseMessage per non-empty line.
+//
+// Both modes wrap the decoded JSON in a [message.GenericJSONPayload]
+// ("core.json.v1") and route through the payload registry — every
+// publish carries the BaseMessage envelope so downstream
+// processors decode through the registry without bespoke handlers.
+// Raw byte passthrough is intentionally NOT a mode here: anything
+// not decodable as JSON should flow through a dedicated processor
+// rather than skipping the registry contract.
+//
+// # Authentication
+//
+//   - "none"   — no auth header is set (default).
+//   - "bearer" — Authorization: Bearer <Token>.
+//   - "basic"  — Authorization: Basic base64(Username:Password).
+//
+// Tokens and passwords live in the operator config today; an
+// env-var substitution layer is on the roadmap. Treat config
+// files containing AuthConfig material as secrets.
+//
+// # Retry and backoff
+//
+// Retries apply to network errors and 5xx responses. 4xx responses
+// are NOT retried by default — they indicate misconfiguration,
+// not transience. Backoff is exponential with a configurable cap.
+// MaxAttempts == 1 disables retry entirely.
+//
+// # Scope (and what this component is NOT)
+//
+// This package ships REST polling. Streaming HTTP (Server-Sent
+// Events) and WebSocket subscription are deliberately deferred:
+//
+//   - Plain WebSocket endpoints — use [input/websocket].
+//   - SSE / event-stream endpoints — a follow-up extension to
+//     this package or a sibling input/sse.
+//   - GraphQL subscriptions — out of scope; clients construct
+//     POST requests with bodies, which the Method/Body config
+//     supports, but the persistent-stream semantics do not.
+//
+// See [ADR-044] for the framework / sister-repo split rationale
+// and the dependency chain that places this component in Phase 4.
+//
+// [ADR-044]: ../../docs/adr/044-ogc-connected-systems-framework-split.md
+// [message.GenericJSONPayload]: ../../message
+package http

--- a/input/http/http.go
+++ b/input/http/http.go
@@ -1,0 +1,555 @@
+// Package http implements the REST polling input component.
+// See doc.go for the full operator guide.
+package http
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	nethttp "net/http"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/metric"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// maxResponseBytes caps the response body we will buffer to keep a
+// misbehaving endpoint from exhausting memory. Set high enough to
+// support typical telemetry payloads while still bounded.
+const maxResponseBytes = 32 * 1024 * 1024 // 32 MiB
+
+// publisher abstracts the NATS publish path so tests can inject a
+// stub. Production wiring uses natsPublisher which composes core
+// NATS / JetStream selection via the resolved port type.
+type publisher interface {
+	Publish(ctx context.Context, subject string, data []byte) error
+}
+
+// natsPublisher is the production publisher. It chooses between
+// JetStream and core NATS based on the resolved port type.
+type natsPublisher struct {
+	client       *natsclient.Client
+	useJetStream bool
+}
+
+// Publish routes through JetStream or core NATS.
+func (p *natsPublisher) Publish(ctx context.Context, subject string, data []byte) error {
+	if p.useJetStream {
+		if err := p.client.PublishToStream(ctx, subject, data); err != nil {
+			return errs.WrapTransient(err, "http-input", "Publish", "JetStream publish")
+		}
+		return nil
+	}
+	nc := p.client.GetConnection()
+	if nc == nil {
+		return errs.WrapTransient(errs.ErrNoConnection, "http-input", "Publish", "no NATS connection")
+	}
+	if err := nc.Publish(subject, data); err != nil {
+		return errs.WrapTransient(err, "http-input", "Publish", "NATS publish")
+	}
+	return nil
+}
+
+// Input implements an HTTP polling input.
+type Input struct {
+	name     string
+	config   Config
+	resolved resolved
+	client   *nethttp.Client
+
+	publisher publisher
+	logger    *slog.Logger
+	metrics   *metrics
+
+	// Lifecycle
+	lifecycleMu sync.Mutex
+	shutdown    chan struct{}
+	done        chan struct{}
+	running     atomic.Bool
+	startTime   time.Time
+	wg          sync.WaitGroup
+
+	// Counters (atomic for thread safety; exposed via Metric()).
+	requestsTotal     atomic.Int64
+	requestsFailed    atomic.Int64
+	messagesPublished atomic.Int64
+	errCount          atomic.Int64
+}
+
+// Compile-time interface assertions.
+var (
+	_ component.Discoverable       = (*Input)(nil)
+	_ component.LifecycleComponent = (*Input)(nil)
+)
+
+// httpInputSchema is the registry-visible schema generated from
+// Config. Built once at package load.
+var httpInputSchema = component.GenerateConfigSchema(reflect.TypeOf(Config{}))
+
+// InputDeps holds runtime dependencies for constructing an Input.
+type InputDeps struct {
+	Name            string
+	Config          Config
+	NATSClient      *natsclient.Client
+	MetricsRegistry *metric.MetricsRegistry
+	Logger          *slog.Logger
+}
+
+// NewInput constructs a new HTTP polling input from the given
+// dependencies. Caller is expected to have called Config.Validate
+// already; the constructor does not re-validate.
+func NewInput(deps InputDeps) *Input {
+	resolved := deps.Config.resolve()
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default().With("component", "http-input", "url", resolved.url)
+	}
+
+	return &Input{
+		name:     deps.Name,
+		config:   deps.Config,
+		resolved: resolved,
+		client:   &nethttp.Client{Timeout: resolved.timeout},
+		publisher: &natsPublisher{
+			client:       deps.NATSClient,
+			useJetStream: resolved.useJetStream,
+		},
+		logger:    logger,
+		metrics:   newMetrics(deps.MetricsRegistry, deps.Name),
+		startTime: time.Now(),
+	}
+}
+
+// Meta returns the component metadata.
+func (h *Input) Meta() component.Metadata {
+	name := h.name
+	if name == "" {
+		name = "http-input"
+	}
+	return component.Metadata{
+		Name:        name,
+		Type:        "input",
+		Description: fmt.Sprintf("HTTP REST polling from %s publishing to %s", h.resolved.url, h.resolved.subject),
+		Version:     "1.0.0",
+	}
+}
+
+// InputPorts returns this component's input ports.
+func (h *Input) InputPorts() []component.Port {
+	return []component.Port{
+		{
+			Name:        "http_source",
+			Direction:   component.DirectionInput,
+			Required:    true,
+			Description: fmt.Sprintf("HTTP endpoint: %s", h.resolved.url),
+		},
+	}
+}
+
+// OutputPorts returns this component's output ports.
+func (h *Input) OutputPorts() []component.Port {
+	portType := "nats"
+	if h.resolved.useJetStream {
+		portType = "jetstream"
+	}
+	return []component.Port{
+		{
+			Name:        portType + "_output",
+			Direction:   component.DirectionOutput,
+			Required:    true,
+			Description: "NATS subject for publishing decoded HTTP responses",
+			Config: component.NATSPort{
+				Subject: h.resolved.subject,
+			},
+		},
+	}
+}
+
+// ConfigSchema returns the component config schema.
+func (h *Input) ConfigSchema() component.ConfigSchema {
+	return httpInputSchema
+}
+
+// Health returns the current health status.
+func (h *Input) Health() component.HealthStatus {
+	return component.HealthStatus{
+		Healthy:    h.running.Load(),
+		LastCheck:  time.Now(),
+		ErrorCount: int(h.errCount.Load()),
+		Uptime:     time.Since(h.startTime),
+	}
+}
+
+// DataFlow returns current data-flow metrics for the input.
+func (h *Input) DataFlow() component.FlowMetrics {
+	published := h.messagesPublished.Load()
+	errCount := h.errCount.Load()
+	uptime := time.Since(h.startTime).Seconds()
+	var msgsPerSec float64
+	if uptime > 0 {
+		msgsPerSec = float64(published) / uptime
+	}
+	var errorRate float64
+	if published > 0 {
+		errorRate = float64(errCount) / float64(published)
+	}
+	return component.FlowMetrics{
+		MessagesPerSecond: msgsPerSec,
+		ErrorRate:         errorRate,
+		LastActivity:      time.Now(),
+	}
+}
+
+// Initialize prepares the http input component. Currently a no-op
+// past Validate; reserved for future DNS pre-warm or auth probe
+// hooks.
+func (h *Input) Initialize() error {
+	return nil
+}
+
+// Start launches the polling loop. Safe to call multiple times;
+// subsequent calls are no-ops until Stop has been called.
+func (h *Input) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, "Input", "Start", "context cannot be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return errs.WrapInvalid(err, "Input", "Start", "context already cancelled")
+	}
+
+	h.lifecycleMu.Lock()
+	defer h.lifecycleMu.Unlock()
+
+	if h.running.Load() {
+		return nil
+	}
+
+	h.shutdown = make(chan struct{})
+	h.done = make(chan struct{})
+	h.running.Store(true)
+	h.wg.Add(1)
+
+	go h.pollLoop(ctx)
+
+	h.logger.Info("HTTP input started",
+		slog.String("url", h.resolved.url),
+		slog.String("subject", h.resolved.subject),
+		slog.String("interval", h.resolved.interval.String()),
+		slog.String("decoder", h.resolved.decoderMode))
+	return nil
+}
+
+// Stop signals shutdown and waits up to timeout for the polling
+// loop to exit.
+func (h *Input) Stop(timeout time.Duration) error {
+	h.lifecycleMu.Lock()
+	if !h.running.Load() {
+		h.lifecycleMu.Unlock()
+		return nil
+	}
+	h.running.Store(false)
+	close(h.shutdown)
+	h.lifecycleMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		h.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		h.logger.Info("HTTP input stopped")
+	case <-time.After(timeout):
+		h.logger.Warn("HTTP input stop timed out")
+	}
+	return nil
+}
+
+// pollLoop runs the request-decode-publish cycle on the configured
+// interval until shutdown.
+func (h *Input) pollLoop(ctx context.Context) {
+	defer h.wg.Done()
+	defer close(h.done)
+
+	// Fire one cycle immediately so operators don't wait
+	// `interval` for the first observation.
+	h.runCycle(ctx)
+
+	ticker := time.NewTicker(h.resolved.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-h.shutdown:
+			return
+		case <-ticker.C:
+			h.runCycle(ctx)
+		}
+	}
+}
+
+// runCycle issues a single poll: doRequest with retry, decode the
+// response, publish each decoded message. Errors are logged and
+// counted; the cycle does not propagate them up because the
+// polling loop is the durable owner of recovery semantics.
+func (h *Input) runCycle(ctx context.Context) {
+	body, err := h.doRequest(ctx)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) {
+			h.logger.Warn("HTTP request failed", slog.Any("error", err))
+		}
+		h.errCount.Add(1)
+		if h.metrics != nil {
+			h.metrics.requestsFailed.Inc()
+		}
+		return
+	}
+	if len(body) == 0 {
+		return
+	}
+	if err := h.decodeAndPublish(ctx, body); err != nil {
+		h.logger.Warn("decode or publish failed", slog.Any("error", err))
+		h.errCount.Add(1)
+		if h.metrics != nil {
+			h.metrics.parseErrors.Inc()
+		}
+	}
+}
+
+// doRequest performs the configured HTTP request with exponential
+// backoff retry. Returns the response body bytes on success.
+// Network errors and 5xx responses are retried; 4xx responses are
+// returned as errors without retry.
+func (h *Input) doRequest(ctx context.Context) ([]byte, error) {
+	var (
+		body    []byte
+		lastErr error
+	)
+	backoff := h.resolved.initialBackoff
+	for attempt := 1; attempt <= h.resolved.maxAttempts; attempt++ {
+		if attempt > 1 {
+			if h.metrics != nil {
+				h.metrics.requestsRetried.Inc()
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-h.shutdown:
+				return nil, errors.New("http-input: shutdown during retry backoff")
+			case <-time.After(backoff):
+			}
+			backoff = nextBackoff(backoff, h.resolved.maxBackoff, h.resolved.multiplier)
+		}
+
+		h.requestsTotal.Add(1)
+		if h.metrics != nil {
+			h.metrics.requestsTotal.Inc()
+		}
+
+		body, lastErr = h.attempt(ctx)
+		if lastErr == nil {
+			return body, nil
+		}
+		// Distinguish retryable vs terminal failures.
+		if !isRetryable(lastErr) {
+			return nil, lastErr
+		}
+	}
+	return nil, fmt.Errorf("http-input: %d attempts exhausted: %w", h.resolved.maxAttempts, lastErr)
+}
+
+// attempt issues a single HTTP request, reads the body up to
+// maxResponseBytes, and classifies the outcome.
+func (h *Input) attempt(ctx context.Context) ([]byte, error) {
+	var bodyReader io.Reader
+	if len(h.resolved.body) > 0 {
+		bodyReader = bytes.NewReader(h.resolved.body)
+	}
+	req, err := nethttp.NewRequestWithContext(ctx, h.resolved.method, h.resolved.url, bodyReader)
+	if err != nil {
+		return nil, &terminalError{err: fmt.Errorf("build request: %w", err)}
+	}
+	for k, v := range h.resolved.headers {
+		req.Header.Set(k, v)
+	}
+	switch h.resolved.auth.Type {
+	case AuthBearer:
+		req.Header.Set("Authorization", "Bearer "+h.resolved.auth.Token)
+	case AuthBasic:
+		creds := h.resolved.auth.Username + ":" + h.resolved.auth.Password
+		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(creds)))
+	}
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		// Network-level error — retryable.
+		return nil, &retryableError{err: err}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 500 && resp.StatusCode < 600 {
+		return nil, &retryableError{err: fmt.Errorf("server returned %d", resp.StatusCode)}
+	}
+	if resp.StatusCode >= 400 {
+		return nil, &terminalError{err: fmt.Errorf("client error %d (%s)", resp.StatusCode, resp.Status)}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return nil, &retryableError{err: fmt.Errorf("read body: %w", err)}
+	}
+	if len(body) > maxResponseBytes {
+		// Drain the remainder so keep-alive can reuse the
+		// connection on the next poll rather than tearing down
+		// and reopening on every oversized response.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil, &terminalError{err: fmt.Errorf("response body exceeds %d bytes", maxResponseBytes)}
+	}
+	return body, nil
+}
+
+// decodeAndPublish dispatches on the configured decoder mode and
+// publishes each resulting message as a BaseMessage envelope.
+func (h *Input) decodeAndPublish(ctx context.Context, body []byte) error {
+	switch h.resolved.decoderMode {
+	case DecoderJSONL:
+		return h.publishJSONL(ctx, body)
+	default: // DecoderJSON
+		return h.publishJSON(ctx, body)
+	}
+}
+
+// publishJSON treats the response body as one JSON object,
+// publishes one envelope.
+func (h *Input) publishJSON(ctx context.Context, body []byte) error {
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return fmt.Errorf("json decode: %w", err)
+	}
+	if h.metrics != nil {
+		h.metrics.messagesParsed.Inc()
+	}
+	return h.publishEnvelope(ctx, data)
+}
+
+// publishJSONL splits the body by newline and publishes one
+// envelope per non-empty line. Parse errors on individual lines
+// are counted but do not abort the cycle.
+func (h *Input) publishJSONL(ctx context.Context, body []byte) error {
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	scanner.Buffer(make([]byte, 64*1024), maxResponseBytes)
+	var firstErr error
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var data map[string]any
+		if err := json.Unmarshal(line, &data); err != nil {
+			h.logger.Debug("jsonl: skipping malformed line", slog.Any("error", err))
+			if h.metrics != nil {
+				h.metrics.parseErrors.Inc()
+			}
+			if firstErr == nil {
+				firstErr = fmt.Errorf("jsonl decode: %w", err)
+			}
+			continue
+		}
+		if h.metrics != nil {
+			h.metrics.messagesParsed.Inc()
+		}
+		if err := h.publishEnvelope(ctx, data); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("jsonl scan: %w", err)
+	}
+	// firstErr is non-nil only if every line failed *or* an early
+	// line failed before a later success. The cycle still
+	// published valid lines; return firstErr so the caller logs it
+	// without surfacing as a complete-cycle failure.
+	return firstErr
+}
+
+// publishEnvelope wraps the decoded data in a GenericJSONPayload
+// BaseMessage and publishes it via the configured NATS path.
+// Required by the payload-registry discipline: every NATS publish
+// is decodeable through message.NewDecoder(reg).
+func (h *Input) publishEnvelope(ctx context.Context, data map[string]any) error {
+	payload := message.NewGenericJSON(data)
+	envelope := message.NewBaseMessage(payload.Schema(), payload, h.envelopeSource())
+	wire, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	return h.publishBytes(ctx, wire)
+}
+
+// envelopeSource returns the BaseMessage Source string. Encodes
+// component-name + URL so downstream consumers can attribute
+// observations to a specific input instance.
+func (h *Input) envelopeSource() string {
+	if h.name == "" {
+		return "http-input"
+	}
+	return "http-input:" + h.name
+}
+
+// publishBytes hands off the marshaled envelope to the configured
+// publisher. The publisher's implementation owns the JetStream vs
+// core NATS dispatch.
+func (h *Input) publishBytes(ctx context.Context, data []byte) error {
+	if err := h.publisher.Publish(ctx, h.resolved.subject, data); err != nil {
+		return err
+	}
+	h.messagesPublished.Add(1)
+	if h.metrics != nil {
+		h.metrics.messagesPublished.Inc()
+	}
+	return nil
+}
+
+// retryableError marks a failure mode worth retrying (network
+// error, 5xx). Unwrapped error preserves the cause for callers
+// that want to inspect via errors.Is / errors.As.
+type retryableError struct{ err error }
+
+func (e *retryableError) Error() string { return e.err.Error() }
+func (e *retryableError) Unwrap() error { return e.err }
+
+// terminalError marks a failure that should not be retried (4xx,
+// build-request failure, response-too-large).
+type terminalError struct{ err error }
+
+func (e *terminalError) Error() string { return e.err.Error() }
+func (e *terminalError) Unwrap() error { return e.err }
+
+func isRetryable(err error) bool {
+	var r *retryableError
+	return errors.As(err, &r)
+}
+
+// nextBackoff applies the exponential multiplier and caps at max.
+func nextBackoff(current, maxBackoff time.Duration, multiplier float64) time.Duration {
+	next := time.Duration(float64(current) * multiplier)
+	if next > maxBackoff {
+		return maxBackoff
+	}
+	return next
+}

--- a/input/http/http_test.go
+++ b/input/http/http_test.go
@@ -1,0 +1,408 @@
+package http
+
+// ADR-044 Phase 4 smoke test. Exercises the http input against
+// httptest.Server fixtures, asserting that decoded JSON publishes
+// arrive as well-formed BaseMessage envelopes via the stub
+// publisher. The publish-side abstraction (publisher interface)
+// lets these tests run without testcontainers / NATS.
+//
+// Coverage targets ADR-044 line 165 — "smoke test against
+// httptest.Server decoding to a registered payload type" — plus
+// the failure modes most likely to bite operators: 5xx retry, 4xx
+// non-retry, bearer / basic auth header shape, POST body
+// passthrough, jsonl line splitting.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadbuiltins"
+)
+
+// stubPublisher captures publishes for assertion. Goroutine-safe.
+type stubPublisher struct {
+	mu       sync.Mutex
+	messages [][]byte
+	wantErr  error
+}
+
+func (s *stubPublisher) Publish(_ context.Context, _ string, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.wantErr != nil {
+		return s.wantErr
+	}
+	out := make([]byte, len(data))
+	copy(out, data)
+	s.messages = append(s.messages, out)
+	return nil
+}
+
+func (s *stubPublisher) all() [][]byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([][]byte, len(s.messages))
+	copy(out, s.messages)
+	return out
+}
+
+// newTestInput constructs an Input wired to the given server URL
+// and stub publisher, skipping Start so tests can drive the
+// request / publish pipeline directly via runCycle.
+func newTestInput(t *testing.T, cfg Config, pub publisher) *Input {
+	t.Helper()
+	cfg.Ports = &component.PortConfig{
+		Outputs: []component.PortDefinition{
+			{Name: "out", Type: "nats", Subject: "test.http.out", Required: true},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("config validate: %v", err)
+	}
+	in := NewInput(InputDeps{
+		Name:   "http-input-test",
+		Config: cfg,
+	})
+	in.publisher = pub
+	return in
+}
+
+// decodeEnvelope parses a published BaseMessage envelope and
+// extracts the inner GenericJSON Data. Fails the test if the
+// envelope doesn't decode cleanly — the whole point of routing
+// through the payload registry is that this works. The wire shape
+// matches BaseMessage's wireFormat (see message/base_message.go).
+func decodeEnvelope(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var envelope struct {
+		ID      string       `json:"id"`
+		Type    message.Type `json:"type"`
+		Payload struct {
+			Data map[string]any `json:"data"`
+		} `json:"payload"`
+		Meta map[string]any `json:"meta"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		t.Fatalf("decode envelope: %v\nraw: %s", err, data)
+	}
+	if envelope.Type.Domain != "core" || envelope.Type.Category != "json" || envelope.Type.Version != "v1" {
+		t.Errorf("envelope type: got %+v, want core.json.v1", envelope.Type)
+	}
+	source, _ := envelope.Meta["source"].(string)
+	if source == "" {
+		t.Errorf("envelope meta.source should be non-empty, got meta=%v", envelope.Meta)
+	}
+	return envelope.Payload.Data
+}
+
+// TestHTTPInput_GetJSON_DecodesAndPublishes is the canonical
+// registry round-trip: the published bytes are decoded via the
+// production message.Decoder bound to a payload-registry with all
+// first-party payloads registered. This is the test that catches
+// envelope drift — if a payload type ever shifts and the
+// shape-cast helper silently keeps passing, this test will fail
+// loud. (Required by feedback_polymorphic_config_needs_json_roundtrip_test.)
+func TestHTTPInput_GetJSON_DecodesAndPublishes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"sensor_id":"temp-001","value":23.5}`))
+	}))
+	defer srv.Close()
+
+	pub := &stubPublisher{}
+	in := newTestInput(t, Config{
+		URL:     srv.URL,
+		Method:  MethodGET,
+		Decoder: &DecoderConfig{Mode: DecoderJSON},
+	}, pub)
+
+	in.runCycle(context.Background())
+
+	msgs := pub.all()
+	if len(msgs) != 1 {
+		t.Fatalf("want 1 published message, got %d", len(msgs))
+	}
+
+	// Production-path decode: through the payload registry, the
+	// same code path downstream consumers use.
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	baseMsg, err := decoder.Decode(msgs[0])
+	if err != nil {
+		t.Fatalf("registry decode: %v", err)
+	}
+	if got := baseMsg.Type(); got.Domain != "core" || got.Category != "json" || got.Version != "v1" {
+		t.Errorf("envelope type: got %+v, want core.json.v1", got)
+	}
+	payload, ok := baseMsg.Payload().(*message.GenericJSONPayload)
+	if !ok {
+		t.Fatalf("payload: got %T, want *message.GenericJSONPayload", baseMsg.Payload())
+	}
+	if payload.Data["sensor_id"] != "temp-001" {
+		t.Errorf("sensor_id: got %v, want temp-001", payload.Data["sensor_id"])
+	}
+	if payload.Data["value"] != 23.5 {
+		t.Errorf("value: got %v, want 23.5", payload.Data["value"])
+	}
+}
+
+func TestHTTPInput_BearerAuthHeaderSent(t *testing.T) {
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	in := newTestInput(t, Config{
+		URL:    srv.URL,
+		Method: MethodGET,
+		Auth:   &AuthConfig{Type: AuthBearer, Token: "secret-token"},
+	}, &stubPublisher{})
+
+	in.runCycle(context.Background())
+	if seen != "Bearer secret-token" {
+		t.Errorf("Authorization header: got %q, want %q", seen, "Bearer secret-token")
+	}
+}
+
+func TestHTTPInput_BasicAuthHeaderSent(t *testing.T) {
+	var seen string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	in := newTestInput(t, Config{
+		URL:    srv.URL,
+		Method: MethodGET,
+		Auth:   &AuthConfig{Type: AuthBasic, Username: "alice", Password: "rabbit"},
+	}, &stubPublisher{})
+
+	in.runCycle(context.Background())
+	want := "Basic " + base64.StdEncoding.EncodeToString([]byte("alice:rabbit"))
+	if seen != want {
+		t.Errorf("Authorization header: got %q, want %q", seen, want)
+	}
+}
+
+func TestHTTPInput_RetriesOn5xx(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		n := hits.Add(1)
+		if n < 3 {
+			http.Error(w, "still warming up", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ready":true}`))
+	}))
+	defer srv.Close()
+
+	pub := &stubPublisher{}
+	in := newTestInput(t, Config{
+		URL: srv.URL,
+		Retry: &RetryConfig{
+			MaxAttempts:    5,
+			InitialBackoff: "1ms",
+			MaxBackoff:     "10ms",
+			Multiplier:     2.0,
+		},
+	}, pub)
+
+	in.runCycle(context.Background())
+
+	if got := hits.Load(); got != 3 {
+		t.Errorf("expected 3 server hits (2 retries), got %d", got)
+	}
+	if len(pub.all()) != 1 {
+		t.Errorf("expected 1 published message after retry, got %d", len(pub.all()))
+	}
+}
+
+func TestHTTPInput_NoRetryOn4xx(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		http.Error(w, "go away", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	pub := &stubPublisher{}
+	in := newTestInput(t, Config{
+		URL: srv.URL,
+		Retry: &RetryConfig{
+			MaxAttempts:    5,
+			InitialBackoff: "1ms",
+			MaxBackoff:     "10ms",
+			Multiplier:     2.0,
+		},
+	}, pub)
+
+	in.runCycle(context.Background())
+
+	if got := hits.Load(); got != 1 {
+		t.Errorf("expected 1 server hit (no retry on 4xx), got %d", got)
+	}
+	if len(pub.all()) != 0 {
+		t.Errorf("expected 0 published messages on 4xx, got %d", len(pub.all()))
+	}
+}
+
+func TestHTTPInput_JSONLDecoderEmitsPerLine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w,
+			"{\"id\":1}\n"+
+				"\n"+ // blank line — skipped
+				"{\"id\":2}\n"+
+				"{\"id\":3}\n")
+	}))
+	defer srv.Close()
+
+	pub := &stubPublisher{}
+	in := newTestInput(t, Config{
+		URL:     srv.URL,
+		Decoder: &DecoderConfig{Mode: DecoderJSONL},
+	}, pub)
+
+	in.runCycle(context.Background())
+
+	msgs := pub.all()
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 published messages, got %d", len(msgs))
+	}
+	for i, raw := range msgs {
+		data := decodeEnvelope(t, raw)
+		want := float64(i + 1)
+		if data["id"] != want {
+			t.Errorf("message[%d] id: got %v, want %v", i, data["id"], want)
+		}
+	}
+}
+
+func TestHTTPInput_PostSendsBody(t *testing.T) {
+	var seen []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		var err error
+		seen, err = readAll(r)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		_, _ = w.Write([]byte(`{"echo":"ok"}`))
+	}))
+	defer srv.Close()
+
+	in := newTestInput(t, Config{
+		URL:    srv.URL,
+		Method: MethodPOST,
+		Body:   `{"q":"select * from things"}`,
+	}, &stubPublisher{})
+
+	in.runCycle(context.Background())
+	if string(seen) != `{"q":"select * from things"}` {
+		t.Errorf("body: got %q, want %q", string(seen), `{"q":"select * from things"}`)
+	}
+}
+
+func TestHTTPInput_MalformedJSONIsCountedButDoesNotPanic(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{not-actually-json`))
+	}))
+	defer srv.Close()
+
+	pub := &stubPublisher{}
+	in := newTestInput(t, Config{URL: srv.URL}, pub)
+
+	in.runCycle(context.Background()) // must not panic
+	if len(pub.all()) != 0 {
+		t.Errorf("expected 0 publishes on malformed JSON, got %d", len(pub.all()))
+	}
+	if in.errCount.Load() == 0 {
+		t.Errorf("expected errCount > 0 on malformed JSON")
+	}
+}
+
+func TestHTTPInput_PublishErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	pub := &stubPublisher{wantErr: errors.New("downstream unavailable")}
+	in := newTestInput(t, Config{URL: srv.URL}, pub)
+	in.runCycle(context.Background())
+
+	if in.errCount.Load() == 0 {
+		t.Errorf("expected errCount > 0 on publish error")
+	}
+}
+
+// TestHTTPInput_ContextCancellationStopsRetries asserts that
+// cancelling the supplied context aborts the backoff sleep
+// promptly rather than waiting for the full retry budget.
+func TestHTTPInput_ContextCancellationStopsRetries(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	pub := &stubPublisher{}
+	in := newTestInput(t, Config{
+		URL: srv.URL,
+		Retry: &RetryConfig{
+			MaxAttempts:    10,
+			InitialBackoff: "500ms",
+			MaxBackoff:     "5s",
+			Multiplier:     2.0,
+		},
+	}, pub)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	start := time.Now()
+	in.runCycle(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Errorf("ctx cancellation should cut retry loop; took %v", elapsed)
+	}
+}
+
+// readAll drains an io.ReadCloser without bringing in another
+// import in the production code.
+func readAll(r *http.Request) ([]byte, error) {
+	body := r.Body
+	if body == nil {
+		return nil, nil
+	}
+	defer body.Close()
+	const initialCap = 1 << 16
+	buf := make([]byte, 0, initialCap)
+	tmp := make([]byte, 4096)
+	for {
+		n, err := body.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if err != nil {
+			if err.Error() == "EOF" {
+				return buf, nil
+			}
+			return buf, err
+		}
+	}
+}

--- a/input/http/metrics.go
+++ b/input/http/metrics.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"fmt"
+
+	"github.com/c360studio/semstreams/metric"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// metrics holds prometheus counters for the http input component.
+type metrics struct {
+	requestsTotal     prometheus.Counter
+	requestsFailed    prometheus.Counter
+	requestsRetried   prometheus.Counter
+	messagesParsed    prometheus.Counter
+	messagesPublished prometheus.Counter
+	parseErrors       prometheus.Counter
+}
+
+// newMetrics constructs and registers the input/http counters
+// under the per-instance service name. Returns nil when the
+// registry is nil — caller must nil-check.
+func newMetrics(registry *metric.MetricsRegistry, name string) *metrics {
+	if registry == nil {
+		return nil
+	}
+	m := &metrics{
+		requestsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "http_input",
+			Name:      "requests_total",
+			Help:      "Total HTTP requests issued (across retries).",
+		}),
+		requestsFailed: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "http_input",
+			Name:      "requests_failed_total",
+			Help:      "Total HTTP requests that ultimately failed after retries.",
+		}),
+		requestsRetried: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "http_input",
+			Name:      "requests_retried_total",
+			Help:      "Total retry attempts beyond the first request.",
+		}),
+		messagesParsed: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "http_input",
+			Name:      "messages_parsed_total",
+			Help:      "Total messages decoded from response bodies.",
+		}),
+		messagesPublished: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "http_input",
+			Name:      "messages_published_total",
+			Help:      "Total messages published to NATS.",
+		}),
+		parseErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "http_input",
+			Name:      "parse_errors_total",
+			Help:      "Total decode errors on response bodies.",
+		}),
+	}
+	service := fmt.Sprintf("http_input_%s", name)
+	registry.RegisterCounter(service, "requests", m.requestsTotal)
+	registry.RegisterCounter(service, "requests_failed", m.requestsFailed)
+	registry.RegisterCounter(service, "requests_retried", m.requestsRetried)
+	registry.RegisterCounter(service, "messages_parsed", m.messagesParsed)
+	registry.RegisterCounter(service, "messages_published", m.messagesPublished)
+	registry.RegisterCounter(service, "parse_errors", m.parseErrors)
+	return m
+}

--- a/input/http/register.go
+++ b/input/http/register.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// CreateInput is the factory function the component registry uses
+// to construct an http input from raw JSON config. Validates the
+// merged config before handing off to NewInput.
+func CreateInput(rawConfig json.RawMessage, deps component.Dependencies) (component.Discoverable, error) {
+	cfg := DefaultConfig()
+	if len(rawConfig) > 0 {
+		var userConfig Config
+		if err := component.SafeUnmarshal(rawConfig, &userConfig); err != nil {
+			return nil, errs.Wrap(err, "http-input-factory", "create", "config parse")
+		}
+		cfg = mergeConfig(cfg, userConfig)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	if deps.NATSClient == nil {
+		return nil, errs.WrapInvalid(fmt.Errorf("NATS client is required"),
+			"http-input-factory", "create", "dependency validation")
+	}
+
+	return NewInput(InputDeps{
+		Name:            "http-input",
+		Config:          cfg,
+		NATSClient:      deps.NATSClient,
+		MetricsRegistry: deps.MetricsRegistry,
+		Logger:          deps.Logger,
+	}), nil
+}
+
+// mergeConfig overlays user-supplied fields onto the defaults.
+// Nested-pointer fields (Auth, Retry, Decoder) are replaced
+// wholesale when the user supplied them — partial overrides
+// inside those sub-objects must be expressed explicitly by the
+// caller. Headers / Ports are passed through unchanged.
+func mergeConfig(base, user Config) Config {
+	out := base
+	if user.URL != "" {
+		out.URL = user.URL
+	}
+	if user.Method != "" {
+		out.Method = user.Method
+	}
+	if user.Body != "" {
+		out.Body = user.Body
+	}
+	if user.Interval != "" {
+		out.Interval = user.Interval
+	}
+	if user.Timeout != "" {
+		out.Timeout = user.Timeout
+	}
+	if user.Headers != nil {
+		out.Headers = user.Headers
+	}
+	if user.Auth != nil {
+		out.Auth = user.Auth
+	}
+	if user.Retry != nil {
+		out.Retry = user.Retry
+	}
+	if user.Decoder != nil {
+		out.Decoder = user.Decoder
+	}
+	if user.Ports != nil {
+		out.Ports = user.Ports
+	}
+	return out
+}
+
+// Register wires the http input into the component registry.
+func Register(registry *component.Registry) error {
+	return registry.RegisterWithConfig(component.RegistrationConfig{
+		Name:        "http_input",
+		Factory:     CreateInput,
+		Schema:      httpInputSchema,
+		Type:        "input",
+		Protocol:    "http",
+		Domain:      "network",
+		Description: "Generic REST polling input. Polls an HTTP endpoint on a schedule and publishes decoded JSON to NATS.",
+		Version:     "1.0.0",
+	})
+}


### PR DESCRIPTION
## Summary

ADR-044 Phase 4 lands the generic REST polling input component — `input/http`. This is the third independently-mergeable phase in the OGC API Connected Systems framework/sister-repo split.

**New package `input/http/`** (~1,541 LOC) implementing the `Discoverable` + `LifecycleComponent` contract following the existing `input/{file,websocket}` shape:

**Config:**
- URL, Method (GET/POST), Body
- Interval (≥ 100ms floor) / Timeout (per-attempt)
- Custom Headers
- Auth: `none` / `bearer` / `basic` with type-specific required-field validation
- Retry: MaxAttempts + exponential backoff with cap
- Decoder modes: `json` (one publish per cycle) or `jsonl` (one publish per line)
- NATS or JetStream output port

**Behavior:**
- Exponential-backoff retry on network errors and 5xx; **no** retry on 4xx (client misconfiguration is not transient)
- `retryableError` / `terminalError` sentinel types classify failures via `errors.As`
- 32 MiB response body cap; oversized responses drain remainder to preserve HTTP/1.1 keep-alive
- Context cancellation cuts retry backoff via `select`
- Per-attempt Timeout (retries get a fresh clock; total cycle time bounded by `MaxAttempts × (Timeout + MaxBackoff)`)

**Payload registry discipline** (per `feedback_nats_publishes_use_payload_registry`):
- Every publish wraps decoded JSON in a `GenericJSONPayload` (`core.json.v1`) `BaseMessage` envelope
- The smoke test routes through `payloadbuiltins.NewTestDecoder` for a **production-path decode** assertion — not a shape-cast shortcut

**`publisher` interface abstraction** lets the smoke test verify decode → publish without testcontainers / NATS infrastructure. Production wiring uses `natsPublisher`, which owns JetStream vs core NATS dispatch via the resolved port type.

## Smoke test coverage (`httptest.Server` fixtures)

Satisfies ADR-044 line 165 "smoke test against httptest.Server decoding to a registered payload type":

- ✅ Registry round-trip on GET-JSON happy path (production decoder)
- ✅ Bearer auth header shape (`Authorization: Bearer <token>`)
- ✅ Basic auth header shape (`Authorization: Basic <base64>`)
- ✅ 5xx retry sequence (server 503s twice then succeeds)
- ✅ 4xx no-retry (single hit, zero publishes)
- ✅ JSONL per-line emit with blank-line skip
- ✅ POST body passthrough
- ✅ Malformed JSON counted but does not panic
- ✅ Publish error surfaces via `errCount`
- ✅ Context cancellation cuts retry backoff promptly

## Scope (deferred)

- Server-Sent Events / streaming HTTP — follow-up `input/sse` or extension when a consumer asks
- WebSocket subscription — use existing `input/websocket`
- A dedicated `network.http.v1` payload carrying URL / status / latency provenance — open follow-up; today's `core.json.v1` is the pragmatic choice
- Redirect cap / TLS skip-verify / per-instance metrics-label collision audit — open follow-ups per go-reviewer recommendations

## Notable

- go-reviewer signed off after two must-fixes applied:
  1. **Registry round-trip in smoke test** — added `payloadbuiltins.NewTestDecoder` path in the canonical happy-path test (was previously shape-casting an anonymous struct; would have silently passed if envelope drifted)
  2. **`Timeout` doc/code alignment** — clarified field as per-attempt (was ambiguously documented "including all retries" while code set per-`Do` call)
- Three cheap nice-to-haves also applied: drained body on size-cap (keep-alive perf), renamed shadowed `bytes` local, dropped unused error return from `mergeConfig`

## Pre-existing CI flake observation

Noted during this work: `TestRunWithBudget_ParentContextCancellationPropagates` in `processor/agentic-loop` failed on main post-PR-#88 merge (CI run 25944353136). Unrelated to Phase 4 (different package). Reproduced 0/20 times locally with race + count. Tracking separately as a follow-up.

## Test plan

- [x] `task lint` — clean
- [x] `go test -race ./input/http/...` — all 10 tests green
- [x] `go vet -tags=integration ./...` and `-tags=live_llm ./...` — clean
- [x] `task schema:generate` — no uncommitted diff
- [x] go-reviewer sign-off after must-fixes applied
- [ ] CI must pass before merge

Phase 5 (`parser/sensorml` — SensorML JSON parser/emitter producing `Graphable` entities with SOSA/SSN triples) is next. Depends on Phase 2 (`vocabulary/sosa`), which is already merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)