### PR TITLE
docs(adr): cross-link ADR-026 milestone 2 to ADR-046

### DIFF
--- a/docs/adr/026-coordinator-agent-dynamic-flow-composition.md
+++ b/docs/adr/026-coordinator-agent-dynamic-flow-composition.md
@@ -16,6 +16,13 @@ broader than dynamic flow composition: it is the **judgment role** in
 the three-layer orchestration architecture (ADR-028). Dynamic flow
 composition is one of its capabilities, not its definition.
 
+**Milestone 2 (parallel flow composition) split into its own ADR
+2026-05-23**: see [ADR-046](046-parallel-fan-out-and-gated-dag-dispatch.md)
+for the two-phase plan. Phase 1 (`for_each` declarative iteration)
+shipped in v1.0.0-beta.82; Phase 2 (`fan_out_gated` lifted from
+semspec's scenario-orchestrator pattern) tracked at GH #139. Future
+references to "ADR-026 milestone 2" should point at ADR-046.
+
 ## Role within the three-layer orchestration architecture
 
 Semstreams commits to rule skeleton + coordinator agent + ops agent (ADR-028). The coordinator is **Layer 3 — Judgment**. Its purpose:


### PR DESCRIPTION
## Summary

One-paragraph addition to ADR-026's status block pointing at [ADR-046](https://github.com/C360Studio/semstreams/blob/main/docs/adr/046-parallel-fan-out-and-gated-dag-dispatch.md) as the canonical milestone-2 spec. Phase 1 shipped beta.82 (closes #134); Phase 2 tracked at #139.

Pure docs — no code change.

## Test plan
- [ ] CI Schema Validation (passive)
- [ ] CI Lint (passive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)