### PR TITLE
feat(research): ADR-045 Phase 1 PR 1 — payloads + research_graph tool

### DIFF
--- a/agentic/research/constants.go
+++ b/agentic/research/constants.go
@@ -1,0 +1,73 @@
+package research
+
+// Domain and version constants for the research message namespace. All
+// three payload types (ResearchIntent, SearchResult, RouteDecision)
+// share the domain and version; only the category differs.
+const (
+	// Domain is the payload registry domain for the ADR-045 graph
+	// search rule chain.
+	Domain = "research"
+
+	// SchemaVersion is the current schema version for research payloads.
+	SchemaVersion = "v1"
+)
+
+// Category constants for research payload types.
+const (
+	// CategoryIntent is the caller's research request. Topic + free-form
+	// hints + budget. Entity IDs and predicates are outputs of the chain,
+	// not inputs (see ADR-045's classifier-first amendment).
+	CategoryIntent = "intent"
+
+	// CategoryResult is the chain's terminal output. Synthesis text plus
+	// evidence refs the parent can quote back, plus decomp trace for
+	// trajectory review.
+	CategoryResult = "result"
+
+	// CategoryRouteDecision is route_search's structured emit: one of
+	// four actions plus action-specific args plus rationale.
+	CategoryRouteDecision = "route_decision"
+)
+
+// RouteAction values for RouteDecision.Action. Closed enum per ADR-045
+// section "Why this is not just-a-better-classifier" — the four actions
+// are the load-bearing taxonomy. Validate rejects values outside this
+// set so structured-emit retries can trigger per ADR-035.
+const (
+	// ActionSynthesizeDirectly short-circuits to synthesize_answer when
+	// classifier output is already enough to answer the topic. Many
+	// parent topics will land here; the chain doesn't pay for multi-hop
+	// work it doesn't need.
+	ActionSynthesizeDirectly = "synthesize_directly"
+
+	// ActionRetighten re-runs nl_classify with refined topic/hints when
+	// the initial classification produced noisy or empty hits. Bounded
+	// at MaxIterations=2 on R2's retighten branch.
+	ActionRetighten = "retighten"
+
+	// ActionWalkSeeds dispatches execute_subqueries with the entity IDs
+	// the classifier surfaced. Multi-hop expansion from concrete seeds —
+	// structurally different from topic-wide decompose.
+	ActionWalkSeeds = "walk_seeds"
+
+	// ActionDecompose dispatches execute_subqueries with a typed
+	// sub-query list (entity_state / predicate_walk / temporal_range /
+	// spatial_polygon). The v1 default-path now used only when the
+	// classifier shows it's necessary.
+	ActionDecompose = "decompose"
+)
+
+// DefaultBudgetTokens is ResearchIntent.BudgetTokens default per
+// docs/operations/22-adr045-phase1-plan.md PR 1 spec.
+const DefaultBudgetTokens = 4000
+
+// DefaultMaxIterations is ResearchIntent.MaxIterations default. The
+// refine loop cap on R4 ships with the same default — see ADR-045
+// rule chain R4.
+const DefaultMaxIterations = 5
+
+// PipelineRole is the role string carried on the research-pipeline
+// LoopEntity in AGENT_LOOPS. Lets downstream tooling (trajectory
+// viewers, ops dashboards) filter research loops from coordinator and
+// task loops without parsing intent payloads.
+const PipelineRole = "research_pipeline"

--- a/agentic/research/doc.go
+++ b/agentic/research/doc.go
@@ -1,0 +1,11 @@
+// Package research defines the payload types for the ADR-045 graph
+// search rule chain: Intent, SearchResult, and RouteDecision.
+//
+// These are the wire shapes the chain's coordinated components and the
+// continuation rule pass through the payload registry. Phase 1 PR 1 lands
+// the registry surface so PRs 2-6 can land components and the rule chain
+// without churn on the schema contract.
+//
+// See docs/adr/045-graph-search-rule-chain.md for the architecture and
+// docs/operations/22-adr045-phase1-plan.md for the PR sequence.
+package research

--- a/agentic/research/intent.go
+++ b/agentic/research/intent.go
@@ -1,0 +1,111 @@
+package research
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// Intent is the caller's request: a free-form topic plus
+// optional hints, plus per-call budgets. Per ADR-045's v2 amendment,
+// the intent carries only what the caller actually knows — no entity
+// IDs, no predicate names, no tier mix; those are outputs of the chain.
+//
+// Hints is intentionally a map[string]string in Phase 1: trajectory
+// data from operator use will inform whether typed hint subtypes are
+// worth adding in Phase 2 (see plan doc Risks for PR 1). Keys are
+// classifier-parseable strings ("entity_kind", "domain", "recency",
+// etc.); unknown keys are passed through and ignored downstream rather
+// than rejected, so operators can experiment without schema churn.
+type Intent struct {
+	// Topic is the natural-language research question or subject.
+	// Required.
+	Topic string `json:"topic"`
+
+	// Hints is an optional, free-form map of classifier hints. Phase 1
+	// keeps the shape flexible; Phase 2 may add typed subtypes once
+	// operator trajectories show what hints get passed.
+	Hints map[string]string `json:"hints,omitempty"`
+
+	// BudgetTokens caps total LLM token spend across the chain. Zero
+	// falls back to DefaultBudgetTokens at consumption time so callers
+	// can omit it.
+	BudgetTokens int `json:"budget_tokens,omitempty"`
+
+	// MaxIterations caps the refine loop in R4. Zero falls back to
+	// DefaultMaxIterations.
+	MaxIterations int `json:"max_iterations,omitempty"`
+}
+
+// Schema implements message.Payload.
+func (p *Intent) Schema() message.Type {
+	return message.Type{
+		Domain:   Domain,
+		Category: CategoryIntent,
+		Version:  SchemaVersion,
+	}
+}
+
+// Validate implements message.Payload. Required: Topic. Hints values
+// are checked for non-empty strings when present (a hint key mapped to
+// "" is a caller bug — empty signals "absent", which should be
+// expressed by omitting the key).
+func (p *Intent) Validate() error {
+	if p == nil {
+		return fmt.Errorf("research intent is nil")
+	}
+	if strings.TrimSpace(p.Topic) == "" {
+		return fmt.Errorf("topic required")
+	}
+	for k, v := range p.Hints {
+		if strings.TrimSpace(k) == "" {
+			return fmt.Errorf("hints contains an empty key")
+		}
+		if strings.TrimSpace(v) == "" {
+			return fmt.Errorf("hints[%q] is empty; omit the key instead", k)
+		}
+	}
+	if p.BudgetTokens < 0 {
+		return fmt.Errorf("budget_tokens must be >= 0, got %d", p.BudgetTokens)
+	}
+	if p.MaxIterations < 0 {
+		return fmt.Errorf("max_iterations must be >= 0, got %d", p.MaxIterations)
+	}
+	return nil
+}
+
+// ResolvedBudgetTokens returns BudgetTokens or DefaultBudgetTokens
+// when zero. Use this at consumption time so callers can omit the
+// field and the chain still has a budget cap.
+func (p *Intent) ResolvedBudgetTokens() int {
+	if p.BudgetTokens == 0 {
+		return DefaultBudgetTokens
+	}
+	return p.BudgetTokens
+}
+
+// ResolvedMaxIterations returns MaxIterations or DefaultMaxIterations
+// when zero.
+func (p *Intent) ResolvedMaxIterations() int {
+	if p.MaxIterations == 0 {
+		return DefaultMaxIterations
+	}
+	return p.MaxIterations
+}
+
+// MarshalJSON implements json.Marshaler. Uses the alias pattern to
+// avoid recursion through the Payload interface (the registry decodes
+// via this method).
+func (p *Intent) MarshalJSON() ([]byte, error) {
+	type alias Intent
+	return json.Marshal((*alias)(p))
+}
+
+// UnmarshalJSON implements json.Unmarshaler. Mirrors MarshalJSON's
+// alias pattern for the round-trip through the payload registry.
+func (p *Intent) UnmarshalJSON(data []byte) error {
+	type alias Intent
+	return json.Unmarshal(data, (*alias)(p))
+}

--- a/agentic/research/predicates.go
+++ b/agentic/research/predicates.go
@@ -1,0 +1,63 @@
+package research
+
+// Predicate constants for triples emitted by the research_graph chain.
+// Every predicate lives under the research.* namespace so graph
+// queries can filter chain triples cleanly without colliding with
+// other agentic systems.
+//
+// Triple emission discipline (ADR-028):
+//   - Bulky payloads (synthesis text, evidence body) live in
+//     ObjectStore via ContentStorable; triples carry the ref.
+//   - LLM-authored predicates (eventual route_rationale and
+//     synthesis predicates introduced in PR 3 and PR 5) MUST default
+//     to WithRuleOpaque(true) per
+//     feedback_llm_authored_predicates_rule_opaque — rules branch on
+//     typed fields, not free-form text. PR 1 reserves the namespace
+//     here; the named constants land with the PRs that emit them so
+//     the contract is reviewable alongside the emission.
+const (
+	// PredicateResearchRequested marks a research-pipeline loop entity
+	// as the target of a research_graph tool invocation. Triple
+	// subject = research-loop entity ID; object = the topic string.
+	// R0 of the rule chain watches for this triple to kick off the
+	// chain.
+	PredicateResearchRequested = "research.requested"
+
+	// PredicateResearchTopic carries the topic verbatim. Distinct from
+	// PredicateResearchRequested because the latter doubles as the
+	// chain-kickoff trigger; this predicate is the durable record of
+	// what the parent actually asked for.
+	PredicateResearchTopic = "research.topic"
+
+	// PredicateResearchHint stamps a single hint key/value pair. One
+	// triple per hint, with the key encoded in the Object field as
+	// "<key>=<value>". Multi-triple is preferred over JSON-stringified
+	// hint maps so graph queries can filter on specific hint keys.
+	PredicateResearchHint = "research.hint"
+
+	// PredicateResearchBudgetTokens carries the resolved per-call token
+	// budget (after defaulting). Stored as string per Triple.Object
+	// shape; consumers parse to int.
+	PredicateResearchBudgetTokens = "research.budget_tokens"
+
+	// PredicateResearchMaxIterations carries the resolved refine-loop
+	// cap (after defaulting).
+	PredicateResearchMaxIterations = "research.max_iterations"
+
+	// PredicateResearchParentLoop links the research-pipeline loop
+	// back to its parent loop entity ID. Stamped by the research_graph
+	// tool from call.LoopID so the continuation rule can route the
+	// SearchResult back to the right caller.
+	PredicateResearchParentLoop = "research.parent_loop"
+
+	// PredicateLoopRole stamps the loop entity's role. Same convention
+	// as other agentic loops; lets ops dashboards filter
+	// research-pipeline loops without parsing intent payloads.
+	PredicateLoopRole = "loop.role"
+)
+
+// TripleSource is the Source field on triples emitted by the
+// research_graph tool. Mirrors the decide / write_todos convention so
+// operators can distinguish chain-kickoff triples from later component
+// emissions in graph queries.
+const TripleSource = "agent-research-graph"

--- a/agentic/research/register.go
+++ b/agentic/research/register.go
@@ -1,0 +1,49 @@
+package research
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/c360studio/semstreams/payloadregistry"
+)
+
+// RegisterPayloads registers the three research payload types with the
+// supplied registry. Called from payloadbuiltins.Register at process
+// bootstrap so every production binary picks up the types without
+// extra wiring.
+//
+// Mirrors the agentic.RegisterPayloads + agentic/operating-model
+// shape so the bootstrap aggregator can call this uniformly.
+func RegisterPayloads(reg *payloadregistry.Registry) error {
+	registrations := []*payloadregistry.Registration{
+		{
+			Domain:      Domain,
+			Category:    CategoryIntent,
+			Version:     SchemaVersion,
+			Description: "ADR-045 graph-search chain research intent: topic + hints + budget",
+			Factory:     func() any { return &Intent{} },
+		},
+		{
+			Domain:      Domain,
+			Category:    CategoryResult,
+			Version:     SchemaVersion,
+			Description: "ADR-045 graph-search chain terminal search result with evidence + synthesis",
+			Factory:     func() any { return &SearchResult{} },
+		},
+		{
+			Domain:      Domain,
+			Category:    CategoryRouteDecision,
+			Version:     SchemaVersion,
+			Description: "ADR-045 route_search component decision: one of four routing actions",
+			Factory:     func() any { return &RouteDecision{} },
+		},
+	}
+
+	var errs []error
+	for _, r := range registrations {
+		if err := reg.Register(r); err != nil {
+			errs = append(errs, fmt.Errorf("register %s.%s.%s: %w", r.Domain, r.Category, r.Version, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/agentic/research/result.go
+++ b/agentic/research/result.go
@@ -1,0 +1,172 @@
+package research
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// Evidence is one item in SearchResult.Evidence — a single entity hit
+// or evidence snippet the chain surfaced. Provenance is mandatory:
+// every evidence item carries enough metadata (EntityID + Tier +
+// Source) for the caller to verify it back against the graph and for
+// synthesize_answer's quote-back validation to reject fabricated refs.
+//
+// ObjectStoreRef is set when the body of the evidence (long text,
+// document, etc.) lives in ObjectStore; consumers read it via that
+// ref. SnippetText carries a short inline preview for prompt-injection
+// readability without triggering ObjectStore round-trips on every hit.
+type Evidence struct {
+	// EntityID is the graph entity this evidence refers to. Required.
+	EntityID string `json:"entity_id"`
+
+	// Tier is the retrieval tier that surfaced this hit: "0" (rules /
+	// predicate queries), "1" (BM25), or "2" (neural — deferred to
+	// Phase 2). Operators may use it to filter evidence by retrieval
+	// method.
+	Tier string `json:"tier"`
+
+	// Source is the retrieval source within the tier — e.g.
+	// "classifier", "predicate_walk", "bm25_index". Required.
+	Source string `json:"source"`
+
+	// Score is the within-tier ranking score (higher = better).
+	// Cross-tier comparison is not meaningful in Phase 1 (per-tier
+	// ordering + recency tie-break); Phase 2 may add a learned ranker.
+	Score float64 `json:"score,omitempty"`
+
+	// SnippetText is a short inline preview (prompt-injection
+	// friendly). Omit when the evidence has no readable preview.
+	SnippetText string `json:"snippet_text,omitempty"`
+
+	// ObjectStoreRef is the ObjectStore key for the full body when
+	// the evidence has bulk content. Empty when the evidence is fully
+	// expressed in the EntityID + triples on the graph.
+	ObjectStoreRef string `json:"objectstore_ref,omitempty"`
+}
+
+// Validate checks the required fields and rejects unknown tier values.
+func (e *Evidence) Validate() error {
+	if strings.TrimSpace(e.EntityID) == "" {
+		return fmt.Errorf("entity_id required")
+	}
+	if strings.TrimSpace(e.Source) == "" {
+		return fmt.Errorf("source required")
+	}
+	switch e.Tier {
+	case "0", "1", "2":
+		// Accepted set. "2" is reserved for Phase 2 but accepted at
+		// the schema level so Phase 1 fixtures can probe forward-compat.
+	default:
+		return fmt.Errorf("tier %q must be \"0\", \"1\", or \"2\"", e.Tier)
+	}
+	return nil
+}
+
+// DecompTrace records what decomposition the chain actually performed,
+// for operator review of router quality. The shape is deliberately
+// loose in Phase 1 — operator trajectories will dictate whether
+// stricter typing is worth the churn (see plan doc PR 5
+// open-questions).
+type DecompTrace struct {
+	// RouterAction is the value emitted by route_search at the chain's
+	// first LLM judgment. One of the four ActionXxx constants.
+	RouterAction string `json:"router_action,omitempty"`
+
+	// SubQueries records the decomposed sub-queries the router
+	// generated when RouterAction == ActionDecompose. Free-form per
+	// Phase 1; typed sub-query schemas land with PR 3's router action
+	// arg schemas.
+	SubQueries []map[string]any `json:"sub_queries,omitempty"`
+
+	// SeedEntities records the walk_seeds entity set when
+	// RouterAction == ActionWalkSeeds.
+	SeedEntities []string `json:"seed_entities,omitempty"`
+
+	// RetightenRounds records how many times R2's retighten branch
+	// fired before terminating (success, cap, or downstream branch).
+	RetightenRounds int `json:"retighten_rounds,omitempty"`
+}
+
+// SearchResult is the chain's terminal output, returned to the parent
+// loop via the continuation rule. Carries synthesis text plus the
+// evidence refs synthesize_answer quoted back, plus the decomp trace
+// for trajectory review.
+type SearchResult struct {
+	// Evidence is the set of hits that informed Synthesis. Every
+	// evidence item synthesize_answer references must appear here;
+	// quote-back validation enforces this in PR 5.
+	Evidence []Evidence `json:"evidence,omitempty"`
+
+	// Synthesis is the natural-language answer produced by
+	// synthesize_answer. Refs quoted in the prose must resolve to
+	// Evidence items above.
+	Synthesis string `json:"synthesis"`
+
+	// DecompTrace is the per-call audit of the chain's routing
+	// choices and decompositions. Optional — present when the chain
+	// took a non-trivial path (anything beyond synthesize_directly).
+	DecompTrace *DecompTrace `json:"decomp_trace,omitempty"`
+
+	// TokensUsed is the total LLM-token spend across the chain's
+	// LLM calls (route_search + assess_sufficiency + synthesize_answer
+	// + any retighten/refine repetitions).
+	TokensUsed int `json:"tokens_used,omitempty"`
+
+	// Iterations is the total refine-loop iterations the chain
+	// executed before terminating. Distinct from RetightenRounds in
+	// DecompTrace — Iterations counts R4's refine loop (capped by
+	// ResearchIntent.MaxIterations); RetightenRounds counts R2's
+	// retighten branch (capped at 2).
+	Iterations int `json:"iterations,omitempty"`
+}
+
+// Schema implements message.Payload.
+func (p *SearchResult) Schema() message.Type {
+	return message.Type{
+		Domain:   Domain,
+		Category: CategoryResult,
+		Version:  SchemaVersion,
+	}
+}
+
+// Validate implements message.Payload. Synthesis is required (the
+// chain's terminal emit always carries at least the synthesized
+// answer; failure paths emit a degraded result with an error string
+// rather than an empty Synthesis). Evidence items are individually
+// validated when present.
+func (p *SearchResult) Validate() error {
+	if p == nil {
+		return fmt.Errorf("search result is nil")
+	}
+	if strings.TrimSpace(p.Synthesis) == "" {
+		return fmt.Errorf("synthesis required")
+	}
+	for i := range p.Evidence {
+		if err := p.Evidence[i].Validate(); err != nil {
+			return fmt.Errorf("evidence[%d]: %w", i, err)
+		}
+	}
+	if p.TokensUsed < 0 {
+		return fmt.Errorf("tokens_used must be >= 0, got %d", p.TokensUsed)
+	}
+	if p.Iterations < 0 {
+		return fmt.Errorf("iterations must be >= 0, got %d", p.Iterations)
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler with the alias-recursion
+// guard.
+func (p *SearchResult) MarshalJSON() ([]byte, error) {
+	type alias SearchResult
+	return json.Marshal((*alias)(p))
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (p *SearchResult) UnmarshalJSON(data []byte) error {
+	type alias SearchResult
+	return json.Unmarshal(data, (*alias)(p))
+}

--- a/agentic/research/roundtrip_test.go
+++ b/agentic/research/roundtrip_test.go
@@ -1,0 +1,348 @@
+package research_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadbuiltins"
+)
+
+// Production-decoder round-trip tests for the three ADR-045 payload
+// types per feedback_production_decoder_round_trip_required. Uses the
+// real payloadbuiltins.NewTestDecoder rather than an anonymous shape-
+// cast so a registry regression (forgotten RegisterPayloads wire-up,
+// domain/category mismatch) surfaces here, not in downstream PRs.
+
+func TestResearchIntent_RoundTripThroughDecoder(t *testing.T) {
+	original := &research.Intent{
+		Topic: "drone hover anomalies in robotics fleet",
+		Hints: map[string]string{
+			"entity_kind": "drone",
+			"domain":      "robotics",
+			"recency":     "last_24h",
+		},
+		BudgetTokens:  8000,
+		MaxIterations: 7,
+	}
+
+	envelope := message.NewBaseMessage(original.Schema(), original, "research-roundtrip-test")
+	wireBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(wireBytes)
+	if err != nil {
+		t.Fatalf("registry decode: %v\nwire: %s", err, wireBytes)
+	}
+
+	if got := decoded.Type(); got != original.Schema() {
+		t.Errorf("type: got %+v, want %+v", got, original.Schema())
+	}
+	got, ok := decoded.Payload().(*research.Intent)
+	if !ok {
+		t.Fatalf("payload: got %T, want *research.Intent", decoded.Payload())
+	}
+	if got.Topic != original.Topic {
+		t.Errorf("topic: got %q, want %q", got.Topic, original.Topic)
+	}
+	if got.BudgetTokens != original.BudgetTokens {
+		t.Errorf("budget_tokens: got %d, want %d", got.BudgetTokens, original.BudgetTokens)
+	}
+	if got.MaxIterations != original.MaxIterations {
+		t.Errorf("max_iterations: got %d, want %d", got.MaxIterations, original.MaxIterations)
+	}
+	if len(got.Hints) != len(original.Hints) {
+		t.Errorf("hints len: got %d, want %d", len(got.Hints), len(original.Hints))
+	}
+	for k, v := range original.Hints {
+		if got.Hints[k] != v {
+			t.Errorf("hints[%q]: got %q, want %q", k, got.Hints[k], v)
+		}
+	}
+}
+
+func TestSearchResult_RoundTripThroughDecoder(t *testing.T) {
+	original := &research.SearchResult{
+		Evidence: []research.Evidence{
+			{
+				EntityID:    "acme.ops.robotics.gcs.drone.001",
+				Tier:        "0",
+				Source:      "classifier",
+				Score:       0.92,
+				SnippetText: "Drone 001 reported hover instability at 14:32Z.",
+			},
+			{
+				EntityID:       "acme.ops.robotics.gcs.drone.014",
+				Tier:           "1",
+				Source:         "bm25_index",
+				Score:          0.71,
+				ObjectStoreRef: "objstore://research/evidence-014.txt",
+			},
+		},
+		Synthesis: "Two drones in the GCS fleet showed hover anomalies within the last 24 hours; drone.001 (Tier 0, classifier) and drone.014 (Tier 1, BM25). See evidence refs.",
+		DecompTrace: &research.DecompTrace{
+			RouterAction:    research.ActionWalkSeeds,
+			SeedEntities:    []string{"acme.ops.robotics.gcs.drone.001"},
+			RetightenRounds: 0,
+		},
+		TokensUsed: 1234,
+		Iterations: 2,
+	}
+
+	envelope := message.NewBaseMessage(original.Schema(), original, "research-roundtrip-test")
+	wireBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(wireBytes)
+	if err != nil {
+		t.Fatalf("registry decode: %v\nwire: %s", err, wireBytes)
+	}
+
+	if got := decoded.Type(); got != original.Schema() {
+		t.Errorf("type: got %+v, want %+v", got, original.Schema())
+	}
+	got, ok := decoded.Payload().(*research.SearchResult)
+	if !ok {
+		t.Fatalf("payload: got %T, want *research.SearchResult", decoded.Payload())
+	}
+	if got.Synthesis != original.Synthesis {
+		t.Errorf("synthesis drift: got %q, want %q", got.Synthesis, original.Synthesis)
+	}
+	if len(got.Evidence) != len(original.Evidence) {
+		t.Fatalf("evidence len: got %d, want %d", len(got.Evidence), len(original.Evidence))
+	}
+	for i := range original.Evidence {
+		if got.Evidence[i].EntityID != original.Evidence[i].EntityID {
+			t.Errorf("evidence[%d].EntityID: got %q, want %q", i, got.Evidence[i].EntityID, original.Evidence[i].EntityID)
+		}
+		if got.Evidence[i].Tier != original.Evidence[i].Tier {
+			t.Errorf("evidence[%d].Tier: got %q, want %q", i, got.Evidence[i].Tier, original.Evidence[i].Tier)
+		}
+	}
+	if got.DecompTrace == nil {
+		t.Fatal("decomp_trace lost on round-trip")
+	}
+	if got.DecompTrace.RouterAction != research.ActionWalkSeeds {
+		t.Errorf("router_action: got %q, want %q", got.DecompTrace.RouterAction, research.ActionWalkSeeds)
+	}
+	if got.TokensUsed != original.TokensUsed {
+		t.Errorf("tokens_used: got %d, want %d", got.TokensUsed, original.TokensUsed)
+	}
+	if got.Iterations != original.Iterations {
+		t.Errorf("iterations: got %d, want %d", got.Iterations, original.Iterations)
+	}
+}
+
+func TestRouteDecision_RoundTripThroughDecoder(t *testing.T) {
+	original := &research.RouteDecision{
+		Action: research.ActionDecompose,
+		Args: map[string]any{
+			"sub_queries": []any{
+				map[string]any{"type": "predicate_walk", "predicate": "sosa.observes"},
+				map[string]any{"type": "temporal_range", "start": "2026-05-22T00:00:00Z", "end": "2026-05-22T23:59:59Z"},
+			},
+		},
+		Rationale: "Topic spans multiple entity kinds and a 24h window; decompose into a predicate walk plus a temporal range and fuse.",
+	}
+
+	envelope := message.NewBaseMessage(original.Schema(), original, "research-roundtrip-test")
+	wireBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(wireBytes)
+	if err != nil {
+		t.Fatalf("registry decode: %v\nwire: %s", err, wireBytes)
+	}
+
+	got, ok := decoded.Payload().(*research.RouteDecision)
+	if !ok {
+		t.Fatalf("payload: got %T, want *research.RouteDecision", decoded.Payload())
+	}
+	if got.Action != original.Action {
+		t.Errorf("action: got %q, want %q", got.Action, original.Action)
+	}
+	if got.Rationale != original.Rationale {
+		t.Errorf("rationale drift: got %q, want %q", got.Rationale, original.Rationale)
+	}
+	if got.Args == nil {
+		t.Fatal("args lost on round-trip")
+	}
+}
+
+func TestResearchIntent_ValidateRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name    string
+		intent  research.Intent
+		wantSub string
+	}{
+		{
+			name:    "missing topic",
+			intent:  research.Intent{Topic: ""},
+			wantSub: "topic required",
+		},
+		{
+			name:    "whitespace topic",
+			intent:  research.Intent{Topic: "   "},
+			wantSub: "topic required",
+		},
+		{
+			name:    "empty hint value",
+			intent:  research.Intent{Topic: "x", Hints: map[string]string{"k": ""}},
+			wantSub: "is empty",
+		},
+		{
+			name:    "negative budget",
+			intent:  research.Intent{Topic: "x", BudgetTokens: -1},
+			wantSub: "budget_tokens must be >= 0",
+		},
+		{
+			name:    "negative max iterations",
+			intent:  research.Intent{Topic: "x", MaxIterations: -1},
+			wantSub: "max_iterations must be >= 0",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.intent.Validate()
+			if err == nil {
+				t.Fatalf("Validate = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("Validate error = %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
+func TestResearchIntent_DefaultsResolvedAtUse(t *testing.T) {
+	p := &research.Intent{Topic: "x"}
+	if got := p.ResolvedBudgetTokens(); got != research.DefaultBudgetTokens {
+		t.Errorf("ResolvedBudgetTokens with zero: got %d, want %d", got, research.DefaultBudgetTokens)
+	}
+	if got := p.ResolvedMaxIterations(); got != research.DefaultMaxIterations {
+		t.Errorf("ResolvedMaxIterations with zero: got %d, want %d", got, research.DefaultMaxIterations)
+	}
+
+	q := &research.Intent{Topic: "x", BudgetTokens: 99, MaxIterations: 11}
+	if got := q.ResolvedBudgetTokens(); got != 99 {
+		t.Errorf("ResolvedBudgetTokens override: got %d, want 99", got)
+	}
+	if got := q.ResolvedMaxIterations(); got != 11 {
+		t.Errorf("ResolvedMaxIterations override: got %d, want 11", got)
+	}
+}
+
+func TestRouteDecision_ValidateEnforcesClosedActionEnum(t *testing.T) {
+	validActions := []string{
+		research.ActionSynthesizeDirectly,
+		research.ActionRetighten,
+		research.ActionWalkSeeds,
+		research.ActionDecompose,
+	}
+	for _, a := range validActions {
+		t.Run("accept_"+a, func(t *testing.T) {
+			p := &research.RouteDecision{Action: a}
+			if err := p.Validate(); err != nil {
+				t.Errorf("Validate(%q) = %v, want nil", a, err)
+			}
+		})
+	}
+
+	invalidActions := []string{"", "bogus", "Synthesize_Directly", "decompose ", "synthesise_directly"}
+	for _, a := range invalidActions {
+		t.Run("reject_"+a, func(t *testing.T) {
+			p := &research.RouteDecision{Action: a}
+			err := p.Validate()
+			if err == nil {
+				t.Errorf("Validate(%q) = nil, want error", a)
+			}
+		})
+	}
+}
+
+func TestRouteDecision_UnmarshalRejectsInvalidAction(t *testing.T) {
+	const raw = `{"action":"bogus","rationale":"won't decode"}`
+	var d research.RouteDecision
+	if err := json.Unmarshal([]byte(raw), &d); err == nil {
+		t.Errorf("Unmarshal accepted bogus action; want decode error")
+	}
+}
+
+func TestRouteDecision_UnmarshalAcceptsEmptyAction(t *testing.T) {
+	// A partially-populated payload (no Action) should decode clean;
+	// strict-emit validation lives in Validate, not UnmarshalJSON.
+	// Tests + partial-update flows depend on this.
+	const raw = `{"rationale":"placeholder; action filled in later"}`
+	var d research.RouteDecision
+	if err := json.Unmarshal([]byte(raw), &d); err != nil {
+		t.Errorf("Unmarshal of empty-action payload failed: %v", err)
+	}
+}
+
+func TestEvidence_ValidateAcceptsPhase2Tier(t *testing.T) {
+	// Tier "2" is reserved for Phase 2 neural retrieval but accepted
+	// at the schema level today so Phase 1 fixtures can probe
+	// forward-compat without churning the validator when Phase 2
+	// lands. Lock in the acceptance so a future contributor doesn't
+	// tighten the enum without realising Phase 2 fixtures depend on it.
+	for _, tier := range []string{"0", "1", "2"} {
+		t.Run("tier_"+tier, func(t *testing.T) {
+			e := &research.Evidence{EntityID: "x", Tier: tier, Source: "s"}
+			if err := e.Validate(); err != nil {
+				t.Errorf("Validate(tier=%q) = %v, want nil", tier, err)
+			}
+		})
+	}
+}
+
+func TestSearchResult_ValidateRejectsInvalidEvidence(t *testing.T) {
+	cases := []struct {
+		name    string
+		result  research.SearchResult
+		wantSub string
+	}{
+		{
+			name:    "missing synthesis",
+			result:  research.SearchResult{Synthesis: ""},
+			wantSub: "synthesis required",
+		},
+		{
+			name: "evidence missing entity_id",
+			result: research.SearchResult{
+				Synthesis: "x",
+				Evidence:  []research.Evidence{{Tier: "0", Source: "classifier"}},
+			},
+			wantSub: "entity_id required",
+		},
+		{
+			name: "evidence bad tier",
+			result: research.SearchResult{
+				Synthesis: "x",
+				Evidence:  []research.Evidence{{EntityID: "e", Tier: "bogus", Source: "x"}},
+			},
+			wantSub: "tier",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.result.Validate()
+			if err == nil {
+				t.Fatalf("Validate = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("Validate error = %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}

--- a/agentic/research/route.go
+++ b/agentic/research/route.go
@@ -1,0 +1,106 @@
+package research
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// RouteDecision is route_search's structured-emit output: one of four
+// routing actions, action-specific args, and a free-form rationale for
+// trajectory review. Phase 1's PR 3 specializes the LLM prompt around
+// these four actions; ADR-045 commits to the closed enum at the
+// schema level (Phase 2 may add actions, but Phase 1 ships strict).
+//
+// Per feedback_llm_authored_predicates_rule_opaque, when this payload
+// is stamped onto loop entity triples, the Rationale field's
+// triple-predicate is published with WithRuleOpaque(true). Rules
+// should not pattern-match on rationale prose — they branch on the
+// typed Action field only.
+type RouteDecision struct {
+	// Action is the routing decision. Must be one of ActionXxx
+	// constants. UnmarshalJSON and Validate both enforce the enum.
+	Action string `json:"action"`
+
+	// Args carries the action-specific argument map. Schemas per
+	// action (PR 3 finalizes the per-action shapes):
+	//   - synthesize_directly: empty (uses classifier output)
+	//   - retighten:           {"topic": string, "hints": map[string]string}
+	//   - walk_seeds:          {"seed_entity_ids": []string}
+	//   - decompose:           {"sub_queries": [{...typed...}]}
+	// The map is intentionally loose at the wire level — strict
+	// per-action shapes are enforced by the consuming component, not
+	// at decode time, so Phase 1 ships without a separate per-action
+	// payload type per action arg shape.
+	Args map[string]any `json:"args,omitempty"`
+
+	// Rationale is the LLM's natural-language justification for the
+	// chosen action. Captured for operator trajectory review;
+	// rule-opaque per discipline memory.
+	Rationale string `json:"rationale,omitempty"`
+}
+
+// Schema implements message.Payload.
+func (p *RouteDecision) Schema() message.Type {
+	return message.Type{
+		Domain:   Domain,
+		Category: CategoryRouteDecision,
+		Version:  SchemaVersion,
+	}
+}
+
+// IsValidRouteAction reports whether s is one of the four canonical
+// router actions. Exported so route_search's structured-emit
+// validator can reuse the closed set.
+func IsValidRouteAction(s string) bool {
+	switch s {
+	case ActionSynthesizeDirectly, ActionRetighten, ActionWalkSeeds, ActionDecompose:
+		return true
+	}
+	return false
+}
+
+// Validate implements message.Payload. Enforces the closed action
+// enum. Args content is not validated here — per-action arg shapes
+// are checked by the consuming component (PR 3+).
+func (p *RouteDecision) Validate() error {
+	if p == nil {
+		return fmt.Errorf("route decision is nil")
+	}
+	if strings.TrimSpace(p.Action) == "" {
+		return fmt.Errorf("action required")
+	}
+	if !IsValidRouteAction(p.Action) {
+		return fmt.Errorf("action %q is not a canonical router action (want one of %q, %q, %q, %q)",
+			p.Action,
+			ActionSynthesizeDirectly, ActionRetighten, ActionWalkSeeds, ActionDecompose)
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler with the alias-recursion
+// guard.
+func (p *RouteDecision) MarshalJSON() ([]byte, error) {
+	type alias RouteDecision
+	return json.Marshal((*alias)(p))
+}
+
+// UnmarshalJSON implements json.Unmarshaler with strict action enum
+// enforcement. Schema-violating values fail at decode rather than
+// surfacing as nil-action downstream.
+func (p *RouteDecision) UnmarshalJSON(data []byte) error {
+	type alias RouteDecision
+	if err := json.Unmarshal(data, (*alias)(p)); err != nil {
+		return err
+	}
+	// Empty payloads (e.g. {}) round-trip clean; reject only when
+	// Action is set to an unrecognised value. This keeps decode
+	// usable for partial payloads in tests while still catching
+	// invalid-action drift on real wire data.
+	if p.Action != "" && !IsValidRouteAction(p.Action) {
+		return fmt.Errorf("route decision: action %q is not a canonical router action", p.Action)
+	}
+	return nil
+}

--- a/payloadbuiltins/register.go
+++ b/payloadbuiltins/register.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/c360studio/semstreams/agentic"
 	agenticoperatingmodel "github.com/c360studio/semstreams/agentic/operating-model"
+	"github.com/c360studio/semstreams/agentic/research"
 	githubwebhook "github.com/c360studio/semstreams/input/github-webhook"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/message/oms"
@@ -48,6 +49,7 @@ func Register(reg *payloadregistry.Registry) error {
 	track(oms.RegisterPayloads(reg))
 	track(agentic.RegisterPayloads(reg))
 	track(agenticoperatingmodel.RegisterPayloads(reg))
+	track(research.RegisterPayloads(reg))
 	track(agenticdispatch.RegisterPayloads(reg))
 	track(rule.RegisterPayloads(reg))
 	track(githubwebhook.RegisterPayloads(reg))

--- a/processor/agentic-tools/executors/register.go
+++ b/processor/agentic-tools/executors/register.go
@@ -97,6 +97,7 @@ var BuiltinGroupKeys = []string{
 	"scratchpad",
 	"summarize_graph",
 	"search_graph",
+	"research_graph",
 	"flow_monitor",
 	// Multi-tool registrations: key is the register-function's domain
 	"github",            // registerGitHub — github_* tools
@@ -183,6 +184,9 @@ func RegisterBuiltins(ctx context.Context, reg *agentictools.ExecutorRegistry, d
 		// required. See project_graph_tools_gateway_first_plan memory.
 		gate("summarize_graph", func() error { return registerSummarizeGraph(reg, deps.NATSClient, logger) })
 		gate("search_graph", func() error { return registerSearchGraph(reg, deps.NATSClient, logger) })
+		gate("research_graph", func() error {
+			return registerResearchGraph(ctx, reg, deps.NATSClient, deps.Platform, logger, loopsBucket)
+		})
 	}
 
 	// Pattern-B registry-backed tools. A nil manager is a legal skip;

--- a/processor/agentic-tools/executors/register_research_graph.go
+++ b/processor/agentic-tools/executors/register_research_graph.go
@@ -1,0 +1,82 @@
+package executors
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/retry"
+	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
+)
+
+// registerResearchGraph opens (or creates) the AGENT_LOOPS bucket
+// and wires the research_graph tool. Bucket config matches
+// agentic-loop/component.go initializeKVBuckets (History=10, TTL=24h)
+// so whichever side reaches the bucket-create call first wins the
+// idempotent Create-or-Get without config drift.
+//
+// Mirrors register_read_loop_result's retry + warn-and-skip path:
+// transient NATS errors at boot don't block the process, but a
+// misconfigured deployment gets a loud log line so operators don't
+// chase silent disablement. A registry-level failure (duplicate
+// name) propagates so RegisterBuiltins surfaces it at boot.
+//
+// The tool needs the AGENT_LOOPS handle — both for the
+// research-pipeline LoopEntity write and for the
+// research.requested.<loopID> trigger key R0 watches.
+func registerResearchGraph(ctx context.Context, tools *agentictools.ExecutorRegistry, natsClient *natsclient.Client, platform component.PlatformMeta, logger *slog.Logger, bucketName string) error {
+	bucket, err := retry.DoWithResult(ctx, retry.Quick(), func() (jetstream.KeyValue, error) {
+		return natsClient.CreateKeyValueBucket(ctx, newLoopResultBucketConfig(bucketName))
+	})
+	if err != nil {
+		logger.Warn("research_graph tool disabled: could not open loops bucket after retries",
+			slog.String("bucket", bucketName),
+			slog.Any("error", err))
+		return nil
+	}
+
+	store := natsClient.NewKVStore(bucket)
+	writer := newNATSResearchKVWriter(store)
+	executor := NewResearchGraphExecutor(writer, platform)
+	executor.SetLogger(logger)
+	if err := tools.RegisterTool(ResearchGraphToolName, executor); err != nil {
+		return fmt.Errorf("register research_graph: %w", err)
+	}
+	logger.Info("Registered research_graph tool",
+		slog.String("bucket", bucketName))
+	return nil
+}
+
+// natsResearchKVWriter adapts natsclient.KVStore to the
+// ResearchKVWriter interface the executor consumes. Keeps the
+// production wiring colocated with the registration shim so the
+// executor itself stays test-friendly (the executor only sees the
+// narrow interface).
+type natsResearchKVWriter struct {
+	kv *natsclient.KVStore
+}
+
+func newNATSResearchKVWriter(kv *natsclient.KVStore) *natsResearchKVWriter {
+	return &natsResearchKVWriter{kv: kv}
+}
+
+// CreateLoopEntity uses KVStore.Create (write-if-not-exists) so a
+// loopID collision surfaces loudly via ErrKVKeyExists rather than
+// silently overwriting prior state.
+func (w *natsResearchKVWriter) CreateLoopEntity(ctx context.Context, loopID string, value []byte) error {
+	_, err := w.kv.Create(ctx, loopID, value)
+	return err
+}
+
+// PutResearchTrigger uses KVStore.Put (last-writer-wins). The trigger
+// key embeds a freshly minted loopID so a Put-vs-Create distinction
+// is moot in practice — Put keeps the implementation simple and lets
+// the chain's idempotency live with R0's debounce logic in PR 6.
+func (w *natsResearchKVWriter) PutResearchTrigger(ctx context.Context, loopID string, value []byte) error {
+	_, err := w.kv.Put(ctx, researchTriggerKeyPrefix+loopID, value)
+	return err
+}

--- a/processor/agentic-tools/executors/register_test.go
+++ b/processor/agentic-tools/executors/register_test.go
@@ -358,7 +358,7 @@ func TestBuiltinGroupKeys_Stability(t *testing.T) {
 		"bash", "web_search", "http_request",
 		"read_loop_result", "decide", "emit_diagnosis",
 		"write_todos", "scratchpad",
-		"summarize_graph", "search_graph", "flow_monitor",
+		"summarize_graph", "search_graph", "research_graph", "flow_monitor",
 		"github", "graph_query",
 		"rules", "flows", "personas", "flow_templates",
 		"component_catalog",

--- a/processor/agentic-tools/executors/research_graph.go
+++ b/processor/agentic-tools/executors/research_graph.go
@@ -1,0 +1,388 @@
+package executors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// ResearchGraphToolName is the name parents use to invoke the
+// ADR-045 graph-search rule chain. PR 1 of the Phase 1 plan
+// (docs/operations/22-adr045-phase1-plan.md) lands the registry +
+// tool seam; PRs 2-6 land the five components + seven rules.
+const ResearchGraphToolName = "research_graph"
+
+// researchTriggerKeyPrefix is the key prefix R0 watches in
+// AGENT_LOOPS. Full key shape: research.requested.<loopID>.
+//
+// PR 1 writes the trigger key only; PR 6 wires R0 to fire on it.
+// Centralising the prefix here keeps the tool and R0's rule
+// config in lockstep — a renaming requires touching both.
+const researchTriggerKeyPrefix = "research.requested."
+
+// loopIDPrefix is the prefix the research_graph tool uses when
+// minting new loop IDs. Mirrors the agentic-dispatch convention
+// (loop_<uuid8>) but uses `rg_` so research-pipeline loops are
+// distinguishable at a glance in operator dashboards without
+// parsing the LoopEntity.Role field.
+const loopIDPrefix = "rg_"
+
+// ResearchKVWriter is the narrow KV surface this executor consumes.
+// Production satisfies it with a natsclient.KVStore scoped to the
+// AGENT_LOOPS bucket; tests substitute an in-memory recorder so
+// they don't need a real NATS connection.
+//
+// Two methods so the tool can write both halves of its KV footprint:
+//
+//   - CreateLoopEntity puts a research-pipeline LoopEntity at key
+//     <loopID>. Use Create semantics (returns ErrKVKeyExists if the
+//     loop_id collides) so an accidental duplicate doesn't silently
+//     overwrite the previous loop's state.
+//
+//   - PutResearchTrigger writes the research_intent payload at key
+//     research.requested.<loopID>. R0 watches this key pattern (see
+//     ADR-045 §Rule chain) and fires the chain on write. Last-write-
+//     wins is fine here because the loop_id is freshly minted and
+//     unique per call.
+type ResearchKVWriter interface {
+	CreateLoopEntity(ctx context.Context, loopID string, value []byte) error
+	PutResearchTrigger(ctx context.Context, loopID string, value []byte) error
+}
+
+// ResearchGraphExecutor implements the research_graph tool. It
+// kicks off the ADR-045 chain by writing two KV records to
+// AGENT_LOOPS:
+//
+//  1. A LoopEntity at key <loopID> with role=research_pipeline so
+//     downstream tools (read_loop_result, flow_monitor) can find
+//     the operation by its loop ID.
+//
+//  2. The research_intent payload wrapped in a BaseMessage envelope
+//     at key research.requested.<loopID> — the R0 trigger key.
+//
+// The tool returns StopLoop=true so the parent's current iteration
+// terminates; the continuation rule (R6 — landed in PR 6) resumes
+// the parent on a subsequent iteration with the search_result
+// payload.
+type ResearchGraphExecutor struct {
+	kv        ResearchKVWriter
+	platform  component.PlatformMeta
+	logger    *slog.Logger
+	now       func() time.Time
+	newLoopID func() string
+}
+
+// ResearchGraphOption configures a ResearchGraphExecutor at
+// construction time.
+type ResearchGraphOption func(*ResearchGraphExecutor)
+
+// WithResearchGraphClock overrides the time source the executor
+// stamps onto the LoopEntity. nil-safe — passing nil preserves
+// the existing clock. Used by tests for deterministic timestamps.
+func WithResearchGraphClock(now func() time.Time) ResearchGraphOption {
+	return func(e *ResearchGraphExecutor) {
+		if now != nil {
+			e.now = now
+		}
+	}
+}
+
+// WithResearchGraphIDGenerator overrides the loop-ID generator.
+// nil-safe; tests use it for deterministic IDs.
+func WithResearchGraphIDGenerator(gen func() string) ResearchGraphOption {
+	return func(e *ResearchGraphExecutor) {
+		if gen != nil {
+			e.newLoopID = gen
+		}
+	}
+}
+
+// NewResearchGraphExecutor constructs the executor. kv must be
+// non-nil — without it the tool can't seed the chain. Logger
+// defaults to slog.Default(); clock and ID generator default to
+// time.Now / uuid-based.
+func NewResearchGraphExecutor(kv ResearchKVWriter, platform component.PlatformMeta, opts ...ResearchGraphOption) *ResearchGraphExecutor {
+	e := &ResearchGraphExecutor{
+		kv:       kv,
+		platform: platform,
+		logger:   slog.Default(),
+		now:      time.Now,
+		newLoopID: func() string {
+			// Use uuid v4 truncated to 8 chars. Mirrors the
+			// agentic-dispatch convention. Collision odds at 8 hex
+			// chars (~4 billion possibilities) are operator-tolerable
+			// for the research-loop volume Phase 1 will see, and the
+			// CreateLoopEntity ErrKVKeyExists path catches a clash.
+			id := uuid.New().String()
+			return loopIDPrefix + id[:8]
+		},
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
+}
+
+// SetLogger replaces the default logger. nil-safe — a nil argument
+// preserves whatever logger the executor already has.
+func (e *ResearchGraphExecutor) SetLogger(logger *slog.Logger) {
+	if logger != nil {
+		e.logger = logger
+	}
+}
+
+// ListTools returns the research_graph tool definition. The schema
+// is strict-mode-compliant (ADR-035): topic is required; hints,
+// budget_tokens, and max_iterations are optional. additionalProperties
+// is closed so providers honouring function.strict reject ad-hoc
+// fields a model might invent.
+func (e *ResearchGraphExecutor) ListTools() []agentic.ToolDefinition {
+	return []agentic.ToolDefinition{{
+		Name: ResearchGraphToolName,
+		Description: "Spawn an asynchronous graph-research operation. The chain runs the existing graph classifier, " +
+			"routes to one of {synthesize_directly, retighten, walk_seeds, decompose}, executes multi-tier subqueries, " +
+			"assesses sufficiency, and synthesises an answer with provenance refs. Returns immediately and terminates " +
+			"this iteration; the SearchResult arrives on a subsequent iteration via the continuation rule. " +
+			"Call this for non-trivial questions where you don't already know the entities or predicates to query; " +
+			"for direct lookups by ID, use query_entity instead.",
+		Parameters: map[string]any{
+			"type":                 "object",
+			"required":             []string{"topic"},
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"topic": map[string]any{
+					"type":        "string",
+					"description": "Natural-language research subject (e.g. \"drone hover anomalies\", \"recent auth failures\").",
+				},
+				"hints": map[string]any{
+					"type":                 "object",
+					"description":          "Optional free-form map of classifier hints (entity_kind, domain, recency, etc.). Keys are strings; values are strings.",
+					"additionalProperties": map[string]any{"type": "string"},
+				},
+				"budget_tokens": map[string]any{
+					"type":        "integer",
+					"description": fmt.Sprintf("Maximum LLM tokens to spend across the chain. Default %d.", research.DefaultBudgetTokens),
+				},
+				"max_iterations": map[string]any{
+					"type":        "integer",
+					"description": fmt.Sprintf("Refine-loop cap (R4). Default %d.", research.DefaultMaxIterations),
+				},
+			},
+		},
+		Strict: true,
+	}}
+}
+
+// Execute routes the tool call. Any other tool name is a routing
+// bug.
+func (e *ResearchGraphExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agentic.ToolResult, error) {
+	if call.Name != ResearchGraphToolName {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("unknown tool: %s", call.Name),
+			ErrorKind: agentic.ToolErrorNotFound,
+		}, errs.WrapInvalid(fmt.Errorf("unknown tool: %s", call.Name), "ResearchGraphExecutor", "Execute", "route tool")
+	}
+	return e.researchGraph(ctx, call)
+}
+
+func (e *ResearchGraphExecutor) researchGraph(ctx context.Context, call agentic.ToolCall) (agentic.ToolResult, error) {
+	intent, err := parseResearchGraphArgs(call.Arguments)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     err.Error(),
+			ErrorKind: agentic.ToolErrorInvalidArgs,
+		}, nil
+	}
+
+	if call.LoopID == "" {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     "research_graph invoked without a loop_id on the tool call; cannot link the research operation back to its parent",
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(fmt.Errorf("tool call missing loop_id"), "ResearchGraphExecutor", "researchGraph", "resolve parent loop")
+	}
+
+	// Validate the assembled intent. parseResearchGraphArgs trusts
+	// arg parsing; Validate is the schema gate before we touch KV.
+	if err := intent.Validate(); err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("invalid research intent: %v", err),
+			ErrorKind: agentic.ToolErrorInvalidArgs,
+		}, nil
+	}
+
+	loopID := e.newLoopID()
+
+	// Resolve defaults onto the persisted intent so downstream
+	// components (R0's publishees in PR 6 onward) read the same
+	// budget/iteration values regardless of whether the caller
+	// omitted them. Doing this on a copy keeps the parser's output
+	// raw (zeros mean "caller omitted") while the persisted shape is
+	// fully populated. Avoids a five-PR footgun where each consumer
+	// would otherwise have to remember ResolvedXxx() before use.
+	persistedIntent := *intent
+	persistedIntent.BudgetTokens = intent.ResolvedBudgetTokens()
+	persistedIntent.MaxIterations = intent.ResolvedMaxIterations()
+
+	// Construct the research-pipeline LoopEntity. State starts at
+	// LoopStateExecuting because the chain begins firing as soon as
+	// R0 sees the trigger key — no exploring / planning phase for a
+	// rule-coordinated chain.
+	loopEntity := agentic.NewLoopEntity(loopID, "", research.PipelineRole, "", persistedIntent.MaxIterations)
+	loopEntity.State = agentic.LoopStateExecuting
+	loopEntity.ParentLoopID = call.LoopID
+	loopEntity.StartedAt = e.now().UTC()
+
+	loopBytes, err := json.Marshal(&loopEntity)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("marshal loop entity: %v", err),
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(err, "ResearchGraphExecutor", "researchGraph", "marshal loop entity")
+	}
+
+	// Order matters: write the LoopEntity record FIRST so that R0's
+	// downstream actions (which may read the loop entity by ID) see
+	// a populated record. The trigger-key write is the chain
+	// kickoff — perform it only after the LoopEntity is durably
+	// stored.
+	if err := e.kv.CreateLoopEntity(ctx, loopID, loopBytes); err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("create research-pipeline loop entity: %v", err),
+			ErrorKind: agentic.ToolErrorNetwork,
+		}, errs.WrapTransient(err, "ResearchGraphExecutor", "researchGraph", "create loop entity")
+	}
+
+	// Wrap the intent in a BaseMessage envelope so the registry
+	// decoder can resolve the type discriminator when R0's
+	// downstream components read this key. Per
+	// feedback_nats_publishes_use_payload_registry: every payload on
+	// a NATS surface wraps in BaseMessage, even when the immediate
+	// consumer reads raw — drift-resilient.
+	envelope := message.NewBaseMessage(persistedIntent.Schema(), &persistedIntent, research.TripleSource)
+	triggerBytes, err := json.Marshal(envelope)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("marshal research intent envelope: %v", err),
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(err, "ResearchGraphExecutor", "researchGraph", "marshal intent envelope")
+	}
+
+	if err := e.kv.PutResearchTrigger(ctx, loopID, triggerBytes); err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("write research trigger key: %v", err),
+			ErrorKind: agentic.ToolErrorNetwork,
+		}, errs.WrapTransient(err, "ResearchGraphExecutor", "researchGraph", "write trigger key")
+	}
+
+	// Construct the per-loop entity ID via the Try variant — runtime
+	// hot paths use TryLoopExecutionEntityID per
+	// feedback_try_loop_entity_id_for_runtime. Surfaces a clean
+	// ToolErrorInternal if the platform meta is malformed instead
+	// of panicking the dispatch goroutine.
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(e.platform.Org, e.platform.Platform, loopID)
+	if err != nil {
+		return agentic.ToolResult{
+			CallID:    call.ID,
+			Error:     fmt.Sprintf("construct loop entity ID: %v", err),
+			ErrorKind: agentic.ToolErrorInternal,
+		}, errs.WrapInvalid(err, "ResearchGraphExecutor", "researchGraph", "construct loop entity ID")
+	}
+
+	e.logger.Info("research_graph dispatched",
+		slog.String("loop_id", loopID),
+		slog.String("parent_loop_id", call.LoopID),
+		slog.String("topic", persistedIntent.Topic),
+		slog.Int("budget_tokens", persistedIntent.BudgetTokens),
+		slog.Int("max_iterations", persistedIntent.MaxIterations))
+
+	resultMetadata := map[string]any{
+		"loop_id":        loopID,
+		"loop_entity_id": loopEntityID,
+		"parent_loop_id": call.LoopID,
+		"topic":          persistedIntent.Topic,
+		"budget_tokens":  persistedIntent.BudgetTokens,
+		"max_iterations": persistedIntent.MaxIterations,
+	}
+
+	return agentic.ToolResult{
+		CallID: call.ID,
+		Content: fmt.Sprintf(
+			"Research operation dispatched.\nloop_id: %s\ntopic: %s\nThe SearchResult will arrive on a subsequent iteration via the continuation rule.",
+			loopID, persistedIntent.Topic),
+		StopLoop: true,
+		Metadata: resultMetadata,
+	}, nil
+}
+
+// parseResearchGraphArgs reads the untyped tool arguments into a
+// ResearchIntent. Missing or wrong-typed topic surfaces as invalid-
+// args so the framework retry policy can step in — small models that
+// miss the schema on the first try get a second chance before the
+// loop fails.
+func parseResearchGraphArgs(raw map[string]any) (*research.Intent, error) {
+	topic, ok := raw["topic"].(string)
+	if !ok || topic == "" {
+		return nil, fmt.Errorf("topic is required and must be a non-empty string")
+	}
+	intent := &research.Intent{Topic: topic}
+
+	if rawHints, present := raw["hints"]; present && rawHints != nil {
+		hintsMap, ok := rawHints.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("hints must be an object with string values")
+		}
+		intent.Hints = make(map[string]string, len(hintsMap))
+		for k, v := range hintsMap {
+			s, ok := v.(string)
+			if !ok {
+				return nil, fmt.Errorf("hints[%q] must be a string", k)
+			}
+			intent.Hints[k] = s
+		}
+	}
+
+	if rawBudget, present := raw["budget_tokens"]; present && rawBudget != nil {
+		// JSON numbers decode to float64 through map[string]any. Both
+		// integer-shaped (4000) and fractional values flow through;
+		// fractional inputs are a caller bug — reject them.
+		f, ok := rawBudget.(float64)
+		if !ok {
+			return nil, fmt.Errorf("budget_tokens must be an integer")
+		}
+		if f != float64(int(f)) {
+			return nil, fmt.Errorf("budget_tokens must be an integer, got %v", rawBudget)
+		}
+		intent.BudgetTokens = int(f)
+	}
+
+	if rawMax, present := raw["max_iterations"]; present && rawMax != nil {
+		f, ok := rawMax.(float64)
+		if !ok {
+			return nil, fmt.Errorf("max_iterations must be an integer")
+		}
+		if f != float64(int(f)) {
+			return nil, fmt.Errorf("max_iterations must be an integer, got %v", rawMax)
+		}
+		intent.MaxIterations = int(f)
+	}
+
+	return intent, nil
+}

--- a/processor/agentic-tools/executors/research_graph_test.go
+++ b/processor/agentic-tools/executors/research_graph_test.go
@@ -1,0 +1,460 @@
+package executors
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadbuiltins"
+)
+
+// fakeResearchKVWriter records the two writes the research_graph tool
+// emits so tests can assert on key, value shape, and ordering without
+// a real NATS connection.
+type fakeResearchKVWriter struct {
+	mu sync.Mutex
+
+	loopEntityCalled bool
+	loopEntityKey    string
+	loopEntityValue  []byte
+	loopEntityErr    error
+
+	triggerCalled bool
+	triggerKey    string
+	triggerValue  []byte
+	triggerErr    error
+
+	// writeOrder records the sequence the tool used. Ordering matters:
+	// the LoopEntity must land before the trigger key so R0's downstream
+	// actions don't read an empty loop record.
+	writeOrder []string
+}
+
+func (f *fakeResearchKVWriter) CreateLoopEntity(_ context.Context, loopID string, value []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.loopEntityCalled = true
+	f.loopEntityKey = loopID
+	f.loopEntityValue = append([]byte(nil), value...)
+	f.writeOrder = append(f.writeOrder, "loop_entity")
+	return f.loopEntityErr
+}
+
+func (f *fakeResearchKVWriter) PutResearchTrigger(_ context.Context, loopID string, value []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.triggerCalled = true
+	f.triggerKey = loopID
+	f.triggerValue = append([]byte(nil), value...)
+	f.writeOrder = append(f.writeOrder, "trigger")
+	return f.triggerErr
+}
+
+func newTestExecutor(writer *fakeResearchKVWriter) *ResearchGraphExecutor {
+	return NewResearchGraphExecutor(
+		writer,
+		component.PlatformMeta{Org: "c360", Platform: "ops"},
+		WithResearchGraphClock(func() time.Time {
+			return time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+		}),
+		WithResearchGraphIDGenerator(func() string { return "rg_test001" }),
+	)
+}
+
+func TestResearchGraphExecutor_ListTools(t *testing.T) {
+	e := newTestExecutor(&fakeResearchKVWriter{})
+	tools := e.ListTools()
+	if len(tools) != 1 {
+		t.Fatalf("ListTools = %d, want 1", len(tools))
+	}
+	tool := tools[0]
+	if tool.Name != ResearchGraphToolName {
+		t.Errorf("name = %q, want %q", tool.Name, ResearchGraphToolName)
+	}
+	required, _ := tool.Parameters["required"].([]string)
+	if len(required) != 1 || required[0] != "topic" {
+		t.Errorf("required = %v, want [\"topic\"]", required)
+	}
+	if !tool.Strict {
+		t.Errorf("Strict = false, want true (ADR-035 strict tool calling)")
+	}
+}
+
+// runHappyPath dispatches a fully-specified research_graph call and
+// returns the tool result for the caller to drill into. Lives outside
+// the test bodies so individual t.Run subtests can focus on one
+// observable each, keeping the per-function statement count under the
+// revive function-length limit.
+func runHappyPath(t *testing.T) (*ResearchGraphExecutor, *fakeResearchKVWriter, agentic.ToolResult) {
+	t.Helper()
+	writer := &fakeResearchKVWriter{}
+	e := newTestExecutor(writer)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "call-1",
+		Name:   ResearchGraphToolName,
+		LoopID: "parent_loop_42",
+		Arguments: map[string]any{
+			"topic": "drone hover anomalies",
+			"hints": map[string]any{
+				"entity_kind": "drone",
+				"domain":      "robotics",
+			},
+			"budget_tokens":  float64(8000),
+			"max_iterations": float64(6),
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("result error: %q", res.Error)
+	}
+	return e, writer, res
+}
+
+func TestResearchGraphExecutor_HappyPath_ToolResult(t *testing.T) {
+	_, writer, res := runHappyPath(t)
+
+	if !res.StopLoop {
+		t.Errorf("StopLoop = false, want true (the chain takes over from here)")
+	}
+	if !writer.loopEntityCalled {
+		t.Fatalf("expected CreateLoopEntity to be called")
+	}
+	if !writer.triggerCalled {
+		t.Fatalf("expected PutResearchTrigger to be called")
+	}
+	if res.Metadata["loop_id"] != "rg_test001" {
+		t.Errorf("metadata loop_id = %v, want rg_test001", res.Metadata["loop_id"])
+	}
+	if res.Metadata["parent_loop_id"] != "parent_loop_42" {
+		t.Errorf("metadata parent_loop_id = %v, want parent_loop_42", res.Metadata["parent_loop_id"])
+	}
+	if !strings.Contains(res.Content, "rg_test001") {
+		t.Errorf("Content missing loop_id: %q", res.Content)
+	}
+}
+
+func TestResearchGraphExecutor_HappyPath_WriteOrdering(t *testing.T) {
+	// R0 watches the trigger key and may dispatch immediately on it;
+	// the LoopEntity record must already be in place when R0 fires,
+	// otherwise downstream actions read a missing loop. Lock the
+	// ordering in here so a future refactor can't reverse it
+	// silently.
+	_, writer, _ := runHappyPath(t)
+
+	if len(writer.writeOrder) != 2 || writer.writeOrder[0] != "loop_entity" || writer.writeOrder[1] != "trigger" {
+		t.Errorf("write order = %v, want [loop_entity, trigger]", writer.writeOrder)
+	}
+	if writer.loopEntityKey != "rg_test001" {
+		t.Errorf("loop entity key = %q, want %q", writer.loopEntityKey, "rg_test001")
+	}
+	if writer.triggerKey != "rg_test001" {
+		t.Errorf("trigger key (loop_id) = %q, want %q", writer.triggerKey, "rg_test001")
+	}
+}
+
+func TestResearchGraphExecutor_HappyPath_LoopEntityShape(t *testing.T) {
+	_, writer, _ := runHappyPath(t)
+
+	var loopEntity agentic.LoopEntity
+	if err := json.Unmarshal(writer.loopEntityValue, &loopEntity); err != nil {
+		t.Fatalf("unmarshal loop entity: %v", err)
+	}
+	if loopEntity.Role != research.PipelineRole {
+		t.Errorf("loop role = %q, want %q", loopEntity.Role, research.PipelineRole)
+	}
+	if loopEntity.ParentLoopID != "parent_loop_42" {
+		t.Errorf("parent_loop_id = %q, want %q", loopEntity.ParentLoopID, "parent_loop_42")
+	}
+	if loopEntity.MaxIterations != 6 {
+		t.Errorf("max_iterations: got %d, want 6", loopEntity.MaxIterations)
+	}
+	if loopEntity.State != agentic.LoopStateExecuting {
+		t.Errorf("state = %q, want %q", loopEntity.State, agentic.LoopStateExecuting)
+	}
+}
+
+func TestResearchGraphExecutor_HappyPath_TriggerIntent(t *testing.T) {
+	// Trigger value decodes through the production registry as a
+	// *research.Intent — proves the registry wiring landed
+	// (feedback_production_decoder_round_trip_required).
+	_, writer, _ := runHappyPath(t)
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(writer.triggerValue)
+	if err != nil {
+		t.Fatalf("decode trigger payload: %v\nwire: %s", err, writer.triggerValue)
+	}
+	intent, ok := decoded.Payload().(*research.Intent)
+	if !ok {
+		t.Fatalf("trigger payload = %T, want *research.Intent", decoded.Payload())
+	}
+	if intent.Topic != "drone hover anomalies" {
+		t.Errorf("intent topic = %q, want %q", intent.Topic, "drone hover anomalies")
+	}
+	if intent.Hints["entity_kind"] != "drone" || intent.Hints["domain"] != "robotics" {
+		t.Errorf("intent hints drifted: %v", intent.Hints)
+	}
+	if intent.BudgetTokens != 8000 {
+		t.Errorf("intent budget_tokens = %d, want 8000", intent.BudgetTokens)
+	}
+	if intent.MaxIterations != 6 {
+		t.Errorf("intent max_iterations = %d, want 6", intent.MaxIterations)
+	}
+}
+
+func TestResearchGraphExecutor_DefaultsFillWhenOmitted(t *testing.T) {
+	writer := &fakeResearchKVWriter{}
+	e := newTestExecutor(writer)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "c1",
+		Name:      ResearchGraphToolName,
+		LoopID:    "parent_loop_7",
+		Arguments: map[string]any{"topic": "x"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("result error: %q", res.Error)
+	}
+
+	if res.Metadata["budget_tokens"] != research.DefaultBudgetTokens {
+		t.Errorf("budget_tokens default = %v, want %d", res.Metadata["budget_tokens"], research.DefaultBudgetTokens)
+	}
+	if res.Metadata["max_iterations"] != research.DefaultMaxIterations {
+		t.Errorf("max_iterations default = %v, want %d", res.Metadata["max_iterations"], research.DefaultMaxIterations)
+	}
+
+	var loop agentic.LoopEntity
+	if err := json.Unmarshal(writer.loopEntityValue, &loop); err != nil {
+		t.Fatalf("unmarshal loop: %v", err)
+	}
+	if loop.MaxIterations != research.DefaultMaxIterations {
+		t.Errorf("loop max_iterations = %d, want %d", loop.MaxIterations, research.DefaultMaxIterations)
+	}
+}
+
+// TestResearchGraphExecutor_DefaultsPersistOnTriggerPayload locks in
+// the post-go-reviewer-pass fix: zero-valued budget/max_iterations
+// from the caller resolve to defaults BEFORE the intent envelope is
+// marshalled, so downstream components reading the trigger key see
+// the same values the LoopEntity and ToolResult metadata carry. The
+// pre-fix shape persisted zeros into the trigger payload — a
+// five-PR footgun (every consumer would have to remember
+// ResolvedXxx()).
+func TestResearchGraphExecutor_DefaultsPersistOnTriggerPayload(t *testing.T) {
+	writer := &fakeResearchKVWriter{}
+	e := newTestExecutor(writer)
+
+	_, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "c1",
+		Name:      ResearchGraphToolName,
+		LoopID:    "parent_loop_7",
+		Arguments: map[string]any{"topic": "x"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(writer.triggerValue)
+	if err != nil {
+		t.Fatalf("decode trigger: %v", err)
+	}
+	intent, ok := decoded.Payload().(*research.Intent)
+	if !ok {
+		t.Fatalf("trigger payload = %T, want *research.Intent", decoded.Payload())
+	}
+	if intent.BudgetTokens != research.DefaultBudgetTokens {
+		t.Errorf("persisted budget_tokens = %d, want default %d (caller omitted; defaults must resolve before persistence)", intent.BudgetTokens, research.DefaultBudgetTokens)
+	}
+	if intent.MaxIterations != research.DefaultMaxIterations {
+		t.Errorf("persisted max_iterations = %d, want default %d", intent.MaxIterations, research.DefaultMaxIterations)
+	}
+}
+
+func TestResearchGraphExecutor_RejectsMissingTopic(t *testing.T) {
+	writer := &fakeResearchKVWriter{}
+	e := newTestExecutor(writer)
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "c1",
+		Name:      ResearchGraphToolName,
+		LoopID:    "parent_loop_7",
+		Arguments: map[string]any{},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("error kind = %q, want %q", res.ErrorKind, agentic.ToolErrorInvalidArgs)
+	}
+	if writer.loopEntityCalled {
+		t.Errorf("CreateLoopEntity must not fire on invalid args")
+	}
+}
+
+func TestResearchGraphExecutor_RejectsMalformedHints(t *testing.T) {
+	writer := &fakeResearchKVWriter{}
+	e := newTestExecutor(writer)
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   ResearchGraphToolName,
+		LoopID: "parent_loop_7",
+		Arguments: map[string]any{
+			"topic": "x",
+			"hints": map[string]any{
+				"entity_kind": 42, // wrong type
+			},
+		},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("error kind = %q, want %q", res.ErrorKind, agentic.ToolErrorInvalidArgs)
+	}
+}
+
+func TestResearchGraphExecutor_RejectsFractionalBudget(t *testing.T) {
+	writer := &fakeResearchKVWriter{}
+	e := newTestExecutor(writer)
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   ResearchGraphToolName,
+		LoopID: "parent_loop_7",
+		Arguments: map[string]any{
+			"topic":         "x",
+			"budget_tokens": 4000.5,
+		},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("error kind = %q, want %q", res.ErrorKind, agentic.ToolErrorInvalidArgs)
+	}
+}
+
+func TestResearchGraphExecutor_RejectsMissingLoopID(t *testing.T) {
+	writer := &fakeResearchKVWriter{}
+	e := newTestExecutor(writer)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "c1",
+		Name:      ResearchGraphToolName,
+		Arguments: map[string]any{"topic": "x"},
+		// LoopID intentionally omitted
+	})
+	if err == nil {
+		t.Errorf("expected error return when loop_id is missing")
+	}
+	if res.ErrorKind != agentic.ToolErrorInternal {
+		t.Errorf("error kind = %q, want %q", res.ErrorKind, agentic.ToolErrorInternal)
+	}
+	if writer.loopEntityCalled {
+		t.Errorf("CreateLoopEntity must not fire when loop_id is missing")
+	}
+}
+
+func TestResearchGraphExecutor_RoutesUnknownTool(t *testing.T) {
+	writer := &fakeResearchKVWriter{}
+	e := newTestExecutor(writer)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   "not_research_graph",
+		LoopID: "parent",
+		Arguments: map[string]any{
+			"topic": "x",
+		},
+	})
+	if err == nil {
+		t.Errorf("expected error return for unknown tool name")
+	}
+	if res.ErrorKind != agentic.ToolErrorNotFound {
+		t.Errorf("error kind = %q, want %q", res.ErrorKind, agentic.ToolErrorNotFound)
+	}
+}
+
+func TestResearchGraphExecutor_LoopEntityWriteFailureSurfaces(t *testing.T) {
+	writer := &fakeResearchKVWriter{
+		loopEntityErr: errors.New("kv unreachable"),
+	}
+	e := newTestExecutor(writer)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "c1",
+		Name:      ResearchGraphToolName,
+		LoopID:    "parent",
+		Arguments: map[string]any{"topic": "x"},
+	})
+	if err == nil {
+		t.Errorf("expected error return on LoopEntity write failure")
+	}
+	if res.ErrorKind != agentic.ToolErrorNetwork {
+		t.Errorf("error kind = %q, want %q", res.ErrorKind, agentic.ToolErrorNetwork)
+	}
+	if writer.triggerCalled {
+		t.Errorf("PutResearchTrigger must not fire after LoopEntity write fails — would orphan the trigger key")
+	}
+}
+
+func TestResearchGraphExecutor_TriggerWriteFailureSurfaces(t *testing.T) {
+	writer := &fakeResearchKVWriter{
+		triggerErr: errors.New("kv unreachable"),
+	}
+	e := newTestExecutor(writer)
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "c1",
+		Name:      ResearchGraphToolName,
+		LoopID:    "parent",
+		Arguments: map[string]any{"topic": "x"},
+	})
+	if err == nil {
+		t.Errorf("expected error return on trigger write failure")
+	}
+	if res.ErrorKind != agentic.ToolErrorNetwork {
+		t.Errorf("error kind = %q, want %q", res.ErrorKind, agentic.ToolErrorNetwork)
+	}
+}
+
+func TestResearchGraphExecutor_TriggerPayloadDecodesViaProductionRegistry(t *testing.T) {
+	// Belt-and-suspenders for feedback_production_decoder_round_trip_required:
+	// the trigger value is the operator-reachable payload R0 reads, so
+	// shape drift must surface in unit tests, not in PR 6's smoke.
+	writer := &fakeResearchKVWriter{}
+	e := newTestExecutor(writer)
+
+	_, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   ResearchGraphToolName,
+		LoopID: "parent",
+		Arguments: map[string]any{
+			"topic": "voltage anomaly across battery packs",
+			"hints": map[string]any{"recency": "last_24h"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(writer.triggerValue)
+	if err != nil {
+		t.Fatalf("production decoder rejected trigger payload: %v", err)
+	}
+	if decoded.Type() != (message.Type{
+		Domain:   research.Domain,
+		Category: research.CategoryIntent,
+		Version:  research.SchemaVersion,
+	}) {
+		t.Errorf("trigger type discriminator wrong: %+v", decoded.Type())
+	}
+}


### PR DESCRIPTION
## Summary

First of six PRs in [docs/operations/22-adr045-phase1-plan.md](../blob/main/docs/operations/22-adr045-phase1-plan.md). Lands the schema foundation for the [ADR-045](../blob/main/docs/adr/045-graph-search-rule-chain.md) graph-search rule chain so PRs 2-6 (five components + rule chain + smoke test) build on stable contracts without churn.

- New `agentic/research/` package with three `message.Payload` types: `Intent`, `SearchResult`, `RouteDecision` (closed action enum)
- New `research_graph` agent tool that creates a research-pipeline LoopEntity in `AGENT_LOOPS` and writes the `research.requested.<loopID>` trigger key R0 watches (PR 6 wires R0)
- Production-decoder round-trip tests for every payload per `feedback_production_decoder_round_trip_required`

**ADDITIVE.** No wire-format changes; no BREAKING; sister-project pin bumps optional.

## Architecture pointers

- Caller's intent carries only `topic` + free-form `hints` + budgets — no entity IDs or predicates (those are outputs of the chain per ADR-045 v2)
- Tool writes LoopEntity FIRST, trigger key SECOND so R0's downstream actions see a populated loop record (`TestResearchGraphExecutor_HappyPath_WriteOrdering` locks this in)
- Caller-omitted `budget_tokens` / `max_iterations` resolve to defaults BEFORE the persisted Intent is marshalled (`TestResearchGraphExecutor_DefaultsPersistOnTriggerPayload`)
- Uses `agentic.TryLoopExecutionEntityID` per `feedback_try_loop_entity_id_for_runtime`
- Intent envelope wraps via `message.NewBaseMessage` per `feedback_nats_publishes_use_payload_registry`

## Test plan

- [x] `task lint` — clean (no revive warnings)
- [x] `go test -race ./...` — full unit sweep green
- [x] `go vet -tags=integration ./...` and `-tags=live_llm ./...` — clean
- [x] `go test ./test/contract/...` — green
- [x] `task schema:generate` — no diff
- [x] go-reviewer pass: all SHOULD-FIX + NIT findings closed; reviewer approval recorded

## Next PR in sequence

PR 2: `nl_classify` component wrapping `graph/query.Classifier`. See plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)