### PR TITLE
feat(parser/sensorml): preserve SensorML position as graph triples (#114)

### DIFF
--- a/parser/sensorml/graphable.go
+++ b/parser/sensorml/graphable.go
@@ -78,6 +78,13 @@ func (a *Asset) Triples() []message.Triple {
 			out = append(out, message.Triple{Subject: a.entityID, Predicate: PredCharacteristicValue, Object: char.Value})
 		}
 	}
+	if base.Position != nil && len(base.Position.Raw) > 0 {
+		out = append(out, message.Triple{
+			Subject:   a.entityID,
+			Predicate: PredPosition,
+			Object:    string(base.Position.Raw),
+		})
+	}
 	out = append(out, a.typeSpecificTriples()...)
 	return out
 }

--- a/parser/sensorml/graphable_test.go
+++ b/parser/sensorml/graphable_test.go
@@ -170,6 +170,79 @@ func TestAsset_NilProcess(t *testing.T) {
 	}
 }
 
+func TestAsset_PositionRoundTripsAsTriple(t *testing.T) {
+	// Issue #114: SensorML position field used to be silently dropped
+	// by the parser's type model and triple emitter. The fix:
+	// preserve the raw GeoJSON-shaped JSON on AbstractProcess.Position
+	// and emit a sensorml.process.position triple (→ sosa:hasLocation).
+	defer vocabulary.SnapshotRegistry()()
+
+	const sml = `{
+		"type": "PhysicalSystem",
+		"id": "platform-001",
+		"label": "Sensor Platform",
+		"position": {"type": "Point", "coordinates": [-122.4194, 37.7749, 10.0]}
+	}`
+
+	process, err := UnmarshalProcess([]byte(sml))
+	if err != nil {
+		t.Fatalf("UnmarshalProcess: %v", err)
+	}
+
+	const platformID = "acme.ops.robotics.gcs.platform.001"
+	asset := NewAsset(platformID, process)
+	triples := asset.Triples()
+
+	// The parser must preserve the raw GeoJSON on the type model.
+	base := process.Base()
+	if base.Position == nil {
+		t.Fatal("expected AbstractProcess.Position to be populated; SensorML position field was silently dropped")
+	}
+	wantGeoJSON := `{"type": "Point", "coordinates": [-122.4194, 37.7749, 10.0]}`
+	if got := string(base.Position.Raw); got != wantGeoJSON {
+		t.Errorf("Position.Raw mismatch:\n got: %q\nwant: %q", got, wantGeoJSON)
+	}
+
+	// And emit a position triple under PredPosition (→ sosa:hasLocation).
+	if !triplePredicateAndObjectMatch(triples, PredPosition, wantGeoJSON) {
+		t.Errorf("expected position triple %q → %q; got %v", PredPosition, wantGeoJSON, triples)
+	}
+
+	// Turtle export must compact PredPosition to sosa:hasLocation
+	// (proving the predicate registration in init() is live).
+	out, err := export.SerializeToString(triples, export.Turtle)
+	if err != nil {
+		t.Fatalf("Turtle export: %v", err)
+	}
+	if !strings.Contains(out, "sosa:hasLocation") {
+		t.Errorf("expected Turtle output to contain sosa:hasLocation, got:\n%s", out)
+	}
+}
+
+func TestAsset_PositionAbsent_NoTripleEmitted(t *testing.T) {
+	// Regression: a process WITHOUT a position field must not
+	// emit a position triple. Guards against Object: "" or
+	// Object: "null" leaks.
+	const sml = `{
+		"type": "PhysicalSystem",
+		"id": "no-position-platform",
+		"label": "Indoor sensor — no geometry"
+	}`
+
+	process, err := UnmarshalProcess([]byte(sml))
+	if err != nil {
+		t.Fatalf("UnmarshalProcess: %v", err)
+	}
+
+	asset := NewAsset("acme.ops.indoor.gcs.platform.001", process)
+	triples := asset.Triples()
+	for _, tr := range triples {
+		if tr.Predicate == PredPosition {
+			t.Errorf("unexpected position triple emitted when SensorML has no position field: %v", tr)
+		}
+	}
+}
+
 func containsTriple(triples []message.Triple, want message.Triple) bool {
 	for _, t := range triples {
 		if t.Subject == want.Subject && t.Predicate == want.Predicate && t.Object == want.Object {

--- a/parser/sensorml/predicates.go
+++ b/parser/sensorml/predicates.go
@@ -59,6 +59,13 @@ const (
 	// PredCharacteristicValue carries a characteristic-list
 	// entry's value (physical property of the device).
 	PredCharacteristicValue = "sensorml.characteristic.value"
+
+	// PredPosition carries the SensorML §7.1.6 position field
+	// verbatim as a GeoJSON-shaped string (Point / Polygon /
+	// LineString). Maps to sosa:hasLocation. The Object value is
+	// the raw GeoJSON-shaped JSON text (string) — consumers parse
+	// it as GeoJSON when they need typed geometry. See issue #114.
+	PredPosition = "sensorml.process.position"
 )
 
 // init registers every dotted predicate this package emits with
@@ -94,6 +101,7 @@ func init() {
 		vocabulary.WithIRI("http://www.w3.org/ns/ssn/hasProperty"))
 	vocabulary.Register(PredCharacteristicValue,
 		vocabulary.WithIRI("http://www.w3.org/ns/ssn/hasProperty"))
+	vocabulary.Register(PredPosition, vocabulary.WithIRI(sosa.HasLocation))
 }
 
 // processClassIRI returns the SOSA class IRI that best matches

--- a/parser/sensorml/types_process.go
+++ b/parser/sensorml/types_process.go
@@ -1,5 +1,7 @@
 package sensorml
 
+import "encoding/json"
+
 // Process is the SensorML JSON polymorphic root. Every concrete
 // process type (PhysicalSystem, PhysicalComponent, SimpleProcess,
 // AggregateProcess) implements Process by reporting its
@@ -52,6 +54,38 @@ type AbstractProcess struct {
 	Outputs         DataComponentList  `json:"outputs,omitempty"`
 	Parameters      DataComponentList  `json:"parameters,omitempty"`
 	TypeOf          *Reference         `json:"typeOf,omitempty"`
+	Position        *Position          `json:"position,omitempty"`
+}
+
+// Position is the SensorML §7.1.6 spatial element. Wire form is a
+// GeoJSON-shaped Point / Polygon / LineString carried verbatim as
+// json.RawMessage so the parser does not have to know every valid
+// geometry shape. Consumers (graph-index-spatial, CS API gateways)
+// read Raw and parse as GeoJSON.
+//
+// MarshalJSON returns Raw directly — round-trips losslessly.
+// UnmarshalJSON copies the incoming bytes into Raw, so the source
+// stream is decoupled from the slice the struct retains.
+//
+// See issue #114.
+type Position struct {
+	Raw json.RawMessage `json:"-"`
+}
+
+// UnmarshalJSON captures the raw position JSON for later passthrough.
+func (p *Position) UnmarshalJSON(data []byte) error {
+	p.Raw = append(p.Raw[:0], data...)
+	return nil
+}
+
+// MarshalJSON returns the captured raw JSON. Returns the JSON
+// literal "null" when Raw is empty so consumers do not see invalid
+// JSON output if the struct was constructed without a payload.
+func (p Position) MarshalJSON() ([]byte, error) {
+	if len(p.Raw) == 0 {
+		return []byte("null"), nil
+	}
+	return p.Raw, nil
 }
 
 // SimpleProcess is a SensorML concrete leaf process — an

--- a/vocabulary/csapi/iris.go
+++ b/vocabulary/csapi/iris.go
@@ -25,6 +25,24 @@ const (
 	// ResultTimeRange) and a result-type discriminator (ResultType).
 	// CS API v1.0 §10.
 	Datastream = Namespace + "Datastream"
+
+	// ControlStream — a stream of Commands sent to one System
+	// (typically an Actuator-bearing platform) for one
+	// ActuatableProperty. CS API v1.0 Part 2 §14. Draft surface;
+	// IRI swaps to the canonical spec form once published.
+	ControlStream = Namespace + "ControlStream"
+
+	// Command — an individual instruction issued through a
+	// ControlStream targeting an ActuatableProperty. CS API v1.0
+	// Part 2 §15. Draft surface; IRI may swap when the spec
+	// publishes.
+	Command = Namespace + "Command"
+
+	// SystemEvent — a discrete notification about a System
+	// (deployment lifecycle, configuration change, alert). Used
+	// by /systems/{id}/events. CS API v1.0 Part 2 §16. Draft
+	// surface; IRI may swap when the spec publishes.
+	SystemEvent = Namespace + "SystemEvent"
 )
 
 // iris is the canonical set of IRIs this package surfaces, indexed
@@ -33,13 +51,19 @@ const (
 // iris_test.go fails loud if these drift apart.
 var iris = map[string]string{
 	// Classes
-	Prefix + ":Datastream": Datastream,
+	Prefix + ":Datastream":    Datastream,
+	Prefix + ":ControlStream": ControlStream,
+	Prefix + ":Command":       Command,
+	Prefix + ":SystemEvent":   SystemEvent,
 
 	// Predicates
 	Prefix + ":producedBy":          ProducedBy,
 	Prefix + ":resultTimeRange":     ResultTimeRange,
 	Prefix + ":phenomenonTimeRange": PhenomenonTimeRange,
 	Prefix + ":resultType":          ResultType,
+	Prefix + ":controlsSystem":      ControlsSystem,
+	Prefix + ":partOfControlStream": PartOfControlStream,
+	Prefix + ":eventForSystem":      EventForSystem,
 }
 
 var reverseIRIs = func() map[string]string {

--- a/vocabulary/csapi/iris_test.go
+++ b/vocabulary/csapi/iris_test.go
@@ -7,12 +7,18 @@ import (
 
 func TestIRIsCoverConstants(t *testing.T) {
 	wantPairs := map[string]string{
-		Prefix + ":Datastream": Datastream,
+		Prefix + ":Datastream":    Datastream,
+		Prefix + ":ControlStream": ControlStream,
+		Prefix + ":Command":       Command,
+		Prefix + ":SystemEvent":   SystemEvent,
 
 		Prefix + ":producedBy":          ProducedBy,
 		Prefix + ":resultTimeRange":     ResultTimeRange,
 		Prefix + ":phenomenonTimeRange": PhenomenonTimeRange,
 		Prefix + ":resultType":          ResultType,
+		Prefix + ":controlsSystem":      ControlsSystem,
+		Prefix + ":partOfControlStream": PartOfControlStream,
+		Prefix + ":eventForSystem":      EventForSystem,
 	}
 	got := IRIs()
 	if len(got) != len(wantPairs) {
@@ -29,8 +35,9 @@ func TestIRIsCoverConstants(t *testing.T) {
 
 func TestConstantsLiveInDeclaredNamespace(t *testing.T) {
 	all := []string{
-		Datastream,
+		Datastream, ControlStream, Command, SystemEvent,
 		ProducedBy, ResultTimeRange, PhenomenonTimeRange, ResultType,
+		ControlsSystem, PartOfControlStream, EventForSystem,
 	}
 	for _, c := range all {
 		if !strings.HasPrefix(c, Namespace) {

--- a/vocabulary/csapi/predicates.go
+++ b/vocabulary/csapi/predicates.go
@@ -22,4 +22,17 @@ const (
 	// Observations — om:Measurement, om:Category, om:CountObservation,
 	// etc. Consumers branch on this to decode the result payload.
 	ResultType = Namespace + "resultType"
+
+	// ControlsSystem binds a ControlStream to the entity ID of the
+	// System it targets with Commands. Inverse counterpart to a
+	// forthcoming `hasControlStream`. CS API v1.0 Part 2 §14.
+	ControlsSystem = Namespace + "controlsSystem"
+
+	// PartOfControlStream binds a Command to the entity ID of the
+	// ControlStream it was issued through. CS API v1.0 Part 2 §15.
+	PartOfControlStream = Namespace + "partOfControlStream"
+
+	// EventForSystem binds a SystemEvent to the entity ID of the
+	// System the event is about. CS API v1.0 Part 2 §16.
+	EventForSystem = Namespace + "eventForSystem"
 )

--- a/vocabulary/sosa/iris.go
+++ b/vocabulary/sosa/iris.go
@@ -43,6 +43,11 @@ const (
 	// downstream observation.
 	Sample = Namespace + "Sample"
 
+	// SamplingFeature — a spatial / temporal proxy a Sample is
+	// drawn from. Carries the geometry and time bounds the Sample
+	// itself doesn't own directly. SOSA §3.10.
+	SamplingFeature = Namespace + "SamplingFeature"
+
 	// Sampler — the device or method that produces a Sample.
 	Sampler = Namespace + "Sampler"
 
@@ -110,6 +115,13 @@ const (
 	// ObservedProperty binds an Observation to the
 	// ObservableProperty it measured.
 	ObservedProperty = Namespace + "observedProperty"
+
+	// HasLocation binds a Feature-of-Interest (System, Sensor,
+	// Sample, etc.) to a Geo-Feature describing its spatial extent.
+	// W3C SSN/SOSA recommendation 2017 §7. Object is typically a
+	// GeoJSON-shaped Point / Polygon / LineString string carried
+	// verbatim through the triple set.
+	HasLocation = Namespace + "hasLocation"
 )
 
 // SSN namespace identifiers. SSN is the systems/deployment overlay

--- a/vocabulary/sosa/iris_test.go
+++ b/vocabulary/sosa/iris_test.go
@@ -18,6 +18,7 @@ func TestIRIsCoverConstants(t *testing.T) {
 		Prefix + ":Platform":           Platform,
 		Prefix + ":Procedure":          Procedure,
 		Prefix + ":Sample":             Sample,
+		Prefix + ":SamplingFeature":    SamplingFeature,
 		Prefix + ":Sampler":            Sampler,
 		Prefix + ":Result":             Result,
 		Prefix + ":Actuator":           Actuator,
@@ -36,6 +37,7 @@ func TestIRIsCoverConstants(t *testing.T) {
 		Prefix + ":hosts":                Hosts,
 		Prefix + ":isHostedBy":           IsHostedBy,
 		Prefix + ":observedProperty":     ObservedProperty,
+		Prefix + ":hasLocation":          HasLocation,
 
 		SSNPrefix + ":System":         SSNSystem,
 		SSNPrefix + ":Deployment":     SSNDeployment,
@@ -64,11 +66,11 @@ func TestIRIsCoverConstants(t *testing.T) {
 func TestConstantsLiveInDeclaredNamespace(t *testing.T) {
 	sosaConsts := []string{
 		Sensor, Observation, FeatureOfInterest, ObservableProperty,
-		Platform, Procedure, Sample, Sampler, Result, Actuator,
+		Platform, Procedure, Sample, SamplingFeature, Sampler, Result, Actuator,
 		Actuation, ActuatableProperty,
 		Observes, HasFeatureOfInterest, MadeBySensor, MadeObservation,
 		UsedProcedure, HasSimpleResult, HasResult, ResultTime,
-		PhenomenonTime, Hosts, IsHostedBy, ObservedProperty,
+		PhenomenonTime, Hosts, IsHostedBy, ObservedProperty, HasLocation,
 	}
 	for _, c := range sosaConsts {
 		if !strings.HasPrefix(c, Namespace) {

--- a/vocabulary/sosa/predicates.go
+++ b/vocabulary/sosa/predicates.go
@@ -21,6 +21,7 @@ var iris = map[string]string{
 	Prefix + ":Platform":           Platform,
 	Prefix + ":Procedure":          Procedure,
 	Prefix + ":Sample":             Sample,
+	Prefix + ":SamplingFeature":    SamplingFeature,
 	Prefix + ":Sampler":            Sampler,
 	Prefix + ":Result":             Result,
 	Prefix + ":Actuator":           Actuator,
@@ -40,6 +41,7 @@ var iris = map[string]string{
 	Prefix + ":hosts":                Hosts,
 	Prefix + ":isHostedBy":           IsHostedBy,
 	Prefix + ":observedProperty":     ObservedProperty,
+	Prefix + ":hasLocation":          HasLocation,
 
 	// SSN classes
 	SSNPrefix + ":System":     SSNSystem,


### PR DESCRIPTION
## Summary

semconnect Stage 13 conformance probe showed that the parser silently dropped the SensorML §7.1.6 `position` field — a POST of a SensorML PhysicalSystem with `position` survives the round trip with every other field preserved, but the spatial information is gone. ~26 CS API ETS assertions cascade-SKIP because `/req/system/location-time` can't satisfy `systemItemHasGeometryOrValidTime` without either geometry or validTime.

**Cause**: `AbstractProcess` had no Position field; `Asset.Triples()` had nothing to emit even if a predicate existed.

**Fix** — three-layer change in `parser/sensorml`:

1. Add `Position` type (raw GeoJSON-shaped `json.RawMessage`, round-trips losslessly) + `Position *Position` field on `AbstractProcess`.
2. Add `PredPosition = "sensorml.process.position"` constant, registered to `sosa.HasLocation`.
3. Emit a position triple in `Asset.Triples()` when `Position` is non-empty.

## Dependency

⚠️ **Depends on #117** (#126) — uses `sosa.HasLocation`. Once #117 merges, the diff here narrows to just the parser changes. The branch was forked off #117's branch.

## Test plan

- [x] `TestAsset_PositionRoundTripsAsTriple` — parses inline SensorML with `position: {Point, [...]}`, asserts `Position.Raw` populated, asserts `PredPosition` triple emitted with raw GeoJSON, asserts Turtle export compacts to `sosa:hasLocation` (proves predicate registration is live).
- [x] `TestAsset_PositionAbsent_NoTripleEmitted` — regression guard: PhysicalSystem without `position` must NOT emit a position triple.
- [x] `go test -race ./parser/sensorml/... ./vocabulary/...` clean.
- [x] `task lint` + `go vet -tags=integration ./...` clean.

## Downstream impact

semconnect's `cs-api.system.position` workaround retires. `systemItemHasGeometryOrValidTime` flips from SKIP to PASS, un-gating the systemfeatures cascade (~26 dependent CS API ETS assertions).

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)