### PR TITLE
feat(rule,agentic-loop): cheap-model substrate bundle (#132 + #133)

### DIFF
--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -1082,8 +1082,8 @@ func (c *Component) persistHandlerResult(ctx context.Context, result HandlerResu
 		// triples ride the same publish budget as the loop completion
 		// stamp and downstream rules see them on the same KV revision
 		// the agent.complete.* event refers to.
-		if result.SyntheticDecide != nil && c.graphWriter != nil {
-			c.graphWriter.WriteSyntheticDecide(ctx, result.SyntheticDecide.LoopID, result.SyntheticDecide.Reason)
+		if result.SyntheticDecide != nil {
+			c.stampSyntheticDecideWithBudget(ctx, result.SyntheticDecide)
 		}
 	}
 
@@ -1107,6 +1107,31 @@ func (c *Component) stampLoopCompletionWithBudget(ctx context.Context, loopID st
 			"state", "complete")
 		if c.metrics != nil {
 			c.metrics.recordGraphWritePublishTimeout("complete")
+		}
+	}
+}
+
+// stampSyntheticDecideWithBudget invokes WriteSyntheticDecide under the
+// graphWritePublishBudget. Records a Prom timeout when the budget
+// expires before the writer returns; publish proceeds either way. Same
+// shape as stampLoopCompletionWithBudget — the synthetic-decide triples
+// must reach the graph before downstream rules wake on the
+// agent.complete.* event, otherwise the recovery rule fires before
+// coordinator.next_action="needs_clarification" is visible.
+func (c *Component) stampSyntheticDecideWithBudget(ctx context.Context, req *SyntheticDecideRequest) {
+	if c.graphWriter == nil {
+		return
+	}
+	timedOut := runWithBudget(ctx, graphWritePublishBudget, func(bctx context.Context) {
+		c.graphWriter.WriteSyntheticDecide(bctx, req.LoopID, req.Reason)
+	})
+	if timedOut {
+		c.logger.Warn("graph write budget expired before synthetic decide stamp returned; publishing agent.complete anyway",
+			"loop_id", req.LoopID,
+			"budget", graphWritePublishBudget,
+			"state", "synthetic_decide")
+		if c.metrics != nil {
+			c.metrics.recordGraphWritePublishTimeout("synthetic_decide")
 		}
 	}
 }

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -1077,6 +1077,14 @@ func (c *Component) persistHandlerResult(ctx context.Context, result HandlerResu
 			c.stampLoopFailureWithBudget(ctx, result.LoopID, result.FailureState)
 		}
 		c.writeTrajectoryToGraph(ctx, result.LoopID)
+		// Terminal-tool-less synthesis (#133). Detected in
+		// handleCompleteResponse; emitted here on the graph path so the
+		// triples ride the same publish budget as the loop completion
+		// stamp and downstream rules see them on the same KV revision
+		// the agent.complete.* event refers to.
+		if result.SyntheticDecide != nil && c.graphWriter != nil {
+			c.graphWriter.WriteSyntheticDecide(ctx, result.SyntheticDecide.LoopID, result.SyntheticDecide.Reason)
+		}
 	}
 
 	c.publishResults(ctx, result)

--- a/processor/agentic-loop/config.go
+++ b/processor/agentic-loop/config.go
@@ -59,7 +59,17 @@ type Config struct {
 	Consumer             ConsumerConfig           `json:"consumer" schema:"type:object,description:JetStream consumer tuning for long-running ports (agent.task/agent.response/tool.result),category:advanced"`
 	Context              ContextConfig            `json:"context" schema:"type:object,description:Context window management. Model limits are resolved from the model registry,category:advanced"`
 	ToolCallGovernance   ToolCallGovernanceConfig `json:"tool_call_governance,omitempty" schema:"type:object,description:Subject-mode tool-call governance (ADR-039). Default mode=disabled is no-op (no governance gate),category:advanced"`
-	Ports                *component.PortConfig    `json:"ports,omitempty" schema:"type:ports,description:Port configuration for inputs and outputs,category:basic"`
+	// SynthesizeTerminalOnCompletion enables the framework to synthesize a
+	// decide(needs_clarification) when a loop completes without a terminal
+	// tool call (#133). Cheap-model substrate recovery: when a small model
+	// returns text-only at completion despite persona prose enforcing a
+	// decide call, the framework stamps coordinator.next_action +
+	// coordinator.decision.reason + coordinator.decision.synthetic="true"
+	// on the loop entity so existing recovery rules match. Default false
+	// for back-compat — new deployments targeting cheap-model substrates
+	// should opt in.
+	SynthesizeTerminalOnCompletion bool                  `json:"synthesize_terminal_on_completion,omitempty" schema:"type:bool,description:Synthesize decide(needs_clarification) when a loop completes without a terminal tool call (#133). Belt-and-suspenders recovery for cheap-model substrates where models occasionally return text-only at completion despite persona prose,default:false,category:advanced"`
+	Ports                          *component.PortConfig `json:"ports,omitempty" schema:"type:ports,description:Port configuration for inputs and outputs,category:basic"`
 }
 
 // ToolCallGovernanceConfig configures subject-mode tool-call governance

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -19,9 +19,28 @@ import (
 )
 
 const (
-	graphMutationSubject = "graph.mutation.triple.add"
-	graphWriterTimeout   = 5 * time.Second
-	graphWriterSource    = "agentic-loop"
+	graphMutationSubject      = "graph.mutation.triple.add"
+	graphMutationBatchSubject = "graph.mutation.triple.add_batch"
+	graphWriterTimeout        = 5 * time.Second
+	graphWriterSource         = "agentic-loop"
+	// syntheticDecideSource is the Source on triples emitted by
+	// WriteSyntheticDecide (#133). Distinct from graphWriterSource
+	// ("agentic-loop") and decideToolSource ("coordinator-decide") so
+	// operator dashboards can attribute provenance — these triples come
+	// from the framework's terminal-tool-less synthesis, not from a
+	// model-emitted decide.
+	syntheticDecideSource = "agentic-loop-synthetic-decide"
+	// syntheticDecideReasonMaxBytes caps the size of the model's text
+	// content carried in the synthetic decide's reason triple. Matches
+	// maxPromptTripleBytes — the reason behaves like a prompt fragment
+	// (BM25/NL-search-relevant text on the loop entity), not a payload.
+	syntheticDecideReasonMaxBytes = 8 * 1024
+	// syntheticDecideReasonPrefix marks the reason as framework-emitted
+	// per the #133 contract. Downstream rules / operators can branch on
+	// the prefix to distinguish model-emitted needs_clarification from
+	// framework-synthesized ones; the coordinator.decision.synthetic
+	// triple is the structured marker for rule matching.
+	syntheticDecideReasonPrefix = "[synthetic-no-terminal] "
 
 	// maxPromptTripleBytes caps the size of the user prompt stored as the
 	// agent.loop.description triple, including the truncation marker. Full
@@ -100,6 +119,111 @@ func (w *graphWriter) writeTriple(ctx context.Context, triple message.Triple) er
 	}
 
 	return nil
+}
+
+// writeBatch marshals and sends a batch of triples atomically per-Subject
+// via NATS request/response. Used by WriteSyntheticDecide (#133) — the
+// three synthetic triples share one loop entity Subject so all-or-nothing
+// CAS semantics keep downstream rule-matching consistent (next_action +
+// reason + synthetic land together or not at all).
+func (w *graphWriter) writeBatch(ctx context.Context, triples []message.Triple) error {
+	if len(triples) == 0 {
+		return nil
+	}
+	req := gtypes.AddTriplesBatchRequest{Triples: triples}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal batch request: %w", err)
+	}
+
+	respData, err := w.natsClient.RequestWithRetry(ctx, graphMutationBatchSubject, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig())
+	if err != nil {
+		return fmt.Errorf("NATS batch request failed: %w", err)
+	}
+
+	var resp gtypes.AddTriplesBatchResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return fmt.Errorf("unmarshal batch response: %w", err)
+	}
+
+	if !resp.Success {
+		return fmt.Errorf("batch mutation failed: %s", resp.Error)
+	}
+
+	return nil
+}
+
+// WriteSyntheticDecide stamps the synthetic decide triples (#133) onto
+// the loop entity when handleCompleteResponse detected a terminal-tool-
+// less completion. Three atomic triples on the loop entity:
+//
+//   - coordinator.decision.next_action = "needs_clarification" so
+//     existing recovery rules (e.g. SemTeams' needs-clarification-
+//     replan) match without changes.
+//   - coordinator.decision.reason = "[synthetic-no-terminal] {model
+//     text, truncated to 8KiB}" so operators can see the model's last
+//     output that bypassed the terminal contract.
+//   - coordinator.decision.synthetic = "true" so rule authors can
+//     branch on framework-emitted vs model-emitted needs_clarification
+//     (e.g. route synthetics straight to coordinator; model-emitted
+//     through plan retry first).
+//
+// Routed through writeBatch so all three triples land atomically — a
+// partial write would corrupt the rule-matching contract.
+func (w *graphWriter) WriteSyntheticDecide(ctx context.Context, loopID, modelText string) {
+	if w.natsClient == nil {
+		return
+	}
+	if w.platform.Org == "" || w.platform.Platform == "" {
+		w.logger.Warn("graph_writer: cannot write synthetic decide, platform identity missing",
+			"loop_id", loopID, "org", w.platform.Org, "platform", w.platform.Platform)
+		return
+	}
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(w.platform.Org, w.platform.Platform, loopID)
+	if err != nil {
+		w.logger.Warn("graph_writer: cannot construct loop entity ID for synthetic decide",
+			"loop_id", loopID, "error", err)
+		return
+	}
+
+	now := time.Now()
+	reason := syntheticDecideReasonPrefix + truncateForTriple(modelText, syntheticDecideReasonMaxBytes-len(syntheticDecideReasonPrefix))
+	triples := []message.Triple{
+		{
+			Subject:    loopEntityID,
+			Predicate:  agvocab.CoordinatorNextAction,
+			Object:     "needs_clarification",
+			Source:     syntheticDecideSource,
+			Timestamp:  now,
+			Confidence: 1.0,
+		},
+		{
+			Subject:    loopEntityID,
+			Predicate:  agvocab.CoordinatorDecisionReason,
+			Object:     reason,
+			Source:     syntheticDecideSource,
+			Timestamp:  now,
+			Confidence: 1.0,
+		},
+		{
+			Subject:    loopEntityID,
+			Predicate:  agvocab.CoordinatorDecisionSynthetic,
+			Object:     "true",
+			Source:     syntheticDecideSource,
+			Timestamp:  now,
+			Confidence: 1.0,
+		},
+	}
+
+	if err := w.writeBatch(ctx, triples); err != nil {
+		w.logger.Warn("graph_writer: failed to write synthetic decide triples",
+			"loop_id", loopID, "loop_entity_id", loopEntityID, "error", err)
+		return
+	}
+	w.logger.Info("graph_writer: stamped synthetic decide on terminal-tool-less completion",
+		"loop_id", loopID,
+		"loop_entity_id", loopEntityID,
+		"hint", "model returned text-only at completion — consider setting tool_choice='required' on the rule (#132) to prevent recurrence; high prevalence of this triple signals model/persona mismatch")
 }
 
 // WriteModelEndpoints emits triples for every endpoint in the model registry.

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -50,6 +50,25 @@ type HandlerResult struct {
 	// FailureState contains enriched failure data for graph emission.
 	// Populated when a loop fails, mirrors CompletionState for the failure path.
 	FailureState *agentic.LoopFailedEvent
+	// SyntheticDecide is populated when handleCompleteResponse detects a
+	// terminal-tool-less completion AND Config.SynthesizeTerminalOnCompletion
+	// is true (#133). Component reads this and routes through graphWriter
+	// to stamp coordinator.next_action="needs_clarification",
+	// coordinator.decision.reason="[synthetic-no-terminal] ...", and
+	// coordinator.decision.synthetic="true" atomically on the loop entity.
+	// Nil means either the loop terminated through a real decide call or
+	// the synthesis opt-in is off; either way, no synthetic triples.
+	SyntheticDecide *SyntheticDecideRequest
+}
+
+// SyntheticDecideRequest carries the data needed for graphWriter to stamp
+// the synthetic decide triples (#133). LoopID identifies the loop entity;
+// Reason is the model's final text content, used as the
+// coordinator.decision.reason payload (prefixed by graphWriter so the
+// "synthetic" provenance is impossible to miss in operator dashboards).
+type SyntheticDecideRequest struct {
+	LoopID string
+	Reason string
 }
 
 // MessageHandler handles incoming messages and coordinates loop execution
@@ -1483,6 +1502,22 @@ func (h *MessageHandler) failLoop(result *HandlerResult, loopID, outcome, reason
 	return nil
 }
 
+// hasTerminalToolCall scans a trajectory's steps for any tool_call to a
+// recognised terminal tool. v1 recognises `decide` only — the canonical
+// coordinator terminal. Additional terminal tool names (submit_work,
+// product-specific) can be added when those flows materialise. Used by
+// the terminal-tool-less synthesis path (#133): when this returns false
+// on a completed loop and Config.SynthesizeTerminalOnCompletion is on,
+// the framework synthesizes a needs_clarification decide.
+func hasTerminalToolCall(steps []agentic.TrajectoryStep) bool {
+	for _, s := range steps {
+		if s.StepType == "tool_call" && s.ToolName == "decide" {
+			return true
+		}
+	}
+	return false
+}
+
 // handleCompleteResponse processes completion responses.
 // It enriches the completion event with full context for rules-based orchestration.
 func (h *MessageHandler) handleCompleteResponse(result *HandlerResult, loopID string, entity agentic.LoopEntity, responseContent string) error {
@@ -1519,14 +1554,36 @@ func (h *MessageHandler) handleCompleteResponse(result *HandlerResult, loopID st
 		Metadata:    entity.Metadata,
 	}
 
-	// Pull token totals from trajectory for cost tracking
+	// Pull token totals from trajectory for cost tracking. Also doubles as
+	// the source-of-truth for the #133 terminal-tool-less check below —
+	// scanning the same trajectory snapshot here avoids a second
+	// trajectoryManager.GetTrajectory round-trip and keeps the cost +
+	// synthesis decisions consistent on the same step set.
+	var trajectorySteps []agentic.TrajectoryStep
 	if traj, trajErr := h.trajectoryManager.GetTrajectory(loopID); trajErr == nil {
 		completion.TokensIn = traj.TotalTokensIn
 		completion.TokensOut = traj.TotalTokensOut
+		trajectorySteps = traj.Steps
 	} else {
 		h.logger.Warn("trajectory unavailable for cost tracking",
 			slog.String("loop_id", loopID),
 			slog.String("error", trajErr.Error()))
+	}
+
+	// Terminal-tool-less completion synthesis (#133). When the loop
+	// reaches state=complete WITHOUT a `decide` tool_call in the
+	// trajectory AND opt-in via Config.SynthesizeTerminalOnCompletion,
+	// surface a SyntheticDecideRequest on the result so Component routes
+	// it through graphWriter. Cheap-model substrate recovery: small
+	// models occasionally return text-only at completion despite
+	// persona prose enforcing a decide call; the synth keeps downstream
+	// rules matching on coordinator.next_action rather than wedging the
+	// chain. Off by default; new flows targeting flash/sub-30B opt in.
+	if h.config.SynthesizeTerminalOnCompletion && !hasTerminalToolCall(trajectorySteps) {
+		result.SyntheticDecide = &SyntheticDecideRequest{
+			LoopID: loopID,
+			Reason: responseContent,
+		}
 	}
 
 	completionMsg := message.NewBaseMessage(completion.Schema(), &completion, "agentic-loop")

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -1502,14 +1502,21 @@ func (h *MessageHandler) failLoop(result *HandlerResult, loopID, outcome, reason
 	return nil
 }
 
-// hasTerminalToolCall scans a trajectory's steps for any tool_call to a
-// recognised terminal tool. v1 recognises `decide` only — the canonical
-// coordinator terminal. Additional terminal tool names (submit_work,
-// product-specific) can be added when those flows materialise. Used by
-// the terminal-tool-less synthesis path (#133): when this returns false
-// on a completed loop and Config.SynthesizeTerminalOnCompletion is on,
-// the framework synthesizes a needs_clarification decide.
-func hasTerminalToolCall(steps []agentic.TrajectoryStep) bool {
+// hasDecideToolCall scans a trajectory's steps for any tool_call to
+// `decide`. Narrow by design — `submit_work` and other terminal tools
+// also drive completion via StopLoop, but synthesis is specifically the
+// coordinator-decide recovery path (the wedge shape is "coordinator
+// completed without emitting a coordinator.next_action triple"). Used
+// by the terminal-tool-less synthesis path (#133): when this returns
+// false on a completed loop and Config.SynthesizeTerminalOnCompletion
+// is on, the framework synthesizes a needs_clarification decide.
+// Broadening to a wider terminal-tool set is a separate decision (the
+// rule pack opting into synthesis should not implicitly assume any tool
+// that calls StopLoop is a decide-equivalent — a submit_work or future
+// emit_diagnosis terminal would be a content-bearing terminal, not a
+// routing decision, and would not want a synth decide overwriting its
+// successful completion).
+func hasDecideToolCall(steps []agentic.TrajectoryStep) bool {
 	for _, s := range steps {
 		if s.StepType == "tool_call" && s.ToolName == "decide" {
 			return true
@@ -1579,7 +1586,7 @@ func (h *MessageHandler) handleCompleteResponse(result *HandlerResult, loopID st
 	// persona prose enforcing a decide call; the synth keeps downstream
 	// rules matching on coordinator.next_action rather than wedging the
 	// chain. Off by default; new flows targeting flash/sub-30B opt in.
-	if h.config.SynthesizeTerminalOnCompletion && !hasTerminalToolCall(trajectorySteps) {
+	if h.config.SynthesizeTerminalOnCompletion && !hasDecideToolCall(trajectorySteps) {
 		result.SyntheticDecide = &SyntheticDecideRequest{
 			LoopID: loopID,
 			Reason: responseContent,

--- a/processor/agentic-loop/handlers_internal_test.go
+++ b/processor/agentic-loop/handlers_internal_test.go
@@ -241,10 +241,10 @@ func TestToolNames(t *testing.T) {
 	}))
 }
 
-// TestHasTerminalToolCall covers the #133 terminal-tool detection helper.
+// TestHasDecideToolCall covers the #133 decide-detection helper.
 // Returns true on any tool_call step naming `decide`; false otherwise
 // (model_call steps, other tool names, context_compaction, empty trajectory).
-func TestHasTerminalToolCall(t *testing.T) {
+func TestHasDecideToolCall(t *testing.T) {
 	cases := []struct {
 		name  string
 		steps []agentic.TrajectoryStep
@@ -291,7 +291,7 @@ func TestHasTerminalToolCall(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, hasTerminalToolCall(tc.steps))
+			assert.Equal(t, tc.want, hasDecideToolCall(tc.steps))
 		})
 	}
 }

--- a/processor/agentic-loop/handlers_internal_test.go
+++ b/processor/agentic-loop/handlers_internal_test.go
@@ -240,3 +240,58 @@ func TestToolNames(t *testing.T) {
 		{Name: "b"},
 	}))
 }
+
+// TestHasTerminalToolCall covers the #133 terminal-tool detection helper.
+// Returns true on any tool_call step naming `decide`; false otherwise
+// (model_call steps, other tool names, context_compaction, empty trajectory).
+func TestHasTerminalToolCall(t *testing.T) {
+	cases := []struct {
+		name  string
+		steps []agentic.TrajectoryStep
+		want  bool
+	}{
+		{
+			name:  "empty",
+			steps: nil,
+			want:  false,
+		},
+		{
+			name: "model_call only",
+			steps: []agentic.TrajectoryStep{
+				{StepType: "model_call"},
+				{StepType: "model_call"},
+			},
+			want: false,
+		},
+		{
+			name: "non-decide tool_calls only",
+			steps: []agentic.TrajectoryStep{
+				{StepType: "tool_call", ToolName: "web_search"},
+				{StepType: "tool_call", ToolName: "scratchpad"},
+				{StepType: "tool_call", ToolName: "bash"},
+			},
+			want: false,
+		},
+		{
+			name: "decide present mid-trajectory",
+			steps: []agentic.TrajectoryStep{
+				{StepType: "tool_call", ToolName: "web_search"},
+				{StepType: "tool_call", ToolName: "decide"},
+				{StepType: "model_call"},
+			},
+			want: true,
+		},
+		{
+			name: "decide as model_call StepType ignored (only tool_calls count)",
+			steps: []agentic.TrajectoryStep{
+				{StepType: "model_call", ToolName: "decide"},
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasTerminalToolCall(tc.steps))
+		})
+	}
+}

--- a/processor/agentic-loop/handlers_test.go
+++ b/processor/agentic-loop/handlers_test.go
@@ -1619,6 +1619,107 @@ func TestHandleModelResponse_Complete_PopulatesTokenFields(t *testing.T) {
 	}
 }
 
+// --- #133 terminal-tool-less synthesis tests ---
+
+// TestHandleCompleteResponse_SyntheticDecide_OptInTextOnly verifies that
+// when Config.SynthesizeTerminalOnCompletion=true AND the model returns
+// text-only at completion (no `decide` in the trajectory), the handler
+// populates result.SyntheticDecide with the loop ID and the model's text
+// content. The Component-side branch in persistHandlerResult routes this
+// through graphWriter.WriteSyntheticDecide to stamp the canonical
+// coordinator.next_action + reason + synthetic triples.
+func TestHandleCompleteResponse_SyntheticDecide_OptInTextOnly(t *testing.T) {
+	cfg := createTestConfig()
+	cfg.SynthesizeTerminalOnCompletion = true
+	handler := agenticloop.NewMessageHandler(cfg)
+
+	ctx := context.Background()
+	taskResult, err := handler.HandleTask(ctx, agenticloop.TaskMessage{
+		TaskID: "task-synth-textonly",
+		Role:   "researcher-research-gather",
+		Model:  "gemini-2.5-flash",
+		Prompt: "Investigate hydraulic actuators",
+	})
+	if err != nil {
+		t.Fatalf("HandleTask() error = %v", err)
+	}
+	loopID := taskResult.LoopID
+
+	// Model completes with text-only — no tool_calls. This is the
+	// cheap-model substrate wedge SemTeams smoke6 surfaced on
+	// 2026-05-22: the model summarises in prose rather than calling
+	// `decide`, the loop transitions to complete cleanly, and no
+	// coordinator.next_action triple ever fires.
+	response := agentic.AgentResponse{
+		RequestID: "req-textonly",
+		Status:    "complete",
+		Message: agentic.ChatMessage{
+			Role:    "assistant",
+			Content: "Here is my summary: hydraulic actuators come in three families...",
+		},
+	}
+
+	result, err := handler.HandleModelResponse(ctx, loopID, response)
+	if err != nil {
+		t.Fatalf("HandleModelResponse() error = %v", err)
+	}
+
+	if result.State != agentic.LoopStateComplete {
+		t.Fatalf("State = %s, want complete", result.State)
+	}
+	if result.SyntheticDecide == nil {
+		t.Fatal("SyntheticDecide should be non-nil on terminal-tool-less completion with opt-in flag set")
+	}
+	if result.SyntheticDecide.LoopID != loopID {
+		t.Errorf("SyntheticDecide.LoopID = %q, want %q", result.SyntheticDecide.LoopID, loopID)
+	}
+	if result.SyntheticDecide.Reason != response.Message.Content {
+		t.Errorf("SyntheticDecide.Reason = %q, want raw model text %q (prefix is added by graphWriter)", result.SyntheticDecide.Reason, response.Message.Content)
+	}
+}
+
+// TestHandleCompleteResponse_SyntheticDecide_DefaultOff verifies that with
+// the default Config (SynthesizeTerminalOnCompletion=false), a terminal-
+// tool-less completion does NOT populate SyntheticDecide. Back-compat:
+// existing flows keep their pre-#133 behaviour (loop completes cleanly,
+// no synthetic triples emitted).
+func TestHandleCompleteResponse_SyntheticDecide_DefaultOff(t *testing.T) {
+	handler := agenticloop.NewMessageHandler(createTestConfig())
+
+	ctx := context.Background()
+	taskResult, err := handler.HandleTask(ctx, agenticloop.TaskMessage{
+		TaskID: "task-synth-default-off",
+		Role:   "general",
+		Model:  "test-model",
+		Prompt: "Test",
+	})
+	if err != nil {
+		t.Fatalf("HandleTask() error = %v", err)
+	}
+	loopID := taskResult.LoopID
+
+	response := agentic.AgentResponse{
+		RequestID: "req-default-off",
+		Status:    "complete",
+		Message: agentic.ChatMessage{
+			Role:    "assistant",
+			Content: "All done",
+		},
+	}
+
+	result, err := handler.HandleModelResponse(ctx, loopID, response)
+	if err != nil {
+		t.Fatalf("HandleModelResponse() error = %v", err)
+	}
+
+	if result.State != agentic.LoopStateComplete {
+		t.Fatalf("State = %s, want complete", result.State)
+	}
+	if result.SyntheticDecide != nil {
+		t.Errorf("SyntheticDecide should remain nil with default opt-in flag false; got %+v", result.SyntheticDecide)
+	}
+}
+
 // --- Per-task tools tests ---
 
 func TestHandleTask_PerTaskTools(t *testing.T) {

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -131,6 +131,21 @@ type Action struct {
 	// model that honours response_format.
 	ResponseFormat *agentic.ResponseFormat `json:"response_format,omitempty"`
 
+	// ToolChoice constrains the spawned loop's tool selection per
+	// iteration. ADR-023. When non-nil, executePublishAgent stamps it
+	// onto the TaskMessage.ToolChoice; the agentic-loop caches it and
+	// threads it onto every AgentRequest in the loop. Nil leaves
+	// model-decides ("auto") behaviour unchanged.
+	//
+	// Primary use case is the cheap-model substrate (gemini-2.5-flash,
+	// small local models) where the model routinely completes a loop
+	// with text-only output despite persona prose enforcing a terminal
+	// tool call. Mode "required" forces _some_ tool every iteration;
+	// Mode "function" with FunctionName forces a specific tool (use on
+	// the terminal-forcing iteration where a structured decision is
+	// expected). Validation runs as part of TaskMessage.Validate().
+	ToolChoice *agentic.ToolChoice `json:"tool_choice,omitempty"`
+
 	// RelatedLoops is cross-arc loop-ID lineage threaded onto the
 	// spawned task so a downstream role can read_loop_result against
 	// upstream loops without the IDs being baked into the prompt. Map
@@ -724,6 +739,21 @@ func stampRelatedLoops(task *agentic.TaskMessage, related map[string]string, ec 
 	task.Metadata[agentic.MetadataKeyRelatedLoops] = resolved
 }
 
+// stampPerSpawnLLMKnobs threads the rule.Action's per-spawn LLM
+// constraints (ResponseFormat — ADR-034; ToolChoice — ADR-023) onto
+// the TaskMessage. The agentic-loop caches each on initial build and
+// threads it onto every AgentRequest in the loop. Nil on either side
+// is a no-op (back-compat: pre-opt-in flows keep their pre-existing
+// tool-calling / model-decides behaviour).
+func stampPerSpawnLLMKnobs(task *agentic.TaskMessage, action Action) {
+	if action.ResponseFormat != nil {
+		task.ResponseFormat = action.ResponseFormat
+	}
+	if action.ToolChoice != nil {
+		task.ToolChoice = action.ToolChoice
+	}
+}
+
 // executePublishAgent executes a publish_agent action, triggering an agentic loop.
 // It publishes a TaskMessage to the specified NATS subject.
 func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action, ec *ExecutionContext) error {
@@ -808,15 +838,7 @@ func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action,
 		task.Metadata[agentic.MetadataKeyDecideActionAllowlist] = allowlist
 	}
 
-	// Per-spawn structured-output constraint. ADR-034. Pass-through:
-	// rule.Action.ResponseFormat → TaskMessage.ResponseFormat. The
-	// agentic-loop caches it on initial build and threads it onto every
-	// AgentRequest in the loop. Nil leaves tool-calling behaviour
-	// unchanged. No substitution applied — the schema body is structured
-	// JSON, not a template.
-	if action.ResponseFormat != nil {
-		task.ResponseFormat = action.ResponseFormat
-	}
+	stampPerSpawnLLMKnobs(&task, action)
 
 	// Per-spawn cross-arc loop-ID lineage. Mirrors the ActionAllowlist
 	// Metadata stamping pattern. See stampRelatedLoops for the why.

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -1216,6 +1216,86 @@ func TestAction_PublishAgent_EmptyResponseFormat(t *testing.T) {
 	assert.Nil(t, task.ResponseFormat, "ResponseFormat should remain nil when action.ResponseFormat unset")
 }
 
+// TestAction_PublishAgent_ToolChoice verifies that action.ToolChoice
+// threads onto TaskMessage.ToolChoice as a pointer pass-through.
+// ADR-023 + #132. Both Mode "required" and Mode "function" round-trip
+// through the BaseMessage envelope.
+func TestAction_PublishAgent_ToolChoice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		tc   *agentic.ToolChoice
+	}{
+		{
+			name: "required",
+			tc:   &agentic.ToolChoice{Mode: "required"},
+		},
+		{
+			name: "function",
+			tc:   &agentic.ToolChoice{Mode: "function", FunctionName: "decide"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			mock := &mockPublisher{}
+			executor := NewActionExecutorFull(nil, nil, mock)
+
+			action := Action{
+				Type:       ActionTypePublishAgent,
+				Subject:    "agent.task.test",
+				Role:       "researcher",
+				Model:      "mock-model",
+				Prompt:     "p",
+				ToolChoice: tt.tc,
+			}
+
+			require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+			require.Len(t, mock.published, 1)
+
+			baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+			require.NoError(t, err)
+			task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+			require.True(t, ok)
+
+			require.NotNil(t, task.ToolChoice, "ToolChoice should round-trip onto TaskMessage")
+			assert.Equal(t, tt.tc.Mode, task.ToolChoice.Mode)
+			assert.Equal(t, tt.tc.FunctionName, task.ToolChoice.FunctionName)
+		})
+	}
+}
+
+// TestAction_PublishAgent_EmptyToolChoice verifies that an unset
+// ToolChoice leaves TaskMessage.ToolChoice nil (back-compat: existing
+// flows that don't opt in keep model-decides "auto" behaviour).
+func TestAction_PublishAgent_EmptyToolChoice(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.test",
+		Role:    "general",
+		Model:   "mock-model",
+		Prompt:  "p",
+		// ToolChoice omitted
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	assert.Nil(t, task.ToolChoice, "ToolChoice should remain nil when action.ToolChoice unset")
+}
+
 // TestAction_PublishAgent_RelatedLoops verifies that
 // action.RelatedLoops threads onto TaskMessage.Metadata under
 // agentic.MetadataKeyRelatedLoops as a map[string]any (the JSON wire

--- a/schemas/agentic-loop.v1.json
+++ b/schemas/agentic-loop.v1.json
@@ -125,6 +125,12 @@
       "default": "AGENT",
       "category": "advanced"
     },
+    "synthesize_terminal_on_completion": {
+      "type": "boolean",
+      "description": "Synthesize decide(needs_clarification) when a loop completes without a terminal tool call (#133). Belt-and-suspenders recovery for cheap-model substrates where models occasionally return text-only at completion despite persona prose",
+      "default": false,
+      "category": "advanced"
+    },
     "timeout": {
       "type": "string",
       "description": "Timeout duration for loop execution (e.g. 120s or 5m)",

--- a/schemas/rule-processor.v1.json
+++ b/schemas/rule-processor.v1.json
@@ -147,6 +147,20 @@
                   "type": "string",
                   "description": "subject"
                 },
+                "tool_choice": {
+                  "type": "object",
+                  "description": "tool_choice",
+                  "properties": {
+                    "function_name": {
+                      "type": "string",
+                      "description": "function_name"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "description": "mode"
+                    }
+                  }
+                },
                 "tools": {
                   "type": "array",
                   "description": "tools",
@@ -387,6 +401,20 @@
                   "type": "string",
                   "description": "subject"
                 },
+                "tool_choice": {
+                  "type": "object",
+                  "description": "tool_choice",
+                  "properties": {
+                    "function_name": {
+                      "type": "string",
+                      "description": "function_name"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "description": "mode"
+                    }
+                  }
+                },
                 "tools": {
                   "type": "array",
                   "description": "tools",
@@ -545,6 +573,20 @@
                   "type": "string",
                   "description": "subject"
                 },
+                "tool_choice": {
+                  "type": "object",
+                  "description": "tool_choice",
+                  "properties": {
+                    "function_name": {
+                      "type": "string",
+                      "description": "function_name"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "description": "mode"
+                    }
+                  }
+                },
                 "tools": {
                   "type": "array",
                   "description": "tools",
@@ -702,6 +744,20 @@
                 "subject": {
                   "type": "string",
                   "description": "subject"
+                },
+                "tool_choice": {
+                  "type": "object",
+                  "description": "tool_choice",
+                  "properties": {
+                    "function_name": {
+                      "type": "string",
+                      "description": "function_name"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "description": "mode"
+                    }
+                  }
                 },
                 "tools": {
                   "type": "array",
@@ -879,6 +935,20 @@
                 "subject": {
                   "type": "string",
                   "description": "subject"
+                },
+                "tool_choice": {
+                  "type": "object",
+                  "description": "tool_choice",
+                  "properties": {
+                    "function_name": {
+                      "type": "string",
+                      "description": "function_name"
+                    },
+                    "mode": {
+                      "type": "string",
+                      "description": "mode"
+                    }
+                  }
                 },
                 "tools": {
                   "type": "array",

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -659,6 +659,19 @@ const (
 	// Example: "fan-out|fan_out"
 	// DataType: string
 	CoordinatorDecisionSAPCoerced = "coordinator.decision.sap_coerced"
+
+	// CoordinatorDecisionSynthetic is set to "true" when the framework
+	// synthesizes a decide on terminal-tool-less completion (#133). The
+	// model finished its loop with a text-only response — no `decide`
+	// tool_call appeared in the trajectory — so agentic-loop emits the
+	// canonical next_action + reason triples (needs_clarification +
+	// "[synthetic-no-terminal] {model text}") plus this marker so
+	// downstream rule authors can distinguish a model-emitted
+	// needs_clarification from a framework-synthesized one. Opt-in via
+	// Config.SynthesizeTerminalOnCompletion.
+	// Example: "true"
+	// DataType: string
+	CoordinatorDecisionSynthetic = "coordinator.decision.synthetic"
 )
 
 // Ops Predicates


### PR DESCRIPTION
## Summary

Bundles #132 (`tool_choice` on `rule.Action.publish_agent`) + #133 (synthesize `decide(needs_clarification)` on terminal-tool-less completion) — the two structural fixes for the cheap-model substrate failure mode SemTeams smoke6-coord-handoff surfaced on 2026-05-22.

Belt-and-suspenders by design: #132 is the **preventive** lever (force a tool call per iteration), #133 is the **recovery** lever (synth a decide so existing recovery rules match when prevention fails).

## #132 — `tool_choice` on `rule.Action.publish_agent`

Mirror the existing `ResponseFormat` plumbing — TINY scope (~20 LOC + tests):

- New `ToolChoice *agentic.ToolChoice` field on `rule.Action`.
- Pass-through in `executePublishAgent` via a new `stampPerSpawnLLMKnobs` helper that groups `ResponseFormat` + `ToolChoice` (also keeps the publish_agent function under the revive 50-stmt cap).
- Validation already runs as part of `TaskMessage.Validate()`; framework already caches + threads `TaskMessage.ToolChoice` onto every `AgentRequest`. No further plumbing needed.

Rule packs can now write:

\`\`\`json
{
  "type": "publish_agent",
  "role": "researcher-research-gather",
  "tools": ["read_loop_result", "web_search", "bash", "scratchpad", "decide"],
  "tool_choice": { "mode": "required" }
}
\`\`\`

…or `{"mode": "function", "function_name": "decide"}` to force the terminal call on a synthesize/decision spawn.

## #133 — synthesize `decide(needs_clarification)` on terminal-tool-less completion

When a loop reaches `state=complete` AND no `decide` tool_call appears in its step history, framework synthesizes a `decide(action="needs_clarification")` so downstream recovery rules pick it up.

- New `Config.SynthesizeTerminalOnCompletion bool` (default **false** for back-compat; new flows targeting cheap-model substrates opt in).
- `handleCompleteResponse` scans the trajectory snapshot it already pulls for cost tracking; if no `decide` step and opt-in flag set, populates `HandlerResult.SyntheticDecide{LoopID, Reason}` with the model's text.
- `graphWriter.WriteSyntheticDecide` stamps three triples atomically on the loop entity (single Subject = atomic per-Subject CAS via `graph.mutation.triple.add_batch`):

  | Predicate | Object |
  |---|---|
  | `coordinator.decision.next_action` | `needs_clarification` |
  | `coordinator.decision.reason` | `[synthetic-no-terminal] {model text, truncated to 8KiB}` |
  | `coordinator.decision.synthetic` | `true` |

- New `CoordinatorDecisionSynthetic` predicate in `vocabulary/agentic` so rule authors can branch on framework- vs model-emitted needs_clarification.
- New Source value `agentic-loop-synthetic-decide` distinguishes provenance in operator dashboards (vs `coordinator-decide` for model-emitted).
- Loud structured log on synthesis emission with hint about #132's `tool_choice="required"` as the preventive measure.

## Tests

**processor/rule** (mirror existing ResponseFormat tests):
- `TestAction_PublishAgent_ToolChoice` (table: `mode=required` + `mode=function`)
- `TestAction_PublishAgent_EmptyToolChoice` (back-compat: nil leaves `TaskMessage.ToolChoice` nil)

**processor/agentic-loop**:
- `TestHasTerminalToolCall` (helper unit cases — empty, model_call only, non-decide tools, decide mid-trajectory, model_call with ToolName="decide" ignored)
- `TestHandleCompleteResponse_SyntheticDecide_OptInTextOnly` (opt-in + text-only completion populates SyntheticDecide with raw model text; graphWriter applies the prefix)
- `TestHandleCompleteResponse_SyntheticDecide_DefaultOff` (default config back-compat — SyntheticDecide stays nil)

## Class

**ADDITIVE.** No wire-format change. New fields all `omitempty` / opt-in. Existing flows see zero behavioural change. Per [[project_breaking_change_horizon]] this rides the next ADDITIVE tag bundle.

## Sister-project impact

- **SemTeams**: unblocks cheap-model substrate work — can set `tool_choice="required"` on gather/synthesize rules and opt into `synthesize_terminal_on_completion` for recovery. #134 (parallel fan-out) remains nice-to-have.
- **SemConnect**: no impact (no agentic-loop / rule consumption today).

## Pre-tag sweep

- ✅ `task lint` clean (no revive warnings)
- ✅ `go test -race ./...` (unit) — all green
- ✅ `go test -race -tags=integration ./...` — all green (initial run had one Docker-sweep flake per the documented testcontainers class; re-run clean)
- ✅ `go vet -tags=integration ./...` clean
- ✅ `go vet -tags=live_llm ./...` clean
- ✅ `task schema:generate` — schemas regenerated, both deltas reviewed
- ✅ `go test ./test/contract/...` clean

## Test plan

- [ ] CI lint + test
- [ ] CI build (cross-compile linux)
- [ ] Confirm sister-project semteams can pin to the resulting tag and gather rule with `tool_choice="required"` keeps gemini-2.5-flash from completing text-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)