### PR TITLE
docs(orchestration): ADR-045 rule-chain + pattern catalog rewrite

### DIFF
--- a/.claude/skills/orchestration-check/SKILL.md
+++ b/.claude/skills/orchestration-check/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orchestration-check
-description: Determine whether logic belongs in a reactive rule, workflow, or component. Use when adding orchestration logic, designing multi-step processes, or reviewing boundary violations.
+description: Determine whether logic belongs in a rule (single trigger or chain), a component, or somewhere else. Use when adding orchestration logic, designing multi-step processes, or reviewing boundary violations.
 argument-hint: [pattern or logic being evaluated]
 ---
 
@@ -12,87 +12,166 @@ $ARGUMENTS
 
 ## The Two Layers
 
+semstreams has **rules** and **components**. There is no separate
+workflow engine — `processor/reactive/` was retired. Multi-step
+patterns are expressed as coordinated rule sets firing components,
+with per-action `MaxIterations` as the iteration cap.
+
 | Layer | Responsibility | Owns | Does NOT Own |
 |-------|---------------|------|--------------|
-| **Reactive Engine** | State detection, triggers, multi-step coordination | Conditions, actions, step sequence, loop limits, timeouts | Actual work execution |
-| **Component** | Execute single units of work | Execution mechanics, internal state | Workflow awareness, caller context |
+| **Rule Engine** | State detection, trigger conditions, action sequencing, iteration caps | Trigger conditions, action sequence, `MaxIterations`, condition evaluation | Work execution, business logic, payload semantics |
+| **Component** | Execute single units of work | Execution mechanics, internal state machine | Caller identity, multi-step coordination |
 
 ## Quick Decision
 
 | Pattern | Use |
 |---------|-----|
-| Condition X met --> fire action Y (no retry) | Single-trigger reactive rule |
-| A --> B --> A --> B... (max N times, with timeouts) | Reactive workflow |
-| Execute LLM call, process tools, write files | Component |
+| A completes → B starts (no retry, no loop) | Single rule, one action |
+| A → B → C → D (no loop) | Rule chain (one rule per transition) |
+| A → if X then B else C | One rule, action-level `when` clauses (ADR-041) |
+| A → B → A → B... (max N times) | Rule chain with per-action `MaxIterations` cap |
+| Fan-out + fan-in synchronization | Fan-out rule + synchronizer-key rule |
+| Execute LLM call, graph query, file I/O, etc. | Component |
 
-## The 5 Rules
+## The 6 Rules
 
-1. **Rules trigger, they don't orchestrate** -- A rule fires one action, not a sequence.
-   - Anti-pattern: Rule A sets `step=1`, Rule B watches for `step=1` and sets `step=2`...
-   - Fix: Use a workflow for multi-step sequences.
+1. **Rules trigger; they don't orchestrate inline.** A rule fires
+   one set of actions, not a sequence of stateful steps.
+   - Anti-pattern: Rule A sets `step=1`, Rule B watches for `step=1`
+     and sets `step=2`, Rule C watches for `step=2`...
+   - Fix: each rule fires a component; state lives on the operation
+     entity, not in step counters.
 
-2. **Workflows coordinate, they don't execute** -- Workflows spawn components, not inline logic.
-   - Anti-pattern: Workflow step contains 100 lines of processing logic.
-   - Fix: Move processing into a component, have workflow publish to trigger it.
+2. **Components execute; they don't coordinate.** Components do one
+   thing and emit a result. They don't dispatch to other components
+   inline.
+   - Anti-pattern: a component calling another component's API
+     directly after finishing its work.
+   - Fix: the component emits its completion event; a rule fires
+     the next component.
 
-3. **Components are workflow-agnostic** -- Components don't know their caller.
-   - Anti-pattern: Component checks `workflow_id` to decide behavior.
-   - Fix: Pass behavior differences as configuration, not caller identity.
+3. **Components are caller-agnostic.** Same component, same
+   behavior, regardless of who triggered it.
+   - Anti-pattern: `if msg.workflow_id != "" { ... }` inside a
+     component.
+   - Fix: behavior differences come from configuration, not caller
+     identity.
 
-4. **State ownership is exclusive** -- Only one layer owns any piece of state.
+4. **State ownership is exclusive.** Only one layer owns a piece
+   of state.
 
    | State | Owner |
    |-------|-------|
-   | Trigger conditions | Rules |
-   | Step progress, iteration count | Workflow |
-   | Execution state (pending tools, loop phase) | Component |
-   | Domain entities | Knowledge graph (ENTITY_STATES) |
+   | Trigger conditions | Rule engine |
+   | Iteration counters | Rule engine (per-action `MatchState`) |
+   | Execution state inside a component | Component |
+   | Domain entities | `graph-ingest` (writes to `ENTITY_STATES`) |
+   | Operational results | Component that produced them (writes to its own bucket) |
 
-5. **If it needs a loop limit, it's a workflow** -- Simple handoffs use rules; cycles use workflows.
+5. **If you need a new KV bucket, ask twice.** Can the data live on
+   an existing entity as triples? Can it live in an existing
+   component's bucket (`AGENT_LOOPS`, etc.) with a distinct key
+   prefix? Can bulky content live in ObjectStore with a ref-triple?
+   If all three are "no" and it's genuinely component-owned
+   operational state, register the new bucket in
+   `entity_watch_buckets` and document it. **Never** create
+   app-side state buckets the rule engine isn't configured to watch.
+
+6. **Engine gaps file as engine work; never as app-side state
+   plumbing.** If the rule engine can't express something you need
+   (e.g., an evidence-array length predicate in `when`), file it as
+   a rule-engine improvement. The semspec trap (7,264 LOC of
+   `workflow/reactive/` that became a migration blocker) is the
+   cautionary tale.
 
 ## Anti-Patterns
 
-- Rule chains that build up state across multiple firings (should be workflow)
-- Workflows with inline processing logic (belongs in components)
-- Components checking workflow context to decide behavior (should be caller-agnostic)
-- Both rules and workflows tracking the same state (exclusive ownership violated)
+- Rule chains that build up step counters across multiple firings
+  (state belongs on the operation entity, not in rule-fired step
+  numbers)
+- Components dispatching to other components inline (rules
+  coordinate, components execute)
+- Components branching on caller identity (configure behavior,
+  don't introspect caller)
+- Both rules and entity triples tracking the same state (exclusive
+  ownership violated)
+- App-side state machines around rule-engine limitations (the
+  semspec trap)
+- New KV buckets without `entity_watch_buckets` registration
+  (invisible to the rule engine)
 
 ## State Storage Boundaries
 
-| Category | Storage | In Knowledge Graph? |
-|----------|---------|---------------------|
-| Domain entities | `ENTITY_STATES` KV | Yes (Graphable) |
-| Operational results | Component-specific KV | No |
-| Events/work items | JetStream streams | No |
+| Category | Storage | Rule-observable? | In Knowledge Graph? |
+|----------|---------|------------------|---------------------|
+| Domain entities | `ENTITY_STATES` KV (only `graph-ingest` writes) | Yes | Yes (`Graphable`) |
+| Operational results | Component-specific KV (e.g., `AGENT_LOOPS` with `COMPLETE_*`) | Yes (via `entity_watch_buckets`) | No |
+| Events / work items | JetStream streams | No (rules watch KV, not streams) | No |
+| Bulky payloads | ObjectStore via `ContentStorable`; ref-triple on owning entity | Indirectly (via refs) | Refs only |
 
-Do NOT write operational results to ENTITY_STATES -- it pollutes the knowledge graph.
+Per ADR-028: **rules carry references, never content.** If a payload
+might exceed ~16KB or contain freeform text, put it in ObjectStore
+and pass a ref. Do NOT write operational results to `ENTITY_STATES`
+— it pollutes the knowledge graph.
 
-## Reactive Rule Example (single trigger)
+## Example: Single trigger (Pattern 1)
 
-```go
-reactive.NewRule("architect-complete-spawn-editor").
-    WatchKV("AGENT_LOOPS", "LOOP_*").
-    When("architect role", func(ctx *reactive.RuleContext) bool {
-        return ctx.State.(*AgentLoopState).Role == "architect"
-    }).
-    When("completed", func(ctx *reactive.RuleContext) bool {
-        return ctx.State.(*AgentLoopState).Outcome == "success"
-    }).
-    Publish("agent.task.editor", ...).
-    Build()
+```json
+{
+  "name": "architect_complete_spawn_editor",
+  "type": "expression",
+  "when": {
+    "bucket": "AGENT_LOOPS",
+    "key_pattern": "COMPLETE_*",
+    "conditions": [
+      {"field": "role", "op": "eq", "value": "architect"},
+      {"field": "outcome", "op": "eq", "value": "success"}
+    ]
+  },
+  "actions": [
+    {
+      "type": "publish_agent",
+      "role": "editor",
+      "payload_ref": "{state.plan_objstore_ref}"
+    }
+  ]
+}
 ```
 
-## Workflow Example (loop with limit)
+## Example: Bounded iteration (Pattern 4)
 
-```go
-reactive.NewWorkflow("review-fix-cycle").
-    WithStateBucket("REVIEW_FIX_STATE").
-    WithMaxIterations(3).
-    WithTimeout(300 * time.Second).
-    AddRule(/* request-review rule */).
-    AddRule(/* fix-issues rule */).
-    AddRule(/* max-iterations-exceeded rule */).
-    MustBuild()
+```json
+{
+  "name": "review_fix_cycle",
+  "when": {"key_pattern": "review.complete.*"},
+  "actions": [
+    {
+      "type": "publish_agent",
+      "role": "fixer",
+      "when": "$state.review.issues_count > 0 AND $state.iteration < 3",
+      "max_iterations": 3
+    },
+    {
+      "type": "publish",
+      "subject": "pipeline.complete.{id}",
+      "when": "$state.review.issues_count == 0 OR $state.iteration >= 3"
+    }
+  ]
+}
 ```
 
-Read `docs/concepts/14-orchestration-layers.md` for full documentation.
+`MaxIterations` default is 3 framework-wide; explicit `0` means
+unlimited. Stable per-action counters survive rule renames if
+`Action.ID` is set explicitly.
+
+## Full pattern catalog + worked examples
+
+Read `docs/concepts/14-orchestration-layers.md` for the canonical
+"How we do workflows in semstreams" reference, including:
+
+- All 5 patterns with JSON rule definitions
+- The semspec trap (what app-side state machines cost long-term)
+- State-storage boundary discipline
+- Debugging orchestration issues
+- Worked examples (agent handoff, review-fix retry, data pipeline
+  validation, ADR-045 graph-search decomp+fusion)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,17 +191,22 @@ Tiers only affect entities with text content. Telemetry-only entities cluster vi
 
 ## Orchestration Boundaries
 
-Two layers: **Reactive Engine** (conditions + actions + workflows) and **Components** (execute work).
+Two layers: **Rule Engine** (conditions + actions + iteration caps) and **Components** (execute work). There is no separate workflow engine — `processor/reactive/` was retired. Multi-step patterns are expressed as coordinated rule sets firing components, with per-action `MaxIterations` providing iteration caps and entity triples + existing KV buckets + ObjectStore providing durable state.
 
 | Pattern | Use |
 |---------|-----|
-| A completes → B starts (no retry) | Reactive rule (single trigger) |
-| A → B → A → B... (max N times) | Reactive workflow (loop limits, timeouts) |
-| Execute LLM call, process tools | Component |
+| A completes → B starts (no retry) | Single rule, one action |
+| A → B → C → D (no loop) | Rule chain (one rule per transition) |
+| A → if X then B else C | One rule, action-level `when` clauses (ADR-041) |
+| A → B → A → B... (max N times) | Rule chain with per-action `MaxIterations` cap |
+| Fan-out + fan-in synchronization | Fan-out rule + synchronizer-key rule |
+| Execute LLM call, graph query, file I/O, etc. | Component |
 
-**Key rules**: Rules trigger, they don't orchestrate. Workflows coordinate, they don't execute. Components are workflow-agnostic. State ownership is exclusive.
+**Key rules**: Rules trigger, they don't do work inline. Components execute, they don't know their caller. State ownership is exclusive — domain entities in `ENTITY_STATES` (only `graph-ingest` writes), operational results in component-specific KV (e.g., `AGENT_LOOPS` with `COMPLETE_*` prefix), events in JetStream streams, bulky payloads in ObjectStore via `ContentStorable` with ref-triples on the owning entity.
 
-Use `/orchestration-check` for the full decision framework. See [Orchestration Layers](docs/concepts/14-orchestration-layers.md).
+**Engine gaps file as engine work, not app-side state plumbing.** semspec's 7,264 LOC of `workflow/reactive/` (the "semspec trap") is the cautionary tale — app-side state machines around rule-engine limitations become migration blockers the framework can't help dig out of. If a pattern needs a primitive the rule engine doesn't have, propose adding it; don't carve out a parallel path.
+
+Use `/orchestration-check` for the decision framework. See [Orchestration Layers — How We Do Workflows in semstreams](docs/concepts/14-orchestration-layers.md) for the full pattern catalog.
 
 ### Rules don't carry payloads
 

--- a/docs/adr/045-graph-search-rule-chain.md
+++ b/docs/adr/045-graph-search-rule-chain.md
@@ -1,0 +1,576 @@
+# ADR-045: Graph Search Decomp+Fusion via Rule-Chain + Components
+
+## Status
+
+**Proposed — 2026-05-19.** Doc-only ADR; no implementation in this tag.
+Independent of ADR-039 (governance), ADR-042 (publisher-mode), ADR-043
+(detonation corpus), ADR-044 (CS API framework split). Builds on existing
+primitives only: rule engine (`processor/rule/` with per-action
+`MaxIterations`), component framework, AGENT_LOOPS KV, ObjectStore via
+`ContentStorable`, triples on entities. Does **not** introduce new KV
+buckets or new orchestration primitives.
+
+Forcing function: the "agent search problem" recurring across the
+agentic stack lacks a clean home in semstreams. The naive answers — a
+search agent role, a `search()` tool in the parent's allowlist, or a
+pre-LLM substrate that runs unconditionally — each fail against our
+empirical floor (`feedback_graph_not_for_agent_reasoning`,
+`feedback_frontier_floor_changes_role_split_calculus`) or the
+reasoning-crimp pathology documented below. This ADR proposes a
+**coordinated rule chain orchestrating typed components** as the
+graph-search decomp+fusion primitive — the canonical semstreams
+"how we do workflows" pattern applied to graph retrieval.
+
+## Context
+
+### The "agent search problem"
+
+[Kumar, 2026](https://dipkumar.dev/posts/agents/agent-search-problem/)
+catalogs five failure shapes that converge on one bottleneck: agents
+must *discover* the right information source before they can reason —
+web search rendering and freshness, RAG multi-hop and chunk
+composition, MCP tool discovery context-blowing, skills loading, and
+in-context navigation. Kumar's punchline frames the gap as
+**infrastructure**, not a reasoning deficit.
+
+### Why this maps hard onto semstreams
+
+semstreams is a knowledge-graph engine with tiered inference (rules /
+BM25 / neural) and multi-gateway query access (GraphQL, MCP, NATS
+Direct). The substrate for unified retrieval exists; the unresolved
+question is **where the decomp+fusion step lives** between the
+gateways and the agent's prompt.
+
+Two empirical findings define the floor any solution must clear:
+
+- **`feedback_graph_not_for_agent_reasoning`** (3 instrumented
+  incidents). Frontier agents (Gemini 3.x Pro, Sonnet 4.6) do **not**
+  navigate the SKG even with `search_graph` / `query_entity` /
+  `summarize_graph` in the allowlist and the persona prompt explicitly
+  encouraging graph-first lookups. semspec's recovery diagnosis quoted
+  verbatim: *"graph_search returned [project] org.sensorhub but agent
+  ignored it."* The fix that worked was **injection-side** (lineage
+  triples into the prompt payload), not query-side.
+
+- **`feedback_frontier_floor_changes_role_split_calculus`**. semteams
+  ADR-040 split researcher+curator on small-model cognitive-load
+  grounds; ADR-041 re-collapsed them on frontier-floor grounds. A
+  persistent "search agent" chain role would re-pay the orchestration
+  cost ADR-041 just amortized down.
+
+### The reasoning crimp (the structural finding)
+
+Independent of those two memories, a third structural problem exists
+when search-class tools sit alongside traditional tools (`web_search`,
+`bash`, `read_file`, …) in the agent's allowlist: **the agent
+systematically does not choose them unless forced.**
+
+This is not prompt tuning. It is selection bias driven by training
+ergonomics: web search / bash / file I/O have thousands of trajectories
+in training data; multi-hop graph-walk + fuse-results does not. The
+LLM lacks trained ergonomics for **graph-shape reasoning loops** even
+when only graph tools are present. Prompt-side encouragement has not
+closed the gap in instrumented runs.
+
+This rules out any architecture requiring the LLM to *drive* a graph
+tool loop — including a constrained-allowlist subagent that has only
+graph tools. The model doesn't crimp toward `bash`; it crimps toward
+in-context priors, because composing multi-hop graph traversals is
+unfamiliar work for it.
+
+### The semspec trap (and why we won't repeat it)
+
+semspec was an early adopter, predating the mature rule engine. To
+work around limitations, it built **its own plan + execution state
+machines** alongside rules — roughly 7,264 LOC of `workflow/reactive/`
+code that imports the now-retired `processor/reactive/` engine and
+maintains its own state plumbing. That code is now a migration
+blocker (Phase 5 of the reactive-workflow retirement) and is unlikely
+to be dug out anytime soon.
+
+The lesson is durable: **gaps in the framework surface upstream as
+engine work; they never get worked around as app-side state
+plumbing.** This ADR commits to using existing primitives only. If
+implementation reveals a genuine gap, it gets filed as a discrete
+engine-improvement ticket, not patched over with new KV buckets or
+custom state machines.
+
+### The trained-ergonomics seam
+
+What the LLM *is* trained for: read text, summarize text, decompose
+questions into sub-questions, judge relevance, compose answers from
+sources. What it is *not* trained for: orchestrate a sequence of
+typed graph queries, normalize scores across retrieval tiers, dedup
+multi-hop walk results, manage iteration budgets.
+
+The architecture should cut along this seam: **code does what code
+is good at, LLM does what LLM is good at**, and the LLM is invoked
+in bounded structured-emit calls at the judgment points where its
+language strengths apply — not as a multi-turn agent loop driving
+graph tools it wasn't trained to drive.
+
+## Decision
+
+Graph search decomp+fusion is implemented as a **coordinated rule
+chain orchestrating typed components**, following the canonical
+semstreams multi-step pattern documented in
+[docs/concepts/14-orchestration-layers.md](../concepts/14-orchestration-layers.md).
+No new orchestration primitive, no new state bucket, no persona dir.
+
+### Parent's surface
+
+One new tool exposed in the parent's allowlist:
+
+```
+research_graph(intent) → async search_result
+```
+
+Calling it emits `research.requested.{loop_id}` (a triple +
+ContentStorable ref for the intent payload) and terminates the
+parent's current iteration. The result arrives on a subsequent
+iteration via the standard continuation rule pattern (same shape as
+any agent loop completion).
+
+The intent payload is structured (not free-form text):
+
+```json
+{
+  "topic": "drone hover anomalies",
+  "entities": ["acme.ops.robotics.gcs.drone.001"],
+  "predicates": ["sosa:hasResult", "ssn:hasDeployment"],
+  "tiers": ["rules", "bm25"],
+  "budget_tokens": 4000,
+  "max_iterations": 5
+}
+```
+
+### Internal architecture
+
+```
+Parent → research_graph(intent)  → terminates iteration
+            │
+            ▼  R1 fires on research.requested.*
+[component] decompose_intent
+            │  one LLM call, structured emit: typed sub-queries
+            ▼  R2 fires on decompose.complete.*
+[component] execute_subqueries
+            │  CODE: parallel multi-tier fan-out via existing gateways
+            │  Tier 0 (rules/predicates) + Tier 1 (BM25) [+ Tier 2 in Phase 2]
+            │  emits evidence array to ObjectStore, ref-triples on loop entity
+            ▼  R3 fires on execute.complete.*
+[component] assess_sufficiency
+            │  one LLM call, structured emit: {sufficient: bool, refined?}
+            ▼  R4 conditional branch:
+            │   - sufficient=false AND iterations<5  → fire execute_subqueries (refined)
+            │   - sufficient=true OR iterations=5    → fire R5
+            │  (per-action MaxIterations=5 caps the refine loop)
+            ▼
+[component] synthesize_answer
+            │  one LLM call, structured emit: final synthesis
+            ▼  R6 emits search_result terminal, fires R-cont
+[continuation rule]
+            ▼
+Parent resumes with search_result evidence in prompt
+```
+
+### Components (four small additions, each a single-purpose unit)
+
+| Component | Type | Body |
+|---|---|---|
+| `decompose_intent` | LLM-wrapping | One bounded structured-emit call: `intent → typed sub-queries[]`. Template fast-path for common shapes (entity_state, predicate_walk, temporal_range, spatial_polygon); LLM call only for novel topics. |
+| `execute_subqueries` | Code | Parallel multi-tier fan-out via existing GraphQL/MCP/NATS-Direct gateways. Score normalization, dedup, ranking. Budget enforcement. Writes evidence to ObjectStore; ref-triples to the research-loop entity. |
+| `assess_sufficiency` | LLM-wrapping | One bounded structured-emit call: `(intent, evidence) → {sufficient: bool, refined_queries?: []}`. The "refine or finalize" decision. |
+| `synthesize_answer` | LLM-wrapping | One bounded structured-emit call: `(intent, evidence) → synthesis`. Refs preserved verbatim. |
+
+The three LLM-wrapping components share underlying infrastructure
+(`model.NewHTTPClient`, beta.43 unified LLM HTTP client invariant).
+Each has its own prompt template specialized for its task — not a
+free-form agent persona, structured input/output schemas. No persona
+dir.
+
+### State storage (uses existing buckets only — no new plumbing)
+
+| State | Where it lives | Reuses |
+|---|---|---|
+| Research operation's identity + iteration count | AGENT_LOOPS KV entry (role = `research_pipeline`) | Existing bucket; same primitives as any agent loop |
+| Original intent + refined-query history | Triples on the research-loop entity | `Graphable` interface; standard pattern |
+| Evidence (potentially bulky) | ObjectStore via `ContentStorable`; ref-triples on loop entity | Existing pattern per ADR-028 ("rules carry references, never content") |
+| Decomposition output, assessment result, synthesis | Triples on the research-loop entity + ObjectStore refs for large payloads | `Graphable` interface |
+| Iteration cap for refine loop | Per-action `MaxIterations=5` on R4 | Existing rule-engine primitive |
+| Search result returned to parent | ObjectStore object + ref-triple; continuation rule fires parent | Same pattern as any agent loop completion |
+
+**No new KV buckets. No new state machines. No new orchestration
+primitive.** Every load-bearing primitive cited is already in `main`.
+
+### Rule chain
+
+Six rules in the flow config (R1–R6 plus the continuation rule):
+
+```yaml
+# R1: kick off the chain
+- name: research_decompose
+  when: kv_write
+    bucket: AGENT_LOOPS
+    key_pattern: "research.requested.*"
+  actions:
+    - type: publish
+      subject: "component.decompose_intent.{loop_id}"
+
+# R2: after decompose, fan out
+- name: research_execute
+  when: kv_write
+    bucket: AGENT_LOOPS
+    key_pattern: "decompose.complete.*"
+  actions:
+    - type: publish
+      subject: "component.execute_subqueries.{loop_id}"
+
+# R3: after execute, assess
+- name: research_assess
+  when: kv_write
+    bucket: AGENT_LOOPS
+    key_pattern: "execute.complete.*"
+  actions:
+    - type: publish
+      subject: "component.assess_sufficiency.{loop_id}"
+
+# R4: conditional refine OR synthesize
+- name: research_refine
+  when: kv_write
+    bucket: AGENT_LOOPS
+    key_pattern: "assess.complete.*"
+  actions:
+    - type: publish
+      subject: "component.execute_subqueries.{loop_id}"
+      when: "$state.assess.sufficient == false"
+      max_iterations: 5                       # per-action cap is the loop limit
+    - type: publish
+      subject: "component.synthesize_answer.{loop_id}"
+      when: "$state.assess.sufficient == true OR $state.iterations >= 5"
+
+# R5: terminal emit (synthesize component writes search_result.complete on success)
+
+# R6: continuation back to parent
+- name: research_continuation
+  when: kv_write
+    bucket: AGENT_LOOPS
+    key_pattern: "search_result.complete.*"
+  actions:
+    - type: publish_agent
+      role: "{state.parent_role}"
+      payload_ref: "{state.search_result_objstore_ref}"
+```
+
+All six rules use existing JSON rule definitions and existing action
+types (`publish`, `publish_agent`). The `when` clauses use the
+unified condition evaluator (ADR-041). `MaxIterations` is the
+existing per-action firing cap.
+
+### Why this is not just-a-better-GraphQL
+
+The chain has **agent reasoning at every judgment point** —
+decomposition (decide which sub-queries to issue from a fuzzy topic),
+assessment (judge whether evidence answers the question, decide
+whether to refine), and synthesis (compose the answer with context).
+A pure deterministic pipeline can't do any of these well. What's
+different from a free-form agent loop is that each LLM invocation is
+**bounded, structured, single-turn** — the LLM never *drives* a tool
+loop, it answers a specific structured question and emits a typed
+result. That's the trained-ergonomics seam.
+
+### Why this avoids the semspec trap
+
+Every load-bearing primitive is already in the framework:
+
+- Coordinated rule chain → existing `processor/rule/`
+- Per-action iteration cap → existing `MaxIterations`
+- Conditional branching → existing action `when` clauses (ADR-041
+  unified evaluator)
+- State on entity → existing `Graphable` interface + triples
+- Bulky payload handling → existing `ContentStorable` + ObjectStore
+- Continuation back to parent → existing rule + `publish_agent`
+  pattern
+
+The four new components are normal components — same lifecycle, same
+port discipline, same flow-discovery, same flowgraph validation as
+every other component. No bypass paths, no parallel state machine,
+no app-side workflow engine.
+
+### Flow packaging (two valid paths, decided at implementation)
+
+Two equally valid ways to package the rule chain:
+
+1. **Inline rules in the parent's flow config** (Phase 1 recommended).
+   Add R1–R6 + four components to whichever flow needs research.
+   Simplest; one new flow, no new spawn primitive.
+2. **Standalone deployable flow** spawned via
+   `start_flow(research_graph_flow_id, intent)` from ADR-042 Phase 4
+   (Phase 2+ recommended). Multiple flows reuse the same research
+   chain; one canonical implementation.
+
+Both use existing primitives. The Phase 1 → Phase 2 transition is a
+configuration change, not an architecture change.
+
+## Consequences
+
+### Wins
+
+- **Dodges the reasoning crimp and trained-ergonomics gap.** The LLM
+  is invoked at the language tasks it's trained for (decompose,
+  assess, synthesize); code does the multi-tier orchestration the
+  LLM isn't trained to drive.
+- **Dodges the graph-not-for-reasoning failure mode.** The agent
+  never decides to navigate the graph — it just gets fused evidence
+  in the next loop's prompt. Same injection-side pattern that worked
+  for lineage triples in beta.51.
+- **Dodges role-split orchestration cost.** No persona dir, no chain
+  role, no per-role rule wiring beyond R1–R6.
+- **Dodges the semspec trap.** Every primitive is existing. No new
+  KV buckets, no parallel state machines, no app-side workflow
+  engine.
+- **First-class observability.** Every stage transition is a triple
+  written to AGENT_LOOPS; the rule engine's audit trail covers the
+  whole chain natively.
+- **Restart-safe by default.** Each component completes and writes
+  state before the next fires; partial failures resume from the
+  last completed stage via standard rule re-evaluation.
+- **Testable.** Each component has unit-test boundaries (input
+  payload → output emit). The chain itself is integration-testable
+  with mock components.
+- **Operator-configurable.** Per-role enable, budget caps, tier mix
+  are flow config — not code.
+
+### Costs
+
+- **Multi-stage latency.** Three to four rule fires + three LLM
+  calls + N code stages per research call. Mitigation: parallel
+  fan-out inside `execute_subqueries`; KV cache for hot intents;
+  P95 SLO.
+- **Parent residual crimp.** Parent still chooses whether to call
+  `research_graph`. Smaller surface than multi-tool but not zero.
+  Mitigation: one-line persona hint ("when in doubt, delegate via
+  `research_graph`"); ops `emit_diagnosis` flags missed
+  delegations.
+- **Four new components.** Maintenance surface. Mitigation: each is
+  single-purpose, small, shares LLM-call infrastructure.
+- **Decomposer can hallucinate sub-queries.** Mitigation: structured
+  emit + schema validation + template fast path covers common
+  intents without LLM.
+- **Synthesis can fabricate refs.** Mitigation: refs must validate
+  against actual evidence in ObjectStore; schema-level enforcement,
+  not prompt-level.
+- **Per-role configuration surface grows.** Each parent role gets
+  `research_graph` enable + budget caps. Mitigation: sensible
+  defaults; opt-in.
+
+### Out of scope (deferred)
+
+- LLM-driven inference of intent from unstructured prior parent
+  output (re-introduces a search choice via the back door).
+- Mid-chain escalation to a peer research operation for cross-corpus
+  fusion (Phase 4).
+- Cross-tenant evidence pooling (ADR-032 territory).
+- Multi-modal evidence (images, audio, structured tables).
+- Real-time evidence freshening during a single research call.
+
+## Alternatives considered
+
+### A. Persistent search-agent chain role
+
+A permanent persona dir + rules + contract for a search-specialist
+role participating alongside coordinator/researcher/curator.
+
+**Rejected.** Re-pays the role-split orchestration cost ADR-041 just
+amortized. Persistent chain role = persistent rule wiring + persona
+fragment per chain + transition contracts upstream. Rule chain
+gets the same benefit at a fraction of the cost.
+
+### B. Tool-among-tools (`search()` next to `bash`, `web_search`, …)
+
+Expose decomp+fusion as one tool in the parent's standard allowlist.
+
+**Rejected.** The reasoning crimp. Agents do not choose search tools
+when traditional tools are co-available. Prompt-side encouragement
+has not closed the gap.
+
+### C. Constrained-allowlist subagent loop
+
+Spawn a transient subagent (via `start_flow`) with a constrained
+allowlist of only graph + fusion tools; the subagent's LLM drives
+a ReAct loop over the constrained surface.
+
+**Rejected.** The trained-ergonomics gap. Even with no alternative
+tools to crimp toward, the LLM lacks fluent trained behavior for
+multi-hop graph-walk + fuse-results trajectories. Asking the LLM
+to drive a graph tool loop is the failure mode, not the constraint
+on alternatives. Cleaner to invoke the LLM at structured language
+tasks (decompose, assess, synthesize) than to ask it to drive a
+loop it wasn't trained for.
+
+### D. Smarter graph-side queries (gateway-only)
+
+Improve GraphQL/MCP/NATS-Direct gateways to do query rewriting,
+multi-hop expansion, fusion at the gateway. Parent calls
+`search_graph` as today; gateway does the decomp transparently.
+
+**Rejected as primary; adopted as complementary.** Two issues as
+primary: still requires the parent to choose `search_graph`
+(reasoning crimp applies); mixes query-pattern boundaries
+(`feedback_gateway_first_only_for_new_capabilities`). But gateway
+improvements *do* increase `execute_subqueries`'s output density and
+reduce iteration count; they ship on their own cadence as supporting
+work.
+
+### E. Pre-LLM substrate enrichment (deterministic decomp+fusion)
+
+Run decomp+fusion as a framework-level component *before* the LLM
+call, unconditionally. Rule-triggered on every loop input creation.
+
+**Rejected.** Three issues:
+- Wasted work when not needed. Substrate runs whether the parent
+  required fresh evidence or not.
+- Deterministic decomp+fusion is hard to write well. Score
+  normalization, sub-query expansion, semantic relevance — all
+  under-specified without LLM reasoning at judgment points.
+- Loses the principal-agent boundary. Substrate enrichment blurs
+  "what the parent asked for" vs "what the framework pre-stuffed."
+
+The rule chain keeps the request/response boundary crisp:
+parent calls `research_graph(intent)`, components emit
+`search_result(evidence)`. Both are auditable artifacts.
+
+### F. Prompt-side encouragement of existing graph tools
+
+"You should use `search_graph` as a first step for any question
+about entities."
+
+**Rejected — already tried.** semspec's recovery diagnosis quotes
+the agent ignoring `graph_search` results even with explicit prompt
+encouragement. Persona prompts already say "Try FIRST for project
+lookups." Behavior unchanged across three instrumented incidents.
+
+### G. Status quo (do nothing)
+
+Continue with direct-tool exposure; treat failures as prompt tuning.
+
+**Rejected.** Three instrumented incidents across two sister projects
+converging on the same shape. Tuning has not moved the floor.
+
+## Phased rollout
+
+**Phase 1** (proposed for next eligible tag — not beta-blocking):
+
+- Four new components: `decompose_intent`, `execute_subqueries`,
+  `assess_sufficiency`, `synthesize_answer`. Each ships with unit
+  tests against the production decoder per
+  `feedback_production_decoder_round_trip_required`.
+- One new parent-side tool: `research_graph(intent)` registered per
+  `/new-payload` discipline.
+- Two new payload types: `research_intent` + `search_result`
+  registered in the payload registry.
+- Six rules (R1–R6) bundled in a reference flow config; parent flows
+  opt in by including the rules or by spawning the flow via
+  `start_flow` (Phase 2 path).
+- Tier coverage: Tier 0 (rules) + Tier 1 (BM25) inside
+  `execute_subqueries`. Tier 2 (neural) deferred to Phase 2.
+- Decomposer: template fast-path only for `entity_state` /
+  `predicate_walk` / `temporal_range` / `spatial_polygon`. LLM-driven
+  decomp for novel topics deferred to Phase 2 (Phase 1 falls through
+  to a degraded "full-text search of intent topic" path for
+  un-templated intents).
+- In-repo smoke test against the deep-research e2e flow.
+- Pre-tag e2e green per
+  `feedback_e2e_required_for_breaking_changes` (this changes the
+  framework-level pattern catalog; touch is contained but the new
+  components need flow-discovery exposure).
+
+**Phase 2** (gated on Phase 1 operator validation):
+
+- Tier 2 (neural) added to `execute_subqueries`.
+- LLM-driven decomp inside `decompose_intent` for novel topics.
+- Token-budget compression via small-LLM emit (refs preserved).
+- Per-parent-role enablement (researcher, curator, ops opt in with
+  different budgets).
+- Deployable as a standalone flow (Phase 2 spawn path via
+  `start_flow`).
+- ops `emit_diagnosis` flags for decomp/assess/synthesis quality.
+
+**Phase 3** (gated on Phase 2 + external use case):
+
+- Web search and external-tool fan-out added to `execute_subqueries`
+  *with detonation pre-flight* (ADR-043) — hard gate, not optional.
+- Cross-source dedup and provenance harmonization.
+
+**Phase 4** (deferred — research):
+
+- Cross-corpus research-to-research escalation.
+- Real-time evidence freshening during a single research call.
+- Multi-modal evidence sources.
+
+## Open questions
+
+1. **Cache key for hot intents.** Same intent from the same
+   chain-entity should not re-run the full chain every iteration.
+   Invalidation predicate: wall-clock TTL, revision count on
+   referenced entities, or both? Resolved in Phase 1 implementation.
+
+2. **Continuation-rule deadline + fallback.** If any stage in the
+   chain stalls or fails, the parent must resume with
+   `search_result.error` evidence so it can make a degraded
+   decision rather than wedge. Deadline value and degraded-result
+   schema TBD in Phase 1.
+
+3. **Engine gaps surfaced during implementation.** If implementation
+   reveals that the current rule engine cannot express something
+   needed (e.g., reading evidence-array length in a `when` clause to
+   gate the refine branch), the gap gets filed as a discrete
+   engine-improvement ticket — not as inline state plumbing in the
+   research chain. The semspec trap is explicit prior art.
+
+4. **Interaction with strict tool calling (ADR-035).** Both
+   `research_intent` and `search_result` payloads need formal
+   schema registration per `/new-payload`. Phase 1 includes the
+   registry entries + round-trip production-decoder test.
+
+5. **Interaction with governance (ADR-039).** The four components'
+   LLM calls go through the same rule-driven governance layer as
+   any other LLM call. Per-loop vs per-role boundaries per
+   `feedback_per_loop_vs_per_role_safety` apply.
+
+6. **Detonation corpus coverage.** Phase 1 reads from graph +
+   ObjectStore (lower prompt-injection risk than web sources, but
+   not zero — BM25 snippets from ingested docs are a possible
+   vector). Phase 3 web fan-out *requires* detonation pre-flight
+   integration — track as a hard gate.
+
+7. **Parent-side delegation hygiene.** How aggressively to prompt
+   the parent toward calling `research_graph`. Initial proposal:
+   one-line persona hint; ops flags missed delegations for
+   trajectory review.
+
+## References
+
+- [Kumar, "The Agent Search Problem,"
+  2026](https://dipkumar.dev/posts/agents/agent-search-problem/)
+- [ADR-027: Ops Agent Meta-Harness](027-ops-agent-meta-harness.md)
+- [ADR-028: Agentic Orchestration Architecture](028-orchestration-architecture.md)
+- [ADR-035: Strict Tool Calling](035-strict-tool-calling.md)
+- [ADR-039: Tool-call Governance Rule-Driven](039-tool-call-governance-rule-driven.md)
+- [ADR-041: Unified Condition Evaluator](041-unified-condition-evaluator.md)
+- [ADR-042: OASF Taxonomy Adoption (Phase 4 deploy_flow agent-tools)](042-oasf-taxonomy-adoption.md)
+- [ADR-043: Prompt-Injection Defense Detonation Corpus](043-prompt-injection-defense-detonation-corpus.md)
+- [docs/concepts/14: Orchestration Layers — How We Do Workflows in
+  semstreams](../concepts/14-orchestration-layers.md) — the canonical
+  pattern catalog this ADR's rule chain instantiates
+- `/kv-or-stream`, `/query-pattern`, `/orchestration-check`,
+  `/new-payload` skills
+- Memory: `feedback_graph_not_for_agent_reasoning`
+- Memory: `feedback_frontier_floor_changes_role_split_calculus`
+- Memory: `feedback_gateway_first_only_for_new_capabilities`
+- Memory: `feedback_llm_authored_predicates_rule_opaque`
+- Memory: `feedback_per_loop_vs_per_role_safety`
+- Memory: `feedback_production_decoder_round_trip_required`
+- Memory: `feedback_e2e_required_for_breaking_changes`
+- Memory: `project_reactive_workflow_retirement` — context for why
+  this ADR uses rule-chain + components rather than a workflow
+  primitive

--- a/docs/concepts/14-orchestration-layers.md
+++ b/docs/concepts/14-orchestration-layers.md
@@ -1,464 +1,319 @@
-# Orchestration Layers
+# Orchestration Layers — How We Do Workflows in semstreams
 
-SemStreams uses a two-layer orchestration model that separates concerns between reactive
-orchestration and component execution. Understanding these layers and their boundaries is
-essential for building maintainable, scalable systems.
+semstreams has two orchestration layers — **rules** and **components**.
+There is no separate workflow engine. Multi-step patterns
+(linear pipelines, conditional branches, bounded iteration loops,
+async fan-out / fan-in) are expressed as **coordinated rule sets that
+fire components**, with per-action `MaxIterations` providing iteration
+caps and `Graphable` entity triples + KV state + ObjectStore providing
+durable storage.
 
-> **Note**: The **Reactive Workflow Engine** handles both rules-style single
-> triggers AND workflow-style multi-step orchestration using the same unified infrastructure.
-> Both are defined in type-safe Go code with compile-time verification.
+This document is the canonical "how we do workflows in semstreams"
+pattern catalog. If you find yourself reaching for a workflow engine,
+state machine, or new KV bucket, **read this first**. Most of the
+time the existing primitives already cover the case.
+
+## Why no separate workflow engine?
+
+A reactive workflow engine (`processor/reactive/`) shipped early in
+semstreams's life. It provided typed multi-phase state machines, async
+callback correlation, loop limits, and timeouts. It also bypassed the
+component framework: raw JetStream resources, invisible to flow
+discovery, broke the flowgraph validator. The capabilities were real;
+the integration discipline wasn't.
+
+Decision (2026-03-12): retire `processor/reactive/`. Absorb the
+capabilities the rule engine was missing (per-action firing caps,
+conditional branching in `when` clauses, configurable state buckets).
+Retirement completed in `main`; only `pkg/workflow/` (state-manager
+primitives) and a legacy `workflow_trigger_payload.go` compatibility
+shim remain. semspec — the early heavy reactive-workflow user — has a
+sister-repo migration tracked separately.
+
+The durable lesson: **a workflow primitive that lives outside the
+component framework creates state-plumbing debt the framework can't
+help you pay down later.** When you find a gap in the rule engine,
+file it as engine work. Don't build app-side state machines around it
+(see "The semspec trap" below).
 
 ## The Two Layers
 
 ```text
 ┌─────────────────────────────────────────────────────────────┐
-│  REACTIVE ENGINE (unified orchestration)                    │
+│  RULE ENGINE  (orchestration)                               │
 │                                                             │
-│  Single triggers (rules pattern):                           │
-│  "When condition X, trigger action Y"                       │
-│  - Watches KV state OR NATS subjects                        │
-│  - Fires single actions (publish, mutate, etc.)             │
+│  Watches: KV state, NATS subjects, wallclock                │
+│  Evaluates: typed conditions (unified evaluator, ADR-041)    │
+│  Fires: actions (publish, publish_agent, deny, etc.)         │
+│  Caps: per-action MaxIterations (default 3, explicit 0 =     │
+│        unlimited)                                            │
 │                                                             │
-│  Multi-step workflows:                                      │
-│  "Execute steps A → B → C with timeouts and loop limits"    │
-│  - Owns workflow state (phase, iteration count)             │
-│  - Enforces timeouts, loop limits                           │
-│  - Async callback correlation                               │
-│                                                             │
-│  All defined as type-safe Go code with ConditionFunc        │
+│  Rules trigger work. They don't do work.                    │
 └─────────────────────────────────────────────────────────────┘
                             │
-                            ▼ spawns
+                            ▼  fires
 ┌─────────────────────────────────────────────────────────────┐
-│  COMPONENTS (execution)                                     │
-│  - agentic-loop: execute agent turns                        │
-│  - graph: process triples                                   │
-│  - etc.                                                     │
+│  COMPONENTS  (execution)                                    │
+│                                                             │
+│  Receive: typed payloads on input ports                     │
+│  Execute: LLM calls, graph queries, file I/O, etc.          │
+│  Emit: results on output ports (KV writes, NATS publishes)   │
+│                                                             │
+│  Components are caller-agnostic. They don't know what       │
+│  triggered them or what comes next.                         │
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### Layer Responsibilities
+### Layer responsibilities
 
-| Layer | Responsibility | Owns | Does NOT Own |
-|-------|---------------|------|--------------|
-| **Reactive Engine** | State detection, multi-step orchestration | Conditions, actions, step sequence, timeouts | Actual work execution |
-| **Component** | Execute single units of work | Execution mechanics | Workflow awareness |
-
-## Reactive Patterns
-
-The reactive engine fires rules in response to three signal kinds:
-
-| Signal | Rule kind | Triggered by |
+| Layer | Owns | Does NOT own |
 |---|---|---|
-| KV state change | expression rule (`type: "expression"`) | A bucket key transitioning to a state where the rule's `When` predicates match |
+| Rule engine | Trigger conditions, action sequencing, iteration caps, condition evaluation | Work execution, business logic, payload semantics |
+| Component | Work execution, internal state machine, output emission | Caller identity, multi-step coordination, cross-component sequencing |
+
+## Signal kinds the rule engine watches
+
+Three kinds of signals fire rules:
+
+| Signal | Rule type | Triggered by |
+|---|---|---|
+| KV state change | expression rule (`type: "expression"`) | A bucket key transitioning to a state where the rule's `when` predicates match |
 | NATS subject match | expression rule (`type: "expression"`) | A message landing on a subject the rule subscribes to |
-| Wallclock | **cron rule (`type: "cron"`)** | A cron expression's `Next()` time elapsing |
+| Wallclock | cron rule (`type: "cron"`) | A cron expression's `Next()` time elapsing (ADR-031) |
 
-Cron rules ship in beta.27
-([ADR-031](../adr/031-time-trigger-primitive.md),
-[migration guide](../operations/migration-beta26-to-beta27.md)). They
-share every existing rule action (`publish`, `publish_agent`,
-`update_kv`, etc.) but bypass condition evaluation — there is no
-"state" for a clock to be in. A `"type": "cron"` rule accepts
-`schedule`, `actions`, `cooldown`, `fire_every_n_events`, `name`,
-`description`, `enabled`, `metadata` and nothing else; condition-side
-fields (`conditions`, `logic`, `on_enter`, `on_exit`, etc.) are
-rejected at config-load time.
+Cron rules accept `schedule`, `actions`, `cooldown`, `fire_every_n_events`,
+`name`, `description`, `enabled`, `metadata` only — condition-side fields
+are rejected at config-load.
 
-The reactive engine supports two coordination patterns through the same unified infrastructure:
+## Pattern Catalog
 
-### Single-Trigger Pattern (Rules-style)
+Five patterns cover essentially all multi-step orchestration in
+semstreams. Each shows the rule shape, the state-storage shape, and
+when to use it.
 
-For simple state-to-action reactions without multi-step coordination:
+### Pattern 1 — Single trigger
 
-```go
-// When architect completes, spawn editor
-reactive.NewRule("architect-complete-spawn-editor").
-    WatchKV("AGENT_LOOPS", "LOOP_*").
-    When("architect role", func(ctx *reactive.RuleContext) bool {
-        state := ctx.State.(*AgentLoopState)
-        return state.Role == "architect"
-    }).
-    When("completed successfully", func(ctx *reactive.RuleContext) bool {
-        state := ctx.State.(*AgentLoopState)
-        return state.Outcome == "success"
-    }).
-    Publish("agent.task.editor", func(ctx *reactive.RuleContext) (message.Payload, error) {
-        state := ctx.State.(*AgentLoopState)
-        return &EditorTask{
-            TaskID: state.TaskID,
-            Prompt: fmt.Sprintf("Implement: %s", state.Result),
-        }, nil
-    }).
-    Build()
-```
+**Shape**: `A completes → B starts (no retry, no loop)`
 
-This is appropriate when:
-- Single condition triggers single action
-- No iteration tracking needed
-- No timeout enforcement required
-- Fire-and-forget semantics
+**Use**: simple handoffs. Architect produces a plan; editor implements
+it. Validator approves a payload; publisher releases it.
 
-### Multi-Step Pattern (Workflow-style)
+**Implementation**: one rule with one action.
 
-For coordinated sequences with loop limits and timeouts, use workflow definitions (see below).
-
-## Workflow Layer
-
-The reactive workflow engine handles multi-step orchestration that requires state tracking, loop limits,
-and timeouts. It fills the gap between reactive rules and external orchestration systems like Temporal.
-
-### Go-Based Type-Safe Workflows
-
-Workflows are defined in type-safe Go code rather than JSON. This provides:
-
-- **Compile-time safety**: Field references and type mismatches are caught by the compiler
-- **IDE support**: Autocomplete, refactoring, and go-to-definition work naturally
-- **Zero `json.RawMessage`**: Direct struct field access replaces string interpolation
-- **Debuggability**: Standard Go debugging tools and stack traces
-- **2 serialization boundaries**: vs. 9+ in the previous JSON-based approach
-
-The reactive engine uses typed Go functions for conditions, payload building, and state mutations,
-eliminating the data corruption issues that plagued string-based template interpolation.
-
-### What Workflows Do Well
-
-- **Step sequencing**: Execute A → B → C in order
-- **Loop limits**: Stop after N iterations of a cycle
-- **Workflow timeouts**: Fail the entire workflow after T seconds
-- **Step timeouts**: Fail individual steps that run too long
-- **State tracking**: Know which step we're on, how many iterations completed
-
-### What Workflows Should NOT Do
-
-- **Execute work directly**: Workflows spawn components; they don't do the work
-- **Complex conditionals**: Use rules for condition evaluation, workflows for sequencing
-- **Human tasks**: Not a BPM engine; use external systems for human-in-the-loop
-
-### Workflow Definition Pattern
-
-Workflows are composed of typed rules that watch KV state and fire actions. Each rule:
-
-1. **Watches** a KV bucket pattern (e.g., `"review-fix.*"`)
-2. **Evaluates** conditions against typed state (e.g., `state.Phase == "reviewing"`)
-3. **Fires** an action when conditions match (e.g., publish async task)
-4. **Mutates** state when the action completes (e.g., update phase, increment iteration)
-
-The engine coordinates these rules through shared KV state, providing:
-
-- Automatic state persistence and recovery
-- Loop iteration tracking
-- Timeout enforcement
-- Concurrent execution safety with optimistic locking
-
-### Example: Review-Fix Cycle with Loop Limit
-
-A workflow is required when there's iteration with a termination condition:
-
-```go
-func ReviewFixCycleWorkflow() *reactive.Definition {
-    const maxIterations = 3
-
-    return reactive.NewWorkflow("review-fix-cycle").
-        WithDescription("Review code, fix issues, re-review until clean or max attempts").
-        WithStateBucket("REVIEW_FIX_STATE").
-        WithStateFactory(func() any { return &ReviewFixState{} }).
-        WithMaxIterations(maxIterations).
-        WithTimeout(300 * time.Second).
-
-        // Rule 1: Request review
-        AddRule(reactive.NewRule("request-review").
-            WatchKV("REVIEW_FIX_STATE", "review-fix.*").
-            When("phase is reviewing", reactive.PhaseIs("reviewing")).
-            When("under max iterations", reactive.IterationLessThan(maxIterations)).
-            When("no pending task", reactive.NoPendingTask()).
-            PublishAsync(
-                "agent.task.reviewer",
-                func(ctx *reactive.RuleContext) (message.Payload, error) {
-                    state := ctx.State.(*ReviewFixState)
-                    return &ReviewRequest{
-                        CodeID: state.CodeID,
-                        Prompt: "Review the code for issues",
-                    }, nil
-                },
-                "review.result.v1",
-                func(ctx *reactive.RuleContext, result any) error {
-                    state := ctx.State.(*ReviewFixState)
-                    reviewResult := result.(*ReviewResult)
-                    state.IssuesFound = reviewResult.IssuesCount
-                    state.ReviewFeedback = reviewResult.Feedback
-                    if reviewResult.IssuesCount == 0 {
-                        state.Phase = "completed"
-                        state.Status = reactive.StatusCompleted
-                    } else {
-                        state.Phase = "fixing"
-                    }
-                    return nil
-                },
-            ).
-            MustBuild()).
-
-        // Rule 2: Fix issues if found
-        AddRule(reactive.NewRule("fix-issues").
-            WatchKV("REVIEW_FIX_STATE", "review-fix.*").
-            When("phase is fixing", reactive.PhaseIs("fixing")).
-            When("no pending task", reactive.NoPendingTask()).
-            PublishAsync(
-                "agent.task.fixer",
-                func(ctx *reactive.RuleContext) (message.Payload, error) {
-                    state := ctx.State.(*ReviewFixState)
-                    return &FixRequest{
-                        CodeID:   state.CodeID,
-                        Feedback: state.ReviewFeedback,
-                        Prompt:   "Fix the issues:\n\n" + state.ReviewFeedback,
-                    }, nil
-                },
-                "fix.result.v1",
-                func(ctx *reactive.RuleContext, result any) error {
-                    state := ctx.State.(*ReviewFixState)
-                    state.Phase = "reviewing"
-                    state.Iteration++
-                    return nil
-                },
-            ).
-            MustBuild()).
-
-        // Rule 3: Handle max iterations exceeded
-        AddRule(reactive.NewRule("max-iterations-exceeded").
-            WatchKV("REVIEW_FIX_STATE", "review-fix.*").
-            When("phase is reviewing", reactive.PhaseIs("reviewing")).
-            When("at max iterations", reactive.Not(reactive.IterationLessThan(maxIterations))).
-            Mutate(func(ctx *reactive.RuleContext, _ any) error {
-                state := ctx.State.(*ReviewFixState)
-                state.Status = reactive.StatusEscalated
-                state.Error = "max review iterations exceeded"
-                return nil
-            }).
-            MustBuild()).
-
-        MustBuild()
-}
-
-// ReviewFixState tracks review-fix cycle execution
-type ReviewFixState struct {
-    reactive.ExecutionState
-    CodeID         string `json:"code_id"`
-    IssuesFound    int    `json:"issues_found"`
-    ReviewFeedback string `json:"review_feedback"`
+```json
+{
+  "name": "architect_complete_spawn_editor",
+  "type": "expression",
+  "when": {
+    "bucket": "AGENT_LOOPS",
+    "key_pattern": "COMPLETE_*",
+    "conditions": [
+      {"field": "role", "op": "eq", "value": "architect"},
+      {"field": "outcome", "op": "eq", "value": "success"}
+    ]
+  },
+  "actions": [
+    {
+      "type": "publish_agent",
+      "role": "editor",
+      "payload_ref": "{state.plan_objstore_ref}"
+    }
+  ]
 }
 ```
 
-This requires a workflow because:
-- Multiple steps with ordering (review → fix → review)
-- Loop that can repeat (fix → review → fix → review)
-- Loop limit (max 3 iterations with type-safe iteration tracking)
-- Workflow timeout (300 seconds total)
-- State tracking (which phase, iteration count, issues found)
+**State**: lives on the `COMPLETE_{loopID}` KV entry the upstream
+component wrote. The rule reads it; no new bucket.
 
-## Component Layer
+### Pattern 2 — Linear pipeline
 
-Components execute single units of work. They are workflow-agnostic — a component doesn't know or
-care whether it's being invoked by a rule, a workflow, or directly.
+**Shape**: `A → B → C → D (no loop)`
 
-### What Components Do
+**Use**: multi-stage processing where each stage's output feeds the
+next. Decompose → fetch → fuse → synthesize is the
+ADR-045 graph-search example.
 
-- **Execute work**: Process messages, call LLMs, write files
-- **Manage internal state**: Tool execution, context, pending operations
-- **Report results**: Publish completion events with outcomes
+**Implementation**: a chain of rules, each watching for the prior
+stage's completion event.
 
-### What Components Should NOT Do
-
-- **Know about workflows**: Components are isolated units
-- **Coordinate with other components**: That's the workflow's job
-- **Enforce cross-step timeouts**: Only per-operation timeouts
-
-### Example: agentic-loop Component
-
-The agentic-loop component executes agent turns:
-
-```text
-Input: Task message on agent.task.*
-Process: Model calls, tool execution, iteration
-Output: Completion event on agent.complete.*
+```json
+[
+  {"name": "stage_1_kickoff", "when": {"key_pattern": "input.received.*"},
+   "actions": [{"type": "publish", "subject": "component.stage_1.{id}"}]},
+  {"name": "stage_2_after_1", "when": {"key_pattern": "stage_1.complete.*"},
+   "actions": [{"type": "publish", "subject": "component.stage_2.{id}"}]},
+  {"name": "stage_3_after_2", "when": {"key_pattern": "stage_2.complete.*"},
+   "actions": [{"type": "publish", "subject": "component.stage_3.{id}"}]},
+  {"name": "stage_4_after_3", "when": {"key_pattern": "stage_3.complete.*"},
+   "actions": [{"type": "publish", "subject": "component.stage_4.{id}"}]}
+]
 ```
 
-The component:
-- Manages its own state machine (exploring → planning → executing → complete)
-- Enforces per-loop iteration limits and timeouts
-- Publishes results without knowing what triggered it or what comes next
+**State**: each stage writes its output as triples on an operation
+entity in an existing KV bucket (e.g., `AGENT_LOOPS`). Bulky payloads
+go to ObjectStore via `ContentStorable`; only refs travel in rule
+payloads. No new bucket; no parallel state machine.
 
-## Rules of Thumb
+### Pattern 3 — Conditional branch
 
-### 1. Rules Trigger, They Don't Orchestrate
+**Shape**: `A → if X then B else C`
 
-A rule should fire one action, not manage a sequence. If you find yourself writing rules that
-depend on previous rule firings to build up state, you need a workflow.
+**Use**: route to different downstream actions based on the result of
+a prior stage. "If validation passes, publish; otherwise, request
+human review."
 
-**Anti-pattern**: Rule A sets `step=1`, Rule B watches for `step=1` and sets `step=2`...
+**Implementation**: one rule with multiple actions, each gated by an
+action-level `when` clause. The unified condition evaluator (ADR-041)
+makes this clean — `when` sees the same fields as rule-level
+conditions.
 
-**Correct**: Rule A triggers a workflow that manages step progression.
-
-### 2. Workflows Coordinate, They Don't Execute
-
-Workflows spawn components; they don't do the work themselves. If your workflow step is doing
-complex processing inline, that logic belongs in a component.
-
-**Anti-pattern**: Workflow step contains 100 lines of processing logic.
-
-**Correct**: Workflow step publishes to a component that does the processing.
-
-### 3. Components Are Workflow-Agnostic
-
-A component doesn't know if it's in a workflow or standalone. It receives input, does work,
-publishes output. This isolation enables reuse and testing.
-
-**Anti-pattern**: Component checks `workflow_id` to decide behavior.
-
-**Correct**: Component behaves the same regardless of caller.
-
-### 4. State Ownership Is Exclusive
-
-Only one layer owns any piece of state. If both rules and workflows are tracking the same state,
-you have a design problem.
-
-| State | Owner |
-|-------|-------|
-| Trigger conditions | Rules |
-| Step progress, iteration count | Workflow |
-| Execution state (pending tools, etc.) | Component |
-
-### 5. If It Needs a Loop Limit, It's a Workflow
-
-Simple handoffs (A completes → B starts) use rules. Cycles with termination conditions
-(A → B → A → B... until X or N times) use workflows.
-
-**Rule**: `when architect completes → spawn editor`
-
-**Workflow**: `reviewer → fixer → reviewer → fixer... max 3 iterations`
-
-## Use Case Examples
-
-### Semspec-Driven Development
-
-A semspec workflow involves multiple agent passes with iteration limits:
-
-```text
-1. Parse semspec for tasks (once)
-2. For each task:
-   a. Architect designs approach
-   b. Editor implements
-   c. Reviewer checks
-   d. If issues: fix and re-review (max 3 times)
-3. Report completion
+```json
+{
+  "name": "route_validation_result",
+  "when": {"key_pattern": "validation.complete.*"},
+  "actions": [
+    {
+      "type": "publish",
+      "subject": "publisher.release.{id}",
+      "when": "$state.validation.passed == true"
+    },
+    {
+      "type": "publish_agent",
+      "role": "human_reviewer",
+      "when": "$state.validation.passed == false"
+    }
+  ]
+}
 ```
 
-**Layer mapping**:
-- **Reactive Workflow**: Owns the multi-step process, loop limits, overall timeout (Go definition)
-- **Rules**: Can trigger the workflow when semspec is approved
-- **Components**: agentic-loop executes each agent role
+**State**: validation result lives on the operation entity. No new
+bucket.
 
-### Simple Agent Handoff
+### Pattern 4 — Bounded iteration
 
-Architect produces a plan, editor implements it (no retry loop):
+**Shape**: `A → B → A → B... (max N times)`
 
-```text
-1. Architect completes with plan
-2. Editor receives plan, implements
-3. Done
+**Use**: review-fix cycles, refine-and-retry loops, retry on
+transient failure with backoff. Cap is required to prevent unbounded
+loops.
+
+**Implementation**: a rule whose action publishes the loop start,
+with `max_iterations` on the action as the cap. The per-action firing
+counter is keyed on a stable action ID (auto-generated fingerprint or
+author-supplied).
+
+```json
+{
+  "name": "review_fix_cycle",
+  "when": {"key_pattern": "review.complete.*"},
+  "actions": [
+    {
+      "type": "publish_agent",
+      "role": "fixer",
+      "when": "$state.review.issues_count > 0 AND $state.iteration < 3",
+      "max_iterations": 3
+    },
+    {
+      "type": "publish",
+      "subject": "pipeline.complete.{id}",
+      "when": "$state.review.issues_count == 0 OR $state.iteration >= 3"
+    }
+  ]
+}
 ```
 
-**Layer mapping**:
-- **Rules**: `when architect completes → publish_agent editor`
-- **Components**: agentic-loop executes architect, then editor
+**Default `MaxIterations`**: 3 (framework-wide, applies when the
+field is unset). Explicit `"max_iterations": 0` means unlimited.
+Authors who want stable counters across rule renames set
+`Action.ID` explicitly.
 
-No workflow needed — it's a simple A → B handoff without loops.
+**State**: iteration count is tracked by the rule engine itself
+(`MatchState.ActionIterations`); no app-side counter needed.
 
-### Data Pipeline with Validation
+### Pattern 5 — Async fan-out / fan-in
 
-Ingest data, validate, retry if malformed, fail after 3 attempts:
+**Shape**: `A → (B, C, D in parallel) → E when all done`
 
-```text
-1. Receive data
-2. Validate format
-3. If invalid and attempts < 3: request correction, goto 2
-4. If invalid and attempts >= 3: fail with error
-5. If valid: process and store
+**Use**: parallel sub-tasks with a synchronization point. Fan out to
+multiple workers; gather results before proceeding.
+
+**Implementation**: one rule with multiple `publish` actions for the
+fan-out; a second rule on a "synchronizer" key pattern for the
+fan-in. The synchronizer is updated by each parallel branch and the
+fan-in rule fires when all expected branches have written.
+
+```json
+[
+  {
+    "name": "fanout_to_workers",
+    "when": {"key_pattern": "fanout.start.*"},
+    "actions": [
+      {"type": "publish", "subject": "component.worker_b.{id}"},
+      {"type": "publish", "subject": "component.worker_c.{id}"},
+      {"type": "publish", "subject": "component.worker_d.{id}"}
+    ]
+  },
+  {
+    "name": "fanin_when_all_complete",
+    "when": {
+      "key_pattern": "fanout.synchronizer.*",
+      "conditions": [
+        {"field": "completed_count", "op": "eq", "value": 3}
+      ]
+    },
+    "actions": [
+      {"type": "publish", "subject": "component.aggregator.{id}"}
+    ]
+  }
+]
 ```
 
-**Layer mapping**:
-- **Reactive Workflow**: Owns validation loop, attempt counter, timeout (Go definition)
-- **Rules**: Can trigger workflow on new data arrival
-- **Components**: validator component, storage component
-
-## Debugging Orchestration Issues
-
-### Symptom: Action Fires Multiple Times Unexpectedly
-
-**Likely cause**: Rule is re-triggering because state oscillates.
-
-**Check**: Is the rule's action modifying state that causes the condition to re-match?
-
-**Fix**: Use idempotent state updates or track "already processed" flags.
-
-### Symptom: Workflow Never Completes
-
-**Likely cause**: Missing termination condition or loop limit.
-
-**Check**: Does every loop have a max_iterations? Does every branch eventually reach completion?
-
-**Fix**: Add explicit loop limits and ensure all conditional branches terminate.
-
-### Symptom: Component Behaves Differently in Workflow vs. Standalone
-
-**Likely cause**: Component has workflow awareness it shouldn't.
-
-**Check**: Is the component checking context about its caller?
-
-**Fix**: Remove caller awareness; component behavior should be input-determined only.
+**State**: each worker writes its result to the operation entity and
+increments the synchronizer count. The fan-in rule reads the count.
+No new bucket; the operation entity carries the synchronization
+state.
 
 ## State Storage Boundaries
 
-The system distinguishes between three categories of data with different storage patterns:
+Three categories of data, with different storage patterns. **The
+discipline here is what keeps you out of the semspec trap** (see
+below).
 
-| Category | Storage | Rules Observable? | In Knowledge Graph? |
-|----------|---------|-------------------|---------------------|
-| **Domain Entities** | `ENTITY_STATES` KV | Yes | Yes (Graphable) |
-| **Operational Results** | Component-specific KV | Yes | No |
-| **Events** | JetStream streams | No | No |
+| Category | Storage | Rule-observable? | In knowledge graph? |
+|---|---|---|---|
+| **Domain entities** | `ENTITY_STATES` KV | Yes | Yes (`Graphable`) |
+| **Operational results** | Component-specific KV (e.g., `AGENT_LOOPS`) | Yes | No |
+| **Events** | JetStream streams | No (rules watch KV, not streams) | No |
+| **Bulky payloads** | ObjectStore via `ContentStorable`; ref-triples on owning entity | Indirectly (via refs) | Refs only |
 
-### Domain Entities (ENTITY_STATES)
+### Domain entities (`ENTITY_STATES`)
 
-Semantic domain objects that implement the `Graphable` interface:
-- Have 6-part hierarchical entity IDs (e.g., `acme.ops.robotics.gcs.drone.001`)
+Semantic domain objects implementing `Graphable`:
+
+- 6-part hierarchical entity ID (`org.platform.domain.system.type.instance`)
 - Persist across multiple events
-- Queryable in knowledge graph
-- Examples: sensors, documents, zones, relationships
+- Queryable in the knowledge graph
 
-**Only `graph-ingest` writes to ENTITY_STATES.**
+**Only `graph-ingest` writes to `ENTITY_STATES`.**
 
-### Operational Results (Component KV)
+### Operational results (component-specific KV)
 
-Execution outcomes that are NOT semantic entities:
+Execution outcomes that are not semantic domain entities:
+
 - Use `COMPLETE_{id}` key pattern for rules observability
 - Stored in component-specific buckets:
-  - `AGENT_LOOPS`: Agent completion state (`COMPLETE_{loopID}`)
-  - `REACTIVE_WORKFLOW_STATE` (configurable): Workflow execution state managed by `pkg/workflow.StateManager`
+  - `AGENT_LOOPS`: agent + research operation state (`COMPLETE_{loopID}`)
+  - Other components may register their own buckets when warranted
 - Transient — represent what happened, not what exists
-- Examples: agent completion, workflow completion, step results
 
-**Reactive workflows use configurable state buckets:**
-
-The reactive workflow engine uses `pkg/workflow.StateManager` with configurable bucket names (default:
-`REACTIVE_WORKFLOW_STATE`). Each workflow definition specifies its state bucket via `WithStateBucket()`.
-
-**Rules can watch these buckets using `entity_watch_buckets` config:**
+Rules can watch multiple buckets via the `entity_watch_buckets`
+config:
 
 ```json
 {
   "entity_watch_buckets": {
     "ENTITY_STATES": ["telemetry.>"],
-    "REACTIVE_WORKFLOW_STATE": ["review-fix.*"],
-    "AGENT_LOOPS": ["COMPLETE_*"]
+    "AGENT_LOOPS": ["COMPLETE_*", "research.*"]
   }
 }
 ```
@@ -466,39 +321,244 @@ The reactive workflow engine uses `pkg/workflow.StateManager` with configurable 
 ### Events (JetStream)
 
 Immediate notifications for downstream processing:
+
 - Published to streams for subscribers
-- Not directly observable by rules (rules watch KV, not streams)
-- Examples: `agent.complete.*`, `workflow.events`
+- Not directly observable by rules
+- Examples: `agent.complete.*`, `graph.ingest.*`
 
-### Anti-Pattern: Mixing Categories
+### Bulky payloads (ObjectStore via `ContentStorable`)
 
-Do NOT write operational results to ENTITY_STATES:
-- Pollutes knowledge graph with non-semantic data
-- Breaks Graphable contract (no entity ID, no triples)
-- Makes graph queries less meaningful
+Per ADR-028: **rules carry references, never content.** If a payload
+might exceed ~16KB or contain freeform text/code/artifacts, write it
+to ObjectStore and put the ref-triple on the owning entity. The rule
+payload carries only the entity ID and ref. Components reading the
+payload dereference on demand.
 
-**Example anti-pattern**:
+### Anti-pattern: writing operational results to `ENTITY_STATES`
+
+Pollutes the knowledge graph with non-semantic data. Breaks
+`Graphable` contract. Makes graph queries less meaningful.
+
 ```go
-// WRONG: Writing workflow completion to ENTITY_STATES
+// WRONG
 entityBucket.Put(ctx, "workflow.review.exec123", completionData)
-```
 
-**Correct pattern**:
-```go
-// RIGHT: Writing to component-specific bucket
-// For reactive workflows, use StateManager
-stateManager.UpdateState(ctx, "review-fix.123", func(state any) error {
-    s := state.(*ReviewFixState)
-    s.Status = reactive.StatusCompleted
-    return nil
-})
-
-// For agent loops, use COMPLETE_ prefix
+// RIGHT — operational results in component bucket with COMPLETE_ prefix
 agentLoopsBucket.Put(ctx, "COMPLETE_exec123", completionData)
 ```
 
+## Rules of Thumb
+
+### 1. Rules trigger; they don't orchestrate inline
+
+A rule fires one set of actions, not a sequence of stateful steps.
+
+**Anti-pattern**: Rule A sets `step=1`, Rule B watches for `step=1`
+and sets `step=2`, Rule C watches for `step=2`...
+
+**Correct**: a multi-step pattern is a coordinated set of rules where
+each rule fires a component; state lives on the operation entity.
+See Pattern 2 (linear pipeline).
+
+### 2. Components execute; they don't coordinate
+
+A component does one thing. If a component is dispatching work to
+other components inline, that orchestration belongs in the rule
+layer.
+
+**Anti-pattern**: a component that, after finishing its work, calls
+into another component's API directly.
+
+**Correct**: the component emits its completion event; a rule
+watches for that event and fires the next component.
+
+### 3. Components are caller-agnostic
+
+A component doesn't know if it's standalone or part of a multi-step
+pattern. Same component, same behavior, regardless of caller.
+
+**Anti-pattern**: `if msg.workflow_id != "" { ... }` inside a
+component.
+
+**Correct**: behavior differences are configured (component config),
+not branched on caller identity.
+
+### 4. State ownership is exclusive
+
+Only one layer owns a piece of state.
+
+| State | Owner |
+|---|---|
+| Trigger conditions | Rule engine |
+| Iteration counters | Rule engine (per-action `MatchState`) |
+| Execution state inside a component | Component |
+| Domain entities | `graph-ingest` (writes to `ENTITY_STATES`) |
+| Operational results | Component that produced them (writes to its own bucket) |
+
+### 5. If you need a new bucket, ask twice
+
+Adding a new KV bucket is a discipline-load decision, not a syntactic
+one. The semspec trap (below) is what happens when new buckets
+proliferate without the framework being able to see them. Before
+adding one:
+
+- Can the data live on an existing entity as triples?
+- Can the data live in an existing component's bucket
+  (`AGENT_LOOPS`, etc.) with a distinct key prefix?
+- Can bulky content live in ObjectStore with a ref-triple on an
+  existing entity?
+
+If the answer to all three is "no," and the bucket is genuinely
+component-owned operational state, register it via `entity_watch_buckets`
+and document it in the component's docs. **Never** create app-side
+state buckets that the rule engine isn't configured to watch.
+
+### 6. Engine gaps file as engine work
+
+If the rule engine can't express something you need (e.g., reading
+an evidence-array length inside a `when` clause), **file it as a
+rule-engine improvement**, not an app-side workaround. The semspec
+trap is the cautionary tale (below).
+
+## The semspec trap (don't repeat it)
+
+semspec was an early adopter, predating the mature rule engine. To
+work around rule-engine limitations, it built **its own plan and
+execution state machines** — roughly 7,264 LOC of `workflow/reactive/`
+code with its own state plumbing alongside the rule engine.
+
+That code is now a migration blocker. It imports the retired
+`processor/reactive/` engine, maintains its own state, has its own
+audit surface, and is invisible to flow discovery and the flowgraph
+validator. The team can't dig out anytime soon.
+
+**The lesson**: when the framework is missing something, the answer
+is engine work upstream, not app-side scaffolding downstream. Every
+time an app adds its own state machine "just for this one case," the
+framework loses the ability to help it later — debugging,
+observability, restart safety, validation, all degrade.
+
+This document is the canonical "how to do workflows in semstreams"
+answer. If the answer isn't here, propose adding it. If a pattern
+genuinely needs a new primitive, propose adding the primitive to the
+rule engine via ADR + engine ticket. Don't carve out a parallel
+state-machine path.
+
+## Debugging Orchestration Issues
+
+### Symptom: action fires multiple times unexpectedly
+
+**Likely cause**: rule re-triggers because state oscillates after the
+action runs.
+
+**Check**: is the action modifying state that causes the rule's
+condition to re-match?
+
+**Fix**: idempotent state updates, or track "already processed"
+flags on the entity. Verify `MaxIterations` is set on the action.
+
+### Symptom: chain stalls partway through
+
+**Likely cause**: a stage completed but the next rule isn't watching
+the right key pattern, or the rule's `when` clause doesn't match the
+emitted state.
+
+**Check**: read the KV bucket; confirm the stage's completion key was
+written; trace the rule engine's evaluation log for the next rule.
+
+**Fix**: align the rule's key pattern and `when` predicates with what
+the prior stage actually writes.
+
+### Symptom: component behaves differently in chain vs. standalone
+
+**Likely cause**: component has caller awareness it shouldn't.
+
+**Check**: does the component branch on a workflow ID, caller role,
+or any field that varies by caller?
+
+**Fix**: remove caller awareness. Behavior differences must come from
+configuration, not caller identity.
+
+### Symptom: looking for "the workflow ID"
+
+**There isn't one.** Multi-step patterns in semstreams are identified
+by the operation entity ID (e.g., the loop ID on the research-pipeline
+entity in `AGENT_LOOPS`). If you're reaching for a separate workflow
+identifier, you're probably about to recreate the semspec trap.
+
+## Use Case Examples
+
+### Simple agent handoff (Pattern 1)
+
+```text
+Architect completes with plan → editor receives plan, implements.
+```
+
+Layer mapping:
+- Rule: `when architect completes → publish_agent editor`
+- Components: `agentic-loop` executes architect, then editor
+
+### Multi-step agent chain with retry (Patterns 2 + 4)
+
+```text
+For each task: architect → editor → reviewer → if issues, fix and re-review (max 3) → done.
+```
+
+Layer mapping:
+- Rules: one per transition; one with `max_iterations: 3` for the fix→review loop
+- Components: `agentic-loop` for each role
+- State: a task entity in an existing bucket carries phase, iteration,
+  feedback
+
+### Data pipeline with validation retry (Pattern 4)
+
+```text
+Ingest → validate → if invalid and attempts < 3, request correction, goto validate → if valid, process.
+```
+
+Layer mapping:
+- Rules: ingest trigger, validation router (Pattern 3 conditional),
+  retry action with `max_iterations: 3`
+- Components: validator, corrector, processor
+- State: an ingestion entity carries attempts and validation result
+
+### Graph search decomp+fusion (Patterns 2 + 4, ADR-045)
+
+```text
+research_graph(intent) → decompose → execute → assess → if not sufficient, refine and re-execute (max 5) → synthesize → return to parent
+```
+
+Layer mapping:
+- Rules: six rules (R1–R6 in ADR-045) coordinating the chain;
+  conditional branch on assessment; refine loop with
+  `max_iterations: 5`; continuation rule fires the parent
+- Components: `decompose_intent`, `execute_subqueries`,
+  `assess_sufficiency`, `synthesize_answer`
+- State: a research-pipeline entity in `AGENT_LOOPS`; evidence in
+  ObjectStore via `ContentStorable`; refs as triples on the entity
+
+See [ADR-045](../adr/045-graph-search-rule-chain.md) for the full
+design.
+
 ## References
 
-- [Advanced Guide: Reactive Workflows](../advanced/10-reactive-workflows.md) — Usage guide and examples
-- [Concept: Agentic Systems](./13-agentic-systems.md) — Agentic loop fundamentals
-- [Concept: Rule-Driven Artifacts](./18-rule-driven-artifacts.md) — Pattern for emitting markdown / JSON / webhook artifacts from rule actions
+- [/orchestration-check](../../.claude/skills/orchestration-check/SKILL.md)
+  — decision skill for choosing between patterns
+- [/kv-or-stream](../../.claude/skills/kv-or-stream/SKILL.md) —
+  facts vs requests heuristic
+- [/new-payload](../../.claude/skills/new-payload/SKILL.md) —
+  payload registry checklist
+- [Concept: KV Twofer](02-kv-twofer.md) — single KV write = state +
+  events + history
+- [Concept: Streams vs KV Watches](03-streams-vs-kv-watches.md) —
+  facts vs requests
+- [Concept: Agentic Systems](13-agentic-systems.md) — agentic loop
+  fundamentals
+- [Concept: Rule-Driven Artifacts](18-rule-driven-artifacts.md) —
+  emitting markdown/JSON/webhook artifacts from rule actions
+- [ADR-028: Agentic Orchestration Architecture](../adr/028-orchestration-architecture.md)
+- [ADR-031: Time-Trigger Primitive (cron rules)](../adr/031-time-trigger-primitive.md)
+- [ADR-041: Unified Condition Evaluator](../adr/041-unified-condition-evaluator.md)
+- [ADR-045: Graph Search Decomp+Fusion via Rule-Chain + Components](../adr/045-graph-search-rule-chain.md)
+- Memory: `project_reactive_workflow_retirement` — historical context
+  on the workflow engine retirement


### PR DESCRIPTION
## Summary

- **ADR-045** (`docs/adr/045-graph-search-rule-chain.md`) proposes graph search decomp+fusion via a rule-chain coordinating four typed components (`decompose_intent` / `execute_subqueries` / `assess_sufficiency` / `synthesize_answer`). Cuts along the trained-ergonomics seam: LLM does language tasks at bounded structured-emit points; code does multi-tier graph orchestration. No new KV buckets, no persona dir, no workflow primitive — uses existing rule engine + AGENT_LOOPS + ObjectStore only.
- **`docs/concepts/14`** rewritten as canonical "How we do workflows in semstreams" pattern catalog (5 patterns: single trigger, linear pipeline, conditional branch, bounded iteration, async fan-out/fan-in). Replaces stale `reactive.NewWorkflow()` builder examples now that `processor/reactive/` is retired.
- **`CLAUDE.md` Orchestration Boundaries** updated: workflow-engine framing dropped, pattern table expanded, "engine gaps file as engine work" rule added with semspec trap callout.
- **`.claude/skills/orchestration-check`** rewritten to match: Two Layers reduced to rule engine + components, Quick Decision expanded to 5 patterns, examples updated to current JSON rule format.

## Architectural rationale (full discussion in the ADR)

Two prior architectural rounds were considered and rejected during the design conversation:

1. **Pre-LLM substrate enrichment** — wasteful (runs every loop), and deterministic decomp+fusion is hard to write well.
2. **Constrained-allowlist subagent loop** — LLMs lack trained ergonomics for graph-shape ReAct loops even when no alternative tools are present. The crimp isn't just about tool preference; it's about training-data coverage of multi-hop graph-walk + fuse trajectories.

The landing architecture (rule-chain + components) cuts along the trained-ergonomics seam and explicitly avoids the **semspec trap** (the 7,264 LOC of `workflow/reactive/` that became a migration blocker when an early app built its own state machines around rule-engine limitations).

## Test plan

- [ ] Doc-only — no code paths affected, no tests required
- [ ] Verify ADR-045 renders cleanly (markdown lint)
- [ ] Verify cross-links between ADR-045, doc 14, CLAUDE.md, and the orchestration-check skill resolve
- [ ] Operator review of ADR-045 before opening Phase 1 implementation work

🤖 Generated with [Claude Code](https://claude.com/claude-code)