### PR TITLE
fix(natsclient): recognize ErrKeyDeleted tombstones in IsKVNotFoundError (#122)

### DIFF
--- a/natsclient/kv.go
+++ b/natsclient/kv.go
@@ -408,18 +408,29 @@ func (kv *KVStore) Watch(ctx context.Context, pattern string) (jetstream.KeyWatc
 
 // Error detection helpers - based on Graph processor experience
 
-// IsKVNotFoundError checks if error indicates key not found
+// IsKVNotFoundError checks if error indicates key absence — either a never-created
+// key (jetstream.ErrKeyNotFound) or a tombstoned key (jetstream.ErrKeyDeleted).
+// Both surface to callers as "the key is not there"; UpdateWithRetry relies on
+// this to set revision=0 and route the updateFn down the create path.
+//
+// The NATS Go SDK's public Get already maps ErrKeyDeleted → ErrKeyNotFound, so
+// in the common KVStore.Get path only ErrKeyNotFound reaches us. The ErrKeyDeleted
+// branch defends paths that bypass that mapping (Watch handler entry-error chains,
+// GetRevision wrappers, future SDK changes). See issue #122 and
+// feedback_jetstream_sentinel_set_coverage.
 func IsKVNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// Check for our custom error
 	if errors.Is(err, ErrKVKeyNotFound) {
 		return true
 	}
-	// Check for raw NATS errors
+	if errors.Is(err, jetstream.ErrKeyNotFound) || errors.Is(err, jetstream.ErrKeyDeleted) {
+		return true
+	}
 	errMsg := err.Error()
 	return strings.Contains(errMsg, "key not found") ||
+		strings.Contains(errMsg, "key was deleted") ||
 		strings.Contains(errMsg, "10037")
 }
 

--- a/natsclient/kv_error_integration_test.go
+++ b/natsclient/kv_error_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c360studio/semstreams/pkg/retry"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -283,6 +284,47 @@ func TestKVStore_ErrorBoundaries(t *testing.T) {
 		entry, err := kv.Get(ctx, "deleted-key")
 		require.NoError(t, err)
 		assert.Equal(t, "new-value", string(entry.Value))
+	})
+
+	t.Run("update_deleted_key_must_exist_caller_surfaces_clean_not_found", func(t *testing.T) {
+		// Companion to "update_deleted_key": that test validated the create-new
+		// semantics (caller's updateFn happily produces a value when current is nil).
+		// This test validates the must-exist semantics: a caller that returns
+		// retry.NonRetryable(ErrKVKeyNotFound) when current is nil must see
+		// that sentinel terminate the retry loop cleanly, NOT burn the full
+		// retry budget into ErrKVMaxRetriesExceeded.
+		//
+		// This is the scenario filed in issue #122. The fix in IsKVNotFoundError
+		// recognizing jetstream.ErrKeyDeleted is the defensive guard; this test
+		// validates the end-to-end behavior the must-exist callers (e.g.
+		// graph-ingest's handleEntityUpdateWithTriples) depend on.
+		kv := client.NewKVStore(bucket, func(opts *KVOptions) {
+			opts.MaxRetries = 3
+			opts.RetryDelay = 10 * time.Millisecond
+			opts.Timeout = time.Second
+		})
+
+		_, err := bucket.Create(ctx, "must-exist-tombstone-key", []byte("initial"))
+		require.NoError(t, err)
+		err = bucket.Delete(ctx, "must-exist-tombstone-key")
+		require.NoError(t, err)
+
+		var nilCurrentObserved int
+		err = kv.UpdateWithRetry(ctx, "must-exist-tombstone-key", func(current []byte) ([]byte, error) {
+			if len(current) == 0 {
+				nilCurrentObserved++
+				return nil, retry.NonRetryable(ErrKVKeyNotFound)
+			}
+			return []byte("should-not-reach"), nil
+		})
+
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrKVKeyNotFound),
+			"must-exist caller on tombstoned key must surface ErrKVKeyNotFound via errors.Is; got: %v", err)
+		assert.False(t, errors.Is(err, ErrKVMaxRetriesExceeded),
+			"NonRetryable must short-circuit before retry exhaustion; got: %v", err)
+		assert.Equal(t, 1, nilCurrentObserved,
+			"updateFn must be invoked exactly once — NonRetryable stops the loop on first attempt")
 	})
 
 	t.Run("panic_recovery", func(t *testing.T) {

--- a/natsclient/kv_integration_test.go
+++ b/natsclient/kv_integration_test.go
@@ -5,6 +5,8 @@ package natsclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -403,13 +405,30 @@ func TestKVStore_Timeout(t *testing.T) {
 
 func TestKVStore_ErrorHelpers(t *testing.T) {
 	t.Run("IsKVNotFoundError", func(t *testing.T) {
-		// Test various not found error formats
+		// Our sentinel
 		assert.True(t, IsKVNotFoundError(ErrKVKeyNotFound))
 		assert.False(t, IsKVNotFoundError(ErrKVKeyExists))
 		assert.False(t, IsKVNotFoundError(nil))
 
-		// Test actual NATS error messages (would need real errors from NATS)
-		// These are the known patterns from the implementation
+		// Raw NATS sentinels — both the not-found and the tombstone-deleted
+		// cases must surface as "key absent" for UpdateWithRetry to route
+		// through the create path. See issue #122.
+		assert.True(t, IsKVNotFoundError(jetstream.ErrKeyNotFound),
+			"raw jetstream.ErrKeyNotFound must be recognized")
+		assert.True(t, IsKVNotFoundError(jetstream.ErrKeyDeleted),
+			"raw jetstream.ErrKeyDeleted (tombstone) must be recognized")
+
+		// Wrapped errors — errors.Is unwrap chain must work for both sentinels.
+		assert.True(t, IsKVNotFoundError(fmt.Errorf("history failed: %w", jetstream.ErrKeyDeleted)),
+			"wrapped ErrKeyDeleted must be recognized via errors.Is")
+		assert.True(t, IsKVNotFoundError(fmt.Errorf("get failed: %w", jetstream.ErrKeyNotFound)),
+			"wrapped ErrKeyNotFound must be recognized via errors.Is")
+
+		// String-match fallback — for errors that don't conform to errors.Is.
+		assert.True(t, IsKVNotFoundError(errors.New("kv get foo: nats: key was deleted")),
+			"raw 'key was deleted' substring must be recognized")
+		assert.True(t, IsKVNotFoundError(errors.New("kv get foo: nats: key not found")),
+			"raw 'key not found' substring must be recognized")
 	})
 
 	t.Run("IsKVConflictError", func(t *testing.T) {

--- a/natsclient/kv_temporal.go
+++ b/natsclient/kv_temporal.go
@@ -100,12 +100,7 @@ func (tr *TemporalResolver) GetAtTimestamp(
 	// Get history (from cache if available)
 	history, err := tr.getCachedHistory(ctx, key)
 	if err != nil {
-		// Check if it's a key not found error from NATS
-		if jetstream.ErrKeyNotFound != nil && err == jetstream.ErrKeyNotFound {
-			return nil, ErrKVKeyNotFound
-		}
-		// Also check for string match in case the error is different
-		if err.Error() == "nats: key not found" {
+		if IsKVNotFoundError(err) {
 			return nil, ErrKVKeyNotFound
 		}
 		return nil, fmt.Errorf("get history: %w", err)


### PR DESCRIPTION
## Summary

- Extend `IsKVNotFoundError` to recognize `jetstream.ErrKeyDeleted` (tombstones) alongside `jetstream.ErrKeyNotFound` via `errors.Is` + substring fallback. Both surface as "key absent" for `UpdateWithRetry`'s create-path routing.
- Audit caught the bespoke wire-string check in `kv_temporal.go` (`err.Error() == "nats: key not found"`) that didn't actually match the SDK's wire string (no `"nats:"` prefix in `ErrKeyNotFound.Error()`). Routed through `IsKVNotFoundError` instead.
- Closes #122.

## What the investigation found

The issue described silent retry-budget burning on tombstoned keys — but in NATS Go v1.48.0 the public `KeyValue.Get` already maps `ErrKeyDeleted` → `ErrKeyNotFound` (jetstream/kv.go:977-978 in the SDK), so the common `KVStore.Get` → `UpdateWithRetry` path hasn't been silently failing. The existing `update_deleted_key` integration test has been validating create-new semantics on tombstoned keys cleanly.

The fix is therefore **defensive coverage**, not a bug-was-burning-prod fix:

1. Paths that bypass the SDK's `Get` mapping (Watch handler entry-error chains, `GetRevision` wrappers, direct `History`-then-error chains) DO surface `ErrKeyDeleted`. `IsKVNotFoundError` now catches them.
2. Future SDK changes that stop mapping the sentinel won't silently regress this codebase.
3. Aligns with `feedback_jetstream_sentinel_set_coverage` discipline — sibling-set coverage, not single-sentinel branches.

## Test plan

- [x] `go test -race -count=1 ./natsclient/...` (unit) — clean
- [x] `go test -race -tags=integration -count=1 ./natsclient/...` — clean, new test passes
- [x] `go vet ./...` + `go vet -tags=integration ./...` + `go vet -tags=live_llm ./...` — clean
- [x] `task lint` — clean
- [x] `task schema:generate` — no drift
- [x] `go test ./test/contract/...` — clean
- [x] Branch integration sweep `go test -race -tags=integration ./...` per `feedback_framework_change_needs_branch_integration_sweep` — clean except two pre-existing flakes (`graph/query` qwen3:1.7b JSON parse; `graph-ingest` testcontainer startup timeout under full-./...-sweep Docker pressure). Both pass in isolation; neither touches the changed code.

## Memory updates

Updated `feedback_jetstream_sentinel_set_coverage` to capture both sibling pairs as case studies:
- `ErrKeyNotFound` vs `ErrNoKeysFound` (list-vs-key absence, beta.66)
- `ErrKeyNotFound` vs `ErrKeyDeleted` (never-existed-vs-tombstoned, this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)