### PR TITLE
fix(query): bump DefaultClassificationTimeout 5s → 30s for cold-start hardware

### DIFF
--- a/graph/query/classifier_llm_adapter.go
+++ b/graph/query/classifier_llm_adapter.go
@@ -13,16 +13,29 @@ import (
 var thinkTagPattern = regexp.MustCompile(`(?s)<think>.*?</think>`)
 
 // DefaultClassificationTimeout caps a single query-classification LLM
-// call when no operator-configured timeout is supplied. Sized small
-// because classification produces a tiny JSON envelope — a slow
-// response is a stuck call, not a long generation; healthy
-// classifiers respond in well under a second. The bound exists so a
-// slow LLM can't eat the full HTTP gateway budget and force
-// handleGlobalSearch's keyword-fallback path to land after the gateway
-// has already returned an error to the client. Operators running
-// reasoning models that legitimately think (qwen3, deepseek-r1) can
-// raise the bound via capability.timeout in the model registry.
-const DefaultClassificationTimeout = 5 * time.Second
+// call when no operator-configured timeout is supplied. Classification
+// produces a tiny JSON envelope, but the wall-clock budget must absorb
+// model cold-start on modest hardware (Ollama loading a 1-2B model from
+// disk can take 10-20s on first inference). Healthy classifiers respond
+// in well under a second once warm; the 30s ceiling exists to bound a
+// stuck call without rejecting cold-start on hardware where production
+// users actually run. The bound still guards the HTTP gateway budget —
+// 30s is well under the gateway's request timeout — so a slow LLM can't
+// eat the full window and force handleGlobalSearch's keyword-fallback
+// path to land after the gateway has already returned an error.
+//
+// Operators running reasoning models that legitimately think (qwen3,
+// deepseek-r1) can raise the bound via capability.timeout in the model
+// registry. Operators on always-warm production hardware can lower it
+// to recover faster fallback to keyword classification when the model
+// is genuinely stuck.
+//
+// History: was 5s pre-2026-05-17. The 5s default caused integration
+// tests to fail on developer hardware where the model wasn't warm, and
+// the same pattern would hit any production operator without a warm-up
+// shim. Bumped to 30s after acknowledging that "clean except the LLM
+// flake" was hiding a real production gotcha.
+const DefaultClassificationTimeout = 30 * time.Second
 
 // LLMClientAdapter adapts a graph/llm.Client to the query.LLMClient interface.
 //


### PR DESCRIPTION
## Summary

- Bumps `DefaultClassificationTimeout` in `graph/query/classifier_llm_adapter.go:25` from 5s to 30s. Updates the comment to explain the rationale and the history of the change.
- Single-constant change. Pre-existing fast unit test (`TestLLMClientAdapter_SubTimeout_BoundsLLMCall`) already covers the sub-context bounding behavior with a stub slow client, so the bounding guarantee remains tested independent of the production default value.

## Why

The 5s default was too tight for model cold-start on modest hardware. Ollama loading qwen3:1.7b can take 10-20s on first inference. The integration test suite consistently failed locally with all six `TestLLMClassifier_Integration_*` tests timing out at exactly 5.00s — the sub-context bound firing.

CI skipped these tests because no Ollama in CI, so the failure was invisible upstream but a real signal of a production gotcha: any operator on modest hardware without a warm-up shim would hit the same wall.

30s gives generous cold-start margin while still bounding stuck calls well under the HTTP gateway request budget. The "keyword-fallback must reach the HTTP layer" invariant is preserved. Operators on always-warm production hardware can lower via `capability.timeout` in the model registry; operators running larger reasoning models can raise it.

## Discipline lesson

Prior sweeps (beta.74/75/76 pre-tag) reported "clean except the LLM classifier 5s flake" as if the failure were noise. It wasn't — it was the test correctly enforcing a production timeout that was unrealistic.

New discipline memory `feedback_no_clean_except_handwave.md` enshrines "never repeatedly verbally classify a failing test as noise" as a project rule. Future sweeps either fix the test, fix the underlying code, file an issue with explicit `t.Skip`, or document as a non-failure with a comment — no more "clean except X" hand-waves.

## Test plan

- [x] `go test -race ./graph/query/...` — pass (existing fast tests verify constant + sub-context bounding)
- [x] `go test -race -tags=integration -run 'TestLLMClassifier_Integration' ./graph/query/...` — all 6 tests now pass deterministically (58s total, ~10s per test)
- [x] `task lint` — clean
- [x] `go vet -tags=integration ./...` — clean
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `task schema:generate && git diff schemas/ specs/` — no drift
- [x] `go test ./test/contract/...` — pass
- [x] `go test -race ./...` — no regressions
- [x] `go test -race -tags=integration ./...` — clean on second run; first run had 2 unrelated intermittent failures (`TestIntegration_CASRetryBehavior`, `TestEntityWatcher_RuleTriggerDebouncing`) both pass in isolation and on second sweep, both untouched by this PR. Tracked separately as #107 per the new discipline.

## Honest reporting (per new discipline)

The PR's primary work succeeds: LLM classifier integration tests now pass deterministically. A pre-existing intermittent-failure pattern in two timing-sensitive integration tests was surfaced as a side observation and tracked in #107 rather than hand-waved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)