### PR TITLE
feat(graph-ingest): wire entity-level mutation NATS handlers (#98 PR-A)

### DIFF
--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -1127,6 +1127,60 @@ func (c *Component) UpdateEntity(ctx context.Context, entity *graph.EntityState)
 	return nil
 }
 
+// updateEntityAtRevision is the CAS-protected variant of UpdateEntity.
+// It only commits if the entity's KV revision still matches expectedRev,
+// otherwise returns natsclient.ErrKVRevisionMismatch. This closes the
+// resurrect-after-delete window the plain UpdateEntity → Put path has:
+// a concurrent DeleteEntity that lands between the caller's read and
+// this write would otherwise turn an update into a silent re-create.
+//
+// Used by the mutation handlers' must-exist contract
+// (graph.mutation.entity.update / .update_with_triples). UpdateEntity
+// itself stays Put-based for callers (e.g. datamanager edge ops) that
+// want last-writer-wins.
+func (c *Component) updateEntityAtRevision(ctx context.Context, entity *graph.EntityState, expectedRev uint64) error {
+	if entity == nil {
+		return errs.WrapInvalid(errs.ErrInvalidData, "Component", "updateEntityAtRevision", "entity cannot be nil")
+	}
+
+	if err := validateEntityID(entity.ID); err != nil {
+		return err
+	}
+
+	if err := ctx.Err(); err != nil {
+		return errs.Wrap(err, "Component", "updateEntityAtRevision", "context cancelled")
+	}
+
+	data, err := json.Marshal(entity)
+	if err != nil {
+		atomic.AddInt64(&c.errors, 1)
+		return errs.Wrap(err, "Component", "updateEntityAtRevision", "entity serialization")
+	}
+
+	if _, err := c.entityBucket.Update(ctx, entity.ID, data, expectedRev); err != nil {
+		// ErrKVRevisionMismatch and other KV errors propagate verbatim so
+		// callers can branch with errors.Is(..., natsclient.ErrKVRevisionMismatch).
+		atomic.AddInt64(&c.errors, 1)
+		return err
+	}
+
+	if c.entityCache != nil {
+		c.entityCache.Delete(entity.ID) //nolint:errcheck
+	}
+
+	atomic.AddInt64(&c.messagesProcessed, 1)
+	atomic.AddInt64(&c.bytesProcessed, int64(len(data)))
+	c.lastActivity.Store(time.Now())
+	c.entitiesUpdated.Inc()
+
+	c.logger.Debug("entity updated (CAS)",
+		slog.String("entity_id", entity.ID),
+		slog.Uint64("expected_revision", expectedRev),
+		slog.Uint64("version", entity.Version))
+
+	return nil
+}
+
 // DeleteEntity removes an entity from the graph
 func (c *Component) DeleteEntity(ctx context.Context, entityID string) error {
 	// Validate entity ID format

--- a/processor/graph-ingest/entity_mutation_integration_test.go
+++ b/processor/graph-ingest/entity_mutation_integration_test.go
@@ -112,6 +112,13 @@ func TestIntegration_HandleEntityCreateWithTriples_PreservesProvenance(t *testin
 			Key:             "test/key",
 			ContentType:     "application/json",
 		},
+		// req.Triples (below) is the canonical set per the
+		// create_with_triples doc-comment. Entity.Triples here is a
+		// distractor that should NOT survive — pinning the
+		// replacement semantic, not append.
+		Triples: []message.Triple{
+			{Subject: entityID, Predicate: "should.be.replaced", Object: "distractor", Timestamp: now, Confidence: 1.0},
+		},
 	}
 	triples := []message.Triple{
 		{Subject: entityID, Predicate: "sensorml.uid", Object: "urn:test:001", Timestamp: now, Confidence: 1.0},
@@ -143,7 +150,11 @@ func TestIntegration_HandleEntityCreateWithTriples_PreservesProvenance(t *testin
 	assert.NotNil(t, stored.StorageRef, "StorageRef preserved")
 	assert.Equal(t, "test-bucket", stored.StorageRef.StorageInstance)
 	assert.Equal(t, "test/key", stored.StorageRef.Key)
-	assert.Len(t, stored.Triples, 2)
+	assert.Len(t, stored.Triples, 2, "req.Triples should REPLACE Entity.Triples, not append")
+	for _, tr := range stored.Triples {
+		assert.NotEqual(t, "should.be.replaced", tr.Predicate,
+			"distractor predicate from req.Entity.Triples must not survive when req.Triples is non-empty")
+	}
 }
 
 func TestIntegration_HandleEntityUpdate_NotFound(t *testing.T) {
@@ -284,6 +295,164 @@ func TestIntegration_HandleEntityDelete_Idempotent(t *testing.T) {
 	require.NoError(t, json.Unmarshal(respBytes, &resp))
 	assert.True(t, resp.Success, "delete of absent entity should succeed (idempotent)")
 	assert.False(t, resp.Deleted, "Deleted should be false when entity was already absent")
+}
+
+// TestIntegration_HandleEntityUpdate_ResurrectAfterDelete pins the
+// CAS fix for the must-exist contract. Without CAS, a delete that
+// lands between the handler's existence check and its write would
+// silently re-create the entity — violating the contract semconnect
+// maps to HTTP 404. With CAS, the write fails with the same
+// "entity not found" shape callers already handle.
+//
+// Simulates the race deterministically: read the current revision,
+// delete out-of-band, then attempt the update — that's the same
+// observable state as "a concurrent delete won the race".
+func TestIntegration_HandleEntityUpdate_ResurrectAfterDelete(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.update.resurrect.001"
+	original := newMutationTestEntity(entityID)
+	require.NoError(t, c.CreateEntity(ctx, original), "seed entity")
+
+	// Simulate the concurrent delete: out-of-band, after the handler
+	// would have done its existence check, but before its write.
+	require.NoError(t, c.DeleteEntity(ctx, entityID), "delete between read and write")
+
+	updated := newMutationTestEntity(entityID)
+	updated.Version = 2
+	req := graph.UpdateEntityRequest{Entity: updated, RequestID: "req-resurrect"}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleEntityUpdate(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.UpdateEntityResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	assert.False(t, resp.Success, "update on deleted entity must NOT silently resurrect")
+	assert.Contains(t, resp.Error, "not found",
+		"error body should signal absence so semconnect can map to HTTP 404")
+
+	exists, err := c.entityExists(ctx, entityID)
+	require.NoError(t, err)
+	assert.False(t, exists, "entity must remain absent after the failed update")
+}
+
+// TestIntegration_HandleEntityUpdate_KVRevisionIncrements pins the
+// cache-invalidation / monotonic-revision contract downstream readers
+// (semconnect ETags, change-detection consumers) depend on.
+func TestIntegration_HandleEntityUpdate_KVRevisionIncrements(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.update.revmono.001"
+	require.NoError(t, c.CreateEntity(ctx, newMutationTestEntity(entityID)), "seed entity")
+
+	// First update: capture revision.
+	first := newMutationTestEntity(entityID)
+	first.Version = 2
+	r1, err := c.handleEntityUpdate(ctx, mustJSON(t, graph.UpdateEntityRequest{Entity: first}))
+	require.NoError(t, err)
+	var resp1 graph.UpdateEntityResponse
+	require.NoError(t, json.Unmarshal(r1, &resp1))
+	require.True(t, resp1.Success, "first update should succeed; err=%q", resp1.Error)
+
+	// Second update: revision must be strictly greater.
+	second := newMutationTestEntity(entityID)
+	second.Version = 3
+	r2, err := c.handleEntityUpdate(ctx, mustJSON(t, graph.UpdateEntityRequest{Entity: second}))
+	require.NoError(t, err)
+	var resp2 graph.UpdateEntityResponse
+	require.NoError(t, json.Unmarshal(r2, &resp2))
+	require.True(t, resp2.Success, "second update should succeed; err=%q", resp2.Error)
+
+	assert.Greater(t, resp2.KVRevision, resp1.KVRevision,
+		"sequential updates must produce strictly increasing KV revisions")
+}
+
+// TestIntegration_HandleEntity_NilEntity pins the nil-body guard
+// across all four entity-shape handlers — the guards exist in the
+// code; this test ensures a future refactor that drops them surfaces
+// the regression.
+func TestIntegration_HandleEntity_NilEntity(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	cases := []struct {
+		name    string
+		payload any
+		handler func([]byte) ([]byte, error)
+	}{
+		{"create", graph.CreateEntityRequest{Entity: nil}, func(b []byte) ([]byte, error) { return c.handleEntityCreate(ctx, b) }},
+		{"create_with_triples", graph.CreateEntityWithTriplesRequest{Entity: nil}, func(b []byte) ([]byte, error) { return c.handleEntityCreateWithTriples(ctx, b) }},
+		{"update", graph.UpdateEntityRequest{Entity: nil}, func(b []byte) ([]byte, error) { return c.handleEntityUpdate(ctx, b) }},
+		{"update_with_triples", graph.UpdateEntityWithTriplesRequest{Entity: nil}, func(b []byte) ([]byte, error) { return c.handleEntityUpdateWithTriples(ctx, b) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			respBytes, err := tc.handler(mustJSON(t, tc.payload))
+			require.NoError(t, err)
+
+			var base struct {
+				Success bool   `json:"success"`
+				Error   string `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(respBytes, &base))
+			assert.False(t, base.Success)
+			assert.Contains(t, base.Error, "entity cannot be nil")
+		})
+	}
+}
+
+// TestIntegration_HandleEntityDelete_EmptyID pins the empty-EntityID
+// guard. Without it, the handler would forward an empty key to
+// entityBucket.Delete and the failure mode would depend on the
+// underlying KV (likely a different error class than "invalid
+// request"). Pin the classification at the handler boundary.
+func TestIntegration_HandleEntityDelete_EmptyID(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	req := graph.DeleteEntityRequest{EntityID: "", RequestID: "req-delete-empty"}
+	respBytes, err := c.handleEntityDelete(ctx, mustJSON(t, req))
+	require.NoError(t, err)
+
+	var resp graph.DeleteEntityResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	assert.False(t, resp.Success)
+	assert.Contains(t, resp.Error, "entity_id cannot be empty")
+}
+
+// TestIntegration_HandleEntityUpdateWithTriples_UnknownRemovePredicate
+// pins the "remove if present" semantic: naming a predicate in
+// RemoveTriples that doesn't exist on the entity is NOT an error,
+// it's a no-op. Downstream gateways (semconnect cs-api PATCH
+// /systems/{id}) rely on this — they emit RemoveTriples blindly
+// when they don't know which predicates were previously written.
+func TestIntegration_HandleEntityUpdateWithTriples_UnknownRemovePredicate(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.update_wt.unknown_remove.001"
+	require.NoError(t, c.CreateEntity(ctx, newMutationTestEntity(entityID)), "seed entity")
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:        newMutationTestEntity(entityID),
+		RemoveTriples: []string{"never.set.predicate"},
+		RequestID:     "req-update-wt-unknown",
+	}
+	respBytes, err := c.handleEntityUpdateWithTriples(ctx, mustJSON(t, req))
+	require.NoError(t, err)
+
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	require.True(t, resp.Success, "unknown RemoveTriples predicate must not fail; err=%q", resp.Error)
+	assert.Equal(t, 0, resp.TriplesRemoved, "no triples should be removed when the named predicate isn't present")
+}
+
+// mustJSON is a test convenience: marshals or fails the test.
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
 }
 
 func TestIntegration_HandleEntity_InvalidJSON(t *testing.T) {

--- a/processor/graph-ingest/entity_mutation_integration_test.go
+++ b/processor/graph-ingest/entity_mutation_integration_test.go
@@ -4,11 +4,13 @@ package graphingest
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -297,30 +299,29 @@ func TestIntegration_HandleEntityDelete_Idempotent(t *testing.T) {
 	assert.False(t, resp.Deleted, "Deleted should be false when entity was already absent")
 }
 
-// TestIntegration_HandleEntityUpdate_ResurrectAfterDelete pins the
-// CAS fix for the must-exist contract. Without CAS, a delete that
-// lands between the handler's existence check and its write would
-// silently re-create the entity — violating the contract semconnect
-// maps to HTTP 404. With CAS, the write fails with the same
-// "entity not found" shape callers already handle.
+// TestIntegration_HandleEntityUpdate_DeleteBeforeUpdate pins the
+// must-exist contract on the *handler* level when the entity is
+// already gone by the time the handler runs. This exercises the
+// fetchEntityState → ErrKVKeyNotFound path (mutations.go:430),
+// NOT the CAS branch (which can only be reached if the delete
+// races between fetchEntityState and updateEntityAtRevision).
 //
-// Simulates the race deterministically: read the current revision,
-// delete out-of-band, then attempt the update — that's the same
-// observable state as "a concurrent delete won the race".
-func TestIntegration_HandleEntityUpdate_ResurrectAfterDelete(t *testing.T) {
+// The CAS branch itself is covered by
+// TestIntegration_UpdateEntityAtRevision_StaleRevisionFromConcurrentDelete
+// below — that test invokes the CAS primitive directly with a
+// stale revision, which is the only deterministic way to exercise
+// the post-fetch race window without a mock bucket.
+func TestIntegration_HandleEntityUpdate_DeleteBeforeUpdate(t *testing.T) {
 	ctx, c := startBatchTestComponent(t)
 
-	const entityID = "c360.test.entity.update.resurrect.001"
+	const entityID = "c360.test.entity.update.delbefore.001"
 	original := newMutationTestEntity(entityID)
 	require.NoError(t, c.CreateEntity(ctx, original), "seed entity")
-
-	// Simulate the concurrent delete: out-of-band, after the handler
-	// would have done its existence check, but before its write.
-	require.NoError(t, c.DeleteEntity(ctx, entityID), "delete between read and write")
+	require.NoError(t, c.DeleteEntity(ctx, entityID), "delete before handler runs")
 
 	updated := newMutationTestEntity(entityID)
 	updated.Version = 2
-	req := graph.UpdateEntityRequest{Entity: updated, RequestID: "req-resurrect"}
+	req := graph.UpdateEntityRequest{Entity: updated, RequestID: "req-delbefore"}
 	reqBytes, err := json.Marshal(req)
 	require.NoError(t, err)
 
@@ -336,6 +337,48 @@ func TestIntegration_HandleEntityUpdate_ResurrectAfterDelete(t *testing.T) {
 	exists, err := c.entityExists(ctx, entityID)
 	require.NoError(t, err)
 	assert.False(t, exists, "entity must remain absent after the failed update")
+}
+
+// TestIntegration_UpdateEntityAtRevision_StaleRevisionFromConcurrentDelete
+// pins the CAS primitive's behavior under the actual race the
+// must-exist contract protects against: a delete lands between
+// the handler's read (which captured revision R1) and the
+// handler's write (CAS attempt at R1). The tombstone bumps the
+// stream sequence, so CAS at R1 fails with ErrKVRevisionMismatch
+// instead of silently resurrecting the entity via Put.
+//
+// Tests the primitive directly (not through the handler) because
+// the handler's fetchEntityState would catch the delete first if
+// we deleted before invoking it — only by calling
+// updateEntityAtRevision with a captured stale revision can we
+// hit the post-fetch, pre-write window deterministically.
+func TestIntegration_UpdateEntityAtRevision_StaleRevisionFromConcurrentDelete(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.cas.staledel.001"
+	original := newMutationTestEntity(entityID)
+	require.NoError(t, c.CreateEntity(ctx, original), "seed entity")
+
+	// Capture the revision while the entity exists — this models the
+	// state the handler holds after fetchEntityState succeeds.
+	_, capturedRev, err := c.fetchEntityState(ctx, entityID)
+	require.NoError(t, err)
+	require.NotZero(t, capturedRev)
+
+	// Out-of-band delete: the tombstone moves the KV sequence past
+	// capturedRev, so any subsequent CAS at capturedRev must fail.
+	require.NoError(t, c.DeleteEntity(ctx, entityID), "delete between read and write")
+
+	updated := newMutationTestEntity(entityID)
+	updated.Version = 2
+	err = c.updateEntityAtRevision(ctx, updated, capturedRev)
+	require.Error(t, err, "CAS at stale revision after concurrent delete must fail")
+	assert.True(t, errors.Is(err, natsclient.ErrKVRevisionMismatch),
+		"stale-revision CAS after delete must produce ErrKVRevisionMismatch; got: %v", err)
+
+	exists, err := c.entityExists(ctx, entityID)
+	require.NoError(t, err)
+	assert.False(t, exists, "failed CAS must not resurrect the deleted entity")
 }
 
 // TestIntegration_HandleEntityUpdate_KVRevisionIncrements pins the

--- a/processor/graph-ingest/entity_mutation_integration_test.go
+++ b/processor/graph-ingest/entity_mutation_integration_test.go
@@ -1,0 +1,319 @@
+//go:build integration
+
+package graphingest
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Round-trip integration tests for the entity-level mutation handlers
+// landed for GH #98 (PR-A). Each handler is exercised through its
+// NATS-callback shape (same surface natsclient.SubscribeForRequests
+// delivers) to validate the wire envelope, success/error flagging,
+// and the create-or-fail / must-exist / idempotent-delete semantics
+// that CS API gateways (semconnect) need to map cleanly to HTTP
+// status codes.
+//
+// PR-A semantics validated here:
+//   - SubjectEntityCreate                : create-or-fail (409-shape on duplicate)
+//   - SubjectEntityCreateWithTriples     : same as above + carries EntityState provenance
+//   - SubjectEntityUpdate                : must-exist (404-shape when absent)
+//   - SubjectEntityUpdateWithTriples     : must-exist + applies AddTriples/RemoveTriples delta
+//   - SubjectEntityDelete                : idempotent (Deleted bool reflects prior presence)
+//
+// PR-B will close the partial-erasure window in the with_triples
+// update path with a single CAS over the entity state; the existing
+// tests below pin the SEMANTICS, not the implementation, so PR-B
+// should not have to rewrite them.
+
+// testMutationType is the synthetic Type used by these integration tests.
+// Kept distinct from any production domain to make filtering / debugging
+// easier.
+var testMutationType = message.Type{
+	Domain:   "test",
+	Category: "mutation",
+	Version:  "v1",
+}
+
+func newMutationTestEntity(id string) *graph.EntityState {
+	now := time.Now()
+	return &graph.EntityState{
+		ID: id,
+		Triples: []message.Triple{
+			{Subject: id, Predicate: "test.kind", Object: "sample", Timestamp: now, Confidence: 1.0},
+		},
+		MessageType: testMutationType,
+		Version:     1,
+		UpdatedAt:   now,
+	}
+}
+
+func TestIntegration_HandleEntityCreate_Success(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	entity := newMutationTestEntity("c360.test.entity.create.success.001")
+	req := graph.CreateEntityRequest{Entity: entity, RequestID: "req-create-1"}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleEntityCreate(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.CreateEntityResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	require.True(t, resp.Success, "create on fresh ID should succeed; err=%q", resp.Error)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, "req-create-1", resp.RequestID, "RequestID should round-trip")
+	assert.NotZero(t, resp.KVRevision, "revision should be set after a successful write")
+	require.NotNil(t, resp.Entity, "Entity should be populated in success response")
+	assert.Equal(t, entity.ID, resp.Entity.ID)
+}
+
+func TestIntegration_HandleEntityCreate_Conflict(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	entity := newMutationTestEntity("c360.test.entity.create.conflict.001")
+	require.NoError(t, c.CreateEntity(ctx, entity), "seed entity")
+
+	req := graph.CreateEntityRequest{Entity: entity, RequestID: "req-create-conflict"}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleEntityCreate(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.CreateEntityResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	assert.False(t, resp.Success, "duplicate create should not succeed")
+	assert.Contains(t, resp.Error, "already exists",
+		"error body should signal conflict so semconnect can map to HTTP 409")
+	assert.Equal(t, "req-create-conflict", resp.RequestID)
+}
+
+func TestIntegration_HandleEntityCreateWithTriples_PreservesProvenance(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.create_wt.provenance.001"
+	now := time.Now()
+	entity := &graph.EntityState{
+		ID:          entityID,
+		MessageType: testMutationType,
+		Version:     7, // provenance: caller asserts this version
+		UpdatedAt:   now,
+		StorageRef: &message.StorageReference{
+			StorageInstance: "test-bucket",
+			Key:             "test/key",
+			ContentType:     "application/json",
+		},
+	}
+	triples := []message.Triple{
+		{Subject: entityID, Predicate: "sensorml.uid", Object: "urn:test:001", Timestamp: now, Confidence: 1.0},
+		{Subject: entityID, Predicate: "sensorml.label", Object: "Test Sensor", Timestamp: now, Confidence: 1.0},
+	}
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity:    entity,
+		Triples:   triples,
+		RequestID: "req-create-wt-prov",
+	}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleEntityCreateWithTriples(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	require.True(t, resp.Success, "create_with_triples on fresh ID should succeed; err=%q", resp.Error)
+	assert.Equal(t, 2, resp.TriplesAdded)
+
+	// Verify provenance survived to storage — the load-bearing reason
+	// for the *_with_triples variant over a plain add_batch upsert.
+	entry, err := c.entityBucket.Get(ctx, entityID)
+	require.NoError(t, err)
+	var stored graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &stored))
+	assert.True(t, testMutationType.Equal(stored.MessageType), "MessageType provenance preserved")
+	assert.NotNil(t, stored.StorageRef, "StorageRef preserved")
+	assert.Equal(t, "test-bucket", stored.StorageRef.StorageInstance)
+	assert.Equal(t, "test/key", stored.StorageRef.Key)
+	assert.Len(t, stored.Triples, 2)
+}
+
+func TestIntegration_HandleEntityUpdate_NotFound(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	entity := newMutationTestEntity("c360.test.entity.update.notfound.001")
+	req := graph.UpdateEntityRequest{Entity: entity, RequestID: "req-update-404"}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleEntityUpdate(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.UpdateEntityResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	assert.False(t, resp.Success, "update on absent entity should not succeed")
+	assert.Contains(t, resp.Error, "not found",
+		"error body should signal absence so semconnect can map to HTTP 404")
+}
+
+func TestIntegration_HandleEntityUpdate_Success(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.update.success.001"
+	original := newMutationTestEntity(entityID)
+	require.NoError(t, c.CreateEntity(ctx, original), "seed entity")
+
+	updated := newMutationTestEntity(entityID)
+	updated.Triples = append(updated.Triples, message.Triple{
+		Subject:    entityID,
+		Predicate:  "test.added",
+		Object:     "by-update",
+		Timestamp:  time.Now(),
+		Confidence: 1.0,
+	})
+	updated.Version = 2
+
+	req := graph.UpdateEntityRequest{Entity: updated, RequestID: "req-update-ok"}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleEntityUpdate(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.UpdateEntityResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	require.True(t, resp.Success, "update on existing entity should succeed; err=%q", resp.Error)
+	assert.Equal(t, int64(2), resp.Version)
+}
+
+func TestIntegration_HandleEntityUpdateWithTriples_AddAndRemove(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.update_wt.delta.001"
+	now := time.Now()
+	seed := &graph.EntityState{
+		ID:          entityID,
+		MessageType: testMutationType,
+		Version:     1,
+		UpdatedAt:   now,
+		Triples: []message.Triple{
+			{Subject: entityID, Predicate: "test.keep", Object: "keep-me", Timestamp: now, Confidence: 1.0},
+			{Subject: entityID, Predicate: "test.drop", Object: "drop-me", Timestamp: now, Confidence: 1.0},
+		},
+	}
+	require.NoError(t, c.CreateEntity(ctx, seed), "seed entity")
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:        seed, // metadata flows through
+		AddTriples:    []message.Triple{{Subject: entityID, Predicate: "test.added", Object: "added-me", Timestamp: now, Confidence: 1.0}},
+		RemoveTriples: []string{"test.drop"},
+		RequestID:     "req-update-wt-delta",
+	}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleEntityUpdateWithTriples(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	require.True(t, resp.Success, "update_with_triples should succeed; err=%q", resp.Error)
+	assert.Equal(t, 1, resp.TriplesAdded)
+	assert.Equal(t, 1, resp.TriplesRemoved)
+
+	// Verify the stored triples reflect the delta.
+	entry, err := c.entityBucket.Get(ctx, entityID)
+	require.NoError(t, err)
+	var stored graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &stored))
+
+	predicates := make(map[string]bool, len(stored.Triples))
+	for _, tr := range stored.Triples {
+		predicates[tr.Predicate] = true
+	}
+	assert.True(t, predicates["test.keep"], "test.keep should survive")
+	assert.False(t, predicates["test.drop"], "test.drop should be removed")
+	assert.True(t, predicates["test.added"], "test.added should be appended")
+}
+
+func TestIntegration_HandleEntityDelete_Existing(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.delete.existing.001"
+	require.NoError(t, c.CreateEntity(ctx, newMutationTestEntity(entityID)), "seed entity")
+
+	req := graph.DeleteEntityRequest{EntityID: entityID, RequestID: "req-delete-1"}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleEntityDelete(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.DeleteEntityResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	require.True(t, resp.Success, "delete of existing entity should succeed; err=%q", resp.Error)
+	assert.True(t, resp.Deleted, "Deleted should be true when the entity was present")
+
+	exists, err := c.entityExists(ctx, entityID)
+	require.NoError(t, err)
+	assert.False(t, exists, "entity should be gone after delete")
+}
+
+func TestIntegration_HandleEntityDelete_Idempotent(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	req := graph.DeleteEntityRequest{
+		EntityID:  "c360.test.entity.delete.absent.001",
+		RequestID: "req-delete-idempotent",
+	}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, err := c.handleEntityDelete(ctx, reqBytes)
+	require.NoError(t, err)
+
+	var resp graph.DeleteEntityResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	assert.True(t, resp.Success, "delete of absent entity should succeed (idempotent)")
+	assert.False(t, resp.Deleted, "Deleted should be false when entity was already absent")
+}
+
+func TestIntegration_HandleEntity_InvalidJSON(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	cases := []struct {
+		name    string
+		handler func([]byte) ([]byte, error)
+	}{
+		{"create", func(b []byte) ([]byte, error) { return c.handleEntityCreate(ctx, b) }},
+		{"create_with_triples", func(b []byte) ([]byte, error) { return c.handleEntityCreateWithTriples(ctx, b) }},
+		{"update", func(b []byte) ([]byte, error) { return c.handleEntityUpdate(ctx, b) }},
+		{"update_with_triples", func(b []byte) ([]byte, error) { return c.handleEntityUpdateWithTriples(ctx, b) }},
+		{"delete", func(b []byte) ([]byte, error) { return c.handleEntityDelete(ctx, b) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			respBytes, err := tc.handler([]byte("not json"))
+			require.NoError(t, err, "handler should never return a non-nil err — error lives in the response body per feedback_natsclient_error_payload_convention")
+
+			// Each shape has a MutationResponse embedded; we can unmarshal
+			// to the base type just to read the Success/Error flags.
+			var base struct {
+				Success bool   `json:"success"`
+				Error   string `json:"error"`
+			}
+			require.NoError(t, json.Unmarshal(respBytes, &base))
+			assert.False(t, base.Success)
+			assert.Contains(t, base.Error, "invalid request")
+		})
+	}
+}

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -1,13 +1,16 @@
-// Package graphingest mutation handlers for triple operations via NATS request/reply.
+// Package graphingest mutation handlers for triple and entity operations via NATS request/reply.
 package graphingest
 
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
 )
 
 const (
@@ -20,6 +23,46 @@ const (
 	SubjectTripleAddBatch = "graph.mutation.triple.add_batch"
 	// SubjectTripleRemove is the NATS subject for remove triple requests
 	SubjectTripleRemove = "graph.mutation.triple.remove"
+
+	// Entity-level mutation subjects. Triple-level subjects (above) treat
+	// the entity as upsert-target — AddTriple's CAS path creates the
+	// entity if it doesn't exist. The entity-level subjects below carry
+	// stricter semantics so CS API gateways (semconnect) can map them to
+	// HTTP create-or-conflict / must-exist / delete contracts without
+	// app-side shims. See GH #98 + docs/operations/22-adr045-phase1-plan.md
+	// (peer queue context).
+
+	// SubjectEntityCreate is the NATS subject for create-or-fail entity
+	// requests. Returns Success=false with "entity already exists" when
+	// the entity ID is present — lets a CS API POST surface 409 Conflict
+	// without a separate existence pre-check.
+	SubjectEntityCreate = "graph.mutation.entity.create"
+
+	// SubjectEntityCreateWithTriples is the NATS subject for atomic
+	// entity+triples creation. Carries the full EntityState shape
+	// (MessageType, Version, StorageRef) so provenance fields survive
+	// — fields AddTriple synthesizes with defaults. Same create-or-fail
+	// semantics as SubjectEntityCreate.
+	SubjectEntityCreateWithTriples = "graph.mutation.entity.create_with_triples"
+
+	// SubjectEntityUpdate is the NATS subject for must-exist entity
+	// updates. Returns Success=false with "entity not found" when the
+	// entity ID is absent — lets a CS API PUT/PATCH surface 404 without
+	// silently upserting a new entity.
+	SubjectEntityUpdate = "graph.mutation.entity.update"
+
+	// SubjectEntityUpdateWithTriples is the NATS subject for must-exist
+	// entity updates with triple-set deltas. AddTriples appends; the
+	// RemoveTriples slice names predicates whose triples are removed.
+	// PR-A applies the delta via read-modify-write (TOCTOU window
+	// possible); PR-B will switch to a single CAS over the entity state
+	// to close the partial-erasure window semconnect Stage 27 flagged.
+	SubjectEntityUpdateWithTriples = "graph.mutation.entity.update_with_triples"
+
+	// SubjectEntityDelete is the NATS subject for entity-scoped delete.
+	// Idempotent — deleting a non-existent entity returns Success=true,
+	// Deleted=false (the NATS KV Delete primitive is itself idempotent).
+	SubjectEntityDelete = "graph.mutation.entity.delete"
 )
 
 // setupMutationHandlers registers NATS request handlers for triple mutations.
@@ -44,8 +87,43 @@ func (c *Component) setupMutationHandlers(ctx context.Context) error {
 	}
 	c.subscriptions = append(c.subscriptions, sub)
 
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityCreate, c.handleEntityCreate)
+	if err != nil {
+		return fmt.Errorf("subscribe entity create: %w", err)
+	}
+	c.subscriptions = append(c.subscriptions, sub)
+
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityCreateWithTriples, c.handleEntityCreateWithTriples)
+	if err != nil {
+		return fmt.Errorf("subscribe entity create_with_triples: %w", err)
+	}
+	c.subscriptions = append(c.subscriptions, sub)
+
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityUpdate, c.handleEntityUpdate)
+	if err != nil {
+		return fmt.Errorf("subscribe entity update: %w", err)
+	}
+	c.subscriptions = append(c.subscriptions, sub)
+
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityUpdateWithTriples, c.handleEntityUpdateWithTriples)
+	if err != nil {
+		return fmt.Errorf("subscribe entity update_with_triples: %w", err)
+	}
+	c.subscriptions = append(c.subscriptions, sub)
+
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityDelete, c.handleEntityDelete)
+	if err != nil {
+		return fmt.Errorf("subscribe entity delete: %w", err)
+	}
+	c.subscriptions = append(c.subscriptions, sub)
+
 	c.logger.Info("mutation handlers registered",
-		"subjects", []string{SubjectTripleAdd, SubjectTripleAddBatch, SubjectTripleRemove})
+		"subjects", []string{
+			SubjectTripleAdd, SubjectTripleAddBatch, SubjectTripleRemove,
+			SubjectEntityCreate, SubjectEntityCreateWithTriples,
+			SubjectEntityUpdate, SubjectEntityUpdateWithTriples,
+			SubjectEntityDelete,
+		})
 	return nil
 }
 
@@ -184,5 +262,359 @@ func (c *Component) handleTripleRemove(ctx context.Context, data []byte) ([]byte
 			KVRevision: kvRevision,
 		},
 		Removed: true,
+	})
+}
+
+// entityExists reports whether the named entity is present in the
+// entity bucket. Returns (true, nil) if present, (false, nil) if not,
+// or (false, err) for any KV error other than "key not found".
+//
+// Per feedback_jetstream_sentinel_set_coverage: ErrKeyNotFound and
+// ErrNoKeysFound are different sentinels. This helper only collapses
+// the single-key not-found path; callers querying key sets must
+// handle both.
+func (c *Component) entityExists(ctx context.Context, entityID string) (bool, error) {
+	_, err := c.entityBucket.Get(ctx, entityID)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
+// entityRevisionAfterWrite returns the KV revision of the entity bucket
+// entry after a successful mutation. Best-effort: a Get failure here
+// surfaces as 0 (the caller's response just omits the KVRevision field).
+func (c *Component) entityRevisionAfterWrite(ctx context.Context, entityID string) uint64 {
+	entry, err := c.entityBucket.Get(ctx, entityID)
+	if err != nil {
+		return 0
+	}
+	return entry.Revision
+}
+
+// handleEntityCreate enforces create-or-fail semantics: returns
+// Success=false with an "entity already exists" error if the entity
+// ID is already present. CS API §7.6 (POST is strictly create) maps
+// that error to HTTP 409 Conflict — the path semconnect Stage 8 had
+// to fall back from when only triple.add_batch (upsert) was wired.
+//
+// PR-A: existence check is a Get followed by CreateEntity (Put). The
+// TOCTOU window between the two is acknowledged; PR-B will switch to
+// the atomic KV Create primitive that fails if the key exists.
+func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte, error) {
+	var req graph.CreateEntityRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return marshalCreateEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("invalid request: %v", err))
+	}
+	if req.Entity == nil {
+		return marshalCreateEntityError(req.TraceID, req.RequestID, "entity cannot be nil")
+	}
+
+	exists, err := c.entityExists(ctx, req.Entity.ID)
+	if err != nil {
+		return marshalCreateEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("existence check failed: %v", err))
+	}
+	if exists {
+		return marshalCreateEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("entity already exists: %s", req.Entity.ID))
+	}
+
+	if err := c.CreateEntity(ctx, req.Entity); err != nil {
+		return marshalCreateEntityError(req.TraceID, req.RequestID, err.Error())
+	}
+
+	return json.Marshal(graph.CreateEntityResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:    true,
+			Timestamp:  time.Now().UnixNano(),
+			KVRevision: c.entityRevisionAfterWrite(ctx, req.Entity.ID),
+			TraceID:    req.TraceID,
+			RequestID:  req.RequestID,
+		},
+		Entity: req.Entity,
+	})
+}
+
+// handleEntityCreateWithTriples is handleEntityCreate that also accepts
+// a Triples slice in the request envelope. When Triples is non-empty
+// it REPLACES Entity.Triples before the write (the canonical set is
+// the request's Triples; Entity carries provenance metadata). When
+// Triples is nil/empty, Entity.Triples is written as-is.
+func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
+	var req graph.CreateEntityWithTriplesRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID,
+			fmt.Sprintf("invalid request: %v", err))
+	}
+	if req.Entity == nil {
+		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID, "entity cannot be nil")
+	}
+
+	exists, err := c.entityExists(ctx, req.Entity.ID)
+	if err != nil {
+		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID,
+			fmt.Sprintf("existence check failed: %v", err))
+	}
+	if exists {
+		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID,
+			fmt.Sprintf("entity already exists: %s", req.Entity.ID))
+	}
+
+	if len(req.Triples) > 0 {
+		req.Entity.Triples = req.Triples
+	}
+
+	if err := c.CreateEntity(ctx, req.Entity); err != nil {
+		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
+	}
+
+	return json.Marshal(graph.CreateEntityWithTriplesResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:    true,
+			Timestamp:  time.Now().UnixNano(),
+			KVRevision: c.entityRevisionAfterWrite(ctx, req.Entity.ID),
+			TraceID:    req.TraceID,
+			RequestID:  req.RequestID,
+		},
+		Entity:       req.Entity,
+		TriplesAdded: len(req.Entity.Triples),
+	})
+}
+
+// handleEntityUpdate enforces must-exist semantics: returns Success=false
+// with "entity not found" when the entity ID is absent. CS API PUT/PATCH
+// maps that to HTTP 404 — distinct from create-or-conflict semantics
+// in handleEntityCreate.
+func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte, error) {
+	var req graph.UpdateEntityRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return marshalUpdateEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("invalid request: %v", err))
+	}
+	if req.Entity == nil {
+		return marshalUpdateEntityError(req.TraceID, req.RequestID, "entity cannot be nil")
+	}
+
+	exists, err := c.entityExists(ctx, req.Entity.ID)
+	if err != nil {
+		return marshalUpdateEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("existence check failed: %v", err))
+	}
+	if !exists {
+		return marshalUpdateEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("entity not found: %s", req.Entity.ID))
+	}
+
+	if err := c.UpdateEntity(ctx, req.Entity); err != nil {
+		return marshalUpdateEntityError(req.TraceID, req.RequestID, err.Error())
+	}
+
+	return json.Marshal(graph.UpdateEntityResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:    true,
+			Timestamp:  time.Now().UnixNano(),
+			KVRevision: c.entityRevisionAfterWrite(ctx, req.Entity.ID),
+			TraceID:    req.TraceID,
+			RequestID:  req.RequestID,
+		},
+		Entity:  req.Entity,
+		Version: int64(req.Entity.Version),
+	})
+}
+
+// handleEntityUpdateWithTriples applies a triple-set delta to an
+// existing entity: appends AddTriples, removes triples whose Predicate
+// is named in RemoveTriples, and writes the result. Entity metadata
+// (MessageType, Version, StorageRef) from the request also flows
+// through.
+//
+// PR-A: read-modify-write — fetch current entity, apply delta in
+// memory, Put. TOCTOU window between fetch and put is acknowledged;
+// PR-B will collapse this to a single CAS over the entity state,
+// closing the partial-erasure window semconnect Stage 27 (2026-05-21)
+// called out across PUT/PATCH/DELETE on systems + datastreams.
+func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
+	var req graph.UpdateEntityWithTriplesRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
+			fmt.Sprintf("invalid request: %v", err))
+	}
+	if req.Entity == nil {
+		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID, "entity cannot be nil")
+	}
+
+	current, err := c.fetchEntityState(ctx, req.Entity.ID)
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
+				fmt.Sprintf("entity not found: %s", req.Entity.ID))
+		}
+		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
+			fmt.Sprintf("fetch current entity failed: %v", err))
+	}
+
+	// Build the merged triple set: start from current.Triples, drop
+	// any whose Predicate appears in RemoveTriples, then append
+	// req.AddTriples. The merged set replaces req.Entity.Triples so
+	// metadata fields (MessageType, Version, StorageRef) flow through.
+	removed := 0
+	if len(req.RemoveTriples) > 0 {
+		removeSet := make(map[string]struct{}, len(req.RemoveTriples))
+		for _, p := range req.RemoveTriples {
+			removeSet[p] = struct{}{}
+		}
+		kept := make([]message.Triple, 0, len(current.Triples))
+		for _, t := range current.Triples {
+			if _, drop := removeSet[t.Predicate]; drop {
+				removed++
+				continue
+			}
+			kept = append(kept, t)
+		}
+		current.Triples = kept
+	}
+	if len(req.AddTriples) > 0 {
+		current.Triples = append(current.Triples, req.AddTriples...)
+	}
+
+	req.Entity.Triples = current.Triples
+
+	if err := c.UpdateEntity(ctx, req.Entity); err != nil {
+		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
+	}
+
+	return json.Marshal(graph.UpdateEntityWithTriplesResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:    true,
+			Timestamp:  time.Now().UnixNano(),
+			KVRevision: c.entityRevisionAfterWrite(ctx, req.Entity.ID),
+			TraceID:    req.TraceID,
+			RequestID:  req.RequestID,
+		},
+		Entity:         req.Entity,
+		TriplesAdded:   len(req.AddTriples),
+		TriplesRemoved: removed,
+		Version:        int64(req.Entity.Version),
+	})
+}
+
+// handleEntityDelete is entity-scoped delete. Idempotent: deleting a
+// non-existent entity returns Success=true, Deleted=false. The NATS
+// KV Delete primitive itself is idempotent, so this handler just
+// distinguishes "the call succeeded" from "the entity actually was
+// present" via the Deleted bool.
+func (c *Component) handleEntityDelete(ctx context.Context, data []byte) ([]byte, error) {
+	var req graph.DeleteEntityRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return marshalDeleteEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("invalid request: %v", err))
+	}
+	if req.EntityID == "" {
+		return marshalDeleteEntityError(req.TraceID, req.RequestID, "entity_id cannot be empty")
+	}
+
+	existed, err := c.entityExists(ctx, req.EntityID)
+	if err != nil {
+		return marshalDeleteEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("existence check failed: %v", err))
+	}
+
+	if err := c.DeleteEntity(ctx, req.EntityID); err != nil {
+		return marshalDeleteEntityError(req.TraceID, req.RequestID, err.Error())
+	}
+
+	return json.Marshal(graph.DeleteEntityResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   true,
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   req.TraceID,
+			RequestID: req.RequestID,
+		},
+		Deleted: existed,
+	})
+}
+
+// fetchEntityState reads + decodes the entity from the KV bucket. The
+// not-found error is returned verbatim so callers can branch on
+// natsclient.ErrKVKeyNotFound via errors.Is.
+func (c *Component) fetchEntityState(ctx context.Context, entityID string) (*graph.EntityState, error) {
+	entry, err := c.entityBucket.Get(ctx, entityID)
+	if err != nil {
+		return nil, err
+	}
+	var state graph.EntityState
+	if err := json.Unmarshal(entry.Value, &state); err != nil {
+		return nil, fmt.Errorf("unmarshal entity state: %w", err)
+	}
+	return &state, nil
+}
+
+// Per-response-shape error marshalers. The body-prefix error
+// convention (feedback_natsclient_error_payload_convention) lives in
+// these helpers — they each emit a Success=false response with the
+// caller's TraceID/RequestID preserved.
+
+func marshalCreateEntityError(traceID, requestID, msg string) ([]byte, error) {
+	return json.Marshal(graph.CreateEntityResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   false,
+			Error:     msg,
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   traceID,
+			RequestID: requestID,
+		},
+	})
+}
+
+func marshalCreateEntityWithTriplesError(traceID, requestID, msg string) ([]byte, error) {
+	return json.Marshal(graph.CreateEntityWithTriplesResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   false,
+			Error:     msg,
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   traceID,
+			RequestID: requestID,
+		},
+	})
+}
+
+func marshalUpdateEntityError(traceID, requestID, msg string) ([]byte, error) {
+	return json.Marshal(graph.UpdateEntityResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   false,
+			Error:     msg,
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   traceID,
+			RequestID: requestID,
+		},
+	})
+}
+
+func marshalUpdateEntityWithTriplesError(traceID, requestID, msg string) ([]byte, error) {
+	return json.Marshal(graph.UpdateEntityWithTriplesResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   false,
+			Error:     msg,
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   traceID,
+			RequestID: requestID,
+		},
+	})
+}
+
+func marshalDeleteEntityError(traceID, requestID, msg string) ([]byte, error) {
+	return json.Marshal(graph.DeleteEntityResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   false,
+			Error:     msg,
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   traceID,
+			RequestID: requestID,
+		},
 	})
 }

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -284,17 +284,6 @@ func (c *Component) entityExists(ctx context.Context, entityID string) (bool, er
 	return false, err
 }
 
-// entityRevisionAfterWrite returns the KV revision of the entity bucket
-// entry after a successful mutation. Best-effort: a Get failure here
-// surfaces as 0 (the caller's response just omits the KVRevision field).
-func (c *Component) entityRevisionAfterWrite(ctx context.Context, entityID string) uint64 {
-	entry, err := c.entityBucket.Get(ctx, entityID)
-	if err != nil {
-		return 0
-	}
-	return entry.Revision
-}
-
 // handleEntityCreate enforces create-or-fail semantics: returns
 // Success=false with an "entity already exists" error if the entity
 // ID is already present. CS API §7.6 (POST is strictly create) maps
@@ -419,12 +408,12 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 // resurrecting the entity (the bug an exists-check + Put pair would
 // have). CS API PUT/PATCH maps Success=false with "entity not found"
 // to HTTP 404; the same error message covers both "absent at read"
-// and "deleted concurrently before write" because semconnect maps both
-// to the same status.
-//
-// Concurrent-update conflicts (revision moved but key still present)
-// surface as "entity modified concurrently"; downstream gateways may
-// choose to retry, surface 409, or escalate.
+// and "concurrent modification or delete during write" because
+// downstream gateways (semconnect) currently map both to the same
+// status. A future PR may want to disambiguate "deleted concurrently"
+// vs "modified concurrently" with distinct error classes — for now
+// they share the "(concurrent modification or delete)" suffix so
+// callers can grep for it without having to peek inside ErrKVRevisionMismatch.
 func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.UpdateEntityRequest
 	if err := json.Unmarshal(data, &req); err != nil {

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -302,8 +302,16 @@ func (c *Component) entityRevisionAfterWrite(ctx context.Context, entityID strin
 // to fall back from when only triple.add_batch (upsert) was wired.
 //
 // PR-A: existence check is a Get followed by CreateEntity (Put). The
-// TOCTOU window between the two is acknowledged; PR-B will switch to
-// the atomic KV Create primitive that fails if the key exists.
+// TOCTOU window between the two means concurrent creates of the same
+// ID are last-writer-wins instead of strict create-or-fail. PR-B will
+// switch to the atomic KV Create primitive (natsclient.KVStore.Create
+// returns ErrKVKeyExists) which closes the window.
+//
+// The Entity field in the success response is read back from storage
+// so it reflects framework-injected triples (hierarchy / referential
+// integrity stubs); the caller-supplied req.Entity is NOT echoed
+// because CreateEntity may mutate it in place (entity.Triples append
+// in component.go).
 func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.CreateEntityRequest
 	if err := json.Unmarshal(data, &req); err != nil {
@@ -328,15 +336,21 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 		return marshalCreateEntityError(req.TraceID, req.RequestID, err.Error())
 	}
 
+	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
+	if err != nil {
+		return marshalCreateEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("post-write read-back failed: %v", err))
+	}
+
 	return json.Marshal(graph.CreateEntityResponse{
 		MutationResponse: graph.MutationResponse{
 			Success:    true,
 			Timestamp:  time.Now().UnixNano(),
-			KVRevision: c.entityRevisionAfterWrite(ctx, req.Entity.ID),
+			KVRevision: rev,
 			TraceID:    req.TraceID,
 			RequestID:  req.RequestID,
 		},
-		Entity: req.Entity,
+		Entity: stored,
 	})
 }
 
@@ -345,6 +359,13 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 // it REPLACES Entity.Triples before the write (the canonical set is
 // the request's Triples; Entity carries provenance metadata). When
 // Triples is nil/empty, Entity.Triples is written as-is.
+//
+// TriplesAdded in the response is the count on the *stored* entity
+// after the write, which may exceed len(req.Triples) when the
+// framework injects hierarchy / referential-integrity triples per
+// component.go:CreateEntity. Callers reasoning about provenance
+// should compare req.Triples against stored.Triples explicitly rather
+// than treating TriplesAdded as authoritative.
 func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.CreateEntityWithTriplesRequest
 	if err := json.Unmarshal(data, &req); err != nil {
@@ -373,23 +394,37 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
 	}
 
+	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
+	if err != nil {
+		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID,
+			fmt.Sprintf("post-write read-back failed: %v", err))
+	}
+
 	return json.Marshal(graph.CreateEntityWithTriplesResponse{
 		MutationResponse: graph.MutationResponse{
 			Success:    true,
 			Timestamp:  time.Now().UnixNano(),
-			KVRevision: c.entityRevisionAfterWrite(ctx, req.Entity.ID),
+			KVRevision: rev,
 			TraceID:    req.TraceID,
 			RequestID:  req.RequestID,
 		},
-		Entity:       req.Entity,
-		TriplesAdded: len(req.Entity.Triples),
+		Entity:       stored,
+		TriplesAdded: len(stored.Triples),
 	})
 }
 
-// handleEntityUpdate enforces must-exist semantics: returns Success=false
-// with "entity not found" when the entity ID is absent. CS API PUT/PATCH
-// maps that to HTTP 404 — distinct from create-or-conflict semantics
-// in handleEntityCreate.
+// handleEntityUpdate enforces must-exist semantics with a CAS-protected
+// write: a concurrent DeleteEntity that lands between the read and the
+// write turns the CAS into ErrKVRevisionMismatch instead of silently
+// resurrecting the entity (the bug an exists-check + Put pair would
+// have). CS API PUT/PATCH maps Success=false with "entity not found"
+// to HTTP 404; the same error message covers both "absent at read"
+// and "deleted concurrently before write" because semconnect maps both
+// to the same status.
+//
+// Concurrent-update conflicts (revision moved but key still present)
+// surface as "entity modified concurrently"; downstream gateways may
+// choose to retry, surface 409, or escalate.
 func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.UpdateEntityRequest
 	if err := json.Unmarshal(data, &req); err != nil {
@@ -400,44 +435,63 @@ func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte
 		return marshalUpdateEntityError(req.TraceID, req.RequestID, "entity cannot be nil")
 	}
 
-	exists, err := c.entityExists(ctx, req.Entity.ID)
+	_, currentRev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return marshalUpdateEntityError(req.TraceID, req.RequestID,
+				fmt.Sprintf("entity not found: %s", req.Entity.ID))
+		}
 		return marshalUpdateEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("existence check failed: %v", err))
-	}
-	if !exists {
-		return marshalUpdateEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("entity not found: %s", req.Entity.ID))
+			fmt.Sprintf("fetch current entity failed: %v", err))
 	}
 
-	if err := c.UpdateEntity(ctx, req.Entity); err != nil {
+	if err := c.updateEntityAtRevision(ctx, req.Entity, currentRev); err != nil {
+		if errors.Is(err, natsclient.ErrKVRevisionMismatch) {
+			return marshalUpdateEntityError(req.TraceID, req.RequestID,
+				fmt.Sprintf("entity not found: %s (concurrent modification or delete)", req.Entity.ID))
+		}
 		return marshalUpdateEntityError(req.TraceID, req.RequestID, err.Error())
+	}
+
+	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
+	if err != nil {
+		return marshalUpdateEntityError(req.TraceID, req.RequestID,
+			fmt.Sprintf("post-write read-back failed: %v", err))
 	}
 
 	return json.Marshal(graph.UpdateEntityResponse{
 		MutationResponse: graph.MutationResponse{
 			Success:    true,
 			Timestamp:  time.Now().UnixNano(),
-			KVRevision: c.entityRevisionAfterWrite(ctx, req.Entity.ID),
+			KVRevision: rev,
 			TraceID:    req.TraceID,
 			RequestID:  req.RequestID,
 		},
-		Entity:  req.Entity,
-		Version: int64(req.Entity.Version),
+		Entity:  stored,
+		Version: int64(stored.Version),
 	})
 }
 
 // handleEntityUpdateWithTriples applies a triple-set delta to an
 // existing entity: appends AddTriples, removes triples whose Predicate
-// is named in RemoveTriples, and writes the result. Entity metadata
-// (MessageType, Version, StorageRef) from the request also flows
-// through.
+// is named in RemoveTriples, and writes the result via CAS. Entity
+// metadata (MessageType, Version, StorageRef) from the request also
+// flows through.
 //
-// PR-A: read-modify-write — fetch current entity, apply delta in
-// memory, Put. TOCTOU window between fetch and put is acknowledged;
-// PR-B will collapse this to a single CAS over the entity state,
-// closing the partial-erasure window semconnect Stage 27 (2026-05-21)
-// called out across PUT/PATCH/DELETE on systems + datastreams.
+// PR-A: the read-modify-write sequence is CAS-protected against
+// concurrent delete (Update at the read revision fails with
+// ErrKVRevisionMismatch if the entity was modified or deleted
+// in-between). A concurrent triple add/remove from another writer
+// also surfaces as the same conflict, which the caller may retry.
+// The merge logic itself runs on stale data when a conflict happens
+// — that's the residual scope semconnect Stage 27 flagged and PR-B
+// will close by moving the delta apply inside an UpdateWithRetry
+// loop, eliminating the partial-erasure window in the
+// delete-all + re-add downstream shim.
+//
+// Unknown predicates in RemoveTriples are silently ignored (not
+// "404'd"); the contract is "remove if present" not "predicate must
+// exist".
 func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.UpdateEntityWithTriplesRequest
 	if err := json.Unmarshal(data, &req); err != nil {
@@ -448,7 +502,7 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID, "entity cannot be nil")
 	}
 
-	current, err := c.fetchEntityState(ctx, req.Entity.ID)
+	current, currentRev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
 		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
 			return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
@@ -484,22 +538,32 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 
 	req.Entity.Triples = current.Triples
 
-	if err := c.UpdateEntity(ctx, req.Entity); err != nil {
+	if err := c.updateEntityAtRevision(ctx, req.Entity, currentRev); err != nil {
+		if errors.Is(err, natsclient.ErrKVRevisionMismatch) {
+			return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
+				fmt.Sprintf("entity not found: %s (concurrent modification or delete)", req.Entity.ID))
+		}
 		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
+	}
+
+	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
+	if err != nil {
+		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
+			fmt.Sprintf("post-write read-back failed: %v", err))
 	}
 
 	return json.Marshal(graph.UpdateEntityWithTriplesResponse{
 		MutationResponse: graph.MutationResponse{
 			Success:    true,
 			Timestamp:  time.Now().UnixNano(),
-			KVRevision: c.entityRevisionAfterWrite(ctx, req.Entity.ID),
+			KVRevision: rev,
 			TraceID:    req.TraceID,
 			RequestID:  req.RequestID,
 		},
-		Entity:         req.Entity,
+		Entity:         stored,
 		TriplesAdded:   len(req.AddTriples),
 		TriplesRemoved: removed,
-		Version:        int64(req.Entity.Version),
+		Version:        int64(stored.Version),
 	})
 }
 
@@ -539,19 +603,27 @@ func (c *Component) handleEntityDelete(ctx context.Context, data []byte) ([]byte
 	})
 }
 
-// fetchEntityState reads + decodes the entity from the KV bucket. The
+// fetchEntityState reads + decodes the entity from the KV bucket and
+// returns its current KV revision alongside the decoded state. The
 // not-found error is returned verbatim so callers can branch on
-// natsclient.ErrKVKeyNotFound via errors.Is.
-func (c *Component) fetchEntityState(ctx context.Context, entityID string) (*graph.EntityState, error) {
+// natsclient.ErrKVKeyNotFound via errors.Is. A zero-length entry is
+// also treated as "not found" — a tombstone replay or a half-finished
+// put can leave a key present with an empty body, and unmarshaling
+// "" would otherwise surface a confusing "unexpected end of JSON
+// input" instead of the clean not-found classification callers expect.
+func (c *Component) fetchEntityState(ctx context.Context, entityID string) (*graph.EntityState, uint64, error) {
 	entry, err := c.entityBucket.Get(ctx, entityID)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
+	}
+	if len(entry.Value) == 0 {
+		return nil, 0, natsclient.ErrKVKeyNotFound
 	}
 	var state graph.EntityState
 	if err := json.Unmarshal(entry.Value, &state); err != nil {
-		return nil, fmt.Errorf("unmarshal entity state: %w", err)
+		return nil, 0, fmt.Errorf("unmarshal entity state: %w", err)
 	}
-	return &state, nil
+	return &state, entry.Revision, nil
 }
 
 // Per-response-shape error marshalers. The body-prefix error


### PR DESCRIPTION
## Summary

Closes part of #98 (PR-A of the two-PR split per [post-beta.77 queue plan](https://github.com/C360Studio/semstreams/blob/main/docs/operations/22-adr045-phase1-plan.md)). Wires five new request-reply subjects in graph-ingest backed by existing Component methods:

\`\`\`
graph.mutation.entity.create
graph.mutation.entity.create_with_triples
graph.mutation.entity.update
graph.mutation.entity.update_with_triples
graph.mutation.entity.delete
\`\`\`

The wire layer enforces semantics CS API gateways need to map cleanly to HTTP:

| Subject | Semantics | HTTP mapping for semconnect |
|---|---|---|
| \`entity.create\` / \`entity.create_with_triples\` | create-or-fail (Success=false on duplicate ID) | POST 409 Conflict |
| \`entity.update\` / \`entity.update_with_triples\` | must-exist (Success=false when absent) | PUT/PATCH 404 |
| \`entity.delete\` | entity-scoped, idempotent (\`Deleted\` reflects prior presence) | DELETE 204 / 404 callable from same path |

\`create_with_triples\` carries the full \`EntityState\` shape (\`MessageType\`, \`Version\`, \`StorageRef\`) so provenance fields survive — the load-bearing distinction over \`triple.add_batch\` where \`AddTriple\` synthesizes those with defaults. Unblocks the SensorML version / S3 key provenance semconnect Stage 8 doc-commented as deferred.

## PR-A vs PR-B scope

**PR-A (this PR)** wires the subjects with read-modify-write semantics for \`update_with_triples\`. There is a TOCTOU window between the existence check and the write — acknowledged in code comments. Lands the 409-Conflict + 404 paths immediately so semconnect can stop reaching into \`add_batch\` for create.

**PR-B (follow-up)** will close the TOCTOU window with a single CAS over the entity state, addressing the partial-erasure window [semconnect Stage 27 called out](https://github.com/C360Studio/semstreams/issues/98#issuecomment-4509748314) across PUT / PATCH / DELETE on systems + datastreams. The PR-A semantics contract is what the integration tests pin; PR-B should not have to rewrite them.

## Implementation notes

- Sentinel: \`natsclient.ErrKVKeyNotFound\` for not-found branches. The \`natsclient.KVStore\` wrapper translates underlying \`nats.go\` / \`jetstream.go\` errors to this custom sentinel — using \`jetstream.ErrKeyNotFound\` directly silently misses the translation (caught during initial test run; see \`feedback_jetstream_sentinel_set_coverage\`).
- Error replies use the existing body-prefix convention (\`feedback_natsclient_error_payload_convention\`). Header-classified errors arrive with #93.
- Per-response-shape error marshalers (one per response type) keep the request-trace/request-id round-trip clean.
- No payload registry registration needed — graph request/reply is exempt per \`graph/mutation_requests.go:7-10\` package doc.

## Coverage

\`processor/graph-ingest/entity_mutation_integration_test.go\` (new):

- \`HandleEntityCreate_Success\` / \`_Conflict\`
- \`HandleEntityCreateWithTriples_PreservesProvenance\` (validates MessageType + StorageRef survive to storage)
- \`HandleEntityUpdate_Success\` / \`_NotFound\`
- \`HandleEntityUpdateWithTriples_AddAndRemove\` (delta apply: keep / drop / add)
- \`HandleEntityDelete_Existing\` / \`_Idempotent\`
- \`HandleEntity_InvalidJSON\` (parametrized across all five handlers)

## Verification

- [x] \`go test -race -count=1 ./processor/graph-ingest/\` clean (~2s)
- [x] \`go test -race -tags=integration -count=1 ./processor/graph-ingest/\` clean (~35s; all existing tests still pass)
- [x] \`task lint\` clean
- [ ] CI green

## Test plan

- [ ] semconnect Stage 8 \`handleSystemPost\` swap from \`triple.add_batch\` to \`entity.create_with_triples\` + add 409 path (downstream PR, gated on this merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)