### PR TITLE
fix(agentic-loop): HandleTask trajectory step was silently dropped

### DIFF
--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -748,6 +748,19 @@ func (h *MessageHandler) buildTaskRequest(loopID string, task TaskMessage, entit
 
 	step := h.buildTaskTrajectoryStep(request.RequestID, task, messages)
 
+	// Persist the task-initiation step eagerly so its `messages` survive into
+	// the trajectory. Every OTHER handler in this file calls AddStep right
+	// after building its step; HandleTask was the lone outlier — its
+	// TrajectorySteps return field is never consumed by the component
+	// (persistHandlerResult only forwards published messages + final state),
+	// so the request-side audit trail was silently dropped. Caught
+	// 2026-05-21 while wiring trajectory_detail:full into the UI.
+	if _, addErr := h.trajectoryManager.AddStep(loopID, step); addErr != nil {
+		h.logger.Warn("failed to add task trajectory step",
+			slog.String("loop_id", loopID),
+			slog.String("error", addErr.Error()))
+	}
+
 	createdData, err := h.buildLoopCreatedData(loopID, task, entity)
 	if err != nil {
 		return HandlerResult{}, err

--- a/processor/agentic-loop/handlers_test.go
+++ b/processor/agentic-loop/handlers_test.go
@@ -117,6 +117,72 @@ func TestHandleTask_CreatesLoop(t *testing.T) {
 	}
 }
 
+// TestHandleTask_PersistsStepInTrajectoryManager is a regression test for the
+// bug class where a handler builds a trajectory step and sets it on
+// result.TrajectorySteps but never calls trajectoryManager.AddStep — so the
+// step is silently dropped from the audit trail because
+// persistHandlerResult does not consume the TrajectorySteps field
+// (component.go's persistHandlerResult forwards Publishes + state only;
+// trajectory data flows via trajectoryManager → finalizeTrajectory →
+// writeTrajectoryToGraph).
+//
+// The analogous tool_call bug was fixed earlier and has its own regression
+// test below (see "tool_call steps were only on result.TrajectorySteps"
+// comment). HandleTask's task-initiation step was the lone remaining
+// outlier; this test prevents another regression of the same shape.
+//
+// Uses TrajectoryDetail=full because that's the mode where the bug
+// surfaced — UI consumers querying full trajectory detail saw missing
+// request-side messages. In summary mode the step still lands but
+// without Messages (by design), so summary mode wouldn't make the
+// data-loss observable to a downstream consumer.
+func TestHandleTask_PersistsStepInTrajectoryManager(t *testing.T) {
+	config := createTestConfig()
+	config.TrajectoryDetail = "full"
+	handler := agenticloop.NewMessageHandler(config)
+
+	taskMsg := agenticloop.TaskMessage{
+		TaskID: "task-trajectory-regression",
+		Role:   "general",
+		Model:  "qwen-32b",
+		Prompt: "Analyze this system",
+	}
+
+	ctx := context.Background()
+	result, err := handler.HandleTask(ctx, taskMsg)
+	if err != nil {
+		t.Fatalf("HandleTask() error = %v", err)
+	}
+
+	traj, trajErr := handler.GetTrajectory(result.LoopID)
+	if trajErr != nil {
+		t.Fatalf("GetTrajectory() error = %v", trajErr)
+	}
+
+	foundModelCall := false
+	for _, s := range traj.Steps {
+		if s.StepType == "model_call" {
+			foundModelCall = true
+			// The whole point of persisting the step is so its `messages`
+			// (the LLM request payload) survive into the trajectory.
+			// Empty messages here would mean the step reached the manager
+			// but lost its content along the way.
+			if len(s.Messages) == 0 {
+				t.Error("Persisted model_call step should carry its request messages in full-detail mode")
+			}
+			if s.Model != "qwen-32b" {
+				t.Errorf("Persisted model_call step Model = %q, want %q", s.Model, "qwen-32b")
+			}
+			break
+		}
+	}
+	if !foundModelCall {
+		t.Error("Trajectory manager should contain a model_call step after HandleTask " +
+			"(regression: task-initiation step was previously only set on result.TrajectorySteps " +
+			"and never added to the manager, so request-side audit was silently dropped)")
+	}
+}
+
 func TestHandleTask_MultipleRoles(t *testing.T) {
 	handler := agenticloop.NewMessageHandler(createTestConfig())
 


### PR DESCRIPTION
## Summary

\`HandleTask\` built its task-initiation trajectory step (the LLM request with messages) and set it on \`result.TrajectorySteps\` but never called \`trajectoryManager.AddStep\` — so the step was silently dropped from the audit trail. \`component.go\`'s \`persistHandlerResult\` forwards \`result.Publishes\` + state only; trajectory data flows via \`trajectoryManager → finalizeTrajectory → writeTrajectoryToGraph\`, never through \`result.TrajectorySteps\`.

Every other handler in \`handlers.go\` already calls \`AddStep\` right after building its step (compaction at line 286, retry at 1367, tool_call at 1619, etc.). \`HandleTask\` was the lone outlier.

Same bug class as the tool_call fix that landed earlier with its own regression test (\`handlers_test.go\` around line 987: *\"prior to fix, tool_call steps were only on result.TrajectorySteps but never added to the trajectory manager\"*). \`HandleTask\` was the last remaining instance of the pattern.

Surfaced while wiring \`trajectory_detail:full\` into the UI — the request-side messages were missing from the trajectory query.

## Changes

1. **\`processor/agentic-loop/handlers.go\`**: \`trajectoryManager.AddStep\` call after \`buildTaskTrajectoryStep\` with warn-level error log (matches the pattern of every other site in the same file).
2. **\`processor/agentic-loop/handlers_test.go\`**: \`TestHandleTask_PersistsStepInTrajectoryManager\` regression test mirroring the tool_call regression test pattern. Uses \`TrajectoryDetail=full\` to exercise the bug-discovery path; verifies the step lands in the trajectory manager AND that Messages + Model survive into the persisted step.

## Verification

- \`go test -race -count=1 ./processor/agentic-loop/\` clean
- \`task lint\` clean
- Stash-revert cycle proves the regression test FAILS without the fix and PASSES with it — the test does what it's supposed to do

## Provenance note

This diff was authored by a sister agent on the working tree without authorization. Reviewed it, verified the claim against the codebase (verified pattern compliance at the four cited line numbers; verified \`persistHandlerResult\` does not consume \`TrajectorySteps\`), added the regression test, and routed through a proper PR. Sister agent has been told to stay out of this repo going forward.

## Test plan

- [ ] CI green
- [ ] Reviewer confirms the regression test mirrors the existing tool_call test pattern intentionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)