### PR TITLE
fix(tests): harden #107 flakes — explicit sync + tuned concurrency + Docker-tolerant startup

### DIFF
--- a/natsclient/test_client.go
+++ b/natsclient/test_client.go
@@ -121,9 +121,18 @@ func WithBucketPrefix(prefix string) TestOption {
 func NewSharedTestClient(opts ...TestOption) (*TestClient, error) {
 	// Default configuration
 	cfg := &testConfig{
-		natsVersion:  "2.12-alpine",
-		timeout:      5 * time.Second,
-		startTimeout: 30 * time.Second,
+		natsVersion: "2.12-alpine",
+		timeout:     5 * time.Second,
+		// 60s startup timeout: comfortable headroom for full
+		// `go test -race -tags=integration ./...` sweeps where Docker
+		// can be under contention from dozens of parallel container
+		// spinups. Steady-state startup is well under 5s; the
+		// generous default only matters when the host is loaded.
+		// Beta.78 sweep showed 30s occasionally insufficient for
+		// hierarchy_sync_integration_test.go and
+		// entity_mutation_integration_test.go (port-not-found within
+		// the deadline). See issue #107.
+		startTimeout: 60 * time.Second,
 	}
 
 	// Apply options
@@ -256,9 +265,18 @@ func NewTestClient(t testing.TB, opts ...TestOption) *TestClient {
 
 	// Default configuration
 	cfg := &testConfig{
-		natsVersion:  "2.12-alpine",
-		timeout:      5 * time.Second,
-		startTimeout: 30 * time.Second,
+		natsVersion: "2.12-alpine",
+		timeout:     5 * time.Second,
+		// 60s startup timeout: comfortable headroom for full
+		// `go test -race -tags=integration ./...` sweeps where Docker
+		// can be under contention from dozens of parallel container
+		// spinups. Steady-state startup is well under 5s; the
+		// generous default only matters when the host is loaded.
+		// Beta.78 sweep showed 30s occasionally insufficient for
+		// hierarchy_sync_integration_test.go and
+		// entity_mutation_integration_test.go (port-not-found within
+		// the deadline). See issue #107.
+		startTimeout: 60 * time.Second,
 	}
 
 	// Apply options

--- a/processor/graph-ingest/cas_integration_test.go
+++ b/processor/graph-ingest/cas_integration_test.go
@@ -294,8 +294,18 @@ func TestIntegration_CASRetryBehavior(t *testing.T) {
 		}
 		require.NoError(t, component.CreateEntity(ctx, initialEntity))
 
-		// High contention: many goroutines hitting same entity
-		concurrency := 50
+		// High contention: many goroutines hitting the same entity.
+		//
+		// Concurrency 25 is the sweet spot: high enough to exercise the
+		// CAS-retry path multiple times per goroutine (each retry observes
+		// a different revision committed by a peer), low enough to fit
+		// inside the default natsclient retry budget (MaxRetries=10 with
+		// exponential backoff) even when Docker is under contention from
+		// a full `go test -race -tags=integration ./...` sweep. Beta.77
+		// + #107 evidence: 50 occasionally flaked under sweep because the
+		// last few goroutines exhausted retries before winning the CAS race.
+		// See [[project_issue_107_flake_hardening]] for the analysis.
+		concurrency := 25
 		var wg sync.WaitGroup
 		var successCount atomic.Int32
 

--- a/processor/rule/entity_watcher_integration_test.go
+++ b/processor/rule/entity_watcher_integration_test.go
@@ -132,10 +132,23 @@ func TestEntityWatcher_RuleTriggerDebouncing(t *testing.T) {
 			time.Sleep(20 * time.Millisecond) // Less than debounce delay
 		}
 
-		// Wait for debounce to fire (100ms + buffer)
-		time.Sleep(200 * time.Millisecond)
+		// Wait for exactly one trigger to fire (the coalesced final state).
+		// Explicit synchronization replaces the previous wall-clock budget,
+		// which flaked under Docker pressure when the watcher took >200ms to
+		// receive the puts. See issue #107.
+		require.Eventually(t, func() bool {
+			triggerMu.Lock()
+			defer triggerMu.Unlock()
+			return triggerCount >= 1
+		}, 2*time.Second, 20*time.Millisecond,
+			"expected at least 1 trigger from the coalesced rapid-updates burst")
 
-		// Should trigger only once with final state (80 > 75)
+		// Hold past the debounce window to confirm no further triggers fire —
+		// the absence check still needs a wall-clock budget (it asserts a
+		// negative). The 300ms window is 3x the debounce delay, comfortable
+		// under load while staying fast in steady state.
+		time.Sleep(300 * time.Millisecond)
+
 		triggerMu.Lock()
 		triggers := triggerCount
 		triggerMu.Unlock()
@@ -165,8 +178,11 @@ func TestEntityWatcher_RuleTriggerDebouncing(t *testing.T) {
 		err = kv.Delete(ctx, entityID)
 		require.NoError(t, err)
 
-		// Wait past debounce period
-		time.Sleep(150 * time.Millisecond)
+		// Wait past debounce period AND a safety buffer for the watcher to
+		// observe both events under Docker pressure. This is an absence
+		// assertion (no triggers fired), so a wall-clock budget is unavoidable;
+		// we use 3x debounce delay + 100ms safety to stay reliable under load.
+		time.Sleep(400 * time.Millisecond)
 
 		// No trigger should have occurred (evaluation canceled)
 		triggerMu.Lock()
@@ -193,13 +209,13 @@ func TestEntityWatcher_RuleTriggerDebouncing(t *testing.T) {
 		_, err = kv.Put(ctx, entityID, stateJSON)
 		require.NoError(t, err)
 
-		// Wait for debounce
-		time.Sleep(200 * time.Millisecond)
-
-		triggerMu.Lock()
-		triggers1 := triggerCount
-		triggerMu.Unlock()
-		assert.Equal(t, int64(1), triggers1, "First update should trigger")
+		// Wait for the first trigger to fire — explicit synchronization
+		// replaces the previous wall-clock budget. Per #107.
+		require.Eventually(t, func() bool {
+			triggerMu.Lock()
+			defer triggerMu.Unlock()
+			return triggerCount >= 1
+		}, 2*time.Second, 20*time.Millisecond, "First update should trigger")
 
 		// Second update after settling
 		state = createEntityStateForDebounce(entityID, 85.0)
@@ -209,13 +225,19 @@ func TestEntityWatcher_RuleTriggerDebouncing(t *testing.T) {
 		_, err = kv.Put(ctx, entityID, stateJSON)
 		require.NoError(t, err)
 
-		// Wait for second debounce
-		time.Sleep(200 * time.Millisecond)
+		// Wait for the second trigger.
+		require.Eventually(t, func() bool {
+			triggerMu.Lock()
+			defer triggerMu.Unlock()
+			return triggerCount >= 2
+		}, 2*time.Second, 20*time.Millisecond,
+			"Second update should trigger new evaluation")
 
 		triggerMu.Lock()
 		triggers2 := triggerCount
 		triggerMu.Unlock()
-		assert.Equal(t, int64(2), triggers2, "Second update should trigger new evaluation")
+		assert.Equal(t, int64(2), triggers2,
+			"Should be exactly 2 triggers — guards against runaway re-evaluation")
 	})
 }
 


### PR DESCRIPTION
## Summary

Three sites of flake under full `go test -race -tags=integration ./...` sweeps where Docker is under contention:

### 1. `processor/rule` `TestEntityWatcher_RuleTriggerDebouncing`

Wall-clock `time.Sleep(200ms)` budget for "expect one trigger" was insufficient when the KV watcher was delayed by Docker pressure. Replaced with `require.Eventually(2s, 20ms)` explicit synchronization per CLAUDE.md "Use explicit synchronization over arbitrary sleeps in concurrent tests".

The absence-check ("no trigger after deletion cancels debounce") keeps a wall-clock budget — it's an absence assertion and no sync signal exists — bumped to 400ms (4x the debounce delay) for headroom.

### 2. `processor/graph-ingest` `TestIntegration_CASRetryBehavior`

50-way concurrency on a single key with the default natsclient retry budget (MaxRetries=10, exponential backoff capping at ~3.3s). In isolation 50 fits comfortably; under sweep Docker pressure adds per-operation latency that pushed the last few goroutines past their retry budget, surfacing as `MaxRetriesExceeded` and `successCount < concurrency`.

Tuned to **25-way concurrency**: still exercises CAS contention deeply (each goroutine sees multiple committed-by-peer revisions on retry) while fitting the default budget comfortably under load.

### 3. `natsclient` test client `startTimeout`

Beta.78 sweep showed 30s occasionally insufficient for `hierarchy_sync_integration_test.go` and `entity_mutation_integration_test.go` (different sites than the seven hardened in beta.77 #112/#118 — the "class contained" claim was disproven). Bumped default to 60s. Steady-state startup is well under 5s, so the generous default only matters under sweep load.

## Test plan

- [x] `go test -race -tags=integration -count=1 ./natsclient/...` clean (51s).
- [x] Hardened tests pass in isolation and adjacent: `go test -race -tags=integration -run "TestEntityWatcher_RuleTriggerDebouncing|TestIntegration_CASRetryBehavior" ./processor/rule/ ./processor/graph-ingest/` clean.
- [x] `task lint` clean.
- No behavior change for production callers — test-only knob bumps + test-only sync pattern.

Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)