### PR TITLE
feat(vocabulary/csapi): add OGC Connected Systems v1.0 Datastream package

### DIFF
--- a/vocabulary/csapi/doc.go
+++ b/vocabulary/csapi/doc.go
@@ -1,0 +1,52 @@
+// Package csapi provides Go constants for the OGC API — Connected
+// Systems v1.0 (CS API) vocabulary — specifically the §10 Datastream
+// concept and its surrounding predicates, which SOSA and OMS do not
+// cover.
+//
+// SOSA models discrete Observations attached to a Sensor; the CS API
+// adds the Datastream concept (§10) — a stream of Observations
+// produced by one System for one ObservableProperty, with temporal
+// bounds and a result-type discriminator. Sister-repo gateways
+// (semconnect, future CS API hosts) that publish or list Datastreams
+// over `POST /datastreams` / `GET /datastreams` need a shared
+// vocabulary primitive so JSON-LD exports resolve and downstream
+// graph consumers can discover Datastreams without grepping for
+// local IRI strings.
+//
+// # Namespace pinning
+//
+// The Namespace constant pins to the OGC spec-rooted IRI stem for
+// Connected Systems v1.0. The CS API is still a working draft; when
+// the OGC publishes canonical IRIs (which may differ in form), this
+// package gets a one-shot constant swap and existing entities re-tag
+// via the migration playbook. The constant-name surface is the load-
+// bearing API — consumers reference [csapi.Datastream] etc., not
+// the string form, so the URI change is invisible at the call site.
+//
+// # Coverage
+//
+// MVP coverage is the load-bearing subset for the CS API §10 →
+// Datastream representation: the Datastream class plus the four
+// predicates needed for the wire shape — ProducedBy, ResultTimeRange,
+// PhenomenonTimeRange, ResultType. The Schema field (SWE Common
+// DataRecord describing observation result structure) is
+// intentionally absent — see [ADR-044] framework-primitives
+// reference §Scope-cut for the rationale (Schema flows as a
+// StorageRef pointer rather than an inline triple).
+//
+// # Standards-at-work, not semweb hell
+//
+// This package follows the [vocabulary] family pattern. Constants
+// are exported strings; no OWL inferencing, no SPARQL, no operator-
+// authored RDF. Prefix registration is automatic on import.
+//
+// # External references
+//
+//   - Spec (working draft): https://docs.ogc.org/DRAFTS/23-001r0.html
+//   - SOSA (compared/parallel): https://www.w3.org/TR/vocab-ssn/
+//   - OMS bundle (parallel observation vocabulary): [oms]
+//
+// [vocabulary]: ..
+// [oms]: ../oms
+// [ADR-044]: ../../docs/adr/044-ogc-connected-systems-framework-split.md
+package csapi

--- a/vocabulary/csapi/iris.go
+++ b/vocabulary/csapi/iris.go
@@ -1,0 +1,75 @@
+package csapi
+
+import (
+	"maps"
+	"strings"
+)
+
+// CS API namespace identifiers. Pinned to the spec-rooted stem used
+// by OGC API Connected Systems v1.0. The spec is a working draft;
+// when canonical IRIs publish, this constant gets a one-shot swap.
+const (
+	// Prefix is the CS API short token used when compacting IRIs.
+	Prefix = "csapi"
+
+	// Namespace is the CS API v1.0 IRI stem.
+	Namespace = "http://www.opengis.net/spec/ogcapi-connectedsystems-1/1.0/"
+)
+
+// CS API class IRIs. Use as the object of an rdf:type triple, or
+// anywhere a Connected-Systems-aware encoder references the type.
+const (
+	// Datastream — a stream of Observations produced by one System
+	// (sensor or system of systems) for one ObservableProperty, with
+	// declared temporal bounds (PhenomenonTimeRange,
+	// ResultTimeRange) and a result-type discriminator (ResultType).
+	// CS API v1.0 §10.
+	Datastream = Namespace + "Datastream"
+)
+
+// iris is the canonical set of IRIs this package surfaces, indexed
+// by their compact form. Adding a constant in iris.go or
+// predicates.go requires adding it here too; the contract test in
+// iris_test.go fails loud if these drift apart.
+var iris = map[string]string{
+	// Classes
+	Prefix + ":Datastream": Datastream,
+
+	// Predicates
+	Prefix + ":producedBy":          ProducedBy,
+	Prefix + ":resultTimeRange":     ResultTimeRange,
+	Prefix + ":phenomenonTimeRange": PhenomenonTimeRange,
+	Prefix + ":resultType":          ResultType,
+}
+
+var reverseIRIs = func() map[string]string {
+	m := make(map[string]string, len(iris))
+	for compact, iri := range iris {
+		m[iri] = compact
+	}
+	return m
+}()
+
+// IRIs returns a copy of the full set of compact → IRI mappings
+// covered by this package.
+func IRIs() map[string]string {
+	out := make(map[string]string, len(iris))
+	maps.Copy(out, iris)
+	return out
+}
+
+// IsKnown reports whether the given IRI is part of this package's
+// coverage.
+func IsKnown(iri string) bool {
+	_, ok := reverseIRIs[iri]
+	return ok
+}
+
+// LocalName returns the local part of a CS API IRI, or the empty
+// string if the IRI is not in the CS API namespace.
+func LocalName(iri string) string {
+	if strings.HasPrefix(iri, Namespace) {
+		return iri[len(Namespace):]
+	}
+	return ""
+}

--- a/vocabulary/csapi/iris_test.go
+++ b/vocabulary/csapi/iris_test.go
@@ -1,0 +1,78 @@
+package csapi
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIRIsCoverConstants(t *testing.T) {
+	wantPairs := map[string]string{
+		Prefix + ":Datastream": Datastream,
+
+		Prefix + ":producedBy":          ProducedBy,
+		Prefix + ":resultTimeRange":     ResultTimeRange,
+		Prefix + ":phenomenonTimeRange": PhenomenonTimeRange,
+		Prefix + ":resultType":          ResultType,
+	}
+	got := IRIs()
+	if len(got) != len(wantPairs) {
+		t.Fatalf("IRIs(): want %d entries, got %d", len(wantPairs), len(got))
+	}
+	for compact, iri := range wantPairs {
+		if gotIRI, ok := got[compact]; !ok {
+			t.Errorf("IRIs() missing %q", compact)
+		} else if gotIRI != iri {
+			t.Errorf("IRIs()[%q] = %q, want %q", compact, gotIRI, iri)
+		}
+	}
+}
+
+func TestConstantsLiveInDeclaredNamespace(t *testing.T) {
+	all := []string{
+		Datastream,
+		ProducedBy, ResultTimeRange, PhenomenonTimeRange, ResultType,
+	}
+	for _, c := range all {
+		if !strings.HasPrefix(c, Namespace) {
+			t.Errorf("%q does not start with CS API namespace %q", c, Namespace)
+		}
+	}
+}
+
+func TestIsKnown(t *testing.T) {
+	cases := []struct {
+		iri  string
+		want bool
+	}{
+		{Datastream, true},
+		{ProducedBy, true},
+		{ResultTimeRange, true},
+		{Namespace + "unmappedButValidCSAPI", false},
+		{"http://example.org/not-csapi", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsKnown(c.iri); got != c.want {
+			t.Errorf("IsKnown(%q) = %v, want %v", c.iri, got, c.want)
+		}
+	}
+}
+
+func TestLocalName(t *testing.T) {
+	cases := []struct {
+		iri  string
+		want string
+	}{
+		{Datastream, "Datastream"},
+		{ProducedBy, "producedBy"},
+		{ResultTimeRange, "resultTimeRange"},
+		{Namespace + "unmappedButValidCSAPI", "unmappedButValidCSAPI"},
+		{"http://example.org/not-csapi", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := LocalName(c.iri); got != c.want {
+			t.Errorf("LocalName(%q) = %q, want %q", c.iri, got, c.want)
+		}
+	}
+}

--- a/vocabulary/csapi/predicates.go
+++ b/vocabulary/csapi/predicates.go
@@ -1,0 +1,25 @@
+package csapi
+
+// CS API predicate IRIs.
+const (
+	// ProducedBy binds a Datastream to the entity ID of the System
+	// (sensor or system of systems) that produces its Observations.
+	// Inverse of a forthcoming `producesDatastream` predicate.
+	ProducedBy = Namespace + "producedBy"
+
+	// ResultTimeRange is the ISO 8601 time-interval representation
+	// of the temporal bounds during which the Datastream produced
+	// result values (clock time of the measurements). CS API §10.4.
+	ResultTimeRange = Namespace + "resultTimeRange"
+
+	// PhenomenonTimeRange is the ISO 8601 time-interval representation
+	// of the temporal bounds of the observed phenomena. May differ
+	// from ResultTimeRange for processed or back-dated observations.
+	// CS API §10.4.
+	PhenomenonTimeRange = Namespace + "phenomenonTimeRange"
+
+	// ResultType discriminates the structure of the Datastream's
+	// Observations — om:Measurement, om:Category, om:CountObservation,
+	// etc. Consumers branch on this to decode the result payload.
+	ResultType = Namespace + "resultType"
+)

--- a/vocabulary/csapi/register.go
+++ b/vocabulary/csapi/register.go
@@ -1,0 +1,22 @@
+package csapi
+
+import (
+	"fmt"
+
+	"github.com/c360studio/semstreams/vocabulary/export"
+)
+
+// Register binds the csapi: prefix into the export prefix table.
+// Importing the package triggers this from init(); idempotent.
+func Register() error {
+	if err := export.Register(Prefix, Namespace); err != nil {
+		return fmt.Errorf("vocabulary/csapi: register csapi prefix: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	if err := Register(); err != nil {
+		panic(err)
+	}
+}

--- a/vocabulary/csapi/register_test.go
+++ b/vocabulary/csapi/register_test.go
@@ -1,0 +1,15 @@
+package csapi
+
+import "testing"
+
+// End-to-end integration with vocabulary/export's prefix compaction
+// is covered by the smoke test suite that iterates over registered
+// prefixes; this test guards the package-local idempotency contract.
+func TestRegisterIsIdempotent(t *testing.T) {
+	if err := Register(); err != nil {
+		t.Fatalf("Register() after init: %v", err)
+	}
+	if err := Register(); err != nil {
+		t.Fatalf("Register() second call: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #97.

## Summary

- New `vocabulary/csapi/` package covers the OGC API Connected Systems v1.0 §10 Datastream concept that neither SOSA nor OMS provide.
- 1 class (`Datastream`) + 4 predicates (`ProducedBy`, `ResultTimeRange`, `PhenomenonTimeRange`, `ResultType`).
- Follows the established `vocabulary/{sosa,oms,swe}` family pattern: `doc.go`, `iris.go`, `predicates.go`, `register.go`, plus the standard 4-test `iris_test.go` + idempotency `register_test.go`.
- Schema (SWE Common DataRecord) intentionally deferred per ADR-044 framework-primitives §Scope-cut — Schema flows as a StorageRef pointer rather than an inline triple.

## What semconnect picks up

Stage 8 (`gateway/cs-api/datastream.go`) currently mints local IRIs to bridge the gap:

| Stage 8 local | This package |
|---|---|
| `urn:c360studio:csapi:Datastream` | `csapi.Datastream` |
| `csapi.datastream.system` | `csapi.ProducedBy` |

Swap in a one-line change. The `X-CS-Datastream-Subset: true` response header can be dropped for the four predicates this package covers (Schema stays gated behind the header until SWE Common gets its own package).

## IRI choice

The CS API spec is a working draft. `Namespace` pins to the OGC spec-rooted stem (`http://www.opengis.net/spec/ogcapi-connectedsystems-1/1.0/`) — when canonical IRIs publish, this package gets a one-shot constant swap and existing entities re-tag via the migration playbook. **The constant-name surface (`csapi.Datastream` etc.) is the load-bearing API** — consumers reference the constants, not the string form, so the URI change is invisible at the call site.

## Naming notes

- `ProducedBy` (not `ProducedBySystem` as the upstream-ask draft suggested) — matches the framework convention that constant names mirror IRI local-name casing (`producedBy`). The disambiguation the draft's `ProducedBySystem` aimed for is preserved in the doc comment, which spells out "produced by a System."
- `Datastream` (not `DatastreamClass`) — matches `vocabulary/{sosa,oms}` convention (`Observation`, `Procedure`, etc. — no `Class` suffix).

## Backward compatibility

Pure addition. New package, no existing-caller impact.

## Test plan

- [x] `go test -race ./vocabulary/csapi/...` — pass (5 tests: cover-constants, namespace-check, IsKnown, LocalName, Register idempotent)
- [x] `task lint` — clean
- [x] `go test -race ./...` — no regressions
- [x] `go test -race -tags=integration ./...` — clean except pre-existing LLM classifier 5s flake (unrelated, CI-skipped)
- [x] `task schema:generate && git diff schemas/ specs/` — no drift
- [x] `go test ./test/contract/...` — pass

## Bundle context

Final item in the beta.75 bundle:
- ✅ #102 (closed #94) — `pkg/errs.Wrap*(nil)` framework footgun + datamanager regex sync
- ✅ #103 (closed #95) — `SpatialResult` carries `Lat`/`Lon`/`Alt`
- This PR (closes #97)

Once merged, beta.75 is ready to tag — three semconnect workarounds drop in a single sister-repo pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)