### PR TITLE
docs: workflow primitives design exercise + phased agentic chains concept

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,7 +206,7 @@ Two layers: **Rule Engine** (conditions + actions + iteration caps) and **Compon
 
 **Engine gaps file as engine work, not app-side state plumbing.** semspec's 7,264 LOC of `workflow/reactive/` (the "semspec trap") is the cautionary tale — app-side state machines around rule-engine limitations become migration blockers the framework can't help dig out of. If a pattern needs a primitive the rule engine doesn't have, propose adding it; don't carve out a parallel path.
 
-Use `/orchestration-check` for the decision framework. See [Orchestration Layers — How We Do Workflows in semstreams](docs/concepts/14-orchestration-layers.md) for the full pattern catalog.
+Use `/orchestration-check` for the decision framework. See [Orchestration Layers — How We Do Workflows in semstreams](docs/concepts/14-orchestration-layers.md) for the full pattern catalog. For multi-step agentic workflows specifically (rule chains spawning agent phases), see [Phased Agentic Chains](docs/concepts/25-phased-agentic-chains.md) — the application of these discipline patterns to the agentic-loop substrate, with the substrate-vs-capability-vs-application split and the inventory of framework primitives that support it.
 
 ### Rules don't carry payloads
 

--- a/docs/concepts/25-phased-agentic-chains.md
+++ b/docs/concepts/25-phased-agentic-chains.md
@@ -1,0 +1,292 @@
+# Phased Agentic Chains
+
+The framework pattern for composing N agent phases connected by rules
+firing on decision triples. Each phase is a role with a persona + tool
+palette + action_allowlist + iteration cap. Within a phase, the LLM
+composes work through tool selection (implicit router). Between
+phases, rules dispatch on decision triples stamped by the previous
+phase (explicit router).
+
+semstreams ships the substrate. Apps compose phases into specific
+chains. The first reference instance is ADR-045's R0-R6 graph-research
+chain (internal graph state); the second is the semteams gatherer
+chain (external composition via `bash` + sandbox container).
+
+If you're building a multi-step agentic workflow on semstreams, **read
+this first**. Most of the primitives you need already ship; the gaps
+that remain are scoped and tracked.
+
+> **Note 2026-05-24**: a broader framework question is in active design
+> review — whether semstreams should grow workflow primitives as a
+> first-class layer (named workflow instances, lifecycle tracking,
+> versioning, introspection) on top of the rules engine. See
+> [`docs/proposals/workflow-primitives-design-exercise.md`](../proposals/workflow-primitives-design-exercise.md).
+> This concept doc remains accurate for sequential agentic chains
+> regardless of that exercise's outcome; if workflow primitives ship,
+> the phased-agentic-chain pattern becomes one workflow shape within
+> a broader workflow-primitives picture.
+
+## Why this pattern exists
+
+Sub-frontier models collapse on multi-turn structured tool calling.
+The Berkeley Function Calling Leaderboard documents the failure
+shape: single-turn accuracy 77.5%, multi-turn 14.8–68%. Asking one
+agent to juggle a five-step workflow in a single context window
+fights the empirical floor of the models that most operators can
+afford to run.
+
+The framework's response is to encode multi-step orchestration as
+**deterministic rule transitions between LLM-judgment phases**
+rather than as a single agent juggling all state in its context
+window. Each phase is focused — small tool palette, narrow persona,
+constrained terminal vocabulary, bounded iteration. Between phases,
+the rule engine handles transitions deterministically. The LLM
+doesn't have to maintain state across phase boundaries; the graph
+carries it.
+
+This is the application of the [Two Layers](14-orchestration-layers.md)
+discipline (rules orchestrate, components execute) to specifically
+agentic workflows.
+
+## Composition
+
+```text
+Phase     = (role, persona, tool_palette, action_allowlist, max_iter)
+Transition = Rule(match: prev_role + decision_triple) → publish_agent(next_phase)
+Chain     = ordered sequence of phases joined by transitions
+```
+
+A chain's vocabulary lives in its rule pack. Categories don't leak to
+the coordinator above (the coordinator knows only category names like
+`research` / `respond_direct`); phases don't leak to the components
+within (a component knows only its inputs and outputs). This layered
+encapsulation is what lets a chain evolve its internal phase graph
+without touching upstream or downstream callers.
+
+## Two-layer dispatch
+
+Every phased agentic chain has two routing layers:
+
+| Layer | Form | Where it lives | Who routes |
+|---|---|---|---|
+| **Phase transitions** | Explicit, structural | Rules pattern-matching on `(prev_role, decision_triple)` | Rule engine |
+| **Within-phase tool use** | Implicit, model-judgment | LLM picks tools from the phase's allowlist, guided by persona prose | The agent in the phase |
+
+The two compose: the LLM dispatches tool calls within the phase until
+it emits `decide(action="...")`, which stamps a triple the rule engine
+picks up to fire the next transition. Phase transitions are
+deterministic and auditable; tool composition is flexible and
+model-driven. This is the same shape as Anthropic skills or any
+multi-step agentic framework, but with the orchestration layer made
+first-class via rules instead of hidden inside a model-driven runtime.
+
+## Graph triples as routing wire
+
+Decision triples on the loop entity are the dispatcher's wire format.
+There is no message-passing layer, no event bus. `decide(action="X")`
+inside a phase stamps `coordinator.decision.next_action="X"` on the
+loop entity; a transition rule matches the triple and fires the next
+`publish_agent`. The mechanics are the same as any other rule firing
+on KV state — the [KV Twofer](02-kv-twofer.md) carries it.
+
+This makes the entire chain:
+
+- **Observable**: every transition is a graph state change
+- **Replayable**: trajectory + rule firings can be reconstructed
+- **Audit-friendly**: who decided what, when, with what reason
+- **Tool-callable**: other agents (or operators) can read chain state via the same graph queries everything else uses
+
+## What semstreams ships (primitive inventory)
+
+For *any* phased agentic chain to be implementable without reinventing
+framework primitives:
+
+| Primitive | Status | Location |
+|---|---|---|
+| Rule engine with predicate matching | ✅ shipped | `processor/rule/` |
+| `publish_agent` rule action | ✅ shipped | `processor/rule/actions.go:118` |
+| `action_allowlist` on rule action | ✅ shipped | `processor/rule/actions.go:118` |
+| `MaxIterations` per-action | ✅ shipped | rule action level |
+| agentic-loop with `decide()` tool | ✅ shipped | `processor/agentic-loop/`, `processor/agentic-tools/decide.go` |
+| `action_allowlist` enforcement + SAP coercion | ✅ shipped | `processor/agentic-tools/decide.go:399` |
+| SAP coercion metric (`action_allowlist_sap_coerced_total`) | ✅ shipped | drift telemetry |
+| Persona system with cross-role namespacing | ✅ shipped | beta.78 file-loader fix |
+| Per-role tool filtering | ✅ shipped | ADR-039 governance |
+| Trajectory manager | ✅ shipped | KV-backed |
+| Loop lineage (`loop_id`, parent chain) | ✅ shipped | message metadata |
+| `read_loop_result` tool | ✅ shipped | inter-phase data passing |
+| `BashExecutor` (local + sandbox) | ✅ shipped | `processor/agentic-tools/executors/bash.go` |
+| Sandbox client | ✅ shipped | `processor/agentic-tools/sandbox/` |
+| Chain-scoped worktree on `BashExecutor` | 🟡 gap | tracked, see issues |
+| Always-warm sandbox documented as default | 🟡 gap | tracked, see issues |
+| Preview-first output for large `bash` fetches | 🟡 gap | tracked, see issues |
+| URL allowlist + egress rate ceilings | 🟡 gap | tracked, see issues |
+| Per-chain URL response cache | 🟡 gap | tracked, see issues |
+| Trajectory enrichment for URL fetches | 🟡 gap | tracked, see issues |
+
+For graph-internal chains (the R0-R6 class), that's the whole list —
+everything an app needs to build a phased agentic chain over internal
+graph state already ships. The gaps are entirely on the
+external-composition axis (the gatherer class).
+
+## Substrate / capability / application split
+
+semstreams serves multiple applications (semteams as a multi-agent
+research application; semconnect as an OGC Connected Systems API
+server; future apps as they appear). Not every app needs every part
+of the framework. The split that lets one substrate serve N apps
+cleanly:
+
+| Layer | What lives here | Example |
+|---|---|---|
+| **Substrate** (semstreams core) | Primitives every consumer uses or might use. The inventory above. | Rule engine, agentic-loop, `BashExecutor` |
+| **Capability** (semstreams package or sister) | Opt-in bundles for a class of apps. Reusable Go components + reference rule shapes. | The R0-R6 components (`nl_classify`, `route_search`, etc.) as reusable primitives any agentic-reasoning app can compose |
+| **Application** (semteams, semconnect, etc.) | Specific phase configuration — rule packs, persona prose, action_allowlist values, tool palette choices, the chain's actual wiring | Semteams's research chain rule pack; semconnect's CS API endpoint configs |
+
+**Substrate ships in semstreams core.** Capabilities ship as
+semstreams packages or sister repos. Applications wire substrate +
+selected capabilities into specific chains.
+
+The boundary is not "config vs code." Even some config
+(deployment recipes, reference compose files, example chain shapes)
+lives in framework because it documents how to use framework
+primitives. The boundary is **reusability across consumers**: if every
+consumer might want it, substrate; if a class of consumers wants it,
+capability; if one specific app wants it, application.
+
+## Reference instance 1: R0-R6 graph-research chain (internal)
+
+Internal-only chain — operates entirely on local graph state. See
+[ADR-045](../adr/045-graph-search-subloop.md) for the full design and
+`docs/operations/22-adr045-phase1-plan.md` for the implementation
+plan.
+
+Phase shape:
+
+```text
+classify → route → execute → assess → synthesize
+```
+
+- **`nl_classify`** — intent → routing-category triple
+- **`route_search`** — picks search strategy → triple
+- **`execute_subqueries`** — runs queries → result triples
+- **`assess_sufficiency`** — done? → triple
+- **`synthesize_answer`** — produces output → terminal triple
+
+Each component is an LLM-judgment step writing a triple the next
+transition rule matches on. The five components ARE substrate
+primitives (reusable across any agentic-reasoning app); the rule pack
+wiring them in this specific sequence is a reference instance, not
+canonical config for every consumer. Apps with different intent
+spaces or different sufficiency criteria compose the same components
+into different chains.
+
+## Reference instance 2: semteams gatherer chain (external)
+
+External-composition chain — the gatherer phase reaches out to the
+web via `web_search` (structured) and `bash` + `curl` (sandboxed).
+See `project_semteams_gatherer_sandbox_case_study` (in agent memory)
+for the production write-up.
+
+Phase shape:
+
+```text
+coordinator → plan → gather → synthesize
+```
+
+The gatherer phase has a mixed tool palette: a structured-tool
+(`web_search`) and a sandbox escape (`bash`). The model picks per
+step based on persona-prose decision criteria; the persona teaches
+the routing heuristic ("when a snippet points at a URL but the
+snippet itself isn't the evidence, use bash"). 13 bash + 11
+web_search calls interleave in one production trajectory on
+gemini-2.5-flash — the compositional pattern that snippet-only
+tooling can't reach.
+
+The chain pattern is identical to R0-R6. The phase shapes differ:
+R0-R6's phases are single-tool LLM-judgment steps; the gatherer
+phase is a mixed-tool composition step. Both fit the pattern.
+
+## Discipline for designing phases
+
+Two memorialized disciplines apply to every phase design:
+
+- **[Tool signatures ask for intent, not structure](#)** (memory:
+  `feedback_tool_signature_intent_not_structure`). Tools require only
+  fields where model judgment is the value-add; backend derives IDs,
+  envelopes, timestamps, defaults from intent. The model writes what
+  it knows; the executor builds the wire format.
+- **[Tool-selection persona prose needs decision criteria](#)**
+  (memory: `feedback_persona_prose_needs_decision_criteria`). Every
+  tool sentence in agent prose must carry a "when to use this"
+  criterion; sentences without criteria get ignored or backfire on
+  small models. Per-tool purpose framing, decision-axis framing,
+  concrete examples of non-obvious idioms, anti-ceremony nudges,
+  negative-shape definitions of punt actions.
+
+These two disciplines together — backend handles structure, persona
+teaches when — are what make phase design tractable for sub-frontier
+models. Tool surface + decision criteria + action_allowlist +
+iteration cap define a phase the model can execute reliably.
+
+## When to use this pattern
+
+Use a phased agentic chain when:
+
+- The workflow has 3+ distinct steps each requiring LLM judgment
+- The steps have a deterministic order (or branching that fits a small DAG)
+- Each step has a focused output that the next step can pattern-match on
+- Audit / replay / governance matter
+
+Use a single-phase agent (just an agentic-loop with a rich tool
+palette) when:
+
+- The workflow is exploratory / open-ended
+- Step order is genuinely model-discovered, not author-specified
+- Composition is more important than sequencing
+
+Use a rule-only chain (no agents at all, just components) when:
+
+- No step requires LLM judgment
+- Everything can be expressed as deterministic component invocations on graph state changes
+- See [Orchestration Layers](14-orchestration-layers.md) §Pattern Catalog
+
+## Anti-patterns
+
+- **`shell_exec` or `run_tool` as a global registry-level escape
+  hatch.** Loses the composition benefit (one model turn per command =
+  the multi-turn collapse failure mode) AND bypasses per-phase
+  governance. Sandbox tools live in specific phase palettes, not the
+  global registry.
+- **Magic-number thresholds in persona prose** ("after 5 web_searches
+  use bash"). Models literally count and bail at the threshold even
+  with thin evidence. Goodhart on iter count. The router rule lives
+  in the *condition shape* ("when a snippet points at a URL but the
+  snippet itself doesn't have the evidence"), not a counter.
+- **Cross-phase summaries in role prose** ("and synthesize will reject
+  if you don't gather X"). Lateral coupling between phases. The
+  dispatcher rule is the right place for cross-phase contracts, not
+  persona prose. See `feedback_persona_prose_needs_decision_criteria`.
+- **Front-loading "how this loop ends" framing** as a structural
+  prelude before the workflow. Empirically reduces work output —
+  phases do less work and bail faster when given an end-state
+  preamble. Counter-intuitive but reproducible.
+- **App-side state machines around rule-engine gaps.** If the chain
+  pattern needs a primitive the rule engine doesn't have, file it as
+  engine work. Don't build app-side state plumbing — see [the semspec
+  trap](14-orchestration-layers.md#the-semspec-trap).
+- **Shipping a chain in semstreams that only one consumer uses.**
+  Specific chain configurations are application concerns. Components
+  generalize; chains don't. If exactly one app wants the chain, the
+  chain belongs in that app; semstreams ships the components it
+  composes.
+
+## See also
+
+- [ADR-028: Orchestration Architecture](../adr/028-orchestration-architecture.md) — the rule-skeleton + coordinator + ops architecture this pattern instantiates
+- [ADR-039: Tool-Call Governance via Rules](../adr/039-rule-driven-tool-governance.md) — the per-role tool-allowlist primitive
+- [ADR-041: Unified Evaluator + Role Compression](../adr/041-unified-evaluator.md) — the `when`-clause guard mechanism used in transition rules
+- [ADR-045: Graph Search Subloop](../adr/045-graph-search-subloop.md) — the first reference instance (R0-R6)
+- [Concepts: Orchestration Layers](14-orchestration-layers.md) — rules vs components vs workflow, the foundational discipline
+- [Concepts: KV Twofer](02-kv-twofer.md) — the wire-format substrate that makes graph-triple routing work
+- [Concepts: Tool-Result Hints and Pagination](24-tool-result-hints-and-pagination.md) — the structured-signaling pattern for tool results that compose with the persona-prose decision-criteria discipline

--- a/docs/operations/22-adr045-phase1-plan.md
+++ b/docs/operations/22-adr045-phase1-plan.md
@@ -18,8 +18,60 @@ green Phase 1 reference flow.
 2. [docs/concepts/14](../concepts/14-orchestration-layers.md) — the
    canonical "How we do workflows in semstreams" pattern catalog this
    plan instantiates.
-3. This doc — the PR sequence and per-PR checklist.
-4. Per-PR design notes (filed as PR description) as each ships.
+3. [docs/concepts/25](../concepts/25-phased-agentic-chains.md) — the
+   phased-agentic-chain pattern this plan is the first reference
+   instance of. Substrate-vs-capability-vs-application split, the
+   primitive inventory, two-layer dispatch, and the discipline
+   memories that apply to every phase design.
+4. This doc — the PR sequence and per-PR checklist.
+5. Per-PR design notes (filed as PR description) as each ships.
+
+## Amendment 2026-05-23 (discipline application from concept doc 25)
+
+After `docs/concepts/25-phased-agentic-chains.md` and the two new
+discipline memories (`feedback_tool_signature_intent_not_structure`,
+`feedback_persona_prose_needs_decision_criteria`) shipped, the plan
+gets the following revisions before PR 3+ continues. These are
+Phase-1-implementation disciplines, independent of the broader
+workflow-primitives design exercise (`docs/proposals/workflow-primitives-design-exercise.md`)
+that gates ADR-046 Phase 2 + #151 — Phase 1 PRs 3-6 are unaffected by
+that exercise.
+
+- **PR 3 `route_decision.args` reshaped** per intent-not-structure
+  discipline. Specifically: `decompose` no longer asks the model for
+  typed sub-query objects (entity_state / predicate_walk / temporal /
+  spatial); model emits decomposition *intent* (axes, focus, scope),
+  backend constructs typed sub-queries. `walk_seeds` no longer asks
+  for full 6-part entity IDs (model can't spell them reliably); model
+  emits seed references (names, partial IDs, or indices into the
+  classifier output candidate set), backend resolves to full IDs via
+  the entity index. Wire-format change; must land before PR 3 ships
+  to avoid schema migration later. See revised PR 3 deliverables
+  below.
+- **PR 3 persona prose** for `route_search` follows
+  `feedback_persona_prose_needs_decision_criteria` — per-action
+  purpose framing, decision-axis framing (no magic-number
+  thresholds), concrete examples for non-obvious choice points
+  (decompose vs walk_seeds vs retighten can look similar from
+  classifier-output shape alone), anti-ceremony nudges, negative-shape
+  definition for `synthesize_directly`. The PR description walks
+  through which sentence carries which pattern.
+- **PR 3 (and PR 5) `action_allowlist`** on each `publish_agent`
+  constrains the spawned role's terminal vocabulary. SAP coercion
+  metric (`action_allowlist_sap_coerced_total`) is the drift
+  telemetry that should inform prompt iteration post-merge.
+- **PR 6 reference flow positioning** — `configs/flows/research-graph-pipeline.yaml`
+  is a *reference example* showing how to compose the five components,
+  not canonical config every operator must enable. Components ship as
+  substrate; chain wiring is application-shaped. Either move under
+  `configs/examples/` or doc-comment the file accordingly. The
+  components themselves remain canonical semstreams primitives.
+- **Phase-2 cleanup candidate**: PR 1 shipped `budget_tokens` and
+  `max_iterations` on the agent-facing `research_graph` tool. These
+  are operator policy (role-default config), not agent intent. Agent
+  doesn't know what budget to set. Backend should override with
+  role-config and ignore agent-emitted values. Schema migration in
+  Phase 2 removes them from the agent-facing tool.
 
 ## Scope
 
@@ -230,12 +282,49 @@ the chain's "not just a better classifier" argument.
     (candidates with entities, scores, snippets)
   - Output: route_decision (action ∈ enum + args + rationale)
   - Structured-emit mode per ADR-035 strict tool calling
-- **Action arg schemas** per action:
+- **Action arg schemas** per action (revised per `feedback_tool_signature_intent_not_structure`):
   - `synthesize_directly`: no args (use classifier output as evidence)
-  - `retighten`: refined topic / hint adjustments
-  - `walk_seeds`: list of seed entity IDs to expand
-  - `decompose`: list of typed sub-queries (entity_state /
-    predicate_walk / temporal_range / spatial_polygon)
+  - `retighten`: refined topic / hint adjustments — same shape as
+    the original `research_intent.hints` map; model expresses what to
+    tighten, backend re-runs `nl_classify` with merged hints
+  - `walk_seeds`: list of **seed references** (candidate-set indices
+    OR partial entity names) — model picks seeds from the candidates
+    the classifier surfaced, backend resolves to full 6-part entity
+    IDs via the entity index. Model must NOT be asked to emit full
+    `org.platform.domain.system.type.instance` strings; small models
+    can't spell them reliably and shouldn't have to
+  - `decompose`: **decomposition intent** — `{axes: []string, focus:
+    string, scope?: {temporal?, spatial?}}`. Model emits the
+    *direction* of the decomposition (e.g., axes=["component",
+    "failure_mode"], focus="hover anomalies", scope={temporal:
+    "last_24h"}); `execute_subqueries` constructs the typed sub-query
+    list (entity_state / predicate_walk / temporal_range /
+    spatial_polygon) deterministically from the intent. This keeps
+    the typed-sub-query schema as a backend contract, not an
+    agent-facing schema the model must reproduce correctly under
+    strict-mode validation.
+
+- **Persona prose discipline** per `feedback_persona_prose_needs_decision_criteria`:
+  - Per-action purpose framing (one-liner per routing action before
+    procedure)
+  - Decision-axis framing for choice points ("when the classifier
+    surfaced N+ high-confidence candidates and the topic is one of
+    them" beats "when classifier_top_score > 0.8")
+  - Concrete examples for the non-obvious choice points (decompose vs
+    walk_seeds vs retighten can look similar from classifier-output
+    shape alone — show one example per)
+  - Anti-ceremony nudge if any action skews "tool of last resort"
+    (likely `decompose` — model defaults to it as the "safe
+    expensive" choice; if `walk_seeds` is the right cheaper option,
+    say so explicitly)
+  - Negative-shape definition for `synthesize_directly` (when NOT to
+    short-circuit — "if the candidates don't cover the topic's named
+    actors, even a clean top-score isn't sufficient")
+- **`action_allowlist`** on the `publish_agent` rule action spawning
+  `route_search`: the four routing actions plus any agreed-on punt
+  action. SAP coercion metric (`action_allowlist_sap_coerced_total`)
+  is the drift telemetry — if it rises post-merge, persona prompt is
+  drifting; iterate the prompt, not the cap.
 - **Governance integration** per ADR-039: the LLM call goes through
   the same rule-driven governance layer as any other agent LLM call.
 - **`route_decision`** authored predicates default to
@@ -419,8 +508,20 @@ tested.
 ### Deliverables
 
 - **`configs/flows/research-graph-pipeline.yaml`** reference flow:
+  - **Positioning** (per concept doc 25 + substrate-vs-app split): this
+    file is a *reference example* showing how the five components
+    compose into a phased agentic chain, not canonical config every
+    operator must enable. The five components are framework
+    substrate; this specific chain wiring is application-shaped.
+    Document this in the file's header doc-comment so future readers
+    don't treat the chain config as canonical. Consider relocating
+    under `configs/examples/` once that convention exists.
   - All five components instantiated.
   - All seven rules (R0–R6 plus the continuation rule R-cont).
+  - Each `publish_agent` rule action declares `action_allowlist`
+    constraining the spawned role's terminal vocabulary (per concept
+    doc 25 + the semteams gatherer-chain pattern). SAP coercion
+    metric monitored as drift telemetry.
   - `entity_watch_buckets` config for AGENT_LOOPS patterns.
   - Per-action `MaxIterations`: 2 on R2's retighten branch, 5 on
     R4's refine branch.
@@ -611,3 +712,16 @@ operator signal.
 - Memory: `feedback_e2e_required_for_breaking_changes`
 - Memory: `feedback_per_loop_vs_per_role_safety`
 - Memory: `feedback_frontier_floor_changes_role_split_calculus`
+- Memory: `feedback_tool_signature_intent_not_structure` — the
+  discipline driving the PR 3 `route_decision.args` revision (and the
+  PR 1 Phase-2 cleanup candidate for `budget_tokens` / `max_iterations`)
+- Memory: `feedback_persona_prose_needs_decision_criteria` — the
+  discipline driving PR 3's `route_search` prompt design
+- [docs/concepts/25-phased-agentic-chains.md](../concepts/25-phased-agentic-chains.md)
+  — the pattern doc this plan is the first reference instance of;
+  also home of the substrate-vs-capability-vs-application split that
+  motivates the PR 6 reference-flow positioning
+- [docs/proposals/workflow-primitives-design-exercise.md](../proposals/workflow-primitives-design-exercise.md)
+  — the broader workflow-primitives-vs-not framework question that
+  gates ADR-046 Phase 2 + #151. ADR-045 Phase 1 PRs 3-6 are
+  unaffected by that exercise.

--- a/docs/proposals/workflow-primitives-design-exercise.md
+++ b/docs/proposals/workflow-primitives-design-exercise.md
@@ -1,0 +1,266 @@
+# Workflow Primitives Design Exercise
+
+**Status**: Proposed — 2026-05-24. Pre-ADR. Resolution gates resumption of ADR-046 Phase 2, GH #151, and any new rule-engine primitive work for fan-out / parallel / lifecycle patterns.
+
+**Supersedes** the rules-engine-primitive-mapping framing in `project_rules_engine_design_review` memory (the original pause-point analysis). That memo correctly diagnosed the five-tag pile (beta.80–beta.84) and identified the design-review pause point. This proposal broadens the question: workflow primitives should be considered as a deliberate framework concern rather than ruled out by dogma.
+
+## Summary
+
+For the past week, the framework has been adding workflow-engine primitives to the rules engine (for_each, .length, array operators, condition.Value resolution, Subject override, tool_choice plumbing) while telling itself it isn't building a workflow engine. The reactive feel of those tags came from a stated discipline ("no separate workflow engine") that was a reasonable safety reaction to semspec's specific failure mode but generalized too far. With multiple consumer classes (agentic, robotic, API server, hybrid) all needing workflow semantics, the framework should decide deliberately whether to ship workflow primitives as a first-class layer on top of the rules engine.
+
+This exercise is the deliberate design session that resolves the question.
+
+## Background
+
+### How we got here
+
+Five tags in five days (beta.80–beta.84) added what was framed as "ADR-046 Phase 1 fan-out patches." In honest hindsight, every primitive shipped was a general workflow-engine capability:
+
+- `for_each` — dynamic iteration over collections
+- `array_contains`, `length_eq`, `length_gt`, `length_lt` — collection predicates
+- `.length` substitution — collection introspection
+- Subject override — cross-entity targeting
+- `condition.Value` substitution — late-binding in conditions
+- `tool_choice` on rule.Action + synth-decide on terminal-tool-less completion — per-spawn constraint + recovery primitive
+
+The per-tag framing made each look reactive. The honest framing makes them coherent: **the rules engine has been growing workflow-runtime capabilities, just incrementally and without naming what it's doing.**
+
+Two observations crystallize the question now:
+
+1. **semspec's actual failure mode** was not "having a workflow engine." It was *"having a workflow engine that bypassed the rules engine, lived outside flow discovery, broke the flowgraph validator, and drifted from rule semantics over time."* A workflow engine that USES the rules engine as dispatch substrate, lives inside the component framework, and shares state semantics with rules would not have hit any of those failure modes. The dogma absorbed the wrong lesson.
+
+2. **The framework's consumer base is broader than agentic.** semconnect is an OGC Connected Systems API server. Robotic automation is a near-term legitimate use case for the substrate (NATS + graph + rules naturally fit sensor/actuator coordination). Robotic patterns surface workflow semantics — long-running coordination, mission lifecycle, state persistence across restarts, real-time deadlines, multi-actuator fan-out, versioned process definitions, operator dashboards — with essentially zero LLM dependency. If we design workflow primitives only around agentic needs, we'll bake in assumptions (LLM-call as primary work unit, sub-second loops, soft deadlines) that miss robotic and other event-driven use cases entirely.
+
+### The "rules sequence, components parallelize" reframe (Path X)
+
+A parallel design conversation arrived at the discipline:
+
+> **Rules sequence. Components parallelize. Components compose a framework-provided bounded-dispatch primitive for capacity-controlled parallel work.**
+
+This is correct at the discipline level and resolves the dynamic-N-agent-fan-out question by reframing it: dynamic-N parallel work belongs in code components (ADR-045 PR 4 pattern), not as agent-loop fan-out at the rule layer. `for_each` over agent loops is scoped to static-N cases with per-loop isolation.
+
+What that discipline doesn't address: **the higher-order workflow concerns (instance lifecycle, state tracking, versioning, introspection) that are shared across multiple consumer classes.** Those are what this exercise evaluates.
+
+### The robotic angle
+
+Robotic automation surfaces workflow needs that are difficult-to-impossible to express in rules + components alone:
+
+| Pattern | Rules engine today | Workflow primitives could |
+|---|---|---|
+| Mission lifecycle (start, in-progress, abort, complete) | Implicit via state matching | Make first-class with operator-meaningful API |
+| State persistence across reboots | App-side KV conventions | Framework-managed instance state |
+| Long-running coordination (hours to days) | Possible but no introspection | Operator dashboards, per-instance metrics |
+| Versioned process definitions | Implicit | Explicit version pinning per instance |
+| Compensation / safe-abort | Per-rule conditions | Lifecycle-aware compensation hook |
+| Multi-sensor fan-in synthesis | Per-rule aggregation (hard) | First-class join with completion semantics |
+| Operator visualization | Rule-firing log | Workflow graph + live instance state |
+
+Each of these is buildable today by an app that's willing to invent conventions. But if multiple consumers build the same conventions, the framework should provide them.
+
+## Central question
+
+**Should semstreams grow workflow primitives as a first-class framework layer that rides on the rules engine, or should it limit itself to rules + components + a narrow substrate primitive (BoundedDispatcher) and require consumers to express workflow semantics ad-hoc?**
+
+This question is open. The exercise's job is to answer it from evidence (pattern sketches across consumer classes), not from dogma.
+
+## Reading order for the design session
+
+Read in order before starting the pattern sketches:
+
+1. This document (you're here)
+2. `project_rules_engine_design_review` memory — the original primitive-mapping framing this re-scopes
+3. `feedback_reactive_patches_vs_engine_completion` memory — the discipline that surfaced the question
+4. `CLAUDE.md` — re-read with fresh eyes; the "no separate workflow engine" stance is what's being re-examined
+5. `docs/concepts/14-orchestration-layers.md` — the existing pattern catalog (rules + components, no workflow layer)
+6. `docs/concepts/25-phased-agentic-chains.md` — the recent pattern doc for sequential agentic chains
+7. `docs/adr/028-orchestration-architecture.md` — the three-layer architecture currently in place
+8. `docs/adr/046-parallel-fan-out-and-gated-dag-dispatch.md` — the ADR that surfaced the gaps; Phase 2 is gated on this exercise
+9. The five recent PR descriptions (#136, #137, #138, #148, #150) — what we actually shipped framed as fan-out patches
+10. `project_semteams_gatherer_sandbox_case_study` memory — production pattern reference
+11. `semspec/processor/scenario-orchestrator/component.go` — the surviving 600 LOC; this is the prior-art for workflow-shaped patterns we're trying not to repeat ad-hoc
+
+## Pattern sketches (the exercise)
+
+Sketch each of these patterns three ways:
+
+- **(a)** Rules + components only
+- **(b)** Rules + components + `BoundedDispatcher` substrate primitive
+- **(c)** Workflow primitives layered on top of rules + components
+
+Evaluate each sketch for: clarity, completeness, operator audit, instance tracking, restart recovery, framework cohesion, and whether the sketch is honest framework code or hides app-side state plumbing.
+
+### Pattern 1 — Agentic: ADR-045 graph-research chain (sequential phased)
+
+Sequential phased agent chain. Five components + seven rules. Current Phase 1 target. The reference instance of the phased-agentic-chain pattern.
+
+Expected outcome: cleanest in (a). Used to validate that workflow primitives don't make the simplest case harder.
+
+### Pattern 2 — Agentic: semteams research-pack with dynamic-N investigators
+
+Decompose topic into N subtopics; one investigator (LLM judgment + web search + bash) per subtopic; aggregate findings; synthesize. N varies per topic.
+
+Per Path X, this is a code component (dynamic-N → component-internal fan-out via errgroup). Sketch must show: per-investigator audit story, per-investigator governance, per-investigator model-tier choice, partial-success handling. Does it cleanly use BoundedDispatcher? Does it want workflow-primitive instance tracking?
+
+### Pattern 3 — Robotic: drone survey mission
+
+Long-running (hours), waypoint navigation, weather/battery branch logic, emergency abort with safe-landing compensation, must resume after reboot, operator dashboard required, mission versioning across deployments.
+
+Almost zero LLM dependency. Pure workflow semantics. The clearest test case for whether workflow primitives are needed — if (a) and (b) feel like reinvention here, (c) is the answer.
+
+### Pattern 4 — Robotic: manufacturing batch run
+
+Multi-station parallel work, per-widget tracking through stations, inspection failure triggers rework subflow, days-long lifecycle, versioned process definitions, real-time station status visibility.
+
+Hybrid workflow + bounded-concurrency. Tests whether BoundedDispatcher + rules suffice for the parallel-station case, and whether workflow primitives add value for the per-widget instance lifecycle.
+
+### Pattern 5 — Event-driven: semconnect API request lifecycle
+
+Per-request state, validation → processing → response, error compensation, no LLM, no long-running, but operator observability matters. Short-lived (seconds to minutes per request).
+
+Tests whether workflow primitives over-engineer the short-lived case. If (a) or (b) feel cleanest here, workflow primitives should be opt-in not default.
+
+### Pattern 6 — Hybrid: semspec scenario-orchestrator (current production)
+
+Bounded-concurrency dispatch over KV-tracked work items. The pattern the surviving 600 LOC in semspec implements. The benchmark we're trying not to repeat ad-hoc.
+
+Sketch should show: does (b) BoundedDispatcher cleanly replace the existing 600 LOC? If yes, semspec can refactor to use the framework primitive, validating BoundedDispatcher's shape. Does (c) make the refactor even cleaner?
+
+## Decision framework
+
+For each pattern, classify the gap:
+
+| Tier | Gap shape | Action |
+|---|---|---|
+| 0 | Expressible with existing rule primitives | None |
+| 1 | Needs 1-2 small rule primitives | Add primitive, keep rules-as-orchestrator framing |
+| 2 | Needs narrow substrate component (concurrency, dispatch helper) | Ship as substrate (e.g. BoundedDispatcher) |
+| 3 | Needs higher-order workflow abstraction (named instance, lifecycle, state tracking, versioning, introspection) that rules + components can't naturally express | Workflow primitive — **the open question this exercise answers** |
+
+If most patterns land in tiers 0-2, the existing framing + BoundedDispatcher is sufficient. If multiple patterns land in tier 3 — and especially if the same workflow primitives keep getting demanded across agentic / robotic / event-driven consumers — workflow primitives ship.
+
+## Known substrate primitive (Tier 2 candidate)
+
+**`BoundedDispatcher`** — a small framework-provided primitive for bounded-concurrency parallel work. Spec sketch:
+
+```go
+// pkg/dispatch/bounded.go (~100-200 LOC)
+type BoundedDispatcher struct {
+    MaxConcurrent int
+    WorkSource    func(ctx context.Context) ([]Work, error)
+    Dispatch      func(ctx context.Context, work Work) error
+    CompletionKV  string  // KV pattern to watch for completion signals
+    OnComplete    func(ctx context.Context, work Work) error
+}
+
+func (d *BoundedDispatcher) Run(ctx context.Context) error {
+    // semaphore-bounded worker pool
+    // each dispatch is async; OnComplete fires on KV-watch hit
+    // when slot frees, pull next from WorkSource
+}
+```
+
+Properties:
+
+- NOT a workflow engine (no DAG, no state-machine semantics, no branching)
+- NOT a rule-engine extension (rules don't gain new fan-out primitives)
+- IS a Go-side substrate component that components compose into their fanning logic
+- IS KV-twofer-aware (integrates cleanly with completion-watch patterns)
+
+This is a clear win regardless of the workflow-primitives outcome. Both candidate paths (with or without workflow primitives on top) include this primitive. The exercise should confirm its shape against patterns 2, 4, 6.
+
+## Possible outcomes
+
+### Outcome A — Rules + BoundedDispatcher is sufficient
+
+Most patterns express cleanly in (b). The five-tag pile + BoundedDispatcher closes the gap. CLAUDE.md keeps the "no separate workflow engine" stance but explicitly:
+
+> *Rules engine + KV twofer + BoundedDispatcher provide workflow-shaped capabilities. No parallel workflow runtime is needed. Higher-order abstractions (lifecycle, versioning, introspection) are app-side conventions until proven otherwise.*
+
+Action: ship BoundedDispatcher in one tag, close the design review, retire the workflow-primitives question as YAGNI for now.
+
+### Outcome B — Workflow primitives ship as deliberate framework layer
+
+Multiple patterns surface tier-3 needs that don't reduce. Framework grows a thin workflow layer:
+
+- Workflow definition as named, versioned artifact (group of rules + components + state conventions)
+- Workflow instance tracking (framework-managed KV bucket with lifecycle states)
+- Workflow primitives: `start_workflow`, `workflow_state`, `workflow_complete`, `workflow_fail`
+- Workflow visualization (auto-derived from rule pack graph)
+- Per-workflow metrics + operator dashboards
+
+All built on rules + components, no parallel dispatch. CLAUDE.md reframes:
+
+> *semstreams is a stateful workflow runtime built on knowledge graphs + NATS JetStream + a rules engine, serving agentic, robotic, and event-driven coordination. The rules engine handles orchestration (sequence, branch, dispatch); components handle execution; the workflow layer provides instance lifecycle, state tracking, versioning, and introspection.*
+
+This becomes ADR-047. Probably 800-1500 LOC of framework code + significant doc work. Tag-bundle-sized.
+
+### Outcome C — Hybrid (recommended starting bias, but not foregone)
+
+BoundedDispatcher ships now (clear win, narrow scope, ~200 LOC, one tag). Workflow primitives gated on a second design exercise once two consumer classes hit the same tier-3 patterns in production. Avoids overshooting; accepts that the question may take a second iteration to fully resolve.
+
+This is the lowest-regret path if the pattern sketches don't decisively favor A or B.
+
+## What's affected by this exercise
+
+| Item | Impact |
+|---|---|
+| ADR-045 Phase 1 (PRs 3-6) | Unaffected — sequential agentic chain, all tier 0. Can proceed in parallel. |
+| ADR-046 Phase 2 / `fan_out_gated` | Deferred until exercise resolves; framing changes per outcome |
+| GH #151 (sibling-loop enumeration) | Deferred; may be tier 0 (composable from existing primitives) or tier 1 (`.triples` ships) per outcome |
+| Five-tag pile (beta.80–beta.84) | Retroactively reframed from "Phase 1 patches" to "rule-engine primitives that compose into workflow patterns" — same code, honest framing |
+| CLAUDE.md "no separate workflow engine" stance | Revised per outcome (either narrowed explicitly or replaced) |
+| `docs/concepts/25-phased-agentic-chains.md` | Adds forward-pointer to this exercise; potentially recontextualized as one workflow pattern within a broader workflow-primitives picture (outcome B) |
+| Sandbox-tier issues (#141–#146) | Unaffected; bash/sandbox/observability work proceeds independently |
+| semspec scenario-orchestrator | Retroactively reframed as the prior art that motivates either BoundedDispatcher (outcome A) or workflow primitives (outcome B); refactor candidate in either case |
+
+## Suggested working approach
+
+The exercise wants concentrated independent work, not spreading across multiple sessions. Recommended:
+
+- **One session, 2-3 hours.** Read the materials in the reading order, then sketch each of the 6 patterns against (a)/(b)/(c). Don't context-switch in or out of this; the framing decision compounds and parallel-sessioning risks the framing drifting.
+- **Output: a decision document.** Pattern sketches + tier classifications + recommendation for outcome A/B/C + draft ADR-047 if outcome is B.
+- **Resist preemptive coding.** No primitive ships until the framing decision lands. The temptation to "just ship .triples since it's small" is exactly the per-tag reactive pattern that got us here.
+
+## What NOT to do in the next session
+
+- Don't open code first. Open the pattern sketches.
+- Don't accept #151's filed proposal at face value. The right answer might be `.triples` (Tier 1), might be "composable from existing primitives" (Tier 0), might be "moot once workflow primitives ship" (Tier 3).
+- Don't ship more "patches." Either the next code tag is named what it IS (BoundedDispatcher, or workflow primitives), or there is no next tag until this exercise resolves.
+- Don't pre-commit to outcome A or B. Run the sketches, let the evidence drive the call.
+
+## Hand-off summary (TL;DR for the next session)
+
+**Status**: paused after beta.84. ADR-046 Phase 2 and #151 are explicitly gated on this exercise. ADR-045 Phase 1 PRs 3-6 are unaffected and can proceed in parallel. SemTeams paused waiting on the framework decision.
+
+**Blocking work**: this design exercise — not code. 2-3 hour concentrated session.
+
+**Next step**: read the reading order, run the 6 pattern sketches against (a)/(b)/(c), classify gaps, recommend outcome A/B/C, draft ADR-047 if outcome is B.
+
+**Output the session should produce**:
+
+1. The 6 pattern sketches with tier classifications
+2. A decision document recommending outcome A, B, or C with reasoning
+3. If outcome B or C: spec for BoundedDispatcher (~200 LOC, one tag)
+4. If outcome B: draft ADR-047 for workflow primitives layer
+5. Updates to:
+   - `project_rules_engine_design_review` memory (close out the original framing, point at the outcome)
+   - `project_workflow_primitives_decision` memory (NEW — capture the outcome + reasoning)
+   - CLAUDE.md (revised stance per outcome)
+   - `docs/concepts/25-phased-agentic-chains.md` (recontextualize per outcome)
+   - GH #151 (close, modify, or proceed per outcome)
+6. Sister-project guidance for semteams: how to design research-pack against the resolved framing
+
+## References
+
+- `project_rules_engine_design_review` — original primitive-mapping framing this re-scopes
+- `feedback_reactive_patches_vs_engine_completion` — the discipline that surfaced the question
+- `feedback_integration_tests_must_drive_production_wire` — the testing discipline that caught the third-iteration wire bug
+- `feedback_reference_configs_verify_triple_stamping` — the documentation-vs-reality discipline
+- `project_semteams_gatherer_sandbox_case_study` — production pattern reference
+- `docs/concepts/14-orchestration-layers.md` — current pattern catalog (no workflow layer)
+- `docs/concepts/25-phased-agentic-chains.md` — sequential agentic chain pattern (today's work)
+- `docs/adr/028-orchestration-architecture.md` — three-layer architecture currently in place
+- `docs/adr/046-parallel-fan-out-and-gated-dag-dispatch.md` — Phase 2 gated on this exercise
+- CLAUDE.md — "no separate workflow engine" stance under examination
+- semspec `processor/scenario-orchestrator/component.go` — surviving 600 LOC, prior art
+- semspec retired `workflow/reactive/` — the cautionary tale (the failure mode we won't repeat)


### PR DESCRIPTION
## Summary

- Add `docs/proposals/workflow-primitives-design-exercise.md` as the gate marker for the broader "workflow primitives vs not" framework question. Re-scopes the original rules-engine-primitive-mapping framing — semspec's failure mode was *bypass* (state machines outside the rule engine + flow discovery), not *existence*. Robotic automation as a near-term consumer class surfaces workflow semantics with ~zero LLM dependency, strengthening the case for a deliberate decision rather than dogma. Exercise specifies six pattern sketches across (a) rules+components only, (b) +`BoundedDispatcher` substrate, (c) +workflow primitives, resolving to outcome A/B/C.
- Add `docs/concepts/25-phased-agentic-chains.md` naming the sequential-agentic-chain pattern (ADR-045 R0-R6 and the semteams gatherer chain as reference instances), with substrate / capability / application split and primitive inventory.

## What this gates

- #151 (sibling-loop enumeration for fan-out join) — deferred until design exercise resolves. Possible outcomes: composable from existing primitives (Tier 0), `.triples` substitution ships (Tier 1), or moot under workflow primitives (Tier 3).
- ADR-046 Phase 2 (`fan_out_gated` orchestrator framing) — deferred until design exercise resolves.

## What this does NOT gate

- ADR-045 Phase 1 PRs 3-6 — sequential chain, all Tier 0, can proceed in parallel.
- Sandbox-tier framework gap issues #141–#146 — bash/sandbox/observability work, independent of rule-engine direction.
- #93 natsclient header-classified errors — separate beta-exit blocker, independent.
- The MILD/ADDITIVE bundle (#100/#101/#116/#120) — separate queue.

## Reading order for whoever runs the exercise

The proposal doc lists eleven items in order. Highlights: re-read CLAUDE.md's "no separate workflow engine" stance with fresh eyes (it's the dogma under examination), the original `project_rules_engine_design_review` memo (preserved as context, not deleted), ADR-046, the five recent PRs (#136, #137, #138, #148, #150), and semspec's surviving `scenario-orchestrator/component.go` as prior art.

## Suggested working approach

One concentrated 2-3 hour session, not split across multiple. The framing decision compounds; parallel-sessioning risks framing drift.

## Test plan

- [x] Markdown only — no code changes
- [x] No schema / vocabulary / payload changes
- [x] CI lint expected to pass (no `.go` files touched)
- [ ] Verify cross-references render correctly on GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)