### PR TITLE
feat(parser/sensorml): preserve uniqueId in emitted triples (#115)

### DIFF
--- a/parser/sensorml/graphable.go
+++ b/parser/sensorml/graphable.go
@@ -63,6 +63,9 @@ func (a *Asset) Triples() []message.Triple {
 	if base.Definition != "" {
 		out = append(out, message.Triple{Subject: a.entityID, Predicate: PredDefinition, Object: base.Definition})
 	}
+	if base.UniqueID != "" {
+		out = append(out, message.Triple{Subject: a.entityID, Predicate: PredUniqueID, Object: base.UniqueID})
+	}
 	for _, ident := range base.Identifiers {
 		if ident.Value != nil {
 			out = append(out, message.Triple{Subject: a.entityID, Predicate: PredIdentifierValue, Object: ident.Value})

--- a/parser/sensorml/graphable_test.go
+++ b/parser/sensorml/graphable_test.go
@@ -243,6 +243,71 @@ func TestAsset_PositionAbsent_NoTripleEmitted(t *testing.T) {
 	}
 }
 
+func TestAsset_UniqueIDEmittedAsTriple(t *testing.T) {
+	// Issue #115: SensorML uniqueId used to be silently dropped by
+	// Asset.Triples() — the parser decoded AbstractProcess.UniqueID
+	// correctly but the emitter had no case for it, so the producer's
+	// globally-unique identifier was lost in the round trip and
+	// downstream consumers (CS API gateways) had no way to surface it.
+	defer vocabulary.SnapshotRegistry()()
+
+	const sml = `{
+		"type": "PhysicalSystem",
+		"id": "platform-001",
+		"label": "Sensor Platform",
+		"uniqueId": "urn:example:dev:42"
+	}`
+
+	process, err := UnmarshalProcess([]byte(sml))
+	if err != nil {
+		t.Fatalf("UnmarshalProcess: %v", err)
+	}
+
+	if got := process.Base().UniqueID; got != "urn:example:dev:42" {
+		t.Fatalf("AbstractProcess.UniqueID parse mismatch: got %q, want %q",
+			got, "urn:example:dev:42")
+	}
+
+	asset := NewAsset("acme.ops.robotics.gcs.platform.001", process)
+	triples := asset.Triples()
+
+	if !triplePredicateAndObjectMatch(triples, PredUniqueID, "urn:example:dev:42") {
+		t.Errorf("expected uid triple %q → %q; got %v",
+			PredUniqueID, "urn:example:dev:42", triples)
+	}
+
+	// Turtle export must compact PredUniqueID to dc:identifier
+	// (proves the predicates.go init() registration is live).
+	out, err := export.SerializeToString(triples, export.Turtle)
+	if err != nil {
+		t.Fatalf("Turtle export: %v", err)
+	}
+	if !strings.Contains(out, "dc:identifier") && !strings.Contains(out, "dcterms:identifier") {
+		t.Errorf("expected Turtle output to contain dc:identifier (or dcterms:identifier), got:\n%s", out)
+	}
+}
+
+func TestAsset_UniqueIDAbsent_NoTripleEmitted(t *testing.T) {
+	const sml = `{
+		"type": "PhysicalSystem",
+		"id": "no-uid-platform",
+		"label": "Platform without uniqueId"
+	}`
+
+	process, err := UnmarshalProcess([]byte(sml))
+	if err != nil {
+		t.Fatalf("UnmarshalProcess: %v", err)
+	}
+
+	asset := NewAsset("acme.ops.test.gcs.platform.001", process)
+	triples := asset.Triples()
+	for _, tr := range triples {
+		if tr.Predicate == PredUniqueID {
+			t.Errorf("unexpected uid triple emitted when SensorML has no uniqueId field: %v", tr)
+		}
+	}
+}
+
 func containsTriple(triples []message.Triple, want message.Triple) bool {
 	for _, t := range triples {
 		if t.Subject == want.Subject && t.Predicate == want.Predicate && t.Object == want.Object {

--- a/parser/sensorml/predicates.go
+++ b/parser/sensorml/predicates.go
@@ -66,6 +66,15 @@ const (
 	// the raw GeoJSON-shaped JSON text (string) — consumers parse
 	// it as GeoJSON when they need typed geometry. See issue #114.
 	PredPosition = "sensorml.process.position"
+
+	// PredUniqueID carries the SensorML §7.1.3 uniqueId — the
+	// producer-assigned globally-unique identifier (URN, UUID,
+	// vendor-scoped string). Distinct from the SemStreams-assigned
+	// 6-part Entity ID, which is the triple Subject; the uid
+	// preserves the original client identifier so consumers can
+	// correlate a POSTed resource against subsequent reads. Maps
+	// to dc:identifier. See issue #115.
+	PredUniqueID = "sensorml.process.uid"
 )
 
 // init registers every dotted predicate this package emits with
@@ -102,6 +111,7 @@ func init() {
 	vocabulary.Register(PredCharacteristicValue,
 		vocabulary.WithIRI("http://www.w3.org/ns/ssn/hasProperty"))
 	vocabulary.Register(PredPosition, vocabulary.WithIRI(sosa.HasLocation))
+	vocabulary.Register(PredUniqueID, vocabulary.WithIRI(vocabulary.DcIdentifier))
 }
 
 // processClassIRI returns the SOSA class IRI that best matches


### PR DESCRIPTION
## Summary

semconnect Stage 18 conformance probe showed `parser/sensorml` silently dropped the SensorML §7.1.3 `uniqueId` — the parser decoded `AbstractProcess.UniqueID` correctly but `Asset.Triples()` had no case for it. The producer-assigned globally-unique identifier (URN, UUID, vendor-scoped string) was lost in the round trip; downstream CS API gateways had to maintain a workaround `cs-api.system.uid` predicate to satisfy the ETS `sensorMlMediaTypeWriteParsesSystemBodyWhenMutationEnabled` and `geoJsonMediaTypeWriteParsesSystemBodyWhenMutationEnabled` assertions.

## Fix

1. Add `PredUniqueID = "sensorml.process.uid"` constant, registered to `vocabulary.DcIdentifier`.
2. Emit a uid triple in `Asset.Triples()` when `base.UniqueID != ""` — right after the definition triple, before identifier values.

## Test plan

- [x] `TestAsset_UniqueIDEmittedAsTriple` — parses inline SensorML with `uniqueId: "urn:example:dev:42"`; asserts value on `AbstractProcess.UniqueID`; asserts `PredUniqueID` triple emitted; asserts Turtle compacts to `dc:identifier`/`dcterms:identifier` (proves registration init is live).
- [x] `TestAsset_UniqueIDAbsent_NoTripleEmitted` — regression guard: no uid → no uid triple.
- [x] `go test -race ./parser/sensorml/...` clean, `task lint` + `go vet -tags=integration ./...` clean.

## Downstream impact

semconnect's `cs-api.system.uid` workaround retires; gateway `systemFromState` / `buildAbstractProcess` can read from the framework predicate. Companion to #114 (position preservation) — same emission-gap pattern.

Independent of #117 / #114; touches different lines in `parser/sensorml/predicates.go` so merges in any order.

Closes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)