### PR TITLE
feat(lifecycle): ADR-047 PR 1 — Lifecycle harness substrate (pkg/lifecycle foundation + Manager + integration tests)

### DIFF
--- a/docs/adr/047-lifecycle-harness-substrate.md
+++ b/docs/adr/047-lifecycle-harness-substrate.md
@@ -136,8 +136,8 @@ type Participant interface {
     Workflow() string         // workflow type identifier
     Phase() string            // current lifecycle phase
     IsTerminal() bool         // true if entity is in terminal phase
-    KVBucket() string         // KV bucket this entity lives in
-    KVKey() string            // KV key shape for this entity
+    KVBucket() string                  // KV bucket this entity lives in
+    KVKey(entityID string) string      // KV key shape for the given entity ID
 
     // ParentEntityID returns the parent workflow instance ID, or
     // empty for root workflows. Enables parent/child workflow

--- a/docs/adr/047-lifecycle-harness-substrate.md
+++ b/docs/adr/047-lifecycle-harness-substrate.md
@@ -166,34 +166,48 @@ func (m *Manager) Register(
 ) error
 
 // ---- Lifecycle operations ----
+//
+// All ops take an explicit workflow string. The workflow argument
+// disambiguates entity IDs that may collide across registered
+// workflow types within a single Manager — the harness does NOT
+// derive workflow from entityID, since multi-workflow buckets and
+// per-workflow ID conventions both exist in practice.
 
-func (m *Manager) Get(ctx context.Context, entityID string) (Participant, error)
+func (m *Manager) Get(ctx context.Context, workflow, entityID string) (Participant, error)
 func (m *Manager) Create(ctx context.Context, initial Participant) error
-func (m *Manager) Update(ctx context.Context, entityID string,
+func (m *Manager) Update(ctx context.Context, workflow, entityID string,
     mutator func(Participant) error) error
-func (m *Manager) UpdateFromOperator(ctx context.Context, entityID string,
+func (m *Manager) UpdateFromOperator(ctx context.Context, workflow, entityID string,
     patch map[string]any) error
-func (m *Manager) Transition(ctx context.Context, entityID, newPhase string) error
-func (m *Manager) Complete(ctx context.Context, entityID string) error
-func (m *Manager) Fail(ctx context.Context, entityID, reason string) error
+func (m *Manager) Transition(ctx context.Context, workflow, entityID, newPhase string,
+    source TransitionSource, note string) error
+func (m *Manager) Complete(ctx context.Context, workflow, entityID string) error
+func (m *Manager) Fail(ctx context.Context, workflow, entityID, reason string) error
 
 // ---- Query operations ----
 
 type ListOptions struct {
-    Phase        string
-    Active       bool
-    UpdatedAfter time.Time
-    Match        map[string]any
-    Limit        int
-    Offset       int
+    Phase  string
+    Active bool
+    Match  map[string]any
+    Limit  int
+    Offset int
 }
 
 func (m *Manager) List(ctx context.Context, workflow string,
     opts ListOptions) ([]Participant, error)
-func (m *Manager) Watch(ctx context.Context, workflow string) <-chan Participant
-func (m *Manager) History(ctx context.Context, entityID string) ([]TransitionEvent, error)
+func (m *Manager) Watch(ctx context.Context, workflow string) (<-chan Participant, error)
+func (m *Manager) History(ctx context.Context, workflow, entityID string) ([]TransitionEvent, error)
 
 // ---- Parent/child relationships ----
+//
+// Children and Ancestors scan across ALL registered workflows
+// (a parent in workflow A may have children in workflow B — e.g.
+// semspec's Plan-owns-Requirements). Complexity is
+// O(sum-of-bucket-sizes) per call; apps with intra-workflow
+// parent-child relationships should prefer
+// List(workflow, Match{"parent_field": parentID}) which stays
+// within one bucket.
 
 func (m *Manager) Children(ctx context.Context, parentEntityID string) ([]Participant, error)
 func (m *Manager) Ancestors(ctx context.Context, entityID string) ([]Participant, error)
@@ -201,9 +215,10 @@ func (m *Manager) Ancestors(ctx context.Context, entityID string) ([]Participant
 // ---- Workflow introspection ----
 
 type WorkflowDef struct {
-    Workflow    string
-    Transitions Transitions
-    Schema      *jsonschema.Schema  // optional, derived from struct tags
+    Workflow               string
+    Transitions            Transitions
+    KVBucket               string
+    OperatorWritableFields []string // sorted JSON field names
 }
 
 func (m *Manager) GetWorkflowDefinition(workflow string) (WorkflowDef, error)
@@ -361,7 +376,7 @@ operators should know about:
 - **`Manager.List` with `Match`**: ~10K active instances per
   workflow is the rough threshold where the per-call scan cost
   starts mattering for operator-dashboard responsiveness. Cheap
-  filters (`Phase`, `Active`, `UpdatedAfter`) are applied before
+  filters (`Phase`, `Active`) are applied before
   `Match`'s reflection step, so workflows whose dashboards
   predominantly filter on phase will scale further. File a
   bottleneck issue when an operator observes List-call latency

--- a/docs/adr/047-lifecycle-harness-substrate.md
+++ b/docs/adr/047-lifecycle-harness-substrate.md
@@ -352,6 +352,49 @@ match_field)` for fast filter resolution at scale. Indexable fields
 opt-in via struct tag (`lifecycle:"indexable"`). Triggered when an
 operator demonstrates a bottleneck — not before.
 
+### Scaling cliff (operator guidance)
+
+The v1 linear-scan paths in `Manager.List`, `Manager.Children`, and
+`Manager.Ancestors` are O(bucket-size) per call. Two scaling cliffs
+operators should know about:
+
+- **`Manager.List` with `Match`**: ~10K active instances per
+  workflow is the rough threshold where the per-call scan cost
+  starts mattering for operator-dashboard responsiveness. Cheap
+  filters (`Phase`, `Active`, `UpdatedAfter`) are applied before
+  `Match`'s reflection step, so workflows whose dashboards
+  predominantly filter on phase will scale further. File a
+  bottleneck issue when an operator observes List-call latency
+  in dashboard refresh; the v2 secondary-index work consumes
+  `lifecycle:"indexable"`-tagged fields and is the upgrade path.
+- **`Manager.Ancestors` and `Manager.Children`**: cross-workflow
+  scans are O(sum-of-bucket-sizes) per call because they walk
+  every registered workflow's bucket. Apps with deep parent-
+  child chains in high-cardinality workflows feel this; apps
+  whose parent-child relationships stay within a single workflow
+  should prefer `List(workflow, Match{"parent_field": parentID})`
+  for the children case (stays within one bucket and benefits
+  from the v2 secondary index when it lands).
+
+Neither `Manager.Get` nor `Manager.Update` is in this scaling
+class — they're O(1) per call, suitable for per-message
+coordinator hotpaths. `List`/`Watch`/`History`/`Children`/
+`Ancestors` are operator-API-shaped (dashboard refresh, debugging,
+audit) not per-message-shaped.
+
+### Phase drift detection
+
+`Manager.Get` (and the `Get` path used by `List`) validate that the
+loaded entity's `Phase()` is declared in the registered
+`Transitions` table. Drift surfaces as a `slog.Warn` log line
+naming the entity, the undeclared phase, and the declared phase
+set. Detection is log-only in v1 — apps wanting structured drift
+detection (e.g. a `Degraded bool` field on the returned wrapper)
+add it as a future API extension. The log signal is enough to
+make the silent degradation visible without a wire-format change;
+the `Degraded`-bool precedent (PR #137 / GH #120) is the
+upgrade path when an operator demonstrates the need.
+
 ### Migration from `pkg/workflow`
 
 Greenfield rip-and-replace:

--- a/docs/adr/047-lifecycle-harness-substrate.md
+++ b/docs/adr/047-lifecycle-harness-substrate.md
@@ -73,6 +73,43 @@ It is a **substrate convention layer** that lets consumers declare
 workflow-shaped entities and get framework infrastructure (KV
 storage, restart recovery, operator API, rule integration) for free.
 
+### Participation is per-entity, not per-deployment
+
+semstreams is general-purpose stream-processing infrastructure;
+the Lifecycle harness has zero dependencies on agentic-loop or any
+other consumer class. Apps that ship no agentic features at all
+(pure UDP-ingest + processor + HTTP-egress deployments) get the
+full harness benefit by implementing `Participant` on their domain
+state structs. The `pkg/lifecycle` package MUST NOT import any
+`processor/agentic-*` package — verified by import lint at PR-1
+land time.
+
+`Participant` is opt-in per ENTITY-TYPE. Within a single app:
+
+- Entity types with declared phases + restart recovery + operator
+  visibility needs (drone missions, sensor lifecycles, manufacturing
+  batches, scenario executions, API request lifecycles) implement
+  `Participant` and use `Manager`.
+- Entity types without that shape (raw telemetry samples, log
+  entries, agent loops whose lifecycle is per-iteration LLM
+  judgment rather than declared state-machine phases, transient
+  inputs) stay outside the harness — they pay zero cost and the
+  harness imposes no requirements on them.
+
+Agentic-loop intentionally stays outside `Participant` in this
+bundle: its lifecycle shape (per-iteration model judgment, dynamic
+trajectory) doesn't fit the declared-transitions-table abstraction
+cleanly. This is an entity-shape fit decision, not a framework
+constraint — a future agentic role with declared phases could
+implement `Participant` if the fit emerges. The 3 vestigial
+`pkg/workflow` lines in agentic-loop are deleted in PR 2 because
+they were never load-bearing, not because agentic-loop is being
+excluded from harness participation as a matter of principle.
+
+Apps must NOT assume the harness implies an agentic dependency,
+and apps using the harness do NOT pull in agentic-loop or any
+other consumer-class package.
+
 ### Greenfield assumption
 
 `pkg/workflow` (the dormant existing surface) is unused except for

--- a/docs/adr/048-bounded-dispatcher-and-triples-substrate.md
+++ b/docs/adr/048-bounded-dispatcher-and-triples-substrate.md
@@ -307,12 +307,46 @@ that powers `.length`:
   `$related.triple.X.triples` substitution paths
 - Resolve to the slice of values (already typed `[]any` after
   `for_each`'s multi-valued resolution shipped in beta.82)
-- For string-context substitution (e.g., inside a prompt),
-  serialize as comma-separated or JSON array depending on caller
-  convention
+- For string-context substitution (e.g., inside a prompt or a
+  property value), serialize as a **JSON array** —
+  `["a","b","c"]` — never CSV. JSON wins because it matches the
+  existing graph encoding for list-typed predicates (e.g.
+  `coordinator.decision.subtopics`, see
+  `vocabulary/agentic/predicates.go:677`) and because CSV
+  ambiguity on commas-in-values is a latent production-bug class
+  the framework refuses to introduce. There is no operator-config
+  flag for serialization — one canonical format, period.
 - For typed-context substitution (e.g., inside a condition
   operator like `array_contains` or `length_eq`), pass through
-  as `[]any`
+  as `[]any` — no string serialization happens.
+
+#### Persona-prose convention for `.triples` recipients
+
+When a rule threads a `.triples`-substituted value into a
+downstream agent's prompt or property, the agent's persona MUST
+include the canonical parse instruction (one templated sentence
+per consuming role):
+
+> *"The property `<field_name>` contains a JSON array of
+> `<item_type>` (e.g. `["loop_a","loop_b","loop_c"]`). Parse it
+> as JSON and iterate each item."*
+
+The framework guarantees JSON-array format; consumer prose
+guarantees the parse expectation. This converts "cognitive load on
+every consumer" into one copy-pasteable sentence, per the
+discipline in [[feedback_persona_prose_needs_decision_criteria]].
+
+**Known limitation — cheap-model substrate:** The JSON-parse step
+assumes a reliable JSON-parsing model. Frontier models (the
+`general` model class in this codebase) handle this trivially.
+Cheap-model substrate (the `decide`-class roles from the beta.80
+cheap-model bundle) may not — silent malformed-parse is a real
+failure surface. When a `.triples`-threaded value flows into a
+cheap-model context, prefer static-N + AND-composition patterns
+(or upgrade the recipient role to `general`). Operator guidance:
+if a cheap-model role consumes `.triples`, instrument the
+trajectory for "did the model successfully iterate every item?"
+before relying on the pattern in production.
 
 Test coverage extends `test/reference_configs_test.go` (the
 beta.84 lint) — any reference config using `.triples` must
@@ -404,12 +438,14 @@ ADR-048)"**
 3. **Should `.triples` substitution support `.triples.length`?**
    It would be `.length` of the resolved list. Lean YES for
    symmetry; semantically equivalent to `.length` directly.
-4. **JSON-vs-CSV serialization of `.triples` in string context**:
-   the safer default is JSON array (`["a","b","c"]`); CSV
-   (`a,b,c`) is more LLM-friendly but ambiguous with commas-in-
-   values. Lean JSON; document.
+4. ~~**JSON-vs-CSV serialization of `.triples` in string context**~~
+   **RESOLVED** — JSON array, no operator-config flag, canonical
+   persona-prose template + cheap-model limitation documented in
+   the Implementation section above. CSV rejected because
+   commas-in-values is a latent production-bug class the framework
+   refuses to introduce.
 
-These resolve during PR drafting.
+Open questions 1-3 resolve during PR drafting.
 
 ## Migration path
 

--- a/pkg/lifecycle/doc.go
+++ b/pkg/lifecycle/doc.go
@@ -1,0 +1,71 @@
+// Package lifecycle provides a substrate convention layer for
+// workflow-shaped entities — named instances with declared phases,
+// restart recovery, operator visibility, and rule integration.
+//
+// # What this is (and is not)
+//
+// This package is a SUBSTRATE CONVENTION LAYER, not a workflow engine.
+// It provides:
+//   - A Participant interface apps implement on their domain state structs
+//   - A Manager harness that handles KV storage, restart recovery,
+//     and operator API integration
+//   - A Transitions table that declares valid phase transitions per workflow
+//   - Struct-tag-based operator-writability declaration (default-deny)
+//
+// It does NOT provide:
+//   - A runtime, DSL, or state-machine interpreter (apps own work logic)
+//   - A separate event bus (uses existing NATS KV primitives)
+//   - A process orchestrator (orchestration stays in the rule engine)
+//   - A replacement for components (components remain the execution layer)
+//
+// See ADR-047 for the full rationale.
+//
+// # Participation is per-entity, not per-deployment
+//
+// The lifecycle harness has ZERO dependencies on agentic-loop or any
+// other consumer class. Apps that ship no agentic features get the
+// full harness benefit. This package MUST NOT import any
+// processor/agentic-* package — verified by import lint.
+//
+// Participant is opt-in per ENTITY-TYPE within a single app:
+//   - Drone missions, sensor lifecycles, manufacturing batches,
+//     scenario executions implement Participant
+//   - Raw telemetry, log entries, agent loops, and transient inputs
+//     stay outside the harness and pay zero cost
+//
+// # Usage
+//
+// Apps annotate state-struct fields with the lifecycle struct tag:
+//
+//	type SystemState struct {
+//	    EntityID_   string `json:"entity_id"    lifecycle:"id"`
+//	    Phase_      string `json:"phase"        lifecycle:"phase,readonly"`
+//	    OwnerOrgID  string `json:"owner_org_id" lifecycle:"operator_writable"`
+//	    InternalState string `json:"internal_state,omitempty"`
+//	    // no tag = not operator-writable (default-deny)
+//	}
+//
+// Tag values:
+//   - id                — marks the EntityID field (one per struct)
+//   - phase             — marks the Phase field (one per struct)
+//   - readonly          — never operator-writable
+//   - operator_writable — opt-in operator-writability via Manager.UpdateFromOperator
+//   - indexable         — flagged for v2 secondary indexing (v1 ignores)
+//
+// Apps register a Workflow type at startup with its valid transitions:
+//
+//	transitions := lifecycle.Transitions{
+//	    "planning":   {"flying", "aborted"},
+//	    "flying":     {"capturing", "landing", "aborted"},
+//	    "capturing":  {"flying"},
+//	    "landing":    {"completed", "failed"},
+//	    "completed":  {},  // terminal — no out-edges
+//	    "failed":     {},
+//	    "aborted":    {},
+//	}
+//	mgr.Register("drone-survey", func() Participant {
+//	    return &MissionState{}
+//	}, transitions)
+//
+// See ADR-047 for the complete worked example.
+package lifecycle

--- a/pkg/lifecycle/errors.go
+++ b/pkg/lifecycle/errors.go
@@ -1,0 +1,55 @@
+package lifecycle
+
+import "errors"
+
+// Package error sentinels. Callers compare with errors.Is.
+var (
+	// ErrWorkflowNotRegistered is returned by Manager operations when the
+	// referenced workflow type was never passed to Manager.Register. This
+	// is always a programming error — registration belongs at startup,
+	// before any Get/Create/Transition calls land.
+	ErrWorkflowNotRegistered = errors.New("lifecycle: workflow not registered")
+
+	// ErrWorkflowAlreadyRegistered is returned by Manager.Register when a
+	// workflow type is registered twice. Registration must be idempotent
+	// at startup, not a fire-and-forget — duplicate registration likely
+	// indicates a wire-up bug, not a benign re-init.
+	ErrWorkflowAlreadyRegistered = errors.New("lifecycle: workflow already registered")
+
+	// ErrEntityNotFound is returned by Manager.Get when no instance exists
+	// at the given EntityID. Distinct from a KV-layer error so callers can
+	// branch cleanly on "doesn't exist yet" vs "KV is broken."
+	ErrEntityNotFound = errors.New("lifecycle: entity not found")
+
+	// ErrInvalidTransition is returned by Manager.Transition when the
+	// requested (from → to) edge is not declared in the registered
+	// Transitions table for the workflow. Surfaces misconfigured rules
+	// at runtime rather than letting the state machine drift.
+	ErrInvalidTransition = errors.New("lifecycle: invalid transition")
+
+	// ErrTerminalPhase is returned by Manager.Transition when the current
+	// phase has no declared out-edges (i.e. is terminal). Distinguishes
+	// "you tried to transition from completed/failed" from a generic
+	// invalid-edge error so operator dashboards can show the right hint.
+	ErrTerminalPhase = errors.New("lifecycle: entity is in terminal phase")
+
+	// ErrMissingIDField is returned by struct-tag parsing when a
+	// registered factory produces a Participant struct with no field
+	// tagged `lifecycle:"id"`. Validates app-side wiring at Register
+	// time, not at first use, so the bug surfaces during startup.
+	ErrMissingIDField = errors.New("lifecycle: state struct missing field with lifecycle:\"id\" tag")
+
+	// ErrMissingPhaseField mirrors ErrMissingIDField for the phase field.
+	ErrMissingPhaseField = errors.New("lifecycle: state struct missing field with lifecycle:\"phase\" tag")
+
+	// ErrFieldNotOperatorWritable is returned by Manager.UpdateFromOperator
+	// when the patch attempts to mutate a field NOT tagged
+	// `lifecycle:"operator_writable"`. Default-deny: unflagged fields are
+	// not operator-writable.
+	ErrFieldNotOperatorWritable = errors.New("lifecycle: field is not operator_writable")
+
+	// ErrInvalidTransitionsTable is returned by Manager.Register when the
+	// Transitions table is internally inconsistent (e.g. an out-edge
+	// references a phase not declared as a key). Catches typos at startup.
+	ErrInvalidTransitionsTable = errors.New("lifecycle: invalid transitions table")
+)

--- a/pkg/lifecycle/errors.go
+++ b/pkg/lifecycle/errors.go
@@ -52,4 +52,24 @@ var (
 	// Transitions table is internally inconsistent (e.g. an out-edge
 	// references a phase not declared as a key). Catches typos at startup.
 	ErrInvalidTransitionsTable = errors.New("lifecycle: invalid transitions table")
+
+	// ErrUpdateRetriesExhausted is returned by Manager.Update (and
+	// any Update-using caller — Transition, Complete, Fail,
+	// UpdateFromOperator) when the per-call CAS-conflict retry
+	// budget (updateRetries) is consumed under persistent contention.
+	//
+	// Operationally this signals one of:
+	//   - A stuck rule writing to the same entity in a tight loop
+	//   - An upstream system hammering the same key past framework
+	//     capacity
+	//   - Misconfigured per-entity fan-in (multiple coordinators
+	//     racing on one state)
+	//
+	// Callers wanting application-layer retry semantics distinct
+	// from the framework's bounded retry can branch on
+	// errors.Is(err, lifecycle.ErrUpdateRetriesExhausted) and apply
+	// their own backoff + retry policy. Operators benefit from
+	// dashboards / metrics / alerts differentiating budget exhaustion
+	// from other Update failure classes.
+	ErrUpdateRetriesExhausted = errors.New("lifecycle: Update retry budget exhausted (persistent CAS contention)")
 )

--- a/pkg/lifecycle/integration_test.go
+++ b/pkg/lifecycle/integration_test.go
@@ -1,0 +1,341 @@
+//go:build integration
+
+// Integration tests for pkg/lifecycle against real NATS via
+// testcontainers. Build-tagged separately so unit tests stay fast;
+// run with `go test -tags=integration -race ./pkg/lifecycle/...`.
+//
+// These tests pin the kvNATSStore adapter against real jetstream
+// semantics. The unit tests (manager_test.go, manager_query_test.go)
+// cover behavior against the kvMockStore; this file covers
+// wire-correctness — particularly the CAS classifier in
+// kvNATSStore.Update which the PR 1b core review flagged as
+// "verify against real jetstream sentinels in the testcontainers
+// slice."
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// integMissionState is the integration-test Participant fixture.
+// Top-level fields only (parseStructTags doesn't recurse into
+// embedded structs per the foundation contract). Bucket name is
+// fixed across integration tests — each test gets a fresh
+// testcontainer (and therefore a fresh KV bucket) so isolation is
+// at the container level.
+type integMissionState struct {
+	EntityIDF      string `json:"entity_id" lifecycle:"id"`
+	PhaseF         string `json:"phase" lifecycle:"phase,readonly"`
+	OwnerOrgIDF    string `json:"owner_org_id" lifecycle:"operator_writable"`
+	ParentMissionF string `json:"parent_mission,omitempty"`
+}
+
+func (m *integMissionState) EntityID() string             { return m.EntityIDF }
+func (m *integMissionState) Workflow() string             { return "integ-mission" }
+func (m *integMissionState) Phase() string                { return m.PhaseF }
+func (m *integMissionState) IsTerminal() bool             { return integMissionTransitions.IsTerminal(m.PhaseF) }
+func (m *integMissionState) KVBucket() string             { return integBucketName }
+func (m *integMissionState) KVKey(entityID string) string { return "mission." + entityID }
+func (m *integMissionState) ParentEntityID() string       { return m.ParentMissionF }
+
+var integMissionTransitions = Transitions{
+	"planning":  {"flying", "aborted"},
+	"flying":    {"capturing", "landing", "aborted"},
+	"capturing": {"flying"},
+	"landing":   {"completed", "failed"},
+	"completed": {},
+	"failed":    {},
+	"aborted":   {},
+}
+
+// integBucketName is the single bucket all integration tests use.
+// Per-container isolation makes per-test bucket names unnecessary.
+const integBucketName = "LIFECYCLE_INTEG"
+
+// setupManager creates a NATS testcontainer, provisions the
+// integBucketName KV bucket, wires NewManager against the live
+// client, and registers the integ-mission workflow. Returns the
+// manager + the underlying natsclient so tests can do raw KV ops
+// (e.g. Delete) where Manager doesn't expose a public path.
+func setupManager(t *testing.T) (*Manager, *natsclient.Client) {
+	t.Helper()
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	ctx := context.Background()
+
+	_, err := tc.Client.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      integBucketName,
+		Description: "lifecycle integration test bucket",
+		History:     10,
+	})
+	require.NoError(t, err, "create KV bucket %q", integBucketName)
+
+	mgr := NewManager(tc.Client, nil)
+	require.NoError(t, mgr.Register("integ-mission",
+		func() Participant { return &integMissionState{} },
+		integMissionTransitions),
+		"Register integ-mission workflow")
+	return mgr, tc.Client
+}
+
+// --- Round-trip: Register/Create/Get/Update/Transition ---
+
+func TestIntegration_LifecycleRoundTrip(t *testing.T) {
+	mgr, _ := setupManager(t)
+	ctx := context.Background()
+
+	require.NoError(t, mgr.Create(ctx, &integMissionState{
+		EntityIDF:   "rt-1",
+		PhaseF:      "planning",
+		OwnerOrgIDF: "acme",
+	}))
+
+	got, err := mgr.Get(ctx, "integ-mission", "rt-1")
+	require.NoError(t, err)
+	gotMission := got.(*integMissionState)
+	require.Equal(t, "planning", gotMission.PhaseF)
+	require.Equal(t, "acme", gotMission.OwnerOrgIDF)
+
+	require.NoError(t, mgr.Update(ctx, "integ-mission", "rt-1", func(p Participant) error {
+		p.(*integMissionState).OwnerOrgIDF = "newcorp"
+		return nil
+	}))
+
+	require.NoError(t, mgr.Transition(ctx, "integ-mission", "rt-1", "flying",
+		TransitionSourceRule, ""))
+
+	after, _ := mgr.Get(ctx, "integ-mission", "rt-1")
+	require.Equal(t, "flying", after.Phase())
+	require.Equal(t, "newcorp", after.(*integMissionState).OwnerOrgIDF)
+}
+
+// --- CAS classifier: verify against real jetstream sentinels ---
+
+func TestIntegration_CASClassifierTriggersOnRealConflict(t *testing.T) {
+	// Load-bearing test for the kvNATSStore.Update classifier
+	// hierarchy (PR 1b core review C1 finding). Concurrently
+	// mutate the same key from N goroutines; the losers MUST
+	// surface as errKVRevisionMismatch so Manager.Update can
+	// retry. If the classifier mis-classifies, the retry won't
+	// trigger and at least one goroutine fails.
+	mgr, _ := setupManager(t)
+	ctx := context.Background()
+
+	require.NoError(t, mgr.Create(ctx, &integMissionState{
+		EntityIDF: "cas-1", PhaseF: "planning",
+	}))
+
+	const writers = updateRetries - 1
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	errs := make(chan error, writers)
+	for i := range writers {
+		go func(tag int) {
+			defer wg.Done()
+			err := mgr.Update(ctx, "integ-mission", "cas-1", func(p Participant) error {
+				p.(*integMissionState).OwnerOrgIDF = fmt.Sprintf("writer-%d", tag)
+				return nil
+			})
+			if err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent update failed (CAS classifier likely mis-classified): %v", err)
+	}
+
+	final, err := mgr.Get(ctx, "integ-mission", "cas-1")
+	require.NoError(t, err)
+	finalOwner := final.(*integMissionState).OwnerOrgIDF
+	require.True(t, strings.HasPrefix(finalOwner, "writer-"),
+		"final owner should be one of the writers, got %q", finalOwner)
+}
+
+// --- Restart-recovery: state persists across Manager instances ---
+
+func TestIntegration_RestartRecoveryPersistsState(t *testing.T) {
+	mgr1, client := setupManager(t)
+	ctx := context.Background()
+
+	require.NoError(t, mgr1.Create(ctx, &integMissionState{
+		EntityIDF:   "rr-1",
+		PhaseF:      "planning",
+		OwnerOrgIDF: "before-restart",
+	}))
+	require.NoError(t, mgr1.Transition(ctx, "integ-mission", "rr-1", "flying",
+		TransitionSourceRule, ""))
+
+	// Simulate a process restart: new Manager against the SAME
+	// natsclient (same NATS server + same bucket). The bucket
+	// already exists so the Register-time CreateKeyValueBucket
+	// hits the "use existing" path; the prior state is intact.
+	mgr2 := NewManager(client, nil)
+	require.NoError(t, mgr2.Register("integ-mission",
+		func() Participant { return &integMissionState{} },
+		integMissionTransitions))
+
+	got, err := mgr2.Get(ctx, "integ-mission", "rr-1")
+	require.NoError(t, err)
+	require.Equal(t, "flying", got.Phase(), "state should persist across Manager restart")
+	require.Equal(t, "before-restart", got.(*integMissionState).OwnerOrgIDF)
+}
+
+// --- Delete + History tombstone ---
+
+func TestIntegration_DeleteThenGetReturnsNotFound(t *testing.T) {
+	mgr, _ := setupManager(t)
+	ctx := context.Background()
+
+	require.NoError(t, mgr.Create(ctx, &integMissionState{
+		EntityIDF: "del-1", PhaseF: "planning",
+	}))
+
+	// Manager doesn't expose a public Delete (apps remove
+	// entities via Transition to a terminal + retention policy,
+	// NOT direct deletion). But the kvStore adapter handles
+	// deletes for jetstream tombstone semantics — this test
+	// pins that path via the registered store.
+	mgr.mu.RLock()
+	reg := mgr.registrations["integ-mission"]
+	mgr.mu.RUnlock()
+
+	require.NoError(t, reg.store.Delete(ctx, "mission.del-1"))
+
+	_, err := mgr.Get(ctx, "integ-mission", "del-1")
+	require.ErrorIs(t, err, ErrEntityNotFound,
+		"Get after Delete must return ErrEntityNotFound")
+}
+
+func TestIntegration_HistoryIncludesDeleteTombstone(t *testing.T) {
+	mgr, _ := setupManager(t)
+	ctx := context.Background()
+
+	require.NoError(t, mgr.Create(ctx, &integMissionState{
+		EntityIDF: "ht-1", PhaseF: "planning",
+	}))
+	require.NoError(t, mgr.Transition(ctx, "integ-mission", "ht-1", "flying",
+		TransitionSourceRule, ""))
+
+	mgr.mu.RLock()
+	reg := mgr.registrations["integ-mission"]
+	mgr.mu.RUnlock()
+	require.NoError(t, reg.store.Delete(ctx, "mission.ht-1"))
+
+	events, err := mgr.History(ctx, "integ-mission", "ht-1")
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(events), 2,
+		"history should include at least Create + delete tombstone, got %+v", events)
+	last := events[len(events)-1]
+	require.Equal(t, "<deleted>", last.To, "last event should be deletion tombstone")
+}
+
+// --- History revision metadata ---
+
+func TestIntegration_HistoryRevisionTimestampsAreMonotonic(t *testing.T) {
+	mgr, _ := setupManager(t)
+	ctx := context.Background()
+
+	require.NoError(t, mgr.Create(ctx, &integMissionState{
+		EntityIDF: "ts-1", PhaseF: "planning",
+	}))
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, mgr.Transition(ctx, "integ-mission", "ts-1", "flying",
+		TransitionSourceRule, ""))
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, mgr.Transition(ctx, "integ-mission", "ts-1", "capturing",
+		TransitionSourceRule, ""))
+
+	events, err := mgr.History(ctx, "integ-mission", "ts-1")
+	require.NoError(t, err)
+	require.Len(t, events, 3)
+
+	for i, ev := range events {
+		require.False(t, ev.At.IsZero(), "event %d has zero CreatedAt", i)
+	}
+	require.True(t, events[0].At.Before(events[1].At), "events[0] should precede events[1]")
+	require.True(t, events[1].At.Before(events[2].At), "events[1] should precede events[2]")
+}
+
+// --- List against real NATS ListKeys ---
+
+func TestIntegration_ListAgainstRealListKeys(t *testing.T) {
+	mgr, _ := setupManager(t)
+	ctx := context.Background()
+
+	for i := range 3 {
+		require.NoError(t, mgr.Create(ctx, &integMissionState{
+			EntityIDF:   fmt.Sprintf("li-%d", i),
+			PhaseF:      "planning",
+			OwnerOrgIDF: "acme",
+		}))
+	}
+
+	got, err := mgr.List(ctx, "integ-mission", ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, got, 3, "List should return all 3 instances")
+
+	filtered, err := mgr.List(ctx, "integ-mission", ListOptions{
+		Match: map[string]any{"owner_org_id": "acme"},
+	})
+	require.NoError(t, err)
+	require.Len(t, filtered, 3, "Match owner_org_id=acme should match all 3")
+}
+
+// --- Watch against real NATS WatchAll ---
+
+func TestIntegration_WatchDeliversBootstrap(t *testing.T) {
+	mgr, _ := setupManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := range 2 {
+		require.NoError(t, mgr.Create(ctx, &integMissionState{
+			EntityIDF: fmt.Sprintf("wi-%d", i),
+			PhaseF:    "planning",
+		}))
+	}
+
+	ch, err := mgr.Watch(ctx, "integ-mission")
+	require.NoError(t, err)
+
+	seen := make(map[string]bool)
+	timeout := time.After(5 * time.Second)
+	for len(seen) < 2 {
+		select {
+		case p, ok := <-ch:
+			if !ok {
+				t.Fatalf("Watch channel closed early; got %d/2 entries", len(seen))
+			}
+			seen[p.EntityID()] = true
+		case <-timeout:
+			t.Fatalf("timed out waiting for Watch bootstrap; got %d/2 so far", len(seen))
+		}
+	}
+	require.True(t, seen["wi-0"] && seen["wi-1"], "bootstrap missing entries: %+v", seen)
+}
+
+// --- Sanity: jetstream sentinel coverage ---
+
+func TestIntegration_GetUnknownKeyReturnsNotFound(t *testing.T) {
+	// Pins kvNATSStore.Get's jetstream.ErrKeyNotFound classifier
+	// against the real jetstream sentinel. If this regresses, the
+	// upstream classifier is silently broken.
+	mgr, _ := setupManager(t)
+	ctx := context.Background()
+
+	_, err := mgr.Get(ctx, "integ-mission", "never-existed")
+	require.True(t, errors.Is(err, ErrEntityNotFound),
+		"Get on missing key should classify as ErrEntityNotFound, got %v", err)
+}

--- a/pkg/lifecycle/kv_store.go
+++ b/pkg/lifecycle/kv_store.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"errors"
+	"time"
 )
 
 // kvStore is the internal abstraction the Manager uses for KV
@@ -44,12 +45,77 @@ type kvStore interface {
 	// the entry is tombstoned, History still sees the deletion in
 	// the revision stream).
 	Delete(ctx context.Context, key string) error
+
+	// ListKeys returns all keys currently present in the bucket
+	// (delete-marker entries excluded). Used by Manager.List's
+	// linear-scan path. Streaming preferred over snapshot for
+	// large buckets — see jetstream.KeyValue.ListKeys vs Keys —
+	// but the v1 implementation collects the snapshot into a
+	// slice for simplicity. The scaling-cliff escape hatch (v2
+	// secondary index) is documented in ADR-047 § KV indexing.
+	ListKeys(ctx context.Context) ([]string, error)
+
+	// History returns every revision of key in chronological order
+	// (oldest first). Used by Manager.History to reconstruct
+	// TransitionEvent records from KV revision metadata. Entries
+	// with IsDelete=true represent tombstone events (Delete calls);
+	// callers filter them depending on whether they want only
+	// successful writes or the full event stream.
+	//
+	// Returns errKVKeyNotFound if the key has no history at all
+	// (never existed). An empty history for a deleted key returns
+	// the delete-marker entry (jetstream preserves the tombstone
+	// in the revision stream).
+	History(ctx context.Context, key string) ([]kvEntry, error)
+
+	// Watch streams real-time updates for every key in the bucket.
+	// The returned channel emits one kvEntry per KV write
+	// (including deletes via IsDelete=true); the channel closes
+	// when ctx is canceled OR the watcher errors out (caller
+	// treats both as "stop iterating").
+	//
+	// Bootstrap semantics: the first batch of entries delivered
+	// are the CURRENT values for all keys (snapshot replay),
+	// followed by live updates. Callers that only want forward
+	// updates filter the bootstrap batch in their loop.
+	//
+	// No per-key filtering at this layer — Manager.Watch already
+	// wants every instance of a workflow (= every key in the
+	// bucket), and filtering wider/narrower would couple the
+	// abstraction to NATS subject-wildcard semantics. Filter
+	// caller-side on kvEntry.Key if needed.
+	Watch(ctx context.Context) (<-chan kvEntry, error)
 }
 
-// (kvEntry, the value type used by Watch/History, lands in the next
-// commit on this branch alongside the query-ops surface that
-// consumes it. Keeping it out of this commit avoids unused-type
-// lint warnings on the foundation slice.)
+// kvEntry is the package-internal KV entry value type. Mirrors the
+// fields Manager.List/Watch/History need from jetstream.KeyValueEntry
+// without forcing the kvStore abstraction (or its mock) to depend
+// on jetstream types.
+type kvEntry struct {
+	// Key is the key the entry lives under.
+	Key string
+
+	// Value is the most recent value bytes. Nil for delete-marker
+	// entries returned by History or Watch.
+	Value []byte
+
+	// Revision is the unique sequence number for this entry.
+	// Monotonic per-bucket in jetstream; the mock mirrors this
+	// (single counter shared across all keys).
+	Revision uint64
+
+	// CreatedAt is when this specific revision was written.
+	// Sourced from jetstream entry metadata in production;
+	// kvMockStore uses its configurable clock. Authoritative
+	// across restarts and clock skew.
+	CreatedAt time.Time
+
+	// IsDelete is true when the entry represents a delete-marker
+	// (tombstone) rather than a put. History and Watch surface
+	// these; Manager.History uses them to render terminal events
+	// in the entity's audit trail.
+	IsDelete bool
+}
 
 // Package-private KV sentinel errors. The kvStore interface returns
 // these; the Manager translates them into the public errors.go

--- a/pkg/lifecycle/kv_store.go
+++ b/pkg/lifecycle/kv_store.go
@@ -1,0 +1,72 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+)
+
+// kvStore is the internal abstraction the Manager uses for KV
+// operations against a single NATS KV bucket. Scoped per-bucket
+// so call sites don't pass the bucket name on every method.
+//
+// The interface is INTERNAL (lowercase) on purpose — apps wire up
+// the Manager via NewManager and never interact with kvStore
+// directly. Two implementations live in this package:
+//   - kvMockStore (kv_store_mock.go) — in-memory map for unit tests
+//   - kvNATSStore (kv_store_nats.go) — thin wrapper over
+//     jetstream.KeyValue for production
+//
+// Method semantics deliberately mirror jetstream.KeyValue's
+// surface (Get / Create / Update with revision-CAS / Delete /
+// ListKeys / History / Watch) so the NATS adapter is a thin
+// translation, NOT a re-implementation of KV semantics.
+type kvStore interface {
+	// Get returns the latest value for key with its current revision.
+	// Returns ErrKVKeyNotFound when the key does not exist (callers
+	// branch on this to surface ErrEntityNotFound at the Manager
+	// layer).
+	Get(ctx context.Context, key string) (value []byte, revision uint64, err error)
+
+	// Create writes value at key with create-only semantics: returns
+	// ErrKVKeyExists when the key already exists. Returns the
+	// revision the new entry was written at.
+	Create(ctx context.Context, key string, value []byte) (revision uint64, err error)
+
+	// Update writes value at key only if the current revision
+	// matches expectedRevision (CAS). Returns ErrKVRevisionMismatch
+	// when the current revision is different — caller must Get-then-
+	// retry with the fresh revision. Returns the new revision on
+	// success.
+	Update(ctx context.Context, key string, value []byte, expectedRevision uint64) (newRevision uint64, err error)
+
+	// Delete places a delete marker at key. Subsequent Get on the
+	// key returns ErrKVKeyNotFound (matching jetstream semantics —
+	// the entry is tombstoned, History still sees the deletion in
+	// the revision stream).
+	Delete(ctx context.Context, key string) error
+}
+
+// (kvEntry, the value type used by Watch/History, lands in the next
+// commit on this branch alongside the query-ops surface that
+// consumes it. Keeping it out of this commit avoids unused-type
+// lint warnings on the foundation slice.)
+
+// Package-private KV sentinel errors. The kvStore interface returns
+// these; the Manager translates them into the public errors.go
+// sentinels (ErrEntityNotFound, ErrInvalidTransition etc.) so apps
+// only see the public surface.
+var (
+	// ErrKVKeyNotFound is returned by kvStore.Get when the key
+	// has no value (never existed or was deleted). Mirrors
+	// jetstream.ErrKeyNotFound.
+	errKVKeyNotFound = errors.New("lifecycle: KV key not found")
+
+	// ErrKVKeyExists is returned by kvStore.Create when the key
+	// already exists. Mirrors jetstream.ErrKeyExists.
+	errKVKeyExists = errors.New("lifecycle: KV key already exists")
+
+	// ErrKVRevisionMismatch is returned by kvStore.Update when the
+	// CAS revision check fails. Manager.Update retries on this
+	// (Get + mutator + Update) up to a bounded retry budget.
+	errKVRevisionMismatch = errors.New("lifecycle: KV revision mismatch (CAS conflict)")
+)

--- a/pkg/lifecycle/kv_store_mock.go
+++ b/pkg/lifecycle/kv_store_mock.go
@@ -37,14 +37,23 @@ type kvMockStore struct {
 }
 
 // kvMockEntry is the per-key in-memory record. Tracks value +
-// revision + creation time. A nil value represents a delete marker
-// (so History could surface the tombstone if needed by the query-ops
-// surface in the next commit).
+// revision + creation time + latest-revision time. A nil value
+// represents a delete marker (so History could surface the tombstone
+// if needed by the query-ops surface in the next commit).
+//
+// createdAt is IMMUTABLE after Create — mirrors real jetstream
+// where the first-create timestamp is preserved across subsequent
+// Update writes. revisionAt advances per write. The next commit's
+// History query op uses createdAt to surface "when did this entity
+// first appear" and revisionAt to surface "when was each revision
+// written" — keeping them distinct here so the mock doesn't diverge
+// from real jetstream semantics under integration-test rewrites.
 type kvMockEntry struct {
-	value     []byte
-	revision  uint64
-	createdAt time.Time
-	deleted   bool
+	value      []byte
+	revision   uint64
+	createdAt  time.Time // immutable post-Create
+	revisionAt time.Time // re-set on every write
+	deleted    bool
 }
 
 // newKVMockStore constructs a fresh in-memory store. The optional
@@ -84,10 +93,12 @@ func (s *kvMockStore) Create(_ context.Context, key string, value []byte) (uint6
 	s.nextRevision++
 	stored := make([]byte, len(value))
 	copy(stored, value)
+	now := s.clock()
 	s.entries[key] = &kvMockEntry{
-		value:     stored,
-		revision:  s.nextRevision,
-		createdAt: s.clock(),
+		value:      stored,
+		revision:   s.nextRevision,
+		createdAt:  now,
+		revisionAt: now,
 	}
 	return s.nextRevision, nil
 }
@@ -107,7 +118,9 @@ func (s *kvMockStore) Update(_ context.Context, key string, value []byte, expect
 	copy(stored, value)
 	entry.value = stored
 	entry.revision = s.nextRevision
-	entry.createdAt = s.clock()
+	entry.revisionAt = s.clock()
+	// createdAt is intentionally NOT touched here — see the type
+	// comment for the rationale.
 	return s.nextRevision, nil
 }
 
@@ -124,6 +137,6 @@ func (s *kvMockStore) Delete(_ context.Context, key string) error {
 	entry.value = nil
 	entry.deleted = true
 	entry.revision = s.nextRevision
-	entry.createdAt = s.clock()
+	entry.revisionAt = s.clock()
 	return nil
 }

--- a/pkg/lifecycle/kv_store_mock.go
+++ b/pkg/lifecycle/kv_store_mock.go
@@ -1,0 +1,129 @@
+package lifecycle
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// kvMockStore is an in-memory kvStore implementation for unit tests.
+// Production wiring uses kvNATSStore (kv_store_nats.go); the mock
+// exists so Manager behavior can be tested without spinning up NATS
+// for every package run.
+//
+// Concurrency model: a single sync.RWMutex protects the map +
+// per-key revision counter. Manager operations against this store
+// are safe to call from concurrent goroutines (tests cover the
+// CAS-retry path).
+//
+// Restart-recovery and real-CAS-semantics tests live in the
+// integration-test bucket (testcontainers + kvNATSStore) — the
+// mock is for fast behavior-shape coverage, not for validating
+// NATS-specific semantics like delete-marker tombstoning or
+// revision-history depth limits.
+type kvMockStore struct {
+	mu      sync.RWMutex
+	entries map[string]*kvMockEntry
+	// nextRevision is a monotonically-increasing counter, NOT
+	// per-key. Mirrors jetstream's stream-level sequence semantics
+	// (every write across the bucket increments the global stream
+	// sequence) so CAS-conflict tests see realistic revision
+	// numbers between unrelated keys.
+	nextRevision uint64
+	// clock is the time source for kvEntry.CreatedAt. Tests can
+	// override for deterministic timestamps; the default uses
+	// time.Now (wallclock).
+	clock func() time.Time
+}
+
+// kvMockEntry is the per-key in-memory record. Tracks value +
+// revision + creation time. A nil value represents a delete marker
+// (so History could surface the tombstone if needed by the query-ops
+// surface in the next commit).
+type kvMockEntry struct {
+	value     []byte
+	revision  uint64
+	createdAt time.Time
+	deleted   bool
+}
+
+// newKVMockStore constructs a fresh in-memory store. The optional
+// clock argument is intended for tests that need deterministic
+// timestamps; nil falls back to time.Now.
+func newKVMockStore(clock func() time.Time) *kvMockStore {
+	if clock == nil {
+		clock = time.Now
+	}
+	return &kvMockStore{
+		entries: make(map[string]*kvMockEntry),
+		clock:   clock,
+	}
+}
+
+func (s *kvMockStore) Get(_ context.Context, key string) ([]byte, uint64, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	entry, ok := s.entries[key]
+	if !ok || entry.deleted {
+		return nil, 0, errKVKeyNotFound
+	}
+	// Defensive copy so callers mutating the returned slice can't
+	// corrupt the store. Matches the contract a real KV connection
+	// would provide (separate network payload per Get).
+	out := make([]byte, len(entry.value))
+	copy(out, entry.value)
+	return out, entry.revision, nil
+}
+
+func (s *kvMockStore) Create(_ context.Context, key string, value []byte) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if entry, ok := s.entries[key]; ok && !entry.deleted {
+		return 0, errKVKeyExists
+	}
+	s.nextRevision++
+	stored := make([]byte, len(value))
+	copy(stored, value)
+	s.entries[key] = &kvMockEntry{
+		value:     stored,
+		revision:  s.nextRevision,
+		createdAt: s.clock(),
+	}
+	return s.nextRevision, nil
+}
+
+func (s *kvMockStore) Update(_ context.Context, key string, value []byte, expectedRevision uint64) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.entries[key]
+	if !ok || entry.deleted {
+		return 0, errKVKeyNotFound
+	}
+	if entry.revision != expectedRevision {
+		return 0, errKVRevisionMismatch
+	}
+	s.nextRevision++
+	stored := make([]byte, len(value))
+	copy(stored, value)
+	entry.value = stored
+	entry.revision = s.nextRevision
+	entry.createdAt = s.clock()
+	return s.nextRevision, nil
+}
+
+func (s *kvMockStore) Delete(_ context.Context, key string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.entries[key]
+	if !ok || entry.deleted {
+		// Idempotent delete — already gone is success, matching
+		// jetstream's tombstone-or-noop behavior.
+		return nil
+	}
+	s.nextRevision++
+	entry.value = nil
+	entry.deleted = true
+	entry.revision = s.nextRevision
+	entry.createdAt = s.clock()
+	return nil
+}

--- a/pkg/lifecycle/kv_store_mock.go
+++ b/pkg/lifecycle/kv_store_mock.go
@@ -24,6 +24,11 @@ import (
 type kvMockStore struct {
 	mu      sync.RWMutex
 	entries map[string]*kvMockEntry
+	// history tracks every write (Put/Update/Delete) per key in
+	// chronological order. Mirrors jetstream's revision-stream
+	// preservation; History() returns slice copies from this map.
+	// Populated by appendHistory from Create/Update/Delete.
+	history map[string][]kvEntry
 	// nextRevision is a monotonically-increasing counter, NOT
 	// per-key. Mirrors jetstream's stream-level sequence semantics
 	// (every write across the bucket increments the global stream
@@ -65,6 +70,7 @@ func newKVMockStore(clock func() time.Time) *kvMockStore {
 	}
 	return &kvMockStore{
 		entries: make(map[string]*kvMockEntry),
+		history: make(map[string][]kvEntry),
 		clock:   clock,
 	}
 }
@@ -100,6 +106,17 @@ func (s *kvMockStore) Create(_ context.Context, key string, value []byte) (uint6
 		createdAt:  now,
 		revisionAt: now,
 	}
+	// History snapshot — copy the value bytes so subsequent
+	// Update mutations to the live entry don't retroactively
+	// rewrite this revision's recorded value.
+	histVal := make([]byte, len(stored))
+	copy(histVal, stored)
+	s.appendHistory(key, kvEntry{
+		Key:       key,
+		Value:     histVal,
+		Revision:  s.nextRevision,
+		CreatedAt: now,
+	})
 	return s.nextRevision, nil
 }
 
@@ -121,6 +138,15 @@ func (s *kvMockStore) Update(_ context.Context, key string, value []byte, expect
 	entry.revisionAt = s.clock()
 	// createdAt is intentionally NOT touched here — see the type
 	// comment for the rationale.
+	// History snapshot — see Create for the value-copy rationale.
+	histVal := make([]byte, len(stored))
+	copy(histVal, stored)
+	s.appendHistory(key, kvEntry{
+		Key:       key,
+		Value:     histVal,
+		Revision:  s.nextRevision,
+		CreatedAt: entry.revisionAt,
+	})
 	return s.nextRevision, nil
 }
 
@@ -138,5 +164,119 @@ func (s *kvMockStore) Delete(_ context.Context, key string) error {
 	entry.deleted = true
 	entry.revision = s.nextRevision
 	entry.revisionAt = s.clock()
+	// Append a tombstone snapshot to history so History() can
+	// surface the delete event. Real jetstream preserves the
+	// delete marker in the revision stream; the mock has to
+	// snapshot explicitly because the live entries map only
+	// holds the latest state.
+	s.appendHistory(key, kvEntry{
+		Key:       key,
+		Value:     nil,
+		Revision:  s.nextRevision,
+		CreatedAt: entry.revisionAt,
+		IsDelete:  true,
+	})
 	return nil
+}
+
+// ListKeys returns all keys currently present (non-deleted) in
+// sorted order. Sorted output keeps List's iteration deterministic
+// across processes so paginated operator queries don't see flap.
+func (s *kvMockStore) ListKeys(_ context.Context) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	keys := make([]string, 0, len(s.entries))
+	for k, entry := range s.entries {
+		if !entry.deleted {
+			keys = append(keys, k)
+		}
+	}
+	// Cheap stable order — sort.Strings rather than introducing
+	// a sort import here when one's already in scope elsewhere.
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
+			keys[j-1], keys[j] = keys[j], keys[j-1]
+		}
+	}
+	return keys, nil
+}
+
+// History returns every revision of the given key in chronological
+// order (oldest first). Includes delete-marker entries with
+// IsDelete=true. Returns errKVKeyNotFound if the key has never
+// existed (no history records at all).
+func (s *kvMockStore) History(_ context.Context, key string) ([]kvEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	hist, ok := s.history[key]
+	if !ok || len(hist) == 0 {
+		return nil, errKVKeyNotFound
+	}
+	// Defensive copy so callers iterating concurrently with
+	// future writes don't see the slice grow under them.
+	out := make([]kvEntry, len(hist))
+	copy(out, hist)
+	return out, nil
+}
+
+// Watch returns a channel emitting every KV write that lands
+// after the snapshot replay. The mock's snapshot is the current
+// live state (non-deleted entries); subsequent writes go through
+// the watcher.
+//
+// The mock does NOT track watchers across calls — each call gets
+// a fresh channel that delivers the snapshot then closes on ctx.
+// Real jetstream's Watch handles concurrent watchers via NATS
+// pub-sub; integration tests cover that behavior. For unit tests,
+// the snapshot-then-close shape is enough to verify Manager.Watch
+// processes entries correctly.
+func (s *kvMockStore) Watch(ctx context.Context) (<-chan kvEntry, error) {
+	out := make(chan kvEntry, 16)
+	// Snapshot under read-lock; deliver outside the lock so
+	// listeners don't pin the mock during slow consumers.
+	s.mu.RLock()
+	snapshot := make([]kvEntry, 0, len(s.entries))
+	for k, entry := range s.entries {
+		if entry.deleted {
+			continue
+		}
+		// Defensive value copy — same contract as Get.
+		val := make([]byte, len(entry.value))
+		copy(val, entry.value)
+		snapshot = append(snapshot, kvEntry{
+			Key:       k,
+			Value:     val,
+			Revision:  entry.revision,
+			CreatedAt: entry.revisionAt,
+		})
+	}
+	s.mu.RUnlock()
+
+	go func() {
+		defer close(out)
+		for _, entry := range snapshot {
+			select {
+			case out <- entry:
+			case <-ctx.Done():
+				return
+			}
+		}
+		// Live updates beyond the snapshot are NOT delivered by
+		// the mock — production NATS would stream them. The
+		// integration-test slice covers that path. For unit
+		// tests, the snapshot is enough to verify Manager.Watch's
+		// decode + dispatch shape.
+		<-ctx.Done()
+	}()
+	return out, nil
+}
+
+// appendHistory records a snapshot of the current entry state in
+// the per-key history slice. Called from Create/Update/Delete to
+// build up the revision stream. Caller holds s.mu (write lock).
+func (s *kvMockStore) appendHistory(key string, entry kvEntry) {
+	if s.history == nil {
+		s.history = make(map[string][]kvEntry)
+	}
+	s.history[key] = append(s.history[key], entry)
 }

--- a/pkg/lifecycle/kv_store_mock.go
+++ b/pkg/lifecycle/kv_store_mock.go
@@ -2,6 +2,7 @@ package lifecycle
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 )
@@ -191,13 +192,7 @@ func (s *kvMockStore) ListKeys(_ context.Context) ([]string, error) {
 			keys = append(keys, k)
 		}
 	}
-	// Cheap stable order — sort.Strings rather than introducing
-	// a sort import here when one's already in scope elsewhere.
-	for i := 1; i < len(keys); i++ {
-		for j := i; j > 0 && keys[j-1] > keys[j]; j-- {
-			keys[j-1], keys[j] = keys[j], keys[j-1]
-		}
-	}
+	sort.Strings(keys)
 	return keys, nil
 }
 

--- a/pkg/lifecycle/kv_store_nats.go
+++ b/pkg/lifecycle/kv_store_nats.go
@@ -1,0 +1,112 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// kvNATSStore is the production kvStore implementation — a thin
+// wrapper over jetstream.KeyValue. Most of the body is type
+// translation from jetstream's sentinel errors to the package-
+// internal errKV* sentinels so the Manager doesn't need to import
+// jetstream directly.
+//
+// Bucket lifecycle: this adapter does NOT create the bucket.
+// Apps provision their own KV buckets per their deployment
+// topology — the harness only consumes them. newKVNATSStore
+// resolves the existing bucket via natsclient.GetKeyValueBucket;
+// missing buckets surface a wrapped error at Manager.Register time.
+type kvNATSStore struct {
+	bucket jetstream.KeyValue
+	name   string // bucket name; kept for log/error messages
+}
+
+// newKVNATSStore opens an existing KV bucket via the natsclient.
+// Returns an error if the bucket does not exist or the client is
+// nil — both surface at Manager.Register time so wiring bugs
+// don't bury themselves until first Get.
+func newKVNATSStore(client *natsclient.Client, bucket string) (kvStore, error) {
+	if client == nil {
+		return nil, errors.New("lifecycle: newKVNATSStore requires non-nil natsclient.Client")
+	}
+	if bucket == "" {
+		return nil, errors.New("lifecycle: newKVNATSStore requires non-empty bucket name")
+	}
+	// Resolve at Register time. Apps must provision the bucket
+	// before any workflow registration; the harness doesn't manage
+	// bucket creation (operator topology choice — replication,
+	// history depth, max-bytes are per-bucket NATS-level decisions
+	// the framework shouldn't make).
+	kv, err := client.GetKeyValueBucket(context.Background(), bucket)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: open KV bucket %q: %w", bucket, err)
+	}
+	return &kvNATSStore{bucket: kv, name: bucket}, nil
+}
+
+func (s *kvNATSStore) Get(ctx context.Context, key string) ([]byte, uint64, error) {
+	entry, err := s.bucket.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) || errors.Is(err, jetstream.ErrKeyDeleted) {
+			return nil, 0, errKVKeyNotFound
+		}
+		return nil, 0, fmt.Errorf("lifecycle: KV Get %s/%s: %w", s.name, key, err)
+	}
+	return entry.Value(), entry.Revision(), nil
+}
+
+func (s *kvNATSStore) Create(ctx context.Context, key string, value []byte) (uint64, error) {
+	rev, err := s.bucket.Create(ctx, key, value)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyExists) {
+			return 0, errKVKeyExists
+		}
+		return 0, fmt.Errorf("lifecycle: KV Create %s/%s: %w", s.name, key, err)
+	}
+	return rev, nil
+}
+
+func (s *kvNATSStore) Update(ctx context.Context, key string, value []byte, expectedRevision uint64) (uint64, error) {
+	rev, err := s.bucket.Update(ctx, key, value, expectedRevision)
+	if err != nil {
+		// jetstream surfaces CAS conflicts as a wrong-revision
+		// error (no dedicated sentinel — pattern matched by
+		// natsclient consumers elsewhere). Substring-classify
+		// against jetstream's error text is fragile; the safer
+		// classifier is "any non-found error on Update with a
+		// non-zero expectedRevision is a CAS conflict OR a key-
+		// gone-during-update." Both reduce to "Manager retries
+		// via Get + mutator + Update under updateRetries budget."
+		//
+		// TODO(integration-test): the testcontainers slice should
+		// exercise this exact path and assert errKVRevisionMismatch
+		// classification against real jetstream sentinels — if
+		// jetstream adds a dedicated CAS-conflict error in a future
+		// release, swap this classifier to errors.Is.
+		if errors.Is(err, jetstream.ErrKeyNotFound) || errors.Is(err, jetstream.ErrKeyDeleted) {
+			return 0, errKVKeyNotFound
+		}
+		// Default to CAS-conflict classification — Manager.Update's
+		// retry loop is the right response for the common case
+		// (concurrent writer beat us). Real-error paths surface
+		// via the wrapped error after retries exhaust.
+		return 0, fmt.Errorf("%w: %w", errKVRevisionMismatch, err)
+	}
+	return rev, nil
+}
+
+func (s *kvNATSStore) Delete(ctx context.Context, key string) error {
+	if err := s.bucket.Delete(ctx, key); err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) || errors.Is(err, jetstream.ErrKeyDeleted) {
+			// Idempotent: already gone is not an error from the
+			// Manager's perspective.
+			return nil
+		}
+		return fmt.Errorf("lifecycle: KV Delete %s/%s: %w", s.name, key, err)
+	}
+	return nil
+}

--- a/pkg/lifecycle/kv_store_nats.go
+++ b/pkg/lifecycle/kv_store_nats.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -73,28 +75,47 @@ func (s *kvNATSStore) Create(ctx context.Context, key string, value []byte) (uin
 func (s *kvNATSStore) Update(ctx context.Context, key string, value []byte, expectedRevision uint64) (uint64, error) {
 	rev, err := s.bucket.Update(ctx, key, value, expectedRevision)
 	if err != nil {
-		// jetstream surfaces CAS conflicts as a wrong-revision
-		// error (no dedicated sentinel — pattern matched by
-		// natsclient consumers elsewhere). Substring-classify
-		// against jetstream's error text is fragile; the safer
-		// classifier is "any non-found error on Update with a
-		// non-zero expectedRevision is a CAS conflict OR a key-
-		// gone-during-update." Both reduce to "Manager retries
-		// via Get + mutator + Update under updateRetries budget."
+		// Classifier hierarchy — narrow to known shapes, refuse to
+		// silently wrap transport/cancellation errors as CAS
+		// conflicts (Manager.Update would otherwise retry a real
+		// network timeout up to updateRetries=5 times, amplifying
+		// one failed write into five).
 		//
-		// TODO(integration-test): the testcontainers slice should
-		// exercise this exact path and assert errKVRevisionMismatch
-		// classification against real jetstream sentinels — if
-		// jetstream adds a dedicated CAS-conflict error in a future
-		// release, swap this classifier to errors.Is.
+		// 1) Context errors propagate unwrapped — caller cancelled
+		//    or timed out, retrying makes no sense.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return 0, fmt.Errorf("lifecycle: KV Update %s/%s: %w", s.name, key, err)
+		}
+		// 2) Transport-level failures propagate unwrapped — these
+		//    are NOT CAS conflicts; retrying without backoff just
+		//    re-hammers a degraded connection.
+		if errors.Is(err, nats.ErrTimeout) || errors.Is(err, nats.ErrNoResponders) ||
+			errors.Is(err, nats.ErrConnectionClosed) || errors.Is(err, nats.ErrConnectionDraining) {
+			return 0, fmt.Errorf("lifecycle: KV Update %s/%s (transport): %w", s.name, key, err)
+		}
+		// 3) Key gone during Update (deleted by concurrent writer)
+		//    surfaces as ErrEntityNotFound at the Manager layer.
 		if errors.Is(err, jetstream.ErrKeyNotFound) || errors.Is(err, jetstream.ErrKeyDeleted) {
 			return 0, errKVKeyNotFound
 		}
-		// Default to CAS-conflict classification — Manager.Update's
-		// retry loop is the right response for the common case
-		// (concurrent writer beat us). Real-error paths surface
-		// via the wrapped error after retries exhaust.
-		return 0, fmt.Errorf("%w: %w", errKVRevisionMismatch, err)
+		// 4) Known CAS-shape errors — jetstream models CAS-fail-on-
+		//    Update as ErrKeyExists internally (same "next revision
+		//    write would collide" shape as Create on existing key).
+		//    Plus substring fallback against the canonical "wrong
+		//    last sequence" message jetstream emits today, so this
+		//    classifier doesn't silently regress if the sentinel
+		//    coverage drifts. TODO(integration-test): pin this
+		//    against real jetstream in the testcontainers slice;
+		//    swap to a dedicated sentinel if/when jetstream adds one.
+		if errors.Is(err, jetstream.ErrKeyExists) ||
+			strings.Contains(err.Error(), "wrong last sequence") {
+			return 0, fmt.Errorf("%w: %w", errKVRevisionMismatch, err)
+		}
+		// 5) Default — surface the raw error wrapped, NOT classified
+		//    as CAS. Unclassified errors hitting Manager.Update's
+		//    retry loop will fail-fast (the retry only triggers on
+		//    errors.Is(errKVRevisionMismatch)).
+		return 0, fmt.Errorf("lifecycle: KV Update %s/%s: %w", s.name, key, err)
 	}
 	return rev, nil
 }

--- a/pkg/lifecycle/kv_store_nats.go
+++ b/pkg/lifecycle/kv_store_nats.go
@@ -131,3 +131,84 @@ func (s *kvNATSStore) Delete(ctx context.Context, key string) error {
 	}
 	return nil
 }
+
+func (s *kvNATSStore) ListKeys(ctx context.Context) ([]string, error) {
+	// jetstream's ListKeys returns a streaming KeyLister to avoid
+	// holding the whole keyset in memory for huge buckets. v1
+	// collects to a slice for the simpler Manager.List contract;
+	// the v2 secondary-index work (ADR-047 § KV indexing) replaces
+	// this scan path for high-cardinality workflows.
+	lister, err := s.bucket.ListKeys(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: KV ListKeys %s: %w", s.name, err)
+	}
+	defer lister.Stop()
+	var keys []string
+	for key := range lister.Keys() {
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func (s *kvNATSStore) History(ctx context.Context, key string) ([]kvEntry, error) {
+	entries, err := s.bucket.History(ctx, key)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			return nil, errKVKeyNotFound
+		}
+		return nil, fmt.Errorf("lifecycle: KV History %s/%s: %w", s.name, key, err)
+	}
+	out := make([]kvEntry, len(entries))
+	for i, entry := range entries {
+		// Operation distinguishes Put/Delete/Purge. Anything
+		// other than Put is a tombstone-shaped event for History
+		// consumers.
+		op := entry.Operation()
+		out[i] = kvEntry{
+			Key:       entry.Key(),
+			Value:     entry.Value(),
+			Revision:  entry.Revision(),
+			CreatedAt: entry.Created(),
+			IsDelete:  op == jetstream.KeyValueDelete || op == jetstream.KeyValuePurge,
+		}
+	}
+	return out, nil
+}
+
+func (s *kvNATSStore) Watch(ctx context.Context) (<-chan kvEntry, error) {
+	watcher, err := s.bucket.WatchAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: KV WatchAll %s: %w", s.name, err)
+	}
+	out := make(chan kvEntry, 16)
+	go func() {
+		// Channel-close on goroutine exit; caller treats close
+		// as "stop iterating" per the kvStore.Watch contract.
+		defer close(out)
+		defer func() { _ = watcher.Stop() }()
+		for entry := range watcher.Updates() {
+			if entry == nil {
+				// jetstream signals end-of-bootstrap with a nil
+				// entry; we don't expose that signal at the
+				// kvStore layer — Manager.Watch doesn't need it
+				// (it processes each entry uniformly). Skip the
+				// nil and keep iterating.
+				continue
+			}
+			op := entry.Operation()
+			ev := kvEntry{
+				Key:       entry.Key(),
+				Value:     entry.Value(),
+				Revision:  entry.Revision(),
+				CreatedAt: entry.Created(),
+				IsDelete:  op == jetstream.KeyValueDelete || op == jetstream.KeyValuePurge,
+			}
+			select {
+			case out <- ev:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}

--- a/pkg/lifecycle/list_options.go
+++ b/pkg/lifecycle/list_options.go
@@ -1,0 +1,64 @@
+package lifecycle
+
+import "time"
+
+// ListOptions parameterizes Manager.List queries against a registered
+// workflow type. All fields are optional; the zero value lists every
+// instance in the workflow's KV bucket (subject to Limit / Offset).
+//
+// Match semantics:
+//   - Phase filters to entries whose Participant.Phase() equals the
+//     given value. Empty string means any phase.
+//   - Active=true filters to entries whose Participant.IsTerminal()
+//     returns false. Active=false (the zero value) does not filter on
+//     terminal status — to list only terminal entries, set
+//     ListOptions.Phase to a specific terminal phase OR add a Match
+//     entry on a field that distinguishes them.
+//   - UpdatedAfter filters to entries whose KV revision timestamp is
+//     strictly later than the given time. Useful for incremental
+//     pagination of large active sets.
+//   - Match is a field-equality map; key is the JSON field name (per
+//     `json:` struct tag), value is the expected value. Multi-tenancy
+//     is expressed app-side via Match{"org_id": "acme"} — the
+//     framework knows nothing about org/tenant semantics. Reflection
+//     is used to read field values at match time; this is acceptable
+//     for v1 linear-scan but flag fields as `lifecycle:"indexable"`
+//     for v2 secondary-index migration once an operator demonstrates a
+//     scaling bottleneck.
+//   - Limit caps the returned slice size. 0 means unlimited (default).
+//   - Offset is a pagination cursor — skip the first Offset matching
+//     entries. Combine with Limit for paged operator-API responses.
+//
+// v1 implementation is linear scan over the bucket; complexity is
+// O(N) per List call where N is the total instance count. Operators
+// hitting this cliff (~10K active instances is a reasonable guideline
+// — file when an operator demonstrates the bottleneck) trigger the
+// v2 secondary index work; the API stays stable across the migration.
+type ListOptions struct {
+	// Phase filters to instances whose current phase equals this
+	// value. Empty string means any phase.
+	Phase string
+
+	// Active=true filters to non-terminal instances. Active=false
+	// (default) does not filter on terminal status. To list only
+	// terminal instances, use Phase with a specific terminal phase
+	// or Match on a discriminating field.
+	Active bool
+
+	// UpdatedAfter filters to instances whose last KV write happened
+	// strictly after this time. Zero value disables the filter.
+	UpdatedAfter time.Time
+
+	// Match is a field-equality map (JSON field name → expected value).
+	// Multi-tenancy and other app-specific filters live here. Field
+	// resolution is reflection-based against the registered state
+	// struct.
+	Match map[string]any
+
+	// Limit caps the returned slice size. 0 (default) means unlimited.
+	Limit int
+
+	// Offset skips the first Offset matching entries before applying
+	// Limit. Use for paged operator-API responses.
+	Offset int
+}

--- a/pkg/lifecycle/list_options.go
+++ b/pkg/lifecycle/list_options.go
@@ -1,12 +1,10 @@
 package lifecycle
 
-import "time"
-
 // ListOptions parameterizes Manager.List queries against a registered
 // workflow type. All fields are optional; the zero value lists every
 // instance in the workflow's KV bucket (subject to Limit / Offset).
 //
-// Match semantics:
+// Filter semantics:
 //
 //   - Phase filters to entries whose Participant.Phase() equals the
 //     given value. Empty string means any phase.
@@ -16,10 +14,6 @@ import "time"
 //     terminal status — to list only terminal entries, set
 //     ListOptions.Phase to a specific terminal phase OR add a Match
 //     entry on a field that distinguishes them.
-//
-//   - UpdatedAfter filters to entries whose KV revision timestamp is
-//     strictly later than the given time. Useful for incremental
-//     pagination of large active sets.
 //
 //   - Match is a field-equality map; key is the JSON field name (per
 //     `json:` struct tag), value is the expected value. Multi-tenancy
@@ -63,6 +57,20 @@ import "time"
 // hitting this cliff (~10K active instances is a reasonable guideline
 // — file when an operator demonstrates the bottleneck) trigger the
 // v2 secondary index work; the API stays stable across the migration.
+//
+// # Dropped from v1 surface — UpdatedAfter time.Time
+//
+// An earlier draft exposed UpdatedAfter for incremental pagination
+// of large active sets ("show me changes since T"). It was removed
+// before v1 ship because plumbing the per-entity revision timestamp
+// from the kvStore layer into the filter chain required widening
+// kvStore.Get's return signature to leak store-layer concerns
+// (CreatedAt) into the Participant model. Apps that need
+// since-timestamp pagination today should store their own
+// LastUpdatedAt unix-timestamp field on the state struct and Match
+// against it. v2 secondary indexing will add the filter back as a
+// first-class API when an operator demonstrates the need; the API
+// stays additive across that migration.
 type ListOptions struct {
 	// Phase filters to instances whose current phase equals this
 	// value. Empty string means any phase.
@@ -73,10 +81,6 @@ type ListOptions struct {
 	// terminal instances, use Phase with a specific terminal phase
 	// or Match on a discriminating field.
 	Active bool
-
-	// UpdatedAfter filters to instances whose last KV write happened
-	// strictly after this time. Zero value disables the filter.
-	UpdatedAfter time.Time
 
 	// Match is a field-equality map (JSON field name → expected value).
 	// Multi-tenancy and other app-specific filters live here. Field

--- a/pkg/lifecycle/list_options.go
+++ b/pkg/lifecycle/list_options.go
@@ -7,16 +7,20 @@ import "time"
 // instance in the workflow's KV bucket (subject to Limit / Offset).
 //
 // Match semantics:
+//
 //   - Phase filters to entries whose Participant.Phase() equals the
 //     given value. Empty string means any phase.
+//
 //   - Active=true filters to entries whose Participant.IsTerminal()
 //     returns false. Active=false (the zero value) does not filter on
 //     terminal status — to list only terminal entries, set
 //     ListOptions.Phase to a specific terminal phase OR add a Match
 //     entry on a field that distinguishes them.
+//
 //   - UpdatedAfter filters to entries whose KV revision timestamp is
 //     strictly later than the given time. Useful for incremental
 //     pagination of large active sets.
+//
 //   - Match is a field-equality map; key is the JSON field name (per
 //     `json:` struct tag), value is the expected value. Multi-tenancy
 //     is expressed app-side via Match{"org_id": "acme"} — the
@@ -25,7 +29,32 @@ import "time"
 //     for v1 linear-scan but flag fields as `lifecycle:"indexable"`
 //     for v2 secondary-index migration once an operator demonstrates a
 //     scaling bottleneck.
+//
+//     Match comparison semantics are STRICT reflect.DeepEqual against
+//     the target field's concrete type. This means:
+//
+//   - Numeric literals are type-strict: Match{"replica_count": 3}
+//     (Go int) does NOT match a field typed uint32(3). Callers
+//     constructing Match maps in Go code must use the exact field
+//     type (e.g. Match{"replica_count": uint32(3)}).
+//
+//   - The zero value matches an unset omitempty field. Match
+//     {"deployed_to": ""} matches every instance whose DeployedTo
+//     field was never set. To skip a filter entirely, omit the key
+//     — there is no "match anything" sentinel.
+//
+//   - String comparison is case-sensitive byte-equal. No fold,
+//     no trim, no glob.
+//
+//     HTTP gateway components (PR 3 of the ADR-047 bundle) handle
+//     query-string-to-Go-type coercion at the gateway boundary — that
+//     is the right place for permissive parsing of operator-supplied
+//     filter values, NOT inside Manager.List. Keeping Manager strict
+//     makes its behavior predictable from Go callers AND keeps the
+//     wire-level coercion layer's responsibility cleanly separated.
+//
 //   - Limit caps the returned slice size. 0 means unlimited (default).
+//
 //   - Offset is a pagination cursor — skip the first Offset matching
 //     entries. Combine with Limit for paged operator-API responses.
 //

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -35,6 +35,17 @@ type Manager struct {
 
 	mu            sync.RWMutex
 	registrations map[string]*registration
+
+	// driftSeen memoizes phase-drift Warn-log emissions so List
+	// callers polling at dashboard frequencies don't generate
+	// N×interval log lines per drifted entity. Keyed by
+	// "<workflow>|<entityID>|<phase>" — re-logs only when the
+	// entity transitions into a NEW drifted phase, never on
+	// repeated observation of the same drift state. Memory is
+	// bounded by total distinct (entity, phase) drift tuples.
+	// sync.Map (not sync.Mutex+map) because the read path
+	// dominates: Get/List are read-heavy.
+	driftSeen sync.Map
 }
 
 // registration holds the per-workflow-type state Manager needs at
@@ -261,11 +272,20 @@ func (m *Manager) getWithRevision(ctx context.Context, reg *registration, entity
 	// log-only is the v1 surface (see reviewer m2 on PR 1b core
 	// + the Degraded-bool precedent from PR #137 / GH #120).
 	if _, declared := reg.transitions[target.Phase()]; !declared {
-		m.logger.Warn("lifecycle: entity phase not declared in transitions table — silent drift detected",
-			slog.String("workflow", reg.workflow),
-			slog.String("entity_id", entityID),
-			slog.String("phase", target.Phase()),
-			slog.Any("declared_phases", reg.transitions.Phases()))
+		// De-dup the Warn per (workflow, entityID, phase) tuple so
+		// List callers polling at dashboard frequencies don't
+		// flood the log substrate with N×interval drift events
+		// per stuck entity. The same drift triggers exactly one
+		// Warn per process; transitioning into a NEW drifted
+		// phase re-logs.
+		driftKey := reg.workflow + "|" + entityID + "|" + target.Phase()
+		if _, alreadyLogged := m.driftSeen.LoadOrStore(driftKey, struct{}{}); !alreadyLogged {
+			m.logger.Warn("lifecycle: entity phase not declared in transitions table — silent drift detected (logged once per process per drift state)",
+				slog.String("workflow", reg.workflow),
+				slog.String("entity_id", entityID),
+				slog.String("phase", target.Phase()),
+				slog.Any("declared_phases", reg.transitions.Phases()))
+		}
 	}
 	return target, revision, nil
 }
@@ -321,7 +341,7 @@ const updateRetries = 5
 //  1. Get current state + revision
 //  2. Call mutator(participant) — mutator mutates the pointer in place
 //  3. Marshal + KV.Update with the revision
-//  4. On ErrKVRevisionMismatch, retry from step 1 (up to updateRetries)
+//  4. On CAS conflict, retry from step 1 (up to updateRetries)
 //
 // mutator errors abort the update immediately with the wrapped error
 // — no retry, no KV write. The mutator must NOT call Manager methods
@@ -331,8 +351,9 @@ const updateRetries = 5
 // Returns ErrEntityNotFound if the entity doesn't exist at any
 // point during the retry budget. Returns the wrapped mutator error
 // if the closure rejected the proposed change. Returns
-// ErrKVRevisionMismatch if the retry budget exhausted under
-// persistent contention.
+// ErrUpdateRetriesExhausted if the retry budget exhausted under
+// persistent contention — callers wanting application-layer retry
+// branch on errors.Is(err, ErrUpdateRetriesExhausted).
 func (m *Manager) Update(ctx context.Context, workflow, entityID string, mutator func(Participant) error) error {
 	if mutator == nil {
 		return errors.New("lifecycle: Update requires non-nil mutator")
@@ -368,7 +389,7 @@ func (m *Manager) Update(ctx context.Context, workflow, entityID string, mutator
 		return nil
 	}
 	return fmt.Errorf("%w: workflow=%q entity_id=%q after %d retries",
-		errKVRevisionMismatch, reg.workflow, entityID, updateRetries)
+		ErrUpdateRetriesExhausted, reg.workflow, entityID, updateRetries)
 }
 
 // Transition moves the entity at entityID from its current phase to

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -48,6 +48,15 @@ type registration struct {
 	structMeta  *structMeta
 	bucket      string
 	store       kvStore
+
+	// keySample is a cached factory instance held solely to
+	// dispatch the KVKey(entityID) method without allocating a
+	// fresh Participant per Get/Update. Per ADR-047's KVKey
+	// contract, KVKey must be a pure function of entityID — no
+	// per-instance struct state is consulted — so sharing one
+	// sample across all calls is safe even under concurrency
+	// (KVKey is read-only on the receiver).
+	keySample Participant
 }
 
 // NewManager constructs a Manager that talks to NATS via the given
@@ -145,6 +154,10 @@ func (m *Manager) Register(workflow string, factory func() Participant, transiti
 			ErrWorkflowNotRegistered, workflow)
 	}
 
+	if sample.Workflow() == "" {
+		return fmt.Errorf("%w: factory for workflow %q returned empty Workflow() — must match the registered name",
+			ErrWorkflowNotRegistered, workflow)
+	}
 	if sample.Workflow() != workflow {
 		return fmt.Errorf("%w: factory for workflow %q returns Workflow()=%q (mismatch — factory's Workflow() must match the registered name)",
 			ErrWorkflowNotRegistered, workflow, sample.Workflow())
@@ -169,6 +182,7 @@ func (m *Manager) Register(workflow string, factory func() Participant, transiti
 		structMeta:  structMeta,
 		bucket:      bucket,
 		store:       store,
+		keySample:   sample,
 	}
 	m.logger.Info("lifecycle: registered workflow",
 		slog.String("workflow", workflow),
@@ -309,7 +323,7 @@ func (m *Manager) Update(ctx context.Context, workflow, entityID string, mutator
 	if err != nil {
 		return err
 	}
-	for attempt := 0; attempt < updateRetries; attempt++ {
+	for range updateRetries {
 		current, revision, err := m.getWithRevision(ctx, reg, entityID)
 		if err != nil {
 			return err
@@ -444,13 +458,33 @@ func (m *Manager) Complete(ctx context.Context, workflow, entityID string) error
 	// Sorted terminals filtered to those reachable from current
 	// phase. Deterministic + sorted means apps see the same
 	// target across processes given the same table.
-	for _, terminal := range reg.transitions.TerminalPhases() {
+	terminals := reg.transitions.TerminalPhases()
+	var reachable []string
+	for _, terminal := range terminals {
 		if slices.Contains(outEdges, terminal) {
-			return m.Transition(ctx, workflow, entityID, terminal, TransitionSourceFramework, "")
+			reachable = append(reachable, terminal)
 		}
 	}
-	return fmt.Errorf("%w: workflow=%q entity_id=%q phase=%q has no edge to any terminal phase (declared terminals: %v)",
-		ErrInvalidTransition, reg.workflow, entityID, from, reg.transitions.TerminalPhases())
+	if len(reachable) == 0 {
+		return fmt.Errorf("%w: workflow=%q entity_id=%q phase=%q has no edge to any terminal phase (declared terminals: %v)",
+			ErrInvalidTransition, reg.workflow, entityID, from, terminals)
+	}
+	// When MORE than one terminal is reachable from the current
+	// phase, Complete's sorted-pick is ambiguous-looking — apps
+	// probably wanted semantic distinction (success vs failure vs
+	// abort) and grabbed the convenience helper. Loud-warn so the
+	// footgun is visible in operator logs without breaking the
+	// caller. Single-reachable terminals are unambiguous and don't
+	// warn.
+	if len(reachable) > 1 {
+		m.logger.Warn("lifecycle: Complete selection is ambiguous — multiple terminals reachable from current phase; consider Transition for explicit selection",
+			slog.String("workflow", reg.workflow),
+			slog.String("entity_id", entityID),
+			slog.String("from", from),
+			slog.String("picked", reachable[0]),
+			slog.Any("alternatives", reachable[1:]))
+	}
+	return m.Transition(ctx, workflow, entityID, reachable[0], TransitionSourceFramework, "")
 }
 
 // Fail transitions the entity to a terminal phase, carrying the
@@ -475,33 +509,27 @@ func (m *Manager) Fail(ctx context.Context, workflow, entityID, reason string) e
 		return fmt.Errorf("%w: workflow %q does not declare a %q phase; call Transition with your preferred error-state phase instead",
 			ErrInvalidTransition, reg.workflow, failedPhase)
 	}
-	// Note: reason is intended for the TransitionEvent.Note in the
-	// History stream, which lands in the next commit. For now the
-	// transition itself goes through; persistence of the reason
-	// will require the history-emission path in Update/Transition.
-	_ = reason
+	// reason flows to Transition.note below; the slog audit inside
+	// Transition picks it up. Full TransitionEvent persistence
+	// (History) lands in the next commit on this branch.
 	return m.Transition(ctx, workflow, entityID, failedPhase, TransitionSourceFramework, reason)
 }
 
 // setPhaseField writes newPhase into the Phase field on p via the
 // cached structMeta's PhaseField metadata. Returns an error if the
 // field index can't be resolved (shouldn't happen at runtime since
-// parseStructTags already validated PhaseField presence at Register
-// time).
+// parseStructTags validated PhaseField presence at Register time).
 //
-// Bounded reflect cost: one FieldByName per call (cached lookup is
-// PR 1b's field-index-cache concern). Acceptable because Transition
-// is a coordinator-frequency operation, not a per-message hotpath.
+// Uses reflect.Value.FieldByIndex with the cached FieldIndex slice
+// from parseStructTags — constant-time indexed access, not the
+// linear FieldByName walk. The reflect cost per Transition is one
+// indirect SetString, no map lookup.
 func setPhaseField(p Participant, sm *structMeta, newPhase string) error {
 	rv := reflect.ValueOf(p)
 	if rv.Kind() == reflect.Pointer {
 		rv = rv.Elem()
 	}
-	field := rv.FieldByName(sm.PhaseField.FieldName)
-	if !field.IsValid() {
-		return fmt.Errorf("lifecycle: phase field %q not found on Participant (registration validation should have caught this)",
-			sm.PhaseField.FieldName)
-	}
+	field := rv.FieldByIndex(sm.PhaseField.FieldIndex)
 	if !field.CanSet() {
 		return fmt.Errorf("lifecycle: phase field %q is not settable (Participant must be a pointer to a struct with exported phase field)",
 			sm.PhaseField.FieldName)
@@ -514,34 +542,13 @@ func setPhaseField(p Participant, sm *structMeta, newPhase string) error {
 	return nil
 }
 
-// keyForEntity returns the KV key for the entity. The Participant
-// declares its own KV key shape via the KVKey() method; this helper
-// is a single indirection so the Manager doesn't sprinkle p.KVKey()
-// calls through every op.
+// keyForEntity returns the KV key for the given entity ID in the
+// workflow's bucket. Pure dispatch — no allocation, no reflect.
 //
-// Resolving the key requires a Participant instance, but the
-// Manager often has only an EntityID string at the call site. Two
-// resolution patterns:
-//   - Caller has Participant in hand (Create, Update mutator):
-//     use p.KVKey() directly
-//   - Caller has only EntityID (Get, Transition pre-Get):
-//     fabricate a factory instance, set its ID field, call KVKey()
-//
-// This helper is the second path. The factory instance is discarded
-// after the KVKey() read, so no state escapes.
+// ADR-047's KVKey(entityID string) signature makes the key a pure
+// function of entityID, so the cached keySample (one instance per
+// registration, populated at Register time) can serve every call.
+// The receiver state isn't consulted; only the entityID arg.
 func keyForEntity(entityID string, reg *registration) string {
-	// Fabricate a factory instance, set its ID field via reflection,
-	// call KVKey(). The ID-field setter is bounded reflect (one
-	// SetString per call); KVKey() is a method call on the user's
-	// own code. The factory-allocated struct is discarded after.
-	sample := reg.factory()
-	rv := reflect.ValueOf(sample)
-	if rv.Kind() == reflect.Pointer {
-		rv = rv.Elem()
-	}
-	idField := rv.FieldByName(reg.structMeta.IDField.FieldName)
-	if idField.IsValid() && idField.CanSet() && idField.Kind() == reflect.String {
-		idField.SetString(entityID)
-	}
-	return sample.KVKey()
+	return reg.keySample.KVKey(entityID)
 }

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -249,6 +249,24 @@ func (m *Manager) getWithRevision(ctx context.Context, reg *registration, entity
 		return nil, 0, fmt.Errorf("lifecycle: unmarshal entity %q (workflow %q): %w",
 			entityID, reg.workflow, err)
 	}
+	// Drift detection — resolves the TODO(manager) marker on
+	// Participant.Phase. An entity whose Phase isn't in the
+	// registered Transitions table is silently treated as
+	// terminal by Transitions.IsTerminal (defensive default), so
+	// it never appears in Active=true lists where an operator
+	// would notice it. Surface the drift loudly via Warn so the
+	// log signal makes the silent degradation visible. Apps
+	// wanting structured detection rather than log-scraping can
+	// add a Degraded-bool wrapper in a future API extension —
+	// log-only is the v1 surface (see reviewer m2 on PR 1b core
+	// + the Degraded-bool precedent from PR #137 / GH #120).
+	if _, declared := reg.transitions[target.Phase()]; !declared {
+		m.logger.Warn("lifecycle: entity phase not declared in transitions table — silent drift detected",
+			slog.String("workflow", reg.workflow),
+			slog.String("entity_id", entityID),
+			slog.String("phase", target.Phase()),
+			slog.Any("declared_phases", reg.transitions.Phases()))
+	}
 	return target, revision, nil
 }
 

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -1,0 +1,547 @@
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"slices"
+	"sync"
+
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// Manager is the framework-provided harness over Participant
+// implementations. One Manager per process; workflow types register
+// at startup via Manager.Register.
+//
+// Concurrency model: registrations map is protected by RWMutex
+// (read-heavy: Register at startup, every Get/Update reads).
+// Per-entity concurrency is delegated to the kvStore's revision-CAS
+// semantics — Manager.Update's mutator closure runs under retry-
+// on-conflict, so concurrent updates to the same entity serialize
+// without an in-process per-entity lock.
+type Manager struct {
+	natsClient *natsclient.Client
+	logger     *slog.Logger
+
+	// storeFactory builds a per-bucket kvStore. The production
+	// constructor (NewManager) wires this to a kvNATSStore-builder
+	// closure over natsClient; tests inject a mock-store factory
+	// via newManagerForTest.
+	storeFactory func(bucket string) (kvStore, error)
+
+	mu            sync.RWMutex
+	registrations map[string]*registration
+}
+
+// registration holds the per-workflow-type state Manager needs at
+// every Get / Create / Update call. Built once at Register time;
+// read-only after — every field is immutable post-Register so the
+// RWMutex only protects the map insert, not the registration body.
+type registration struct {
+	workflow    string
+	factory     func() Participant
+	transitions Transitions
+	structMeta  *structMeta
+	bucket      string
+	store       kvStore
+}
+
+// NewManager constructs a Manager that talks to NATS via the given
+// client. Logger may be nil — falls back to slog.Default.
+//
+// Workflow registration happens via Manager.Register at app
+// startup; this constructor itself does not touch NATS (per-bucket
+// kvStore handles open lazily at Register time so deployments with
+// no workflows registered pay no KV cost).
+func NewManager(client *natsclient.Client, logger *slog.Logger) *Manager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	m := &Manager{
+		natsClient:    client,
+		logger:        logger,
+		registrations: make(map[string]*registration),
+	}
+	m.storeFactory = m.defaultStoreFactory
+	return m
+}
+
+// newManagerForTest constructs a Manager wired to the given store
+// factory, bypassing NATS entirely. Test-only — production callers
+// use NewManager.
+func newManagerForTest(logger *slog.Logger, factory func(bucket string) (kvStore, error)) *Manager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Manager{
+		logger:        logger,
+		storeFactory:  factory,
+		registrations: make(map[string]*registration),
+	}
+}
+
+// defaultStoreFactory is NewManager's wiring to kvNATSStore. Kept
+// as a method so newManagerForTest can override storeFactory before
+// any Register call lands.
+func (m *Manager) defaultStoreFactory(bucket string) (kvStore, error) {
+	return newKVNATSStore(m.natsClient, bucket)
+}
+
+// Register declares a workflow type to the Manager. Must be called
+// at app startup, before any Get / Create / Update calls land.
+// Idempotent at the wiring level — re-registering the same workflow
+// returns ErrWorkflowAlreadyRegistered to surface a duplicate-init
+// wiring bug.
+//
+// The factory returns a fresh zero-value Participant; Manager.Get
+// uses it as the json.Unmarshal target so the codec can populate
+// the app's typed state struct. Factory must return a POINTER
+// receiver (json.Unmarshal can't populate value-typed Participant
+// implementations).
+//
+// transitions is validated against Transitions.Validate before
+// registration commits; an invalid table is rejected with the
+// validation error wrapped as ErrInvalidTransitionsTable.
+func (m *Manager) Register(workflow string, factory func() Participant, transitions Transitions) error {
+	if workflow == "" {
+		return fmt.Errorf("%w: workflow name required", ErrWorkflowNotRegistered)
+	}
+	if factory == nil {
+		return fmt.Errorf("%w: factory required for workflow %q", ErrWorkflowNotRegistered, workflow)
+	}
+
+	if err := transitions.Validate(); err != nil {
+		return err
+	}
+
+	sample := factory()
+	if sample == nil {
+		return fmt.Errorf("%w: factory for workflow %q returned nil", ErrWorkflowNotRegistered, workflow)
+	}
+
+	// Validate factory return shape — must be a non-nil pointer to a
+	// settable struct (json.Unmarshal target + reflect.Value field
+	// writes both require addressability).
+	rv := reflect.ValueOf(sample)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
+		return fmt.Errorf("%w: factory for workflow %q must return non-nil pointer (got %v)",
+			ErrWorkflowNotRegistered, workflow, rv.Kind())
+	}
+
+	structMeta, err := parseStructTags(rv)
+	if err != nil {
+		return err
+	}
+
+	bucket := sample.KVBucket()
+	if bucket == "" {
+		// Defensive: an empty KVBucket would route every workflow's
+		// instances into bucket "" — almost certainly a wiring bug.
+		return fmt.Errorf("%w: factory for workflow %q returned empty KVBucket",
+			ErrWorkflowNotRegistered, workflow)
+	}
+
+	if sample.Workflow() != workflow {
+		return fmt.Errorf("%w: factory for workflow %q returns Workflow()=%q (mismatch — factory's Workflow() must match the registered name)",
+			ErrWorkflowNotRegistered, workflow, sample.Workflow())
+	}
+
+	store, err := m.storeFactory(bucket)
+	if err != nil {
+		return fmt.Errorf("lifecycle: open KV bucket %q for workflow %q: %w", bucket, workflow, err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.registrations[workflow]; exists {
+		return fmt.Errorf("%w: workflow %q", ErrWorkflowAlreadyRegistered, workflow)
+	}
+
+	m.registrations[workflow] = &registration{
+		workflow:    workflow,
+		factory:     factory,
+		transitions: transitions,
+		structMeta:  structMeta,
+		bucket:      bucket,
+		store:       store,
+	}
+	m.logger.Info("lifecycle: registered workflow",
+		slog.String("workflow", workflow),
+		slog.String("bucket", bucket),
+		slog.Int("phase_count", len(transitions)))
+	return nil
+}
+
+// lookupByWorkflow finds the registration for the given workflow type.
+// Returns ErrWorkflowNotRegistered when the type was never registered.
+func (m *Manager) lookupByWorkflow(workflow string) (*registration, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	reg, ok := m.registrations[workflow]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrWorkflowNotRegistered, workflow)
+	}
+	return reg, nil
+}
+
+// Get loads the instance at entityID for the given workflow type.
+// Returns ErrEntityNotFound when no instance exists at the key,
+// ErrWorkflowNotRegistered when the workflow type isn't registered.
+//
+// The returned Participant is a fresh instance — mutating it does
+// NOT persist. Use Manager.Update with a mutator closure to commit
+// changes.
+//
+// Drift validation: TODO(manager) — see Participant.Phase doc-comment.
+// Currently this just returns whatever Phase() the deserialized struct
+// reports, even if it's not in the registered Transitions table.
+// PR 1b's query-ops slice adds the drift check.
+func (m *Manager) Get(ctx context.Context, workflow, entityID string) (Participant, error) {
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return nil, err
+	}
+	return m.getFromRegistration(ctx, reg, entityID)
+}
+
+// getFromRegistration is the shared Get-by-resolved-registration
+// path. Reused by Update so it doesn't re-take the registrations
+// RLock per retry.
+func (m *Manager) getFromRegistration(ctx context.Context, reg *registration, entityID string) (Participant, error) {
+	p, _, err := m.getWithRevision(ctx, reg, entityID)
+	return p, err
+}
+
+// getWithRevision returns the Participant plus the KV revision at
+// which it was loaded — required for Update's CAS write. The Get
+// public method discards the revision; Update uses it.
+func (m *Manager) getWithRevision(ctx context.Context, reg *registration, entityID string) (Participant, uint64, error) {
+	key := keyForEntity(entityID, reg)
+	value, revision, err := reg.store.Get(ctx, key)
+	if err != nil {
+		if errors.Is(err, errKVKeyNotFound) {
+			return nil, 0, fmt.Errorf("%w: workflow=%q entity_id=%q",
+				ErrEntityNotFound, reg.workflow, entityID)
+		}
+		return nil, 0, fmt.Errorf("lifecycle: KV get for %q: %w", entityID, err)
+	}
+	target := reg.factory()
+	if err := json.Unmarshal(value, target); err != nil {
+		return nil, 0, fmt.Errorf("lifecycle: unmarshal entity %q (workflow %q): %w",
+			entityID, reg.workflow, err)
+	}
+	return target, revision, nil
+}
+
+// Create commits a fresh Participant to KV. Returns an error if
+// an instance already exists at the same EntityID (create-only
+// semantics — apps that want to overwrite must Delete first OR
+// use Update with a fresh Get).
+//
+// The initial.EntityID() value is used as both the JSON identity
+// and the KV key derivation source (via Participant.KVKey()).
+func (m *Manager) Create(ctx context.Context, initial Participant) error {
+	if initial == nil {
+		return errors.New("lifecycle: Create requires non-nil Participant")
+	}
+	reg, err := m.lookupByWorkflow(initial.Workflow())
+	if err != nil {
+		return err
+	}
+	// Validate the initial Phase is declared in the transitions
+	// table — typo at Create time is friendlier than typo discovered
+	// at first Transition attempt.
+	if _, declared := reg.transitions[initial.Phase()]; !declared {
+		return fmt.Errorf("%w: initial phase %q not declared in transitions table for workflow %q",
+			ErrInvalidTransition, initial.Phase(), reg.workflow)
+	}
+	value, err := json.Marshal(initial)
+	if err != nil {
+		return fmt.Errorf("lifecycle: marshal Create payload: %w", err)
+	}
+	key := keyForEntity(initial.EntityID(), reg)
+	if _, err := reg.store.Create(ctx, key, value); err != nil {
+		if errors.Is(err, errKVKeyExists) {
+			return fmt.Errorf("lifecycle: Create — entity %q already exists in workflow %q",
+				initial.EntityID(), reg.workflow)
+		}
+		return fmt.Errorf("lifecycle: KV create for %q: %w", initial.EntityID(), err)
+	}
+	return nil
+}
+
+// updateRetries bounds the CAS-conflict retry budget per Update call.
+// A higher number defends against tight loops of concurrent updates;
+// too high invites unbounded latency under contention. 5 is enough
+// to absorb typical bursts (a few rules racing on the same entity)
+// without becoming a hidden bottleneck if a rule is stuck rewriting
+// the same entity in a tight loop.
+const updateRetries = 5
+
+// Update mutates the entity at entityID via the given mutator
+// closure, under CAS retry semantics:
+//
+//  1. Get current state + revision
+//  2. Call mutator(participant) — mutator mutates the pointer in place
+//  3. Marshal + KV.Update with the revision
+//  4. On ErrKVRevisionMismatch, retry from step 1 (up to updateRetries)
+//
+// mutator errors abort the update immediately with the wrapped error
+// — no retry, no KV write. The mutator must NOT call Manager methods
+// (re-entry would deadlock the registrations RWMutex and risk
+// CAS-loop tail-chases).
+//
+// Returns ErrEntityNotFound if the entity doesn't exist at any
+// point during the retry budget. Returns the wrapped mutator error
+// if the closure rejected the proposed change. Returns
+// ErrKVRevisionMismatch if the retry budget exhausted under
+// persistent contention.
+func (m *Manager) Update(ctx context.Context, workflow, entityID string, mutator func(Participant) error) error {
+	if mutator == nil {
+		return errors.New("lifecycle: Update requires non-nil mutator")
+	}
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return err
+	}
+	for attempt := 0; attempt < updateRetries; attempt++ {
+		current, revision, err := m.getWithRevision(ctx, reg, entityID)
+		if err != nil {
+			return err
+		}
+		if err := mutator(current); err != nil {
+			return fmt.Errorf("lifecycle: Update mutator rejected change for %q: %w", entityID, err)
+		}
+		value, err := json.Marshal(current)
+		if err != nil {
+			return fmt.Errorf("lifecycle: marshal Update payload for %q: %w", entityID, err)
+		}
+		key := keyForEntity(entityID, reg)
+		if _, err := reg.store.Update(ctx, key, value, revision); err != nil {
+			if errors.Is(err, errKVRevisionMismatch) {
+				// CAS conflict — concurrent writer beat us. Retry.
+				continue
+			}
+			if errors.Is(err, errKVKeyNotFound) {
+				return fmt.Errorf("%w: workflow=%q entity_id=%q (deleted during Update)",
+					ErrEntityNotFound, reg.workflow, entityID)
+			}
+			return fmt.Errorf("lifecycle: KV update for %q: %w", entityID, err)
+		}
+		return nil
+	}
+	return fmt.Errorf("%w: workflow=%q entity_id=%q after %d retries",
+		errKVRevisionMismatch, reg.workflow, entityID, updateRetries)
+}
+
+// Transition moves the entity at entityID from its current phase to
+// newPhase, atomically with any CAS retries. Validates the transition
+// against the registered Transitions table:
+//
+//   - newPhase must be declared in the table (typo catcher)
+//   - (current → newPhase) must be a declared edge
+//   - current phase must NOT be terminal (terminal entities cannot
+//     transition further — surfaces ErrTerminalPhase distinctly so
+//     dashboards can show "cannot abort an already-completed mission")
+//
+// source identifies what triggered the transition (rule action,
+// operator API, component direct call, framework auto). Persisted
+// in the History stream for audit (the History query op lands in
+// the next commit).
+//
+// Note is an optional free-text annotation; Manager.Fail uses it
+// to carry the failure reason. Pass "" when not relevant.
+func (m *Manager) Transition(ctx context.Context, workflow, entityID, newPhase string, source TransitionSource, note string) error {
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return err
+	}
+	if _, declared := reg.transitions[newPhase]; !declared {
+		return fmt.Errorf("%w: target phase %q not declared in transitions table for workflow %q",
+			ErrInvalidTransition, newPhase, reg.workflow)
+	}
+	return m.Update(ctx, workflow, entityID, func(p Participant) error {
+		from := p.Phase()
+		if reg.transitions.IsTerminal(from) {
+			return fmt.Errorf("%w: workflow=%q entity_id=%q from=%q",
+				ErrTerminalPhase, reg.workflow, entityID, from)
+		}
+		if !reg.transitions.IsValidTransition(from, newPhase) {
+			return fmt.Errorf("%w: workflow=%q entity_id=%q from=%q to=%q (not a declared edge)",
+				ErrInvalidTransition, reg.workflow, entityID, from, newPhase)
+		}
+		// Mutate the Phase field in place via reflection (the
+		// alternative — requiring Participant.SetPhase(string) on
+		// the interface — puts boilerplate on every app's state
+		// struct; the cached structMeta.PhaseField makes this a
+		// single field-by-index reflect write).
+		if err := setPhaseField(p, reg.structMeta, newPhase); err != nil {
+			return err
+		}
+		// Source + note are observable today via slog; the History
+		// query op in the next commit reconstructs full TransitionEvent
+		// records from KV revision metadata + a per-update audit
+		// triple. For now the log line is the audit trail.
+		// TODO(history): emit a TransitionEvent{From, To, At,
+		// Triggered: source, Note: note} stamped onto the entity (or
+		// a side KV history bucket) so History can return it.
+		m.logger.Debug("lifecycle: transition",
+			slog.String("workflow", reg.workflow),
+			slog.String("entity_id", entityID),
+			slog.String("from", from),
+			slog.String("to", newPhase),
+			slog.String("source", string(source)),
+			slog.String("note", note))
+		return nil
+	})
+}
+
+// Complete transitions the entity to the first terminal phase
+// REACHABLE from its current phase (sorted iteration of declared
+// terminals + first one with an in-edge from the current phase).
+// Deterministic across processes — picks the same target every time
+// given the same transitions table.
+//
+// Errors with ErrTerminalPhase if the entity is already terminal,
+// or ErrInvalidTransition if no terminal phase is reachable from
+// the current phase (e.g. transitions table declares terminals but
+// the current phase has no edge to any of them — wiring bug worth
+// surfacing).
+//
+// Apps with semantic terminal-name distinctions (failed vs aborted
+// vs cancelled vs completed) should call Transition directly with
+// the specific terminal phase rather than relying on Complete's
+// selection. Complete is the convenience for "mark this done" in
+// workflows where the natural success-terminal is unambiguous from
+// the current phase's edge set.
+//
+// There is a small race window between the internal Get-for-current-
+// phase and the subsequent Transition: if a concurrent writer
+// transitions the entity to terminal between our two operations,
+// the Transition call surfaces ErrTerminalPhase. The benign-race
+// outcome (entity is terminal as desired) reads as an error to
+// the caller — acceptable trade-off for the simpler API.
+func (m *Manager) Complete(ctx context.Context, workflow, entityID string) error {
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return err
+	}
+	current, err := m.Get(ctx, workflow, entityID)
+	if err != nil {
+		return err
+	}
+	from := current.Phase()
+	if reg.transitions.IsTerminal(from) {
+		return fmt.Errorf("%w: workflow=%q entity_id=%q from=%q",
+			ErrTerminalPhase, reg.workflow, entityID, from)
+	}
+	outEdges := reg.transitions[from]
+	// Sorted terminals filtered to those reachable from current
+	// phase. Deterministic + sorted means apps see the same
+	// target across processes given the same table.
+	for _, terminal := range reg.transitions.TerminalPhases() {
+		if slices.Contains(outEdges, terminal) {
+			return m.Transition(ctx, workflow, entityID, terminal, TransitionSourceFramework, "")
+		}
+	}
+	return fmt.Errorf("%w: workflow=%q entity_id=%q phase=%q has no edge to any terminal phase (declared terminals: %v)",
+		ErrInvalidTransition, reg.workflow, entityID, from, reg.transitions.TerminalPhases())
+}
+
+// Fail transitions the entity to a terminal phase, carrying the
+// reason in the TransitionEvent.Note for audit. Selects the
+// terminal phase by exact-name match against the reserved name
+// "failed" if present; otherwise errors (apps that don't declare
+// a "failed" phase must call Transition directly with their
+// preferred error-state phase).
+//
+// The reason argument is required (empty string rejected) — a Fail
+// with no reason defeats the audit purpose.
+func (m *Manager) Fail(ctx context.Context, workflow, entityID, reason string) error {
+	if reason == "" {
+		return errors.New("lifecycle: Fail requires non-empty reason (operators need the failure cause in the audit trail)")
+	}
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return err
+	}
+	const failedPhase = "failed"
+	if _, declared := reg.transitions[failedPhase]; !declared {
+		return fmt.Errorf("%w: workflow %q does not declare a %q phase; call Transition with your preferred error-state phase instead",
+			ErrInvalidTransition, reg.workflow, failedPhase)
+	}
+	// Note: reason is intended for the TransitionEvent.Note in the
+	// History stream, which lands in the next commit. For now the
+	// transition itself goes through; persistence of the reason
+	// will require the history-emission path in Update/Transition.
+	_ = reason
+	return m.Transition(ctx, workflow, entityID, failedPhase, TransitionSourceFramework, reason)
+}
+
+// setPhaseField writes newPhase into the Phase field on p via the
+// cached structMeta's PhaseField metadata. Returns an error if the
+// field index can't be resolved (shouldn't happen at runtime since
+// parseStructTags already validated PhaseField presence at Register
+// time).
+//
+// Bounded reflect cost: one FieldByName per call (cached lookup is
+// PR 1b's field-index-cache concern). Acceptable because Transition
+// is a coordinator-frequency operation, not a per-message hotpath.
+func setPhaseField(p Participant, sm *structMeta, newPhase string) error {
+	rv := reflect.ValueOf(p)
+	if rv.Kind() == reflect.Pointer {
+		rv = rv.Elem()
+	}
+	field := rv.FieldByName(sm.PhaseField.FieldName)
+	if !field.IsValid() {
+		return fmt.Errorf("lifecycle: phase field %q not found on Participant (registration validation should have caught this)",
+			sm.PhaseField.FieldName)
+	}
+	if !field.CanSet() {
+		return fmt.Errorf("lifecycle: phase field %q is not settable (Participant must be a pointer to a struct with exported phase field)",
+			sm.PhaseField.FieldName)
+	}
+	if field.Kind() != reflect.String {
+		return fmt.Errorf("lifecycle: phase field %q has type %v, expected string",
+			sm.PhaseField.FieldName, field.Kind())
+	}
+	field.SetString(newPhase)
+	return nil
+}
+
+// keyForEntity returns the KV key for the entity. The Participant
+// declares its own KV key shape via the KVKey() method; this helper
+// is a single indirection so the Manager doesn't sprinkle p.KVKey()
+// calls through every op.
+//
+// Resolving the key requires a Participant instance, but the
+// Manager often has only an EntityID string at the call site. Two
+// resolution patterns:
+//   - Caller has Participant in hand (Create, Update mutator):
+//     use p.KVKey() directly
+//   - Caller has only EntityID (Get, Transition pre-Get):
+//     fabricate a factory instance, set its ID field, call KVKey()
+//
+// This helper is the second path. The factory instance is discarded
+// after the KVKey() read, so no state escapes.
+func keyForEntity(entityID string, reg *registration) string {
+	// Fabricate a factory instance, set its ID field via reflection,
+	// call KVKey(). The ID-field setter is bounded reflect (one
+	// SetString per call); KVKey() is a method call on the user's
+	// own code. The factory-allocated struct is discarded after.
+	sample := reg.factory()
+	rv := reflect.ValueOf(sample)
+	if rv.Kind() == reflect.Pointer {
+		rv = rv.Elem()
+	}
+	idField := rv.FieldByName(reg.structMeta.IDField.FieldName)
+	if idField.IsValid() && idField.CanSet() && idField.Kind() == reflect.String {
+		idField.SetString(entityID)
+	}
+	return sample.KVKey()
+}

--- a/pkg/lifecycle/manager_query.go
+++ b/pkg/lifecycle/manager_query.go
@@ -1,0 +1,371 @@
+// Package lifecycle — query-ops surface (List, Watch, History).
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strings"
+)
+
+// List returns instances of the given workflow type matching opts.
+// v1 implementation is linear-scan over the workflow's bucket: every
+// key is fetched, deserialized, and run through the filter chain.
+// Complexity is O(N) per call where N is the bucket size.
+//
+// Scaling cliff: ~10K active instances is fine for v1 linear scan;
+// beyond that the secondary-index v2 work (ADR-047 § KV indexing)
+// is the upgrade path. Operators hitting the cliff demonstrate the
+// bottleneck and trigger v2 work; the ListOptions surface stays
+// stable across the migration so callers don't need to change.
+//
+// Filter ordering (cheap → expensive) so Match's reflect-based
+// comparisons only run on candidates that already passed the
+// cheap Phase / Active / UpdatedAfter filters. This is the
+// reviewer-recommended optimization to keep reflect cost bounded.
+//
+// Returned slice ownership: each Participant is a fresh instance
+// (factory-produced + json-deserialized). Mutating returned
+// pointers does NOT persist — use Update with a mutator closure
+// to commit changes. Order is the bucket's ListKeys order (sorted
+// for the mock; jetstream returns key insertion order plus
+// pagination — operator dashboards should sort caller-side if
+// needed).
+func (m *Manager) List(ctx context.Context, workflow string, opts ListOptions) ([]Participant, error) {
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve Match field indices ONCE per call (cached lookup by
+	// JSON field name → reflect FieldIndex slice). The inner-loop
+	// per-candidate reflect cost is then FieldByIndex (constant-
+	// time) not FieldByName (linear walk). For a Match with K keys
+	// scanned over N entities, this is K+N reflect ops, not K*N.
+	matchPlan, err := buildMatchPlan(reg.structMeta, opts.Match)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: List Match resolution for workflow %q: %w", reg.workflow, err)
+	}
+
+	keys, err := reg.store.ListKeys(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: List ListKeys for workflow %q: %w", reg.workflow, err)
+	}
+
+	out := make([]Participant, 0, len(keys))
+	skipped := 0
+	// Iterate via the existing per-entityID resolution path so
+	// drift-detection-when-added (TODO(manager) on Participant.Phase)
+	// flows through one code path, not two. Apps that need raw KV
+	// scan without Participant decoding can drop to natsclient
+	// directly — out of scope for the harness.
+	for _, key := range keys {
+		// Derive the entityID from the key. v1 uses the convention
+		// that KVKey(entityID) produces a key from which entityID
+		// can be recovered. We extract by inverse: compute the
+		// keySample-generated key for a sentinel ID, find the
+		// position of the sentinel, then for each scanned key,
+		// slice at that position.
+		//
+		// TODO(list-perf): cache the key→entityID transform at
+		// Register time too (mirror of keyForEntity). Today this
+		// is invoked per candidate. Land alongside the v2
+		// secondary index — scan-path optimization belongs there.
+		entityID, ok := entityIDFromKey(key, reg)
+		if !ok {
+			// Key doesn't match our workflow's KVKey shape — skip
+			// rather than error. A bucket may hold keys from
+			// multiple sources if operators share buckets across
+			// workflows (uncommon but supported).
+			skipped++
+			continue
+		}
+		participant, _, getErr := m.getWithRevision(ctx, reg, entityID)
+		if getErr != nil {
+			// Entity gone between ListKeys and Get — race;
+			// quietly skip rather than fail the whole List call.
+			if errors.Is(getErr, ErrEntityNotFound) {
+				continue
+			}
+			return nil, fmt.Errorf("lifecycle: List Get %q: %w", entityID, getErr)
+		}
+
+		if !matchesPhaseFilter(participant, opts.Phase) {
+			continue
+		}
+		if !matchesActiveFilter(participant, opts.Active) {
+			continue
+		}
+		if !matchesMatchPlan(participant, matchPlan) {
+			continue
+		}
+		out = append(out, participant)
+	}
+
+	if skipped > 0 {
+		m.logger.Debug("lifecycle: List skipped keys not matching workflow shape",
+			slog.String("workflow", reg.workflow),
+			slog.Int("skipped", skipped))
+	}
+
+	// Apply Offset / Limit on the filtered set.
+	if opts.Offset > 0 {
+		if opts.Offset >= len(out) {
+			return []Participant{}, nil
+		}
+		out = out[opts.Offset:]
+	}
+	if opts.Limit > 0 && len(out) > opts.Limit {
+		out = out[:opts.Limit]
+	}
+	return out, nil
+}
+
+// Watch streams Participant snapshots for every write to the
+// workflow's bucket. Bootstrap-then-live: the first batch is the
+// snapshot of current state, then live updates as KV writes
+// land. The returned channel closes when ctx is canceled OR the
+// underlying watcher errors (caller treats both as "stop
+// iterating").
+//
+// Each delivered Participant is a fresh instance. Mutating it
+// does NOT persist (same contract as Get).
+//
+// Delete-marker events are NOT delivered as Participants —
+// they're skipped (no instance to render). Apps that need to
+// react to deletions should use the kvStore primitive directly
+// via a follow-up tool — Watch's contract is "current Participants
+// you can read."
+func (m *Manager) Watch(ctx context.Context, workflow string) (<-chan Participant, error) {
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return nil, err
+	}
+	src, err := reg.store.Watch(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle: Watch for workflow %q: %w", reg.workflow, err)
+	}
+	out := make(chan Participant, 16)
+	go func() {
+		defer close(out)
+		for entry := range src {
+			if entry.IsDelete {
+				// Skip tombstones — Watch contract is current
+				// Participants. Apps needing deletion signals
+				// hook the kvStore.Watch directly via a future
+				// API; out of scope for the harness today.
+				continue
+			}
+			target := reg.factory()
+			if err := json.Unmarshal(entry.Value, target); err != nil {
+				m.logger.Warn("lifecycle: Watch unmarshal failed; skipping entry",
+					slog.String("workflow", reg.workflow),
+					slog.String("key", entry.Key),
+					slog.Uint64("revision", entry.Revision),
+					slog.String("error", err.Error()))
+				continue
+			}
+			select {
+			case out <- target:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out, nil
+}
+
+// History returns the phase-transition history for the entity at
+// entityID, derived from KV revision replay. Each TransitionEvent
+// represents one write to the entity's KV key.
+//
+// Reconstruction semantics (v1 — best-effort from KV alone):
+//   - Each revision is decoded as a Participant snapshot
+//   - From = previous revision's Phase (empty for the first revision)
+//   - To = this revision's Phase
+//   - At = revision's CreatedAt timestamp
+//   - Triggered = TransitionSourceFramework (cannot recover the
+//     original source from KV alone — source/note persistence is a
+//     future enhancement that would write an audit triple alongside
+//     the state update)
+//   - Note = "" (same limitation as Triggered)
+//
+// Returns ErrEntityNotFound if the entity has no KV history (never
+// existed). An entity that existed and was deleted returns its
+// history including the final delete-marker as a synthetic
+// transition with To="<deleted>" so audit trails can show the
+// terminal event.
+//
+// Revisions where the Phase did NOT change (Update calls that
+// mutated other fields but not Phase) are skipped — History
+// surfaces phase-transition events specifically, not every
+// state mutation. Apps wanting the full revision stream should
+// drop to the kvStore primitive directly.
+func (m *Manager) History(ctx context.Context, workflow, entityID string) ([]TransitionEvent, error) {
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return nil, err
+	}
+	key := keyForEntity(entityID, reg)
+	entries, err := reg.store.History(ctx, key)
+	if err != nil {
+		if errors.Is(err, errKVKeyNotFound) {
+			return nil, fmt.Errorf("%w: workflow=%q entity_id=%q",
+				ErrEntityNotFound, reg.workflow, entityID)
+		}
+		return nil, fmt.Errorf("lifecycle: History for %q: %w", entityID, err)
+	}
+
+	events := make([]TransitionEvent, 0, len(entries))
+	previousPhase := ""
+	for _, entry := range entries {
+		if entry.IsDelete {
+			// Surface the deletion as a synthetic terminal event
+			// so audit trails are complete.
+			events = append(events, TransitionEvent{
+				From:      previousPhase,
+				To:        "<deleted>",
+				At:        entry.CreatedAt,
+				Triggered: TransitionSourceFramework,
+			})
+			previousPhase = "<deleted>"
+			continue
+		}
+		snapshot := reg.factory()
+		if err := json.Unmarshal(entry.Value, snapshot); err != nil {
+			// Don't fail the whole History call on a single bad
+			// revision — log and skip. A corrupt revision in the
+			// stream shouldn't black out the entity's audit trail.
+			m.logger.Warn("lifecycle: History unmarshal failed; skipping revision",
+				slog.String("workflow", reg.workflow),
+				slog.String("entity_id", entityID),
+				slog.Uint64("revision", entry.Revision),
+				slog.String("error", err.Error()))
+			continue
+		}
+		thisPhase := snapshot.Phase()
+		if thisPhase == previousPhase {
+			// Update that didn't change phase — not a transition.
+			continue
+		}
+		events = append(events, TransitionEvent{
+			From:      previousPhase,
+			To:        thisPhase,
+			At:        entry.CreatedAt,
+			Triggered: TransitionSourceFramework,
+		})
+		previousPhase = thisPhase
+	}
+	return events, nil
+}
+
+// ---- internal helpers ----
+
+// matchPlan caches the structMeta resolution for ListOptions.Match
+// keys — one FieldIndex slice per match key, so the per-candidate
+// loop uses constant-time FieldByIndex instead of linear FieldByName.
+type matchPlan struct {
+	specs []matchSpec
+}
+
+type matchSpec struct {
+	jsonName string
+	field    *fieldMeta
+	wantVal  any
+}
+
+// buildMatchPlan resolves Match map keys against the structMeta's
+// FieldsByJSONName at List-call time. Errors if a Match key doesn't
+// correspond to a known field — apps that pass a typo'd key need
+// the loud failure, not silent zero matches.
+func buildMatchPlan(sm *structMeta, match map[string]any) (*matchPlan, error) {
+	if len(match) == 0 {
+		return &matchPlan{}, nil
+	}
+	plan := &matchPlan{specs: make([]matchSpec, 0, len(match))}
+	for key, want := range match {
+		field, ok := sm.FieldsByJSONName[key]
+		if !ok {
+			return nil, fmt.Errorf("lifecycle: Match key %q does not match any field on the registered state struct (check json: tags)",
+				key)
+		}
+		plan.specs = append(plan.specs, matchSpec{
+			jsonName: key,
+			field:    field,
+			wantVal:  want,
+		})
+	}
+	return plan, nil
+}
+
+// matchesMatchPlan runs the cached plan against a Participant.
+// Pure FieldByIndex reads + reflect.DeepEqual per spec; no map
+// lookups in the inner loop.
+func matchesMatchPlan(p Participant, plan *matchPlan) bool {
+	if plan == nil || len(plan.specs) == 0 {
+		return true
+	}
+	rv := reflect.ValueOf(p)
+	if rv.Kind() == reflect.Pointer {
+		rv = rv.Elem()
+	}
+	for _, spec := range plan.specs {
+		got := rv.FieldByIndex(spec.field.FieldIndex).Interface()
+		if !reflect.DeepEqual(got, spec.wantVal) {
+			return false
+		}
+	}
+	return true
+}
+
+// matchesPhaseFilter returns true when Phase filter is empty OR
+// matches the participant's current phase.
+func matchesPhaseFilter(p Participant, phase string) bool {
+	if phase == "" {
+		return true
+	}
+	return p.Phase() == phase
+}
+
+// matchesActiveFilter returns true when Active filter is false
+// (no filter) OR when the participant is not terminal.
+func matchesActiveFilter(p Participant, active bool) bool {
+	if !active {
+		return true
+	}
+	return !p.IsTerminal()
+}
+
+// entityIDFromKey extracts the entityID from a KV key by inverse
+// of the registration's keySample.KVKey(entityID) transform. v1
+// uses a sentinel-substitution approach: compute the prefix/suffix
+// once per call from a known sentinel ID, then slice the input key.
+//
+// Returns (entityID, true) when the key matches the workflow's
+// KVKey shape; ("", false) when it doesn't (key from a different
+// workflow sharing the bucket, or operator-injected debug keys).
+//
+// TODO(list-perf): the sentinel-detection is currently per-call.
+// Cache the prefix/suffix on registration at Register time so List
+// only pays the detection cost once per Register, not once per
+// List call. Lands alongside the v2 secondary index work.
+func entityIDFromKey(key string, reg *registration) (string, bool) {
+	const sentinel = "___LIFECYCLE_ENTITY_ID_SENTINEL___"
+	sample := reg.keySample.KVKey(sentinel)
+	idx := strings.Index(sample, sentinel)
+	if idx < 0 {
+		// KVKey didn't incorporate the entityID — apps using
+		// constant-key shapes don't roundtrip through this helper.
+		// Treat as "doesn't match" so List quietly skips.
+		return "", false
+	}
+	prefix := sample[:idx]
+	suffix := sample[idx+len(sentinel):]
+	if !strings.HasPrefix(key, prefix) || !strings.HasSuffix(key, suffix) {
+		return "", false
+	}
+	return key[len(prefix) : len(key)-len(suffix)], true
+}

--- a/pkg/lifecycle/manager_query.go
+++ b/pkg/lifecycle/manager_query.go
@@ -25,7 +25,7 @@ import (
 //
 // Filter ordering (cheap → expensive) so Match's reflect-based
 // comparisons only run on candidates that already passed the
-// cheap Phase / Active / UpdatedAfter filters. This is the
+// cheap Phase / Active method-call filters. This is the
 // reviewer-recommended optimization to keep reflect cost bounded.
 //
 // Returned slice ownership: each Participant is a fresh instance
@@ -140,6 +140,18 @@ func (m *Manager) List(ctx context.Context, workflow string, opts ListOptions) (
 // react to deletions should use the kvStore primitive directly
 // via a follow-up tool — Watch's contract is "current Participants
 // you can read."
+//
+// CALLER MUST CANCEL ctx when done iterating. The watcher
+// goroutine and its underlying jetstream subscription pin until
+// ctx.Done(); a caller that simply stops reading the channel
+// without canceling leaks the goroutine and the NATS subscription
+// until the next write-then-block triggers buffer back-pressure.
+// Pattern:
+//
+//	ctx, cancel := context.WithCancel(parentCtx)
+//	defer cancel()
+//	ch, err := mgr.Watch(ctx, workflow)
+//	// ...drain ch...
 func (m *Manager) Watch(ctx context.Context, workflow string) (<-chan Participant, error) {
 	reg, err := m.lookupByWorkflow(workflow)
 	if err != nil {
@@ -366,7 +378,10 @@ func (m *Manager) findByEntityID(ctx context.Context, entityID string) (Particip
 	m.mu.RUnlock()
 
 	for _, reg := range regs {
-		p, err := m.Get(ctx, reg.workflow, entityID)
+		// Use getFromRegistration directly — m.Get would re-take
+		// the registrations RLock once per workflow to re-resolve
+		// reg by name. The snapshot above is sufficient.
+		p, err := m.getFromRegistration(ctx, reg, entityID)
 		if err == nil {
 			return p, nil
 		}

--- a/pkg/lifecycle/manager_query.go
+++ b/pkg/lifecycle/manager_query.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
+	"sort"
 	"strings"
 )
 
@@ -176,6 +177,247 @@ func (m *Manager) Watch(ctx context.Context, workflow string) (<-chan Participan
 		}
 	}()
 	return out, nil
+}
+
+// UpdateFromOperator applies a patch map to the entity, validating
+// that every patched field is tagged `lifecycle:"operator_writable"`
+// in the registered state struct. Default-deny: fields without the
+// tag are rejected with ErrFieldNotOperatorWritable. The patch is
+// applied atomically under Manager.Update's CAS-retry contract.
+//
+// Patch values are STRICT-typed against the target field's concrete
+// type (reflect.Type.AssignableTo); a Go-typed mismatch (e.g. int
+// against a uint32 field) is rejected. HTTP gateway components
+// (PR 3 of the ADR-047 bundle) handle query-string-to-Go-type
+// coercion at the wire boundary — that is the right place for
+// permissive parsing of operator-supplied values, NOT inside
+// UpdateFromOperator.
+//
+// Returns ErrEntityNotFound if the entity doesn't exist (same as
+// Update). Returns ErrFieldNotOperatorWritable for the first
+// disallowed key encountered. Returns a wrapped type-mismatch
+// error for the first incompatible patch value.
+func (m *Manager) UpdateFromOperator(ctx context.Context, workflow, entityID string, patch map[string]any) error {
+	if len(patch) == 0 {
+		return nil // no-op patch is success — operators sometimes
+		// hit endpoints with empty bodies and shouldn't see errors
+	}
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return err
+	}
+
+	// Pre-validate the entire patch against operator_writable +
+	// type compatibility BEFORE the Update mutator runs. Rejecting
+	// late inside the mutator would cost a KV round-trip for a
+	// patch that was never going to apply.
+	plan := make([]operatorPatchSpec, 0, len(patch))
+	for key, value := range patch {
+		field, ok := reg.structMeta.FieldsByJSONName[key]
+		if !ok {
+			return fmt.Errorf("lifecycle: UpdateFromOperator key %q does not match any field on workflow %q",
+				key, reg.workflow)
+		}
+		if !field.OperatorWritable {
+			return fmt.Errorf("%w: workflow=%q field=%q",
+				ErrFieldNotOperatorWritable, reg.workflow, key)
+		}
+		plan = append(plan, operatorPatchSpec{
+			field:    field,
+			wantVal:  value,
+			jsonName: key,
+		})
+	}
+
+	return m.Update(ctx, workflow, entityID, func(p Participant) error {
+		rv := reflect.ValueOf(p)
+		if rv.Kind() == reflect.Pointer {
+			rv = rv.Elem()
+		}
+		for _, spec := range plan {
+			target := rv.FieldByIndex(spec.field.FieldIndex)
+			patchVal := reflect.ValueOf(spec.wantVal)
+			// nil-valued patches set the field to its zero
+			// value — matches operator intent "clear this field."
+			if !patchVal.IsValid() {
+				target.SetZero()
+				continue
+			}
+			if !patchVal.Type().AssignableTo(target.Type()) {
+				return fmt.Errorf("lifecycle: UpdateFromOperator field %q: cannot assign %v to %v",
+					spec.jsonName, patchVal.Type(), target.Type())
+			}
+			target.Set(patchVal)
+		}
+		return nil
+	})
+}
+
+// operatorPatchSpec is the pre-validated, per-patch-key wiring
+// resolved at the top of UpdateFromOperator. Cached locally rather
+// than computed inside the mutator so CAS-retry doesn't re-validate
+// on every iteration.
+type operatorPatchSpec struct {
+	field    *fieldMeta
+	wantVal  any
+	jsonName string
+}
+
+// Children returns Participants whose ParentEntityID() equals the
+// given parentEntityID, across ALL registered workflows. v1
+// implementation is a linear scan over every registered workflow's
+// bucket; complexity is O(sum-of-bucket-sizes) per call.
+//
+// Cross-workflow semantics: a parent in workflow A can have
+// children in workflow B (e.g. semspec's Plan-owns-Requirements
+// pattern — Plan and Requirement are distinct workflows). Children
+// returns all of them merged into one slice; sort caller-side if
+// needed.
+//
+// Scaling consideration: high parent-child fan-out apps should
+// prefer List(workflow, Match{"parent_field": parentID}) where
+// parent_field is the JSON name of the ParentEntityID-backing
+// struct field. That stays within one workflow's bucket and works
+// with the v2 secondary-index path when it lands. Children is the
+// generic helper for the cross-workflow case; List + Match is the
+// scaling-friendly path for the common intra-workflow case.
+func (m *Manager) Children(ctx context.Context, parentEntityID string) ([]Participant, error) {
+	m.mu.RLock()
+	regs := make([]*registration, 0, len(m.registrations))
+	for _, reg := range m.registrations {
+		regs = append(regs, reg)
+	}
+	m.mu.RUnlock()
+
+	var out []Participant
+	for _, reg := range regs {
+		participants, err := m.List(ctx, reg.workflow, ListOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("lifecycle: Children scan workflow %q: %w", reg.workflow, err)
+		}
+		for _, p := range participants {
+			if p.ParentEntityID() == parentEntityID {
+				out = append(out, p)
+			}
+		}
+	}
+	return out, nil
+}
+
+// Ancestors returns Participants walking from the given entityID
+// up the parent chain, ROOT-FIRST (the entity itself is NOT
+// included; ancestors[0] is the immediate parent, ancestors[last]
+// is the root). Stops when ParentEntityID() returns empty string
+// or when a parent can't be resolved (logged + walk truncated).
+//
+// Cross-workflow: each ancestor may be in a different workflow
+// than the starting entity. v1 implementation resolves each
+// ancestor by scanning every registered workflow's bucket for the
+// entityID — O(workflows × bucket-size) per ancestor lookup. Apps
+// with deep parent chains in high-cardinality workflows feel this;
+// the v2 secondary-index work (ADR-047 § KV indexing) makes the
+// per-ancestor lookup constant-time.
+//
+// Returns empty slice (not error) for entities with no parent
+// (already at root). Returns ErrEntityNotFound if the starting
+// entityID itself can't be resolved.
+func (m *Manager) Ancestors(ctx context.Context, entityID string) ([]Participant, error) {
+	current, err := m.findByEntityID(ctx, entityID)
+	if err != nil {
+		return nil, err
+	}
+	var out []Participant
+	parentID := current.ParentEntityID()
+	for parentID != "" {
+		parent, err := m.findByEntityID(ctx, parentID)
+		if err != nil {
+			if errors.Is(err, ErrEntityNotFound) {
+				// Truncate the walk loudly — the chain is
+				// broken (parent referenced but deleted or
+				// never created). Log so operators see the
+				// dangling ref; return what we have.
+				m.logger.Warn("lifecycle: Ancestors walk truncated — parent not found",
+					slog.String("starting_entity", entityID),
+					slog.String("missing_parent", parentID))
+				return out, nil
+			}
+			return nil, err
+		}
+		out = append(out, parent)
+		parentID = parent.ParentEntityID()
+	}
+	return out, nil
+}
+
+// findByEntityID resolves an entityID to a Participant by scanning
+// every registered workflow's bucket. Returns ErrEntityNotFound if
+// the ID isn't present in any bucket.
+//
+// Internal helper for Ancestors; not exposed publicly because the
+// linear-scan cost across all workflows is bounded only by the
+// total instance count. Apps wanting "which workflow does this ID
+// belong to" should track that mapping themselves.
+func (m *Manager) findByEntityID(ctx context.Context, entityID string) (Participant, error) {
+	m.mu.RLock()
+	regs := make([]*registration, 0, len(m.registrations))
+	for _, reg := range m.registrations {
+		regs = append(regs, reg)
+	}
+	m.mu.RUnlock()
+
+	for _, reg := range regs {
+		p, err := m.Get(ctx, reg.workflow, entityID)
+		if err == nil {
+			return p, nil
+		}
+		if !errors.Is(err, ErrEntityNotFound) {
+			return nil, err
+		}
+	}
+	return nil, fmt.Errorf("%w: entity_id=%q (scanned %d workflows)",
+		ErrEntityNotFound, entityID, len(regs))
+}
+
+// GetWorkflowDefinition returns the WorkflowDef for the given
+// workflow type, suitable for operator-dashboard introspection
+// (state-machine diagram rendering, patchable-field listing, etc.).
+//
+// Returns ErrWorkflowNotRegistered if the workflow isn't registered.
+func (m *Manager) GetWorkflowDefinition(workflow string) (WorkflowDef, error) {
+	reg, err := m.lookupByWorkflow(workflow)
+	if err != nil {
+		return WorkflowDef{}, err
+	}
+	return WorkflowDef{
+		Workflow:               reg.workflow,
+		Transitions:            reg.transitions,
+		KVBucket:               reg.bucket,
+		OperatorWritableFields: reg.structMeta.OperatorWritableJSONNames(),
+	}, nil
+}
+
+// ListWorkflows returns the WorkflowDef for every registered
+// workflow type, sorted by workflow name for deterministic
+// operator-dashboard output across restarts.
+func (m *Manager) ListWorkflows() []WorkflowDef {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	names := make([]string, 0, len(m.registrations))
+	for name := range m.registrations {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]WorkflowDef, 0, len(names))
+	for _, name := range names {
+		reg := m.registrations[name]
+		out = append(out, WorkflowDef{
+			Workflow:               reg.workflow,
+			Transitions:            reg.transitions,
+			KVBucket:               reg.bucket,
+			OperatorWritableFields: reg.structMeta.OperatorWritableJSONNames(),
+		})
+	}
+	return out
 }
 
 // History returns the phase-transition history for the entity at

--- a/pkg/lifecycle/manager_query_test.go
+++ b/pkg/lifecycle/manager_query_test.go
@@ -259,3 +259,237 @@ func TestManager_History_UnknownWorkflow(t *testing.T) {
 		t.Fatalf("History on unregistered workflow should error ErrWorkflowNotRegistered, got %v", err)
 	}
 }
+
+// --- UpdateFromOperator ---
+
+func TestManager_UpdateFromOperator_HappyPath(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "ufo-1", "planning")
+
+	err := mgr.UpdateFromOperator(context.Background(), "mission", "ufo-1", map[string]any{
+		"owner_org_id": "newcorp",
+	})
+	if err != nil {
+		t.Fatalf("UpdateFromOperator: %v", err)
+	}
+	got, _ := mgr.Get(context.Background(), "mission", "ufo-1")
+	if got.(*missionState).OwnerOrgIDF != "newcorp" {
+		t.Errorf("patch didn't apply: %+v", got)
+	}
+}
+
+func TestManager_UpdateFromOperator_RejectsNonOperatorWritableField(t *testing.T) {
+	// Phase is tagged readonly (implicit via lifecycle:"phase").
+	// Patch must be rejected with ErrFieldNotOperatorWritable.
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "ufo-2", "planning")
+
+	err := mgr.UpdateFromOperator(context.Background(), "mission", "ufo-2", map[string]any{
+		"phase": "flying", // not operator_writable
+	})
+	if !errors.Is(err, ErrFieldNotOperatorWritable) {
+		t.Fatalf("operator patch of phase should error ErrFieldNotOperatorWritable, got %v", err)
+	}
+}
+
+func TestManager_UpdateFromOperator_RejectsUnknownKey(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "ufo-3", "planning")
+
+	err := mgr.UpdateFromOperator(context.Background(), "mission", "ufo-3", map[string]any{
+		"frobnicator_count": 42,
+	})
+	if err == nil || !strings.Contains(err.Error(), "frobnicator_count") {
+		t.Fatalf("unknown patch key should reject naming the key, got %v", err)
+	}
+}
+
+func TestManager_UpdateFromOperator_RejectsTypeMismatch(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "ufo-4", "planning")
+
+	err := mgr.UpdateFromOperator(context.Background(), "mission", "ufo-4", map[string]any{
+		"owner_org_id": 42, // int, but field is string
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot assign") {
+		t.Fatalf("type-mismatched patch should reject with assign-mention, got %v", err)
+	}
+}
+
+func TestManager_UpdateFromOperator_EmptyPatchIsNoOp(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "ufo-5", "planning")
+
+	if err := mgr.UpdateFromOperator(context.Background(), "mission", "ufo-5", nil); err != nil {
+		t.Errorf("nil patch should be no-op, got %v", err)
+	}
+	if err := mgr.UpdateFromOperator(context.Background(), "mission", "ufo-5", map[string]any{}); err != nil {
+		t.Errorf("empty patch should be no-op, got %v", err)
+	}
+}
+
+// --- Children ---
+
+func TestManager_Children_FindsByParentEntityID(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "parent", PhaseF: "planning"}))
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "child-1", PhaseF: "planning", ParentMissionF: "parent"}))
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "child-2", PhaseF: "planning", ParentMissionF: "parent"}))
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "orphan", PhaseF: "planning"}))
+
+	got, err := mgr.Children(context.Background(), "parent")
+	if err != nil {
+		t.Fatalf("Children: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 children, got %d: %+v", len(got), got)
+	}
+	seen := make(map[string]bool)
+	for _, p := range got {
+		seen[p.EntityID()] = true
+	}
+	for _, want := range []string{"child-1", "child-2"} {
+		if !seen[want] {
+			t.Errorf("Children missing %q", want)
+		}
+	}
+}
+
+func TestManager_Children_EmptyWhenNoChildren(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "alone", "planning")
+	got, err := mgr.Children(context.Background(), "alone")
+	if err != nil {
+		t.Fatalf("Children: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 children, got %d", len(got))
+	}
+}
+
+// --- Ancestors ---
+
+func TestManager_Ancestors_WalksParentChain(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "root", PhaseF: "planning"}))
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "mid", PhaseF: "planning", ParentMissionF: "root"}))
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "leaf", PhaseF: "planning", ParentMissionF: "mid"}))
+
+	got, err := mgr.Ancestors(context.Background(), "leaf")
+	if err != nil {
+		t.Fatalf("Ancestors: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 ancestors (mid, root), got %d: %+v", len(got), got)
+	}
+	if got[0].EntityID() != "mid" || got[1].EntityID() != "root" {
+		t.Errorf("Ancestors order wrong; want [mid, root], got [%s, %s]",
+			got[0].EntityID(), got[1].EntityID())
+	}
+}
+
+func TestManager_Ancestors_EmptyForRoot(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "rootless", "planning")
+	got, err := mgr.Ancestors(context.Background(), "rootless")
+	if err != nil {
+		t.Fatalf("Ancestors: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 ancestors for root entity, got %d", len(got))
+	}
+}
+
+func TestManager_Ancestors_NotFoundForMissingEntity(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, err := mgr.Ancestors(context.Background(), "never-existed")
+	if !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("Ancestors on missing entity should error ErrEntityNotFound, got %v", err)
+	}
+}
+
+func TestManager_Ancestors_TruncatesOnBrokenChain(t *testing.T) {
+	// Parent reference points to an entity that doesn't exist —
+	// walk truncates loudly via Warn log, returns what it found.
+	mgr, _ := newTestManager(t)
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "orphan", PhaseF: "planning", ParentMissionF: "missing-parent"}))
+	got, err := mgr.Ancestors(context.Background(), "orphan")
+	if err != nil {
+		t.Fatalf("Ancestors with broken chain should not error, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("broken-chain walk should return empty, got %d entries", len(got))
+	}
+}
+
+// --- WorkflowDefinition introspection ---
+
+func TestManager_GetWorkflowDefinition_HappyPath(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	def, err := mgr.GetWorkflowDefinition("mission")
+	if err != nil {
+		t.Fatalf("GetWorkflowDefinition: %v", err)
+	}
+	if def.Workflow != "mission" {
+		t.Errorf("Workflow wrong: %q", def.Workflow)
+	}
+	if def.KVBucket != "MISSIONS" {
+		t.Errorf("KVBucket wrong: %q", def.KVBucket)
+	}
+	if len(def.Transitions) != len(missionTransitions) {
+		t.Errorf("Transitions count wrong: %d vs %d", len(def.Transitions), len(missionTransitions))
+	}
+	// Sorted output for operator-dashboard stability (PR 1a lock-in).
+	wantFields := []string{"owner_org_id"}
+	if len(def.OperatorWritableFields) != len(wantFields) {
+		t.Errorf("OperatorWritableFields count wrong: got %v, want %v",
+			def.OperatorWritableFields, wantFields)
+	}
+}
+
+func TestManager_GetWorkflowDefinition_UnknownWorkflow(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, err := mgr.GetWorkflowDefinition("never-registered")
+	if !errors.Is(err, ErrWorkflowNotRegistered) {
+		t.Fatalf("expected ErrWorkflowNotRegistered, got %v", err)
+	}
+}
+
+func TestManager_ListWorkflows_SortedByName(t *testing.T) {
+	// Register two workflows, verify sorted output.
+	store := newKVMockStore(nil)
+	mgr := newManagerForTest(nil, func(_ string) (kvStore, error) {
+		return store, nil
+	})
+	must(t, mgr.Register("mission", missionFactory, missionTransitions))
+	must(t, mgr.Register("alt", func() Participant { return &altParticipant{} },
+		Transitions{"a": {"b"}, "b": {}}))
+
+	defs := mgr.ListWorkflows()
+	if len(defs) != 2 {
+		t.Fatalf("expected 2 workflow defs, got %d", len(defs))
+	}
+	if defs[0].Workflow != "alt" || defs[1].Workflow != "mission" {
+		t.Errorf("ListWorkflows should be sorted by name; got [%q, %q]",
+			defs[0].Workflow, defs[1].Workflow)
+	}
+}
+
+// altParticipant is a minimal second Participant impl for the
+// ListWorkflows-sorted-output test. Shares the bucket with
+// mission (deliberate — keeps the test fixture simple); apps
+// in production would use separate buckets. Top-level fields
+// only — parseStructTags doesn't recurse into nested struct
+// types per the foundation contract.
+type altParticipant struct {
+	EntityIDF string `json:"entity_id" lifecycle:"id"`
+	PhaseF    string `json:"phase" lifecycle:"phase"`
+}
+
+func (a *altParticipant) EntityID() string             { return a.EntityIDF }
+func (a *altParticipant) Workflow() string             { return "alt" }
+func (a *altParticipant) Phase() string                { return a.PhaseF }
+func (a *altParticipant) IsTerminal() bool             { return a.PhaseF == "b" }
+func (a *altParticipant) KVBucket() string             { return "MISSIONS" }
+func (a *altParticipant) KVKey(entityID string) string { return "alt." + entityID }
+func (a *altParticipant) ParentEntityID() string       { return "" }

--- a/pkg/lifecycle/manager_query_test.go
+++ b/pkg/lifecycle/manager_query_test.go
@@ -1,0 +1,261 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- List ---
+
+func TestManager_List_EmptyBucketReturnsEmpty(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	got, err := mgr.List(context.Background(), "mission", ListOptions{})
+	if err != nil {
+		t.Fatalf("List on empty bucket: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("List on empty bucket returned %d entries, want 0", len(got))
+	}
+}
+
+func TestManager_List_HappyPath(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "l-1", "planning")
+	mustCreate(t, mgr, "l-2", "planning")
+	mustCreate(t, mgr, "l-3", "planning")
+
+	got, err := mgr.List(context.Background(), "mission", ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("List returned %d entries, want 3", len(got))
+	}
+	seen := make(map[string]bool)
+	for _, p := range got {
+		seen[p.EntityID()] = true
+	}
+	for _, want := range []string{"l-1", "l-2", "l-3"} {
+		if !seen[want] {
+			t.Errorf("List missing entity %q", want)
+		}
+	}
+}
+
+func TestManager_List_PhaseFilter(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "p-planning", "planning")
+	mustCreate(t, mgr, "p-flying", "planning")
+	must(t, mgr.Transition(context.Background(), "mission", "p-flying", "flying", TransitionSourceRule, ""))
+
+	got, err := mgr.List(context.Background(), "mission", ListOptions{Phase: "flying"})
+	if err != nil {
+		t.Fatalf("List with Phase filter: %v", err)
+	}
+	if len(got) != 1 || got[0].EntityID() != "p-flying" {
+		t.Errorf("Phase filter returned %d entries: %+v", len(got), got)
+	}
+}
+
+func TestManager_List_ActiveFilter(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "a-active", "planning")
+	mustCreate(t, mgr, "a-terminal", "planning")
+	must(t, mgr.Transition(context.Background(), "mission", "a-terminal", "aborted", TransitionSourceOperator, ""))
+
+	got, err := mgr.List(context.Background(), "mission", ListOptions{Active: true})
+	if err != nil {
+		t.Fatalf("List with Active filter: %v", err)
+	}
+	if len(got) != 1 || got[0].EntityID() != "a-active" {
+		t.Errorf("Active=true should exclude terminals; got %d entries: %+v", len(got), got)
+	}
+}
+
+func TestManager_List_MatchFilter(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "m-acme", PhaseF: "planning", OwnerOrgIDF: "acme"}))
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "m-other", PhaseF: "planning", OwnerOrgIDF: "other"}))
+
+	got, err := mgr.List(context.Background(), "mission", ListOptions{
+		Match: map[string]any{"owner_org_id": "acme"},
+	})
+	if err != nil {
+		t.Fatalf("List with Match: %v", err)
+	}
+	if len(got) != 1 || got[0].EntityID() != "m-acme" {
+		t.Errorf("Match filter returned %d entries: %+v", len(got), got)
+	}
+}
+
+func TestManager_List_RejectsUnknownMatchKey(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "x", "planning")
+	_, err := mgr.List(context.Background(), "mission", ListOptions{
+		Match: map[string]any{"nonexistent_field": "value"},
+	})
+	if err == nil {
+		t.Fatal("Match with unknown key must error (typos should surface loudly)")
+	}
+	if !strings.Contains(err.Error(), "nonexistent_field") {
+		t.Errorf("error should mention the unknown key %q, got %q", "nonexistent_field", err)
+	}
+}
+
+func TestManager_List_LimitOffset(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	for i := range 5 {
+		mustCreate(t, mgr, fmt.Sprintf("lo-%d", i), "planning")
+	}
+
+	got, err := mgr.List(context.Background(), "mission", ListOptions{Limit: 2, Offset: 1})
+	if err != nil {
+		t.Fatalf("List with Limit/Offset: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("Limit=2 should cap at 2 entries, got %d", len(got))
+	}
+}
+
+func TestManager_List_UnknownWorkflow(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, err := mgr.List(context.Background(), "never-registered", ListOptions{})
+	if !errors.Is(err, ErrWorkflowNotRegistered) {
+		t.Fatalf("List on unregistered workflow should error ErrWorkflowNotRegistered, got %v", err)
+	}
+}
+
+// --- Watch ---
+
+func TestManager_Watch_DeliversBootstrapSnapshot(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "w-1", "planning")
+	mustCreate(t, mgr, "w-2", "planning")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := mgr.Watch(ctx, "mission")
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+
+	// Consume snapshot — bounded wait so a broken Watch doesn't
+	// hang the test for the suite's default timeout.
+	seen := make(map[string]bool)
+	timeout := time.After(2 * time.Second)
+	for len(seen) < 2 {
+		select {
+		case p, ok := <-ch:
+			if !ok {
+				t.Fatalf("Watch channel closed early; got %d/%d", len(seen), 2)
+			}
+			seen[p.EntityID()] = true
+		case <-timeout:
+			t.Fatalf("timed out waiting for snapshot; got %d/%d so far", len(seen), 2)
+		}
+	}
+	if !seen["w-1"] || !seen["w-2"] {
+		t.Errorf("snapshot missing entries: %+v", seen)
+	}
+}
+
+func TestManager_Watch_StopsOnCtxCancel(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := mgr.Watch(ctx, "mission")
+	if err != nil {
+		t.Fatalf("Watch: %v", err)
+	}
+	cancel()
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return // closed — pass
+			}
+			// Drain pre-cancel snapshot items.
+		case <-deadline:
+			t.Fatal("Watch channel did not close within 1s after ctx cancel")
+		}
+	}
+}
+
+// --- History ---
+
+func TestManager_History_HappyPath(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "h-1", "planning")
+	must(t, mgr.Transition(context.Background(), "mission", "h-1", "flying", TransitionSourceRule, ""))
+	must(t, mgr.Transition(context.Background(), "mission", "h-1", "capturing", TransitionSourceRule, ""))
+
+	events, err := mgr.History(context.Background(), "mission", "h-1")
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	// Expected: Create (""→"planning"), planning→flying, flying→capturing
+	want := []struct{ from, to string }{
+		{"", "planning"},
+		{"planning", "flying"},
+		{"flying", "capturing"},
+	}
+	if len(events) != len(want) {
+		t.Fatalf("expected %d events, got %d: %+v", len(want), len(events), events)
+	}
+	for i, w := range want {
+		if events[i].From != w.from || events[i].To != w.to {
+			t.Errorf("event %d: got %q→%q, want %q→%q",
+				i, events[i].From, events[i].To, w.from, w.to)
+		}
+	}
+}
+
+func TestManager_History_ReturnsNotFoundForMissingEntity(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, err := mgr.History(context.Background(), "mission", "never-existed")
+	if !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("History on missing entity should error ErrEntityNotFound, got %v", err)
+	}
+}
+
+func TestManager_History_SkipsNonPhaseUpdates(t *testing.T) {
+	// Update that mutates owner_org_id but not Phase should NOT
+	// appear in History — History surfaces phase-transition
+	// events specifically, not every state mutation.
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "h-2", "planning")
+	must(t, mgr.Update(context.Background(), "mission", "h-2", func(p Participant) error {
+		p.(*missionState).OwnerOrgIDF = "first-update"
+		return nil
+	}))
+	must(t, mgr.Update(context.Background(), "mission", "h-2", func(p Participant) error {
+		p.(*missionState).OwnerOrgIDF = "second-update"
+		return nil
+	}))
+
+	events, err := mgr.History(context.Background(), "mission", "h-2")
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	// Only the Create event should be there — the two Updates
+	// didn't change Phase.
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event (Create only — Updates without phase change should be skipped), got %d: %+v",
+			len(events), events)
+	}
+	if events[0].From != "" || events[0].To != "planning" {
+		t.Errorf("Create event wrong: %+v", events[0])
+	}
+}
+
+func TestManager_History_UnknownWorkflow(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, err := mgr.History(context.Background(), "never-registered", "x")
+	if !errors.Is(err, ErrWorkflowNotRegistered) {
+		t.Fatalf("History on unregistered workflow should error ErrWorkflowNotRegistered, got %v", err)
+	}
+}

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -20,13 +21,32 @@ type missionState struct {
 	ParentMissionF string `json:"parent_mission,omitempty"`
 }
 
-func (m *missionState) EntityID() string       { return m.EntityIDF }
-func (m *missionState) Workflow() string       { return "mission" }
-func (m *missionState) Phase() string          { return m.PhaseF }
-func (m *missionState) IsTerminal() bool       { return missionTransitions.IsTerminal(m.PhaseF) }
-func (m *missionState) KVBucket() string       { return "MISSIONS" }
-func (m *missionState) KVKey() string          { return "mission." + m.EntityIDF }
-func (m *missionState) ParentEntityID() string { return m.ParentMissionF }
+func (m *missionState) EntityID() string             { return m.EntityIDF }
+func (m *missionState) Workflow() string             { return "mission" }
+func (m *missionState) Phase() string                { return m.PhaseF }
+func (m *missionState) IsTerminal() bool             { return missionTransitions.IsTerminal(m.PhaseF) }
+func (m *missionState) KVBucket() string             { return "MISSIONS" }
+func (m *missionState) KVKey(entityID string) string { return "mission." + entityID }
+func (m *missionState) ParentEntityID() string       { return m.ParentMissionF }
+
+// valueMission is the deliberately-broken Participant shape for the
+// "factory must return pointer" Register-time rejection test. Value-
+// receiver methods + factory-returns-by-value. NOT a usable
+// Participant in production — exists solely so the test fixture
+// reaches the rv.Kind() != reflect.Pointer rejection path in
+// Manager.Register.
+type valueMission struct {
+	EntityIDF string `json:"entity_id" lifecycle:"id"`
+	PhaseF    string `json:"phase" lifecycle:"phase"`
+}
+
+func (v valueMission) EntityID() string             { return v.EntityIDF }
+func (v valueMission) Workflow() string             { return "value-mission" }
+func (v valueMission) Phase() string                { return v.PhaseF }
+func (v valueMission) IsTerminal() bool             { return false }
+func (v valueMission) KVBucket() string             { return "MISSIONS" }
+func (v valueMission) KVKey(entityID string) string { return "v." + entityID }
+func (v valueMission) ParentEntityID() string       { return "" }
 
 var missionTransitions = Transitions{
 	"planning":  {"flying", "aborted"},
@@ -104,43 +124,28 @@ func TestManager_Register_RejectsFactoryReturningNil(t *testing.T) {
 }
 
 func TestManager_Register_RejectsFactoryReturningValue(t *testing.T) {
-	// json.Unmarshal can't populate value-typed Participants; the
-	// reflect SetString on the phase field would also panic on a
-	// non-addressable value. Reject at Register time so the wiring
-	// bug surfaces at startup.
-	type valueMission struct{ missionState }
-	type valueImpl struct {
-		MissionState valueMission
-	}
-	_ = valueImpl{}
-	// Constructing a value-typed Participant requires a non-pointer
-	// return. The Participant interface is satisfied by missionState
-	// (value receiver methods would work but we use pointer
-	// receivers); valueFactory returns the value directly, not a
-	// pointer.
-	valueFactory := func() Participant {
-		// missionState's methods are pointer-receiver, so we have
-		// to return *missionState via a dereference trick — but
-		// the simpler shape is: a separate type that implements
-		// Participant with value receivers, intentionally NOT
-		// returning a pointer. For this test the goal is just to
-		// trigger the "non-pointer factory return" rejection.
-		var ms = missionState{}
-		// reflect.ValueOf(ms).Kind() == reflect.Struct, not Pointer.
-		// We need to return ms as Participant, but missionState's
-		// methods are on the pointer receiver. Cast through any:
-		type valueParticipant struct{ s missionState }
-		// Simpler: just define an inline type with value receivers.
-		// Skip the gymnastics — return missionState by value.
-		_ = ms
-		return nil // can't easily express value-typed Participant inline
-	}
+	// Value-typed Participant returns from the factory are rejected
+	// at Register time. json.Unmarshal can't populate value
+	// receivers (no addressability), and reflect.Value.SetString on
+	// the phase field would panic on a non-pointer. Catching this
+	// at Register surfaces the wiring bug at startup, not at the
+	// first Get/Transition attempt in prod.
+	//
+	// Uses the package-scoped valueMission fixture (value-receiver
+	// methods, factory returns by value) so the test exercises the
+	// REAL "non-pointer factory return" code path at manager.go's
+	// rv.Kind() != reflect.Pointer check.
 	mgr := newManagerForTest(nil, func(string) (kvStore, error) {
 		return newKVMockStore(nil), nil
 	})
-	err := mgr.Register("mission", valueFactory, missionTransitions)
+	err := mgr.Register("value-mission", func() Participant {
+		return valueMission{EntityIDF: "x", PhaseF: "planning"}
+	}, missionTransitions)
 	if err == nil {
-		t.Fatal("nil-returning factory must error (this is the simplest hostile shape)")
+		t.Fatal("value-typed factory return must be rejected")
+	}
+	if !strings.Contains(err.Error(), "pointer") {
+		t.Errorf("rejection should mention 'pointer' for operator debugging, got %q", err)
 	}
 }
 
@@ -284,6 +289,110 @@ func TestManager_Update_RetriesOnCASConflict(t *testing.T) {
 	got, _ := mgr.Get(context.Background(), "mission", "u-3")
 	if got.(*missionState).OwnerOrgIDF != "after-retry" {
 		t.Errorf("retry didn't apply final mutation: %+v", got)
+	}
+}
+
+func TestManager_Update_ConcurrentMutationsSerialize(t *testing.T) {
+	// N goroutines mutate the same entity concurrently. Each
+	// appends a unique tag to the OwnerOrgIDF field. After all
+	// goroutines return, the final field value must contain
+	// every tag (none lost to silent CAS-conflict drops) and no
+	// duplicates (the CAS retry loop must read-then-write
+	// atomically — read-stale-then-write-stale would either
+	// double-append or drop entries).
+	//
+	// N is bounded by updateRetries because of the convergence
+	// arithmetic: with N writers, the worst-case loser needs
+	// up to N-1 retries (each "round" of retries advances exactly
+	// one writer). Using N == updateRetries-1 keeps the test
+	// reliably non-flaky while still exercising the full CAS-
+	// retry serialization path. The "what happens under
+	// budget-exhaustion contention" case is covered separately
+	// by TestManager_Update_ExhaustsRetriesUnderPersistentConflict.
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "concurrent", "planning")
+
+	const goroutines = updateRetries - 1
+	tags := make([]string, goroutines)
+	for i := range goroutines {
+		tags[i] = fmt.Sprintf("tag-%02d", i)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(tag string) {
+			defer wg.Done()
+			err := mgr.Update(context.Background(), "mission", "concurrent", func(p Participant) error {
+				ms := p.(*missionState)
+				if ms.OwnerOrgIDF == "" {
+					ms.OwnerOrgIDF = tag
+				} else {
+					ms.OwnerOrgIDF = ms.OwnerOrgIDF + "," + tag
+				}
+				return nil
+			})
+			if err != nil {
+				t.Errorf("concurrent Update %q: %v", tag, err)
+			}
+		}(tags[i])
+	}
+	wg.Wait()
+
+	got, err := mgr.Get(context.Background(), "mission", "concurrent")
+	if err != nil {
+		t.Fatalf("Get after concurrent updates: %v", err)
+	}
+	final := got.(*missionState).OwnerOrgIDF
+	parts := strings.Split(final, ",")
+	if len(parts) != goroutines {
+		t.Fatalf("expected %d tags in final value, got %d: %q", goroutines, len(parts), final)
+	}
+	seen := make(map[string]int, goroutines)
+	for _, part := range parts {
+		seen[part]++
+	}
+	if len(seen) != goroutines {
+		t.Errorf("expected %d distinct tags, got %d (dup detection): %v", goroutines, len(seen), seen)
+	}
+	for _, tag := range tags {
+		if seen[tag] != 1 {
+			t.Errorf("tag %q appeared %d times, expected 1", tag, seen[tag])
+		}
+	}
+}
+
+func TestManager_Update_MutatorCanSetPhaseDirectly(t *testing.T) {
+	// Current behavior: Manager.Update's mutator can mutate the
+	// Phase field directly without going through Transition. This
+	// bypasses the transitions-table validation that Transition
+	// applies. This test LOCKS the current behavior — either it
+	// continues to be allowed (apps that need it have an escape
+	// hatch) OR a future change deliberately closes it (and
+	// updates the test).
+	//
+	// Discipline call: apps SHOULD use Transition for phase
+	// changes; the convenience of mutator-can-do-anything is
+	// occasionally useful for state-recovery shims (e.g. clearing
+	// drift on a known-corrupt instance). Documented here so the
+	// behavior isn't ambiguous in either direction.
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "direct", "planning")
+
+	err := mgr.Update(context.Background(), "mission", "direct", func(p Participant) error {
+		// Skip from planning to completed — not a declared edge
+		// in the transitions table, but Update doesn't validate
+		// edges (Transition does). The Update succeeds.
+		ms := p.(*missionState)
+		ms.PhaseF = "completed"
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("mutator setting Phase directly should succeed (Update doesn't validate edges): %v", err)
+	}
+	got, _ := mgr.Get(context.Background(), "mission", "direct")
+	if got.Phase() != "completed" {
+		t.Errorf("direct Phase mutation didn't persist: %q", got.Phase())
 	}
 }
 

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -1,0 +1,499 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// missionState is the test fixture for Manager unit tests. Shape
+// mirrors the ADR-047 worked example so the tests double as a
+// readable spec for "how does a Participant implementation actually
+// look in practice." Implements the Participant interface and uses
+// the canonical struct-tag layout.
+type missionState struct {
+	EntityIDF      string `json:"entity_id" lifecycle:"id"`
+	PhaseF         string `json:"phase" lifecycle:"phase,readonly"`
+	OwnerOrgIDF    string `json:"owner_org_id" lifecycle:"operator_writable"`
+	ParentMissionF string `json:"parent_mission,omitempty"`
+}
+
+func (m *missionState) EntityID() string       { return m.EntityIDF }
+func (m *missionState) Workflow() string       { return "mission" }
+func (m *missionState) Phase() string          { return m.PhaseF }
+func (m *missionState) IsTerminal() bool       { return missionTransitions.IsTerminal(m.PhaseF) }
+func (m *missionState) KVBucket() string       { return "MISSIONS" }
+func (m *missionState) KVKey() string          { return "mission." + m.EntityIDF }
+func (m *missionState) ParentEntityID() string { return m.ParentMissionF }
+
+var missionTransitions = Transitions{
+	"planning":  {"flying", "aborted"},
+	"flying":    {"capturing", "landing", "aborted"},
+	"capturing": {"flying"},
+	"landing":   {"completed", "failed"},
+	"completed": {},
+	"failed":    {},
+	"aborted":   {},
+}
+
+func missionFactory() Participant { return &missionState{} }
+
+// newTestManager builds a Manager wired to a fresh in-memory mock
+// store, registers the mission workflow, and returns both for the
+// test body. Centralizes the boilerplate so each test focuses on
+// the behavior under test.
+func newTestManager(t *testing.T) (*Manager, *kvMockStore) {
+	t.Helper()
+	store := newKVMockStore(nil)
+	mgr := newManagerForTest(nil, func(bucket string) (kvStore, error) {
+		if bucket != "MISSIONS" {
+			t.Fatalf("test fixture only supports MISSIONS bucket, got %q", bucket)
+		}
+		return store, nil
+	})
+	if err := mgr.Register("mission", missionFactory, missionTransitions); err != nil {
+		t.Fatalf("Register mission: %v", err)
+	}
+	return mgr, store
+}
+
+// --- Register ---
+
+func TestManager_Register_HappyPath(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	// Re-registering must reject as ErrWorkflowAlreadyRegistered;
+	// idempotent-re-init is a wiring bug, not a benign no-op.
+	err := mgr.Register("mission", missionFactory, missionTransitions)
+	if !errors.Is(err, ErrWorkflowAlreadyRegistered) {
+		t.Errorf("re-register should error with ErrWorkflowAlreadyRegistered, got %v", err)
+	}
+}
+
+func TestManager_Register_RejectsInvalidTransitions(t *testing.T) {
+	mgr := newManagerForTest(nil, func(string) (kvStore, error) {
+		return newKVMockStore(nil), nil
+	})
+	bad := Transitions{
+		"a": {"b"}, // "b" never declared as a key
+	}
+	err := mgr.Register("mission", missionFactory, bad)
+	if !errors.Is(err, ErrInvalidTransitionsTable) {
+		t.Fatalf("expected ErrInvalidTransitionsTable, got %v", err)
+	}
+}
+
+func TestManager_Register_RejectsNilFactory(t *testing.T) {
+	mgr := newManagerForTest(nil, func(string) (kvStore, error) {
+		return newKVMockStore(nil), nil
+	})
+	if err := mgr.Register("mission", nil, missionTransitions); err == nil {
+		t.Fatal("nil factory must be rejected")
+	}
+}
+
+func TestManager_Register_RejectsFactoryReturningNil(t *testing.T) {
+	mgr := newManagerForTest(nil, func(string) (kvStore, error) {
+		return newKVMockStore(nil), nil
+	})
+	err := mgr.Register("mission", func() Participant { return nil }, missionTransitions)
+	if err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("nil-returning factory must be rejected with nil-mentioning error, got %v", err)
+	}
+}
+
+func TestManager_Register_RejectsFactoryReturningValue(t *testing.T) {
+	// json.Unmarshal can't populate value-typed Participants; the
+	// reflect SetString on the phase field would also panic on a
+	// non-addressable value. Reject at Register time so the wiring
+	// bug surfaces at startup.
+	type valueMission struct{ missionState }
+	type valueImpl struct {
+		MissionState valueMission
+	}
+	_ = valueImpl{}
+	// Constructing a value-typed Participant requires a non-pointer
+	// return. The Participant interface is satisfied by missionState
+	// (value receiver methods would work but we use pointer
+	// receivers); valueFactory returns the value directly, not a
+	// pointer.
+	valueFactory := func() Participant {
+		// missionState's methods are pointer-receiver, so we have
+		// to return *missionState via a dereference trick — but
+		// the simpler shape is: a separate type that implements
+		// Participant with value receivers, intentionally NOT
+		// returning a pointer. For this test the goal is just to
+		// trigger the "non-pointer factory return" rejection.
+		var ms = missionState{}
+		// reflect.ValueOf(ms).Kind() == reflect.Struct, not Pointer.
+		// We need to return ms as Participant, but missionState's
+		// methods are on the pointer receiver. Cast through any:
+		type valueParticipant struct{ s missionState }
+		// Simpler: just define an inline type with value receivers.
+		// Skip the gymnastics — return missionState by value.
+		_ = ms
+		return nil // can't easily express value-typed Participant inline
+	}
+	mgr := newManagerForTest(nil, func(string) (kvStore, error) {
+		return newKVMockStore(nil), nil
+	})
+	err := mgr.Register("mission", valueFactory, missionTransitions)
+	if err == nil {
+		t.Fatal("nil-returning factory must error (this is the simplest hostile shape)")
+	}
+}
+
+func TestManager_Register_RejectsMismatchedWorkflowName(t *testing.T) {
+	mgr := newManagerForTest(nil, func(string) (kvStore, error) {
+		return newKVMockStore(nil), nil
+	})
+	// Factory returns missionState which declares Workflow()=="mission",
+	// but we register it under a different name. Mismatch should reject.
+	err := mgr.Register("survey", missionFactory, missionTransitions)
+	if err == nil || !strings.Contains(err.Error(), "mismatch") {
+		t.Fatalf("workflow-name mismatch should reject with mismatch-mentioning error, got %v", err)
+	}
+}
+
+// --- Get ---
+
+func TestManager_Get_ReturnsNotFound(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, err := mgr.Get(context.Background(), "mission", "does-not-exist")
+	if !errors.Is(err, ErrEntityNotFound) {
+		t.Fatalf("Get on missing entity should error ErrEntityNotFound, got %v", err)
+	}
+}
+
+func TestManager_Get_UnknownWorkflow(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	_, err := mgr.Get(context.Background(), "never-registered", "irrelevant")
+	if !errors.Is(err, ErrWorkflowNotRegistered) {
+		t.Fatalf("Get on unregistered workflow should error ErrWorkflowNotRegistered, got %v", err)
+	}
+}
+
+// --- Create + Get round-trip ---
+
+func TestManager_Create_AndGet_RoundTrip(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	initial := &missionState{
+		EntityIDF:   "mission-001",
+		PhaseF:      "planning",
+		OwnerOrgIDF: "acme",
+	}
+	if err := mgr.Create(context.Background(), initial); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := mgr.Get(context.Background(), "mission", "mission-001")
+	if err != nil {
+		t.Fatalf("Get after Create: %v", err)
+	}
+	gotMission, ok := got.(*missionState)
+	if !ok {
+		t.Fatalf("Get returned %T, want *missionState", got)
+	}
+	if gotMission.PhaseF != "planning" || gotMission.OwnerOrgIDF != "acme" {
+		t.Errorf("round-trip lost fields: %+v", gotMission)
+	}
+}
+
+func TestManager_Create_RejectsDuplicate(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	initial := &missionState{EntityIDF: "dup", PhaseF: "planning"}
+	if err := mgr.Create(context.Background(), initial); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	err := mgr.Create(context.Background(), initial)
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("duplicate Create should error with already-exists, got %v", err)
+	}
+}
+
+func TestManager_Create_RejectsUndeclaredInitialPhase(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	bad := &missionState{EntityIDF: "x", PhaseF: "exploded"}
+	err := mgr.Create(context.Background(), bad)
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("Create with undeclared initial phase should error ErrInvalidTransition, got %v", err)
+	}
+}
+
+// --- Update ---
+
+func TestManager_Update_HappyPath(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "u-1", "planning")
+
+	err := mgr.Update(context.Background(), "mission", "u-1", func(p Participant) error {
+		ms := p.(*missionState)
+		ms.OwnerOrgIDF = "newcorp"
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, _ := mgr.Get(context.Background(), "mission", "u-1")
+	if got.(*missionState).OwnerOrgIDF != "newcorp" {
+		t.Errorf("mutation didn't persist: %+v", got)
+	}
+}
+
+func TestManager_Update_MutatorErrorAborts(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "u-2", "planning")
+
+	sentinel := errors.New("mutator says no")
+	err := mgr.Update(context.Background(), "mission", "u-2", func(_ Participant) error {
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Errorf("mutator error must wrap and surface, got %v", err)
+	}
+	// State must be unchanged after mutator-reject (no KV write happened).
+	got, _ := mgr.Get(context.Background(), "mission", "u-2")
+	if got.(*missionState).PhaseF != "planning" {
+		t.Errorf("mutator-reject should not have written; got phase %q", got.(*missionState).PhaseF)
+	}
+}
+
+func TestManager_Update_RetriesOnCASConflict(t *testing.T) {
+	// Use a mock store that injects a CAS conflict on the first Update,
+	// then succeeds on retry. Verifies the retry loop actually runs.
+	store := newKVMockStore(nil)
+	conflictStore := &flakyOnceUpdateStore{kvMockStore: store}
+	mgr := newManagerForTest(nil, func(_ string) (kvStore, error) {
+		return conflictStore, nil
+	})
+	if err := mgr.Register("mission", missionFactory, missionTransitions); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	mustCreate(t, mgr, "u-3", "planning")
+
+	err := mgr.Update(context.Background(), "mission", "u-3", func(p Participant) error {
+		p.(*missionState).OwnerOrgIDF = "after-retry"
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Update should have succeeded on retry, got %v", err)
+	}
+	if !conflictStore.firstConflictInjected {
+		t.Error("retry path didn't trigger — flakyOnceUpdateStore never injected its conflict")
+	}
+	got, _ := mgr.Get(context.Background(), "mission", "u-3")
+	if got.(*missionState).OwnerOrgIDF != "after-retry" {
+		t.Errorf("retry didn't apply final mutation: %+v", got)
+	}
+}
+
+func TestManager_Update_ExhaustsRetriesUnderPersistentConflict(t *testing.T) {
+	// Mock store that conflicts on EVERY Update — Manager must give
+	// up after updateRetries attempts and surface the CAS error.
+	store := newKVMockStore(nil)
+	alwaysConflict := &alwaysConflictUpdateStore{kvMockStore: store}
+	mgr := newManagerForTest(nil, func(_ string) (kvStore, error) {
+		return alwaysConflict, nil
+	})
+	if err := mgr.Register("mission", missionFactory, missionTransitions); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	mustCreate(t, mgr, "u-4", "planning")
+
+	err := mgr.Update(context.Background(), "mission", "u-4", func(_ Participant) error {
+		return nil
+	})
+	if err == nil || !errors.Is(err, errKVRevisionMismatch) {
+		t.Fatalf("persistent conflict should exhaust retries with CAS error, got %v", err)
+	}
+	if alwaysConflict.updateCalls != updateRetries {
+		t.Errorf("expected exactly %d Update attempts, got %d", updateRetries, alwaysConflict.updateCalls)
+	}
+}
+
+// --- Transition ---
+
+func TestManager_Transition_HappyPath(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "t-1", "planning")
+
+	err := mgr.Transition(context.Background(), "mission", "t-1", "flying", TransitionSourceRule, "")
+	if err != nil {
+		t.Fatalf("Transition planning→flying: %v", err)
+	}
+	got, _ := mgr.Get(context.Background(), "mission", "t-1")
+	if got.Phase() != "flying" {
+		t.Errorf("Phase didn't update, got %q", got.Phase())
+	}
+}
+
+func TestManager_Transition_RejectsUndeclaredTarget(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "t-2", "planning")
+	err := mgr.Transition(context.Background(), "mission", "t-2", "exploded", TransitionSourceRule, "")
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("target not in table should error ErrInvalidTransition, got %v", err)
+	}
+}
+
+func TestManager_Transition_RejectsInvalidEdge(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "t-3", "planning")
+	// planning → completed isn't a declared edge.
+	err := mgr.Transition(context.Background(), "mission", "t-3", "completed", TransitionSourceRule, "")
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("non-edge transition should error ErrInvalidTransition, got %v", err)
+	}
+}
+
+func TestManager_Transition_RejectsFromTerminal(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "t-4", "planning")
+	// Walk to a terminal first.
+	must(t, mgr.Transition(context.Background(), "mission", "t-4", "aborted", TransitionSourceOperator, ""))
+	// Now try to transition out of terminal — should error specifically
+	// ErrTerminalPhase (distinguished from ErrInvalidTransition so
+	// dashboards can show the right hint).
+	err := mgr.Transition(context.Background(), "mission", "t-4", "planning", TransitionSourceRule, "")
+	if !errors.Is(err, ErrTerminalPhase) {
+		t.Fatalf("transition from terminal should error ErrTerminalPhase, got %v", err)
+	}
+}
+
+// --- Complete ---
+
+func TestManager_Complete_PicksFirstReachableTerminal(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "c-1", "planning")
+	// Walk to landing so a terminal transition is possible.
+	must(t, mgr.Transition(context.Background(), "mission", "c-1", "flying", TransitionSourceRule, ""))
+	must(t, mgr.Transition(context.Background(), "mission", "c-1", "landing", TransitionSourceRule, ""))
+
+	if err := mgr.Complete(context.Background(), "mission", "c-1"); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	got, _ := mgr.Get(context.Background(), "mission", "c-1")
+	// landing → {completed, failed}; sorted declared terminals are
+	// {aborted, completed, failed}; first sorted terminal that is
+	// ALSO reachable from landing is "completed". Deterministic.
+	if got.Phase() != "completed" {
+		t.Errorf("Complete from landing should pick first sorted reachable terminal 'completed', got %q",
+			got.Phase())
+	}
+	if !got.IsTerminal() {
+		t.Errorf("entity should be terminal after Complete, got %q", got.Phase())
+	}
+}
+
+func TestManager_Complete_RejectsFromTerminal(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "c-2", "planning")
+	must(t, mgr.Transition(context.Background(), "mission", "c-2", "aborted", TransitionSourceOperator, ""))
+
+	err := mgr.Complete(context.Background(), "mission", "c-2")
+	if !errors.Is(err, ErrTerminalPhase) {
+		t.Fatalf("Complete on already-terminal entity should error ErrTerminalPhase, got %v", err)
+	}
+}
+
+func TestManager_Complete_NoReachableTerminalErrors(t *testing.T) {
+	// Custom transitions table where the non-terminal phase has no
+	// edge to any terminal — Complete should surface the wiring bug.
+	noReachableTerminal := Transitions{
+		"start":     {"middle"},
+		"middle":    {"start"}, // cycle, no terminal reachable
+		"completed": {},
+	}
+	store := newKVMockStore(nil)
+	mgr := newManagerForTest(nil, func(_ string) (kvStore, error) {
+		return store, nil
+	})
+	if err := mgr.Register("mission", missionFactory, noReachableTerminal); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	must(t, mgr.Create(context.Background(), &missionState{EntityIDF: "stuck", PhaseF: "start"}))
+
+	err := mgr.Complete(context.Background(), "mission", "stuck")
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("Complete with no reachable terminal should error ErrInvalidTransition, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "no edge to any terminal") {
+		t.Errorf("error should mention 'no edge to any terminal' for operator debugging, got %q", err)
+	}
+}
+
+// --- Fail ---
+
+func TestManager_Fail_RequiresReason(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	err := mgr.Fail(context.Background(), "mission", "anything", "")
+	if err == nil {
+		t.Fatal("Fail with empty reason must error (audit-trail discipline)")
+	}
+}
+
+func TestManager_Fail_TransitionsToFailedPhase(t *testing.T) {
+	mgr, _ := newTestManager(t)
+	mustCreate(t, mgr, "f-1", "planning")
+	must(t, mgr.Transition(context.Background(), "mission", "f-1", "flying", TransitionSourceRule, ""))
+	must(t, mgr.Transition(context.Background(), "mission", "f-1", "landing", TransitionSourceRule, ""))
+
+	if err := mgr.Fail(context.Background(), "mission", "f-1", "engine failure"); err != nil {
+		t.Fatalf("Fail: %v", err)
+	}
+	got, _ := mgr.Get(context.Background(), "mission", "f-1")
+	if got.Phase() != "failed" {
+		t.Errorf("Fail should transition to 'failed', got %q", got.Phase())
+	}
+}
+
+// --- helpers ---
+
+func mustCreate(t *testing.T, mgr *Manager, id, phase string) {
+	t.Helper()
+	err := mgr.Create(context.Background(), &missionState{EntityIDF: id, PhaseF: phase})
+	if err != nil {
+		t.Fatalf("mustCreate %q@%q: %v", id, phase, err)
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// flakyOnceUpdateStore wraps kvMockStore to inject one CAS conflict
+// on the FIRST Update call. Used by the retry-on-conflict test.
+type flakyOnceUpdateStore struct {
+	*kvMockStore
+	mu                    sync.Mutex
+	firstConflictInjected bool
+}
+
+func (f *flakyOnceUpdateStore) Update(ctx context.Context, key string, value []byte, expectedRevision uint64) (uint64, error) {
+	f.mu.Lock()
+	if !f.firstConflictInjected {
+		f.firstConflictInjected = true
+		f.mu.Unlock()
+		return 0, errKVRevisionMismatch
+	}
+	f.mu.Unlock()
+	return f.kvMockStore.Update(ctx, key, value, expectedRevision)
+}
+
+// alwaysConflictUpdateStore makes EVERY Update conflict, used to
+// verify Manager exhausts updateRetries and surfaces the CAS error.
+type alwaysConflictUpdateStore struct {
+	*kvMockStore
+	mu          sync.Mutex
+	updateCalls int
+}
+
+func (a *alwaysConflictUpdateStore) Update(_ context.Context, _ string, _ []byte, _ uint64) (uint64, error) {
+	a.mu.Lock()
+	a.updateCalls++
+	a.mu.Unlock()
+	return 0, errKVRevisionMismatch
+}

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -412,8 +412,8 @@ func TestManager_Update_ExhaustsRetriesUnderPersistentConflict(t *testing.T) {
 	err := mgr.Update(context.Background(), "mission", "u-4", func(_ Participant) error {
 		return nil
 	})
-	if err == nil || !errors.Is(err, errKVRevisionMismatch) {
-		t.Fatalf("persistent conflict should exhaust retries with CAS error, got %v", err)
+	if err == nil || !errors.Is(err, ErrUpdateRetriesExhausted) {
+		t.Fatalf("persistent conflict should exhaust retries with ErrUpdateRetriesExhausted, got %v", err)
 	}
 	if alwaysConflict.updateCalls != updateRetries {
 		t.Errorf("expected exactly %d Update attempts, got %d", updateRetries, alwaysConflict.updateCalls)

--- a/pkg/lifecycle/participant.go
+++ b/pkg/lifecycle/participant.go
@@ -34,6 +34,16 @@ type Participant interface {
 	// Phase returns the current lifecycle phase (e.g. "planning",
 	// "flying", "completed"). Must be a key in the Transitions
 	// table registered for this Workflow.
+	//
+	// TODO(manager): Manager.Get / Manager.List should validate that
+	// the returned Phase is actually declared in the registered
+	// Transitions table for this workflow type, and surface drift
+	// loudly (degraded-wrapper or error per the Degraded-bool
+	// precedent from PR #137 / GH #120). Without that check, an
+	// entity whose Phase() returns "completed-with-typo" silently
+	// reads as terminal forever (Transitions.IsTerminal defaults
+	// unknown phases to terminal as a defensive fallback) and never
+	// surfaces in Active=true lists where an operator would notice.
 	Phase() string
 
 	// IsTerminal returns true when the entity is in a phase with no
@@ -66,6 +76,45 @@ type Participant interface {
 	ParentEntityID() string
 }
 
+// TransitionSource identifies what caused a phase transition. Closed
+// set of typed constants — Manager.Transition takes a TransitionSource
+// parameter, and rule actions / operator API / component direct calls
+// each pass the appropriate constant rather than authoring a string
+// literal at the call site (typos like "oprator" silently break
+// dashboard filtering otherwise).
+//
+// Wire-compatible with string serialization: string(TransitionSourceRule)
+// is "rule", round-trips through JSON / KV as-is.
+type TransitionSource string
+
+// Defined TransitionSource values. The set is closed; adding a new
+// kind requires both a constant here and a Manager call site that
+// produces it.
+const (
+	// TransitionSourceRule is set when a rule action invoked
+	// Manager.Transition (the common case for state-machine
+	// progression driven by the rule engine).
+	TransitionSourceRule TransitionSource = "rule"
+
+	// TransitionSourceOperator is set when the operator API
+	// (POST /workflows/{type}/{id}/transition) invoked
+	// Manager.Transition. Audit trails distinguish operator-
+	// initiated transitions from automated ones via this value.
+	TransitionSourceOperator TransitionSource = "operator"
+
+	// TransitionSourceComponent is set when a component invoked
+	// Manager.Transition directly (rare; usually rules orchestrate
+	// transitions and components only call Update / Complete /
+	// Fail). Reserved for cases where the component's work IS the
+	// transition (e.g. landing-executor → landed phase).
+	TransitionSourceComponent TransitionSource = "component"
+
+	// TransitionSourceFramework is set by Manager.Create,
+	// Manager.Complete, and Manager.Fail — i.e. the harness's own
+	// transition-emitting operations rather than caller-driven ones.
+	TransitionSourceFramework TransitionSource = "framework"
+)
+
 // TransitionEvent is one entry in an entity's phase-transition
 // history. Manager.History returns these in chronological order.
 //
@@ -87,16 +136,11 @@ type TransitionEvent struct {
 	// — so it's authoritative across restarts and clock skew.
 	At time.Time
 
-	// Triggered identifies what caused the transition. One of:
-	//   "rule"      — a rule action invoked Manager.Transition
-	//   "operator"  — an operator API call invoked Manager.Transition
-	//   "component" — a component invoked Manager.Transition directly
-	//   "framework" — Create / Complete / Fail (auto-classified)
-	//
-	// Operator dashboards can filter / color-code by this field;
-	// audit trails distinguish operator-initiated from automated
-	// transitions.
-	Triggered string
+	// Triggered identifies what caused the transition. Closed set
+	// of values defined by TransitionSource. Operator dashboards
+	// can filter / color-code by this field; audit trails
+	// distinguish operator-initiated from automated transitions.
+	Triggered TransitionSource
 
 	// Note is an optional free-text annotation. Manager.Fail uses
 	// this to carry the failure reason; Manager.Transition can pass

--- a/pkg/lifecycle/participant.go
+++ b/pkg/lifecycle/participant.go
@@ -59,13 +59,23 @@ type Participant interface {
 	// provision their own buckets per their deployment topology.
 	KVBucket() string
 
-	// KVKey returns the KV key shape for this instance within the
-	// bucket. Apps choose the convention — common shapes include
-	// the bare EntityID, a slug-prefixed key (e.g. "mission.<id>"),
-	// or a multi-segment key for partitioned access. Whatever the
-	// app picks, it must be stable for the instance's lifetime
-	// (the harness uses it for both reads and writes).
-	KVKey() string
+	// KVKey returns the KV key shape for the given entity ID within
+	// the bucket. Apps choose the convention — common shapes include
+	// the bare entityID, a workflow-prefixed key (e.g. "mission."+id),
+	// or a multi-segment key for partitioned access.
+	//
+	// IMPORTANT: KVKey is a pure function of entityID. Implementations
+	// MUST NOT read other fields of the Participant struct — Manager
+	// caches one sample instance per registration and calls KVKey on
+	// it with the resolved entityID, so per-instance struct state
+	// (Phase, OwnerOrgID, etc.) is not populated at the call site.
+	// Apps needing multi-field key derivation should encode the
+	// extra context into the entityID itself (e.g. "<slug>.<id>")
+	// or capture immutable workflow-level state in package vars at
+	// Register time. This signature shape was chosen to keep
+	// Manager.Get/Create/Update reflect-free in the per-message
+	// hotpath — see ADR-047's "Participation is per-entity" section.
+	KVKey(entityID string) string
 
 	// ParentEntityID returns the parent workflow instance's EntityID,
 	// or empty string for root workflows. Enables parent/child

--- a/pkg/lifecycle/participant.go
+++ b/pkg/lifecycle/participant.go
@@ -35,15 +35,15 @@ type Participant interface {
 	// "flying", "completed"). Must be a key in the Transitions
 	// table registered for this Workflow.
 	//
-	// TODO(manager): Manager.Get / Manager.List should validate that
-	// the returned Phase is actually declared in the registered
-	// Transitions table for this workflow type, and surface drift
-	// loudly (degraded-wrapper or error per the Degraded-bool
-	// precedent from PR #137 / GH #120). Without that check, an
-	// entity whose Phase() returns "completed-with-typo" silently
-	// reads as terminal forever (Transitions.IsTerminal defaults
-	// unknown phases to terminal as a defensive fallback) and never
-	// surfaces in Active=true lists where an operator would notice.
+	// Drift detection: Manager.Get / Manager.List emit a Warn log
+	// when Phase() returns a value not declared in the registered
+	// Transitions table — the entity is silently degraded
+	// (Transitions.IsTerminal defaults unknown phases to terminal
+	// as a defensive fallback) but the log signal makes the
+	// degradation visible to operators. Apps wanting structured
+	// detection rather than log-scraping can add a Degraded-bool
+	// wrapper in a future API extension; log-only is the v1
+	// surface.
 	Phase() string
 
 	// IsTerminal returns true when the entity is in a phase with no

--- a/pkg/lifecycle/participant.go
+++ b/pkg/lifecycle/participant.go
@@ -1,0 +1,134 @@
+package lifecycle
+
+import "time"
+
+// Participant is the contract a lifecycle-tracked entity satisfies.
+// Apps implement this on their domain state structs to get framework
+// infrastructure (KV storage, restart recovery, rule integration,
+// operator API).
+//
+// The interface is small by design — six required methods plus one
+// optional parent-link method. All state and behavior beyond the
+// declared phases lives in the implementing struct's own fields and
+// methods; the harness only reads what it needs to operate
+// (identity, current phase, terminal-detection, KV placement).
+//
+// Implementations are expected to be plain data structs with these
+// methods — NOT runtime objects with mutable internal state. The
+// Manager round-trips Participant values through JSON (or another
+// codec) on every Get/Update, so any non-serializable fields will
+// be silently dropped on restart. Apps that need transient runtime
+// state should keep it OUTSIDE the Participant struct.
+type Participant interface {
+	// EntityID returns the 6-part federated graph entity ID
+	// (org.platform.domain.system.type.instance). Used as the
+	// canonical identifier across the graph, KV, and operator API.
+	EntityID() string
+
+	// Workflow returns the workflow type identifier (e.g.
+	// "drone-survey", "csapi-system"). Must match a string passed
+	// to Manager.Register at startup. Stable per implementation
+	// type — never varies per instance.
+	Workflow() string
+
+	// Phase returns the current lifecycle phase (e.g. "planning",
+	// "flying", "completed"). Must be a key in the Transitions
+	// table registered for this Workflow.
+	Phase() string
+
+	// IsTerminal returns true when the entity is in a phase with no
+	// declared out-edges (i.e. completed, failed, aborted). Used by
+	// Manager.List with ListOptions.Active to filter active vs
+	// finished instances. By convention, derived from Phase() against
+	// the registered Transitions table — see DefaultIsTerminal helper.
+	IsTerminal() bool
+
+	// KVBucket returns the NATS KV bucket this entity lives in
+	// (e.g. "MISSIONS", "CSAPI_SYSTEMS"). Stable per implementation
+	// type. The framework does NOT create the bucket — apps
+	// provision their own buckets per their deployment topology.
+	KVBucket() string
+
+	// KVKey returns the KV key shape for this instance within the
+	// bucket. Apps choose the convention — common shapes include
+	// the bare EntityID, a slug-prefixed key (e.g. "mission.<id>"),
+	// or a multi-segment key for partitioned access. Whatever the
+	// app picks, it must be stable for the instance's lifetime
+	// (the harness uses it for both reads and writes).
+	KVKey() string
+
+	// ParentEntityID returns the parent workflow instance's EntityID,
+	// or empty string for root workflows. Enables parent/child
+	// workflow relationships (e.g. semspec's Plan-owns-Requirements
+	// pattern, or a research-pack-spawns-investigators pattern).
+	// Implementations with no parent-child relationships return ""
+	// unconditionally.
+	ParentEntityID() string
+}
+
+// TransitionEvent is one entry in an entity's phase-transition
+// history. Manager.History returns these in chronological order.
+//
+// History is derived from KV revision replay (every write to the
+// entity's KV key is one revision; Manager.Update synthesizes a
+// TransitionEvent when From != To). No separate history bucket is
+// required — the KV bucket's own revision log IS the history.
+type TransitionEvent struct {
+	// From is the phase the entity was in before the transition.
+	// Empty string for the Create event (entity didn't exist before).
+	From string
+
+	// To is the phase the entity entered. Equal to the entity's
+	// Phase() at the time of the transition.
+	To string
+
+	// At is the wallclock time the transition was committed to KV.
+	// Sourced from the KV revision's metadata, not from app code
+	// — so it's authoritative across restarts and clock skew.
+	At time.Time
+
+	// Triggered identifies what caused the transition. One of:
+	//   "rule"      — a rule action invoked Manager.Transition
+	//   "operator"  — an operator API call invoked Manager.Transition
+	//   "component" — a component invoked Manager.Transition directly
+	//   "framework" — Create / Complete / Fail (auto-classified)
+	//
+	// Operator dashboards can filter / color-code by this field;
+	// audit trails distinguish operator-initiated from automated
+	// transitions.
+	Triggered string
+
+	// Note is an optional free-text annotation. Manager.Fail uses
+	// this to carry the failure reason; Manager.Transition can pass
+	// arbitrary context. Empty by default.
+	Note string
+}
+
+// WorkflowDef describes a registered workflow type. Returned by
+// Manager.GetWorkflowDefinition and Manager.ListWorkflows; intended
+// primarily for operator dashboard introspection (e.g. rendering a
+// state-machine diagram derivable directly from the Transitions table).
+//
+// Apps don't construct WorkflowDef directly — the framework synthesizes
+// it from the data passed to Manager.Register.
+type WorkflowDef struct {
+	// Workflow is the workflow type identifier (matches what was
+	// passed to Manager.Register and what Participant.Workflow returns).
+	Workflow string
+
+	// Transitions is the declared phase-transition table registered
+	// for this workflow. The state-machine diagram is derivable
+	// directly from this map.
+	Transitions Transitions
+
+	// KVBucket is the NATS KV bucket this workflow's instances live
+	// in. Operator API uses this to route List/Watch operations.
+	KVBucket string
+
+	// OperatorWritableFields lists the JSON field paths that are
+	// tagged `lifecycle:"operator_writable"` on the registered state
+	// struct. Used by UpdateFromOperator to enforce default-deny;
+	// also exposed in the operator API for clients to know which
+	// fields are patchable.
+	OperatorWritableFields []string
+}

--- a/pkg/lifecycle/tags.go
+++ b/pkg/lifecycle/tags.go
@@ -178,6 +178,31 @@ func parseStructTags(v reflect.Value) (*structMeta, error) {
 			sm.PhaseField = meta
 		}
 
+		// json:"-" + lifecycle:"operator_writable" is a wire/harness
+		// contradiction: the operator-patch JSON can't reach a field
+		// json-tagged "-", so claiming it's operator-writable is
+		// guaranteed-broken at runtime. The internal Match path can
+		// still see the field (it reflects directly, not through
+		// json.Unmarshal), but operator-patch routing is the
+		// load-bearing reason for the tag — reject at startup.
+		if meta.OperatorWritable {
+			if jsonTag, ok := field.Tag.Lookup("json"); ok {
+				if name, _, _ := strings.Cut(jsonTag, ","); name == "-" {
+					return nil, fmt.Errorf("lifecycle: field %s tagged operator_writable but json:%q means the wire can't reach it",
+						field.Name, "-")
+				}
+			}
+		}
+
+		// Field-name collision (e.g. Foo + FOO both falling back to
+		// "foo", or a tagged json name colliding with another field's
+		// fallback) silently aliases two fields to the same operator-
+		// patch routing target. Reject at parse time so the wiring bug
+		// surfaces at app startup, not at first patch in prod.
+		if existing, dup := sm.FieldsByJSONName[jsonName]; dup {
+			return nil, fmt.Errorf("lifecycle: fields %s and %s on struct %s both resolve to JSON name %q — rename one or set distinct json: tags",
+				existing.FieldName, field.Name, t.Name(), jsonName)
+		}
 		sm.FieldsByJSONName[jsonName] = meta
 	}
 

--- a/pkg/lifecycle/tags.go
+++ b/pkg/lifecycle/tags.go
@@ -15,6 +15,15 @@ type fieldMeta struct {
 	// FieldName is the Go struct field name (e.g. "OwnerOrgID").
 	FieldName string
 
+	// FieldIndex is the reflect index path to the field (suitable
+	// for reflect.Value.FieldByIndex). Cached at parse time so
+	// runtime callers (setPhaseField, Match comparisons) avoid the
+	// FieldByName linear-walk cost per call. The slice form
+	// supports embedded-struct paths if the harness ever needs to
+	// reach into embedded types; today every Participant field is
+	// at top level so the slice always has length 1.
+	FieldIndex []int
+
 	// JSONName is the JSON wire-field name (per the field's `json:`
 	// tag, falling back to the lowercased Go field name). Used by
 	// operator-patch routing because operator patches arrive as JSON
@@ -120,8 +129,9 @@ func parseStructTags(v reflect.Value) (*structMeta, error) {
 		jsonName := jsonNameForField(field)
 
 		meta := &fieldMeta{
-			FieldName: field.Name,
-			JSONName:  jsonName,
+			FieldName:  field.Name,
+			FieldIndex: []int{i},
+			JSONName:   jsonName,
 		}
 
 		tag, hasTag := field.Tag.Lookup("lifecycle")

--- a/pkg/lifecycle/tags.go
+++ b/pkg/lifecycle/tags.go
@@ -1,0 +1,212 @@
+package lifecycle
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// fieldMeta captures the parsed lifecycle-tag attributes for one
+// struct field. The package uses it internally for register-time
+// validation and runtime operator-patch enforcement; apps don't
+// construct it directly.
+type fieldMeta struct {
+	// FieldName is the Go struct field name (e.g. "OwnerOrgID").
+	FieldName string
+
+	// JSONName is the JSON wire-field name (per the field's `json:`
+	// tag, falling back to the lowercased Go field name). Used by
+	// operator-patch routing because operator patches arrive as JSON
+	// keys.
+	JSONName string
+
+	// IsID is true when the field is tagged `lifecycle:"id"`.
+	IsID bool
+
+	// IsPhase is true when the field is tagged `lifecycle:"phase"`.
+	IsPhase bool
+
+	// ReadOnly is true when the field has the `readonly` modifier.
+	// Implicitly true for IsID and IsPhase fields (Manager owns
+	// transitions and identity). Operator patches against ReadOnly
+	// fields are rejected with ErrFieldNotOperatorWritable.
+	ReadOnly bool
+
+	// OperatorWritable is true when the field is tagged
+	// `lifecycle:"operator_writable"`. Default-deny — fields without
+	// this flag are NOT operator-writable.
+	OperatorWritable bool
+
+	// Indexable is true when the field is tagged `lifecycle:"indexable"`.
+	// v1 ignores this flag; v2 secondary-index work consumes it
+	// when scaling pressure surfaces.
+	Indexable bool
+}
+
+// structMeta is the parsed lifecycle-tag picture for one registered
+// Participant type. Computed once at Register time from a sample
+// instance via reflection; consulted on every UpdateFromOperator call
+// and on every List operation that uses Match.
+type structMeta struct {
+	// IDField is the field tagged `lifecycle:"id"`. Exactly one
+	// per struct (validated at parse time).
+	IDField *fieldMeta
+
+	// PhaseField is the field tagged `lifecycle:"phase"`. Exactly
+	// one per struct.
+	PhaseField *fieldMeta
+
+	// FieldsByJSONName is the parsed metadata for every field on
+	// the struct, keyed by JSON-wire-field name (NOT Go field name).
+	// Operator patches arrive as JSON, so this is the natural lookup.
+	FieldsByJSONName map[string]*fieldMeta
+}
+
+// OperatorWritableJSONNames returns the JSON field names that are
+// tagged operator_writable, in sorted order. Exposed to
+// WorkflowDef.OperatorWritableFields so the operator API can advertise
+// the patchable surface.
+func (sm *structMeta) OperatorWritableJSONNames() []string {
+	names := make([]string, 0, len(sm.FieldsByJSONName))
+	for jsonName, meta := range sm.FieldsByJSONName {
+		if meta.OperatorWritable {
+			names = append(names, jsonName)
+		}
+	}
+	// Sort for stable WorkflowDef output (operator dashboards
+	// rendering field lists shouldn't see flap on every restart).
+	sort.Strings(names)
+	return names
+}
+
+// parseStructTags reflects over the given struct value and returns
+// the parsed lifecycle-tag metadata. Returns ErrMissingIDField /
+// ErrMissingPhaseField when those tags are absent.
+//
+// The reflect.Value passed in must be a struct or pointer to struct.
+// Pointers are dereferenced once; nested pointers and interfaces are
+// not recursed (Participant implementations are expected to be plain
+// data structs, not deeply-nested object graphs — see
+// participant.go's interface contract).
+func parseStructTags(v reflect.Value) (*structMeta, error) {
+	// Dereference one level of pointer if present. Factory functions
+	// typically return pointers (e.g. `func() Participant { return
+	// &MissionState{} }`), so this is the common case.
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("lifecycle: parseStructTags requires struct or *struct, got %v", v.Kind())
+	}
+
+	t := v.Type()
+	sm := &structMeta{
+		FieldsByJSONName: make(map[string]*fieldMeta, t.NumField()),
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		// Skip unexported fields — Manager.UpdateFromOperator could
+		// not patch them anyway (operator patches arrive as JSON
+		// keys; encoding/json ignores unexported fields). Including
+		// them in FieldsByJSONName would let Match accidentally rely
+		// on something the wire can't reach.
+		if !field.IsExported() {
+			continue
+		}
+
+		jsonName := jsonNameForField(field)
+
+		meta := &fieldMeta{
+			FieldName: field.Name,
+			JSONName:  jsonName,
+		}
+
+		tag, hasTag := field.Tag.Lookup("lifecycle")
+		if hasTag {
+			for part := range strings.SplitSeq(tag, ",") {
+				switch strings.TrimSpace(part) {
+				case "id":
+					meta.IsID = true
+				case "phase":
+					meta.IsPhase = true
+				case "readonly":
+					meta.ReadOnly = true
+				case "operator_writable":
+					meta.OperatorWritable = true
+				case "indexable":
+					meta.Indexable = true
+				case "":
+					// trailing comma or empty tag — tolerate quietly
+				default:
+					return nil, fmt.Errorf("lifecycle: field %s has unknown lifecycle tag value %q",
+						field.Name, part)
+				}
+			}
+		}
+
+		// IDs and Phases are implicitly readonly (Manager owns
+		// them — apps don't operator-patch identity or transitions).
+		// Operator-writable + (id|phase) is a contradiction; reject
+		// at parse time so the wire-up bug surfaces at startup.
+		if (meta.IsID || meta.IsPhase) && meta.OperatorWritable {
+			roleTag := "phase"
+			if meta.IsID {
+				roleTag = "id"
+			}
+			return nil, fmt.Errorf("lifecycle: field %s cannot be both lifecycle:%q and lifecycle:%q",
+				field.Name, roleTag, "operator_writable")
+		}
+		if meta.IsID || meta.IsPhase {
+			meta.ReadOnly = true
+		}
+
+		if meta.IsID {
+			if sm.IDField != nil {
+				return nil, fmt.Errorf("lifecycle: multiple fields tagged lifecycle:\"id\" on struct %s (only one allowed)",
+					t.Name())
+			}
+			sm.IDField = meta
+		}
+		if meta.IsPhase {
+			if sm.PhaseField != nil {
+				return nil, fmt.Errorf("lifecycle: multiple fields tagged lifecycle:\"phase\" on struct %s (only one allowed)",
+					t.Name())
+			}
+			sm.PhaseField = meta
+		}
+
+		sm.FieldsByJSONName[jsonName] = meta
+	}
+
+	if sm.IDField == nil {
+		return nil, fmt.Errorf("%w: %s", ErrMissingIDField, t.Name())
+	}
+	if sm.PhaseField == nil {
+		return nil, fmt.Errorf("%w: %s", ErrMissingPhaseField, t.Name())
+	}
+	return sm, nil
+}
+
+// jsonNameForField returns the JSON wire-field name for a struct
+// field — the `json:` tag's first comma-separated segment, or the
+// lowercased Go field name when no `json:` tag is present (matching
+// encoding/json's default).
+func jsonNameForField(field reflect.StructField) string {
+	tag, ok := field.Tag.Lookup("json")
+	if !ok {
+		return strings.ToLower(field.Name)
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	if name == "" || name == "-" {
+		// `json:",omitempty"` (empty name) → fall back to Go name.
+		// `json:"-"` (explicit skip) → use the Go name internally
+		// so reflection can still find it for Match purposes; the
+		// field won't appear in operator-patch JSON anyway because
+		// encoding/json refuses to marshal/unmarshal it.
+		return strings.ToLower(field.Name)
+	}
+	return name
+}

--- a/pkg/lifecycle/tags_test.go
+++ b/pkg/lifecycle/tags_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -94,7 +95,7 @@ func TestParseStructTags_DuplicateID(t *testing.T) {
 		Phase string `json:"phase" lifecycle:"phase"`
 	}
 	_, err := parseStructTags(reflect.ValueOf(&doubleID{}))
-	if err == nil || !contains(err.Error(), "multiple fields tagged") {
+	if err == nil || !strings.Contains(err.Error(), "multiple fields tagged") {
 		t.Fatalf("expected duplicate-id error, got %v", err)
 	}
 }
@@ -106,7 +107,7 @@ func TestParseStructTags_DuplicatePhase(t *testing.T) {
 		B  string `json:"b" lifecycle:"phase"`
 	}
 	_, err := parseStructTags(reflect.ValueOf(&doublePhase{}))
-	if err == nil || !contains(err.Error(), "multiple fields tagged") {
+	if err == nil || !strings.Contains(err.Error(), "multiple fields tagged") {
 		t.Fatalf("expected duplicate-phase error, got %v", err)
 	}
 }
@@ -118,7 +119,7 @@ func TestParseStructTags_UnknownTagValue(t *testing.T) {
 		Junk  string `json:"junk" lifecycle:"frobnicate"`
 	}
 	_, err := parseStructTags(reflect.ValueOf(&weirdTag{}))
-	if err == nil || !contains(err.Error(), "frobnicate") {
+	if err == nil || !strings.Contains(err.Error(), "frobnicate") {
 		t.Fatalf("expected unknown-tag-value error mentioning 'frobnicate', got %v", err)
 	}
 }
@@ -173,5 +174,54 @@ func TestParseStructTags_RejectsNonStruct(t *testing.T) {
 	_, err := parseStructTags(reflect.ValueOf(&x))
 	if err == nil {
 		t.Fatal("non-struct must be rejected")
+	}
+}
+
+func TestParseStructTags_RejectsJSONNameCollision(t *testing.T) {
+	// Foo (no json tag) → "foo"; FOO (no json tag) → "foo".
+	// Both fall back to the same resolved JSON name. Without the
+	// collision check, the second-visited field would silently
+	// overwrite the first in FieldsByJSONName — and if one is
+	// tagged operator_writable while the other isn't, operator-
+	// patch routing aliases. Reject at parse time so the wiring
+	// bug surfaces at app startup, not at first patch in prod.
+	type colliding struct {
+		ID    string `json:"id" lifecycle:"id"`
+		Phase string `json:"phase" lifecycle:"phase"`
+		Foo   string
+		FOO   string `lifecycle:"operator_writable"`
+	}
+	_, err := parseStructTags(reflect.ValueOf(&colliding{}))
+	if err == nil {
+		t.Fatal("colliding JSON field names must be rejected")
+	}
+	// Error must name both Go field names AND the collided JSON
+	// name so the operator can locate the bug in their struct
+	// definition without a debugger pass.
+	msg := err.Error()
+	for _, want := range []string{"Foo", "FOO", "foo"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("collision error should mention %q (got %q)", want, msg)
+		}
+	}
+}
+
+func TestParseStructTags_RejectsJSONDashPlusOperatorWritable(t *testing.T) {
+	// json:"-" + lifecycle:"operator_writable" is a wire/harness
+	// contradiction — operator patches arrive via JSON, but
+	// json:"-" tells encoding/json to skip the field, so the
+	// patch routing is guaranteed-broken at runtime. Catch it
+	// at parse time, not on the first 403 in operator land.
+	type wireUnreachableButOperatorWritable struct {
+		ID         string `json:"id" lifecycle:"id"`
+		Phase      string `json:"phase" lifecycle:"phase"`
+		HiddenButW string `json:"-" lifecycle:"operator_writable"`
+	}
+	_, err := parseStructTags(reflect.ValueOf(&wireUnreachableButOperatorWritable{}))
+	if err == nil {
+		t.Fatal("json:\"-\" + operator_writable must be rejected as a wire/harness contradiction")
+	}
+	if !strings.Contains(err.Error(), "HiddenButW") {
+		t.Errorf("rejection should name the offending field, got %q", err)
 	}
 }

--- a/pkg/lifecycle/tags_test.go
+++ b/pkg/lifecycle/tags_test.go
@@ -1,0 +1,177 @@
+package lifecycle
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// canonicalState is the ADR-047 example state struct used to exercise
+// the full happy-path of struct-tag parsing. Mirrors the shape from
+// doc.go's usage example so failures here also catch documentation
+// drift.
+type canonicalState struct {
+	EntityIDF  string `json:"entity_id"    lifecycle:"id"`
+	PhaseF     string `json:"phase"        lifecycle:"phase,readonly"`
+	OwnerOrgID string `json:"owner_org_id" lifecycle:"operator_writable"`
+	DeployedTo string `json:"deployed_to,omitempty" lifecycle:"operator_writable,indexable"`
+	Internal   string `json:"internal,omitempty"` // no tag = default-deny
+	unexported string //nolint:unused // intentionally present for the parser-skip test
+}
+
+func TestParseStructTags_HappyPath(t *testing.T) {
+	sm, err := parseStructTags(reflect.ValueOf(&canonicalState{}))
+	if err != nil {
+		t.Fatalf("canonical struct must parse, got %v", err)
+	}
+
+	if sm.IDField == nil || sm.IDField.JSONName != "entity_id" {
+		t.Errorf("IDField wrong: %+v", sm.IDField)
+	}
+	if sm.PhaseField == nil || sm.PhaseField.JSONName != "phase" {
+		t.Errorf("PhaseField wrong: %+v", sm.PhaseField)
+	}
+	if !sm.PhaseField.ReadOnly {
+		t.Error("PhaseField should be ReadOnly (implicit via id/phase tags)")
+	}
+
+	owner := sm.FieldsByJSONName["owner_org_id"]
+	if owner == nil || !owner.OperatorWritable || owner.Indexable {
+		t.Errorf("owner_org_id should be OperatorWritable + not Indexable, got %+v", owner)
+	}
+
+	deployed := sm.FieldsByJSONName["deployed_to"]
+	if deployed == nil || !deployed.OperatorWritable || !deployed.Indexable {
+		t.Errorf("deployed_to should be OperatorWritable + Indexable, got %+v", deployed)
+	}
+
+	internal := sm.FieldsByJSONName["internal"]
+	if internal == nil || internal.OperatorWritable {
+		t.Errorf("internal (no tag) must default-deny OperatorWritable, got %+v", internal)
+	}
+
+	if _, ok := sm.FieldsByJSONName["unexported"]; ok {
+		t.Error("unexported fields must be skipped — operator JSON can't reach them")
+	}
+}
+
+func TestParseStructTags_OperatorWritableFields_Sorted(t *testing.T) {
+	sm, err := parseStructTags(reflect.ValueOf(&canonicalState{}))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := sm.OperatorWritableJSONNames()
+	want := []string{"deployed_to", "owner_org_id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("OperatorWritableJSONNames = %v, want %v (sorted)", got, want)
+	}
+}
+
+func TestParseStructTags_MissingID(t *testing.T) {
+	type noID struct {
+		Phase string `json:"phase" lifecycle:"phase"`
+	}
+	_, err := parseStructTags(reflect.ValueOf(&noID{}))
+	if !errors.Is(err, ErrMissingIDField) {
+		t.Fatalf("expected ErrMissingIDField, got %v", err)
+	}
+}
+
+func TestParseStructTags_MissingPhase(t *testing.T) {
+	type noPhase struct {
+		EntityID string `json:"entity_id" lifecycle:"id"`
+	}
+	_, err := parseStructTags(reflect.ValueOf(&noPhase{}))
+	if !errors.Is(err, ErrMissingPhaseField) {
+		t.Fatalf("expected ErrMissingPhaseField, got %v", err)
+	}
+}
+
+func TestParseStructTags_DuplicateID(t *testing.T) {
+	type doubleID struct {
+		A     string `json:"a" lifecycle:"id"`
+		B     string `json:"b" lifecycle:"id"`
+		Phase string `json:"phase" lifecycle:"phase"`
+	}
+	_, err := parseStructTags(reflect.ValueOf(&doubleID{}))
+	if err == nil || !contains(err.Error(), "multiple fields tagged") {
+		t.Fatalf("expected duplicate-id error, got %v", err)
+	}
+}
+
+func TestParseStructTags_DuplicatePhase(t *testing.T) {
+	type doublePhase struct {
+		ID string `json:"id" lifecycle:"id"`
+		A  string `json:"a" lifecycle:"phase"`
+		B  string `json:"b" lifecycle:"phase"`
+	}
+	_, err := parseStructTags(reflect.ValueOf(&doublePhase{}))
+	if err == nil || !contains(err.Error(), "multiple fields tagged") {
+		t.Fatalf("expected duplicate-phase error, got %v", err)
+	}
+}
+
+func TestParseStructTags_UnknownTagValue(t *testing.T) {
+	type weirdTag struct {
+		ID    string `json:"id" lifecycle:"id"`
+		Phase string `json:"phase" lifecycle:"phase"`
+		Junk  string `json:"junk" lifecycle:"frobnicate"`
+	}
+	_, err := parseStructTags(reflect.ValueOf(&weirdTag{}))
+	if err == nil || !contains(err.Error(), "frobnicate") {
+		t.Fatalf("expected unknown-tag-value error mentioning 'frobnicate', got %v", err)
+	}
+}
+
+func TestParseStructTags_IDPlusOperatorWritableRejected(t *testing.T) {
+	type idPlusWritable struct {
+		ID    string `json:"id" lifecycle:"id,operator_writable"`
+		Phase string `json:"phase" lifecycle:"phase"`
+	}
+	_, err := parseStructTags(reflect.ValueOf(&idPlusWritable{}))
+	if err == nil {
+		t.Fatal("id + operator_writable must be rejected as a wiring contradiction")
+	}
+}
+
+func TestParseStructTags_PhasePlusOperatorWritableRejected(t *testing.T) {
+	type phasePlusWritable struct {
+		ID    string `json:"id" lifecycle:"id"`
+		Phase string `json:"phase" lifecycle:"phase,operator_writable"`
+	}
+	_, err := parseStructTags(reflect.ValueOf(&phasePlusWritable{}))
+	if err == nil {
+		t.Fatal("phase + operator_writable must be rejected as a wiring contradiction")
+	}
+}
+
+func TestParseStructTags_JSONNameFallbacks(t *testing.T) {
+	// Field with no json tag → lowercased Go name.
+	// Field with `json:"-"` → still indexable via lowercased Go name
+	//   (operator-patch JSON can't reach it but Match still can).
+	// Field with `json:",omitempty"` (empty name) → lowercased Go name.
+	type tricky struct {
+		ID         string `json:"id" lifecycle:"id"`
+		Phase      string `json:"phase" lifecycle:"phase"`
+		NoTag      string
+		HyphenName string `json:"-"`
+		EmptyName  string `json:",omitempty"`
+	}
+	sm, err := parseStructTags(reflect.ValueOf(&tricky{}))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, want := range []string{"notag", "hyphenname", "emptyname"} {
+		if _, ok := sm.FieldsByJSONName[want]; !ok {
+			t.Errorf("expected JSON name fallback %q in FieldsByJSONName, missing", want)
+		}
+	}
+}
+
+func TestParseStructTags_RejectsNonStruct(t *testing.T) {
+	x := 42
+	_, err := parseStructTags(reflect.ValueOf(&x))
+	if err == nil {
+		t.Fatal("non-struct must be rejected")
+	}
+}

--- a/pkg/lifecycle/transitions.go
+++ b/pkg/lifecycle/transitions.go
@@ -1,0 +1,132 @@
+package lifecycle
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+)
+
+// Transitions declares the valid phase transitions for a workflow
+// type. Keys are source phases; values are slices of valid destination
+// phases. Terminal phases have empty out-edges.
+//
+// Example (drone-survey mission):
+//
+//	transitions := lifecycle.Transitions{
+//	    "planning":   {"flying", "aborted"},
+//	    "flying":     {"capturing", "landing", "aborted"},
+//	    "capturing":  {"flying"},
+//	    "landing":    {"completed", "failed"},
+//	    "completed":  {},  // terminal
+//	    "failed":     {},  // terminal
+//	    "aborted":    {},  // terminal
+//	}
+//
+// The table is checked structurally by Validate at Register time and
+// then consulted by Manager.Transition on every transition request.
+// Edges not declared in the table are rejected with ErrInvalidTransition.
+type Transitions map[string][]string
+
+// Validate checks structural consistency of the transitions table.
+// Returns ErrInvalidTransitionsTable wrapped with a descriptive message
+// when:
+//   - The table is empty (no phases declared)
+//   - An out-edge references a phase that isn't a key in the table
+//     (typo catcher — every reachable phase must be declared, even
+//     terminal ones with empty out-edges)
+//   - A phase has duplicate out-edges (e.g. {"flying": ["landing",
+//     "landing"]}) — defends against copy-paste bugs in rule packs
+//
+// Returns nil when the table is internally consistent.
+//
+// Note: Validate does NOT check reachability from an initial phase
+// (apps may have multiple entry points) or absence of cycles (cycles
+// are legitimate — e.g. capturing → flying → capturing in the drone
+// example).
+func (t Transitions) Validate() error {
+	if len(t) == 0 {
+		return fmt.Errorf("%w: transitions table is empty", ErrInvalidTransitionsTable)
+	}
+
+	for phase, outEdges := range t {
+		if phase == "" {
+			return fmt.Errorf("%w: empty-string phase key not allowed", ErrInvalidTransitionsTable)
+		}
+
+		seen := make(map[string]struct{}, len(outEdges))
+		for _, target := range outEdges {
+			if target == "" {
+				return fmt.Errorf("%w: phase %q has empty-string out-edge", ErrInvalidTransitionsTable, phase)
+			}
+			if _, dup := seen[target]; dup {
+				return fmt.Errorf("%w: phase %q has duplicate out-edge to %q",
+					ErrInvalidTransitionsTable, phase, target)
+			}
+			seen[target] = struct{}{}
+
+			if _, declared := t[target]; !declared {
+				return fmt.Errorf("%w: phase %q has out-edge to undeclared phase %q (declare it as a key with empty out-edges if terminal)",
+					ErrInvalidTransitionsTable, phase, target)
+			}
+		}
+	}
+	return nil
+}
+
+// IsTerminal returns true when the given phase has no declared
+// out-edges in the table (or isn't declared at all — defensive
+// fallback to treat unknown phases as terminal so a misconfigured
+// instance can't transition unexpectedly).
+//
+// Apps that derive Participant.IsTerminal from the Transitions table
+// can use this helper directly:
+//
+//	func (m *MissionState) IsTerminal() bool {
+//	    return missionTransitions.IsTerminal(m.Phase())
+//	}
+func (t Transitions) IsTerminal(phase string) bool {
+	outEdges, declared := t[phase]
+	if !declared {
+		return true
+	}
+	return len(outEdges) == 0
+}
+
+// IsValidTransition returns true when (from → to) is a declared edge
+// in the table. Used by Manager.Transition to gate transitions, but
+// safe for app-side use too (e.g. to filter operator-facing
+// "available next phases" UI).
+func (t Transitions) IsValidTransition(from, to string) bool {
+	outEdges, declared := t[from]
+	if !declared {
+		return false
+	}
+	return slices.Contains(outEdges, to)
+}
+
+// Phases returns the set of declared phases in sorted order. Useful
+// for operator dashboards rendering state-machine diagrams or for
+// validation tooling enumerating the workflow's surface.
+func (t Transitions) Phases() []string {
+	phases := make([]string, 0, len(t))
+	for phase := range t {
+		phases = append(phases, phase)
+	}
+	sort.Strings(phases)
+	return phases
+}
+
+// TerminalPhases returns the subset of declared phases that are
+// terminal (no out-edges), sorted. Operator dashboards use this to
+// group instances by terminal-vs-active when ListOptions.Active is
+// not set.
+func (t Transitions) TerminalPhases() []string {
+	terminal := make([]string, 0)
+	for phase, outEdges := range t {
+		if len(outEdges) == 0 {
+			terminal = append(terminal, phase)
+		}
+	}
+	sort.Strings(terminal)
+	return terminal
+}

--- a/pkg/lifecycle/transitions_test.go
+++ b/pkg/lifecycle/transitions_test.go
@@ -3,6 +3,7 @@ package lifecycle
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -44,7 +45,7 @@ func TestTransitions_Validate_RejectsUndeclaredTarget(t *testing.T) {
 	if !errors.Is(err, ErrInvalidTransitionsTable) {
 		t.Fatalf("undeclared target should error, got %v", err)
 	}
-	if err.Error() == "" || !contains(err.Error(), "exploded") {
+	if err.Error() == "" || !strings.Contains(err.Error(), "exploded") {
 		t.Errorf("error should mention the undeclared phase %q for operator debugging, got %q",
 			"exploded", err)
 	}
@@ -152,16 +153,4 @@ func TestTransitions_TerminalPhases_StableSorted(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("TerminalPhases() = %v, want %v (sorted)", got, want)
 	}
-}
-
-// contains is a tiny test-only helper. strings.Contains would do but
-// avoiding the import in *_test.go for a single use keeps the file
-// dependency-light.
-func contains(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/lifecycle/transitions_test.go
+++ b/pkg/lifecycle/transitions_test.go
@@ -1,0 +1,167 @@
+package lifecycle
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// droneTransitions is the worked-example table from ADR-047 / doc.go.
+// Reused across tests so a single canonical fixture validates the
+// surface; if the example diverges from what code accepts the test
+// suite catches it.
+var droneTransitions = Transitions{
+	"planning":  {"flying", "aborted"},
+	"flying":    {"capturing", "landing", "aborted"},
+	"capturing": {"flying"},
+	"landing":   {"completed", "failed"},
+	"completed": {},
+	"failed":    {},
+	"aborted":   {},
+}
+
+func TestTransitions_Validate_AcceptsCanonicalExample(t *testing.T) {
+	if err := droneTransitions.Validate(); err != nil {
+		t.Fatalf("ADR-047 worked example must validate, got %v", err)
+	}
+}
+
+func TestTransitions_Validate_RejectsEmpty(t *testing.T) {
+	if err := (Transitions{}).Validate(); !errors.Is(err, ErrInvalidTransitionsTable) {
+		t.Fatalf("empty table should error with ErrInvalidTransitionsTable, got %v", err)
+	}
+}
+
+func TestTransitions_Validate_RejectsUndeclaredTarget(t *testing.T) {
+	// Out-edge to "exploded" but "exploded" never declared as a key.
+	// Most common typo class — catches it at Register time, not at
+	// the first transition attempt in production.
+	bad := Transitions{
+		"flying":  {"landing", "exploded"},
+		"landing": {},
+	}
+	err := bad.Validate()
+	if !errors.Is(err, ErrInvalidTransitionsTable) {
+		t.Fatalf("undeclared target should error, got %v", err)
+	}
+	if err.Error() == "" || !contains(err.Error(), "exploded") {
+		t.Errorf("error should mention the undeclared phase %q for operator debugging, got %q",
+			"exploded", err)
+	}
+}
+
+func TestTransitions_Validate_RejectsDuplicateOutEdge(t *testing.T) {
+	bad := Transitions{
+		"a": {"b", "b"},
+		"b": {},
+	}
+	if err := bad.Validate(); !errors.Is(err, ErrInvalidTransitionsTable) {
+		t.Fatalf("duplicate out-edges should error, got %v", err)
+	}
+}
+
+func TestTransitions_Validate_RejectsEmptyPhaseName(t *testing.T) {
+	bad := Transitions{
+		"":  {"a"},
+		"a": {},
+	}
+	if err := bad.Validate(); !errors.Is(err, ErrInvalidTransitionsTable) {
+		t.Fatalf("empty-string phase key should error, got %v", err)
+	}
+}
+
+func TestTransitions_Validate_RejectsEmptyTargetName(t *testing.T) {
+	bad := Transitions{
+		"a": {""},
+		"":  {},
+	}
+	if err := bad.Validate(); !errors.Is(err, ErrInvalidTransitionsTable) {
+		t.Fatalf("empty-string out-edge should error, got %v", err)
+	}
+}
+
+func TestTransitions_Validate_AcceptsCycles(t *testing.T) {
+	// capturing → flying → capturing is intentional in the drone
+	// example. Validate must not flag legitimate cycles.
+	withCycle := Transitions{
+		"flying":    {"capturing"},
+		"capturing": {"flying"},
+	}
+	if err := withCycle.Validate(); err != nil {
+		t.Fatalf("cycles must validate (drone capturing↔flying example), got %v", err)
+	}
+}
+
+func TestTransitions_IsTerminal(t *testing.T) {
+	tests := []struct {
+		phase string
+		want  bool
+	}{
+		{"completed", true},
+		{"failed", true},
+		{"aborted", true},
+		{"flying", false},
+		{"planning", false},
+		// Unknown phases default to terminal — defensive fallback so
+		// a misconfigured entity can't transition unexpectedly.
+		{"never-declared", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.phase, func(t *testing.T) {
+			if got := droneTransitions.IsTerminal(tt.phase); got != tt.want {
+				t.Errorf("IsTerminal(%q) = %v, want %v", tt.phase, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransitions_IsValidTransition(t *testing.T) {
+	tests := []struct {
+		from, to string
+		want     bool
+	}{
+		{"planning", "flying", true},
+		{"flying", "capturing", true},
+		{"capturing", "flying", true}, // cycle is legitimate
+		{"landing", "completed", true},
+		{"planning", "completed", false},    // not a declared edge
+		{"completed", "flying", false},      // terminal phase, no out-edges
+		{"never-declared", "flying", false}, // unknown source phase
+		{"flying", "never-declared", false}, // unknown target phase (not in flying's edges)
+	}
+	for _, tt := range tests {
+		t.Run(tt.from+"->"+tt.to, func(t *testing.T) {
+			if got := droneTransitions.IsValidTransition(tt.from, tt.to); got != tt.want {
+				t.Errorf("IsValidTransition(%q, %q) = %v, want %v", tt.from, tt.to, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransitions_Phases_StableSorted(t *testing.T) {
+	got := droneTransitions.Phases()
+	want := []string{"aborted", "capturing", "completed", "failed", "flying", "landing", "planning"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Phases() = %v, want %v (sorted)", got, want)
+	}
+}
+
+func TestTransitions_TerminalPhases_StableSorted(t *testing.T) {
+	got := droneTransitions.TerminalPhases()
+	want := []string{"aborted", "completed", "failed"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("TerminalPhases() = %v, want %v (sorted)", got, want)
+	}
+}
+
+// contains is a tiny test-only helper. strings.Contains would do but
+// avoiding the import in *_test.go for a single use keeps the file
+// dependency-light.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Ships PR 1 of the ADR-047/048 four-PR bundle: the `pkg/lifecycle` substrate package. Apps implement `Participant` on their domain state structs and get framework-provided KV-backed lifecycle management (Register / Get / Create / Update / Transition / Complete / Fail / UpdateFromOperator / List / Watch / History / Children / Ancestors / workflow introspection).

Foundation only — no rule integration, no operator gateway, no BoundedDispatcher yet. Those land in PRs 2-4 of the bundle.

## Bundle context

- **PR 1 (this)** — `pkg/lifecycle` substrate
- **PR 2** — rule integration (`lifecycle_*` action types + `$entity.lifecycle.*` substitutions) + greenfield rip of dormant `pkg/workflow` + the 3 vestigial lines in agentic-loop
- **PR 3** — operator gateway components (HTTP/WebSocket handlers for `/workflows/*`)
- **PR 4** — `pkg/dispatch.BoundedDispatcher` + `.triples` substitution

## 9 commits — top-down progression

| Commit | Slice |
|---|---|
| `22fd32d` | docs(adr): ADR-047 participant carve-out + ADR-048 .triples JSON resolution |
| `84b1ad6` | feat(lifecycle): foundation types — Participant, Transitions, ListOptions, struct tags |
| `5f5c91a` | fix(lifecycle): apply go-reviewer findings on PR 1a foundation |
| `8d9227e` | feat(lifecycle): Manager core + kvStore interface + natsclient adapter |
| `b63c091` | fix(lifecycle): apply go-reviewer findings on Manager core (incl. ADR-047 KVKey signature amendment) |
| `2dcc52b` | feat(lifecycle): Manager.List + Watch + History (query-ops slice 1) |
| `580ad2e` | feat(lifecycle): UpdateFromOperator + Children/Ancestors + workflow introspection + drift detection (query-ops slice 2) |
| `3708de4` | test(lifecycle): integration tests via testcontainers |
| `7ae33bb` | fix(lifecycle): apply go-reviewer findings on complete PR 1 cross-slice pass |

## ADR amendments shipped in this PR

Two amendments to ADR-047 + ADR-048 (themselves merged in PR #153) landed alongside the code:

- **ADR-047 "Participation is per-entity, not per-deployment"** — codifies the load-bearing discipline that `pkg/lifecycle` has zero `processor/agentic-*` dependencies. Apps shipping no agentic features get the full harness benefit. Verified by import lint at PR-1 land time (`go list -deps ./pkg/lifecycle/... | grep agentic` → empty).
- **ADR-047 `KVKey(entityID string) string` signature change** — original ADR signature was `KVKey() string` which forced a per-Get factory allocation + reflect-SetString on the ID field, putting reflect in the per-message hotpath. Amended to take entityID directly so `Manager.Get/Create/Update` are alloc-free + reflect-free per call.
- **ADR-048 `.triples` JSON string serialization (Open Q4 closed)** — resolved to JSON array (never CSV, no operator config flag). Includes canonical persona-prose template for `.triples` recipients + cheap-model substrate limitation note.

## Discipline claims (verified)

| Claim | Verification |
|---|---|
| Zero `processor/agentic-*` imports | `go list -deps ./pkg/lifecycle/... \| grep agentic` → empty |
| Reflect bounded to documented sites | Register-time `parseStructTags` (cached); per-Transition `setPhaseField` via cached `FieldByIndex`; `List` Match via cached `buildMatchPlan`. NO reflect in Get/Create/Update body. |
| Default-deny operator-writability | Struct-tag parser rejects untagged fields; `UpdateFromOperator` enforces against cached `structMeta` |
| CAS retry bounded | `updateRetries=5`; budget-exhaustion surfaces as the exported `ErrUpdateRetriesExhausted` so callers can branch on `errors.Is` |
| Public API matches ADR exactly | Final review's m2 finding closed the drift; ADR signatures align with shipped code |

## Three review passes (all addressed before submission)

- **Pass 1**: PR 1a foundation only → 5 findings (Major-1 field-name collision rejection, Minor-1 typed TransitionSource enum, Major-2 Match docstring lock, Minor-2 drift-detection TODO, nit) — fixed in `5f5c91a`
- **Pass 2**: PR 1b core only → 6 findings (Critical-1 CAS classifier narrowing in `kvNATSStore.Update`, Major-1 reflect elimination via KVKey signature amendment, Major-2 value-typed factory test, Minor-1 Complete ambiguous-selection warn, Minor-2 `_ = reason` cleanup, Nit-2 mock createdAt vs revisionAt split) — fixed in `b63c091`
- **Pass 3**: complete cross-slice → 2 Majors + 4 Minors (M1 `ListOptions.UpdatedAfter` dropped from v1 surface, M2 `ErrUpdateRetriesExhausted` exported, m1 drift-log de-dup via sync.Map, m2 ADR signature alignment, m3 `findByEntityID` lock-thrash, m4 Watch caller-must-cancel doc) — fixed in `7ae33bb`

## Test verification

```
go test -race -count=1 ./pkg/lifecycle/...
→ ok 1.428s (78 unit tests PASS)

go test -tags=integration -race -count=1 -timeout=10m ./pkg/lifecycle/...
→ ok 7.524s (10 integration tests PASS via testcontainers + real NATS)

task lint  (vet + fmt + revive)
→ no warnings
```

## Reviewer-deferred follow-ups (post-merge)

Three nits the final reviewer explicitly classified as post-merge polish, not blocking:
- **n1**: `Children` returns nil vs `[]Participant{}` for empty results — cosmetic; tests pass either way
- **n2**: `UpdateFromOperator` empty-patch could log Debug — arguable; current behavior is operator-friendly silent success
- **n3**: `integMissionState` (integration fixture) + `missionState` (unit fixture) consolidation — cleanup, doesn't affect coverage

One TODO in code for the integration-test slice to revisit if/when jetstream adds a dedicated CAS-conflict sentinel — current classifier uses `errors.Is(err, jetstream.ErrKeyExists)` + `strings.Contains(err.Error(), \"wrong last sequence\")` fallback, pinned by `TestIntegration_CASClassifierTriggersOnRealConflict`.

## Test plan

- [ ] `task lint` passes on CI
- [ ] `go test -race ./pkg/lifecycle/...` passes on CI
- [ ] `go test -tags=integration -race ./pkg/lifecycle/...` passes on CI (testcontainer-gated)
- [ ] Reviewer confirms commit-by-commit progression is reviewable as a top-down walk
- [ ] Reviewer confirms the three discipline-claim verifications (no agentic deps, reflect bounded, default-deny ops-writability) hold

🤖 Generated with [Claude Code](https://claude.com/claude-code)