### PR TITLE
feat(vocabulary): add sosa hasLocation + SamplingFeature + CS API Part 2 IRIs (#117)

### DIFF
--- a/vocabulary/csapi/iris.go
+++ b/vocabulary/csapi/iris.go
@@ -25,6 +25,24 @@ const (
 	// ResultTimeRange) and a result-type discriminator (ResultType).
 	// CS API v1.0 §10.
 	Datastream = Namespace + "Datastream"
+
+	// ControlStream — a stream of Commands sent to one System
+	// (typically an Actuator-bearing platform) for one
+	// ActuatableProperty. CS API v1.0 Part 2 §14. Draft surface;
+	// IRI swaps to the canonical spec form once published.
+	ControlStream = Namespace + "ControlStream"
+
+	// Command — an individual instruction issued through a
+	// ControlStream targeting an ActuatableProperty. CS API v1.0
+	// Part 2 §15. Draft surface; IRI may swap when the spec
+	// publishes.
+	Command = Namespace + "Command"
+
+	// SystemEvent — a discrete notification about a System
+	// (deployment lifecycle, configuration change, alert). Used
+	// by /systems/{id}/events. CS API v1.0 Part 2 §16. Draft
+	// surface; IRI may swap when the spec publishes.
+	SystemEvent = Namespace + "SystemEvent"
 )
 
 // iris is the canonical set of IRIs this package surfaces, indexed
@@ -33,13 +51,19 @@ const (
 // iris_test.go fails loud if these drift apart.
 var iris = map[string]string{
 	// Classes
-	Prefix + ":Datastream": Datastream,
+	Prefix + ":Datastream":    Datastream,
+	Prefix + ":ControlStream": ControlStream,
+	Prefix + ":Command":       Command,
+	Prefix + ":SystemEvent":   SystemEvent,
 
 	// Predicates
 	Prefix + ":producedBy":          ProducedBy,
 	Prefix + ":resultTimeRange":     ResultTimeRange,
 	Prefix + ":phenomenonTimeRange": PhenomenonTimeRange,
 	Prefix + ":resultType":          ResultType,
+	Prefix + ":controlsSystem":      ControlsSystem,
+	Prefix + ":partOfControlStream": PartOfControlStream,
+	Prefix + ":eventForSystem":      EventForSystem,
 }
 
 var reverseIRIs = func() map[string]string {

--- a/vocabulary/csapi/iris_test.go
+++ b/vocabulary/csapi/iris_test.go
@@ -7,12 +7,18 @@ import (
 
 func TestIRIsCoverConstants(t *testing.T) {
 	wantPairs := map[string]string{
-		Prefix + ":Datastream": Datastream,
+		Prefix + ":Datastream":    Datastream,
+		Prefix + ":ControlStream": ControlStream,
+		Prefix + ":Command":       Command,
+		Prefix + ":SystemEvent":   SystemEvent,
 
 		Prefix + ":producedBy":          ProducedBy,
 		Prefix + ":resultTimeRange":     ResultTimeRange,
 		Prefix + ":phenomenonTimeRange": PhenomenonTimeRange,
 		Prefix + ":resultType":          ResultType,
+		Prefix + ":controlsSystem":      ControlsSystem,
+		Prefix + ":partOfControlStream": PartOfControlStream,
+		Prefix + ":eventForSystem":      EventForSystem,
 	}
 	got := IRIs()
 	if len(got) != len(wantPairs) {
@@ -29,8 +35,9 @@ func TestIRIsCoverConstants(t *testing.T) {
 
 func TestConstantsLiveInDeclaredNamespace(t *testing.T) {
 	all := []string{
-		Datastream,
+		Datastream, ControlStream, Command, SystemEvent,
 		ProducedBy, ResultTimeRange, PhenomenonTimeRange, ResultType,
+		ControlsSystem, PartOfControlStream, EventForSystem,
 	}
 	for _, c := range all {
 		if !strings.HasPrefix(c, Namespace) {

--- a/vocabulary/csapi/predicates.go
+++ b/vocabulary/csapi/predicates.go
@@ -22,4 +22,17 @@ const (
 	// Observations — om:Measurement, om:Category, om:CountObservation,
 	// etc. Consumers branch on this to decode the result payload.
 	ResultType = Namespace + "resultType"
+
+	// ControlsSystem binds a ControlStream to the entity ID of the
+	// System it targets with Commands. Inverse counterpart to a
+	// forthcoming `hasControlStream`. CS API v1.0 Part 2 §14.
+	ControlsSystem = Namespace + "controlsSystem"
+
+	// PartOfControlStream binds a Command to the entity ID of the
+	// ControlStream it was issued through. CS API v1.0 Part 2 §15.
+	PartOfControlStream = Namespace + "partOfControlStream"
+
+	// EventForSystem binds a SystemEvent to the entity ID of the
+	// System the event is about. CS API v1.0 Part 2 §16.
+	EventForSystem = Namespace + "eventForSystem"
 )

--- a/vocabulary/sosa/iris.go
+++ b/vocabulary/sosa/iris.go
@@ -43,6 +43,11 @@ const (
 	// downstream observation.
 	Sample = Namespace + "Sample"
 
+	// SamplingFeature — a spatial / temporal proxy a Sample is
+	// drawn from. Carries the geometry and time bounds the Sample
+	// itself doesn't own directly. SOSA §3.10.
+	SamplingFeature = Namespace + "SamplingFeature"
+
 	// Sampler — the device or method that produces a Sample.
 	Sampler = Namespace + "Sampler"
 
@@ -110,6 +115,13 @@ const (
 	// ObservedProperty binds an Observation to the
 	// ObservableProperty it measured.
 	ObservedProperty = Namespace + "observedProperty"
+
+	// HasLocation binds a Feature-of-Interest (System, Sensor,
+	// Sample, etc.) to a Geo-Feature describing its spatial extent.
+	// W3C SSN/SOSA recommendation 2017 §7. Object is typically a
+	// GeoJSON-shaped Point / Polygon / LineString string carried
+	// verbatim through the triple set.
+	HasLocation = Namespace + "hasLocation"
 )
 
 // SSN namespace identifiers. SSN is the systems/deployment overlay

--- a/vocabulary/sosa/iris_test.go
+++ b/vocabulary/sosa/iris_test.go
@@ -18,6 +18,7 @@ func TestIRIsCoverConstants(t *testing.T) {
 		Prefix + ":Platform":           Platform,
 		Prefix + ":Procedure":          Procedure,
 		Prefix + ":Sample":             Sample,
+		Prefix + ":SamplingFeature":    SamplingFeature,
 		Prefix + ":Sampler":            Sampler,
 		Prefix + ":Result":             Result,
 		Prefix + ":Actuator":           Actuator,
@@ -36,6 +37,7 @@ func TestIRIsCoverConstants(t *testing.T) {
 		Prefix + ":hosts":                Hosts,
 		Prefix + ":isHostedBy":           IsHostedBy,
 		Prefix + ":observedProperty":     ObservedProperty,
+		Prefix + ":hasLocation":          HasLocation,
 
 		SSNPrefix + ":System":         SSNSystem,
 		SSNPrefix + ":Deployment":     SSNDeployment,
@@ -64,11 +66,11 @@ func TestIRIsCoverConstants(t *testing.T) {
 func TestConstantsLiveInDeclaredNamespace(t *testing.T) {
 	sosaConsts := []string{
 		Sensor, Observation, FeatureOfInterest, ObservableProperty,
-		Platform, Procedure, Sample, Sampler, Result, Actuator,
+		Platform, Procedure, Sample, SamplingFeature, Sampler, Result, Actuator,
 		Actuation, ActuatableProperty,
 		Observes, HasFeatureOfInterest, MadeBySensor, MadeObservation,
 		UsedProcedure, HasSimpleResult, HasResult, ResultTime,
-		PhenomenonTime, Hosts, IsHostedBy, ObservedProperty,
+		PhenomenonTime, Hosts, IsHostedBy, ObservedProperty, HasLocation,
 	}
 	for _, c := range sosaConsts {
 		if !strings.HasPrefix(c, Namespace) {

--- a/vocabulary/sosa/predicates.go
+++ b/vocabulary/sosa/predicates.go
@@ -21,6 +21,7 @@ var iris = map[string]string{
 	Prefix + ":Platform":           Platform,
 	Prefix + ":Procedure":          Procedure,
 	Prefix + ":Sample":             Sample,
+	Prefix + ":SamplingFeature":    SamplingFeature,
 	Prefix + ":Sampler":            Sampler,
 	Prefix + ":Result":             Result,
 	Prefix + ":Actuator":           Actuator,
@@ -40,6 +41,7 @@ var iris = map[string]string{
 	Prefix + ":hosts":                Hosts,
 	Prefix + ":isHostedBy":           IsHostedBy,
 	Prefix + ":observedProperty":     ObservedProperty,
+	Prefix + ":hasLocation":          HasLocation,
 
 	// SSN classes
 	SSNPrefix + ":System":     SSNSystem,


### PR DESCRIPTION
## Summary

semconnect (sister gateway repo) has been carrying local vocabulary constants that belong upstream. This adds the genuinely-missing IRIs called out in #117; several items on the original list (`sosa.Procedure`, `sosa.Sample`, `sosa.SSNDeployment`) already existed since ADR-044 Phase 2 — those just need the gateway to update imports.

### Added to `vocabulary/sosa`
- **`HasLocation`** (predicate) — `sosa:hasLocation`. Binds a Feature-of-Interest to a Geo-Feature describing its spatial extent. **Required by #114 (SensorML position preservation)** to emit the position triple under a canonical predicate.
- **`SamplingFeature`** (class) — `sosa:SamplingFeature`. The spatial / temporal proxy a Sample is drawn from. Mentioned in #117's list alongside Procedure / Sample / Deployment.

### Added to `vocabulary/csapi` (Part 2 surface)
- **`ControlStream`** (class) — `csapi:ControlStream`. A stream of Commands targeting one System for one ActuatableProperty.
- **`Command`** (class) — `csapi:Command`. An individual instruction.
- **`SystemEvent`** (class) — `csapi:SystemEvent`. A discrete notification about a System.
- **`ControlsSystem`**, **`PartOfControlStream`**, **`EventForSystem`** predicates.

All Part 2 surfaces are marked as tracking the working draft; when the canonical IRIs publish, the constants get a one-shot swap (same convention as the existing `csapi.Namespace` doc-comment).

### Pre-existing IRIs that semconnect was wrongly thought to need

The issue body listed these as missing but they exist already since ADR-044 Phase 2 (`vocabulary/sosa/iris.go`, commit `050280e`, 2026-05-15):
- `sosa.Procedure` ✓
- `sosa.Sample` ✓
- `sosa.SSNDeployment` ✓ — `semconnect/gateway/cs-api/deployments.go` carries a stale comment claiming this doesn't exist; it does. The local `ssnDeployment` const can be dropped in favor of `sosa.SSNDeployment` with no other changes.

## Test plan

- [x] `TestIRIsCoverConstants` extended in both `sosa` and `csapi` to cover all new entries.
- [x] `TestConstantsLiveInDeclaredNamespace` extended to verify all new constants start with their respective namespace stems.
- [x] `go test -race ./vocabulary/...` — all 11 packages clean.
- [x] `task lint` clean; `go vet -tags=integration ./...` + `go vet -tags=live_llm ./...` clean.

## Downstream impact

- **semconnect**: can drop local `ssnDeployment` const + the "doesn't exist upstream" comment in `gateway/cs-api/deployments.go`. Position-preservation workaround retires once #114 (which uses `sosa.HasLocation` from this PR) lands.
- **#114 + #115**: blocked on this. PRs coming next.

Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)