### PR TITLE
fix(tests): bound testcontainers wait at ForAll level + realistic fast-startup budget

### DIFF
--- a/natsclient/test_client.go
+++ b/natsclient/test_client.go
@@ -151,10 +151,17 @@ func NewSharedTestClient(opts ...TestOption) (*TestClient, error) {
 		Image:        "nats:" + cfg.natsVersion,
 		ExposedPorts: []string{"4222/tcp", "8222/tcp"},
 		Cmd:          args,
+		// Startup timeout applied at the ForAll level so it bounds BOTH
+		// strategies. Prior pattern only set it on ForHTTP, leaving
+		// ForListeningPort with its own (shorter) default — under Docker
+		// API pressure the port-listening check would burn through retries
+		// before the HTTP timeout could engage. Symptom:
+		//   "retries: 532, port: '', last err: port '4222/tcp' not found,
+		//   ctx err: context deadline exceeded"
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("4222/tcp"),
-			wait.ForHTTP("/").WithPort("8222/tcp").WithStartupTimeout(cfg.startTimeout),
-		),
+			wait.ForHTTP("/").WithPort("8222/tcp"),
+		).WithStartupTimeoutDefault(cfg.startTimeout),
 	}
 
 	// Start container
@@ -279,10 +286,17 @@ func NewTestClient(t testing.TB, opts ...TestOption) *TestClient {
 		Image:        "nats:" + cfg.natsVersion,
 		ExposedPorts: []string{"4222/tcp", "8222/tcp"},
 		Cmd:          args,
+		// Startup timeout applied at the ForAll level so it bounds BOTH
+		// strategies. Prior pattern only set it on ForHTTP, leaving
+		// ForListeningPort with its own (shorter) default — under Docker
+		// API pressure the port-listening check would burn through retries
+		// before the HTTP timeout could engage. Symptom:
+		//   "retries: 532, port: '', last err: port '4222/tcp' not found,
+		//   ctx err: context deadline exceeded"
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort("4222/tcp"),
-			wait.ForHTTP("/").WithPort("8222/tcp").WithStartupTimeout(cfg.startTimeout),
-		),
+			wait.ForHTTP("/").WithPort("8222/tcp"),
+		).WithStartupTimeoutDefault(cfg.startTimeout),
 	}
 
 	// Start container

--- a/natsclient/test_options.go
+++ b/natsclient/test_options.go
@@ -4,11 +4,17 @@ import "time"
 
 // Additional helper options for specific use cases
 
-// WithFastStartup configures NATS for fastest possible startup (good for unit tests)
+// WithFastStartup configures NATS for fastest possible RUNTIME (short
+// connection timeout, no extra features). Container startup itself still
+// needs a realistic budget — Docker API responsiveness under parallel
+// test pressure routinely exceeds 10s even when NATS itself is ready in
+// under a second. Use the package default (30s) for the container
+// startup wait; the "fast" part is the 2s connection timeout once the
+// container is up.
 func WithFastStartup() TestOption {
 	return func(cfg *testConfig) {
 		cfg.timeout = 2 * time.Second
-		cfg.startTimeout = 10 * time.Second
+		cfg.startTimeout = 30 * time.Second
 	}
 }
 


### PR DESCRIPTION
## Summary

Two more flakes surfaced in the post-#113 pre-tag sweep — both in the natsclient test-client helper. PR #112 fixed five other sites; these are the last two known instances of the testcontainers-wait flake class.

### 1. \`test_client.go\` — startup timeout only on \`ForHTTP\`, not \`ForListeningPort\`

\`\`\`go
// Before
wait.ForAll(
    wait.ForListeningPort(\"4222/tcp\"),
    wait.ForHTTP(\"/\").WithPort(\"8222/tcp\").WithStartupTimeout(cfg.startTimeout),
)
\`\`\`

Under Docker API pressure, \`ForListeningPort\` burns through retries using its own (shorter) default before the \`ForHTTP\` timeout can engage. Symptom in \`input/udp\`:

\`\`\`
retries: 532, port: \"\", last err: port \"4222/tcp\" not found,
ctx err: context deadline exceeded
\`\`\`

Moved the timeout to the composite via \`.WithStartupTimeoutDefault(cfg.startTimeout)\` so it bounds **both** wait strategies uniformly.

### 2. \`test_options.go\` — \`WithFastStartup\` container budget unrealistic

The option set \`cfg.startTimeout = 10 * time.Second\`. The \"fast\" framing referred to NATS runtime configuration (no JetStream, short connection timeout), but 10s for container startup is unrealistic under parallel-test Docker pressure — Docker API alone can take that long to respond.

Bumped to 30s (matches the package default) and clarified the doc comment that \"fast\" means runtime, not container readiness. The 2s connection timeout is preserved.

## Verification

- \`go test -race -tags=integration -count=1 ./...\` clean, exit 0
- \`task lint\` clean
- Both prior failures (\`TestUDPInput_Creation_InvalidPort\`, \`TestWebSocketInput_NilConnectionHandling\`) now pass in <3s

## Test plan

- [x] Pre-tag sweep clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)