### PR TITLE
feat(rule,decide): for_each declarative fan-out — ADR-046 Phase 1 (#134)

### DIFF
--- a/docs/adr/046-parallel-fan-out-and-gated-dag-dispatch.md
+++ b/docs/adr/046-parallel-fan-out-and-gated-dag-dispatch.md
@@ -1,0 +1,223 @@
+# ADR-046: Parallel Fan-Out — `for_each` primitive + gated-DAG dispatch
+
+## Status
+
+**Proposed.** Phase 1 (`for_each` foundation) targets beta.82. Phase 2
+(gated-DAG dispatch) defers behind operator validation of Phase 1 and a
+dedicated implementation session. Closes ADR-026 milestone 2 (parallel
+flow composition) which has been deferred since ADR-026 shipped Phase 1.
+References GH #134.
+
+## Context
+
+SemTeams's deep-research and dev-via-spec packs hit the same shape: a
+coordinator role decides "split this work into N independent subtasks"
+and the framework executes them sequentially. With N=4 subtopics and a
+per-investigator wall-clock of T, the wall-clock cost is **4T** even
+though every subtopic is independent by construction (that's what the
+decomposer determined).
+
+The existing fan-out pattern in `configs/rules/deep-research/03-fan-out-subtopics.json`
+is explicitly a milestone artifact:
+
+> *"True parallel fan-out (N agents at once) is out of scope for this
+> milestone — that needs the coordinator's flow-composition tools
+> (ADR-026 milestone 2). See ADR-026 + ADR-028."*
+
+GH #134 surfaces the gap with concrete SemTeams smoke6 evidence
+(2026-05-22): 4-subtopic investigation runs serial through coordinator
+re-iteration because the rule engine has no primitive for "iterate this
+list, spawn N concurrent agents."
+
+### Prior art — semspec's `scenario-orchestrator`
+
+`semspec/processor/scenario-orchestrator/component.go` ships a working
+implementation of the harder shape (gated-DAG dispatch with bounded
+concurrency). Key patterns worth lifting verbatim:
+
+1. **Stateless re-evaluation on completion.** A completion KV watcher
+   re-triggers `dispatchRequirements`, which re-evaluates from KV truth.
+   No in-flight tracking; the dispatcher is idempotent.
+2. **Synchronous reconcile from KV before dispatch.** Closes the race
+   where the completion cache lags the truth on rapid re-fires.
+3. **DAG gating filter** — `filterReadyRequirements` keeps only items
+   whose `DependsOn` deps are completed AND themselves not yet completed.
+4. **Bounded-concurrency semaphore** — `chan struct{}, MaxConcurrent` +
+   `sync.WaitGroup` + error channel.
+5. **Join is implicit.** When `len(ready) == 0`, dispatch is done; no
+   explicit counter, no aggregation primitive.
+
+The semspec executor handles the no-deps case (all-ready immediately,
+all dispatched in parallel) as a degenerate instance of the gated-DAG
+case — empty DAG edges.
+
+### Why two primitives, not one
+
+The semspec gated-DAG pattern subsumes the simple-iteration case
+mathematically. But it carries operational complexity that the
+no-deps use case (SemTeams's deep-research 4-subtopic shape) doesn't
+need:
+
+- Completion-watcher infrastructure
+- Stateless re-eval scheduler
+- Bounded-concurrency tuning per flow
+- DAG validation at decompose-time
+
+For the **no-deps subset** (decompose → N independent investigators
+→ synthesizer), declarative `for_each` over a list is the minimum
+viable surface. Rule author writes:
+
+```json
+{
+  "type": "publish_agent",
+  "for_each": "$entity.triple.coordinator.decision.subtopics",
+  "for_each_var": "subtopic",
+  "role": "researcher-investigate",
+  "prompt": "Investigate: $subtopic"
+}
+```
+
+Framework iterates the list, publishes N TaskMessages, returns. The
+agentic-loop's existing JetStream consumer parallelism handles N
+concurrent executions automatically — no scheduler needed.
+
+The **DependsOn-shaped case** (decomposer emits a DAG; some subtasks
+gate others; recover from partial failure mid-DAG) needs the full
+gated-DAG executor. That's a richer primitive worth its own session.
+
+## Decision
+
+Two complementary primitives shipped in two phases.
+
+### Phase 1 — `for_each` (beta.82 target, this ADR's first PR)
+
+Declarative list-iteration on `rule.Action`:
+
+- New fields on `rule.Action`:
+  - `ForEach string` — substitution-resolvable reference to a list-typed value (e.g. `$entity.triple.coordinator.decision.subtopics`)
+  - `ForEachVar string` — variable name bound per-iteration (e.g. `subtopic` → `$subtopic` in `prompt` / `properties` substitutes the current item)
+- New substitution path that resolves list-typed triple objects to
+  `[]any` instead of stringifying via `fmt.Sprintf("%v", ...)`.
+- New `ExecutionContext.SubstituteVariablesWithIterVar(template,
+  varName, value)` overlay method — the for_each loop passes the
+  current iteration's value as a string-typed overlay binding.
+- `decide` tool stamps a `coordinator.decision.subtopics` triple (JSON-
+  encoded `[]string`) when `args.Subtopics` is non-empty. Without this
+  there's no list-typed triple to iterate against from a coordinator
+  fan-out decision.
+- `executePublishAgent` checks `ForEach`; if set, resolves the list and
+  iterates, calling the existing publish logic per item with the
+  iter-var overlay.
+
+Constraints:
+- `ForEach` works only on `publish_agent` (the only action with the
+  use case today). Wider applicability is a follow-up.
+- No `DependsOn` between iterations — pure broadcast. Iterations are
+  independent by contract.
+- No bounded concurrency at the dispatch layer. Each iteration is a
+  NATS publish (non-blocking); concurrency is determined by the
+  downstream consumer's `MaxAckPending` and worker pool. Operators
+  who need a cap set it on the JetStream consumer.
+- No framework-side join. The coordinator-as-counter pattern (issue
+  #134 Option 3) handles join semantics rule-side: a downstream rule
+  fires on each child completion, queries the graph for sibling
+  completion count, emits `synthesize` when count == expected. This
+  is the same pattern that ships today for sequential fan-out; the
+  only thing that changes is spawn parallelism.
+
+Forward-compat: a future `fan_out_gated` action (Phase 2) is additive.
+Rule packs that use Phase 1's `for_each` for no-deps flows don't need
+to migrate; they coexist.
+
+### Phase 2 — `fan_out_gated` (post-beta.82, separate ADR-046 amendment)
+
+Lift semspec's `scenario-orchestrator` pattern to framework as a new
+action type or workflow primitive:
+
+- Accepts a list of work items with `depends_on` edges (an internal DAG).
+- Completion-watcher integration (NATS KV watch on per-flow completion
+  bucket).
+- Stateless re-evaluation on each completion update: reconcile from
+  KV, filter to currently-ready, dispatch under bounded concurrency.
+- Implicit join (no-ready-left = done).
+- Optional `max_concurrent` config knob, semaphore-based.
+
+Implementation references `semspec/processor/scenario-orchestrator/component.go`
+as prior-art canonical implementation. Open questions deferred to
+Phase 2 design:
+
+- Where the DAG lives: in the rule (declared inline), in a graph
+  entity, in a flow definition.
+- Completion source-of-truth bucket name and key shape.
+- Failure semantics: stop-on-first-failure vs continue-others vs
+  retry-with-backoff per node.
+- Integration with the cheap-model substrate work (beta.80): if a
+  child loop completes via synthetic-decide on terminal-tool-less
+  output, does the gated dispatcher treat that as "complete" for
+  dependent dispatch?
+
+## Trade-offs and alternatives considered
+
+**Lift gated-DAG dispatch directly without Phase 1.** Rejected for
+this tag — semspec's pattern is ~600 LOC of executor logic plus
+completion-watcher integration plus bounded-concurrency knobs. Worth
+its own session with focused design + e2e. Forcing it through today's
+session risks the same "half-finished engine work" failure mode that
+the [project_engine_gaps_not_app_state](orchestration-check skill)
+warns about.
+
+**Generalize `for_each` across all action types in Phase 1.** Rejected
+as scope creep. `publish_agent` is the only action with the immediate
+use case; broadening surface costs LOC + tests without unblocking a
+known consumer. Additive when a need surfaces.
+
+**Skip the `coordinator.decision.subtopics` triple emission; require
+operators to add a separate triple-stamping rule.** Rejected — the
+decide tool is already the canonical decomposition emission point; not
+stamping the list as a triple was an artifact of the sequential
+pattern not needing it. Adding the triple emission is forward-compat
+(operators get the triple for free) and removes a rule-author
+sharp edge.
+
+## Open questions (Phase 1)
+
+- **Map iteration?** Phase 1 ships `[]any` only. If a rule author
+  needs to iterate a `map[string]string` (e.g. per-role config),
+  that's a separate `for_each_map` follow-up. Not blocking.
+- **Nested for_each?** Out of scope. Phase 1 supports a single
+  iteration scope per action.
+- **for_each on Subject / Subject template?** Phase 1 iterates the
+  body (Properties, Prompt, related_loops values). Subject
+  substitution iterates too — same `ec` overlay applies to all
+  substituted strings on the action.
+
+## Implementation plan
+
+**Phase 1 (this PR, ~300 LOC):**
+1. `rule.Action` fields + JSON schema regen
+2. `ExecutionContext.SubstituteVariablesWithIterVar` overlay
+3. List-typed-triple resolution path
+4. `executePublishAgent` iteration loop
+5. `decide` stamps `coordinator.decision.subtopics` triple when
+   action=fan_out and subtopics non-empty
+6. Tests: substitution unit + iteration integration cases
+
+**Phase 2 (post-beta.82, separate PR with design amendment to this ADR):**
+1. Design amendment: completion-bucket layout, DAG storage shape,
+   failure semantics
+2. `fan_out_gated` action implementation
+3. Completion watcher + stateless re-eval scheduler
+4. Bounded concurrency
+5. e2e scenario validating depends_on respected under concurrent
+   completion arrival
+
+## References
+
+- GH #134 — original parallel-fan-out issue
+- ADR-026 — coordinator agent, references this as milestone 2
+- ADR-028 — orchestration architecture (rule skeleton + coordinator + ops)
+- `semspec/processor/scenario-orchestrator/component.go` — gated-DAG
+  prior art
+- `configs/rules/deep-research/03-fan-out-subtopics.json` — the
+  existing sequential fan-out shape this replaces (the comment in
+  that file points here)

--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -296,6 +296,36 @@ func (e *DecideExecutor) decide(ctx context.Context, call agentic.ToolCall) (age
 		})
 	}
 
+	// ADR-046 Phase 1: stamp subtopics as a triple so a downstream rule
+	// can iterate via for_each. JSON-encoded []string keeps the Object
+	// scalar-typed (graph-ingest's per-triple validators assume scalar
+	// Objects); the for_each substitution layer parses it back to
+	// []string at resolution time. Skip on empty/nil subtopics — the
+	// decoder pattern is "missing predicate ⇒ no fan-out target,"
+	// which lines up with how rules match on optional triples.
+	if len(args.Subtopics) > 0 {
+		subtopicsJSON, marshalErr := json.Marshal(args.Subtopics)
+		if marshalErr != nil {
+			// Failure to marshal a string slice is a programmer bug, not
+			// an LLM-driven error — log loudly and continue without the
+			// triple. The next_action + reason triples still publish so
+			// rule matching on those is not blocked.
+			e.logger.Warn("decide tool failed to marshal subtopics for triple emission",
+				"loop_id", call.LoopID,
+				"subtopic_count", len(args.Subtopics),
+				"error", marshalErr)
+		} else {
+			triples = append(triples, message.Triple{
+				Subject:    loopEntityID,
+				Predicate:  agvocab.CoordinatorDecisionSubtopics,
+				Object:     string(subtopicsJSON),
+				Source:     decideToolSource,
+				Timestamp:  now,
+				Confidence: 1.0,
+			})
+		}
+	}
+
 	// Atomic batch publish: all triples share loopEntityID, so the
 	// graph-ingest per-Subject CAS handler applies them as one unit.
 	// Pre-2026-05-13 this was a per-triple loop that could leave the

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -479,10 +479,13 @@ func TestNormaliseActionForSAP(t *testing.T) {
 	}
 }
 
-// TestDecideExecutor_HappyPath verifies a valid decide call emits the two
-// expected triples on the coordinator's loop entity, returns StopLoop=true,
-// and puts the full args in the tool result Content so downstream agents
-// can fetch subtopics via read_loop_result.
+// TestDecideExecutor_HappyPath verifies a valid decide call emits the
+// expected triples on the coordinator's loop entity, returns
+// StopLoop=true, and puts the full args in the tool result Content so
+// downstream agents can fetch subtopics via read_loop_result. ADR-046
+// Phase 1 added a third triple (CoordinatorDecisionSubtopics) on the
+// fan_out path so downstream rules can iterate via for_each without an
+// out-of-band read of the loop's Result.
 func TestDecideExecutor_HappyPath(t *testing.T) {
 	pub := &recordingPublisher{}
 	e := newDecideExecutor(pub)
@@ -507,8 +510,11 @@ func TestDecideExecutor_HappyPath(t *testing.T) {
 		t.Errorf("expected StopLoop=true")
 	}
 
-	if len(pub.triples) != 2 {
-		t.Fatalf("expected 2 triples published, got %d", len(pub.triples))
+	// next_action + reason + subtopics — three triples on fan_out with
+	// non-empty subtopics. The third (subtopics) shipped in ADR-046
+	// Phase 1; the test pre-dates it.
+	if len(pub.triples) != 3 {
+		t.Fatalf("expected 3 triples (next_action + reason + subtopics), got %d", len(pub.triples))
 	}
 
 	wantSubject := "acme.test.agent.agentic-loop.execution.loop-abc"
@@ -755,4 +761,105 @@ func TestDecideExecutor_LoopEntityIDFormat(t *testing.T) {
 	}
 	// Sanity: no fmt.Sprint-shaped junk in the subject.
 	_ = fmt.Sprintf("%s", want)
+}
+
+// --- #134 / ADR-046 Phase 1: subtopics-triple emission tests ---
+
+// TestDecideExecutor_StampsSubtopicsTriple verifies the new ADR-046
+// Phase 1 emission: when args.Subtopics is non-empty, the decide tool
+// stamps coordinator.decision.subtopics as a JSON-encoded []string
+// triple alongside the canonical next_action + reason triples. Lets
+// downstream rules iterate via for_each without out-of-band read of
+// the loop's Result JSON.
+func TestDecideExecutor_StampsSubtopicsTriple(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutor(pub)
+
+	_, _ = e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Arguments: map[string]any{
+			"action":    "fan_out",
+			"reason":    "researcher produced three subtopics",
+			"subtopics": []any{"hydraulics", "pneumatics", "electrics"},
+		},
+	})
+
+	// Expect three triples on the AtomicBatch path: next_action, reason,
+	// subtopics. (Allowlist not set, so no SAP-coerced triple.)
+	if got := len(pub.triples); got != 3 {
+		t.Fatalf("triple count = %d, want 3 (next_action + reason + subtopics)", got)
+	}
+
+	var subtopicsTriple *message.Triple
+	for i := range pub.triples {
+		if pub.triples[i].Predicate == agvocab.CoordinatorDecisionSubtopics {
+			subtopicsTriple = &pub.triples[i]
+		}
+	}
+	if subtopicsTriple == nil {
+		t.Fatalf("no CoordinatorDecisionSubtopics triple emitted; got predicates: %v", tripPredicates(pub.triples))
+	}
+
+	// The Object must be a JSON-encoded []string so the for_each
+	// substitution layer can parse it back.
+	encoded, ok := subtopicsTriple.Object.(string)
+	if !ok {
+		t.Fatalf("Subtopics triple Object = %T, want string (JSON-encoded)", subtopicsTriple.Object)
+	}
+	var decoded []string
+	if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+		t.Fatalf("Subtopics triple Object failed to parse as []string: %v (object: %q)", err, encoded)
+	}
+	wantSubtopics := []string{"hydraulics", "pneumatics", "electrics"}
+	if len(decoded) != len(wantSubtopics) {
+		t.Errorf("decoded subtopics len = %d, want %d", len(decoded), len(wantSubtopics))
+	}
+	for i := range wantSubtopics {
+		if i < len(decoded) && decoded[i] != wantSubtopics[i] {
+			t.Errorf("subtopic[%d] = %q, want %q", i, decoded[i], wantSubtopics[i])
+		}
+	}
+
+	// Source attribution preserved.
+	if got, want := subtopicsTriple.Source, decideToolSource; got != want {
+		t.Errorf("source = %q, want %q", got, want)
+	}
+}
+
+// TestDecideExecutor_OmitsSubtopicsTripleWhenEmpty verifies back-compat:
+// a decide call without subtopics (action=done, retry, etc.) emits ONLY
+// the next_action + reason triples. The CoordinatorDecisionSubtopics
+// triple is opt-in via args.Subtopics being non-empty.
+func TestDecideExecutor_OmitsSubtopicsTripleWhenEmpty(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutor(pub)
+
+	_, _ = e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Arguments: map[string]any{
+			"action": "done",
+			"reason": "all subtasks complete",
+			// subtopics deliberately omitted
+		},
+	})
+
+	for _, tr := range pub.triples {
+		if tr.Predicate == agvocab.CoordinatorDecisionSubtopics {
+			t.Errorf("CoordinatorDecisionSubtopics triple should not emit when args.Subtopics is empty")
+		}
+	}
+}
+
+// tripPredicates is a tiny helper to format the predicate set from a
+// triple slice for assertion error messages.
+func tripPredicates(triples []message.Triple) []string {
+	out := make([]string, len(triples))
+	for i, tr := range triples {
+		out[i] = tr.Predicate
+	}
+	return out
 }

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"log/slog"
 
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/component"
+	gtypes "github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/processor/rule/expression"
 )
@@ -255,6 +257,40 @@ type Action struct {
 	// "$caller.id denied: insufficient role $caller.role" or
 	// "$caller.id approved for tool $message.tool_name").
 	Reason string `json:"reason,omitempty"`
+
+	// ForEach is a substitution-resolvable reference to a list-typed
+	// value the action iterates over. Each iteration binds the current
+	// item to the variable named in ForEachVar and re-runs the action's
+	// body with that overlay applied to all substituted strings
+	// (Prompt, Properties, related_loops values, Subject template).
+	// ADR-046 Phase 1; only publish_agent honours this today.
+	//
+	// Example shape: ForEach=`$entity.triple.coordinator.decision.subtopics`,
+	// ForEachVar=`subtopic`. When the trigger entity has that triple set
+	// to ["hydraulics", "pneumatics", "electrics"], the rule spawns
+	// three publish_agent dispatches with $subtopic bound to each value
+	// in turn. Iterations are independent by contract — no DependsOn
+	// edges in Phase 1 (gated-DAG dispatch is Phase 2). Each iteration
+	// is a non-blocking NATS publish; the agentic-loop's JetStream
+	// consumer parallelism gives N concurrent loop executions
+	// automatically.
+	//
+	// Empty/unset disables iteration (back-compat: existing rules with
+	// no ForEach fire exactly once, current behaviour).
+	//
+	// Resolution: the substitution layer extracts list-typed triple
+	// objects as []any; non-list resolution (string, missing triple)
+	// is logged and treated as a single-element list containing the
+	// resolved value so author errors surface loudly rather than
+	// silently no-op. Empty list resolves to zero iterations (no
+	// dispatch) — a valid degenerate case (decomposer found nothing).
+	ForEach string `json:"for_each,omitempty"`
+
+	// ForEachVar names the per-iteration substitution variable the
+	// resolved ForEach item binds to. Referenced as `$<name>` in any
+	// substituted string on the action body. Required when ForEach is
+	// set; ignored otherwise.
+	ForEachVar string `json:"for_each_var,omitempty"`
 }
 
 // ParseTTL parses the TTL string into a duration.
@@ -719,13 +755,15 @@ func (e *ActionExecutor) resolveToolNames(names []string) []agentic.ToolDefiniti
 
 // stampRelatedLoops writes the cross-arc loop-ID lineage map onto
 // the TaskMessage.Metadata under agentic.MetadataKeyRelatedLoops.
-// Each value goes through ec.SubstituteVariables so rule authors can
-// declare `"researcher": "$entity.triple.research_loop_id"` and the
-// resolved loop ID flows through. String-to-string by design — see
-// agentic.MetadataKeyRelatedLoops. Empty/nil RelatedLoops is a no-op
-// (back-compat: pre-existing flows that don't opt in see no
-// Metadata change).
-func stampRelatedLoops(task *agentic.TaskMessage, related map[string]string, ec *ExecutionContext) {
+// Each value goes through ec.SubstituteVariablesWithIterVar so rule
+// authors can declare `"researcher": "$entity.triple.research_loop_id"`
+// and the resolved loop ID flows through, with the for_each iter-var
+// (ADR-046 Phase 1) also bound when set so authors can thread the
+// current item into a related-loop label if a use case arises.
+// String-to-string by design — see agentic.MetadataKeyRelatedLoops.
+// Empty/nil RelatedLoops is a no-op (back-compat: pre-existing flows
+// that don't opt in see no Metadata change).
+func stampRelatedLoops(task *agentic.TaskMessage, related map[string]string, ec *ExecutionContext, iterVarName, iterVarValue string) {
 	if len(related) == 0 {
 		return
 	}
@@ -734,7 +772,7 @@ func stampRelatedLoops(task *agentic.TaskMessage, related map[string]string, ec 
 	}
 	resolved := make(map[string]any, len(related))
 	for label, loopID := range related {
-		resolved[label] = ec.SubstituteVariables(loopID)
+		resolved[label] = ec.SubstituteVariablesWithIterVar(loopID, iterVarName, iterVarValue)
 	}
 	task.Metadata[agentic.MetadataKeyRelatedLoops] = resolved
 }
@@ -754,11 +792,51 @@ func stampPerSpawnLLMKnobs(task *agentic.TaskMessage, action Action) {
 	}
 }
 
-// executePublishAgent executes a publish_agent action, triggering an agentic loop.
-// It publishes a TaskMessage to the specified NATS subject.
+// diagnoseForEachResolutionFailure returns a short human-readable
+// reason string describing why ResolveListValue returned ok=false on
+// the given reference. Three possibilities the resolver can fail on:
+// (a) reference uses a namespace Phase 1 doesn't support, (b) the
+// target entity is nil (message-path rule with no trigger entity),
+// (c) the predicate is missing from the entity at fire-time, or (d)
+// the Object exists but isn't list-shaped. Used in the for_each
+// non-list Warn so operators don't have to retrace the resolver to
+// figure out which sub-condition failed.
+func diagnoseForEachResolutionFailure(reference string, ec *ExecutionContext) string {
+	const entityPrefix = "$entity.triple."
+	const relatedPrefix = "$related.triple."
+	var entity *gtypes.EntityState
+	var predicate string
+	switch {
+	case strings.HasPrefix(reference, entityPrefix):
+		entity = ec.Entity
+		predicate = strings.TrimPrefix(reference, entityPrefix)
+	case strings.HasPrefix(reference, relatedPrefix):
+		entity = ec.Related
+		predicate = strings.TrimPrefix(reference, relatedPrefix)
+	default:
+		return "unsupported namespace (Phase 1 supports $entity.triple.* and $related.triple.* only)"
+	}
+	if entity == nil {
+		return "trigger entity is nil (message-path rule with no entity in scope?)"
+	}
+	for _, triple := range entity.Triples {
+		if triple.Predicate == predicate {
+			return fmt.Sprintf("predicate found but Object shape %T is not list-coercible", triple.Object)
+		}
+	}
+	return fmt.Sprintf("predicate %q not present on entity at fire time (typo or race with late triple arrival)", predicate)
+}
+
+// executePublishAgent executes a publish_agent action, triggering an
+// agentic loop. ADR-046 Phase 1: when action.ForEach is set, the body
+// runs once per resolved list item with $<ForEachVar> bound to the
+// current value. Otherwise it runs exactly once with no iter-var
+// overlay (current behaviour). Each iteration is a non-blocking NATS
+// publish; the agentic-loop's JetStream consumer gives N concurrent
+// loop executions for free.
 func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action, ec *ExecutionContext) error {
-	entityID := ec.EntityID
-	// Validate required fields
+	// Validate required fields up front, before any iteration —
+	// missing fields are an authoring error, not a per-item failure.
 	if action.Subject == "" {
 		return errors.New("subject is required for publish_agent action")
 	}
@@ -772,9 +850,71 @@ func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action,
 		return errors.New("prompt is required for publish_agent action")
 	}
 
-	// Substitute variables in subject and prompt
-	subject := ec.SubstituteVariables(action.Subject)
-	prompt := ec.SubstituteVariables(action.Prompt)
+	// ADR-046 Phase 1: for_each iteration. Resolve the list once,
+	// then dispatch one TaskMessage per item with the iter-var
+	// overlay bound. Empty list resolves to zero dispatches (a valid
+	// degenerate case: decomposer found nothing). Missing/invalid
+	// list reference logs at Warn and degenerates to a single
+	// dispatch with the iter-var unbound — author error stays loud
+	// (the unresolved-template warning trips on $<ForEachVar>
+	// references) rather than silently no-op.
+	if action.ForEach != "" {
+		if action.ForEachVar == "" {
+			return errors.New("for_each_var is required when for_each is set on publish_agent action")
+		}
+		items, ok := ec.ResolveListValue(action.ForEach)
+		if !ok {
+			if e.logger != nil {
+				// Diagnostic surface: which sub-condition failed so the
+				// operator doesn't have to retrace ResolveListValue's
+				// branches. Three possibilities — entity nil
+				// (message-path rule with no trigger entity), predicate
+				// missing (race with late triple arrival or typo), or
+				// Object shape wrong (scalar string where a list was
+				// expected). The for_each_resolution_failure_reason
+				// field lets dashboard grouping pivot on the cause.
+				e.logger.Warn("publish_agent for_each: list reference did not resolve to a list; degenerating to single dispatch with iter-var unbound",
+					"for_each", action.ForEach,
+					"for_each_var", action.ForEachVar,
+					"rule_id", ec.RuleID(),
+					"entity_id", ec.EntityID,
+					"for_each_resolution_failure_reason", diagnoseForEachResolutionFailure(action.ForEach, ec),
+					"hint", "verify the predicate name + that it carries a list-typed Object (decide stamps coordinator.decision.subtopics as a JSON-encoded []string)")
+			}
+			return e.publishAgentOnce(ctx, action, ec, "", "")
+		}
+		if len(items) == 0 {
+			if e.logger != nil {
+				e.logger.Info("publish_agent for_each: empty list — no dispatches",
+					"for_each", action.ForEach,
+					"rule_id", ec.RuleID(),
+					"entity_id", ec.EntityID)
+			}
+			return nil
+		}
+		for _, item := range items {
+			if err := e.publishAgentOnce(ctx, action, ec, action.ForEachVar, item); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	return e.publishAgentOnce(ctx, action, ec, "", "")
+}
+
+// publishAgentOnce is the per-iteration publish-agent body. Carries
+// the iter-var overlay (empty varName disables it — the non-for_each
+// path passes "" / ""). Extracted from executePublishAgent so the
+// for_each loop can call it N times without duplicating the publish
+// + state-stamp logic.
+func (e *ActionExecutor) publishAgentOnce(ctx context.Context, action Action, ec *ExecutionContext, iterVarName, iterVarValue string) error {
+	entityID := ec.EntityID
+
+	// Substitute variables in subject and prompt — iter-var overlay
+	// applies to all substituted strings on this iteration.
+	subject := ec.SubstituteVariablesWithIterVar(action.Subject, iterVarName, iterVarValue)
+	prompt := ec.SubstituteVariablesWithIterVar(action.Prompt, iterVarName, iterVarValue)
 
 	// Generate a unique task ID
 	taskID := fmt.Sprintf("rule-%s-%d", entityID, time.Now().UnixNano())
@@ -785,8 +925,8 @@ func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action,
 		Role:         action.Role,
 		Model:        action.Model,
 		Prompt:       prompt,
-		WorkflowSlug: ec.SubstituteVariables(action.WorkflowSlug),
-		WorkflowStep: ec.SubstituteVariables(action.WorkflowStep),
+		WorkflowSlug: ec.SubstituteVariablesWithIterVar(action.WorkflowSlug, iterVarName, iterVarValue),
+		WorkflowStep: ec.SubstituteVariablesWithIterVar(action.WorkflowStep, iterVarName, iterVarValue),
 	}
 
 	// Inherit ParentLoopID when the trigger entity is a loop execution. Without
@@ -842,7 +982,7 @@ func (e *ActionExecutor) executePublishAgent(ctx context.Context, action Action,
 
 	// Per-spawn cross-arc loop-ID lineage. Mirrors the ActionAllowlist
 	// Metadata stamping pattern. See stampRelatedLoops for the why.
-	stampRelatedLoops(&task, action.RelatedLoops, ec)
+	stampRelatedLoops(&task, action.RelatedLoops, ec, iterVarName, iterVarValue)
 
 	if e.logger != nil {
 		e.logger.Debug("Triggering agent task",

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -1296,6 +1296,167 @@ func TestAction_PublishAgent_EmptyToolChoice(t *testing.T) {
 	assert.Nil(t, task.ToolChoice, "ToolChoice should remain nil when action.ToolChoice unset")
 }
 
+// --- #134 / ADR-046 Phase 1: for_each iteration tests ---
+
+// TestAction_PublishAgent_ForEach_DispatchesPerItem verifies the core
+// fan-out contract: a publish_agent with for_each over a list-typed
+// triple dispatches one TaskMessage per item with $<for_each_var>
+// bound to the current value. Each TaskMessage carries the
+// substituted prompt + a distinct task ID.
+func TestAction_PublishAgent_ForEach_DispatchesPerItem(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	// Trigger entity carries the subtopics list as a JSON-encoded
+	// triple Object — the wire shape the decide tool emits.
+	ec := &ExecutionContext{
+		EntityID: "acme.ops.robot.gcs.coordinator.001",
+		Entity: &gtypes.EntityState{
+			Triples: []message.Triple{
+				{
+					Predicate: "coordinator.decision.subtopics",
+					Object:    `["hydraulics","pneumatics","electrics"]`,
+				},
+			},
+		},
+	}
+
+	action := Action{
+		Type:       ActionTypePublishAgent,
+		Subject:    "agent.task.investigator",
+		Role:       "researcher-investigate",
+		Model:      "mock-model",
+		Prompt:     "Investigate subtopic: $subtopic",
+		ForEach:    "$entity.triple.coordinator.decision.subtopics",
+		ForEachVar: "subtopic",
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, ec))
+	require.Len(t, mock.published, 3, "one TaskMessage per subtopic")
+
+	decoder := newActionsTestDecoder(t)
+	seen := make([]string, 0, 3)
+	for _, msg := range mock.published {
+		baseMsg, err := decoder.Decode(msg.data)
+		require.NoError(t, err)
+		task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+		require.True(t, ok)
+		seen = append(seen, task.Prompt)
+	}
+	assert.Equal(t, []string{
+		"Investigate subtopic: hydraulics",
+		"Investigate subtopic: pneumatics",
+		"Investigate subtopic: electrics",
+	}, seen, "prompt must reflect per-iteration substitution")
+}
+
+// TestAction_PublishAgent_ForEach_EmptyListNoDispatch verifies the
+// degenerate case: an empty list (decomposer found nothing) produces
+// zero dispatches and no error. Lets rule authors write
+// for_each-driven flows without special-casing the empty path.
+func TestAction_PublishAgent_ForEach_EmptyListNoDispatch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	ec := &ExecutionContext{
+		EntityID: "e.1",
+		Entity: &gtypes.EntityState{
+			Triples: []message.Triple{
+				{Predicate: "coordinator.decision.subtopics", Object: `[]`},
+			},
+		},
+	}
+
+	action := Action{
+		Type:       ActionTypePublishAgent,
+		Subject:    "agent.task.x",
+		Role:       "researcher",
+		Model:      "mock-model",
+		Prompt:     "p $subtopic",
+		ForEach:    "$entity.triple.coordinator.decision.subtopics",
+		ForEachVar: "subtopic",
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, ec))
+	assert.Empty(t, mock.published, "empty list should produce no dispatches")
+}
+
+// TestAction_PublishAgent_ForEach_MissingVarErrors verifies the
+// authoring guard: setting ForEach without ForEachVar is a hard
+// error (template substitution wouldn't have anything to bind to).
+func TestAction_PublishAgent_ForEach_MissingVarErrors(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.x",
+		Role:    "researcher",
+		Model:   "mock-model",
+		Prompt:  "p",
+		ForEach: "$entity.triple.subtopics",
+		// ForEachVar deliberately omitted
+	}
+
+	err := executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "for_each_var is required")
+}
+
+// TestAction_PublishAgent_ForEach_NonListDegeneratesToSingle verifies
+// that a ForEach reference pointing at a non-list (scalar string
+// predicate, missing triple) degenerates to a single dispatch with
+// the iter-var unbound. The unresolved $<varName> in the Prompt
+// surfaces via the standard unresolved-template warning — author
+// error stays loud, doesn't silently no-op.
+func TestAction_PublishAgent_ForEach_NonListDegeneratesToSingle(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	ec := &ExecutionContext{
+		EntityID: "e.1",
+		Entity: &gtypes.EntityState{
+			Triples: []message.Triple{
+				{Predicate: "agent.role", Object: "researcher"},
+			},
+		},
+	}
+
+	action := Action{
+		Type:       ActionTypePublishAgent,
+		Subject:    "agent.task.x",
+		Role:       "researcher",
+		Model:      "mock-model",
+		Prompt:     "investigate $x",            // intentionally references unbound iter-var
+		ForEach:    "$entity.triple.agent.role", // scalar, not list
+		ForEachVar: "x",
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, ec))
+	require.Len(t, mock.published, 1, "non-list reference degenerates to single dispatch")
+
+	// Verify the literal $<varName> token reached the dispatched
+	// prompt — that's the contract for "author error stays loud."
+	// Without an overlay binding, substitution leaves $x verbatim,
+	// the unresolved-template warning fires, and the operator sees
+	// the predicate-name typo (or whatever caused the non-list
+	// resolution) in the dispatched task body.
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+	assert.Equal(t, "investigate $x", task.Prompt,
+		"iter-var must remain unbound on degenerate path so the unresolved-template warning surfaces the author error")
+}
+
 // TestAction_PublishAgent_RelatedLoops verifies that
 // action.RelatedLoops threads onto TaskMessage.Metadata under
 // agentic.MetadataKeyRelatedLoops as a map[string]any (the JSON wire

--- a/processor/rule/execution_context.go
+++ b/processor/rule/execution_context.go
@@ -2,6 +2,7 @@
 package rule
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -125,6 +126,38 @@ func (ec *ExecutionContext) RuleID() string {
 // feed the result into an identifier (KV key, NATS subject) will then
 // get a loud failure instead of mysteriously wrong behaviour.
 func (ec *ExecutionContext) SubstituteVariables(template string) string {
+	return ec.substituteVariablesWith(template, nil)
+}
+
+// SubstituteVariablesWithIterVar runs substitution with an extra
+// single-variable overlay bound for the duration of the call. ADR-046
+// Phase 1: for_each iteration in publish_agent passes the current
+// item value as `varName`, which substitutes `$<varName>` in the
+// template. Other namespaces ($entity, $message, $state, etc.) resolve
+// as usual. Empty varName degenerates to SubstituteVariables — useful
+// for callers that conditionally bind a var.
+func (ec *ExecutionContext) SubstituteVariablesWithIterVar(template, varName, value string) string {
+	if varName == "" {
+		return ec.SubstituteVariables(template)
+	}
+	return ec.substituteVariablesWith(template, map[string]string{varName: value})
+}
+
+// substituteVariablesWith is the shared implementation under
+// SubstituteVariables and SubstituteVariablesWithIterVar. The overlay
+// map (nil when no iter-var is bound) carries names without the leading
+// `$` — substitution writes `$<name>` → value as a plain string-replace.
+// Overlay variables apply before the unresolved-template warning, so a
+// matched iter-var doesn't trip the warning even if the name doesn't
+// belong to a recognised framework namespace.
+//
+// Phase 1 (#134 / ADR-046) ships a single overlay key — the for_each
+// iter-var. Phase 2 (gated-DAG dispatch) may introduce multi-key
+// overlays (e.g. $item + $index); when it does, the iteration order
+// here becomes load-bearing for prefix-shadowing cases ($i vs $item
+// would collide). Phase 2 must either sort keys longest-first before
+// substitution or namespace its overlay keys to avoid the foot.
+func (ec *ExecutionContext) substituteVariablesWith(template string, overlay map[string]string) string {
 	result := template
 
 	// Time substitutions
@@ -169,9 +202,122 @@ func (ec *ExecutionContext) SubstituteVariables(template string) string {
 	// unresolved-template warning below.
 	result = applyMessageSubstitutions(result, ec.MessageData)
 
+	// Iter-var overlay (ADR-046 Phase 1 for_each). Applied last so an
+	// iter-var token like $subtopic resolves even if the operator
+	// accidentally chose a name that overlaps a framework namespace —
+	// last-write-wins is the predictable behaviour. Iter-vars are
+	// always present-or-absent (the for_each loop never binds nil);
+	// missing tokens behave the same as any other unresolved template
+	// variable and trip the warning below.
+	for name, value := range overlay {
+		result = strings.ReplaceAll(result, "$"+name, value)
+	}
+
 	ec.warnUnresolvedTemplateVars(template, result)
 
 	return result
+}
+
+// ResolveListValue extracts a list-typed value from a substitution
+// reference. ADR-046 Phase 1 for_each uses this — the rule author
+// writes `for_each: "$entity.triple.coordinator.decision.subtopics"`
+// and the framework needs the list shape preserved (not stringified
+// via fmt.Sprintf as SubstituteVariables would do).
+//
+// Supported reference shapes:
+//
+//   - "$entity.triple.<predicate>" — triple object on the trigger
+//     entity. The Object field is stored as `any`, so a list-shaped
+//     value (e.g. set by a tool that stamped []string) round-trips as
+//     []any after JSON unmarshal. JSON-encoded string lists (e.g.
+//     `"[\"a\",\"b\"]"`) are parsed transparently.
+//   - "$related.triple.<predicate>" — same on the related entity.
+//
+// Other namespaces ($message.*, $state.*, etc.) are not supported in
+// Phase 1 — the use case is decomposer-emitted subtopics on the
+// trigger entity. Adding namespaces is additive when needed.
+//
+// Returns (items, true) on successful list resolution. (nil, false)
+// when the reference resolved but the value isn't list-shaped (e.g.
+// the operator referenced a string predicate); the caller logs and
+// treats this as a single-iteration degenerate case so author errors
+// surface loudly rather than as a silent no-op. (nil, true) when the
+// reference resolved to an empty list — a valid no-iteration case.
+func (ec *ExecutionContext) ResolveListValue(reference string) ([]string, bool) {
+	if !strings.HasPrefix(reference, "$entity.triple.") && !strings.HasPrefix(reference, "$related.triple.") {
+		return nil, false
+	}
+	var entity *gtypes.EntityState
+	var predicate string
+	switch {
+	case strings.HasPrefix(reference, "$entity.triple."):
+		entity = ec.Entity
+		predicate = strings.TrimPrefix(reference, "$entity.triple.")
+	case strings.HasPrefix(reference, "$related.triple."):
+		entity = ec.Related
+		predicate = strings.TrimPrefix(reference, "$related.triple.")
+	}
+	if entity == nil {
+		return nil, false
+	}
+	for _, triple := range entity.Triples {
+		if triple.Predicate != predicate {
+			continue
+		}
+		return coerceTripleObjectToStrings(triple.Object)
+	}
+	return nil, false
+}
+
+// coerceTripleObjectToStrings extracts a []string from a triple's
+// Object field. Handles the three concrete shapes that round-trip
+// through JSON: native []any (typical after JSON unmarshal of a list),
+// []string (Go-constructed entity states in tests), and string-typed
+// JSON-encoded list (the wire shape if a tool stamps the list as a
+// JSON string for transport compactness — coordinator.decision.subtopics
+// uses this so the triple Object stays primitive-typed on the wire).
+// Returns (nil, false) on any other shape — the caller treats that as
+// "author referenced a non-list predicate" and logs.
+//
+// Non-string items in []any / parsed JSON lists are stringified via
+// fmt.Sprintf("%v", item) — intended use case is string lists (the
+// decide tool's []string subtopics, future similar emissions).
+// Numeric / bool lists work but cross a silent type boundary; if a
+// rule author iterates `[1, 2, 3]` they get `["1", "2", "3"]` bound to
+// the iter-var without warning. Acceptable for Phase 1 because no
+// production caller emits non-string lists today; revisit if that
+// changes.
+func coerceTripleObjectToStrings(obj any) ([]string, bool) {
+	switch v := obj.(type) {
+	case []string:
+		return v, true
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			out = append(out, fmt.Sprintf("%v", item))
+		}
+		return out, true
+	case string:
+		// JSON-encoded list fallback. Tools that stamp lists as a
+		// triple via the canonical wire path (json.Marshal of
+		// []string) produce this shape. Bail to "not a list" only on
+		// a parse failure; trim whitespace first so leading/trailing
+		// space doesn't fail the bracket-prefix sniff.
+		trimmed := strings.TrimSpace(v)
+		if !strings.HasPrefix(trimmed, "[") {
+			return nil, false
+		}
+		var parsed []any
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+			return nil, false
+		}
+		out := make([]string, 0, len(parsed))
+		for _, item := range parsed {
+			out = append(out, fmt.Sprintf("%v", item))
+		}
+		return out, true
+	}
+	return nil, false
 }
 
 // warnUnresolvedTemplateVars logs a warning when any $entity/$related/$state

--- a/processor/rule/for_each_substitution_test.go
+++ b/processor/rule/for_each_substitution_test.go
@@ -1,0 +1,168 @@
+package rule
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+)
+
+// TestSubstituteVariablesWithIterVar_BindsOverlay verifies the
+// per-iteration overlay (#134 / ADR-046 Phase 1). $<varName> in the
+// template resolves to the bound value; framework-namespace tokens
+// still resolve as usual. Empty varName degenerates to the standard
+// SubstituteVariables path.
+func TestSubstituteVariablesWithIterVar_BindsOverlay(t *testing.T) {
+	ec := &ExecutionContext{EntityID: "acme.ops.robot.gcs.drone.001"}
+
+	got := ec.SubstituteVariablesWithIterVar("subtopic=$subtopic for $entity.id", "subtopic", "hydraulics")
+	assert.Equal(t, "subtopic=hydraulics for acme.ops.robot.gcs.drone.001", got)
+}
+
+// TestSubstituteVariablesWithIterVar_EmptyVarNameDegenerates verifies
+// that calling with an empty varName behaves exactly like
+// SubstituteVariables (no overlay applied). Lets the for_each loop's
+// non-iter path share a single call site.
+func TestSubstituteVariablesWithIterVar_EmptyVarNameDegenerates(t *testing.T) {
+	ec := &ExecutionContext{EntityID: "acme.ops.robot.gcs.drone.001"}
+
+	got := ec.SubstituteVariablesWithIterVar("hello $entity.id", "", "ignored")
+	assert.Equal(t, "hello acme.ops.robot.gcs.drone.001", got)
+}
+
+// TestResolveListValue_TripleObjectShapes verifies the three concrete
+// triple-Object shapes the for_each resolver handles: native []string,
+// []any (typical JSON unmarshal shape), and JSON-encoded string. All
+// must produce the same []string output so authors don't have to
+// reason about how the list was stored upstream.
+func TestResolveListValue_TripleObjectShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		obj  any
+		want []string
+	}{
+		{
+			name: "native []string",
+			obj:  []string{"a", "b", "c"},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "[]any (JSON unmarshal shape)",
+			obj:  []any{"a", "b", "c"},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "JSON-encoded string (decide tool wire shape)",
+			obj:  `["a","b","c"]`,
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "JSON-encoded with whitespace",
+			obj:  `  ["a", "b", "c"]  `,
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "empty list still resolves",
+			obj:  []any{},
+			want: []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ec := &ExecutionContext{
+				Entity: &gtypes.EntityState{
+					Triples: []message.Triple{
+						{Predicate: "coordinator.decision.subtopics", Object: tc.obj, Timestamp: time.Now()},
+					},
+				},
+			}
+			got, ok := ec.ResolveListValue("$entity.triple.coordinator.decision.subtopics")
+			require.True(t, ok, "should resolve list")
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestResolveListValue_NonListReturnsFalse verifies that a reference
+// pointing at a scalar-typed triple Object resolves but returns
+// ok=false — the for_each caller logs and degenerates to a single
+// dispatch with the iter-var unbound (author-error-loud, not silent).
+func TestResolveListValue_NonListReturnsFalse(t *testing.T) {
+	ec := &ExecutionContext{
+		Entity: &gtypes.EntityState{
+			Triples: []message.Triple{
+				{Predicate: "agent.role", Object: "researcher", Timestamp: time.Now()},
+			},
+		},
+	}
+	got, ok := ec.ResolveListValue("$entity.triple.agent.role")
+	assert.False(t, ok, "scalar string should not resolve as list")
+	assert.Nil(t, got)
+}
+
+// TestResolveListValue_MissingPredicateReturnsFalse covers the case
+// where the operator referenced a predicate that doesn't exist on
+// the entity at fire time (race with late-arriving triples, typo, etc.).
+func TestResolveListValue_MissingPredicateReturnsFalse(t *testing.T) {
+	ec := &ExecutionContext{
+		Entity: &gtypes.EntityState{
+			Triples: []message.Triple{
+				{Predicate: "agent.role", Object: "researcher", Timestamp: time.Now()},
+			},
+		},
+	}
+	got, ok := ec.ResolveListValue("$entity.triple.nonexistent.predicate")
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+// TestResolveListValue_UnsupportedNamespaceReturnsFalse ensures Phase
+// 1's narrow surface — only $entity.triple.* and $related.triple.*
+// are supported list references. $message.* / $state.* deliberately
+// don't resolve as lists today.
+func TestResolveListValue_UnsupportedNamespaceReturnsFalse(t *testing.T) {
+	ec := &ExecutionContext{
+		MessageData: map[string]any{
+			"items": []any{"a", "b"},
+		},
+	}
+	got, ok := ec.ResolveListValue("$message.items")
+	assert.False(t, ok, "$message.* list refs not supported in Phase 1")
+	assert.Nil(t, got)
+}
+
+// TestResolveListValue_MalformedJSONReturnsFalse verifies that a
+// string-typed Object that LOOKS like a JSON list but doesn't parse
+// degenerates to ok=false. The author sees a Warn from the for_each
+// caller; doesn't silently iterate a garbled list.
+func TestResolveListValue_MalformedJSONReturnsFalse(t *testing.T) {
+	ec := &ExecutionContext{
+		Entity: &gtypes.EntityState{
+			Triples: []message.Triple{
+				{Predicate: "broken.list", Object: `["a", "b" "c]`, Timestamp: time.Now()},
+			},
+		},
+	}
+	got, ok := ec.ResolveListValue("$entity.triple.broken.list")
+	assert.False(t, ok, "malformed JSON should not resolve as list")
+	assert.Nil(t, got)
+}
+
+// TestCoerceTripleObjectToStrings_JSONRoundTrip closes the wire-path
+// contract: a list emitted as []string → JSON-marshaled → stored as a
+// string-typed triple Object → resolves back to the same []string.
+// Mirrors the decide tool's emission path verbatim.
+func TestCoerceTripleObjectToStrings_JSONRoundTrip(t *testing.T) {
+	original := []string{"hydraulics", "pneumatics", "electrics"}
+	encoded, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	got, ok := coerceTripleObjectToStrings(string(encoded))
+	require.True(t, ok)
+	assert.Equal(t, original, got)
+}

--- a/schemas/rule-processor.v1.json
+++ b/schemas/rule-processor.v1.json
@@ -69,6 +69,14 @@
                   "type": "object",
                   "description": "context_data"
                 },
+                "for_each": {
+                  "type": "string",
+                  "description": "for_each"
+                },
+                "for_each_var": {
+                  "type": "string",
+                  "description": "for_each_var"
+                },
                 "id": {
                   "type": "string",
                   "description": "id"
@@ -323,6 +331,14 @@
                   "type": "object",
                   "description": "context_data"
                 },
+                "for_each": {
+                  "type": "string",
+                  "description": "for_each"
+                },
+                "for_each_var": {
+                  "type": "string",
+                  "description": "for_each_var"
+                },
                 "id": {
                   "type": "string",
                   "description": "id"
@@ -495,6 +511,14 @@
                   "type": "object",
                   "description": "context_data"
                 },
+                "for_each": {
+                  "type": "string",
+                  "description": "for_each"
+                },
+                "for_each_var": {
+                  "type": "string",
+                  "description": "for_each_var"
+                },
                 "id": {
                   "type": "string",
                   "description": "id"
@@ -666,6 +690,14 @@
                 "context_data": {
                   "type": "object",
                   "description": "context_data"
+                },
+                "for_each": {
+                  "type": "string",
+                  "description": "for_each"
+                },
+                "for_each_var": {
+                  "type": "string",
+                  "description": "for_each_var"
                 },
                 "id": {
                   "type": "string",
@@ -857,6 +889,14 @@
                 "context_data": {
                   "type": "object",
                   "description": "context_data"
+                },
+                "for_each": {
+                  "type": "string",
+                  "description": "for_each"
+                },
+                "for_each_var": {
+                  "type": "string",
+                  "description": "for_each_var"
                 },
                 "id": {
                   "type": "string",

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -660,6 +660,21 @@ const (
 	// DataType: string
 	CoordinatorDecisionSAPCoerced = "coordinator.decision.sap_coerced"
 
+	// CoordinatorDecisionSubtopics carries the list of subtopics from a
+	// coordinator's fan-out decision as a JSON-encoded []string. ADR-046
+	// Phase 1 (#134). Emitted by the decide tool when args.Subtopics is
+	// non-empty so a downstream rule can iterate the list via
+	// `for_each: "$entity.triple.coordinator.decision.subtopics"`
+	// without the rule author having to read the loop's Result JSON
+	// out-of-band. The Object stays string-typed on the wire
+	// (JSON-encoded) so it round-trips through graph-ingest's per-triple
+	// validators which assume scalar Object types; the for_each
+	// substitution layer parses the JSON back into []string at
+	// resolution time.
+	// Example: `["hydraulics", "pneumatics", "electrics"]`
+	// DataType: string (JSON-encoded []string)
+	CoordinatorDecisionSubtopics = "coordinator.decision.subtopics"
+
 	// CoordinatorDecisionSynthetic is set to "true" when the framework
 	// synthesizes a decide on terminal-tool-less completion (#133). The
 	// model finished its loop with a text-only response — no `decide`


### PR DESCRIPTION
## Summary

Phase 1 of ADR-026 milestone 2 / GH #134. ADDITIVE declarative fan-out primitive for the no-deps subset; Phase 2 (gated-DAG dispatch lifted from semspec's scenario-orchestrator pattern) deferred behind operator validation + its own ADR amendment.

Closes the immediate SemTeams 4-subtopic wall-clock issue: coordinator decides fan_out → decide stamps subtopics triple → rule with `for_each` over `coordinator.decision.subtopics` spawns N investigators in parallel. **4T serial → 1T parallel.**

## What's in the bundle

### ADR-046 design doc (new)

`docs/adr/046-parallel-fan-out-and-gated-dag-dispatch.md`. Explicit Phase 1 (`for_each`) vs Phase 2 (`fan_out_gated`) split. References `semspec/processor/scenario-orchestrator/component.go` as Phase 2 prior art — stateless re-evaluation on completion, completion-watcher integration, DAG gating filter, bounded-concurrency semaphore, implicit join.

Two primitives, not one: `for_each` handles the no-deps subset (SemTeams's immediate need); `fan_out_gated` handles `depends_on` edges (when a future use case surfaces).

### Rule engine — `for_each` primitive

- `rule.Action` gains `ForEach string` + `ForEachVar string` fields
- `executePublishAgent` refactored into thin dispatcher + `publishAgentOnce` per-iteration body
- New `ExecutionContext.SubstituteVariablesWithIterVar(template, varName, value)` + shared `substituteVariablesWith(template, overlay)` implementation
- New `ResolveListValue` + `coerceTripleObjectToStrings` handle three triple-Object shapes that round-trip through JSON: native `[]string`, `[]any` (JSON unmarshal output), and string-typed JSON-encoded list (decide's chosen wire shape; keeps Object scalar-typed for graph-ingest's per-triple validators)
- Non-list reference degenerates to a single dispatch with iter-var unbound — the unresolved-template warning trips on the still-literal `$<varName>` so author errors stay loud
- `diagnoseForEachResolutionFailure` adds a structured "why" to the Warn (entity nil / predicate missing / Object shape wrong / namespace unsupported)
- `stampRelatedLoops` signature extended with iter-var args so `RelatedLoops` values substitute too

### Decide tool — subtopics-triple emission

- New `CoordinatorDecisionSubtopics` predicate in `vocabulary/agentic`
- `decide` stamps `coordinator.decision.subtopics` as a JSON-encoded `[]string` triple when `args.Subtopics` is non-empty, alongside `next_action` + `reason`. Atomic `AddTriplesBatch` path preserved. Marshal-error fallback logs but doesn't drop canonical triples.

## go-reviewer pass

Reviewer verdict: **Ship.** No blockers. Four nits all landed in PR:

1. `coerceTripleObjectToStrings` docstring: non-string item stringification documented
2. `substituteVariablesWith` docstring: single-overlay-key Phase 1 contract documented; Phase 2 multi-key foot warned
3. Warn hint enriched with `for_each_resolution_failure_reason` field via `diagnoseForEachResolutionFailure`
4. Non-list-degenerate test asserts literal `$x` reaches dispatched prompt

Reviewer also flagged the wire round-trip concern (decide's JSON-encoded string → graph-ingest re-marshal → for_each resolver) and verified it through the persistence path. Contract holds.

## Phase 1 constraints (all explicit in the ADR)

- `for_each` works only on `publish_agent` (only action with the use case today)
- No `depends_on` between iterations — pure broadcast
- No bounded concurrency at the dispatch layer (each iteration is a non-blocking NATS publish; JetStream consumer parallelism does the rest)
- No framework-side join. Coordinator-as-counter pattern handles join rule-side.

Forward-compat with Phase 2: rule packs that adopt `for_each` for no-deps flows don't need to migrate when `fan_out_gated` arrives.

## Pre-tag sweep

- ✅ `task lint` clean
- ✅ `go test -race ./...` unit sweep all green
- ✅ `go test -race -tags=integration ./...` clean on rerun (3 testcontainers Docker-sweep flakes all pass individually — documented class)
- ✅ **`task e2e:agentic`** clean (reviewer-recommended gate — new orchestration primitive worth e2e validation of the spawn→fan-out→graph→recovery path)
- ✅ `go vet -tags=integration` / `-tags=live_llm` clean
- ✅ `task schema:generate` — `for_each` + `for_each_var` surface on all five publish_agent variants

## Sister-project impact

- **semteams**: pin to beta.82 to use `for_each` on the 4-subtopic deep-research case. Rule shape:
  ```json
  {
    "type": "publish_agent",
    "for_each": "$entity.triple.coordinator.decision.subtopics",
    "for_each_var": "subtopic",
    "role": "researcher-investigate",
    "prompt": "Investigate: $subtopic"
  }
  ```
- **semconnect**: no direct impact.

## Test plan

- [ ] CI lint + test
- [ ] CI build (cross-compile linux)
- [ ] Confirm semteams can pin to the resulting tag and validate 4-subtopic deep-research runs in ~1T wall-clock (vs 4T serial today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)