### PR TITLE
docs(configs): add graph-backend.json slim example + port-type guide (#99)

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -56,6 +56,42 @@ Full-featured deployment with external ML services for embeddings and LLM enhanc
 - `semembed:8081` - Embedding service
 - `seminstruct:8083` - LLM instruction service
 
+## Graph-Backend Deployments (`graph-backend.json`)
+
+Some downstream consumers — typically gateways or sister-repos that publish mutations directly via `graph.mutation.triple.*` request/reply and read via `graph.index.query.*` / `graph.query.entity` / `graph.spatial.query.*` — need the framework as a **graph backend**, not as a full source-data pipeline.
+
+`configs/graph-backend.json` wires only the five graph processors plus the minimum services:
+
+- `graph-ingest` — mutation responder (auto-wires `graph.mutation.triple.{add,add_batch,remove}` request handlers regardless of input port declarations)
+- `graph-index` — entity-state KV watcher → predicate / outgoing / incoming / alias index responders
+- `graph-index-spatial` — entity-state KV watcher → spatial query responder
+- `graph-index-temporal` — entity-state KV watcher → temporal query responder
+- `graph-query` — `graph.query.>` request/reply responder
+
+Plus `service-manager` + `component-manager` only. No `udp`, `iot_sensor`, `document_processor`, `objectstore`, `rule`, `graph-gateway`, file inputs/outputs — those are all part of the source-data pipeline that a gateway-backed deployment does not use.
+
+### Dummy input port on `graph-ingest`
+
+`graph-ingest.Config.Validate()` requires `len(Ports.Inputs) >= 1` even when the component is responding to mutation handlers rather than reading from a JetStream pipeline. The example uses a benign dummy:
+
+```json
+{"name": "unused_in", "subject": "_graph_backend.unused.ingest", "type": "nats"}
+```
+
+The `nats` port type (vs `jetstream`) is the key — declaring a `jetstream` input would force `EnsureStream` for a stream that never receives publishes.
+
+### Port types — when to use which
+
+| Type | Purpose | Stream / subject requirement |
+|------|---------|------------------------------|
+| `jetstream` | Durable JetStream subscription; messages persisted to a stream | Stream must exist (auto-created by `EnsureStream`); messages are durable |
+| `nats` | Core NATS subscription; no persistence, ephemeral fan-out | Subject can be any; no stream lifecycle |
+| `kv-watch` | Watch a NATS KV bucket for changes; receives every put + delete | Bucket must exist (auto-created when listed in `services`) |
+| `kv` / `kv-write` | Write into a NATS KV bucket | Bucket must exist |
+| `nats-request` | Reply to NATS request/reply messages on the subject | No stream; subject is a request endpoint |
+
+`graph-ingest`'s `graph.mutation.*` handlers are wired automatically by `setupMutationHandlers` — they do not need to be declared as ports. Same for `graph-query`'s `graph.query.>` handlers (these DO appear as `nats-request` ports for documentation, but the component would still respond if the port were absent).
+
 ## Graph Component Architecture
 
 The graph processing layer uses a modular component architecture with KV-watch based event flow:

--- a/configs/graph-backend.json
+++ b/configs/graph-backend.json
@@ -1,0 +1,125 @@
+{
+  "version": "1.1.0",
+  "platform": {
+    "org": "example",
+    "id": "graph-backend",
+    "type": "graph-backend",
+    "region": "local",
+    "instance_id": "backend-001",
+    "environment": "development"
+  },
+  "tier": "rules",
+  "nats": {
+    "urls": ["nats://localhost:4222"]
+  },
+  "services": {
+    "service-manager": {
+      "name": "service-manager",
+      "enabled": true,
+      "config": {
+        "http_port": 8080,
+        "swagger_ui": true,
+        "server_info": {
+          "title": "SemStreams Graph Backend",
+          "description": "Slim graph-only instance — mutation handlers + index responders + query responder, no source-data pipeline.",
+          "version": "0.1.0"
+        }
+      }
+    },
+    "component-manager": {
+      "name": "component-manager",
+      "enabled": true,
+      "config": {}
+    }
+  },
+  "components": {
+    "graph-ingest": {
+      "type": "processor",
+      "name": "graph-ingest",
+      "enabled": true,
+      "config": {
+        "ports": {
+          "inputs": [
+            {"name": "unused_in", "subject": "_graph_backend.unused.ingest", "type": "nats"}
+          ],
+          "outputs": [
+            {"name": "entity_states", "subject": "ENTITY_STATES", "type": "kv-write"}
+          ]
+        },
+        "enable_hierarchy": true
+      }
+    },
+    "graph-index": {
+      "type": "processor",
+      "name": "graph-index",
+      "enabled": true,
+      "config": {
+        "ports": {
+          "inputs": [
+            {"name": "entity_watch", "subject": "ENTITY_STATES", "type": "kv-watch"}
+          ],
+          "outputs": [
+            {"name": "outgoing_index", "subject": "OUTGOING_INDEX", "type": "kv"},
+            {"name": "incoming_index", "subject": "INCOMING_INDEX", "type": "kv"},
+            {"name": "alias_index", "subject": "ALIAS_INDEX", "type": "kv"},
+            {"name": "predicate_index", "subject": "PREDICATE_INDEX", "type": "kv"}
+          ]
+        },
+        "workers": 2,
+        "batch_size": 50
+      }
+    },
+    "graph-index-spatial": {
+      "type": "processor",
+      "name": "graph-index-spatial",
+      "enabled": true,
+      "config": {
+        "ports": {
+          "inputs": [
+            {"name": "entity_watch", "subject": "ENTITY_STATES", "type": "kv-watch"}
+          ],
+          "outputs": [
+            {"name": "spatial_index", "subject": "SPATIAL_INDEX", "type": "kv"}
+          ]
+        },
+        "geohash_precision": 6,
+        "workers": 1,
+        "batch_size": 50
+      }
+    },
+    "graph-index-temporal": {
+      "type": "processor",
+      "name": "graph-index-temporal",
+      "enabled": true,
+      "config": {
+        "ports": {
+          "inputs": [
+            {"name": "entity_watch", "subject": "ENTITY_STATES", "type": "kv-watch"}
+          ],
+          "outputs": [
+            {"name": "temporal_index", "subject": "TEMPORAL_INDEX", "type": "kv"}
+          ]
+        },
+        "time_resolution": "hour",
+        "workers": 1,
+        "batch_size": 50
+      }
+    },
+    "graph-query": {
+      "type": "processor",
+      "name": "graph-query",
+      "enabled": true,
+      "config": {
+        "ports": {
+          "inputs": [
+            {"name": "query_requests", "subject": "graph.query.>", "type": "nats-request"}
+          ],
+          "outputs": []
+        },
+        "request_timeout": "30s",
+        "max_traversal_depth": 5,
+        "max_traversal_nodes": 100
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

For sister-repos / gateways (semconnect's conformance backend is the exemplar) that publish mutations directly via `graph.mutation.triple.*` and read via `graph.index.query.*` / `graph.query.entity` / `graph.spatial.query.*`, the minimum framework instance needs five graph processors and nothing else. Authoring the slim shape today requires reading `componentregistry/register.go`, `component/port.go`, `processor/graph-ingest/component.go` (port validation), and `processor/graph-ingest/mutations.go` (auto-wired subjects). That's not light lifting.

## Changes

1. **`configs/graph-backend.json`** — slim config: 5 graph processors (`graph-ingest`, `graph-index`, `graph-index-spatial`, `graph-index-temporal`, `graph-query`) + `service-manager` + `component-manager`. Mirrors the working `semconnect/conformance/compose.semstreams.config.json` structure that's been exercising the OGC Team Engine harness since semconnect Stage 9 (2026-05-16). Platform identifiers swapped for generic `example/graph-backend` defaults; NATS URL set to `localhost`.

2. **`configs/README.md`** — new "Graph-Backend Deployments" section:
   - Lists the 5 processors and the auto-wired subjects each responds on (`graph.mutation.triple.*`, `graph.query.>`, etc.).
   - Explains the dummy `"unused_in"` input port pattern (`graph-ingest.Config.Validate()` requires `len(Ports.Inputs) >= 1`).
   - Port-type guide table (`jetstream` vs `nats` vs `kv-watch` vs `kv` / `kv-write` vs `nats-request`) — closes the "nats vs jetstream" choice that the semconnect team had to derive from source.

## Deferred

The tertiary item from #99 (slim-mode for `graph-ingest` dropping the `>=1` input port requirement, or a `mode: "responder-only"` config flag) is deferred — that's a behavior change in `graph-ingest.Config.Validate()`, not a doc/config addition, and warrants its own discussion. The dummy-port pattern documented here is operator-friendly enough for now.

Closes #99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)