### PR TITLE
feat(graph-ingest): atomic create + UpdateWithRetry for entity mutations (#98 PR-B)

### DIFF
--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -4,6 +4,7 @@ package graphingest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -907,8 +908,31 @@ func validateEntityID(id string) error {
 	return nil
 }
 
-// CreateEntity creates a new entity in the graph
+// CreateEntity creates a new entity in the graph using upsert (Put)
+// semantics. Existing callers that need last-writer-wins behavior
+// (graph/datamanager edge ops) stay on this path. New atomic-create
+// callers (the NATS mutation handlers' POST 409 path) use
+// CreateEntityStrict, which fails fast with natsclient.ErrKVKeyExists
+// when the ID is already present.
 func (c *Component) CreateEntity(ctx context.Context, entity *graph.EntityState) error {
+	return c.createEntity(ctx, entity, false)
+}
+
+// CreateEntityStrict creates a new entity atomically — if the ID is
+// already present, returns natsclient.ErrKVKeyExists without
+// overwriting. Closes the concurrent-create TOCTOU window the
+// graph.mutation.entity.create handler used to have when it relied
+// on exists-check + Put.
+func (c *Component) CreateEntityStrict(ctx context.Context, entity *graph.EntityState) error {
+	return c.createEntity(ctx, entity, true)
+}
+
+// createEntity is the shared body for CreateEntity / CreateEntityStrict.
+// atomicCreate=true switches the KV write from Put (upsert) to
+// Create (atomic key-create); everything else (hierarchy inference,
+// referential integrity stubs, cache invalidation, metrics) is
+// identical.
+func (c *Component) createEntity(ctx context.Context, entity *graph.EntityState, atomicCreate bool) error {
 	if entity == nil {
 		return errs.WrapInvalid(errs.ErrInvalidData, "Component", "CreateEntity", "entity cannot be nil")
 	}
@@ -946,10 +970,24 @@ func (c *Component) CreateEntity(ctx context.Context, entity *graph.EntityState)
 		return errs.Wrap(err, "Component", "CreateEntity", "entity serialization")
 	}
 
-	// Store in KV bucket (single write with all triples)
-	if _, err := c.entityBucket.Put(ctx, entity.ID, data); err != nil {
+	// Store in KV bucket. Put is upsert (last-writer-wins); Create is
+	// atomic create-or-fail (returns natsclient.ErrKVKeyExists on
+	// conflict). The ErrKVKeyExists sentinel is bubbled verbatim so
+	// handlers can branch with errors.Is.
+	var writeErr error
+	if atomicCreate {
+		_, writeErr = c.entityBucket.Create(ctx, entity.ID, data)
+		if writeErr != nil && errors.Is(writeErr, natsclient.ErrKVKeyExists) {
+			// Expected conflict shape — don't count as a component
+			// error and don't wrap (preserves sentinel identity).
+			return writeErr
+		}
+	} else {
+		_, writeErr = c.entityBucket.Put(ctx, entity.ID, data)
+	}
+	if writeErr != nil {
 		atomic.AddInt64(&c.errors, 1)
-		return errs.Wrap(err, "Component", "CreateEntity", "KV store")
+		return errs.Wrap(writeErr, "Component", "CreateEntity", "KV store")
 	}
 
 	// Invalidate cache on write (cache consistency)
@@ -970,9 +1008,20 @@ func (c *Component) CreateEntity(ctx context.Context, entity *graph.EntityState)
 		slog.String("entity_id", entity.ID),
 		slog.Int("triples", len(entity.Triples)))
 
-	// Ensure referenced entities exist (fallback for referential integrity)
-	// This creates stub entities for any entity IDs referenced in relationship triples
-	// that don't already exist, guaranteeing graph consistency.
+	c.ensureRelationshipTargetsExist(ctx, entity)
+
+	return nil
+}
+
+// ensureRelationshipTargetsExist walks the entity's relationship triples
+// and, for each referenced entity that doesn't yet exist, creates a
+// stub. Bounded to 5 concurrent KV ops. Errors are best-effort —
+// referential integrity is a fallback, not a hard contract — so a
+// failure is logged but does not propagate.
+//
+// Extracted from createEntity to keep that function under the
+// revive.toml function-length cap (50 statements).
+func (c *Component) ensureRelationshipTargetsExist(ctx context.Context, entity *graph.EntityState) {
 	// Deduplicate target IDs — multiple triples may reference the same entity.
 	uniqueTargets := make(map[string]struct{})
 	for _, triple := range entity.Triples {
@@ -984,8 +1033,6 @@ func (c *Component) CreateEntity(ctx context.Context, entity *graph.EntityState)
 		}
 	}
 
-	// Check referential integrity for all unique targets in parallel, bounded to 5
-	// concurrent KV operations. Errors are best-effort — they don't fail entity creation.
 	sem := make(chan struct{}, 5)
 	var wg sync.WaitGroup
 
@@ -1020,8 +1067,6 @@ func (c *Component) CreateEntity(ctx context.Context, entity *graph.EntityState)
 	}
 
 	wg.Wait()
-
-	return nil
 }
 
 // ensureReferencedEntityExists creates a stub entity if the referenced entity doesn't exist.

--- a/processor/graph-ingest/entity_mutation_integration_test.go
+++ b/processor/graph-ingest/entity_mutation_integration_test.go
@@ -5,6 +5,8 @@ package graphingest
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -527,5 +529,170 @@ func TestIntegration_HandleEntity_InvalidJSON(t *testing.T) {
 			assert.False(t, base.Success)
 			assert.Contains(t, base.Error, "invalid request")
 		})
+	}
+}
+
+// --- PR-B tests: atomic create + UpdateWithRetry for update_with_triples ---
+
+// TestIntegration_CreateEntityStrict_AtomicConflict pins the
+// fundamental contract of the new atomic-create primitive: a second
+// create for the same ID surfaces natsclient.ErrKVKeyExists, and
+// the original entity content is untouched (no upsert).
+//
+// Tests the primitive directly so the contract is independent of
+// handler wiring; the handler-level mapping to "entity already
+// exists" + HTTP 409 is verified by
+// TestIntegration_HandleEntityCreate_Conflict (PR-A test, still
+// green because the semantic survives the refactor).
+func TestIntegration_CreateEntityStrict_AtomicConflict(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.atomic.create.001"
+	first := newMutationTestEntity(entityID)
+	require.NoError(t, c.CreateEntityStrict(ctx, first), "first create on fresh ID should succeed")
+
+	second := newMutationTestEntity(entityID)
+	second.Triples = []message.Triple{
+		{Subject: entityID, Predicate: "test.marker", Object: "second", Timestamp: time.Now(), Confidence: 1.0},
+	}
+	err := c.CreateEntityStrict(ctx, second)
+	require.Error(t, err, "second create on the same ID must fail")
+	assert.True(t, errors.Is(err, natsclient.ErrKVKeyExists),
+		"second create must surface ErrKVKeyExists sentinel so handlers can branch on it; got: %v", err)
+
+	// First entity's content survives — no upsert.
+	entry, err := c.entityBucket.Get(ctx, entityID)
+	require.NoError(t, err)
+	var stored graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &stored))
+	for _, tr := range stored.Triples {
+		assert.NotEqual(t, "test.marker", tr.Predicate,
+			"second create's distinct triple must not be present — atomic create must not overwrite")
+	}
+}
+
+// TestIntegration_CreateEntityStrict_ConcurrentRaceOneWinner pins the
+// concurrency guarantee CreateEntityStrict provides over the prior
+// exists-check + Put pattern: with N goroutines all trying to create
+// the same ID, exactly one wins and N-1 see ErrKVKeyExists. The
+// PR-A pattern would allow last-writer-wins with all N reporting
+// success — a 409-Conflict contract violation.
+func TestIntegration_CreateEntityStrict_ConcurrentRaceOneWinner(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.atomic.race.001"
+	const N = 5
+
+	var wg sync.WaitGroup
+	results := make([]error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			entity := newMutationTestEntity(entityID)
+			entity.Triples = append(entity.Triples, message.Triple{
+				Subject:    entityID,
+				Predicate:  "test.creator",
+				Object:     idx,
+				Timestamp:  time.Now(),
+				Confidence: 1.0,
+			})
+			results[idx] = c.CreateEntityStrict(ctx, entity)
+		}(i)
+	}
+	wg.Wait()
+
+	winners := 0
+	conflicts := 0
+	for i, err := range results {
+		switch {
+		case err == nil:
+			winners++
+		case errors.Is(err, natsclient.ErrKVKeyExists):
+			conflicts++
+		default:
+			t.Errorf("goroutine %d: unexpected error: %v", i, err)
+		}
+	}
+	assert.Equal(t, 1, winners, "exactly one concurrent create must win")
+	assert.Equal(t, N-1, conflicts, "all other concurrent creates must surface ErrKVKeyExists")
+}
+
+// TestIntegration_HandleEntityUpdateWithTriples_ConcurrentUpdatesSurvive
+// pins the closing of the partial-erasure window semconnect Stage 27
+// flagged. N goroutines each call handleEntityUpdateWithTriples to
+// add a distinct triple; with PR-B's UpdateWithRetry path, every
+// goroutine eventually succeeds (CAS-conflicts retry against the
+// fresh state) and all N triples land on the entity. The PR-A path
+// (single CAS, fail-on-conflict) would have surfaced revision
+// mismatches and the loser goroutines' triples would be missing
+// from the final state.
+//
+// This is the load-bearing test for PR-B's semantic guarantee:
+// concurrent updates compose, they don't silently erase each other.
+func TestIntegration_HandleEntityUpdateWithTriples_ConcurrentUpdatesSurvive(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.entity.concurrent.upd.001"
+	require.NoError(t, c.CreateEntity(ctx, newMutationTestEntity(entityID)), "seed entity")
+
+	const N = 5
+	var wg sync.WaitGroup
+	results := make([]string, N) // empty on success, error msg on failure
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			req := graph.UpdateEntityWithTriplesRequest{
+				Entity: newMutationTestEntity(entityID),
+				AddTriples: []message.Triple{
+					{
+						Subject:    entityID,
+						Predicate:  fmt.Sprintf("test.concurrent.%d", idx),
+						Object:     idx,
+						Timestamp:  time.Now(),
+						Confidence: 1.0,
+					},
+				},
+				RequestID: fmt.Sprintf("req-conc-%d", idx),
+			}
+			respBytes, err := c.handleEntityUpdateWithTriples(ctx, mustJSON(t, req))
+			if err != nil {
+				results[idx] = fmt.Sprintf("handler returned err: %v", err)
+				return
+			}
+			var resp graph.UpdateEntityWithTriplesResponse
+			if err := json.Unmarshal(respBytes, &resp); err != nil {
+				results[idx] = fmt.Sprintf("unmarshal: %v", err)
+				return
+			}
+			if !resp.Success {
+				results[idx] = resp.Error
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i, msg := range results {
+		assert.Empty(t, msg,
+			"concurrent update %d must succeed via UpdateWithRetry; PR-A semantics would have surfaced a revision mismatch here", i)
+	}
+
+	// All N concurrent triples must be present on the final entity —
+	// none were silently erased by another goroutine's race.
+	entry, err := c.entityBucket.Get(ctx, entityID)
+	require.NoError(t, err)
+	var stored graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &stored))
+
+	predicates := make(map[string]bool, len(stored.Triples))
+	for _, tr := range stored.Triples {
+		predicates[tr.Predicate] = true
+	}
+	for i := 0; i < N; i++ {
+		p := fmt.Sprintf("test.concurrent.%d", i)
+		assert.True(t, predicates[p],
+			"concurrent triple %q must survive on the final entity (PR-B retry semantics)", p)
 	}
 }

--- a/processor/graph-ingest/entity_mutation_integration_test.go
+++ b/processor/graph-ingest/entity_mutation_integration_test.go
@@ -616,6 +616,8 @@ func TestIntegration_CreateEntityStrict_ConcurrentRaceOneWinner(t *testing.T) {
 	}
 	assert.Equal(t, 1, winners, "exactly one concurrent create must win")
 	assert.Equal(t, N-1, conflicts, "all other concurrent creates must surface ErrKVKeyExists")
+	assert.Equal(t, N, winners+conflicts,
+		"every outcome must be either winner or ErrKVKeyExists — no unaccounted-for failures")
 }
 
 // TestIntegration_HandleEntityUpdateWithTriples_ConcurrentUpdatesSurvive
@@ -630,6 +632,14 @@ func TestIntegration_CreateEntityStrict_ConcurrentRaceOneWinner(t *testing.T) {
 //
 // This is the load-bearing test for PR-B's semantic guarantee:
 // concurrent updates compose, they don't silently erase each other.
+//
+// Flake risk: if UpdateWithRetry's MaxAttempts is exhausted under
+// extreme load (CI + race detector + N goroutines all retrying
+// against each other), one goroutine could surface
+// ErrKVMaxRetriesExceeded. N=5 is well within the per-bucket retry
+// budget under normal conditions. If this test flakes, the
+// remediation is t.Skip + an issue tracking why the retry budget
+// is insufficient, NOT bumping MaxAttempts to hide the symptom.
 func TestIntegration_HandleEntityUpdateWithTriples_ConcurrentUpdatesSurvive(t *testing.T) {
 	ctx, c := startBatchTestComponent(t)
 
@@ -695,4 +705,13 @@ func TestIntegration_HandleEntityUpdateWithTriples_ConcurrentUpdatesSurvive(t *t
 		assert.True(t, predicates[p],
 			"concurrent triple %q must survive on the final entity (PR-B retry semantics)", p)
 	}
+
+	// Metadata fields from each caller's req.Entity must also flow through
+	// the merge loop — testMutationType is what every caller sent, so the
+	// stored entity must carry it. If a retry path silently dropped
+	// metadata (e.g., wrote only the merged triples without the carrier's
+	// metadata), this assertion fails. Pins the contract claimed in
+	// handleEntityUpdateWithTriples's doc-comment.
+	assert.True(t, testMutationType.Equal(stored.MessageType),
+		"req.Entity.MessageType must survive across UpdateWithRetry attempts")
 }

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/retry"
 )
 
 const (
@@ -284,23 +285,22 @@ func (c *Component) entityExists(ctx context.Context, entityID string) (bool, er
 	return false, err
 }
 
-// handleEntityCreate enforces create-or-fail semantics: returns
-// Success=false with an "entity already exists" error if the entity
-// ID is already present. CS API §7.6 (POST is strictly create) maps
-// that error to HTTP 409 Conflict — the path semconnect Stage 8 had
-// to fall back from when only triple.add_batch (upsert) was wired.
+// handleEntityCreate enforces create-or-fail semantics atomically:
+// returns Success=false with an "entity already exists" error if the
+// entity ID is already present. CS API §7.6 (POST is strictly create)
+// maps that error to HTTP 409 Conflict — the path semconnect Stage 8
+// had to fall back from when only triple.add_batch (upsert) was wired.
 //
-// PR-A: existence check is a Get followed by CreateEntity (Put). The
-// TOCTOU window between the two means concurrent creates of the same
-// ID are last-writer-wins instead of strict create-or-fail. PR-B will
-// switch to the atomic KV Create primitive (natsclient.KVStore.Create
-// returns ErrKVKeyExists) which closes the window.
+// PR-B: uses natsclient.KVStore.Create via Component.CreateEntityStrict
+// for atomic create-or-fail. Concurrent creates of the same ID see
+// exactly one winner; losers get ErrKVKeyExists. The PR-A
+// exists-check + Put pattern is gone; no TOCTOU window remains.
 //
 // The Entity field in the success response is read back from storage
 // so it reflects framework-injected triples (hierarchy / referential
 // integrity stubs); the caller-supplied req.Entity is NOT echoed
-// because CreateEntity may mutate it in place (entity.Triples append
-// in component.go).
+// because CreateEntityStrict may mutate it in place (entity.Triples
+// append in component.go's hierarchy inference path).
 func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.CreateEntityRequest
 	if err := json.Unmarshal(data, &req); err != nil {
@@ -311,17 +311,11 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 		return marshalCreateEntityError(req.TraceID, req.RequestID, "entity cannot be nil")
 	}
 
-	exists, err := c.entityExists(ctx, req.Entity.ID)
-	if err != nil {
-		return marshalCreateEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("existence check failed: %v", err))
-	}
-	if exists {
-		return marshalCreateEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("entity already exists: %s", req.Entity.ID))
-	}
-
-	if err := c.CreateEntity(ctx, req.Entity); err != nil {
+	if err := c.CreateEntityStrict(ctx, req.Entity); err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyExists) {
+			return marshalCreateEntityError(req.TraceID, req.RequestID,
+				fmt.Sprintf("entity already exists: %s", req.Entity.ID))
+		}
 		return marshalCreateEntityError(req.TraceID, req.RequestID, err.Error())
 	}
 
@@ -349,10 +343,13 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 // the request's Triples; Entity carries provenance metadata). When
 // Triples is nil/empty, Entity.Triples is written as-is.
 //
+// Atomicity matches handleEntityCreate: CreateEntityStrict is used
+// for atomic create-or-fail (returns ErrKVKeyExists on duplicate ID).
+//
 // TriplesAdded in the response is the count on the *stored* entity
 // after the write, which may exceed len(req.Triples) when the
 // framework injects hierarchy / referential-integrity triples per
-// component.go:CreateEntity. Callers reasoning about provenance
+// component.go:createEntity. Callers reasoning about provenance
 // should compare req.Triples against stored.Triples explicitly rather
 // than treating TriplesAdded as authoritative.
 func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
@@ -365,21 +362,15 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID, "entity cannot be nil")
 	}
 
-	exists, err := c.entityExists(ctx, req.Entity.ID)
-	if err != nil {
-		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID,
-			fmt.Sprintf("existence check failed: %v", err))
-	}
-	if exists {
-		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID,
-			fmt.Sprintf("entity already exists: %s", req.Entity.ID))
-	}
-
 	if len(req.Triples) > 0 {
 		req.Entity.Triples = req.Triples
 	}
 
-	if err := c.CreateEntity(ctx, req.Entity); err != nil {
+	if err := c.CreateEntityStrict(ctx, req.Entity); err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyExists) {
+			return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID,
+				fmt.Sprintf("entity already exists: %s", req.Entity.ID))
+		}
 		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
 	}
 
@@ -463,20 +454,27 @@ func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte
 
 // handleEntityUpdateWithTriples applies a triple-set delta to an
 // existing entity: appends AddTriples, removes triples whose Predicate
-// is named in RemoveTriples, and writes the result via CAS. Entity
-// metadata (MessageType, Version, StorageRef) from the request also
-// flows through.
+// is named in RemoveTriples, and writes the result via CAS-with-retry.
+// Entity metadata (MessageType, Version, StorageRef) from the request
+// flows through verbatim; the merged triple set replaces what's in
+// req.Entity.Triples.
 //
-// PR-A: the read-modify-write sequence is CAS-protected against
-// concurrent delete (Update at the read revision fails with
-// ErrKVRevisionMismatch if the entity was modified or deleted
-// in-between). A concurrent triple add/remove from another writer
-// also surfaces as the same conflict, which the caller may retry.
-// The merge logic itself runs on stale data when a conflict happens
-// — that's the residual scope semconnect Stage 27 flagged and PR-B
-// will close by moving the delta apply inside an UpdateWithRetry
-// loop, eliminating the partial-erasure window in the
-// delete-all + re-add downstream shim.
+// PR-B: the delta apply runs inside natsclient.KVStore.UpdateWithRetry,
+// so concurrent writes that bump the entity revision between read
+// and write trigger a re-fetch + re-apply of the delta against the
+// fresh state. Closes the partial-erasure window semconnect Stage 27
+// flagged in the cs-api delete-all + re-add shim: a concurrent
+// triple add from another writer no longer makes the delta drop work
+// silently.
+//
+// Must-exist contract is preserved: if the entity is absent on the
+// first attempt OR gets deleted between attempts, the update
+// function returns retry.NonRetryable(ErrKVKeyNotFound) and the
+// handler surfaces "entity not found" — same shape semconnect maps
+// to HTTP 404. CAS-conflict-without-delete (another writer modified
+// the entity) is silently retried up to the bucket's configured
+// MaxAttempts; the caller sees the final successful state in the
+// response.
 //
 // Unknown predicates in RemoveTriples are silently ignored (not
 // "404'd"); the contract is "remove if present" not "predicate must
@@ -491,46 +489,68 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID, "entity cannot be nil")
 	}
 
-	current, currentRev, err := c.fetchEntityState(ctx, req.Entity.ID)
+	// PR-B: the delta apply runs *inside* UpdateWithRetry's update
+	// function, so each retry re-applies AddTriples/RemoveTriples
+	// against the fresh current state. PR-A read once then CAS'd,
+	// losing concurrent triples on the retry path.
+	//
+	// triplesRemoved is captured by the closure and assigned on each
+	// attempt; the LAST attempt (the one that succeeded or NonRetryable'd)
+	// owns the final value. UpdateWithRetry invokes updateFn at least
+	// once and at most retryConfig.MaxAttempts times.
+	var triplesRemoved int
+	err := c.entityBucket.UpdateWithRetry(ctx, req.Entity.ID, func(current []byte) ([]byte, error) {
+		// Must-exist contract: an empty current value means the entity
+		// is absent (either never created OR deleted between attempts).
+		// retry.NonRetryable stops the retry loop and surfaces the
+		// sentinel for the handler to map to "entity not found".
+		if len(current) == 0 {
+			return nil, retry.NonRetryable(natsclient.ErrKVKeyNotFound)
+		}
+
+		var currentState graph.EntityState
+		if err := json.Unmarshal(current, &currentState); err != nil {
+			return nil, retry.NonRetryable(
+				fmt.Errorf("unmarshal current entity: %w", err))
+		}
+
+		// Re-apply the delta on each attempt: drop triples whose
+		// Predicate appears in RemoveTriples, then append AddTriples.
+		// triplesRemoved is reset each attempt so it reflects the
+		// final successful apply.
+		triplesRemoved = 0
+		merged := currentState.Triples
+		if len(req.RemoveTriples) > 0 {
+			removeSet := make(map[string]struct{}, len(req.RemoveTriples))
+			for _, p := range req.RemoveTriples {
+				removeSet[p] = struct{}{}
+			}
+			kept := make([]message.Triple, 0, len(currentState.Triples))
+			for _, t := range currentState.Triples {
+				if _, drop := removeSet[t.Predicate]; drop {
+					triplesRemoved++
+					continue
+				}
+				kept = append(kept, t)
+			}
+			merged = kept
+		}
+		if len(req.AddTriples) > 0 {
+			merged = append(merged, req.AddTriples...)
+		}
+
+		// Build the new entity: caller's metadata (req.Entity) +
+		// merged triples. Shallow copy so we don't mutate the
+		// caller-owned pointer (see PR-A go-reviewer F2 finding).
+		newEntity := *req.Entity
+		newEntity.Triples = merged
+
+		return json.Marshal(&newEntity)
+	})
 	if err != nil {
 		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
 			return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
 				fmt.Sprintf("entity not found: %s", req.Entity.ID))
-		}
-		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
-			fmt.Sprintf("fetch current entity failed: %v", err))
-	}
-
-	// Build the merged triple set: start from current.Triples, drop
-	// any whose Predicate appears in RemoveTriples, then append
-	// req.AddTriples. The merged set replaces req.Entity.Triples so
-	// metadata fields (MessageType, Version, StorageRef) flow through.
-	removed := 0
-	if len(req.RemoveTriples) > 0 {
-		removeSet := make(map[string]struct{}, len(req.RemoveTriples))
-		for _, p := range req.RemoveTriples {
-			removeSet[p] = struct{}{}
-		}
-		kept := make([]message.Triple, 0, len(current.Triples))
-		for _, t := range current.Triples {
-			if _, drop := removeSet[t.Predicate]; drop {
-				removed++
-				continue
-			}
-			kept = append(kept, t)
-		}
-		current.Triples = kept
-	}
-	if len(req.AddTriples) > 0 {
-		current.Triples = append(current.Triples, req.AddTriples...)
-	}
-
-	req.Entity.Triples = current.Triples
-
-	if err := c.updateEntityAtRevision(ctx, req.Entity, currentRev); err != nil {
-		if errors.Is(err, natsclient.ErrKVRevisionMismatch) {
-			return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
-				fmt.Sprintf("entity not found: %s (concurrent modification or delete)", req.Entity.ID))
 		}
 		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
 	}
@@ -551,7 +571,7 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		},
 		Entity:         stored,
 		TriplesAdded:   len(req.AddTriples),
-		TriplesRemoved: removed,
+		TriplesRemoved: triplesRemoved,
 		Version:        int64(stored.Version),
 	})
 }

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -479,6 +479,13 @@ func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte
 // Unknown predicates in RemoveTriples are silently ignored (not
 // "404'd"); the contract is "remove if present" not "predicate must
 // exist".
+//
+// Retry exhaustion: on the unlikely path where every retry attempt
+// hits a CAS conflict and MaxAttempts is reached, UpdateWithRetry
+// returns natsclient.ErrKVMaxRetriesExceeded. The handler surfaces
+// it verbatim through the body-prefix error convention; downstream
+// gateways may retry the whole request or escalate. Distinct from
+// "entity not found", which is the NonRetryable absence path.
 func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.UpdateEntityWithTriplesRequest
 	if err := json.Unmarshal(data, &req); err != nil {


### PR DESCRIPTION
## Summary

Closes the two semantic gaps PR-A (#119) doc-commented as deferred. Both issues track back to the [semconnect Stage 27 comment](https://github.com/C360Studio/semstreams/issues/98#issuecomment-4509748314) on #98.

### 1. Atomic create-or-fail

PR-A used \`exists-check\` + \`Component.CreateEntity\` (Put-based, upsert) — concurrent creates of the same ID raced to last-writer-wins. PR-B adds **\`Component.CreateEntityStrict\`** which routes through \`natsclient.KVStore.Create\` for atomic create-or-fail. Returns \`ErrKVKeyExists\` on conflict; the handler maps it to \"entity already exists\" for the HTTP 409 path.

\`CreateEntity\` (Put-based) stays as the public API for the existing \`graph/datamanager\` edge-ops callers that want last-writer-wins. Both paths share the heavy body (validation, hierarchy inference, metrics, referential-integrity stubs) via a private \`createEntity(ctx, entity, atomicCreate)\` helper.

### 2. UpdateWithRetry for \`update_with_triples\`

PR-A's path was \`fetch → merge → single CAS → fail-on-conflict\`. The merge ran on stale data because the CAS only catches \"revision moved\", not \"underlying triple set changed\". semconnect Stage 27 flagged this as the **partial-erasure window** in the cs-api delete-all + re-add shim: concurrent triple writes from another writer could erase each other.

\`handleEntityUpdateWithTriples\` now runs the delta-apply **inside \`natsclient.KVStore.UpdateWithRetry\`**. Each retry attempt re-fetches the entity, re-applies \`RemoveTriples\` + \`AddTriples\` against the fresh state, and re-CAS-commits. **Concurrent writers compose**: all their triples survive on the final entity.

Must-exist contract preserved by returning \`retry.NonRetryable(ErrKVKeyNotFound)\` from the update function when the entity is absent on any attempt.

## Coverage

- **\`CreateEntityStrict_AtomicConflict\`** — direct primitive test: second create returns \`ErrKVKeyExists\`, first create's content survives.
- **\`CreateEntityStrict_ConcurrentRaceOneWinner\`** — N goroutines race for the same ID; exactly one wins, N-1 see \`ErrKVKeyExists\`. Would fail under PR-A's exists-check + Put pattern (last-writer-wins for all N).
- **\`HandleEntityUpdateWithTriples_ConcurrentUpdatesSurvive\`** — N goroutines each add a distinct triple via \`update_with_triples\`; all N triples must survive on the final entity. PR-A's single-CAS path would have surfaced revision mismatches and lost the loser goroutines' triples.

Existing PR-A tests carry through unchanged — they pin semantics (create-or-fail, must-exist, idempotent-delete), not implementation.

## Refactor side-effect

\`createEntity\` grew past the \`revive.toml\` function-length cap after the atomic-create merge (54 > 50 stmts). Extracted the referential-integrity-stubs block into \`ensureRelationshipTargetsExist\` — same semantics, smaller per-function surface.

## Verification

- [x] \`go test -race -count=1 ./processor/graph-ingest/\` clean
- [x] \`go test -race -tags=integration -count=1 ./processor/graph-ingest/\` clean
- [x] \`task lint\` clean
- [ ] CI green
- [ ] go-reviewer pass (about to kick off)

## Closes

- #98 fully (PR-A landed the wire surface in #119; PR-B closes the atomicity contracts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)