### PR TITLE
docs(adr-045): amend with classifier-first chain + topic/hints intent

### DIFF
--- a/docs/adr/045-graph-search-rule-chain.md
+++ b/docs/adr/045-graph-search-rule-chain.md
@@ -2,13 +2,35 @@
 
 ## Status
 
-**Proposed — 2026-05-19.** Doc-only ADR; no implementation in this tag.
-Independent of ADR-039 (governance), ADR-042 (publisher-mode), ADR-043
-(detonation corpus), ADR-044 (CS API framework split). Builds on existing
-primitives only: rule engine (`processor/rule/` with per-action
-`MaxIterations`), component framework, AGENT_LOOPS KV, ObjectStore via
-`ContentStorable`, triples on entities. Does **not** introduce new KV
-buckets or new orchestration primitives.
+**Proposed — 2026-05-19; amended 2026-05-21.** Doc-only ADR; no
+implementation in this tag. Independent of ADR-039 (governance),
+ADR-042 (publisher-mode), ADR-043 (detonation corpus), ADR-044 (CS API
+framework split). Builds on existing primitives only: rule engine
+(`processor/rule/` with per-action `MaxIterations`), component
+framework, AGENT_LOOPS KV, ObjectStore via `ContentStorable`, triples
+on entities, **and the existing `graph/query.Classifier`** (regex
+keyword + embedding + LLM variants composable via
+`classifier_chain.go`). Does **not** introduce new KV buckets or new
+orchestration primitives.
+
+**2026-05-21 amendment** (rolled into this revision; original v1 was
+merged in PR #109): repositioned the first LLM step from
+intent-decomposition to **classify-and-route over the existing
+classifier's output**. Two driving notes:
+
+1. `graph/query.Classifier` already exists (regex/embedding/LLM
+   variants) and is the natural first hit for any natural-language
+   topic. The chain should reuse it, not duplicate it.
+2. The v1 intent payload required fields (entity IDs, predicates)
+   that the caller realistically only knows *after* a graph search
+   — circular. v2 takes only what the caller has: a topic + optional
+   hints.
+
+The shift strengthens the trained-ergonomics argument: "look at a
+classifier's hits and decide what to do next" is one of the most
+heavily trained LLM behaviors (humans-using-search-engines is well
+represented in training data). Cold-start query planning is much
+rarer.
 
 Forcing function: the "agent search problem" recurring across the
 agentic stack lacks a clean home in semstreams. The naive answers — a
@@ -36,10 +58,12 @@ in-context navigation. Kumar's punchline frames the gap as
 ### Why this maps hard onto semstreams
 
 semstreams is a knowledge-graph engine with tiered inference (rules /
-BM25 / neural) and multi-gateway query access (GraphQL, MCP, NATS
-Direct). The substrate for unified retrieval exists; the unresolved
-question is **where the decomp+fusion step lives** between the
-gateways and the agent's prompt.
+BM25 / neural), multi-gateway query access (GraphQL, MCP, NATS
+Direct), and an existing classifier-driven NL query path
+(`graph/query.Classifier`, with keyword/embedding/LLM variants). The
+substrate for unified retrieval exists; the unresolved question is
+**where the decomp+fusion step lives** between those primitives and
+the agent's prompt.
 
 Two empirical findings define the floor any solution must clear:
 
@@ -97,17 +121,20 @@ custom state machines.
 
 ### The trained-ergonomics seam
 
-What the LLM *is* trained for: read text, summarize text, decompose
-questions into sub-questions, judge relevance, compose answers from
-sources. What it is *not* trained for: orchestrate a sequence of
-typed graph queries, normalize scores across retrieval tiers, dedup
-multi-hop walk results, manage iteration budgets.
+What the LLM *is* trained for: read text, summarize text, examine a
+list of search results and decide what to do next, judge relevance,
+compose answers from sources. What it is *not* trained for:
+orchestrate a sequence of typed graph queries from a cold start,
+normalize scores across retrieval tiers, dedup multi-hop walk
+results, manage iteration budgets.
 
-The architecture should cut along this seam: **code does what code
-is good at, LLM does what LLM is good at**, and the LLM is invoked
-in bounded structured-emit calls at the judgment points where its
-language strengths apply — not as a multi-turn agent loop driving
-graph tools it wasn't trained to drive.
+The architecture should cut along this seam: **code does what code is
+good at, LLM does what LLM is good at**, and the LLM is invoked in
+bounded structured-emit calls at the judgment points where its
+language strengths apply — including, critically, the one where it
+*examines a concrete classifier hit set and decides what to do next*.
+Not as a multi-turn agent loop driving graph tools it wasn't trained
+to drive.
 
 ## Decision
 
@@ -122,7 +149,7 @@ No new orchestration primitive, no new state bucket, no persona dir.
 One new tool exposed in the parent's allowlist:
 
 ```
-research_graph(intent) → async search_result
+research_graph(topic, hints?) → async search_result
 ```
 
 Calling it emits `research.requested.{loop_id}` (a triple +
@@ -131,72 +158,100 @@ parent's current iteration. The result arrives on a subsequent
 iteration via the standard continuation rule pattern (same shape as
 any agent loop completion).
 
-The intent payload is structured (not free-form text):
+The intent payload contains only fields the **caller actually
+knows** — no entity IDs, no predicate names, no tier mix, none of
+which a parent agent could supply without doing a graph search
+first:
 
 ```json
 {
   "topic": "drone hover anomalies",
-  "entities": ["acme.ops.robotics.gcs.drone.001"],
-  "predicates": ["sosa:hasResult", "ssn:hasDeployment"],
-  "tiers": ["rules", "bm25"],
+  "hints": {
+    "entity_kind": "drone",        // optional, free-form
+    "domain": "robotics",          // optional
+    "recency": "last_24h"          // optional, classifier-parseable
+  },
   "budget_tokens": 4000,
   "max_iterations": 5
 }
 ```
 
+Entity IDs, predicates, and tier selection are **outputs** of the
+chain (returned to the parent inside `search_result`), not inputs.
+
 ### Internal architecture
 
 ```
-Parent → research_graph(intent)  → terminates iteration
+Parent → research_graph(topic, hints?)  → terminates iteration
             │
-            ▼  R1 fires on research.requested.*
-[component] decompose_intent
-            │  one LLM call, structured emit: typed sub-queries
-            ▼  R2 fires on decompose.complete.*
-[component] execute_subqueries
-            │  CODE: parallel multi-tier fan-out via existing gateways
-            │  Tier 0 (rules/predicates) + Tier 1 (BM25) [+ Tier 2 in Phase 2]
-            │  emits evidence array to ObjectStore, ref-triples on loop entity
-            ▼  R3 fires on execute.complete.*
-[component] assess_sufficiency
-            │  one LLM call, structured emit: {sufficient: bool, refined?}
-            ▼  R4 conditional branch:
-            │   - sufficient=false AND iterations<5  → fire execute_subqueries (refined)
-            │   - sufficient=true OR iterations=5    → fire R5
-            │  (per-action MaxIterations=5 caps the refine loop)
-            ▼
-[component] synthesize_answer
-            │  one LLM call, structured emit: final synthesis
-            ▼  R6 emits search_result terminal, fires R-cont
+            ▼  R0 fires on research.requested.*
+[component] nl_classify
+            │  wraps existing graph/query.Classifier (regex + embedding + LLM
+            │  chain via classifier_chain.go); produces initial candidate
+            │  matches with entities, scores, snippets
+            ▼  R1 fires on classify.complete.*
+[component] route_search
+            │  FIRST LLM JUDGMENT STEP — examines classifier output, emits
+            │  one of four routing decisions:
+            │    (a) "classification sufficient"  → short-circuit to synthesize
+            │    (b) "retighten"                  → refined nl_classify call
+            │                                       (max_iterations on this branch)
+            │    (c) "walk_seeds"                 → execute_subqueries with the
+            │                                       entities the classifier surfaced
+            │    (d) "decompose"                  → execute_subqueries with a
+            │                                       typed sub-query list
+            ▼  R2 conditional branch on route.decision:
+   ┌────────────────────┬──────────────────────────┬───────────────────┐
+   ▼ (a)                ▼ (b)                      ▼ (c)/(d)
+[synthesize_answer]  [nl_classify w/refined]    [execute_subqueries]
+   │                    │                          │
+   │                    │ (loops back to R1)       ▼  R3 fires on execute.complete.*
+   │                    │                       [assess_sufficiency]
+   │                    │                          │  LLM judges relevance, emits
+   │                    │                          │  {sufficient, refined_queries?}
+   │                    │                          ▼  R4 conditional refine OR synthesize
+   │                    │                       ┌──┴──┐
+   │                    │                       ▼     ▼
+   │                    │       [execute_subqueries] [synthesize_answer]
+   │                    │           (max_iter=5)
+   │                    │                       │     │
+   ▼                    ▼                       ▼     ▼
+   └────────────────────┴───────────────────────┴─────┘
+            ▼  R5 emits search_result terminal, fires R-cont
 [continuation rule]
             ▼
 Parent resumes with search_result evidence in prompt
 ```
 
-### Components (four small additions, each a single-purpose unit)
+### Components (five small additions, each a single-purpose unit)
 
 | Component | Type | Body |
 |---|---|---|
-| `decompose_intent` | LLM-wrapping | One bounded structured-emit call: `intent → typed sub-queries[]`. Template fast-path for common shapes (entity_state, predicate_walk, temporal_range, spatial_polygon); LLM call only for novel topics. |
-| `execute_subqueries` | Code | Parallel multi-tier fan-out via existing GraphQL/MCP/NATS-Direct gateways. Score normalization, dedup, ranking. Budget enforcement. Writes evidence to ObjectStore; ref-triples to the research-loop entity. |
-| `assess_sufficiency` | LLM-wrapping | One bounded structured-emit call: `(intent, evidence) → {sufficient: bool, refined_queries?: []}`. The "refine or finalize" decision. |
-| `synthesize_answer` | LLM-wrapping | One bounded structured-emit call: `(intent, evidence) → synthesis`. Refs preserved verbatim. |
+| `nl_classify` | Wraps existing primitive | Calls `graph/query.Classifier.ClassifyQuery(topic)` (using `classifier_chain.go` to compose keyword + embedding + LLM variants per operator config) and executes the resulting `SearchOptions` against the graph. Returns initial candidate set: entities + scores + snippets. No new LLM calls beyond what the existing classifier already does. |
+| `route_search` | LLM-wrapping | One bounded structured-emit call: `(topic, classifier_output) → {action, args}`. Action ∈ {`synthesize_directly`, `retighten`, `walk_seeds`, `decompose`}. This is the first dedicated LLM judgment in the chain, and it is the one most aligned with trained ergonomics (read results, decide next move). |
+| `execute_subqueries` | Code | Parallel multi-tier fan-out via existing GraphQL/MCP/NATS-Direct gateways. Accepts either a seed-entity list (from `walk_seeds`) or a typed sub-query list (from `decompose`). Score normalization, dedup, ranking. Budget enforcement. Writes evidence to ObjectStore; ref-triples to the research-loop entity. |
+| `assess_sufficiency` | LLM-wrapping | One bounded structured-emit call: `(topic, evidence) → {sufficient: bool, refined_queries?: []}`. The "refine or finalize" decision after multi-hop execution. |
+| `synthesize_answer` | LLM-wrapping | One bounded structured-emit call: `(topic, evidence) → synthesis`. Refs preserved verbatim. Reached either via short-circuit from `route_search` or via the standard `assess → synthesize` path. |
 
-The three LLM-wrapping components share underlying infrastructure
-(`model.NewHTTPClient`, beta.43 unified LLM HTTP client invariant).
-Each has its own prompt template specialized for its task — not a
-free-form agent persona, structured input/output schemas. No persona
-dir.
+The three LLM-wrapping components (`route_search`,
+`assess_sufficiency`, `synthesize_answer`) share underlying
+infrastructure (`model.NewHTTPClient`, beta.43 unified LLM HTTP
+client invariant). Each has its own prompt template specialized for
+its task — not a free-form agent persona, structured input/output
+schemas. No persona dir.
 
 ### State storage (uses existing buckets only — no new plumbing)
 
 | State | Where it lives | Reuses |
 |---|---|---|
-| Research operation's identity + iteration count | AGENT_LOOPS KV entry (role = `research_pipeline`) | Existing bucket; same primitives as any agent loop |
-| Original intent + refined-query history | Triples on the research-loop entity | `Graphable` interface; standard pattern |
-| Evidence (potentially bulky) | ObjectStore via `ContentStorable`; ref-triples on loop entity | Existing pattern per ADR-028 ("rules carry references, never content") |
-| Decomposition output, assessment result, synthesis | Triples on the research-loop entity + ObjectStore refs for large payloads | `Graphable` interface |
+| Research operation's identity + iteration counts | AGENT_LOOPS KV entry (role = `research_pipeline`) | Existing bucket; same primitives as any agent loop |
+| Original topic + hints + retighten history | Triples on the research-loop entity | `Graphable` interface; standard pattern |
+| Classifier candidate set (initial + retightened) | Triples on the loop entity (refs to ObjectStore for snippet bodies) | `ContentStorable`; standard pattern |
+| Routing decisions emitted by `route_search` | Triples on the loop entity | `Graphable` interface |
+| Multi-hop evidence (potentially bulky) | ObjectStore via `ContentStorable`; ref-triples on loop entity | Existing pattern per ADR-028 ("rules carry references, never content") |
+| Assessment result, synthesis | Triples on the loop entity + ObjectStore refs for large payloads | `Graphable` interface |
 | Iteration cap for refine loop | Per-action `MaxIterations=5` on R4 | Existing rule-engine primitive |
+| Iteration cap for retighten loop | Per-action `MaxIterations=2` on R2's retighten branch | Existing rule-engine primitive |
 | Search result returned to parent | ObjectStore object + ref-triple; continuation rule fires parent | Same pattern as any agent loop completion |
 
 **No new KV buckets. No new state machines. No new orchestration
@@ -204,26 +259,43 @@ primitive.** Every load-bearing primitive cited is already in `main`.
 
 ### Rule chain
 
-Six rules in the flow config (R1–R6 plus the continuation rule):
+Six rules plus the continuation rule:
 
 ```yaml
-# R1: kick off the chain
-- name: research_decompose
+# R0: kick off the chain — run the existing classifier on the topic
+- name: research_classify
   when: kv_write
     bucket: AGENT_LOOPS
     key_pattern: "research.requested.*"
   actions:
     - type: publish
-      subject: "component.decompose_intent.{loop_id}"
+      subject: "component.nl_classify.{loop_id}"
 
-# R2: after decompose, fan out
-- name: research_execute
+# R1: after classification, route on results
+- name: research_route
   when: kv_write
     bucket: AGENT_LOOPS
-    key_pattern: "decompose.complete.*"
+    key_pattern: "classify.complete.*"
   actions:
     - type: publish
+      subject: "component.route_search.{loop_id}"
+
+# R2: route_search emits one of four decisions; dispatch accordingly
+- name: research_dispatch
+  when: kv_write
+    bucket: AGENT_LOOPS
+    key_pattern: "route.complete.*"
+  actions:
+    - type: publish
+      subject: "component.synthesize_answer.{loop_id}"
+      when: '$state.route.action == "synthesize_directly"'
+    - type: publish
+      subject: "component.nl_classify.{loop_id}"
+      when: '$state.route.action == "retighten"'
+      max_iterations: 2          # cap retighten loop separately from refine loop
+    - type: publish
       subject: "component.execute_subqueries.{loop_id}"
+      when: '$state.route.action == "walk_seeds" OR $state.route.action == "decompose"'
 
 # R3: after execute, assess
 - name: research_assess
@@ -242,11 +314,11 @@ Six rules in the flow config (R1–R6 plus the continuation rule):
   actions:
     - type: publish
       subject: "component.execute_subqueries.{loop_id}"
-      when: "$state.assess.sufficient == false"
-      max_iterations: 5                       # per-action cap is the loop limit
+      when: '$state.assess.sufficient == false'
+      max_iterations: 5         # per-action cap is the refine loop limit
     - type: publish
       subject: "component.synthesize_answer.{loop_id}"
-      when: "$state.assess.sufficient == true OR $state.iterations >= 5"
+      when: '$state.assess.sufficient == true OR $state.iterations >= 5'
 
 # R5: terminal emit (synthesize component writes search_result.complete on success)
 
@@ -261,22 +333,45 @@ Six rules in the flow config (R1–R6 plus the continuation rule):
       payload_ref: "{state.search_result_objstore_ref}"
 ```
 
-All six rules use existing JSON rule definitions and existing action
+All rules use existing JSON rule definitions and existing action
 types (`publish`, `publish_agent`). The `when` clauses use the
 unified condition evaluator (ADR-041). `MaxIterations` is the
-existing per-action firing cap.
+existing per-action firing cap. **Two independent loop caps** —
+retighten (R2, default 2) and refine (R4, default 5) — because
+they bound different failure modes.
 
-### Why this is not just-a-better-GraphQL
+### Why this is not just-a-better-classifier
 
-The chain has **agent reasoning at every judgment point** —
-decomposition (decide which sub-queries to issue from a fuzzy topic),
-assessment (judge whether evidence answers the question, decide
-whether to refine), and synthesis (compose the answer with context).
-A pure deterministic pipeline can't do any of these well. What's
-different from a free-form agent loop is that each LLM invocation is
-**bounded, structured, single-turn** — the LLM never *drives* a tool
-loop, it answers a specific structured question and emits a typed
-result. That's the trained-ergonomics seam.
+The chain leads with `nl_classify` (existing primitive) but the
+load-bearing work happens in **`route_search`**, which is the LLM
+judgment step that turns a classifier hit set into one of four
+typed actions. Without it, this *would* be just-a-better-classifier
+or just-a-better-GraphQL. With it:
+
+- The chain can **short-circuit** when classification is sufficient
+  — many parent topics will not need multi-hop work, and the chain
+  doesn't pay for it.
+- The chain can **retighten** when classification produced noisy or
+  empty hits — a refined `nl_classify` re-run rather than a
+  brute-force multi-hop walk.
+- The chain can **walk seeds** when the classifier surfaced
+  promising entities but the parent needs their context — multi-hop
+  expansion from specific seed entities is structurally different
+  from a topic-wide decomp.
+- The chain can **decompose** when the topic genuinely needs
+  multiple typed sub-queries — the original v1 path, but now used
+  only when the classifier shows it's necessary, not by default.
+
+Each of these is a judgment the classifier alone cannot make and a
+free-form ReAct loop cannot make fluently. `route_search` is the
+single LLM call where the model does exactly what it was trained for:
+read search results, decide next action.
+
+`assess_sufficiency` is the second LLM judgment (after multi-hop
+execution): did we get what we need, or do we refine? `synthesize_answer`
+is the third: compose the answer with provenance. Three LLM judgment
+calls, each at a point well-aligned with trained ergonomics, none of
+which asks the LLM to drive a tool loop.
 
 ### Why this avoids the semspec trap
 
@@ -286,12 +381,14 @@ Every load-bearing primitive is already in the framework:
 - Per-action iteration cap → existing `MaxIterations`
 - Conditional branching → existing action `when` clauses (ADR-041
   unified evaluator)
+- NL classification → existing `graph/query.Classifier` +
+  `classifier_chain.go`
 - State on entity → existing `Graphable` interface + triples
 - Bulky payload handling → existing `ContentStorable` + ObjectStore
 - Continuation back to parent → existing rule + `publish_agent`
   pattern
 
-The four new components are normal components — same lifecycle, same
+The five new components are normal components — same lifecycle, same
 port discipline, same flow-discovery, same flowgraph validation as
 every other component. No bypass paths, no parallel state machine,
 no app-side workflow engine.
@@ -301,7 +398,7 @@ no app-side workflow engine.
 Two equally valid ways to package the rule chain:
 
 1. **Inline rules in the parent's flow config** (Phase 1 recommended).
-   Add R1–R6 + four components to whichever flow needs research.
+   Add R0–R6 + five components to whichever flow needs research.
    Simplest; one new flow, no new spawn primitive.
 2. **Standalone deployable flow** spawned via
    `start_flow(research_graph_flow_id, intent)` from ADR-042 Phase 4
@@ -316,15 +413,26 @@ configuration change, not an architecture change.
 ### Wins
 
 - **Dodges the reasoning crimp and trained-ergonomics gap.** The LLM
-  is invoked at the language tasks it's trained for (decompose,
-  assess, synthesize); code does the multi-tier orchestration the
-  LLM isn't trained to drive.
+  is invoked at three language tasks it's trained for (examine
+  classifier hits and route, judge multi-hop evidence sufficiency,
+  synthesize); code does the multi-tier orchestration the LLM isn't
+  trained to drive.
+- **Reuses the existing `graph/query.Classifier` instead of
+  duplicating it.** Phase 1 ships without re-implementing
+  NL-to-search-options logic — that work is years old and well-tested.
+- **Caller's surface matches what the caller actually knows.** Topic
+  + hints, no required entity IDs or predicate names. No circular
+  dependency on a prior graph search.
+- **Short-circuit path.** Many parent topics are answerable from the
+  classifier's output alone; the chain doesn't pay for multi-hop
+  work when it isn't needed. Full chain is the expensive path, not
+  the default.
 - **Dodges the graph-not-for-reasoning failure mode.** The agent
   never decides to navigate the graph — it just gets fused evidence
   in the next loop's prompt. Same injection-side pattern that worked
   for lineage triples in beta.51.
 - **Dodges role-split orchestration cost.** No persona dir, no chain
-  role, no per-role rule wiring beyond R1–R6.
+  role, no per-role rule wiring beyond R0–R6.
 - **Dodges the semspec trap.** Every primitive is existing. No new
   KV buckets, no parallel state machines, no app-side workflow
   engine.
@@ -337,31 +445,38 @@ configuration change, not an architecture change.
 - **Testable.** Each component has unit-test boundaries (input
   payload → output emit). The chain itself is integration-testable
   with mock components.
-- **Operator-configurable.** Per-role enable, budget caps, tier mix
-  are flow config — not code.
+- **Operator-configurable.** Per-role enable, budget caps, classifier
+  variant choice (keyword/embedding/LLM via existing
+  `classifier_chain.go` config) are all flow config — not code.
 
 ### Costs
 
-- **Multi-stage latency.** Three to four rule fires + three LLM
-  calls + N code stages per research call. Mitigation: parallel
-  fan-out inside `execute_subqueries`; KV cache for hot intents;
-  P95 SLO.
+- **Multi-stage latency.** Up to five rule fires + three LLM calls
+  + N code stages per research call on the full path. Short-circuit
+  path is much cheaper (classifier + route_search only).
+  Mitigation: parallel fan-out inside `execute_subqueries`; KV cache
+  for hot intents; P95 SLO.
 - **Parent residual crimp.** Parent still chooses whether to call
   `research_graph`. Smaller surface than multi-tool but not zero.
   Mitigation: one-line persona hint ("when in doubt, delegate via
-  `research_graph`"); ops `emit_diagnosis` flags missed
-  delegations.
-- **Four new components.** Maintenance surface. Mitigation: each is
-  single-purpose, small, shares LLM-call infrastructure.
-- **Decomposer can hallucinate sub-queries.** Mitigation: structured
-  emit + schema validation + template fast path covers common
-  intents without LLM.
+  `research_graph`"); ops `emit_diagnosis` flags missed delegations.
+- **Five new components.** Maintenance surface. Mitigation: each is
+  single-purpose, small; the three LLM-wrapping ones share
+  infrastructure; `nl_classify` is a thin wrapper over an existing
+  primitive.
+- **Router can hallucinate the routing decision.** Mitigation:
+  structured emit + schema-validated `action ∈ enum`; ops
+  observability of router decisions.
 - **Synthesis can fabricate refs.** Mitigation: refs must validate
   against actual evidence in ObjectStore; schema-level enforcement,
   not prompt-level.
+- **Two independent iteration caps to tune.** Retighten (R2) and
+  refine (R4) defaults will need calibration from Phase 1
+  trajectories. Mitigation: sensible starting values (2 and 5);
+  operator-configurable.
 - **Per-role configuration surface grows.** Each parent role gets
-  `research_graph` enable + budget caps. Mitigation: sensible
-  defaults; opt-in.
+  `research_graph` enable + budget caps + classifier-variant
+  selection. Mitigation: sensible defaults; opt-in.
 
 ### Out of scope (deferred)
 
@@ -401,11 +516,11 @@ a ReAct loop over the constrained surface.
 
 **Rejected.** The trained-ergonomics gap. Even with no alternative
 tools to crimp toward, the LLM lacks fluent trained behavior for
-multi-hop graph-walk + fuse-results trajectories. Asking the LLM
-to drive a graph tool loop is the failure mode, not the constraint
-on alternatives. Cleaner to invoke the LLM at structured language
-tasks (decompose, assess, synthesize) than to ask it to drive a
-loop it wasn't trained for.
+multi-hop graph-walk + fuse-results trajectories. Asking the LLM to
+drive a graph tool loop is the failure mode, not the constraint on
+alternatives. Cleaner to invoke the LLM at structured language
+tasks (route classifier output, assess multi-hop evidence,
+synthesize) than to ask it to drive a loop it wasn't trained for.
 
 ### D. Smarter graph-side queries (gateway-only)
 
@@ -436,7 +551,7 @@ call, unconditionally. Rule-triggered on every loop input creation.
   "what the parent asked for" vs "what the framework pre-stuffed."
 
 The rule chain keeps the request/response boundary crisp:
-parent calls `research_graph(intent)`, components emit
+parent calls `research_graph(topic, hints?)`, components emit
 `search_result(evidence)`. Both are auditable artifacts.
 
 ### F. Prompt-side encouragement of existing graph tools
@@ -449,7 +564,27 @@ the agent ignoring `graph_search` results even with explicit prompt
 encouragement. Persona prompts already say "Try FIRST for project
 lookups." Behavior unchanged across three instrumented incidents.
 
-### G. Status quo (do nothing)
+### G. Decomposition-first chain (v1 of this ADR, superseded)
+
+The v1 design used a `decompose_intent` LLM step as the chain
+opener, asking the LLM to expand a structured intent into typed
+sub-queries from a cold start.
+
+**Rejected in v2.** Two issues:
+- The intent payload required entity IDs and predicates the caller
+  realistically doesn't know without a prior graph search —
+  circular.
+- Cold-start query planning ("decompose this topic into typed
+  sub-queries") is much rarer in training data than "look at search
+  results and decide next move." The classifier-first chain hits
+  the trained-ergonomics seam more squarely.
+
+The v2 chain (this revision) reuses `decompose` as one of four
+routing actions inside `route_search`, invoked only when the
+classifier output indicates the topic genuinely needs typed
+sub-query expansion.
+
+### H. Status quo (do nothing)
 
 Continue with direct-tool exposure; treat failures as prompt tuning.
 
@@ -460,24 +595,28 @@ converging on the same shape. Tuning has not moved the floor.
 
 **Phase 1** (proposed for next eligible tag — not beta-blocking):
 
-- Four new components: `decompose_intent`, `execute_subqueries`,
-  `assess_sufficiency`, `synthesize_answer`. Each ships with unit
-  tests against the production decoder per
+- Five new components: `nl_classify`, `route_search`,
+  `execute_subqueries`, `assess_sufficiency`, `synthesize_answer`.
+  Each ships with unit tests against the production decoder per
   `feedback_production_decoder_round_trip_required`.
-- One new parent-side tool: `research_graph(intent)` registered per
-  `/new-payload` discipline.
+- `nl_classify` integration with `graph/query.Classifier` reuses
+  the existing keyword + embedding + LLM chain
+  (`classifier_chain.go`); the LLM variant of the classifier has
+  been operator-validated as of beta.76 (timeout bump to 30s in
+  PR #108 hardened it for cold-start hardware).
+- One new parent-side tool: `research_graph(topic, hints?)`
+  registered per `/new-payload` discipline.
 - Two new payload types: `research_intent` + `search_result`
   registered in the payload registry.
-- Six rules (R1–R6) bundled in a reference flow config; parent flows
-  opt in by including the rules or by spawning the flow via
+- Six rules (R0–R6) bundled in a reference flow config; parent
+  flows opt in by including the rules or by spawning the flow via
   `start_flow` (Phase 2 path).
-- Tier coverage: Tier 0 (rules) + Tier 1 (BM25) inside
-  `execute_subqueries`. Tier 2 (neural) deferred to Phase 2.
-- Decomposer: template fast-path only for `entity_state` /
-  `predicate_walk` / `temporal_range` / `spatial_polygon`. LLM-driven
-  decomp for novel topics deferred to Phase 2 (Phase 1 falls through
-  to a degraded "full-text search of intent topic" path for
-  un-templated intents).
+- `route_search` action enum: `{synthesize_directly, retighten,
+  walk_seeds, decompose}`. Phase 1 implements all four; calibration
+  of which decisions the router favors comes from operator
+  trajectories.
+- Tier coverage inside `execute_subqueries`: Tier 0 (rules) + Tier 1
+  (BM25). Tier 2 (neural) deferred to Phase 2.
 - In-repo smoke test against the deep-research e2e flow.
 - Pre-tag e2e green per
   `feedback_e2e_required_for_breaking_changes` (this changes the
@@ -487,13 +626,14 @@ converging on the same shape. Tuning has not moved the floor.
 **Phase 2** (gated on Phase 1 operator validation):
 
 - Tier 2 (neural) added to `execute_subqueries`.
-- LLM-driven decomp inside `decompose_intent` for novel topics.
 - Token-budget compression via small-LLM emit (refs preserved).
 - Per-parent-role enablement (researcher, curator, ops opt in with
   different budgets).
 - Deployable as a standalone flow (Phase 2 spawn path via
   `start_flow`).
-- ops `emit_diagnosis` flags for decomp/assess/synthesis quality.
+- ops `emit_diagnosis` flags for `route_search` / `assess` /
+  `synthesize` quality (e.g., "router chose `decompose` when
+  `walk_seeds` would have sufficed").
 
 **Phase 3** (gated on Phase 2 + external use case):
 
@@ -509,10 +649,12 @@ converging on the same shape. Tuning has not moved the floor.
 
 ## Open questions
 
-1. **Cache key for hot intents.** Same intent from the same
+1. **Cache key for hot topics.** Same topic + hints from the same
    chain-entity should not re-run the full chain every iteration.
    Invalidation predicate: wall-clock TTL, revision count on
-   referenced entities, or both? Resolved in Phase 1 implementation.
+   referenced entities, or both? Composes with the existing
+   classifier's own caching (if any). Resolved in Phase 1
+   implementation.
 
 2. **Continuation-rule deadline + fallback.** If any stage in the
    chain stalls or fails, the parent must resume with
@@ -520,30 +662,44 @@ converging on the same shape. Tuning has not moved the floor.
    decision rather than wedge. Deadline value and degraded-result
    schema TBD in Phase 1.
 
-3. **Engine gaps surfaced during implementation.** If implementation
-   reveals that the current rule engine cannot express something
-   needed (e.g., reading evidence-array length in a `when` clause to
-   gate the refine branch), the gap gets filed as a discrete
-   engine-improvement ticket — not as inline state plumbing in the
-   research chain. The semspec trap is explicit prior art.
+3. **Retighten vs refine cap calibration.** Phase 1 proposes
+   `MaxIterations=2` on the retighten branch (R2) and
+   `MaxIterations=5` on the refine branch (R4). Are these the right
+   defaults? Tuning from Phase 1 trajectories.
 
-4. **Interaction with strict tool calling (ADR-035).** Both
+4. **Router action enum vs free-form emit.** Phase 1 commits to a
+   four-action enum; do we need a fifth "give up" action that
+   short-circuits to `search_result.error`, or does the deadline
+   fallback (Q2) cover it adequately?
+
+5. **Engine gaps surfaced during implementation.** If implementation
+   reveals that the current rule engine cannot express something
+   needed (e.g., reading classifier-candidate-count in a `when`
+   clause to gate the route decision), the gap gets filed as a
+   discrete engine-improvement ticket — not as inline state
+   plumbing in the research chain. The semspec trap is explicit
+   prior art.
+
+6. **Interaction with strict tool calling (ADR-035).** Both
    `research_intent` and `search_result` payloads need formal
    schema registration per `/new-payload`. Phase 1 includes the
-   registry entries + round-trip production-decoder test.
+   registry entries + round-trip production-decoder test. The
+   router's emit schema (the four-action enum) likewise needs
+   strict-mode validation.
 
-5. **Interaction with governance (ADR-039).** The four components'
-   LLM calls go through the same rule-driven governance layer as
-   any other LLM call. Per-loop vs per-role boundaries per
+7. **Interaction with governance (ADR-039).** The four LLM-wrapping
+   components' calls go through the same rule-driven governance
+   layer as any other LLM call. Per-loop vs per-role boundaries per
    `feedback_per_loop_vs_per_role_safety` apply.
 
-6. **Detonation corpus coverage.** Phase 1 reads from graph +
+8. **Detonation corpus coverage.** Phase 1 reads from graph +
    ObjectStore (lower prompt-injection risk than web sources, but
    not zero — BM25 snippets from ingested docs are a possible
-   vector). Phase 3 web fan-out *requires* detonation pre-flight
-   integration — track as a hard gate.
+   vector that surfaces through the classifier). Phase 3 web
+   fan-out *requires* detonation pre-flight integration — track as
+   a hard gate.
 
-7. **Parent-side delegation hygiene.** How aggressively to prompt
+9. **Parent-side delegation hygiene.** How aggressively to prompt
    the parent toward calling `research_graph`. Initial proposal:
    one-line persona hint; ops flags missed delegations for
    trajectory review.
@@ -552,6 +708,9 @@ converging on the same shape. Tuning has not moved the floor.
 
 - [Kumar, "The Agent Search Problem,"
   2026](https://dipkumar.dev/posts/agents/agent-search-problem/)
+- [`graph/query.Classifier`](../../graph/query/classifier.go) +
+  [classifier_chain.go](../../graph/query/classifier_chain.go) —
+  the existing NL classification primitive Phase 1 reuses
 - [ADR-027: Ops Agent Meta-Harness](027-ops-agent-meta-harness.md)
 - [ADR-028: Agentic Orchestration Architecture](028-orchestration-architecture.md)
 - [ADR-035: Strict Tool Calling](035-strict-tool-calling.md)

--- a/docs/concepts/14-orchestration-layers.md
+++ b/docs/concepts/14-orchestration-layers.md
@@ -522,23 +522,34 @@ Layer mapping:
 - Components: validator, corrector, processor
 - State: an ingestion entity carries attempts and validation result
 
-### Graph search decomp+fusion (Patterns 2 + 4, ADR-045)
+### Graph search decomp+fusion (Patterns 2 + 3 + 4, ADR-045)
 
 ```text
-research_graph(intent) → decompose → execute → assess → if not sufficient, refine and re-execute (max 5) → synthesize → return to parent
+research_graph(topic, hints?)
+  → nl_classify  (reuses existing graph/query.Classifier)
+  → route_search (LLM examines candidates, emits one of 4 actions)
+  → branch:
+       synthesize_directly  → synthesize → return
+       retighten            → loop back to nl_classify (max 2)
+       walk_seeds           → execute → assess → refine? (max 5) → synthesize → return
+       decompose            → execute → assess → refine? (max 5) → synthesize → return
 ```
 
 Layer mapping:
-- Rules: six rules (R1–R6 in ADR-045) coordinating the chain;
-  conditional branch on assessment; refine loop with
-  `max_iterations: 5`; continuation rule fires the parent
-- Components: `decompose_intent`, `execute_subqueries`,
-  `assess_sufficiency`, `synthesize_answer`
-- State: a research-pipeline entity in `AGENT_LOOPS`; evidence in
-  ObjectStore via `ContentStorable`; refs as triples on the entity
+- Rules: seven rules (R0–R6 in ADR-045) coordinating the chain;
+  conditional branch on `route_search` decision; conditional branch
+  on `assess_sufficiency`; retighten loop with `max_iterations: 2`
+  (R2); refine loop with `max_iterations: 5` (R4); continuation rule
+  fires the parent
+- Components: `nl_classify` (wraps existing classifier),
+  `route_search`, `execute_subqueries`, `assess_sufficiency`,
+  `synthesize_answer`
+- State: a research-pipeline entity in `AGENT_LOOPS`; classifier
+  candidates + multi-hop evidence in ObjectStore via
+  `ContentStorable`; refs as triples on the entity
 
 See [ADR-045](../adr/045-graph-search-rule-chain.md) for the full
-design.
+design and the classify-and-route rationale.
 
 ## References
 


### PR DESCRIPTION
## Summary

Amends ADR-045 (merged in #109) to address two notes from post-merge review:

1. **Reuse the existing classifier.** `graph/query.Classifier` already exists with keyword + embedding + LLM variants composable via `classifier_chain.go`. PR #108's recent timeout bump validated the LLM-classifier path for cold-start hardware. The chain should reuse it as the first hit, not duplicate it.
2. **Caller surface = what the caller knows.** v1's intent payload required entity IDs and predicate names that a caller realistically would only learn *from* a graph search. Circular. v2 takes topic + optional hints only; entity IDs and predicates become outputs.

## v2 chain shape

```text
research_graph(topic, hints?)
  → nl_classify    (wraps existing graph/query.Classifier)
  → route_search   (FIRST LLM JUDGMENT — examines classifier output,
                    emits one of 4 routing actions)
  → branch:
       synthesize_directly  → synthesize → return     (short-circuit)
       retighten            → loop to nl_classify     (max 2)
       walk_seeds           → execute → assess → refine? → synthesize
       decompose            → execute → assess → refine? → synthesize
```

Strengthens the trained-ergonomics argument from the v1 ADR: \"examine classifier hits and decide next action\" is one of the most heavily trained LLM behaviors (humans-using-search-engines is well-represented in training data). v1's \"decompose intent from cold start\" was much rarer in training.

## Changes

- **Five components** (was four). Added `nl_classify`. Renamed and re-scoped `decompose_intent` → `route_search` (now a routing decision, not a sub-query generator).
- **Seven rules R0–R6** (was six). Added R0 for classifier kickoff. R2 became the routing dispatcher with three conditional branches (synthesize_directly / retighten / walk_seeds-or-decompose).
- **Two independent iteration caps**: retighten (R2, max 2) and refine (R4, max 5) — they bound different failure modes.
- **Intent payload**: topic + hints only (no required entity IDs, no required predicates).
- **Alternatives section**: v1's decompose-first design preserved as Alternative G (superseded by v2). A–F and H unchanged.
- **doc 14 worked example**: updated to show all four route branches.

## Test plan

- [ ] Doc-only — no code paths affected, no tests required
- [ ] Verify ADR-045 amendment renders cleanly (markdown lint)
- [ ] Verify cross-links to `graph/query/classifier.go` and `classifier_chain.go` resolve
- [ ] Operator review of v2 design before Phase 1 implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)