### PR TITLE
feat(processor): ADR-045 Phase 1 PR 2 — nl_classify component

### DIFF
--- a/agentic/research/classifier_output.go
+++ b/agentic/research/classifier_output.go
@@ -1,0 +1,170 @@
+package research
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// Candidate is one entity hit the classifier surfaced for the topic.
+// Mirrors the search_graph EntityDigest shape (entity_id + label +
+// type + relevance score + optional snippet) so PR 4
+// (execute_subqueries) can consume nl_classify's output and search-
+// graph's output through one evidence schema.
+//
+// Provenance is mandatory: every Candidate carries the Tier ("0"
+// keyword / "1" embedding/BM25 / "2" neural — Phase 2) and Source
+// (the retrieval method, e.g. "classifier_chain", "search_graph") so
+// downstream rules can filter by retrieval pathway.
+type Candidate struct {
+	// EntityID is the matching graph entity. Required.
+	EntityID string `json:"entity_id"`
+
+	// Label is a human-readable name for the entity. Optional; empty
+	// when the candidate source doesn't carry a label (some graph
+	// queries return only IDs).
+	Label string `json:"label,omitempty"`
+
+	// Type is the entity's domain type when known (e.g. "drone",
+	// "sensor"). Optional.
+	Type string `json:"type,omitempty"`
+
+	// Relevance is the within-tier ranking score (higher = better).
+	// Per ADR-045 Phase 1, cross-tier comparison isn't meaningful —
+	// PR 4 keeps per-tier ordering + recency tie-break; Phase 2 may
+	// add a learned ranker.
+	Relevance float64 `json:"relevance,omitempty"`
+
+	// SnippetText is a short inline preview useful for prompt
+	// injection. Omit when the candidate has no readable preview.
+	SnippetText string `json:"snippet_text,omitempty"`
+
+	// Tier is the retrieval tier that surfaced this hit. Same
+	// taxonomy as Evidence.Tier in result.go so the evidence schema
+	// stays consistent across PR 2 (this file) and PR 4.
+	Tier string `json:"tier"`
+
+	// Source is the retrieval source within the tier — e.g.
+	// "classifier_chain", "search_graph". Required so PR 4 can
+	// classify candidates by retrieval pathway.
+	Source string `json:"source"`
+}
+
+// Validate checks the required fields and the closed Tier enum.
+func (c *Candidate) Validate() error {
+	if strings.TrimSpace(c.EntityID) == "" {
+		return fmt.Errorf("entity_id required")
+	}
+	if strings.TrimSpace(c.Source) == "" {
+		return fmt.Errorf("source required")
+	}
+	switch c.Tier {
+	case "0", "1", "2":
+		// Accepted set; mirrors Evidence.Tier.
+	default:
+		return fmt.Errorf("tier %q must be \"0\", \"1\", or \"2\"", c.Tier)
+	}
+	return nil
+}
+
+// ClassifierOutput is the nl_classify component's emit: the
+// classifier hints (extracted from ClassificationResult.Options) plus
+// the initial candidate set surfaced by executing the resulting
+// SearchOptions against the graph. R1 fires on this payload (via the
+// classify.complete.<loop_id> trigger key) and route_search (PR 3)
+// consumes it to choose one of the four routing actions.
+type ClassifierOutput struct {
+	// Topic is the topic the classifier ran on. Echoed so the
+	// downstream consumer (route_search) doesn't have to read the
+	// intent payload separately.
+	Topic string `json:"topic"`
+
+	// Tier is which classifier tier produced the hint set:
+	// "0" (keyword), "1" (embedding/BM25), or "3" (LLM). The
+	// numbering follows ClassifierChain conventions (T0/T1/T2/T3 — T2
+	// neural is Phase 2, not currently emitted). Empty/"0" is the
+	// default fall-through when no tier matched.
+	//
+	// IMPORTANT: this is the *classifier* tier and shares no enum
+	// with [Candidate.Tier] / [Evidence.Tier], which are *retrieval*
+	// tiers ("0"/"1"/"2"). A LLM-tier classifier may surface
+	// Tier="3" here while its surfaced candidates carry Tier="0" or
+	// "1". Don't copy this string into a Candidate without
+	// re-mapping — Candidate.Validate rejects "3".
+	Tier string `json:"tier,omitempty"`
+
+	// Intent is the LLM-or-embedding-detected intent classification.
+	// Empty when the keyword tier matched (KeywordClassifier doesn't
+	// set Intent — its semantics live in the Options map).
+	Intent string `json:"intent,omitempty"`
+
+	// Confidence is the classifier's confidence in the hint set.
+	// 1.0 for keyword matches, <=1.0 from embedding similarity.
+	Confidence float64 `json:"confidence,omitempty"`
+
+	// Hints is the operator-facing flattened classifier output: time
+	// range, geo bounds, path intent, aggregation type, etc. Wire
+	// shape matches ClassificationResult.Options so consumers can
+	// reconstruct a SearchOptions when they need to re-execute.
+	Hints map[string]any `json:"hints,omitempty"`
+
+	// Candidates is the initial candidate set: entities the
+	// classifier surfaced, with scores + snippets where available.
+	// Empty when the topic produced no hits — PR 3's route_search
+	// will choose "retighten" or "decompose" in that case.
+	Candidates []Candidate `json:"candidates,omitempty"`
+
+	// Degraded is set when the candidate retrieval fell back to a
+	// less-rich path (e.g. server-side semantic fallback). Carried
+	// through so PR 3's router can treat the candidates as
+	// advisory.
+	Degraded bool `json:"degraded,omitempty"`
+
+	// DegradedReason is a short operator-readable label describing
+	// the fallback path when Degraded is true. Empty otherwise.
+	DegradedReason string `json:"degraded_reason,omitempty"`
+}
+
+// Schema implements message.Payload.
+func (p *ClassifierOutput) Schema() message.Type {
+	return message.Type{
+		Domain:   Domain,
+		Category: CategoryClassifierOutput,
+		Version:  SchemaVersion,
+	}
+}
+
+// Validate implements message.Payload. Topic is required; Candidates
+// are individually validated when present.
+func (p *ClassifierOutput) Validate() error {
+	if p == nil {
+		return fmt.Errorf("classifier output is nil")
+	}
+	if strings.TrimSpace(p.Topic) == "" {
+		return fmt.Errorf("topic required")
+	}
+	for i := range p.Candidates {
+		if err := p.Candidates[i].Validate(); err != nil {
+			return fmt.Errorf("candidates[%d]: %w", i, err)
+		}
+	}
+	if p.Confidence < 0 {
+		return fmt.Errorf("confidence must be >= 0, got %v", p.Confidence)
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler with the alias-recursion
+// guard.
+func (p *ClassifierOutput) MarshalJSON() ([]byte, error) {
+	type alias ClassifierOutput
+	return json.Marshal((*alias)(p))
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (p *ClassifierOutput) UnmarshalJSON(data []byte) error {
+	type alias ClassifierOutput
+	return json.Unmarshal(data, (*alias)(p))
+}

--- a/agentic/research/constants.go
+++ b/agentic/research/constants.go
@@ -27,6 +27,12 @@ const (
 	// CategoryRouteDecision is route_search's structured emit: one of
 	// four actions plus action-specific args plus rationale.
 	CategoryRouteDecision = "route_decision"
+
+	// CategoryClassifierOutput is the nl_classify component's emit:
+	// classifier hints + initial candidate set. R1 fires on the
+	// matching trigger key; route_search (PR 3) consumes the payload
+	// to pick a routing action.
+	CategoryClassifierOutput = "classifier_output"
 )
 
 // RouteAction values for RouteDecision.Action. Closed enum per ADR-045

--- a/agentic/research/register.go
+++ b/agentic/research/register.go
@@ -37,6 +37,13 @@ func RegisterPayloads(reg *payloadregistry.Registry) error {
 			Description: "ADR-045 route_search component decision: one of four routing actions",
 			Factory:     func() any { return &RouteDecision{} },
 		},
+		{
+			Domain:      Domain,
+			Category:    CategoryClassifierOutput,
+			Version:     SchemaVersion,
+			Description: "ADR-045 nl_classify component output: classifier hints + initial candidate set",
+			Factory:     func() any { return &ClassifierOutput{} },
+		},
 	}
 
 	var errs []error

--- a/agentic/research/roundtrip_test.go
+++ b/agentic/research/roundtrip_test.go
@@ -141,6 +141,121 @@ func TestSearchResult_RoundTripThroughDecoder(t *testing.T) {
 	}
 }
 
+func TestClassifierOutput_RoundTripThroughDecoder(t *testing.T) {
+	original := &research.ClassifierOutput{
+		Topic:      "drone hover anomalies in robotics fleet",
+		Tier:       "0",
+		Intent:     "",
+		Confidence: 1.0,
+		Hints: map[string]any{
+			"path_intent":     true,
+			"path_start_node": "drone-001",
+		},
+		Candidates: []research.Candidate{
+			{
+				EntityID:    "acme.ops.robotics.gcs.drone.001",
+				Label:       "Drone 001",
+				Type:        "drone",
+				Relevance:   0.92,
+				SnippetText: "Drone 001 reported hover instability at 14:32Z.",
+				Tier:        "0",
+				Source:      "classifier_chain",
+			},
+			{
+				EntityID:  "acme.ops.robotics.gcs.drone.014",
+				Type:      "drone",
+				Relevance: 0.71,
+				Tier:      "0",
+				Source:    "search_graph",
+			},
+		},
+		Degraded:       true,
+		DegradedReason: "search_graph fell back to semantic strategy",
+	}
+
+	envelope := message.NewBaseMessage(original.Schema(), original, "research-roundtrip-test")
+	wireBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(wireBytes)
+	if err != nil {
+		t.Fatalf("registry decode: %v\nwire: %s", err, wireBytes)
+	}
+	got, ok := decoded.Payload().(*research.ClassifierOutput)
+	if !ok {
+		t.Fatalf("payload: got %T, want *research.ClassifierOutput", decoded.Payload())
+	}
+	if got.Topic != original.Topic {
+		t.Errorf("topic: got %q, want %q", got.Topic, original.Topic)
+	}
+	if got.Tier != original.Tier {
+		t.Errorf("tier: got %q, want %q", got.Tier, original.Tier)
+	}
+	if !got.Degraded || got.DegradedReason != original.DegradedReason {
+		t.Errorf("degraded fields drifted: %+v", got)
+	}
+	if len(got.Candidates) != len(original.Candidates) {
+		t.Fatalf("candidates len: got %d, want %d", len(got.Candidates), len(original.Candidates))
+	}
+	for i := range original.Candidates {
+		if got.Candidates[i].EntityID != original.Candidates[i].EntityID {
+			t.Errorf("candidates[%d].EntityID: got %q, want %q", i, got.Candidates[i].EntityID, original.Candidates[i].EntityID)
+		}
+		if got.Candidates[i].Tier != original.Candidates[i].Tier {
+			t.Errorf("candidates[%d].Tier: got %q, want %q", i, got.Candidates[i].Tier, original.Candidates[i].Tier)
+		}
+	}
+}
+
+func TestClassifierOutput_ValidateRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name    string
+		output  research.ClassifierOutput
+		wantSub string
+	}{
+		{
+			name:    "missing topic",
+			output:  research.ClassifierOutput{Topic: ""},
+			wantSub: "topic required",
+		},
+		{
+			name:    "negative confidence",
+			output:  research.ClassifierOutput{Topic: "x", Confidence: -0.1},
+			wantSub: "confidence",
+		},
+		{
+			name: "candidate missing entity_id",
+			output: research.ClassifierOutput{
+				Topic:      "x",
+				Candidates: []research.Candidate{{Tier: "0", Source: "classifier_chain"}},
+			},
+			wantSub: "entity_id required",
+		},
+		{
+			name: "candidate bad tier",
+			output: research.ClassifierOutput{
+				Topic:      "x",
+				Candidates: []research.Candidate{{EntityID: "e", Tier: "bogus", Source: "x"}},
+			},
+			wantSub: "tier",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.output.Validate()
+			if err == nil {
+				t.Fatalf("Validate = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("Validate error = %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
 func TestRouteDecision_RoundTripThroughDecoder(t *testing.T) {
 	original := &research.RouteDecision{
 		Action: research.ActionDecompose,

--- a/componentregistry/register.go
+++ b/componentregistry/register.go
@@ -36,6 +36,7 @@ import (
 	jsongeneric "github.com/c360studio/semstreams/processor/json_generic"
 	jsonmap "github.com/c360studio/semstreams/processor/json_map"
 	oasfgenerator "github.com/c360studio/semstreams/processor/oasf-generator"
+	researchclassify "github.com/c360studio/semstreams/processor/research-graph-classify"
 	"github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/storage/objectstore"
 )
@@ -187,6 +188,13 @@ func registerSemanticLayer(registry *component.Registry) error {
 	// Query coordinator (orchestrates queries across components)
 	if err := graphquery.Register(registry); err != nil {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "graph-query component registration")
+	}
+
+	// Research graph chain (ADR-045): nl_classify stage. Subsequent
+	// PRs add route_search, execute_subqueries, assess_sufficiency,
+	// and synthesize_answer.
+	if err := researchclassify.Register(registry); err != nil {
+		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-classify component registration")
 	}
 
 	// Statistical/Semantic tier components (enabled via config)

--- a/processor/research-graph-classify/adapters.go
+++ b/processor/research-graph-classify/adapters.go
@@ -1,0 +1,279 @@
+package researchclassify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/graph/query"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/payloadregistry"
+)
+
+// classifierChainAdapter adapts *query.ClassifierChain to the
+// Classifier interface so tests can swap implementations without
+// constructing a real chain.
+type classifierChainAdapter struct {
+	chain *query.ClassifierChain
+}
+
+// ClassifyQuery delegates to the underlying chain. A nil chain
+// returns nil; the handler treats nil ClassificationResult as "fall
+// through with no hints" rather than an error.
+func (a *classifierChainAdapter) ClassifyQuery(ctx context.Context, topic string) *query.ClassificationResult {
+	if a == nil || a.chain == nil {
+		return nil
+	}
+	return a.chain.ClassifyQuery(ctx, topic)
+}
+
+// natsErrorPrefix is the body-prefix convention natsclient handlers
+// use to surface Go errors as response payloads (see
+// feedback_natsclient_error_payload_convention). One named constant
+// instead of `len("error: ")` magic numbers across call sites.
+const natsErrorPrefix = "error: "
+
+// extractNATSBodyError returns the trimmed error message if respData
+// carries the natsErrorPrefix shape; the bool flags whether a match
+// happened. Mirrors processor/agentic-tools/executors helper of the
+// same intent, kept local until natsclient grows a shared helper.
+func extractNATSBodyError(respData []byte) (string, bool) {
+	if len(respData) < len(natsErrorPrefix) {
+		return "", false
+	}
+	if string(respData[:len(natsErrorPrefix)]) != natsErrorPrefix {
+		return "", false
+	}
+	return string(respData[len(natsErrorPrefix):]), true
+}
+
+// searchGraphSubject is the existing graph-query NATS surface for
+// natural-language search. PR 2 reuses it (rather than introducing a
+// new endpoint) so the candidate-retrieval path shares wiring with
+// the search_graph agent tool (PR #54). PR 4 (execute_subqueries) is
+// expected to use the same subject for cross-tier retrieval; sharing
+// the surface keeps the evidence schema consistent.
+const searchGraphSubject = "graph.query.searchGraph"
+
+// searchGraphRetriever satisfies CandidateRetriever via a NATS
+// request to graph.query.searchGraph. Returns degraded=true when the
+// server-side fallback fired so PR 3's router can downgrade
+// confidence.
+type searchGraphRetriever struct {
+	client  *natsclient.Client
+	timeout time.Duration
+}
+
+func newSearchGraphRetriever(client *natsclient.Client, timeout time.Duration) *searchGraphRetriever {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return &searchGraphRetriever{client: client, timeout: timeout}
+}
+
+// searchGraphRequest mirrors the agent tool's wire shape (see
+// processor/agentic-tools/executors/search_graph.go). Limit is
+// surfaced via max_communities — the server-side resolver uses it
+// to cap the result fan-out.
+type searchGraphRequest struct {
+	Query          string `json:"query"`
+	MaxCommunities int    `json:"max_communities,omitempty"`
+}
+
+// searchGraphResponse is a deliberate subset of
+// processor/graph-query.GlobalSearchResponse — only the fields
+// nl_classify needs. A future GlobalSearchResponse field addition
+// won't surface here automatically; a contract test against the real
+// type would catch drift but is deferred to PR 4 (where
+// execute_subqueries consumes the same shape).
+type searchGraphResponse struct {
+	Strategy           string                `json:"strategy,omitempty"`
+	Count              int                   `json:"count"`
+	EntityDigests      []searchEntityDigest  `json:"entity_digests,omitempty"`
+	CommunitySummaries []searchCommunityItem `json:"community_summaries,omitempty"`
+	Degraded           bool                  `json:"degraded,omitempty"`
+	DegradedReason     string                `json:"degraded_reason,omitempty"`
+}
+
+// searchEntityDigest mirrors processor/graph-query.EntityDigest
+// (graphrag.go:180). The upstream type does NOT yet carry a snippet
+// field, so we don't either — adding one here would silently decode
+// as empty and create the "warning-not-fail masks integration drift"
+// shape from the discipline memory. SnippetText on the emitted
+// Candidate stays empty until upstream EntityDigest grows a snippet
+// field; the route_search prompt (PR 3) treats absent snippets as
+// "consult entity directly" rather than an error.
+type searchEntityDigest struct {
+	ID        string  `json:"id"`
+	Type      string  `json:"type,omitempty"`
+	Label     string  `json:"label,omitempty"`
+	Relevance float64 `json:"relevance,omitempty"`
+}
+
+type searchCommunityItem struct {
+	Summary string `json:"summary,omitempty"`
+}
+
+// FetchCandidates implements CandidateRetriever. Maps the
+// graph.query.searchGraph response into research.Candidate items.
+//
+// The configured RetrieveTimeout is applied as a child context of
+// the inbound ctx so the budget is the MIN of the caller's remaining
+// deadline (typically the handler's ClassifyTimeout-derived context)
+// and the per-call retrieval cap. Without the inner derivation,
+// RetrieveTimeout would also be passed to client.Request as the
+// underlying NATS request deadline and the two timeouts could
+// double-count; the inner ctx wins both.
+func (r *searchGraphRetriever) FetchCandidates(ctx context.Context, topic string, _ map[string]any, limit int) (CandidateSet, error) {
+	if r.client == nil {
+		return CandidateSet{}, errors.New("nats client not configured")
+	}
+	if strings.TrimSpace(topic) == "" {
+		return CandidateSet{}, errors.New("topic required for candidate retrieval")
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+	if r.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.timeout)
+		defer cancel()
+	}
+	req := searchGraphRequest{
+		Query:          topic,
+		MaxCommunities: limit,
+	}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return CandidateSet{}, fmt.Errorf("marshal search request: %w", err)
+	}
+	respData, err := r.client.Request(ctx, searchGraphSubject, reqData, r.timeout)
+	if err != nil {
+		return CandidateSet{}, fmt.Errorf("request %s: %w", searchGraphSubject, err)
+	}
+	// natsclient handler-error convention (body-prefix "error: ...")
+	// per feedback_natsclient_error_payload_convention. The check is
+	// inlined here because pulling in the agentic-tools helper would
+	// invert the dependency graph. Follow-up: lifting
+	// natsclient.ExtractHandlerError into natsclient itself, so
+	// summarize_graph + search_graph + this adapter share one helper
+	// — file alongside the planned #93 header-classified-errors
+	// migration.
+	if errMsg, ok := extractNATSBodyError(respData); ok {
+		return CandidateSet{}, fmt.Errorf("search_graph server error: %s", errMsg)
+	}
+
+	var resp searchGraphResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return CandidateSet{}, fmt.Errorf("decode search response: %w", err)
+	}
+
+	cands := make([]research.Candidate, 0, len(resp.EntityDigests))
+	for i, d := range resp.EntityDigests {
+		if i >= limit {
+			break
+		}
+		if strings.TrimSpace(d.ID) == "" {
+			continue
+		}
+		cands = append(cands, research.Candidate{
+			EntityID:  d.ID,
+			Label:     d.Label,
+			Type:      d.Type,
+			Relevance: d.Relevance,
+			Tier:      "0",
+			Source:    "search_graph",
+		})
+	}
+	return CandidateSet{
+		Candidates:     cands,
+		Degraded:       resp.Degraded,
+		DegradedReason: resp.DegradedReason,
+	}, nil
+}
+
+// natsLoopStore adapts natsclient.KVStore to the LoopStore interface.
+// Implementation choices:
+//
+//   - GetIntent reads research.requested.<loopID> and decodes via
+//     the production message.Decoder. NewTestDecoder isn't suitable
+//     here because production traffic goes through this path; we use
+//     a per-process decoder cached on the adapter.
+//
+//   - PutClassifierOutput writes to classify.complete.<loopID> using
+//     KVStore.Put. Last-writer-wins is fine — the loop_id is unique
+//     per research operation, so concurrent writes for the same key
+//     shouldn't occur outside of retries (which write the same
+//     bytes).
+//
+//   - PutSnapshot writes to classify.snapshot.<loopID>, a stable
+//     non-trigger key for downstream queryability. Same Put
+//     semantics.
+type natsLoopStore struct {
+	kv      *natsclient.KVStore
+	decoder *message.Decoder
+}
+
+// newNATSLoopStore wires the LoopStore using the supplied KV store
+// and the process-wide payload registry. registry must be non-nil —
+// without it the BaseMessage envelope written by research_graph (PR
+// 1) cannot be decoded. The factory caller (NewProcessor) is
+// responsible for surfacing a nil-registry config error cleanly.
+func newNATSLoopStore(kv *natsclient.KVStore, registry *payloadregistry.Registry) *natsLoopStore {
+	return &natsLoopStore{
+		kv:      kv,
+		decoder: message.NewDecoder(registry),
+	}
+}
+
+// loopStoreKeyIntent returns the AGENT_LOOPS key holding the
+// research_intent payload. Mirrors processor/agentic-tools/executors/
+// research_graph.go's researchTriggerKeyPrefix.
+func loopStoreKeyIntent(loopID string) string { return "research.requested." + loopID }
+
+// loopStoreKeyClassifyComplete is R1's trigger key.
+func loopStoreKeyClassifyComplete(loopID string) string { return "classify.complete." + loopID }
+
+// loopStoreKeySnapshot is the non-trigger queryable snapshot key.
+func loopStoreKeySnapshot(loopID string) string { return "classify.snapshot." + loopID }
+
+// GetIntent decodes the research_intent payload from the trigger
+// key. errIntentNotFound is returned when the key doesn't exist so
+// the handler can log + drop without a retry storm.
+func (s *natsLoopStore) GetIntent(ctx context.Context, loopID string) (*research.Intent, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyIntent(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errIntentNotFound
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyIntent(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode intent: %w", err)
+	}
+	intent, ok := decoded.Payload().(*research.Intent)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.Intent", decoded.Payload())
+	}
+	return intent, nil
+}
+
+// PutClassifierOutput writes the envelope at R1's trigger key.
+func (s *natsLoopStore) PutClassifierOutput(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeyClassifyComplete(loopID), envelope)
+	return err
+}
+
+// PutSnapshot writes the envelope at the stable snapshot key. Best-
+// effort: the handler logs and continues on failure rather than
+// aborting the chain.
+func (s *natsLoopStore) PutSnapshot(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeySnapshot(loopID), envelope)
+	return err
+}

--- a/processor/research-graph-classify/component.go
+++ b/processor/research-graph-classify/component.go
@@ -1,0 +1,462 @@
+package researchclassify
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph/llm"
+	"github.com/c360studio/semstreams/graph/query"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/model"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// Component implements the nl_classify processor. The struct field
+// set is intentionally small; the lifecycle methods (Start/Stop)
+// own the NATS / model-registry plumbing and the per-message handler
+// hands off to the pure classifyAndRetrieve function in handler.go.
+type Component struct {
+	config Config
+	deps   component.Dependencies
+	logger *slog.Logger
+
+	// Injected dependencies. Tests replace these directly via the
+	// constructor; production wires them via Start() from the
+	// natsclient + model registry on deps.
+	classifier Classifier
+	retriever  CandidateRetriever
+	loops      LoopStore
+
+	// llmClient is non-nil when EnableLLMClassifier is true and the
+	// model registry yields a query_classification capability. Owned
+	// here so Stop can close it.
+	llmClient llm.Client
+
+	// Lifecycle state. One mutex guards started/startTime/
+	// subscriptions across Start, Stop, Health, and DataFlow — the
+	// pair-of-mutexes shape that graph-query and json_map use opened
+	// a race window between Stop's `!started` guard and Health's
+	// `started` read (caught in PR 2 review). One mutex collapses
+	// the window without losing the Start/Stop serialisation, since
+	// neither method ever returns to the caller mid-mutation while
+	// holding the lock.
+	mu        sync.RWMutex
+	started   bool
+	startTime time.Time
+	wg        sync.WaitGroup
+
+	// NATS subscriptions kept for cleanup at Stop.
+	subscriptions []*natsclient.Subscription
+
+	// Atomic counters for DataFlow / observability.
+	messagesProcessed int64
+	messagesEmitted   int64
+	errors            int64
+	lastActivity      atomic.Value // time.Time
+
+	// Lifecycle reporter (COMPONENT_STATUS KV; same convention as
+	// json_map).
+	lifecycleReporter component.LifecycleReporter
+}
+
+// Ensure interface compliance.
+var (
+	_ component.Discoverable       = (*Component)(nil)
+	_ component.LifecycleComponent = (*Component)(nil)
+)
+
+// NewProcessor is the component-factory shape registered with the
+// component registry. Parses + validates config, applies defaults,
+// and constructs the Component with the injected production
+// adapters (NATS-backed LoopStore + searchGraphRetriever). The
+// classifier chain is built keyword-only at construction; the LLM
+// tier is wired in Start() when the model registry supplies a
+// query_classification capability.
+func NewProcessor(rawConfig json.RawMessage, deps component.Dependencies) (component.Discoverable, error) {
+	var config Config
+	if err := json.Unmarshal(rawConfig, &config); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config unmarshal")
+	}
+	if config.Ports == nil {
+		config = DefaultConfig()
+	}
+	config.ApplyDefaults()
+	if err := config.Validate(); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config validate")
+	}
+
+	if deps.NATSClient == nil {
+		return nil, errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "NewProcessor", "NATSClient required")
+	}
+
+	logger := deps.GetLoggerWithComponent(ComponentName)
+
+	return &Component{
+		config:     config,
+		deps:       deps,
+		logger:     logger,
+		classifier: &classifierChainAdapter{chain: query.NewClassifierChain(query.NewKeywordClassifier(), nil, nil)},
+		retriever:  newSearchGraphRetriever(deps.NATSClient, config.RetrieveTimeout),
+		loops:      nil, // wired in Start() once the bucket is open
+	}, nil
+}
+
+// Initialize is part of the LifecycleComponent contract. nl_classify
+// has nothing to initialise pre-Start — bucket open and LLM client
+// wire happen in Start() where they can fail loudly and propagate
+// without breaking other components in the same Initialize phase.
+func (c *Component) Initialize() error { return nil }
+
+// Start opens the AGENT_LOOPS bucket, optionally wires the LLM tier
+// into the classifier chain, subscribes to the configured input
+// ports, and reports idle.
+func (c *Component) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "Start", "context cannot be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return errs.WrapInvalid(err, ComponentName, "Start", "context already cancelled")
+	}
+
+	c.mu.Lock()
+	if c.started {
+		c.mu.Unlock()
+		return errs.WrapFatal(errs.ErrAlreadyStarted, ComponentName, "Start", "already started")
+	}
+	c.mu.Unlock()
+
+	if err := c.openLoopsBucket(ctx); err != nil {
+		return err
+	}
+
+	c.initLLMClassifierIfEnabled()
+
+	if err := c.subscribeInputs(ctx); err != nil {
+		return err
+	}
+
+	c.startLifecycleReporter(ctx)
+
+	c.mu.Lock()
+	c.started = true
+	c.startTime = time.Now()
+	c.mu.Unlock()
+
+	if c.lifecycleReporter != nil {
+		if err := c.lifecycleReporter.ReportStage(ctx, "idle"); err != nil {
+			c.logger.Debug("failed to report idle stage", slog.Any("error", err))
+		}
+	}
+
+	c.logger.Info("nl_classify component started",
+		slog.String("loops_bucket", c.config.LoopsBucket),
+		slog.Bool("llm_classifier", c.llmClient != nil),
+		slog.Int("max_candidates", c.config.MaxCandidates))
+	return nil
+}
+
+// openLoopsBucket opens (or idempotently creates) the AGENT_LOOPS KV
+// bucket and constructs the LoopStore adapter. Mirrors json_map's
+// COMPONENT_STATUS open pattern.
+func (c *Component) openLoopsBucket(ctx context.Context) error {
+	bucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      c.config.LoopsBucket,
+		Description: "Agent loops bucket; shared with agentic-loop and research_graph tool",
+		History:     10,
+		TTL:         24 * time.Hour,
+	})
+	if err != nil {
+		return errs.WrapTransient(err, ComponentName, "Start", "open loops bucket")
+	}
+	if c.deps.PayloadRegistry == nil {
+		return errs.WrapFatal(errs.ErrMissingConfig, ComponentName, "Start", "PayloadRegistry dependency required to decode research_intent from AGENT_LOOPS")
+	}
+	store := c.deps.NATSClient.NewKVStore(bucket)
+	c.loops = newNATSLoopStore(store, c.deps.PayloadRegistry)
+	return nil
+}
+
+// initLLMClassifierIfEnabled mirrors graph-query's initLLMClassifier:
+// resolves the query_classification capability against the model
+// registry and wires the LLM tier when available. Absence is a
+// clean keyword-only fallback, not a startup error.
+func (c *Component) initLLMClassifierIfEnabled() {
+	if !c.config.EnableLLMClassifier {
+		return
+	}
+	if c.deps.ModelRegistry == nil {
+		c.logger.Debug("LLM classifier enable requested but no model registry available; using keyword-only")
+		return
+	}
+	resolved, ep, err := model.ResolveEndpointWithConfig(c.deps.ModelRegistry, model.CapabilityQueryClassification)
+	if err != nil {
+		c.logger.Debug("no query_classification capability configured; keyword-only classifier",
+			slog.Any("error", err))
+		return
+	}
+	timeout := model.ResolveCapabilityTimeout(c.deps.ModelRegistry, model.CapabilityQueryClassification, query.DefaultClassificationTimeout, c.logger)
+	cfg := llm.OpenAIConfigFromEndpoint(resolved, ep, c.logger)
+	cfg.Timeout = timeout
+	client, err := llm.NewOpenAIClient(cfg)
+	if err != nil {
+		c.logger.Warn("failed to construct LLM classifier client; using keyword-only",
+			slog.Any("error", err))
+		return
+	}
+	c.llmClient = client
+	adapter := query.NewLLMClientAdapter(client, timeout)
+	llmClassifier := query.NewLLMClassifier(adapter, nil)
+	c.classifier = &classifierChainAdapter{
+		chain: query.NewClassifierChain(query.NewKeywordClassifier(), nil, llmClassifier),
+	}
+	c.logger.Info("LLM tier wired into classifier chain",
+		slog.String("model", resolved.Model),
+		slog.Duration("timeout", timeout))
+}
+
+// subscribeInputs wires NATS subscriptions for each input port.
+func (c *Component) subscribeInputs(ctx context.Context) error {
+	for _, port := range c.config.Ports.Inputs {
+		if port.Subject == "" {
+			continue
+		}
+		if port.Type != "nats" {
+			c.logger.Warn("unsupported port type; skipping",
+				slog.String("port", port.Name),
+				slog.String("type", port.Type))
+			continue
+		}
+		sub, err := c.deps.NATSClient.Subscribe(ctx, port.Subject, func(msgCtx context.Context, msg *nats.Msg) {
+			c.handleMessage(msgCtx, msg.Subject, msg.Data)
+		})
+		if err != nil {
+			return errs.WrapTransient(err, ComponentName, "Start",
+				fmt.Sprintf("subscribe to %s", port.Subject))
+		}
+		c.subscriptions = append(c.subscriptions, sub)
+		c.logger.Debug("subscribed to NATS subject",
+			slog.String("port", port.Name),
+			slog.String("subject", port.Subject))
+	}
+	return nil
+}
+
+// startLifecycleReporter wires the COMPONENT_STATUS KV reporter if
+// available; degrades to a no-op reporter on failure (same pattern as
+// json_map).
+func (c *Component) startLifecycleReporter(ctx context.Context) {
+	statusBucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      "COMPONENT_STATUS",
+		Description: "Component lifecycle status tracking",
+	})
+	if err != nil {
+		c.logger.Warn("COMPONENT_STATUS bucket unavailable; lifecycle reporting disabled",
+			slog.Any("error", err))
+		c.lifecycleReporter = component.NewNoOpLifecycleReporter()
+		return
+	}
+	c.lifecycleReporter = component.NewLifecycleReporterFromConfig(component.LifecycleReporterConfig{
+		KV:               statusBucket,
+		ComponentName:    ComponentName,
+		Logger:           c.logger,
+		EnableThrottling: true,
+	})
+}
+
+// Stop drains subscriptions, closes the LLM client, and reports
+// shutdown. Flips `started` under c.mu so a concurrent Health /
+// DataFlow read can't see a torn read of the lifecycle flag.
+func (c *Component) Stop(timeout time.Duration) error {
+	c.mu.Lock()
+	if !c.started {
+		c.mu.Unlock()
+		return nil
+	}
+	c.started = false
+	c.mu.Unlock()
+
+	for _, sub := range c.subscriptions {
+		if sub == nil {
+			continue
+		}
+		if err := sub.Unsubscribe(); err != nil {
+			c.logger.Debug("unsubscribe failed during stop", slog.Any("error", err))
+		}
+	}
+	c.subscriptions = nil
+
+	// Wait for in-flight handlers to finish, bounded by the caller's
+	// timeout. Goroutine-leak avoidance per the standard pattern.
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		c.logger.Warn("Stop timeout reached with handlers in flight",
+			slog.Duration("timeout", timeout))
+	}
+
+	if c.llmClient != nil {
+		if err := c.llmClient.Close(); err != nil {
+			c.logger.Debug("LLM client close failed during stop", slog.Any("error", err))
+		}
+		c.llmClient = nil
+	}
+	return nil
+}
+
+// handleMessage is the per-message hot path. Recovers loop_id from
+// the subject, loads the intent, runs classifyAndRetrieve, and
+// writes the classifier_output envelope + the classify.complete
+// trigger key. Errors are logged and counted; we do not propagate
+// to NATS because the publisher is fire-and-forget (no reply
+// expected) — propagation would silently drop the message.
+func (c *Component) handleMessage(ctx context.Context, subject string, _ []byte) {
+	c.wg.Add(1)
+	defer c.wg.Done()
+	atomic.AddInt64(&c.messagesProcessed, 1)
+	c.lastActivity.Store(time.Now())
+
+	loopID := extractLoopIDFromSubject(subject)
+	if loopID == "" {
+		c.logger.Error("could not extract loop_id from subject; ignoring message",
+			slog.String("subject", subject))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	if c.config.ClassifyTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.config.ClassifyTimeout)
+		defer cancel()
+	}
+
+	intent, err := c.loops.GetIntent(ctx, loopID)
+	if err != nil {
+		c.logger.Error("could not load research intent; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	output, err := classifyAndRetrieve(ctx, c.classifier, c.retriever, intent, c.config.MaxCandidates)
+	if err != nil {
+		c.logger.Error("classify+retrieve failed; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	envelope := message.NewBaseMessage(output.Schema(), output, ComponentName)
+	envelopeBytes, err := json.Marshal(envelope)
+	if err != nil {
+		c.logger.Error("marshal classifier output envelope failed",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	// Write snapshot first (for queryability), then the trigger key
+	// that R1 watches. Order matches research_graph's LoopEntity-then-
+	// trigger discipline (PR 1) — R1's downstream actions need the
+	// snapshot to be readable when they fire.
+	if err := c.loops.PutSnapshot(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Warn("snapshot write failed; chain continues but downstream readback may miss it",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+	}
+
+	if err := c.loops.PutClassifierOutput(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Error("classify.complete trigger write failed; R1 will not fire",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	atomic.AddInt64(&c.messagesEmitted, 1)
+	c.logger.Info("nl_classify produced classifier_output",
+		slog.String("loop_id", loopID),
+		slog.String("topic", intent.Topic),
+		slog.String("tier", output.Tier),
+		slog.Int("candidates", len(output.Candidates)),
+		slog.Bool("degraded", output.Degraded))
+}
+
+// Meta implements Discoverable.
+func (c *Component) Meta() component.Metadata {
+	return component.Metadata{
+		Name:        ComponentName,
+		Type:        "processor",
+		Description: "ADR-045 nl_classify: classifies a research topic via graph/query.ClassifierChain and surfaces initial candidate entities for downstream route_search.",
+		Version:     "0.1.0",
+	}
+}
+
+// InputPorts implements Discoverable.
+func (c *Component) InputPorts() []component.Port {
+	ports := make([]component.Port, 0, len(c.config.Ports.Inputs))
+	for _, p := range c.config.Ports.Inputs {
+		ports = append(ports, component.Port{
+			Name:      p.Name,
+			Direction: component.DirectionInput,
+			Required:  p.Required,
+			Config: component.NATSPort{
+				Subject: p.Subject,
+			},
+		})
+	}
+	return ports
+}
+
+// OutputPorts implements Discoverable. nl_classify has no NATS-
+// publishing output port: its emits are KV writes to AGENT_LOOPS.
+// The empty slice surfaces honestly in flow-discovery so operators
+// don't expect a NATS subject they'll never see.
+func (c *Component) OutputPorts() []component.Port { return []component.Port{} }
+
+// ConfigSchema implements Discoverable.
+func (c *Component) ConfigSchema() component.ConfigSchema { return configSchema }
+
+// Health implements Discoverable.
+func (c *Component) Health() component.HealthStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return component.HealthStatus{
+		Healthy:    c.started,
+		LastCheck:  time.Now(),
+		ErrorCount: int(atomic.LoadInt64(&c.errors)),
+		Uptime:     time.Since(c.startTime),
+	}
+}
+
+// DataFlow implements Discoverable.
+func (c *Component) DataFlow() component.FlowMetrics {
+	processed := atomic.LoadInt64(&c.messagesProcessed)
+	errCount := atomic.LoadInt64(&c.errors)
+	var errRate float64
+	if processed > 0 {
+		errRate = float64(errCount) / float64(processed)
+	}
+	last, _ := c.lastActivity.Load().(time.Time)
+	return component.FlowMetrics{
+		ErrorRate:    errRate,
+		LastActivity: last,
+	}
+}

--- a/processor/research-graph-classify/component_test.go
+++ b/processor/research-graph-classify/component_test.go
@@ -1,0 +1,355 @@
+package researchclassify
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph/query"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadbuiltins"
+)
+
+// fakeLoopStore replaces the natsLoopStore for handler integration
+// tests. Records GetIntent calls and PutClassifierOutput /
+// PutSnapshot writes so the test can assert on key + envelope shape.
+type fakeLoopStore struct {
+	mu sync.Mutex
+
+	intent    *research.Intent
+	intentErr error
+
+	getCalls int
+
+	snapshotKey      string
+	snapshotEnvelope []byte
+	snapshotErr      error
+
+	classifyKey      string
+	classifyEnvelope []byte
+	classifyErr      error
+
+	writeOrder []string
+}
+
+func (s *fakeLoopStore) GetIntent(_ context.Context, _ string) (*research.Intent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getCalls++
+	if s.intentErr != nil {
+		return nil, s.intentErr
+	}
+	return s.intent, nil
+}
+
+func (s *fakeLoopStore) PutSnapshot(_ context.Context, loopID string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.snapshotKey = loopID
+	s.snapshotEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "snapshot")
+	return s.snapshotErr
+}
+
+func (s *fakeLoopStore) PutClassifierOutput(_ context.Context, loopID string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.classifyKey = loopID
+	s.classifyEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "classify_complete")
+	return s.classifyErr
+}
+
+// newTestComponent constructs a Component with all injected
+// dependencies stubbed for handler-path testing. The deps struct is
+// intentionally minimal: handleMessage doesn't touch deps once Start
+// has wired the injected fields, so we can leave deps.NATSClient nil.
+// quietLogger returns an slog.Logger that discards output so
+// handler.go's structured log lines don't pollute test output.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func newTestComponent(loops LoopStore, classifier Classifier, retriever CandidateRetriever) *Component {
+	return &Component{
+		config:     DefaultConfig(),
+		classifier: classifier,
+		retriever:  retriever,
+		loops:      loops,
+		logger:     quietLogger(),
+	}
+}
+
+func TestComponent_HandleMessage_HappyPath(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "drone hover anomalies"},
+	}
+	classifier := &fakeClassifier{result: &query.ClassificationResult{
+		Tier:       0,
+		Options:    map[string]any{"path_intent": true},
+		Confidence: 1.0,
+	}}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{
+			{EntityID: "acme.ops.robotics.gcs.drone.001", Tier: "0", Source: "search_graph", Relevance: 0.9},
+		},
+	}
+	c := newTestComponent(loops, classifier, retriever)
+	c.logger = quietLogger()
+
+	c.handleMessage(context.Background(), "component.nl_classify.rg_test001", nil)
+
+	if loops.classifyKey != "rg_test001" {
+		t.Errorf("classify trigger key = %q, want %q", loops.classifyKey, "rg_test001")
+	}
+	if loops.snapshotKey != "rg_test001" {
+		t.Errorf("snapshot key = %q, want %q", loops.snapshotKey, "rg_test001")
+	}
+	if len(loops.writeOrder) != 2 || loops.writeOrder[0] != "snapshot" || loops.writeOrder[1] != "classify_complete" {
+		t.Errorf("write order = %v, want [snapshot, classify_complete]", loops.writeOrder)
+	}
+
+	// Envelope decodes through the production registry as a
+	// *research.ClassifierOutput — proves the registry wiring is
+	// consistent with what R1's reader will use
+	// (feedback_production_decoder_round_trip_required).
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(loops.classifyEnvelope)
+	if err != nil {
+		t.Fatalf("decode classify envelope: %v", err)
+	}
+	out, ok := decoded.Payload().(*research.ClassifierOutput)
+	if !ok {
+		t.Fatalf("decoded type = %T, want *research.ClassifierOutput", decoded.Payload())
+	}
+	if out.Topic != "drone hover anomalies" {
+		t.Errorf("topic in envelope = %q, want %q", out.Topic, "drone hover anomalies")
+	}
+	if out.Tier != "0" {
+		t.Errorf("tier = %q, want \"0\"", out.Tier)
+	}
+	if len(out.Candidates) != 1 {
+		t.Fatalf("candidates len = %d, want 1", len(out.Candidates))
+	}
+}
+
+func TestComponent_HandleMessage_BadSubject(t *testing.T) {
+	loops := &fakeLoopStore{intent: &research.Intent{Topic: "x"}}
+	c := newTestComponent(loops, &fakeClassifier{}, &fakeRetriever{})
+	c.logger = quietLogger()
+
+	c.handleMessage(context.Background(), "totally.wrong.subject", nil)
+
+	if loops.getCalls != 0 {
+		t.Errorf("GetIntent called %d times for malformed subject; want 0", loops.getCalls)
+	}
+	if loops.classifyKey != "" {
+		t.Errorf("classify write happened on malformed subject (key=%q)", loops.classifyKey)
+	}
+	if atomic.LoadInt64(&c.errors) == 0 {
+		t.Errorf("expected an error to be counted")
+	}
+}
+
+func TestComponent_HandleMessage_IntentNotFound(t *testing.T) {
+	loops := &fakeLoopStore{intentErr: errIntentNotFound}
+	c := newTestComponent(loops, &fakeClassifier{}, &fakeRetriever{})
+	c.logger = quietLogger()
+
+	c.handleMessage(context.Background(), "component.nl_classify.rg_test001", nil)
+
+	if loops.classifyKey != "" {
+		t.Errorf("classify write happened despite missing intent (key=%q)", loops.classifyKey)
+	}
+	if atomic.LoadInt64(&c.errors) == 0 {
+		t.Errorf("expected an error to be counted")
+	}
+}
+
+func TestComponent_HandleMessage_RetrieverFailure(t *testing.T) {
+	loops := &fakeLoopStore{intent: &research.Intent{Topic: "x"}}
+	classifier := &fakeClassifier{result: &query.ClassificationResult{Tier: 0}}
+	retriever := &fakeRetriever{err: errors.New("nats unreachable")}
+	c := newTestComponent(loops, classifier, retriever)
+	c.logger = quietLogger()
+
+	c.handleMessage(context.Background(), "component.nl_classify.rg_test001", nil)
+
+	if loops.classifyKey != "" {
+		t.Errorf("classify write should not happen when retriever fails (key=%q)", loops.classifyKey)
+	}
+	if atomic.LoadInt64(&c.errors) == 0 {
+		t.Errorf("expected an error to be counted")
+	}
+}
+
+func TestComponent_HandleMessage_SnapshotFailureDoesNotBlockTrigger(t *testing.T) {
+	// PutSnapshot is best-effort: a failure there should NOT skip
+	// the classify.complete trigger write — R1 still needs to fire.
+	loops := &fakeLoopStore{
+		intent:      &research.Intent{Topic: "x"},
+		snapshotErr: errors.New("snapshot kv error"),
+	}
+	classifier := &fakeClassifier{result: &query.ClassificationResult{Tier: 0}}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{{EntityID: "x", Tier: "0", Source: "search_graph"}},
+	}
+	c := newTestComponent(loops, classifier, retriever)
+	c.logger = quietLogger()
+
+	c.handleMessage(context.Background(), "component.nl_classify.rg_test001", nil)
+
+	if loops.classifyKey == "" {
+		t.Errorf("classify.complete trigger should fire even when snapshot fails")
+	}
+}
+
+func TestComponent_HandleMessage_ClassifyTriggerFailureCounts(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:      &research.Intent{Topic: "x"},
+		classifyErr: errors.New("trigger kv error"),
+	}
+	classifier := &fakeClassifier{result: &query.ClassificationResult{Tier: 0}}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{{EntityID: "x", Tier: "0", Source: "search_graph"}},
+	}
+	c := newTestComponent(loops, classifier, retriever)
+	c.logger = quietLogger()
+
+	c.handleMessage(context.Background(), "component.nl_classify.rg_test001", nil)
+
+	if atomic.LoadInt64(&c.errors) == 0 {
+		t.Errorf("expected an error to be counted when trigger write fails")
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 0 {
+		t.Errorf("messagesEmitted should not increment on trigger failure")
+	}
+}
+
+func TestComponent_EnvelopeShape_DecodesViaProductionRegistry(t *testing.T) {
+	// Belt-and-suspenders for
+	// feedback_production_decoder_round_trip_required: the envelope
+	// must decode through the same registry production R1 will use.
+	loops := &fakeLoopStore{intent: &research.Intent{Topic: "voltage"}}
+	classifier := &fakeClassifier{result: &query.ClassificationResult{Tier: 1, Confidence: 0.8}}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{{EntityID: "battery.01", Tier: "1", Source: "search_graph"}},
+	}
+	c := newTestComponent(loops, classifier, retriever)
+	c.logger = quietLogger()
+
+	c.handleMessage(context.Background(), "component.nl_classify.rg_x", nil)
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(loops.classifyEnvelope)
+	if err != nil {
+		t.Fatalf("envelope decode failed: %v\nwire: %s", err, loops.classifyEnvelope)
+	}
+	if decoded.Type() != (message.Type{
+		Domain:   research.Domain,
+		Category: research.CategoryClassifierOutput,
+		Version:  research.SchemaVersion,
+	}) {
+		t.Errorf("envelope type discriminator wrong: %+v", decoded.Type())
+	}
+	// Snapshot should be byte-equal to classify envelope (same
+	// payload, separate keys for queryability vs trigger).
+	if string(loops.snapshotEnvelope) != string(loops.classifyEnvelope) {
+		t.Errorf("snapshot vs classify envelope diverged")
+	}
+}
+
+func TestDiscoverableSurface(t *testing.T) {
+	loops := &fakeLoopStore{}
+	c := newTestComponent(loops, &fakeClassifier{}, &fakeRetriever{})
+	c.logger = quietLogger()
+	c.mu.Lock()
+	c.started = true
+	c.startTime = time.Now().Add(-5 * time.Minute)
+	c.mu.Unlock()
+
+	meta := c.Meta()
+	if meta.Name != ComponentName {
+		t.Errorf("Meta.Name = %q, want %q", meta.Name, ComponentName)
+	}
+	if meta.Type != "processor" {
+		t.Errorf("Meta.Type = %q, want processor", meta.Type)
+	}
+
+	if ports := c.InputPorts(); len(ports) == 0 {
+		t.Errorf("InputPorts should have at least one port")
+	}
+	if ports := c.OutputPorts(); len(ports) != 0 {
+		t.Errorf("OutputPorts should be empty (component emits to KV, not NATS subjects)")
+	}
+
+	if schema := c.ConfigSchema(); schema.Properties == nil {
+		t.Errorf("ConfigSchema returned empty properties")
+	}
+
+	health := c.Health()
+	if !health.Healthy {
+		t.Errorf("Health should be healthy when started=true")
+	}
+	if health.Uptime <= 0 {
+		t.Errorf("Health.Uptime = %v, want > 0", health.Uptime)
+	}
+}
+
+func TestConfig_ValidateRejectsMissingPorts(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr bool
+	}{
+		{"no ports", Config{}, true},
+		{"empty inputs", Config{Ports: &component.PortConfig{}}, true},
+		{"ok", Config{Ports: &component.PortConfig{Inputs: []component.PortDefinition{{Name: "in", Subject: "x"}}}}, false},
+		{"negative max", Config{
+			Ports:         &component.PortConfig{Inputs: []component.PortDefinition{{Name: "in", Subject: "x"}}},
+			MaxCandidates: -1,
+		}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.cfg.Validate()
+			if c.wantErr && err == nil {
+				t.Errorf("Validate = nil, want error")
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("Validate = %v, want nil", err)
+			}
+		})
+	}
+}
+
+func TestConfig_ApplyDefaults(t *testing.T) {
+	c := Config{}
+	c.ApplyDefaults()
+	if c.LoopsBucket != "AGENT_LOOPS" {
+		t.Errorf("LoopsBucket = %q, want AGENT_LOOPS", c.LoopsBucket)
+	}
+	if c.MaxCandidates != 25 {
+		t.Errorf("MaxCandidates = %d, want 25", c.MaxCandidates)
+	}
+	if c.ClassifyTimeout != 30*time.Second {
+		t.Errorf("ClassifyTimeout = %v, want 30s", c.ClassifyTimeout)
+	}
+}
+
+func TestNewProcessor_RejectsNilNATSClient(t *testing.T) {
+	cfg := DefaultConfig()
+	raw, _ := json.Marshal(cfg)
+	_, err := NewProcessor(raw, component.Dependencies{})
+	if err == nil {
+		t.Errorf("expected error when NATSClient is nil")
+	}
+}

--- a/processor/research-graph-classify/config.go
+++ b/processor/research-graph-classify/config.go
@@ -1,0 +1,98 @@
+package researchclassify
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+)
+
+// ComponentName is the canonical registry name + log subsystem.
+const ComponentName = "research-graph-classify"
+
+// Config holds operator-tunable knobs for the nl_classify component.
+//
+// LLM classifier wiring follows the same model-registry capability
+// seam as processor/graph-query: the operator declares
+// CapabilityQueryClassification in the model registry; the component
+// resolves it at Start() time. Absence is a clean disable (keyword-
+// only chain) rather than a startup error — same shape as
+// graph-query's initLLMClassifier.
+type Config struct {
+	Ports *component.PortConfig `json:"ports,omitempty" schema:"type:ports,description:Port configuration. nl_classify requires one nats input subscribing to component.nl_classify.> ,category:basic"`
+
+	LoopsBucket string `json:"loops_bucket,omitempty" schema:"type:string,description:NATS KV bucket name holding research-pipeline loops and trigger/completion keys,default:AGENT_LOOPS,category:advanced"`
+
+	ClassifyTimeout time.Duration `json:"classify_timeout,omitempty" schema:"type:duration,description:Timeout for the classifier chain (+ optional LLM tier). Honors capability.query_classification override when set on the model registry,default:30s,category:advanced"`
+
+	RetrieveTimeout time.Duration `json:"retrieve_timeout,omitempty" schema:"type:duration,description:Timeout for the downstream graph.query.searchGraph request that fetches initial candidate entities,default:30s,category:advanced"`
+
+	MaxCandidates int `json:"max_candidates,omitempty" schema:"type:int,description:Cap on number of candidate entities to surface from the search_graph response (latency vs route_search prompt budget). 0 means default (25). ,default:25,max:200,category:advanced"`
+
+	// EnableLLMClassifier toggles wiring the T3 LLM tier into the
+	// classifier chain when a query_classification capability is
+	// configured in the model registry. Default false matches PR 2's
+	// "thinnest viable" stance — operators opt in once they've
+	// observed which topics the keyword tier handles.
+	EnableLLMClassifier bool `json:"enable_llm_classifier,omitempty" schema:"type:bool,description:When true and a query_classification capability is configured on the model registry, wire the LLM tier into the classifier chain,default:false,category:advanced"`
+}
+
+// Validate validates the configuration. MaxCandidates < 0 is
+// rejected; 0 falls through to ApplyDefaults (treated as "use
+// default"). The schema tag intentionally omits `min:1` so JSON-
+// omitted MaxCandidates keys round-trip clean through validation.
+func (c *Config) Validate() error {
+	if c.Ports == nil || len(c.Ports.Inputs) == 0 {
+		return errors.New("ports configuration with at least one input port is required")
+	}
+	if c.MaxCandidates < 0 {
+		return errors.New("max_candidates must be >= 0")
+	}
+	return nil
+}
+
+// ApplyDefaults fills in defaults for unset fields.
+func (c *Config) ApplyDefaults() {
+	if c.LoopsBucket == "" {
+		c.LoopsBucket = "AGENT_LOOPS"
+	}
+	if c.ClassifyTimeout == 0 {
+		c.ClassifyTimeout = 30 * time.Second
+	}
+	if c.RetrieveTimeout == 0 {
+		c.RetrieveTimeout = 30 * time.Second
+	}
+	if c.MaxCandidates == 0 {
+		c.MaxCandidates = 25
+	}
+}
+
+// DefaultConfig returns a default Config skeleton with the standard
+// nl_classify input port. Operators typically copy this and add a
+// chain-specific port name override.
+func DefaultConfig() Config {
+	return Config{
+		Ports: &component.PortConfig{
+			Inputs: []component.PortDefinition{
+				{
+					Name:        "trigger",
+					Type:        "nats",
+					Subject:     "component.nl_classify.>",
+					Required:    true,
+					Description: "R0's publish target. Subject suffix carries the research-pipeline loop_id.",
+				},
+			},
+			Outputs: []component.PortDefinition{},
+		},
+		LoopsBucket:         "AGENT_LOOPS",
+		ClassifyTimeout:     30 * time.Second,
+		RetrieveTimeout:     30 * time.Second,
+		MaxCandidates:       25,
+		EnableLLMClassifier: false,
+	}
+}
+
+// configSchema is the static configuration schema, generated from
+// Config struct tags at package init.
+var configSchema = component.GenerateConfigSchema(reflect.TypeOf(Config{}))

--- a/processor/research-graph-classify/doc.go
+++ b/processor/research-graph-classify/doc.go
@@ -1,0 +1,24 @@
+// Package researchclassify implements the nl_classify component from
+// ADR-045 Phase 1 (PR 2 of six per
+// docs/operations/22-adr045-phase1-plan.md).
+//
+// nl_classify is the thinnest stage of the graph-search rule chain.
+// It receives a publish trigger on component.nl_classify.<loop_id>,
+// reads the research.Intent payload from AGENT_LOOPS, runs the
+// existing graph/query.ClassifierChain (keyword + optional embedding
+// + optional LLM variants) on the topic, executes the resulting
+// SearchOptions against the graph to retrieve initial candidates,
+// and writes a research.ClassifierOutput payload that R1 (PR 6)
+// will fire route_search on.
+//
+// Architectural notes:
+//
+//   - The component wraps the existing classifier primitive; no new
+//     LLM calls beyond what the classifier chain already performs.
+//   - SearchOptions execution flows through the existing
+//     graph.query.searchGraph NATS surface so PR 4
+//     (execute_subqueries) and this component share one evidence
+//     schema (Candidate ≡ subset of GlobalSearchResponse.EntityDigests).
+//   - All public methods are safe for concurrent use across loops;
+//     the component holds no per-call mutable state.
+package researchclassify

--- a/processor/research-graph-classify/handler.go
+++ b/processor/research-graph-classify/handler.go
@@ -1,0 +1,155 @@
+package researchclassify
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/graph/query"
+)
+
+// Classifier is the narrow surface this component consumes from
+// graph/query. Production satisfies it with *query.ClassifierChain
+// (via classifierChainAdapter so the nil-check + Tier expansion live
+// in adapters.go); tests substitute a fake that returns deterministic
+// ClassificationResult shapes per scenario.
+type Classifier interface {
+	ClassifyQuery(ctx context.Context, topic string) *query.ClassificationResult
+}
+
+// CandidateRetriever fetches initial candidate entities for a topic.
+// Production wraps a NATS request to graph.query.searchGraph; tests
+// supply an in-memory fake so the per-variant pathway tests don't
+// need a live graph stack.
+//
+// hints carries the classifier-derived SearchOptions facets (already
+// flattened by ClassificationResult.Options) so the implementation
+// can pass them through to the downstream search. Returning Degraded
+// lets the implementation flag fallback paths (e.g. semantic
+// fallback fired) without losing the candidates that came back.
+type CandidateRetriever interface {
+	FetchCandidates(ctx context.Context, topic string, hints map[string]any, limit int) (CandidateSet, error)
+}
+
+// CandidateSet is the retriever's return shape — separate type so
+// the interface can evolve (add Strategy field, etc.) without
+// changing the retriever signature.
+type CandidateSet struct {
+	Candidates     []research.Candidate
+	Degraded       bool
+	DegradedReason string
+}
+
+// LoopStore is the AGENT_LOOPS read/write surface this component
+// consumes. Production wraps natsclient.KVStore; tests substitute an
+// in-memory map.
+//
+// Three methods so the component can:
+//
+//   - GetIntent: load the research_intent payload from the
+//     research.requested.<loopID> key written by research_graph (PR 1).
+//   - PutClassifierOutput: persist the ClassifierOutput envelope at
+//     the classify.complete.<loopID> key — the trigger R1 watches.
+//   - PutSnapshot: optionally stash a copy of the classifier output
+//     at a stable, non-trigger key (classify.snapshot.<loopID>) so
+//     downstream components / human operators can read the full
+//     output without racing R1's wildcard watcher. PR 6 may unify
+//     this with the completion key once the rule contract is
+//     finalised; for PR 2 the snapshot key is a no-op in tests
+//     unless explicitly observed.
+type LoopStore interface {
+	GetIntent(ctx context.Context, loopID string) (*research.Intent, error)
+	PutClassifierOutput(ctx context.Context, loopID string, envelope []byte) error
+	PutSnapshot(ctx context.Context, loopID string, envelope []byte) error
+}
+
+// errIntentNotFound is the sentinel returned by LoopStore.GetIntent
+// when no research.requested.<loopID> key exists. The handler
+// surfaces it as a non-retryable error — a missing intent means R0
+// fired without the trigger key being written, which is a flow
+// configuration bug, not a transient failure.
+var errIntentNotFound = fmt.Errorf("research intent not found")
+
+// extractLoopIDFromSubject pulls the loop_id off the NATS subject
+// component.nl_classify.<loop_id>. Returns empty string if the
+// subject doesn't match the expected pattern; the handler treats an
+// empty result as a routing bug.
+//
+// Format is stable per ADR-045 §Rule chain — R0's publish action
+// uses `subject: "component.nl_classify.{loop_id}"`. Any deviation
+// is a misconfigured rule, not a parsing problem.
+func extractLoopIDFromSubject(subject string) string {
+	const prefix = "component.nl_classify."
+	if !strings.HasPrefix(subject, prefix) {
+		return ""
+	}
+	return subject[len(prefix):]
+}
+
+// classifyAndRetrieve runs the classifier chain on the intent's
+// topic, fetches candidates via the retriever, and returns the
+// assembled ClassifierOutput. Pure function over the injected
+// interfaces — no NATS / KV plumbing leaks in here so the test
+// matrix can drive it through fakes.
+func classifyAndRetrieve(ctx context.Context, classifier Classifier, retriever CandidateRetriever, intent *research.Intent, maxCandidates int) (*research.ClassifierOutput, error) {
+	if intent == nil {
+		return nil, fmt.Errorf("intent is nil")
+	}
+	if classifier == nil {
+		return nil, fmt.Errorf("classifier is nil")
+	}
+	if retriever == nil {
+		return nil, fmt.Errorf("retriever is nil")
+	}
+
+	result := classifier.ClassifyQuery(ctx, intent.Topic)
+	output := &research.ClassifierOutput{
+		Topic: intent.Topic,
+	}
+	if result != nil {
+		output.Tier = tierLabel(result.Tier)
+		output.Intent = result.Intent
+		output.Confidence = result.Confidence
+		// Copy the Options map defensively so a downstream caller
+		// can't mutate the classifier's internal state by mutating
+		// the output.
+		if len(result.Options) > 0 {
+			output.Hints = make(map[string]any, len(result.Options))
+			for k, v := range result.Options {
+				output.Hints[k] = v
+			}
+		}
+	}
+
+	candidates, err := retriever.FetchCandidates(ctx, intent.Topic, output.Hints, maxCandidates)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve candidates: %w", err)
+	}
+	output.Candidates = candidates.Candidates
+	output.Degraded = candidates.Degraded
+	output.DegradedReason = candidates.DegradedReason
+
+	if err := output.Validate(); err != nil {
+		return nil, fmt.Errorf("assembled output failed validation: %w", err)
+	}
+	return output, nil
+}
+
+// tierLabel renders a ClassifierChain tier number as the string
+// taxonomy ClassifierOutput uses. Per chain conventions: 0=keyword,
+// 1=embedding/BM25 (the chain doesn't currently distinguish T1/T2 at
+// emit time so both surface as "1"), 3=LLM. Phase 2 may surface
+// neural as "2" explicitly when the embedding tier splits.
+func tierLabel(tier int) string {
+	switch tier {
+	case 0:
+		return "0"
+	case 1, 2:
+		return "1"
+	case 3:
+		return "3"
+	default:
+		return ""
+	}
+}

--- a/processor/research-graph-classify/handler_test.go
+++ b/processor/research-graph-classify/handler_test.go
@@ -1,0 +1,327 @@
+package researchclassify
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/graph/query"
+)
+
+// fakeClassifier returns a canned ClassificationResult so each test
+// scenario drives a specific tier pathway through classifyAndRetrieve.
+type fakeClassifier struct {
+	result *query.ClassificationResult
+}
+
+func (f *fakeClassifier) ClassifyQuery(_ context.Context, _ string) *query.ClassificationResult {
+	return f.result
+}
+
+// fakeRetriever records the inputs it was called with and returns
+// configured candidates. The thread-safety is overkill for unit
+// tests but mirrors what the production NATS adapter would face.
+type fakeRetriever struct {
+	mu             sync.Mutex
+	called         bool
+	gotTopic       string
+	gotHints       map[string]any
+	gotLimit       int
+	candidates     []research.Candidate
+	degraded       bool
+	degradedReason string
+	err            error
+}
+
+func (f *fakeRetriever) FetchCandidates(_ context.Context, topic string, hints map[string]any, limit int) (CandidateSet, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called = true
+	f.gotTopic = topic
+	f.gotHints = hints
+	f.gotLimit = limit
+	if f.err != nil {
+		return CandidateSet{}, f.err
+	}
+	return CandidateSet{
+		Candidates:     f.candidates,
+		Degraded:       f.degraded,
+		DegradedReason: f.degradedReason,
+	}, nil
+}
+
+func TestExtractLoopIDFromSubject(t *testing.T) {
+	cases := []struct {
+		name    string
+		subject string
+		want    string
+	}{
+		{"happy path", "component.nl_classify.rg_test001", "rg_test001"},
+		{"missing prefix", "graph.query.entity", ""},
+		{"prefix only", "component.nl_classify.", ""},
+		{"compound loop_id", "component.nl_classify.rg-2026-05-22_001", "rg-2026-05-22_001"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := extractLoopIDFromSubject(c.subject)
+			// Empty-from-prefix-only is an acceptable signal of "no
+			// loop_id"; the handler reads empty as a bug.
+			if c.subject == "component.nl_classify." {
+				if got != "" {
+					t.Errorf("prefix-only should yield empty loop_id, got %q", got)
+				}
+				return
+			}
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestTierLabel(t *testing.T) {
+	cases := map[int]string{0: "0", 1: "1", 2: "1", 3: "3", 99: ""}
+	for tier, want := range cases {
+		if got := tierLabel(tier); got != want {
+			t.Errorf("tierLabel(%d) = %q, want %q", tier, got, want)
+		}
+	}
+}
+
+func TestClassifyAndRetrieve_KeywordTier(t *testing.T) {
+	classifier := &fakeClassifier{result: &query.ClassificationResult{
+		Tier:       0,
+		Intent:     "",
+		Options:    map[string]any{"path_intent": true, "path_start_node": "drone-001"},
+		Confidence: 1.0,
+	}}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{
+			{EntityID: "acme.ops.robotics.gcs.drone.001", Tier: "0", Source: "search_graph", Relevance: 0.9},
+		},
+	}
+	intent := &research.Intent{Topic: "drones related to drone-001"}
+
+	out, err := classifyAndRetrieve(context.Background(), classifier, retriever, intent, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out.Tier != "0" {
+		t.Errorf("tier = %q, want %q", out.Tier, "0")
+	}
+	if out.Intent != "" {
+		t.Errorf("keyword tier should leave Intent empty, got %q", out.Intent)
+	}
+	if out.Confidence != 1.0 {
+		t.Errorf("confidence = %v, want 1.0", out.Confidence)
+	}
+	if out.Hints["path_intent"] != true || out.Hints["path_start_node"] != "drone-001" {
+		t.Errorf("hints propagation drift: %+v", out.Hints)
+	}
+	if len(out.Candidates) != 1 || out.Candidates[0].EntityID != "acme.ops.robotics.gcs.drone.001" {
+		t.Errorf("candidates drift: %+v", out.Candidates)
+	}
+	if !retriever.called {
+		t.Errorf("retriever was not called")
+	}
+	if retriever.gotTopic != intent.Topic {
+		t.Errorf("retriever topic = %q, want %q", retriever.gotTopic, intent.Topic)
+	}
+	if retriever.gotLimit != 10 {
+		t.Errorf("retriever limit = %d, want 10", retriever.gotLimit)
+	}
+}
+
+func TestClassifyAndRetrieve_EmbeddingTier(t *testing.T) {
+	classifier := &fakeClassifier{result: &query.ClassificationResult{
+		Tier:       1,
+		Intent:     "similarity_search",
+		Options:    map[string]any{"use_embeddings": true},
+		Confidence: 0.78,
+	}}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{
+			{EntityID: "doc.001", Tier: "1", Source: "search_graph", Relevance: 0.78},
+		},
+	}
+	intent := &research.Intent{Topic: "documents similar to onboarding guide"}
+
+	out, err := classifyAndRetrieve(context.Background(), classifier, retriever, intent, 25)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Chain Tier 1 surfaces as "1" in the ClassifierOutput taxonomy
+	// (embedding/BM25 share the slot; T2 neural is Phase 2).
+	if out.Tier != "1" {
+		t.Errorf("tier = %q, want %q", out.Tier, "1")
+	}
+	if out.Intent != "similarity_search" {
+		t.Errorf("embedding intent lost: %q", out.Intent)
+	}
+	if out.Confidence != 0.78 {
+		t.Errorf("confidence = %v, want 0.78", out.Confidence)
+	}
+}
+
+func TestClassifyAndRetrieve_LLMTier(t *testing.T) {
+	classifier := &fakeClassifier{result: &query.ClassificationResult{
+		Tier:       3,
+		Intent:     "temporal_aggregate",
+		Options:    map[string]any{"time_range": map[string]any{"start": "2026-05-21", "end": "2026-05-22"}},
+		Confidence: 0.91,
+	}}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{
+			{EntityID: "sensor.42", Tier: "0", Source: "search_graph"},
+		},
+	}
+	intent := &research.Intent{Topic: "average voltage across batteries last 24 hours"}
+
+	out, err := classifyAndRetrieve(context.Background(), classifier, retriever, intent, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if out.Tier != "3" {
+		t.Errorf("tier = %q, want %q", out.Tier, "3")
+	}
+	if out.Intent != "temporal_aggregate" {
+		t.Errorf("LLM intent lost: %q", out.Intent)
+	}
+}
+
+func TestClassifyAndRetrieve_NilClassifierResultFallsThrough(t *testing.T) {
+	// Per ClassifierChain semantics: a nil ClassificationResult
+	// (defensive nil-chain branch) flows through as an empty-hints
+	// output. The handler should still surface the retriever's
+	// candidates so the chain can proceed.
+	classifier := &fakeClassifier{result: nil}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{
+			{EntityID: "fallback.001", Tier: "0", Source: "search_graph"},
+		},
+	}
+	intent := &research.Intent{Topic: "x"}
+
+	out, err := classifyAndRetrieve(context.Background(), classifier, retriever, intent, 25)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.Tier != "" {
+		t.Errorf("expected empty tier on nil result, got %q", out.Tier)
+	}
+	if len(out.Hints) != 0 {
+		t.Errorf("expected empty hints on nil result, got %+v", out.Hints)
+	}
+	if len(out.Candidates) != 1 {
+		t.Errorf("expected fallback candidates passed through, got %+v", out.Candidates)
+	}
+}
+
+func TestClassifyAndRetrieve_DegradedPassthrough(t *testing.T) {
+	classifier := &fakeClassifier{result: &query.ClassificationResult{Tier: 0}}
+	retriever := &fakeRetriever{
+		candidates:     []research.Candidate{{EntityID: "x", Tier: "0", Source: "search_graph"}},
+		degraded:       true,
+		degradedReason: "server-side semantic fallback fired",
+	}
+	intent := &research.Intent{Topic: "x"}
+
+	out, err := classifyAndRetrieve(context.Background(), classifier, retriever, intent, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !out.Degraded || out.DegradedReason == "" {
+		t.Errorf("degraded fields lost: %+v", out)
+	}
+}
+
+func TestClassifyAndRetrieve_RetrieverErrorSurfaces(t *testing.T) {
+	classifier := &fakeClassifier{result: &query.ClassificationResult{Tier: 0}}
+	retriever := &fakeRetriever{err: errors.New("nats unreachable")}
+	intent := &research.Intent{Topic: "x"}
+
+	_, err := classifyAndRetrieve(context.Background(), classifier, retriever, intent, 10)
+	if err == nil {
+		t.Fatalf("expected error from retriever, got nil")
+	}
+	if !strings.Contains(err.Error(), "retrieve candidates") {
+		t.Errorf("expected wrapped retriever error, got: %v", err)
+	}
+}
+
+func TestClassifyAndRetrieve_NilInputsRejected(t *testing.T) {
+	t.Run("nil intent", func(t *testing.T) {
+		_, err := classifyAndRetrieve(context.Background(), &fakeClassifier{}, &fakeRetriever{}, nil, 10)
+		if err == nil {
+			t.Fatal("expected error for nil intent")
+		}
+	})
+	t.Run("nil classifier", func(t *testing.T) {
+		_, err := classifyAndRetrieve(context.Background(), nil, &fakeRetriever{}, &research.Intent{Topic: "x"}, 10)
+		if err == nil {
+			t.Fatal("expected error for nil classifier")
+		}
+	})
+	t.Run("nil retriever", func(t *testing.T) {
+		_, err := classifyAndRetrieve(context.Background(), &fakeClassifier{}, nil, &research.Intent{Topic: "x"}, 10)
+		if err == nil {
+			t.Fatal("expected error for nil retriever")
+		}
+	})
+}
+
+func TestClassifyAndRetrieve_OutputValidationCatchesBadCandidate(t *testing.T) {
+	// The handler validates the assembled output before returning so
+	// downstream consumers can rely on Validate-pass payloads.
+	classifier := &fakeClassifier{result: &query.ClassificationResult{Tier: 0}}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{
+			{EntityID: "", Tier: "0", Source: "search_graph"}, // invalid
+		},
+	}
+	intent := &research.Intent{Topic: "x"}
+
+	_, err := classifyAndRetrieve(context.Background(), classifier, retriever, intent, 10)
+	if err == nil {
+		t.Fatal("expected validation error for bad candidate, got nil")
+	}
+	if !strings.Contains(err.Error(), "validation") {
+		t.Errorf("expected validation-wrapped error, got: %v", err)
+	}
+}
+
+// TestClassifyAndRetrieve_HintsAreDefensiveCopy locks in the
+// defensive map copy from handler.go so a downstream consumer
+// mutating ClassifierOutput.Hints doesn't bleed into the classifier's
+// internal Options map.
+func TestClassifyAndRetrieve_HintsAreDefensiveCopy(t *testing.T) {
+	sourceOptions := map[string]any{"path_intent": true}
+	classifier := &fakeClassifier{result: &query.ClassificationResult{
+		Tier:    0,
+		Options: sourceOptions,
+	}}
+	retriever := &fakeRetriever{
+		candidates: []research.Candidate{{EntityID: "x", Tier: "0", Source: "search_graph"}},
+	}
+	intent := &research.Intent{Topic: "x"}
+
+	out, err := classifyAndRetrieve(context.Background(), classifier, retriever, intent, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Mutate the returned hints; the source must be untouched.
+	out.Hints["path_intent"] = false
+	out.Hints["mutated_key"] = "leak"
+	if sourceOptions["path_intent"] != true {
+		t.Errorf("source Options mutated through ClassifierOutput.Hints — defensive copy missing")
+	}
+	if _, leaked := sourceOptions["mutated_key"]; leaked {
+		t.Errorf("source Options gained a key from caller mutation — defensive copy missing")
+	}
+}

--- a/processor/research-graph-classify/register.go
+++ b/processor/research-graph-classify/register.go
@@ -1,0 +1,20 @@
+package researchclassify
+
+import "github.com/c360studio/semstreams/component"
+
+// Register registers the nl_classify processor with the supplied
+// component registry. Called from componentregistry.Register at
+// process bootstrap so production binaries pick the component up
+// without extra wiring.
+func Register(registry *component.Registry) error {
+	return registry.RegisterWithConfig(component.RegistrationConfig{
+		Name:        ComponentName,
+		Factory:     NewProcessor,
+		Schema:      configSchema,
+		Type:        "processor",
+		Protocol:    "nl_classify",
+		Domain:      "research",
+		Description: "ADR-045 nl_classify: classify a research topic via the existing graph/query.ClassifierChain and surface initial candidate entities for downstream route_search.",
+		Version:     "0.1.0",
+	})
+}

--- a/schemas/research-graph-classify.v1.json
+++ b/schemas/research-graph-classify.v1.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "research-graph-classify.v1.json",
+  "type": "object",
+  "title": "research-graph-classify Configuration",
+  "description": "ADR-045 nl_classify: classify a research topic via the existing graph/query.ClassifierChain and surface initial candidate entities for downstream route_search.",
+  "properties": {
+    "loops_bucket": {
+      "type": "string",
+      "description": "NATS KV bucket name holding research-pipeline loops and trigger/completion keys",
+      "default": "AGENT_LOOPS",
+      "category": "advanced"
+    },
+    "max_candidates": {
+      "type": "integer",
+      "description": "Cap on number of candidate entities to surface from the search_graph response (latency vs route_search prompt budget). 0 means default (25).",
+      "default": 25,
+      "maximum": 200,
+      "category": "advanced"
+    },
+    "ports": {
+      "type": "string",
+      "description": "Port configuration. nl_classify requires one nats input subscribing to component.nl_classify.\u003e",
+      "category": "basic"
+    }
+  },
+  "required": [],
+  "x-component-metadata": {
+    "name": "research-graph-classify",
+    "type": "processor",
+    "protocol": "nl_classify",
+    "domain": "research",
+    "version": "0.1.0"
+  }
+}

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1017,6 +1017,7 @@ components:
                         - $ref: ../schemas/oasf-generator.v1.json
                         - $ref: ../schemas/objectstore.v1.json
                         - $ref: ../schemas/otel-exporter.v1.json
+                        - $ref: ../schemas/research-graph-classify.v1.json
                         - $ref: ../schemas/rule-processor.v1.json
                         - $ref: ../schemas/slim-bridge.v1.json
                         - $ref: ../schemas/udp.v1.json


### PR DESCRIPTION
## Summary

Second of six PRs landing the [ADR-045](../blob/main/docs/adr/045-graph-search-rule-chain.md) graph-search rule chain, per [`docs/operations/22-adr045-phase1-plan.md`](../blob/main/docs/operations/22-adr045-phase1-plan.md) § "PR 2 — `nl_classify` component". PR 1 (#131, payloads + research_graph tool) merged 2026-05-22 in commit 519f398.

This PR lands the thinnest component stage:
- `research.ClassifierOutput` payload (Candidate + tier + intent + hints + degraded) registered alongside PR 1's three types
- `nl_classify` component wrapping `graph/query.ClassifierChain`, executing the resulting SearchOptions against `graph.query.searchGraph`, and emitting both a snapshot record + the `classify.complete.<loopID>` trigger key R1 watches (PR 6 wires the rule)

**ADDITIVE.** No wire-format changes; sister-project pin-bumps optional.

## Architecture pointers

- **Three-interface seam** (`Classifier` / `CandidateRetriever` / `LoopStore`) lets the test matrix drive per-variant pathways without a live graph stack
- **Snapshot-then-trigger ordering** in `handleMessage` mirrors PR 1's LoopEntity-then-trigger discipline — snapshot is queryable record, classify.complete is R1's wildcard watch target
- **Production-decoder round-trip** for the emitted envelope locked in at both registry-level (`agentic/research/roundtrip_test.go`) and handler-level (`component_test.go`) per `feedback_production_decoder_round_trip_required`
- **Optional LLM tier** wires via the model registry's `query_classification` capability — mirrors graph-query's `initLLMClassifier` pattern. Default off
- **Single-mutex lifecycle** (collapsed split pair from PR 2 review) closes Stop-vs-Health race window
- **RetrieveTimeout** applied as child context inside `FetchCandidates` so the inner ctx wins both gates instead of double-counting against the outer classify deadline

## Test plan

- [x] `task lint` — clean (no revive warnings)
- [x] `go test -race ./...` — full unit sweep green
- [x] `go vet -tags=integration ./...` and `-tags=live_llm ./...` — clean
- [x] `go test ./test/contract/...` — green (research-graph-classify schema slot + research.classifier_output.v1 registration consistency)
- [x] `task schema:generate` — adds `schemas/research-graph-classify.v1.json` + one ref line in `specs/openapi.v3.yaml`; no further diff after staging
- [x] go-reviewer pre-push pass: M1 (Stop race), M2 (atomic test reads), S1 (tier taxonomy doc), S2 (Snippet field drift), S4 (RetrieveTimeout dead config), S5 (MaxCandidates schema lie), N1 (named natsErrorPrefix const) all closed with reviewer approval

## Next PR in sequence

PR 3: `route_search` component (first LLM judgment step — emits one of `synthesize_directly` / `retighten` / `walk_seeds` / `decompose`). ~450 LOC. See plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)