### PR TITLE
fix(graph-index-spatial): stop silent-success on polygon query validation failures

### DIFF
--- a/processor/graph-index-spatial/query.go
+++ b/processor/graph-index-spatial/query.go
@@ -255,7 +255,7 @@ func (c *Component) handleQueryPolygonNATS(ctx context.Context, data []byte) ([]
 		return nil, errs.WrapInvalid(err, "Component", "handleQueryPolygonNATS", "invalid request envelope")
 	}
 	if len(req.Polygon) == 0 {
-		return nil, errs.WrapInvalid(nil, "Component", "handleQueryPolygonNATS", "missing \"polygon\" field")
+		return nil, errs.WrapInvalid(errs.ErrInvalidData, "Component", "handleQueryPolygonNATS", "missing \"polygon\" field")
 	}
 	if req.Limit <= 0 {
 		req.Limit = 100
@@ -272,14 +272,14 @@ func (c *Component) handleQueryPolygonNATS(ctx context.Context, data []byte) ([]
 	// issue separate polygon queries, then UNION the results.
 	poly, ok := geom.(geojson.Polygon)
 	if !ok {
-		return nil, errs.WrapInvalid(nil, "Component", "handleQueryPolygonNATS",
+		return nil, errs.WrapInvalid(errs.ErrInvalidData, "Component", "handleQueryPolygonNATS",
 			fmt.Sprintf("expected Polygon geometry, got %q", geom.Type()))
 	}
 	poly = poly.Normalize().(geojson.Polygon)
 
 	bbox := geojson.ComputeBBox(poly)
 	if len(bbox) != 4 {
-		return nil, errs.WrapInvalid(nil, "Component", "handleQueryPolygonNATS",
+		return nil, errs.WrapInvalid(errs.ErrInvalidData, "Component", "handleQueryPolygonNATS",
 			"polygon has no coordinates")
 	}
 

--- a/processor/graph-index-spatial/validation_error_test.go
+++ b/processor/graph-index-spatial/validation_error_test.go
@@ -1,0 +1,95 @@
+package graphindexspatial
+
+// Regression tests for the polygon-query validation paths that previously
+// called errs.WrapInvalid(nil, ...) and returned (nil, nil) — silently
+// surfacing invalid input as an empty success reply on the NATS wire.
+//
+// See GH #94 for the underlying pkg/errs.Wrap*(nil, ...) footgun. This file
+// asserts the call-site hotfix is in place; once #94 lands at the framework
+// layer, the explicit errs.ErrInvalidData sentinel here remains valid and
+// the tests continue to pass.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// The three sites the hotfix patched — each formerly passed nil as the inner
+// error to errs.WrapInvalid, which returned nil, which the handler returned
+// as (nil, nil), which the NATS wire encoded as an empty success reply.
+func TestHandleQueryPolygonNATS_MissingPolygonFieldReturnsClassifiedError(t *testing.T) {
+	c := &Component{}
+	body := []byte(`{"limit": 10}`)
+
+	data, err := c.handleQueryPolygonNATS(context.Background(), body)
+
+	assertSilentSuccessRegression(t, "missing polygon", data, err)
+	assertCarriesInvalidSentinel(t, "missing polygon", err)
+}
+
+func TestHandleQueryPolygonNATS_WrongGeometryTypeReturnsClassifiedError(t *testing.T) {
+	c := &Component{}
+	body := []byte(`{"polygon": {"type": "Point", "coordinates": [0, 0]}, "limit": 10}`)
+
+	data, err := c.handleQueryPolygonNATS(context.Background(), body)
+
+	assertSilentSuccessRegression(t, "wrong geometry type", data, err)
+	assertCarriesInvalidSentinel(t, "wrong geometry type", err)
+}
+
+func TestHandleQueryPolygonNATS_EmptyPolygonCoordinatesReturnsClassifiedError(t *testing.T) {
+	c := &Component{}
+	body := []byte(`{"polygon": {"type": "Polygon", "coordinates": []}, "limit": 10}`)
+
+	data, err := c.handleQueryPolygonNATS(context.Background(), body)
+
+	assertSilentSuccessRegression(t, "empty polygon coordinates", data, err)
+	assertCarriesInvalidSentinel(t, "empty polygon coordinates", err)
+}
+
+// Malformed JSON wraps the real json.Unmarshal error, not a sentinel. The
+// (nil, nil) silent-success regression never affected this path — it's
+// covered here only to prove the invariant that every validation failure
+// out of this handler classifies as Invalid.
+func TestHandleQueryPolygonNATS_MalformedJSONReturnsClassifiedError(t *testing.T) {
+	c := &Component{}
+	body := []byte(`{not valid json`)
+
+	data, err := c.handleQueryPolygonNATS(context.Background(), body)
+
+	assertSilentSuccessRegression(t, "malformed json envelope", data, err)
+}
+
+// assertSilentSuccessRegression encodes the contract the hotfix restores:
+// validation failures must return a non-nil, classified-Invalid error AND
+// nil data — never (nil, nil), which natsclient.SubscribeForRequests would
+// encode as an empty success reply.
+func assertSilentSuccessRegression(t *testing.T, label string, data []byte, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("%s: expected non-nil error, got (nil, %v) — silent-success regression", label, data)
+	}
+	if data != nil {
+		t.Errorf("%s: expected nil data on validation failure, got %q", label, data)
+	}
+	if !errs.IsInvalid(err) {
+		t.Errorf("%s: expected errs.IsInvalid(err) == true, got class %q for err=%v",
+			label, errs.Classify(err), err)
+	}
+}
+
+// assertCarriesInvalidSentinel asserts the hotfix used errs.ErrInvalidData
+// as the inner error rather than nil. Distinct from IsInvalid because the
+// classification can be Invalid without the specific sentinel (e.g. wrapped
+// json.Unmarshal errors). When GH #94 lands at the pkg/errs framework
+// layer, this assertion remains correct — the explicit sentinel is still
+// load-bearing for downstream errors.Is checks.
+func assertCarriesInvalidSentinel(t *testing.T, label string, err error) {
+	t.Helper()
+	if !errors.Is(err, errs.ErrInvalidData) {
+		t.Errorf("%s: expected errors.Is(err, errs.ErrInvalidData), got err=%v", label, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Three validation paths in `handleQueryPolygonNATS` (missing polygon, wrong geometry type, empty coordinates) were calling `errs.WrapInvalid(nil, ...)`, which short-circuits to return `nil` per `pkg/errs/errs.go:276`. The handler then returned `(nil, nil)`, which `natsclient.SubscribeForRequests` encodes as an empty success reply — silent failure indistinguishable from a valid zero-match query.
- Pass `errs.ErrInvalidData` as the inner-error sentinel so the wrap produces a non-nil classified error. Downstream callers see `errs.IsInvalid(err) == true` and can route to HTTP 400.
- Add regression tests asserting each formerly-broken path now returns `(nil, classifiedInvalidErr)`.

## Background

semconnect Stage 5 (`C360Studio/semconnect` PR #5) hit this while wiring `GET /areas`. They worked around with client-side validation, but any other consumer of `graph.spatial.query.polygon` with a malformed payload gets silent failure today.

Hotfix only — the underlying `pkg/errs.Wrap*(nil, ...)` footgun is tracked separately in #94 and will ship at the framework layer. Once #94 lands, the explicit `errs.ErrInvalidData` sentinel here remains valid (and load-bearing for downstream `errors.Is` checks), so this change does not need to revert.

## Why `errs.ErrInvalidData` rather than `errors.New(...)`

Using the package-level sentinel means downstream consumers can write:

```go
if errors.Is(err, errs.ErrInvalidData) { ... }
```

…and match across all three sites without parsing the formatted message. Behavior is the same: `errs.IsInvalid(err) == true`, NATS wire carries the classified error once GH #93 ships header-based encoding.

## Related issues

- #93 — natsclient error-reply structuring (umbrella; this PR is downstream-visible because the wire still uses the `error: ` body-prefix until #93 Phase 1 ships)
- #94 — `pkg/errs.Wrap*(nil, ...)` framework footgun (root cause; this PR is the targeted hotfix at the 3 known live sites)
- #95 — `SpatialResult` coords (separate semconnect Stage 5 finding, not in this PR)

## Test plan

- [x] `go test -race ./processor/graph-index-spatial/...` — 4 new tests pass (3 silent-success regressions + 1 invariant for malformed JSON)
- [x] `task lint` — clean
- [x] `task schema:generate` + `git diff schemas/ specs/` — no drift
- [x] `go test ./test/contract/...` — pass
- [ ] Reviewer: confirm `errs.ErrInvalidData` is the right sentinel for "validation failed in handler" (vs. a more specific sentinel) — open to swapping if there's a better choice

🤖 Generated with [Claude Code](https://claude.com/claude-code)