### PR TITLE
feat(service,config,graph-ingest): semconnect upstream-asks (#100 + #101 + #120)

### DIFF
--- a/cmd/semstreams/flags.go
+++ b/cmd/semstreams/flags.go
@@ -54,9 +54,15 @@ func parseFlags() *CLIConfig {
 		getEnvDuration("SEMSTREAMS_SHUTDOWN_TIMEOUT", 30*time.Second),
 		"Graceful shutdown timeout (env: SEMSTREAMS_SHUTDOWN_TIMEOUT)")
 
+	// Default is 0 (disabled). When set, binds a dedicated /health +
+	// /healthz listener on this port independent of the service-manager
+	// UI's HTTP port — convenience for Docker / Kubernetes probes that
+	// want a stable, lightweight health surface. The service-manager's
+	// main HTTP server still serves /health on services.service-manager.
+	// config.http_port; this flag is additive.
 	flag.IntVar(&cfg.HealthPort, "health-port",
-		getEnvInt("SEMSTREAMS_HEALTH_PORT", 8080),
-		"Health check port, 0 to disable (env: SEMSTREAMS_HEALTH_PORT)")
+		getEnvInt("SEMSTREAMS_HEALTH_PORT", 0),
+		"Dedicated /health + /healthz listener port, 0 to disable (env: SEMSTREAMS_HEALTH_PORT). Independent of services.service-manager.config.http_port.")
 
 	flag.BoolVar(&cfg.ShowVersion, "version", false, "Show version information")
 	flag.BoolVar(&cfg.ShowVersion, "v", false, "Show version information")

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -177,7 +177,7 @@ func run() error {
 	}
 
 	// 12. Run application with signal handling
-	return runWithSignalHandling(ctx, manager, cliCfg.ShutdownTimeout)
+	return runWithSignalHandling(ctx, manager, cliCfg.ShutdownTimeout, cliCfg.HealthPort)
 }
 
 // parseCLI parses and validates CLI flags.
@@ -237,6 +237,15 @@ func ensureStreamsWithSpinner(ctx context.Context, cfg *config.Config, natsClien
 	// Use a quiet logger for stream creation (we have the spinner for feedback)
 	quietLogger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	streamsManager := config.NewStreamsManager(natsClient, quietLogger)
+
+	// #101: diagnostic verification of operator-configured JetStream
+	// account limits against the server's actual limits. Best-effort
+	// (Debug on internal failure); a real gap surfaces as a Warn so
+	// operators see it before EnsureStreams hits a CreateStream error.
+	if err := streamsManager.VerifyJetStreamLimits(ctx, cfg); err != nil {
+		spinner.StopWithError(err)
+		return fmt.Errorf("verify jetstream limits: %w", err)
+	}
 
 	if err := streamsManager.EnsureStreams(ctx, cfg); err != nil {
 		spinner.StopWithError(err)
@@ -475,8 +484,11 @@ func createServiceIfEnabled(
 	return nil
 }
 
-// runWithSignalHandling starts services and handles shutdown signals
-func runWithSignalHandling(ctx context.Context, manager *service.Manager, shutdownTimeout time.Duration) error {
+// runWithSignalHandling starts services and handles shutdown signals.
+// healthPort is the optional dedicated health-port listener (#100); 0
+// disables it. The listener is bound AFTER StartAll succeeds so it never
+// reports "healthy" while services are still spinning up.
+func runWithSignalHandling(ctx context.Context, manager *service.Manager, shutdownTimeout time.Duration, healthPort int) error {
 	slog.Debug("Setting up signal handling")
 	signalCtx, signalCancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer signalCancel()
@@ -486,6 +498,17 @@ func runWithSignalHandling(ctx context.Context, manager *service.Manager, shutdo
 		return fmt.Errorf("start services: %w", err)
 	}
 	slog.Info("All services started successfully")
+
+	// Optional dedicated health-port listener (#100). Binds /health and
+	// /healthz on a port independent of the service-manager UI's
+	// HTTPPort — convenience for Docker / k8s probes. Zero is a no-op
+	// (the default). Bind failure logs at Warn level inside the manager;
+	// boot continues since the service-manager's main /health is the
+	// authoritative health surface.
+	if err := manager.StartHealthListener(healthPort); err != nil {
+		slog.Warn("dedicated health listener failed to start; continuing without it",
+			"port", healthPort, "error", err)
+	}
 
 	<-signalCtx.Done()
 	slog.Info("Received shutdown signal")

--- a/config/config.go
+++ b/config/config.go
@@ -138,12 +138,35 @@ type NATSTLSConfig struct {
 	CAFile   string `json:"ca_file,omitempty"`
 }
 
-// JetStreamConfig for JetStream settings
+// JetStreamConfig for JetStream settings. Per #101, fields below are
+// either verification hints (MaxMemory/MaxFileStore) or reserved for
+// future plumbing (Domain/RetentionPolicy/ReplicationFactor); JetStream
+// account limits are exclusively server-side configuration via
+// nats.conf — the nats.go SDK exposes AccountInfo as read-only and
+// offers no client-side mutation surface, so the framework cannot push
+// operator intent. What it CAN do is compare configured-vs-server at
+// boot and Warn on gap (see StreamsManager.VerifyJetStreamLimits) so an
+// operator who set max_file_store: 10GB in the framework config but
+// didn't update nats.conf isn't left wondering why stream-create
+// eventually fails with "insufficient storage resources".
 type JetStreamConfig struct {
-	Enabled           bool   `json:"enabled"`
-	Domain            string `json:"domain,omitempty"`
-	MaxMemory         int64  `json:"max_memory,omitempty"`
-	MaxFileStore      int64  `json:"max_file_store,omitempty"`
+	Enabled bool   `json:"enabled"`
+	Domain  string `json:"domain,omitempty"`
+	// MaxMemory is the operator's expected server-side
+	// max_memory_store limit. VerifyJetStreamLimits Warns at boot if
+	// this exceeds the server's actual AccountInfo.Limits.MaxMemory.
+	// 0 disables the check (the default for operators who manage
+	// JetStream sizing entirely via nats.conf without surfacing intent
+	// in the framework config).
+	MaxMemory int64 `json:"max_memory,omitempty"`
+	// MaxFileStore is the operator's expected server-side
+	// max_file_store limit. Same Warn-on-gap semantics as MaxMemory.
+	MaxFileStore int64 `json:"max_file_store,omitempty"`
+	// RetentionPolicy and ReplicationFactor are reserved for future
+	// per-stream-default plumbing — they're per-stream concepts in
+	// JetStream, not account-level, so the framework would have to
+	// route them through StreamConfig defaults rather than at this
+	// level. Not currently honored anywhere.
 	RetentionPolicy   string `json:"retention_policy,omitempty"`
 	ReplicationFactor int    `json:"replication_factor,omitempty"`
 }

--- a/config/streams.go
+++ b/config/streams.go
@@ -139,6 +139,11 @@ var flowsStreamConfig = StreamConfig{
 // any actual capacity miss surfaces as a CreateStream error there.
 func (sm *StreamsManager) VerifyJetStreamLimits(ctx context.Context, cfg *Config) error {
 	configured := cfg.NATS.JetStream
+	// Skip when JetStream itself is disabled in the framework config —
+	// no AccountInfo to query meaningfully.
+	if !configured.Enabled {
+		return nil
+	}
 	// Skip when neither limit is set — nothing to compare against.
 	if configured.MaxMemory <= 0 && configured.MaxFileStore <= 0 {
 		return nil

--- a/config/streams.go
+++ b/config/streams.go
@@ -122,6 +122,79 @@ var flowsStreamConfig = StreamConfig{
 	Replicas: 1,
 }
 
+// VerifyJetStreamLimits reads the operator's MaxMemory / MaxFileStore
+// hints from cfg.NATS.JetStream and logs a Warn for each value that
+// exceeds the server's actual account limit. JetStream account limits
+// are server-side configuration (nats.conf or jetstream-domain
+// configuration); the nats.go SDK exposes AccountInfo as read-only, so
+// the framework cannot push the operator's intent — but it CAN surface
+// the gap loudly so an operator who set max_file_store: 10GB in the
+// framework config but didn't update nats.conf isn't left wondering
+// why stream-create fails with "insufficient storage resources" at
+// runtime (#101). Zero or unset values skip the check.
+//
+// Best-effort: a failure to fetch AccountInfo (server down, JetStream
+// disabled, AccountInfo unsupported) logs at Debug and returns nil —
+// the check is diagnostic, not gating. EnsureStreams runs anyway and
+// any actual capacity miss surfaces as a CreateStream error there.
+func (sm *StreamsManager) VerifyJetStreamLimits(ctx context.Context, cfg *Config) error {
+	configured := cfg.NATS.JetStream
+	// Skip when neither limit is set — nothing to compare against.
+	if configured.MaxMemory <= 0 && configured.MaxFileStore <= 0 {
+		return nil
+	}
+
+	js, err := sm.natsClient.JetStream()
+	if err != nil {
+		sm.logger.Debug("VerifyJetStreamLimits: JetStream context unavailable; skipping limit verification",
+			"error", err)
+		return nil
+	}
+
+	infoCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	info, err := js.AccountInfo(infoCtx)
+	if err != nil {
+		sm.logger.Debug("VerifyJetStreamLimits: AccountInfo() failed; skipping limit verification",
+			"error", err,
+			"hint", "diagnostic-only — EnsureStreams will surface any real capacity miss")
+		return nil
+	}
+
+	if jetStreamLimitExceeds(configured.MaxMemory, info.Limits.MaxMemory) {
+		sm.logger.Warn("nats.jetstream.max_memory exceeds server limit",
+			"configured", configured.MaxMemory,
+			"server_limit", info.Limits.MaxMemory,
+			"hint", "JetStream account limits are server-side config (nats.conf 'jetstream { max_memory_store: N }'). The framework config block is a verification hint, not a control surface — update nats.conf and restart the server, or lower the framework config to match.")
+	}
+	if jetStreamLimitExceeds(configured.MaxFileStore, info.Limits.MaxStore) {
+		sm.logger.Warn("nats.jetstream.max_file_store exceeds server limit",
+			"configured", configured.MaxFileStore,
+			"server_limit", info.Limits.MaxStore,
+			"hint", "JetStream account limits are server-side config (nats.conf 'jetstream { max_file_store: N }'). The framework config block is a verification hint, not a control surface — update nats.conf and restart the server, or lower the framework config to match.")
+	}
+	return nil
+}
+
+// jetStreamLimitExceeds is the pure predicate behind
+// VerifyJetStreamLimits's per-field gap check. Returns true when an
+// operator-configured limit is set (>0) AND the server reports a
+// finite limit (!= -1, the AccountLimits sentinel for "unlimited") AND
+// the configured value exceeds the server's. Extracted so the predicate
+// is unit-testable without standing up a NATS server (the integration
+// test against the testcontainers nats-server only exercises the
+// unlimited-server early-return branch, since testcontainers reports
+// -1 / -1 by default).
+func jetStreamLimitExceeds(configured, serverLimit int64) bool {
+	if configured <= 0 {
+		return false
+	}
+	if serverLimit == -1 {
+		return false
+	}
+	return configured > serverLimit
+}
+
 // EnsureStreams creates all required JetStream streams based on:
 // 1. System streams (LOGS for out-of-band logging)
 // 2. Explicit streams defined in config.Streams (highest priority)

--- a/config/streams_jetstream_limits_integration_test.go
+++ b/config/streams_jetstream_limits_integration_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// TestVerifyJetStreamLimits_ZeroIsNoOp verifies that when neither
+// MaxMemory nor MaxFileStore is set, the verification returns nil
+// without making a server round-trip. Back-compat: operators who
+// don't surface JetStream intent in the framework config see no
+// behavior change.
+func TestVerifyJetStreamLimits_ZeroIsNoOp(t *testing.T) {
+	client := natsclient.NewTestClient(t, natsclient.WithJetStream())
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	sm := NewStreamsManager(client.Client, logger)
+
+	cfg := &Config{
+		NATS: NATSConfig{
+			JetStream: JetStreamConfig{
+				Enabled: true,
+				// MaxMemory and MaxFileStore both unset (0)
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := sm.VerifyJetStreamLimits(ctx, cfg)
+	require.NoError(t, err)
+
+	// No log line should mention "exceeds server limit" — nothing to
+	// verify means nothing to warn about.
+	assert.NotContains(t, buf.String(), "exceeds server limit")
+}
+
+// TestVerifyJetStreamLimits_UnlimitedServerSkipsWarn verifies the
+// -1-is-unlimited contract: when the server reports MaxStore=-1
+// (or MaxMemory=-1), even an absurd operator-configured limit produces
+// no Warn. -1 is the JetStream AccountLimits sentinel for "no limit",
+// so any positive configured value is trivially satisfied. The
+// testcontainers nats-server reports -1 by default (no nats.conf
+// constraints on the test container) — exercises this path.
+func TestVerifyJetStreamLimits_UnlimitedServerSkipsWarn(t *testing.T) {
+	client := natsclient.NewTestClient(t, natsclient.WithJetStream())
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	sm := NewStreamsManager(client.Client, logger)
+
+	const oneAbsurdPiB = int64(1024 * 1024 * 1024 * 1024 * 1024)
+	cfg := &Config{
+		NATS: NATSConfig{
+			JetStream: JetStreamConfig{
+				Enabled:      true,
+				MaxMemory:    oneAbsurdPiB,
+				MaxFileStore: oneAbsurdPiB,
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := sm.VerifyJetStreamLimits(ctx, cfg)
+	require.NoError(t, err)
+
+	logs := buf.String()
+	// On an unlimited server, neither limit predicate fires. Both must
+	// take the -1-skip branch (otherwise the absurd PiB values would
+	// trigger Warns).
+	assert.False(t, strings.Contains(logs, "exceeds server limit"),
+		"expected NO warn against unlimited server; got logs: %s", logs)
+}
+
+// TestVerifyJetStreamLimits_NoWarnWhenWithinBudget verifies that a
+// configured limit at or below the server's actual budget produces no
+// Warn. Uses a deliberately tiny value (1 byte) to ensure the test
+// container's defaults exceed it regardless of OS / docker setup.
+func TestVerifyJetStreamLimits_NoWarnWhenWithinBudget(t *testing.T) {
+	client := natsclient.NewTestClient(t, natsclient.WithJetStream())
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	sm := NewStreamsManager(client.Client, logger)
+
+	cfg := &Config{
+		NATS: NATSConfig{
+			JetStream: JetStreamConfig{
+				Enabled:      true,
+				MaxFileStore: 1, // 1 byte — trivially below any server limit
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := sm.VerifyJetStreamLimits(ctx, cfg)
+	require.NoError(t, err)
+
+	assert.NotContains(t, buf.String(), "exceeds server limit",
+		"trivial 1-byte limit should never trip the gap warning")
+}

--- a/config/streams_jetstream_limits_test.go
+++ b/config/streams_jetstream_limits_test.go
@@ -1,0 +1,43 @@
+package config
+
+import "testing"
+
+// TestJetStreamLimitExceeds exercises the gap-detection predicate
+// behind VerifyJetStreamLimits's per-field Warn branch (#101). Pure
+// function over int64 pairs so the full truth table is unit-testable
+// without booting a NATS server.
+func TestJetStreamLimitExceeds(t *testing.T) {
+	cases := []struct {
+		name        string
+		configured  int64
+		serverLimit int64
+		want        bool
+	}{
+		// "Not configured" branches — operator hasn't set the field;
+		// nothing to verify against.
+		{"zero configured", 0, 1024, false},
+		{"negative configured", -1, 1024, false},
+		// "Unlimited server" branch — -1 sentinel means no gap is
+		// possible regardless of operator intent.
+		{"unlimited server, configured nonzero", 1024 * 1024, -1, false},
+		{"unlimited server, configured tiny", 1, -1, false},
+		// "Within budget" branch — operator's hint matches or is
+		// strictly less than the server's actual limit.
+		{"configured at exact server limit", 1024, 1024, false},
+		{"configured below server limit", 512, 1024, false},
+		// "Gap" branch — the only true case. Triggers the Warn.
+		{"configured exceeds server limit by 1", 1025, 1024, true},
+		{"configured 1PiB vs 10GB server", 1024 * 1024 * 1024 * 1024 * 1024, 10 * 1024 * 1024 * 1024, true},
+		// Edge: server reports 0 (zero finite limit, not -1
+		// unlimited). Any positive configured value exceeds it.
+		{"server zero (finite), configured positive", 1, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := jetStreamLimitExceeds(tc.configured, tc.serverLimit)
+			if got != tc.want {
+				t.Errorf("jetStreamLimitExceeds(%d, %d) = %v, want %v", tc.configured, tc.serverLimit, got, tc.want)
+			}
+		})
+	}
+}

--- a/graph/mutation_responses.go
+++ b/graph/mutation_responses.go
@@ -29,6 +29,10 @@ import (
 //     a separate read path to recover the post-write state, or
 //     accept the write-without-echo and continue.
 //
+//     Gateways translating this state to HTTP SHOULD return 200 OK
+//     with the Degraded flag echoed in the response body; do NOT
+//     return 202 Accepted — the write is COMMITTED, not pending.
+//
 //   - Success=false → write did NOT commit. Error carries the
 //     pre-write failure reason. Callers MAY retry per the Error
 //     semantics (transient transport errors are safe to retry;

--- a/graph/mutation_responses.go
+++ b/graph/mutation_responses.go
@@ -10,10 +10,42 @@ import (
 
 // Mutation Response Types
 
-// MutationResponse is the base response for all mutations
+// MutationResponse is the base response for all mutations.
+//
+// Three response shapes for entity-mutation handlers (#120):
+//
+//   - Success=true, Degraded=false → write committed, payload fully
+//     populated (Entity, KVRevision, Version, TriplesAdded all
+//     authoritative). Callers can rely on the response as the
+//     post-write source of truth.
+//
+//   - Success=true, Degraded=true → write committed durably, but the
+//     post-write read-back failed (context cancellation, JetStream
+//     node failover, bucket re-keyed). Entity may be nil and
+//     KVRevision may be 0; Error carries the read-back failure
+//     reason. **Callers MUST NOT retry** — a retry on create returns
+//     409 Conflict (the entity is there), and on update returns CAS
+//     mismatch (the revision moved). Either fetch the entity through
+//     a separate read path to recover the post-write state, or
+//     accept the write-without-echo and continue.
+//
+//   - Success=false → write did NOT commit. Error carries the
+//     pre-write failure reason. Callers MAY retry per the Error
+//     semantics (transient transport errors are safe to retry;
+//     validation errors are not).
+//
+// Triple-mutation handlers (AddTriple/RemoveTriple/AddTriplesBatch)
+// don't use Degraded today — they have no post-write read-back step.
+// The field stays nil for those paths.
 type MutationResponse struct {
-	Success    bool   `json:"success"`
-	Error      string `json:"error,omitempty"`
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+	// Degraded is true when the write committed but the post-write
+	// read-back failed. See type docstring for the full three-state
+	// contract. Only entity-mutation handlers populate this; nil on
+	// triple-mutation responses. Omitted in JSON when false (the
+	// common case).
+	Degraded   bool   `json:"degraded,omitempty"`
 	TraceID    string `json:"trace_id,omitempty"`
 	RequestID  string `json:"request_id,omitempty"`
 	Timestamp  int64  `json:"timestamp"`             // Unix nano timestamp

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -321,8 +321,10 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
-		return marshalCreateEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("post-write read-back failed: %v", err))
+		// Write committed; read-back failed. #120 contract: degraded
+		// success rather than Success=false, so callers don't retry
+		// into a 409 Conflict on what's already there.
+		return marshalCreateEntityDegraded(req.TraceID, req.RequestID, err.Error())
 	}
 
 	return json.Marshal(graph.CreateEntityResponse{
@@ -376,8 +378,8 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
-		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID,
-			fmt.Sprintf("post-write read-back failed: %v", err))
+		// #120: write committed, read-back failed → degraded success.
+		return marshalCreateEntityWithTriplesDegraded(req.TraceID, req.RequestID, err.Error())
 	}
 
 	return json.Marshal(graph.CreateEntityWithTriplesResponse{
@@ -435,8 +437,9 @@ func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
-		return marshalUpdateEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("post-write read-back failed: %v", err))
+		// #120: write committed, read-back failed → degraded success.
+		// CAS revision moved; a retry would mismatch.
+		return marshalUpdateEntityDegraded(req.TraceID, req.RequestID, err.Error())
 	}
 
 	return json.Marshal(graph.UpdateEntityResponse{
@@ -564,8 +567,8 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
-		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
-			fmt.Sprintf("post-write read-back failed: %v", err))
+		// #120: write committed, read-back failed → degraded success.
+		return marshalUpdateEntityWithTriplesDegraded(req.TraceID, req.RequestID, err.Error())
 	}
 
 	return json.Marshal(graph.UpdateEntityWithTriplesResponse{
@@ -688,6 +691,67 @@ func marshalUpdateEntityWithTriplesError(traceID, requestID, msg string) ([]byte
 		MutationResponse: graph.MutationResponse{
 			Success:   false,
 			Error:     msg,
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   traceID,
+			RequestID: requestID,
+		},
+	})
+}
+
+// Per-response-shape "degraded success" marshalers (#120). Emitted
+// when the write committed durably but the post-write read-back
+// failed (context cancellation, JetStream node failover, bucket
+// re-keyed). Caller-visible contract: Success=true, Degraded=true,
+// Entity=nil, KVRevision=0, Error carries the read-back failure
+// reason. The triple-rich response shapes also zero out
+// TriplesAdded/TriplesRemoved/Version since those are derived from
+// the same stored entity we couldn't read back.
+
+func marshalCreateEntityDegraded(traceID, requestID, readbackErr string) ([]byte, error) {
+	return json.Marshal(graph.CreateEntityResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   true,
+			Degraded:  true,
+			Error:     fmt.Sprintf("post-write read-back failed: %s", readbackErr),
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   traceID,
+			RequestID: requestID,
+		},
+	})
+}
+
+func marshalCreateEntityWithTriplesDegraded(traceID, requestID, readbackErr string) ([]byte, error) {
+	return json.Marshal(graph.CreateEntityWithTriplesResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   true,
+			Degraded:  true,
+			Error:     fmt.Sprintf("post-write read-back failed: %s", readbackErr),
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   traceID,
+			RequestID: requestID,
+		},
+	})
+}
+
+func marshalUpdateEntityDegraded(traceID, requestID, readbackErr string) ([]byte, error) {
+	return json.Marshal(graph.UpdateEntityResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   true,
+			Degraded:  true,
+			Error:     fmt.Sprintf("post-write read-back failed: %s", readbackErr),
+			Timestamp: time.Now().UnixNano(),
+			TraceID:   traceID,
+			RequestID: requestID,
+		},
+	})
+}
+
+func marshalUpdateEntityWithTriplesDegraded(traceID, requestID, readbackErr string) ([]byte, error) {
+	return json.Marshal(graph.UpdateEntityWithTriplesResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:   true,
+			Degraded:  true,
+			Error:     fmt.Sprintf("post-write read-back failed: %s", readbackErr),
 			Timestamp: time.Now().UnixNano(),
 			TraceID:   traceID,
 			RequestID: requestID,

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -703,16 +703,25 @@ func marshalUpdateEntityWithTriplesError(traceID, requestID, msg string) ([]byte
 // failed (context cancellation, JetStream node failover, bucket
 // re-keyed). Caller-visible contract: Success=true, Degraded=true,
 // Entity=nil, KVRevision=0, Error carries the read-back failure
-// reason. The triple-rich response shapes also zero out
-// TriplesAdded/TriplesRemoved/Version since those are derived from
-// the same stored entity we couldn't read back.
+// reason prefixed by degradedReadbackErrPrefix. The triple-rich
+// response shapes also zero out TriplesAdded/TriplesRemoved/Version
+// since those are derived from the same stored entity we couldn't
+// read back.
+
+// degradedReadbackErrPrefix is the canonical prefix on the Error field
+// of any degraded-success mutation response. Extracted as a constant
+// so the four marshalers below and the regression test in
+// mutations_degraded_test.go can both reference the same source of
+// truth — a future refactor of the wording lands in one place rather
+// than five.
+const degradedReadbackErrPrefix = "post-write read-back failed: "
 
 func marshalCreateEntityDegraded(traceID, requestID, readbackErr string) ([]byte, error) {
 	return json.Marshal(graph.CreateEntityResponse{
 		MutationResponse: graph.MutationResponse{
 			Success:   true,
 			Degraded:  true,
-			Error:     fmt.Sprintf("post-write read-back failed: %s", readbackErr),
+			Error:     degradedReadbackErrPrefix + readbackErr,
 			Timestamp: time.Now().UnixNano(),
 			TraceID:   traceID,
 			RequestID: requestID,
@@ -725,7 +734,7 @@ func marshalCreateEntityWithTriplesDegraded(traceID, requestID, readbackErr stri
 		MutationResponse: graph.MutationResponse{
 			Success:   true,
 			Degraded:  true,
-			Error:     fmt.Sprintf("post-write read-back failed: %s", readbackErr),
+			Error:     degradedReadbackErrPrefix + readbackErr,
 			Timestamp: time.Now().UnixNano(),
 			TraceID:   traceID,
 			RequestID: requestID,
@@ -738,7 +747,7 @@ func marshalUpdateEntityDegraded(traceID, requestID, readbackErr string) ([]byte
 		MutationResponse: graph.MutationResponse{
 			Success:   true,
 			Degraded:  true,
-			Error:     fmt.Sprintf("post-write read-back failed: %s", readbackErr),
+			Error:     degradedReadbackErrPrefix + readbackErr,
 			Timestamp: time.Now().UnixNano(),
 			TraceID:   traceID,
 			RequestID: requestID,
@@ -751,7 +760,7 @@ func marshalUpdateEntityWithTriplesDegraded(traceID, requestID, readbackErr stri
 		MutationResponse: graph.MutationResponse{
 			Success:   true,
 			Degraded:  true,
-			Error:     fmt.Sprintf("post-write read-back failed: %s", readbackErr),
+			Error:     degradedReadbackErrPrefix + readbackErr,
 			Timestamp: time.Now().UnixNano(),
 			TraceID:   traceID,
 			RequestID: requestID,

--- a/processor/graph-ingest/mutations_degraded_test.go
+++ b/processor/graph-ingest/mutations_degraded_test.go
@@ -94,8 +94,8 @@ func TestMarshalDegraded_AllFourEntityShapes(t *testing.T) {
 			if mr.KVRevision != 0 {
 				t.Errorf("KVRevision = %d, want 0 (no read-back to source the revision from)", mr.KVRevision)
 			}
-			if !strings.Contains(mr.Error, "post-write read-back failed") {
-				t.Errorf("Error = %q, want it to start with 'post-write read-back failed'", mr.Error)
+			if !strings.HasPrefix(mr.Error, degradedReadbackErrPrefix) {
+				t.Errorf("Error = %q, want prefix %q", mr.Error, degradedReadbackErrPrefix)
 			}
 			if !strings.Contains(mr.Error, readbackErr) {
 				t.Errorf("Error = %q, want it to include the underlying read-back reason %q", mr.Error, readbackErr)

--- a/processor/graph-ingest/mutations_degraded_test.go
+++ b/processor/graph-ingest/mutations_degraded_test.go
@@ -1,0 +1,136 @@
+package graphingest
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/graph"
+)
+
+// TestMarshalDegraded_AllFourEntityShapes verifies the #120 contract
+// for all four entity-mutation handlers' post-write read-back failure
+// path. Each marshaler must produce Success=true + Degraded=true +
+// Entity=nil + KVRevision=0 + Error containing the read-back failure
+// reason. The four call sites in mutations.go share this contract;
+// keeping the assertions table-driven catches any single-site drift.
+func TestMarshalDegraded_AllFourEntityShapes(t *testing.T) {
+	cases := []struct {
+		name             string
+		marshal          func(traceID, requestID, readbackErr string) ([]byte, error)
+		decodeWithEntity func([]byte) (resp graph.MutationResponse, hasEntity bool, err error)
+	}{
+		{
+			name:    "create_entity",
+			marshal: marshalCreateEntityDegraded,
+			decodeWithEntity: func(b []byte) (graph.MutationResponse, bool, error) {
+				var r graph.CreateEntityResponse
+				if err := json.Unmarshal(b, &r); err != nil {
+					return graph.MutationResponse{}, false, err
+				}
+				return r.MutationResponse, r.Entity != nil, nil
+			},
+		},
+		{
+			name:    "create_entity_with_triples",
+			marshal: marshalCreateEntityWithTriplesDegraded,
+			decodeWithEntity: func(b []byte) (graph.MutationResponse, bool, error) {
+				var r graph.CreateEntityWithTriplesResponse
+				if err := json.Unmarshal(b, &r); err != nil {
+					return graph.MutationResponse{}, false, err
+				}
+				return r.MutationResponse, r.Entity != nil, nil
+			},
+		},
+		{
+			name:    "update_entity",
+			marshal: marshalUpdateEntityDegraded,
+			decodeWithEntity: func(b []byte) (graph.MutationResponse, bool, error) {
+				var r graph.UpdateEntityResponse
+				if err := json.Unmarshal(b, &r); err != nil {
+					return graph.MutationResponse{}, false, err
+				}
+				return r.MutationResponse, r.Entity != nil, nil
+			},
+		},
+		{
+			name:    "update_entity_with_triples",
+			marshal: marshalUpdateEntityWithTriplesDegraded,
+			decodeWithEntity: func(b []byte) (graph.MutationResponse, bool, error) {
+				var r graph.UpdateEntityWithTriplesResponse
+				if err := json.Unmarshal(b, &r); err != nil {
+					return graph.MutationResponse{}, false, err
+				}
+				return r.MutationResponse, r.Entity != nil, nil
+			},
+		},
+	}
+
+	const (
+		traceID     = "trace-123"
+		requestID   = "req-456"
+		readbackErr = "context cancelled before read-back completed"
+	)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := tc.marshal(traceID, requestID, readbackErr)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			mr, hasEntity, err := tc.decodeWithEntity(data)
+			if err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if !mr.Success {
+				t.Errorf("Success = false, want true (write committed; degraded read-back)")
+			}
+			if !mr.Degraded {
+				t.Errorf("Degraded = false, want true")
+			}
+			if hasEntity {
+				t.Errorf("Entity should be nil on degraded path; got non-nil")
+			}
+			if mr.KVRevision != 0 {
+				t.Errorf("KVRevision = %d, want 0 (no read-back to source the revision from)", mr.KVRevision)
+			}
+			if !strings.Contains(mr.Error, "post-write read-back failed") {
+				t.Errorf("Error = %q, want it to start with 'post-write read-back failed'", mr.Error)
+			}
+			if !strings.Contains(mr.Error, readbackErr) {
+				t.Errorf("Error = %q, want it to include the underlying read-back reason %q", mr.Error, readbackErr)
+			}
+			if mr.TraceID != traceID {
+				t.Errorf("TraceID = %q, want %q", mr.TraceID, traceID)
+			}
+			if mr.RequestID != requestID {
+				t.Errorf("RequestID = %q, want %q", mr.RequestID, requestID)
+			}
+			if mr.Timestamp == 0 {
+				t.Error("Timestamp = 0, want non-zero")
+			}
+		})
+	}
+}
+
+// TestMutationResponse_DegradedOmittedWhenFalse confirms that the JSON
+// wire shape omits the degraded field on the success-clean path (back-
+// compat for callers that may not handle the new field — they see no
+// new key in the JSON they were already parsing).
+func TestMutationResponse_DegradedOmittedWhenFalse(t *testing.T) {
+	resp := graph.CreateEntityResponse{
+		MutationResponse: graph.MutationResponse{
+			Success:    true,
+			Degraded:   false,
+			Timestamp:  1,
+			KVRevision: 42,
+		},
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "degraded") {
+		t.Errorf("Degraded=false should be omitted from JSON; got: %s", string(b))
+	}
+}

--- a/service/service_manager.go
+++ b/service/service_manager.go
@@ -430,6 +430,17 @@ func (m *Manager) StopAll(timeout time.Duration) error {
 	m.order = nil
 	m.mu.Unlock()
 
+	// Stop the dedicated health listener first (cheap shutdown, no
+	// pending requests to drain at scale). No-op when not started.
+	// #100: production shutdown runs through StopAll (cmd/semstreams's
+	// shutdown() calls manager.StopAll, NOT manager.Stop), so the
+	// teardown has to live here to actually free the port on graceful
+	// drain. Log-and-continue: health-listener shutdown failure must
+	// not block the main HTTP server shutdown.
+	if err := m.StopHealthListener(); err != nil {
+		logger.Warn("dedicated health listener stop failed; continuing main shutdown", "error", err)
+	}
+
 	// Stop the HTTP server if running
 	// This was missing and causing containers to not shutdown cleanly!
 	if m.isHTTPManager {

--- a/service/service_manager.go
+++ b/service/service_manager.go
@@ -37,6 +37,15 @@ type Manager struct {
 	httpMiddleware []HTTPMiddleware // applied outermost-first; see ADR-030 Phase 1
 	config         ManagerConfig
 
+	// Optional dedicated health-port listener (#100). Operators set
+	// cmd/semstreams's -health-port (or SEMSTREAMS_HEALTH_PORT env) to
+	// bind a parallel listener serving ONLY /health and /healthz — a
+	// lightweight surface for Docker/k8s probes that is independent of
+	// the service-manager UI port. Zero means disabled (the default).
+	// Both endpoints reuse the Manager's existing handleSystemHealth /
+	// handleLiveness handlers; no separate health logic.
+	healthServer *http.Server
+
 	// Track if we're the instance managing HTTP
 	isHTTPManager bool
 
@@ -818,6 +827,18 @@ func (m *Manager) Start(ctx context.Context) error {
 func (m *Manager) Stop(timeout time.Duration) error {
 	// Config watching is now handled by Manager, no need to stop it here
 
+	// Stop the dedicated health listener first (cheaper shutdown, no
+	// pending requests to drain at scale). No-op when not started.
+	if err := m.StopHealthListener(); err != nil {
+		// Log-and-continue — health listener shutdown failure must not
+		// block the main HTTP server shutdown.
+		logger := m.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn("dedicated health listener stop failed; continuing main shutdown", "error", err)
+	}
+
 	// Stop HTTP server if running
 	if m.isHTTPManager {
 		if err := m.stopHTTPServer(); err != nil {
@@ -1002,6 +1023,91 @@ func (m *Manager) startHTTPServer() error {
 		}
 	}()
 
+	return nil
+}
+
+// StartHealthListener binds a dedicated /health + /healthz listener on
+// the given port. Intended for Docker / Kubernetes probes that want a
+// stable port independent of the service-manager UI's HTTPPort (#100).
+// Port 0 is a no-op (disabled — the default for the -health-port flag).
+//
+// The listener serves the SAME handler functions as the main HTTP mux's
+// /health and /healthz routes; it reads m.services / m.natsClient under
+// the same m.mu locks. Failure to bind logs at Warn level but does NOT
+// fail the boot — the main /health on HTTPPort is the authoritative
+// health surface; this dedicated listener is convenience-only.
+//
+// Idempotent: calling twice with the same non-zero port returns an
+// error rather than re-binding; callers should call StopHealthListener
+// first if they need to switch ports at runtime.
+func (m *Manager) StartHealthListener(port int) error {
+	if port == 0 {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.healthServer != nil {
+		return fmt.Errorf("health listener already started; call StopHealthListener before re-binding")
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", m.handleSystemHealth)
+	mux.HandleFunc("/healthz", m.handleLiveness)
+
+	m.healthServer = &http.Server{
+		Addr:    ":" + strconv.Itoa(port),
+		Handler: mux,
+		BaseContext: func(_ net.Listener) context.Context {
+			if m.lifecycleCtx != nil {
+				return m.lifecycleCtx
+			}
+			return context.Background()
+		},
+		// Health probes are short-lived; keep timeouts tight so a
+		// misbehaving probe client can't pin a goroutine.
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		IdleTimeout:  30 * time.Second,
+	}
+
+	server := m.healthServer
+	logger := m.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Info("Starting dedicated health listener", "port", port, "routes", []string{"/health", "/healthz"})
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Warn("dedicated health listener error", "port", port, "error", err)
+		}
+	}()
+	return nil
+}
+
+// StopHealthListener gracefully shuts down the dedicated health-port
+// listener if one was started. No-op when the listener is not running.
+// Same 5s graceful-shutdown budget as stopHTTPServer.
+func (m *Manager) StopHealthListener() error {
+	m.mu.Lock()
+	server := m.healthServer
+	m.healthServer = nil
+	m.mu.Unlock()
+
+	if server == nil {
+		return nil
+	}
+
+	logger := m.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		logger.Warn("dedicated health listener shutdown failed", "error", err)
+		return fmt.Errorf("shutdown dedicated health listener: %w", err)
+	}
 	return nil
 }
 

--- a/service/service_manager_health_listener_test.go
+++ b/service/service_manager_health_listener_test.go
@@ -113,6 +113,49 @@ func TestStartHealthListener_DoubleStartErrors(t *testing.T) {
 	}
 }
 
+// TestStopAll_TearsDownHealthListener verifies the #100 production
+// shutdown contract: cmd/semstreams/main.go's shutdown() calls
+// manager.StopAll, NOT manager.Stop, so the dedicated health-port
+// listener must be torn down by StopAll (otherwise the port stays
+// bound until process exit and graceful-drain semantics are broken).
+// Reviewer-found blocker on the original PR — keeps regression
+// coverage on the path the reviewer was right to flag.
+func TestStopAll_TearsDownHealthListener(t *testing.T) {
+	deps := createTestServiceDependencies(nil)
+	manager := createTestServiceManager(ManagerConfig{HTTPPort: 0}, deps)
+
+	port := freePort(t)
+	if err := manager.StartHealthListener(port); err != nil {
+		t.Fatalf("StartHealthListener(%d) error = %v", port, err)
+	}
+
+	// Sanity: listener is up before shutdown.
+	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
+	waitForListener(t, addr+"/healthz", 3*time.Second)
+
+	// StopAll is the production shutdown entry point. It must tear
+	// down the dedicated health listener as part of its sequence.
+	if err := manager.StopAll(5 * time.Second); err != nil {
+		t.Fatalf("StopAll error = %v", err)
+	}
+
+	// Port should be free now — re-binding it succeeds. Poll briefly
+	// since Shutdown returns once the listener stops accepting but the
+	// OS may take a moment to release the port (TIME_WAIT etc.).
+	deadline := time.Now().Add(3 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err == nil {
+			_ = l.Close()
+			return
+		}
+		lastErr = err
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("port %d never freed after StopAll within 3s; last bind error: %v", port, lastErr)
+}
+
 // freePort asks the kernel for an unused TCP port. Used by tests that
 // need a real port without colliding under parallel test runs.
 func freePort(t *testing.T) int {

--- a/service/service_manager_health_listener_test.go
+++ b/service/service_manager_health_listener_test.go
@@ -1,0 +1,150 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestStartHealthListener_BindsHealthAndHealthz verifies that
+// StartHealthListener binds /health and /healthz on the requested port
+// and routes them to the Manager's existing handler functions. Closes
+// the loop on #100 — the -health-port flag is no longer dead code.
+func TestStartHealthListener_BindsHealthAndHealthz(t *testing.T) {
+	// Pass nil NATS so handleSystemHealth skips the NATS branch — the
+	// in-suite mockNATSClient creates an empty natsclient.Client whose
+	// internal fields are nil and panic on GetStatus(). Health listener
+	// behaviour is orthogonal to NATS readiness anyway; aggregating zero
+	// sub-statuses returns a healthy aggregate by the health package's
+	// rule (no sub-statuses = trivially healthy).
+	deps := createTestServiceDependencies(nil)
+	manager := createTestServiceManager(ManagerConfig{HTTPPort: 0}, deps)
+
+	port := freePort(t)
+	if err := manager.StartHealthListener(port); err != nil {
+		t.Fatalf("StartHealthListener(%d) error = %v", port, err)
+	}
+	t.Cleanup(func() {
+		if err := manager.StopHealthListener(); err != nil {
+			t.Errorf("StopHealthListener cleanup error = %v", err)
+		}
+	})
+
+	// Wait briefly for the listener to come up. ListenAndServe is async
+	// in a goroutine; we poll until the port is reachable to keep the
+	// test deterministic without a wall-clock sleep.
+	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
+	waitForListener(t, addr+"/healthz", 3*time.Second)
+
+	// /healthz is the liveness probe — should always 200 once the
+	// listener is up. No service state required.
+	resp, err := http.Get(addr + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /healthz status = %d, want 200", resp.StatusCode)
+	}
+
+	// /health aggregates service + NATS status. The mock NATS reports
+	// connected, no services registered, so the aggregate is healthy.
+	resp, err = http.Get(addr + "/health")
+	if err != nil {
+		t.Fatalf("GET /health error = %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET /health status = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestStartHealthListener_ZeroIsNoOp verifies the default disabled
+// path: port 0 (the flag's "0 to disable" sentinel) is a no-op, no
+// listener bound, no error returned. Back-compat — operators with the
+// flag unset see no change.
+func TestStartHealthListener_ZeroIsNoOp(t *testing.T) {
+	// Pass nil NATS so handleSystemHealth skips the NATS branch — the
+	// in-suite mockNATSClient creates an empty natsclient.Client whose
+	// internal fields are nil and panic on GetStatus(). Health listener
+	// behaviour is orthogonal to NATS readiness anyway; aggregating zero
+	// sub-statuses returns a healthy aggregate by the health package's
+	// rule (no sub-statuses = trivially healthy).
+	deps := createTestServiceDependencies(nil)
+	manager := createTestServiceManager(ManagerConfig{HTTPPort: 0}, deps)
+
+	if err := manager.StartHealthListener(0); err != nil {
+		t.Errorf("StartHealthListener(0) error = %v, want nil (no-op)", err)
+	}
+	if manager.healthServer != nil {
+		t.Error("healthServer should remain nil when port is 0")
+	}
+	// Stop should also be a no-op when no listener was started.
+	if err := manager.StopHealthListener(); err != nil {
+		t.Errorf("StopHealthListener with no listener error = %v, want nil", err)
+	}
+}
+
+// TestStartHealthListener_DoubleStartErrors verifies the idempotency
+// guard: calling twice with a non-zero port returns an error rather
+// than silently re-binding (which would either fail at bind time with
+// a confusing OS error or leak the first listener).
+func TestStartHealthListener_DoubleStartErrors(t *testing.T) {
+	// Pass nil NATS so handleSystemHealth skips the NATS branch — the
+	// in-suite mockNATSClient creates an empty natsclient.Client whose
+	// internal fields are nil and panic on GetStatus(). Health listener
+	// behaviour is orthogonal to NATS readiness anyway; aggregating zero
+	// sub-statuses returns a healthy aggregate by the health package's
+	// rule (no sub-statuses = trivially healthy).
+	deps := createTestServiceDependencies(nil)
+	manager := createTestServiceManager(ManagerConfig{HTTPPort: 0}, deps)
+
+	port := freePort(t)
+	if err := manager.StartHealthListener(port); err != nil {
+		t.Fatalf("first StartHealthListener error = %v", err)
+	}
+	t.Cleanup(func() { _ = manager.StopHealthListener() })
+
+	if err := manager.StartHealthListener(port); err == nil {
+		t.Error("second StartHealthListener should error; got nil")
+	}
+}
+
+// freePort asks the kernel for an unused TCP port. Used by tests that
+// need a real port without colliding under parallel test runs.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen for free port: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	return port
+}
+
+// waitForListener polls url with short HTTP GETs until one succeeds or
+// the budget expires. Avoids brittle sleep-based readiness in tests.
+func waitForListener(t *testing.T, url string, budget time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(budget)
+	client := &http.Client{Timeout: 200 * time.Millisecond}
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			_ = resp.Body.Close()
+			return
+		}
+		// Short, bounded backoff under the overall budget — not a
+		// wall-clock sleep that scales with system pressure.
+		select {
+		case <-time.After(20 * time.Millisecond):
+		case <-context.Background().Done():
+			return
+		}
+	}
+	t.Fatalf("listener at %s never came up within %s", url, budget)
+}


### PR DESCRIPTION
## Summary

Closes semconnect's three remaining non-wire-format upstream-asks. All ADDITIVE — no wire-format change; new fields `omitempty`; new methods opt-in (zero default disables).

The fourth and final semconnect upstream-ask is **#93 natsclient header-classified errors** which is BREAKING and lands as its own standalone tag (beta-exit blocker).

## #100 — `-health-port` flag wired

The flag was declared, parsed, validated — and never read. Operators setting `-health-port=8080` got nothing; Docker healthchecks pointed at port 8080 got connection-refused.

Now:
- `service.Manager` gains `StartHealthListener(port)` / `StopHealthListener()` binding a dedicated `/health` + `/healthz` listener on the requested port. Reuses existing `handleSystemHealth` / `handleLiveness` handlers — single source of health truth.
- `cmd/semstreams/main.go` calls `StartHealthListener` after `StartAll` succeeds (never reports "healthy" while services are still spinning up).
- Flag default changed from `8080` → `0` (disabled). Operators who never set the flag see no change; operators who set it now get the expected listener.
- Help text rewritten to match reality.

## #101 — `nats.jetstream.*` validate-and-warn

SDK reality changed the resolution shape: nats.go's `AccountInfo` is **read-only**. The upstream-ask's Option A pseudocode (`js.UpdateAccountInfo(...)`) doesn't exist as a mutation surface. The framework cannot push JetStream account limits — that's exclusively server-side configuration via `nats.conf`.

What it CAN do is surface the gap loudly:
- New `StreamsManager.VerifyJetStreamLimits` queries `AccountInfo` at boot and Warns when configured `MaxMemory`/`MaxFileStore` exceeds the server's actual limits, with a hint pointing operators at `nats.conf` as the control surface.
- `-1` sentinel ("unlimited" per `AccountLimits`) skips the check.
- Best-effort: `AccountInfo` failure logs at Debug and returns nil (diagnostic, not gating).
- Wired before `EnsureStreams` in `cmd/semstreams/main.go`.
- Short-circuits when `JetStream.Enabled == false`.
- Pure predicate `jetStreamLimitExceeds` extracted for unit testability — testcontainers nats-server reports `-1/-1` so the warn-on-overflow branch can't be exercised against it; unit table covers all 9 cases.
- `JetStreamConfig` field godoc rewritten to document actual semantics (`MaxMemory`/`MaxFileStore` are verification hints; `Domain`/`RetentionPolicy`/`ReplicationFactor` reserved).

## #120 — `Degraded bool` on `MutationResponse`

Per `project_breaking_change_horizon`: `Degraded bool` is the ADDITIVE resolution direction (Success-flip would have been MILD BREAKING).

Three-state contract documented in the type godoc:

| State | Meaning | Caller behaviour |
|---|---|---|
| `Success=true, Degraded=false` | Write committed; payload fully populated. | Use response as post-write source of truth. |
| `Success=true, Degraded=true` | Write committed; post-write read-back failed. `Entity` may be nil and `KVRevision` may be 0. | **MUST NOT retry** (would 409 / CAS mismatch). Fetch via separate read path or accept write-without-echo. |
| `Success=false` | Write did NOT commit. | MAY retry per Error semantics. |

HTTP mapping guidance added to the docstring: gateways SHOULD return `200 OK` with `Degraded` echoed in the body; **do NOT** return `202 Accepted` (the write is committed, not pending).

All four entity-mutation handlers' post-write read-back failure path updated; four parallel `marshalCreate/UpdateEntityDegraded` helpers added. `degradedReadbackErrPrefix` constant ensures the four marshalers and the regression test share one source of truth.

## Reviewer pass

go-reviewer found one blocker + four nits. Both blocker and three small nits landed on this PR (commit `063c57a`); two stay as follow-ups.

**Blocker** (fixed `063c57a`):
- `StopHealthListener` was on `Manager.Stop` but production shutdown goes through `Manager.StopAll`. Listener would have leaked the port on graceful drain. Wired into `StopAll` immediately before `stopHTTPServer`; new `TestStopAll_TearsDownHealthListener` regression test exercises the production shutdown path end-to-end and asserts the port frees.

**Small nits landed**:
- `VerifyJetStreamLimits` short-circuits on `JetStream.Enabled=false`.
- Extracted `const degradedReadbackErrPrefix` so marshalers + test share one source of truth.
- Added HTTP 200-not-202 mapping guidance to `MutationResponse` docstring.

**Nits deferred (follow-up)**:
- `JetStreamConfig.RetentionPolicy` / `ReplicationFactor` are operator-reachable but reserved. Worth either wiring as per-stream defaults or having `validator.go` Warn when set-but-ignored.
- `TestStartHealthListener_ZeroIsNoOp`'s `healthServer` field check is technically unlocked but has no concurrent writer.

## Sister-project impact

- **semconnect**: pin to beta.81 to land the cleanup. cs-api's `ingestTriples` can drop the `add_batch` upsert workaround (already superseded by beta.78 entity-create handlers); HTTP wrappers should now handle the `Success=true+Degraded=true` shape (fetch entity through a separate read path if needed, or accept write-without-echo). Operators setting `-health-port` now get a real listener; `nats.jetstream.max_file_store` now surfaces gaps at boot.
- **semteams**: no direct impact.

## Pre-tag sweep

- ✅ `task lint` clean
- ✅ `go test -race ./...` (unit) all green
- ✅ `go test -race -tags=integration ./...` full sweep: 113 ok / 0 FAIL on rerun
- ✅ `go vet -tags=integration ./...` clean
- ✅ `go vet -tags=live_llm ./...` clean
- ✅ `task schema:generate` — no schema delta (`Degraded` is a Go-only response field; no operator config surface)
- ✅ Contract tests green

## Test plan

- [ ] CI lint + test
- [ ] CI build (cross-compile linux)
- [ ] Confirm semconnect can pin to the resulting tag and: (a) Docker healthcheck on `-health-port` succeeds, (b) cs-api's HTTP wrapper handles `Success=true+Degraded=true` as 200 OK, (c) operator with a `nats.jetstream.max_file_store` larger than the server's actual limit sees the boot-time Warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)