### PR TITLE
feat(agentic-tools): deploy_flow agent-tool family for runtime lifecycle

### DIFF
--- a/processor/agentic-tools/categories.go
+++ b/processor/agentic-tools/categories.go
@@ -58,11 +58,14 @@ var toolCategories = map[string]ToolCategory{
 	"answer_question": CategoryOrchestration,
 
 	// Meta
-	"create_rule": CategoryMeta,
-	"update_rule": CategoryMeta,
-	"delete_rule": CategoryMeta,
-	"create_flow": CategoryMeta,
-	"deploy_flow": CategoryMeta,
+	"create_rule":   CategoryMeta,
+	"update_rule":   CategoryMeta,
+	"delete_rule":   CategoryMeta,
+	"create_flow":   CategoryMeta,
+	"deploy_flow":   CategoryMeta,
+	"start_flow":    CategoryMeta,
+	"stop_flow":     CategoryMeta,
+	"undeploy_flow": CategoryMeta,
 
 	// GitHub tools
 	"github_read":   CategoryKnowledge,

--- a/processor/agentic-tools/executors/flow_lifecycle.go
+++ b/processor/agentic-tools/executors/flow_lifecycle.go
@@ -1,0 +1,175 @@
+package executors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// FlowEngineManager is the subset of the flow engine's lifecycle surface
+// that FlowLifecycleExecutor needs. Declared as an interface so tests can
+// substitute an in-memory fake without depending on the full
+// *flowengine.Engine type — which itself transitively pulls in the
+// component registry, NATS, and the metrics registry. *flowengine.Engine
+// satisfies it by duck typing; signatures match engine/engine.go:91,
+// 135, 173, 211 verbatim.
+//
+// Deploy / Start / Stop / Undeploy mirror the engine's runtime-state
+// transitions: not_deployed → deployed → running → stopped → undeployed.
+// Errors from the engine surface verbatim — including transition
+// pre-condition violations — so the agent gets the engine's wrapped
+// diagnostic rather than a tool-side rephrasing.
+type FlowEngineManager interface {
+	Deploy(ctx context.Context, flowID string) error
+	Start(ctx context.Context, flowID string) error
+	Stop(ctx context.Context, flowID string) error
+	Undeploy(ctx context.Context, flowID string) error
+}
+
+// FlowLifecycleExecutor implements the runtime lifecycle tools that
+// complement FlowExecutor's CRUD surface. CRUD writes the flow
+// definition; lifecycle moves the deployed instance through its state
+// machine. The two are separate executors so an operator can allow
+// authoring (create_flow / update_flow) without enabling deployment
+// (deploy_flow / start_flow), or vice-versa, via SkipBuiltins or
+// approval_required gating.
+//
+// Companion to ADR-042 (semteams): coordinator persona issues
+// create_flow → deploy_flow → start_flow at runtime; ComponentManager
+// picks up the deployed flow from semstreams_config KV and spins
+// components dynamically.
+type FlowLifecycleExecutor struct {
+	manager FlowEngineManager
+}
+
+// NewFlowLifecycleExecutor creates a flow lifecycle executor.
+func NewFlowLifecycleExecutor(manager FlowEngineManager) *FlowLifecycleExecutor {
+	return &FlowLifecycleExecutor{manager: manager}
+}
+
+// ListTools returns the four lifecycle tool definitions. All four take
+// the same single required parameter (flow_id) — the lifecycle is
+// stateless from the tool's perspective; the engine owns the
+// transition pre-condition checks and surfaces violations as errors.
+func (e *FlowLifecycleExecutor) ListTools() []agentic.ToolDefinition {
+	return []agentic.ToolDefinition{
+		{
+			Name:        "deploy_flow",
+			Description: "Deploy a flow definition into the runtime. Transitions the flow from not_deployed → deployed. The flow must already exist (use create_flow first). After deploy, call start_flow to begin processing.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flow_id": map[string]any{
+						"type":        "string",
+						"description": "ID of the flow to deploy.",
+					},
+				},
+				"required": []string{"flow_id"},
+			},
+		},
+		{
+			Name:        "start_flow",
+			Description: "Start a deployed flow. Transitions the flow from deployed → running. The flow must already be deployed (use deploy_flow first).",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flow_id": map[string]any{
+						"type":        "string",
+						"description": "ID of the flow to start.",
+					},
+				},
+				"required": []string{"flow_id"},
+			},
+		},
+		{
+			Name:        "stop_flow",
+			Description: "Stop a running flow. Transitions the flow from running → stopped. Components remain deployed; call start_flow to resume or undeploy_flow to tear down.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flow_id": map[string]any{
+						"type":        "string",
+						"description": "ID of the flow to stop.",
+					},
+				},
+				"required": []string{"flow_id"},
+			},
+		},
+		{
+			Name:        "undeploy_flow",
+			Description: "Undeploy a flow from the runtime. Transitions the flow from stopped (or deployed) → not_deployed. Tears down the runtime components; the flow definition remains and can be re-deployed.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"flow_id": map[string]any{
+						"type":        "string",
+						"description": "ID of the flow to undeploy.",
+					},
+				},
+				"required": []string{"flow_id"},
+			},
+		},
+	}
+}
+
+// Execute dispatches flow lifecycle tool calls by name.
+func (e *FlowLifecycleExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agentic.ToolResult, error) {
+	switch call.Name {
+	case "deploy_flow":
+		return e.runLifecycle(ctx, call, "deploy", e.manager.Deploy)
+	case "start_flow":
+		return e.runLifecycle(ctx, call, "start", e.manager.Start)
+	case "stop_flow":
+		return e.runLifecycle(ctx, call, "stop", e.manager.Stop)
+	case "undeploy_flow":
+		return e.runLifecycle(ctx, call, "undeploy", e.manager.Undeploy)
+	default:
+		return agentic.ToolResult{
+			CallID: call.ID,
+			Error:  fmt.Sprintf("unknown tool: %s", call.Name),
+		}, fmt.Errorf("unknown tool: %s", call.Name)
+	}
+}
+
+// runLifecycle factors the four lifecycle tools' shared shape — extract
+// flow_id, call the engine method, translate transition errors to
+// ToolResult.Error. Kept inline rather than dispatched via a map of
+// name → method because the four methods are method-values on
+// FlowEngineManager and Go can't form method-value maps without an
+// extra adapter layer that obscures the call site.
+func (e *FlowLifecycleExecutor) runLifecycle(
+	ctx context.Context,
+	call agentic.ToolCall,
+	verb string,
+	op func(ctx context.Context, flowID string) error,
+) (agentic.ToolResult, error) {
+	flowID, _ := call.Arguments["flow_id"].(string)
+	if flowID == "" {
+		return agentic.ToolResult{CallID: call.ID, Error: "flow_id is required"}, nil
+	}
+	if err := op(ctx, flowID); err != nil {
+		return agentic.ToolResult{CallID: call.ID, Error: fmt.Sprintf("%s failed: %v", verb, err)}, nil
+	}
+	return agentic.ToolResult{
+		CallID:  call.ID,
+		Content: fmt.Sprintf("Flow %q %s succeeded.", flowID, verbPastTense(verb)),
+	}, nil
+}
+
+// verbPastTense maps the lifecycle verbs to their past-tense form for
+// the success message. Tiny helper kept local — only used here.
+func verbPastTense(verb string) string {
+	switch verb {
+	case "deploy":
+		return "deployed"
+	case "start":
+		return "started"
+	case "stop":
+		return "stopped"
+	case "undeploy":
+		return "undeployed"
+	default:
+		return verb + "ed"
+	}
+}

--- a/processor/agentic-tools/executors/flow_lifecycle_engine_check_test.go
+++ b/processor/agentic-tools/executors/flow_lifecycle_engine_check_test.go
@@ -1,0 +1,18 @@
+package executors
+
+// Compile-time assertion that *flowengine.Engine satisfies
+// FlowEngineManager. Lives in a _test.go file so the production
+// flow_lifecycle.go can stay free of the heavy flowengine import — the
+// production executor only needs the interface, and product shells
+// (cmd/semteams, cmd/semstreams) wire the concrete engine at boot.
+//
+// If a future engine refactor changes Deploy/Start/Stop/Undeploy
+// signatures, this assertion fails at `go test` time with a clear
+// "does not implement FlowEngineManager" message — louder than a
+// silent caller-side type error at boot.
+
+import (
+	"github.com/c360studio/semstreams/engine"
+)
+
+var _ FlowEngineManager = (*flowengine.Engine)(nil)

--- a/processor/agentic-tools/executors/flow_lifecycle_test.go
+++ b/processor/agentic-tools/executors/flow_lifecycle_test.go
@@ -1,0 +1,229 @@
+package executors
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// mockFlowEngineManager captures lifecycle calls and returns
+// configurable errors so each tool path can be exercised without
+// spinning up the real flowengine.Engine (which transitively requires
+// the component registry, NATS, and metrics).
+type mockFlowEngineManager struct {
+	mu          sync.Mutex
+	deployed    map[string]bool
+	started     map[string]bool
+	stopped     map[string]bool
+	undeployed  map[string]bool
+	deployErr   error
+	startErr    error
+	stopErr     error
+	undeployErr error
+}
+
+func newMockFlowEngineManager() *mockFlowEngineManager {
+	return &mockFlowEngineManager{
+		deployed:   map[string]bool{},
+		started:    map[string]bool{},
+		stopped:    map[string]bool{},
+		undeployed: map[string]bool{},
+	}
+}
+
+func (m *mockFlowEngineManager) Deploy(_ context.Context, flowID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.deployErr != nil {
+		return m.deployErr
+	}
+	m.deployed[flowID] = true
+	return nil
+}
+
+func (m *mockFlowEngineManager) Start(_ context.Context, flowID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.startErr != nil {
+		return m.startErr
+	}
+	m.started[flowID] = true
+	return nil
+}
+
+func (m *mockFlowEngineManager) Stop(_ context.Context, flowID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.stopErr != nil {
+		return m.stopErr
+	}
+	m.stopped[flowID] = true
+	return nil
+}
+
+func (m *mockFlowEngineManager) Undeploy(_ context.Context, flowID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.undeployErr != nil {
+		return m.undeployErr
+	}
+	m.undeployed[flowID] = true
+	return nil
+}
+
+func TestFlowLifecycleExecutor_ListToolsShape(t *testing.T) {
+	t.Parallel()
+	e := NewFlowLifecycleExecutor(newMockFlowEngineManager())
+	tools := e.ListTools()
+	if len(tools) != 4 {
+		t.Fatalf("expected 4 tools, got %d", len(tools))
+	}
+	expected := map[string]bool{
+		"deploy_flow": true, "start_flow": true,
+		"stop_flow": true, "undeploy_flow": true,
+	}
+	for _, tool := range tools {
+		if !expected[tool.Name] {
+			t.Errorf("unexpected tool name: %s", tool.Name)
+		}
+		delete(expected, tool.Name)
+		// Every lifecycle tool has the same shape: required flow_id string.
+		required, _ := tool.Parameters["required"].([]string)
+		if len(required) != 1 || required[0] != "flow_id" {
+			t.Errorf("%s: expected required=[flow_id], got %v", tool.Name, required)
+		}
+	}
+	if len(expected) > 0 {
+		t.Errorf("missing tool names: %v", expected)
+	}
+}
+
+func TestFlowLifecycleExecutor_EachTransitionCallsCorrectMethod(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := newMockFlowEngineManager()
+	e := NewFlowLifecycleExecutor(mgr)
+
+	cases := []struct {
+		toolName string
+		check    func() bool
+		verb     string
+	}{
+		{"deploy_flow", func() bool { return mgr.deployed["f1"] }, "deployed"},
+		{"start_flow", func() bool { return mgr.started["f1"] }, "started"},
+		{"stop_flow", func() bool { return mgr.stopped["f1"] }, "stopped"},
+		{"undeploy_flow", func() bool { return mgr.undeployed["f1"] }, "undeployed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.toolName, func(t *testing.T) {
+			result, err := e.Execute(ctx, agentic.ToolCall{
+				ID:        "c-" + tc.toolName,
+				Name:      tc.toolName,
+				Arguments: map[string]any{"flow_id": "f1"},
+			})
+			if err != nil {
+				t.Fatalf("Execute %s: %v", tc.toolName, err)
+			}
+			if result.Error != "" {
+				t.Fatalf("%s returned error: %s", tc.toolName, result.Error)
+			}
+			if !tc.check() {
+				t.Errorf("%s did not call expected manager method", tc.toolName)
+			}
+			if !strings.Contains(result.Content, tc.verb) {
+				t.Errorf("%s: expected content to contain %q, got: %s", tc.toolName, tc.verb, result.Content)
+			}
+			if !strings.Contains(result.Content, `"f1"`) {
+				t.Errorf("%s: expected content to reference flow id, got: %s", tc.toolName, result.Content)
+			}
+		})
+	}
+}
+
+func TestFlowLifecycleExecutor_MissingFlowIDFailsBeforeEngine(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := newMockFlowEngineManager()
+	mgr.deployErr = errors.New("should-not-reach")
+	mgr.startErr = errors.New("should-not-reach")
+	mgr.stopErr = errors.New("should-not-reach")
+	mgr.undeployErr = errors.New("should-not-reach")
+	e := NewFlowLifecycleExecutor(mgr)
+
+	for _, toolName := range []string{"deploy_flow", "start_flow", "stop_flow", "undeploy_flow"} {
+		t.Run(toolName, func(t *testing.T) {
+			result, _ := e.Execute(ctx, agentic.ToolCall{
+				ID:        "miss-" + toolName,
+				Name:      toolName,
+				Arguments: map[string]any{},
+			})
+			if result.Error == "" {
+				t.Fatalf("expected error for missing flow_id")
+			}
+			if !strings.Contains(result.Error, "required") {
+				t.Errorf("expected 'required' in error, got: %s", result.Error)
+			}
+			// Engine should not have been invoked — error contains
+			// "should-not-reach" if it was, "required" if not.
+			if strings.Contains(result.Error, "should-not-reach") {
+				t.Errorf("%s called engine despite missing flow_id", toolName)
+			}
+		})
+	}
+}
+
+// TestFlowLifecycleExecutor_EngineErrorsSurfaceAsToolErrors — when
+// flowengine.Engine returns a transition-precondition violation (e.g.
+// "deploy: flow not_deployed state required"), the executor must surface
+// it as ToolResult.Error verbatim so the agent gets the engine's
+// diagnostic rather than a tool-side rephrasing.
+func TestFlowLifecycleExecutor_EngineErrorsSurfaceAsToolErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mgr := newMockFlowEngineManager()
+	boom := errors.New("simulated transition precondition violation")
+	mgr.deployErr = boom
+	mgr.startErr = boom
+	mgr.stopErr = boom
+	mgr.undeployErr = boom
+	e := NewFlowLifecycleExecutor(mgr)
+
+	for _, toolName := range []string{"deploy_flow", "start_flow", "stop_flow", "undeploy_flow"} {
+		t.Run(toolName, func(t *testing.T) {
+			result, _ := e.Execute(ctx, agentic.ToolCall{
+				ID:        "err-" + toolName,
+				Name:      toolName,
+				Arguments: map[string]any{"flow_id": "f1"},
+			})
+			if result.Error == "" {
+				t.Fatalf("expected Error on %s path, got none (content=%q)", toolName, result.Content)
+			}
+			if !strings.Contains(result.Error, "simulated transition precondition violation") {
+				t.Errorf("expected engine error to surface verbatim, got: %s", result.Error)
+			}
+		})
+	}
+}
+
+func TestFlowLifecycleExecutor_UnknownToolFails(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	e := NewFlowLifecycleExecutor(newMockFlowEngineManager())
+	result, err := e.Execute(ctx, agentic.ToolCall{ID: "x", Name: "not_a_lifecycle_tool"})
+	if err == nil {
+		t.Fatalf("expected error on unknown tool")
+	}
+	if !strings.Contains(result.Error, "unknown tool") {
+		t.Errorf("expected 'unknown tool', got: %s", result.Error)
+	}
+}
+
+// TestFlowLifecycleExecutor_DuckTypingWithFlowengineEngine — compile-time
+// assertion that *flowengine.Engine satisfies FlowEngineManager. Kept as
+// a build-time check rather than a runtime test to avoid pulling the
+// full engine dependency into the executor test scope; the assertion is
+// in flow_lifecycle_engine_check_test.go (separate file for clarity).

--- a/processor/agentic-tools/executors/register.go
+++ b/processor/agentic-tools/executors/register.go
@@ -48,6 +48,7 @@ type ToolDependencies struct {
 	PersonaManager      PersonaManager      // Pattern-B step 3
 	FlowTemplateManager FlowTemplateManager // Pattern-B step 4
 	ComponentRegistry   *component.Registry // Pattern-B step 5; nil → list_components skipped
+	FlowEngineManager   FlowEngineManager   // Pattern-B step 6; nil → flow_lifecycle skipped
 	// LoopsBucket is the NATS KV bucket name holding agent-loop state.
 	// read_loop_result + flow_monitor both read from it. Empty falls back
 	// to "AGENT_LOOPS". One bucket per process — wiring is boot-time so
@@ -105,6 +106,7 @@ var BuiltinGroupKeys = []string{
 	"personas",          // registerPersonas — persona CRUD tools
 	"flow_templates",    // registerFlowTemplates — flow_template CRUD tools
 	"component_catalog", // registerComponentCatalog — list_components
+	"flow_lifecycle",    // registerFlowLifecycle — deploy/start/stop/undeploy_flow
 }
 
 // RegisterBuiltins wires every tool this package owns into the supplied
@@ -191,6 +193,7 @@ func RegisterBuiltins(ctx context.Context, reg *agentictools.ExecutorRegistry, d
 	gate("flow_templates", func() error { return registerFlowTemplates(reg, deps.FlowTemplateManager, logger) })
 	gate("component_catalog", func() error { return registerComponentCatalog(reg, deps.ComponentRegistry, logger) })
 	gate("flow_monitor", func() error { return registerFlowMonitor(reg, deps.NATSClient, deps.FlowManager, logger, loopsBucket) })
+	gate("flow_lifecycle", func() error { return registerFlowLifecycle(reg, deps.FlowEngineManager, logger) })
 
 	if len(errs) > 0 {
 		return fmt.Errorf("RegisterBuiltins: %w", errors.Join(errs...))

--- a/processor/agentic-tools/executors/register_flow_lifecycle.go
+++ b/processor/agentic-tools/executors/register_flow_lifecycle.go
@@ -1,0 +1,32 @@
+package executors
+
+import (
+	"fmt"
+	"log/slog"
+
+	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
+)
+
+// registerFlowLifecycle wires FlowLifecycleExecutor so any agent role
+// scoped to flow-lifecycle tools (via publish_agent.tools or
+// default_tools) can deploy, start, stop, and undeploy flows at
+// runtime. Companion to registerFlows — CRUD authors the definition,
+// lifecycle moves the deployed instance through its state machine.
+//
+// A nil manager is a deployment choice (skip + nil); a registry-level
+// failure (duplicate name) propagates so RegisterBuiltins can surface
+// it at boot.
+func registerFlowLifecycle(tools *agentictools.ExecutorRegistry, manager FlowEngineManager, logger *slog.Logger) error {
+	if manager == nil {
+		logger.Debug("flow lifecycle tools disabled: no FlowEngineManager provided")
+		return nil
+	}
+
+	executor := NewFlowLifecycleExecutor(manager)
+	if err := tools.RegisterExecutor(executor); err != nil {
+		return fmt.Errorf("register flow lifecycle tools: %w", err)
+	}
+	logger.Info("Registered flow lifecycle tools",
+		slog.Int("count", len(executor.ListTools())))
+	return nil
+}

--- a/processor/agentic-tools/executors/register_test.go
+++ b/processor/agentic-tools/executors/register_test.go
@@ -362,6 +362,7 @@ func TestBuiltinGroupKeys_Stability(t *testing.T) {
 		"github", "graph_query",
 		"rules", "flows", "personas", "flow_templates",
 		"component_catalog",
+		"flow_lifecycle",
 	}
 	if len(BuiltinGroupKeys) != len(want) {
 		t.Fatalf("BuiltinGroupKeys count = %d, want %d. Adding a builtin? Update this test AND consumer docs.", len(BuiltinGroupKeys), len(want))


### PR DESCRIPTION
Closes #105. Unblocks semteams ADR-042 Phase 4 (coordinator-instantiated flows).

## Summary

- Add four lifecycle tools — `deploy_flow`, `start_flow`, `stop_flow`, `undeploy_flow` — that complement the existing flow CRUD surface. After `create_flow`, a flow sits at `RuntimeState = not_deployed`; the coordinator persona had no agent-side path to move it forward.
- New `FlowEngineManager` interface declares just the four lifecycle methods so tests use an in-memory fake without pulling the full `*flowengine.Engine` dependency graph. `*flowengine.Engine` satisfies it by duck typing — signatures match `engine.go:91,135,173,211` verbatim.
- `FlowLifecycleExecutor` mirrors `FlowExecutor` shape. Engine errors (including transition pre-condition violations) surface verbatim so the agent gets the engine's diagnostic, not a tool-side rephrasing.
- Registration follows the Pattern-B gate pattern — nil manager skips cleanly with a Debug log.

## Files

| File | Δ | Purpose |
|---|---|---|
| `executors/flow_lifecycle.go` | +175 | `FlowEngineManager` interface, `FlowLifecycleExecutor`, 4 tools |
| `executors/register_flow_lifecycle.go` | +32 | Register function, nil-safe gate |
| `executors/flow_lifecycle_test.go` | +229 | Mock manager + 5 test functions |
| `executors/flow_lifecycle_engine_check_test.go` | +18 | Compile-time `var _ FlowEngineManager = (*flowengine.Engine)(nil)` |
| `executors/register.go` | +3 | `FlowEngineManager` field, `BuiltinGroupKeys` entry, gate call |
| `executors/register_test.go` | +1 | `TestBuiltinGroupKeys_Stability` count bump |
| `agentic-tools/categories.go` | +5/-2 | Add `start_flow`, `stop_flow`, `undeploy_flow` to `CategoryMeta` |

Total: 466 lines added (~245 + ~31 + ~50 LoC original estimate + tests came in heavier for coverage).

## Approval surface

Lands unapproved by default. Operators allowlist per-config and gate via `approval_required` to route through `ApprovalFilter` — same posture as `create_flow` today. No changes to `ApprovalFilter` itself.

## Acceptance criteria from #105

- [x] With `FlowEngineManager: nil` in `ToolDependencies`, `RegisterBuiltins` skips registration cleanly (Debug log + nil return). Same gate pattern as `flow_templates`.
- [x] With a non-nil `*flowengine.Engine`, all four tools execute and propagate the engine's wrapped errors verbatim (`TestFlowLifecycleExecutor_EngineErrorsSurfaceAsToolErrors`).
- [x] `approval_required: [\"deploy_flow\", \"start_flow\"]` routing path unchanged — `ApprovalFilter` untouched.
- [x] Existing flow tests stay green (`go test -race ./...` clean).

## What semstreams own shell does NOT get from this PR

`cmd/semstreams/main.go` is intentionally not wired. Per the upstream ask, semteams will plumb `FlowEngineManager` in `cmd/semteams`'s own main. The reference shell continues to expose `create_flow` without `deploy_flow`; the gate skips cleanly.

If the reference shell should be symmetric (so any agent in the framework binary can deploy flows it authors), that's a one-line wire-up in `cmd/semstreams/main.go:155` once `flowengine.NewEngine` is constructed alongside `buildFlowManager`. Worth a follow-up issue; out of scope here to keep the framework-vs-shell boundary clean.

## Test plan

- [x] `go test -race ./processor/agentic-tools/...` — pass (5 new tests + existing stability check updated)
- [x] `task lint` — clean (categories.go auto-formatted by `go fmt`)
- [x] `go vet -tags=integration ./...` — clean
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `go test -race ./...` — no regressions
- [x] `go test -race -tags=integration ./...` — clean except pre-existing LLM classifier 5s flake (unrelated, CI-skipped)
- [x] `task schema:generate && git diff schemas/ specs/` — no drift
- [x] `go test ./test/contract/...` — pass

## Semteams next step (downstream)

In `cmd/semteams/main.go`:

\`\`\`go
flowEngine := flowengine.NewEngine(configManager, flowStore, componentRegistry, natsClient, logger, metricsRegistry)
// thread into ToolDependencies.FlowEngineManager
\`\`\`

~15 LoC total per the ask. No semteams-side bridge needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)