### PR TITLE
feat(gateway,lifecycle): ADR-047 PR 3 — lifecycle-gateway + Dependencies wire-through (completes the bundle)

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/c360studio/semstreams/payloadbuiltins"
 	"github.com/c360studio/semstreams/payloadregistry"
 	"github.com/c360studio/semstreams/persona"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
 	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
 	"github.com/c360studio/semstreams/processor/agentic-tools/executors"
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
@@ -151,6 +152,12 @@ func run() error {
 	svcDeps := createServiceDependencies(natsClient, metricsRegistry, logger, platform, configManager, componentRegistry)
 	svcDeps.ToolRegistry = toolRegistry
 	svcDeps.PayloadRegistry = payloadReg
+	// Lifecycle harness Manager (ADR-047). Plumbed identically to
+	// cmd/semstreams/main.go so the e2e binary doesn't drift from
+	// the framework binary — registry-singleton-style migrations
+	// past have left one binary wired and the other half-migrated
+	// (see [[feedback_e2e_required_for_breaking_changes]]).
+	svcDeps.LifecycleManager = lifecycle.NewManager(natsClient, logger)
 
 	if err := configureAndCreateServices(cfg, manager, svcDeps); err != nil {
 		return err

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/c360studio/semstreams/payloadbuiltins"
 	"github.com/c360studio/semstreams/payloadregistry"
 	"github.com/c360studio/semstreams/persona"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
 	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
 	"github.com/c360studio/semstreams/processor/agentic-tools/executors"
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
@@ -170,6 +171,17 @@ func run() error {
 	svcDeps := createServiceDependencies(natsClient, metricsRegistry, logger, platform, configManager, componentRegistry)
 	svcDeps.ToolRegistry = toolRegistry
 	svcDeps.PayloadRegistry = payloadReg
+
+	// 10b. Build the shared Lifecycle harness Manager (ADR-047) and
+	// plumb it into service dependencies. The framework binary
+	// itself registers no Participant workflows — that's app-side
+	// responsibility — but the Manager is always available so the
+	// rule processor's lifecycle_* actions + lifecycle-gateway
+	// can operate the moment an app does call Manager.Register.
+	// This matches the wiring discipline from
+	// [[feedback_verify_main_go_wire_for_sister_asks]] —
+	// half-migrated framework binaries silently break workflows.
+	svcDeps.LifecycleManager = lifecycle.NewManager(natsClient, logger)
 
 	// 11. Configure and create services
 	if err := configureAndCreateServices(cfg, manager, svcDeps); err != nil {

--- a/component/dependencies.go
+++ b/component/dependencies.go
@@ -9,6 +9,7 @@ import (
 	"github.com/c360studio/semstreams/model"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/payloadregistry"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
 	"github.com/c360studio/semstreams/pkg/security"
 	"github.com/c360studio/semstreams/types"
 )
@@ -57,6 +58,28 @@ type Dependencies struct {
 	ToolRegistry      ToolRegistryReader        // Shared tool executor registry (can be nil; agentic-tools requires it)
 	PayloadRegistry   *payloadregistry.Registry // Shared payload registry (can be nil; components unmarshaling BaseMessage require it)
 	ComponentRegistry Lookup                    // Sibling component lookup (can be nil)
+
+	// LifecycleManager is the shared pkg/lifecycle.Manager that
+	// owns workflow-shaped entity instances (ADR-047). Apps that
+	// declare Participant-implementing entities (drone missions,
+	// sensor lifecycles, manufacturing batches, scenario executions)
+	// build the Manager in main.go, call Manager.Register for each
+	// app workflow, and pass it through Dependencies. Both the rule
+	// processor (lifecycle_* actions + $entity.lifecycle.* condition
+	// fields) and the lifecycle-gateway (operator HTTP API) read
+	// from this field.
+	//
+	// Concrete type (not an interface) per the PayloadRegistry
+	// precedent — pkg/lifecycle is a framework-owned leaf package,
+	// not an external/pluggable surface, and consumers narrow to
+	// their own minimum-surface interfaces locally (see
+	// processor/rule.LifecycleManager) when they want to abstract
+	// for testing.
+	//
+	// Can be nil — apps without any lifecycle-managed entity types
+	// pay zero cost, and the consumers that DO read this field
+	// loud-fail with a wiring error rather than silently no-op'ing.
+	LifecycleManager *lifecycle.Manager
 }
 
 // GetLogger returns the configured logger or a default logger if none is provided

--- a/componentregistry/register.go
+++ b/componentregistry/register.go
@@ -8,6 +8,7 @@ import (
 	"github.com/c360studio/semstreams/component"
 	graphgateway "github.com/c360studio/semstreams/gateway/graph-gateway"
 	gatewayhttp "github.com/c360studio/semstreams/gateway/http"
+	lifecyclegateway "github.com/c360studio/semstreams/gateway/lifecycle-gateway"
 	a2ainput "github.com/c360studio/semstreams/input/a2a"
 	fileinput "github.com/c360studio/semstreams/input/file"
 	githubwebhook "github.com/c360studio/semstreams/input/github-webhook"
@@ -165,6 +166,14 @@ func registerProtocolLayer(registry *component.Registry) error {
 	// Gateways
 	if err := gatewayhttp.Register(registry); err != nil {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "HTTP gateway component registration")
+	}
+
+	// Lifecycle harness operator gateway (ADR-047 PR 3) — operator
+	// HTTP+WebSocket surface over pkg/lifecycle.Manager. Requires
+	// deps.LifecycleManager wired at service init; the factory
+	// loud-fails at component construction if missing.
+	if err := lifecyclegateway.Register(registry); err != nil {
+		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "lifecycle-gateway component registration")
 	}
 
 	return nil

--- a/gateway/lifecycle-gateway/component.go
+++ b/gateway/lifecycle-gateway/component.go
@@ -1,0 +1,379 @@
+// Package lifecyclegateway — Discoverable + Gateway + factory.
+package lifecyclegateway
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+)
+
+// ComponentName is the registry name. Exported so apps can resolve
+// the component from ComponentRegistry by string without copying the
+// literal.
+const ComponentName = "lifecycle-gateway"
+
+// Config is the operator-facing configuration surface.
+type Config struct {
+	// PathPrefix is mounted under the parent component prefix (the
+	// arg to RegisterHTTPHandlers). Default "workflows" so the
+	// fully-resolved routes look like /lifecycle-gateway/workflows
+	// or /workflows when mounted at root. Leading slash is added
+	// automatically; trailing slash is normalized.
+	PathPrefix string `json:"path_prefix,omitempty"`
+
+	// EnableWebSocket toggles the WS upgrade path for
+	// {prefix}/{type}?stream=true. Default true. Operators that
+	// don't need live updates (purely poll-based dashboards) can
+	// disable it to remove the upgrade-handler surface.
+	EnableWebSocket bool `json:"enable_websocket"`
+
+	// MaxBodyBytes caps the size of operator-supplied JSON bodies on
+	// POST {type}/{id}/state and POST {type}/{id}/transition (S2
+	// reviewer fix — unbounded reads were a DoS vector). Default 1MB.
+	// Operators that genuinely need larger patch bodies (uncommon —
+	// operator_writable surface should be narrow) raise this
+	// explicitly. Zero or negative means "no override" → default.
+	MaxBodyBytes int64 `json:"max_body_bytes,omitempty"`
+
+	// AllowedOrigins is the WebSocket-upgrade origin allowlist
+	// (S7 reviewer fix — the gateway's POST surface mutates state,
+	// so default-permissive cross-origin is a real risk; an explicit
+	// allowlist forces operators to make the cross-origin decision
+	// rather than inheriting the default). Empty list means
+	// "permit all" — the gateway emits a Warn log at Start time so
+	// operators see the policy choice in their logs. Wildcards are
+	// not supported; explicit origins only.
+	AllowedOrigins []string `json:"allowed_origins,omitempty"`
+}
+
+// Validate enforces operator-friendly constraints on the config.
+// Defaults are applied by ApplyDefaults; Validate runs AFTER defaults
+// so any invariant violation is genuine.
+func (c *Config) Validate() error {
+	// PathPrefix-after-trim must be non-empty (S4 reviewer fix —
+	// "/" or "//" trim to "" and broke the registered mux pattern).
+	if strings.Trim(c.PathPrefix, "/") == "" {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, "Config", "Validate",
+			"path_prefix must be non-empty after stripping leading/trailing slashes")
+	}
+	return nil
+}
+
+// DefaultMaxBodyBytes is the request-body size cap applied to
+// operator-supplied JSON on POST endpoints when Config.MaxBodyBytes
+// is zero or negative. 1 MiB is generous for `operator_writable`
+// patches (the protected-field surface should be narrow) and small
+// enough to make resource-exhaustion attacks visible.
+const DefaultMaxBodyBytes int64 = 1 << 20
+
+// ApplyDefaults populates omitted fields. Called by the factory
+// before Validate so operator-provided values stay sticky and
+// unset fields fall back to framework conventions.
+func (c *Config) ApplyDefaults() {
+	if c.PathPrefix == "" {
+		c.PathPrefix = "workflows"
+	}
+	if c.MaxBodyBytes <= 0 {
+		c.MaxBodyBytes = DefaultMaxBodyBytes
+	}
+	// EnableWebSocket defaults to true via inverted-default trick:
+	// the JSON unmarshal-default for a bool is false, but the
+	// framework convention is "WebSocket on by default" because the
+	// canonical operator-dashboard pattern uses live updates. Apps
+	// that genuinely want it off must set EnableWebSocket=false
+	// AND tag the config with a non-default marker (today, since
+	// false IS the JSON default, we can't distinguish "not set" from
+	// "set to false"). Operator-facing docs explicitly state the
+	// default-true convention; the `*bool` pointer-field upgrade is
+	// listed in `[[project_adr_047_048_bundle_progress]]` for a
+	// fast-follow after the bundle tag if operators surface confusion.
+}
+
+// DefaultConfig returns a Config ready for use in tests +
+// reasonable-default deployments.
+func DefaultConfig() Config {
+	return Config{
+		PathPrefix:      "workflows",
+		EnableWebSocket: true,
+		MaxBodyBytes:    DefaultMaxBodyBytes,
+	}
+}
+
+var schema = component.GenerateConfigSchema(reflect.TypeOf(Config{}))
+
+// LifecycleManager is the subset of *lifecycle.Manager used by the
+// gateway. Defined as an interface here (consumer-defined, matching
+// the rule processor's pattern in processor/rule.LifecycleManager)
+// so tests can swap in a mock without depending on pkg/lifecycle
+// internals (kvMockStore is unexported by design).
+//
+// The interface is wide enough to support all 8 endpoints + the WS
+// watch surface; production deployments pass the concrete
+// *lifecycle.Manager via Dependencies.LifecycleManager which
+// implements every method implicitly.
+type LifecycleManager interface {
+	ListWorkflows() []lifecycle.WorkflowDef
+	List(ctx context.Context, workflow string, opts lifecycle.ListOptions) ([]lifecycle.Participant, error)
+	Get(ctx context.Context, workflow, entityID string) (lifecycle.Participant, error)
+	History(ctx context.Context, workflow, entityID string) ([]lifecycle.TransitionEvent, error)
+	Children(ctx context.Context, parentEntityID string) ([]lifecycle.Participant, error)
+	UpdateFromOperator(ctx context.Context, workflow, entityID string, patch map[string]any) error
+	Transition(ctx context.Context, workflow, entityID, newPhase string, source lifecycle.TransitionSource, note string) error
+	Watch(ctx context.Context, workflow string) (<-chan lifecycle.Participant, error)
+}
+
+// Component is the lifecycle-gateway runtime. Wraps the shared
+// Manager + emits the HTTP/WS surface.
+type Component struct {
+	name    string
+	config  Config
+	manager LifecycleManager
+	logger  *slog.Logger
+	upgrade websocket.Upgrader
+
+	// Lifecycle state (atomic).
+	running atomic.Bool
+
+	// Metrics.
+	requestsTotal   atomic.Uint64
+	requestsSuccess atomic.Uint64
+	requestsFailed  atomic.Uint64
+	wsConnections   atomic.Int64 // current live WS connections
+
+	mu         sync.RWMutex
+	startTime  time.Time
+	lastErr    string
+	cachedRoot string // set by RegisterHTTPHandlers; read by serveHTTP
+}
+
+// CreateLifecycleGateway is the component-factory function. The
+// rule processor and lifecycle-gateway both pull the same
+// Manager from deps.LifecycleManager. Refusing to instantiate when
+// the manager is nil is the loud-fail signal: a deployment that
+// configures the gateway but doesn't wire a Manager has no
+// workflows to expose — failing at boot surfaces the gap before an
+// operator hits an empty endpoint and assumes "no instances."
+func CreateLifecycleGateway(rawConfig json.RawMessage, deps component.Dependencies) (component.Discoverable, error) {
+	if deps.LifecycleManager == nil {
+		return nil, errs.WrapFatal(errs.ErrMissingConfig, "Component", "CreateLifecycleGateway",
+			"deps.LifecycleManager is nil — the gateway requires a registered pkg/lifecycle.Manager (build it in main.go, call Manager.Register for each workflow, then pass via Dependencies.LifecycleManager)")
+	}
+
+	var cfg Config
+	if len(rawConfig) > 0 {
+		if err := component.SafeUnmarshal(rawConfig, &cfg); err != nil {
+			return nil, errs.WrapInvalid(err, "Component", "CreateLifecycleGateway",
+				"config unmarshal")
+		}
+	}
+	cfg.ApplyDefaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, errs.Wrap(err, "Component", "CreateLifecycleGateway",
+			"config validation")
+	}
+
+	logger := deps.GetLoggerWithComponent(ComponentName)
+
+	return &Component{
+		name:    ComponentName,
+		config:  cfg,
+		manager: deps.LifecycleManager,
+		logger:  logger,
+		upgrade: websocket.Upgrader{
+			CheckOrigin: makeOriginCheck(cfg.AllowedOrigins),
+		},
+	}, nil
+}
+
+// makeOriginCheck builds the WebSocket Upgrader's CheckOrigin
+// function from the configured allowlist. Empty allowlist =
+// permit-all (with a Warn log at Start time so operators see the
+// choice). Non-empty allowlist = exact-match the Origin header
+// against the list.
+func makeOriginCheck(allowed []string) func(*http.Request) bool {
+	if len(allowed) == 0 {
+		return func(_ *http.Request) bool { return true }
+	}
+	allow := make(map[string]struct{}, len(allowed))
+	for _, o := range allowed {
+		allow[o] = struct{}{}
+	}
+	return func(r *http.Request) bool {
+		_, ok := allow[r.Header.Get("Origin")]
+		return ok
+	}
+}
+
+// Register registers the lifecycle-gateway factory.
+func Register(registry *component.Registry) error {
+	return registry.RegisterWithConfig(component.RegistrationConfig{
+		Name:        ComponentName,
+		Factory:     CreateLifecycleGateway,
+		Schema:      schema,
+		Type:        "gateway",
+		Protocol:    "http",
+		Domain:      "lifecycle",
+		Description: "Operator HTTP + WebSocket gateway over pkg/lifecycle.Manager (ADR-047)",
+		Version:     "0.1.0",
+	})
+}
+
+// Meta implements component.Discoverable.
+func (c *Component) Meta() component.Metadata {
+	return component.Metadata{
+		Name:        c.name,
+		Type:        "gateway",
+		Description: "Lifecycle harness operator gateway",
+		Version:     "0.1.0",
+	}
+}
+
+// InputPorts returns no input ports — the gateway is request-driven, not NATS-fed.
+func (c *Component) InputPorts() []component.Port { return []component.Port{} }
+
+// OutputPorts returns no output ports — the gateway is request-driven, not NATS-fed.
+func (c *Component) OutputPorts() []component.Port { return []component.Port{} }
+
+// ConfigSchema implements component.Discoverable.
+func (c *Component) ConfigSchema() component.ConfigSchema { return schema }
+
+// Initialize is a no-op; the Manager is wired at factory time.
+func (c *Component) Initialize() error { return nil }
+
+// Start records the start time + flips running. The gateway has no
+// background goroutines of its own — handlers serve on demand via
+// the parent HTTP server.
+func (c *Component) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, "Component", "Start",
+			"context cannot be nil")
+	}
+	if c.running.Load() {
+		return errs.WrapFatal(errs.ErrAlreadyStarted, "Component", "Start",
+			"gateway already running")
+	}
+	c.mu.Lock()
+	c.startTime = time.Now()
+	c.mu.Unlock()
+	c.running.Store(true)
+
+	// Loud-log the security-sensitive default-permissive origin
+	// policy so operators see the choice in their startup logs
+	// rather than discovering it after a cross-origin incident.
+	if c.config.EnableWebSocket && len(c.config.AllowedOrigins) == 0 {
+		c.logger.Warn("lifecycle-gateway: WebSocket origin check is default-permissive",
+			slog.String("policy", "AllowedOrigins is empty; cross-origin upgrades will be accepted"),
+			slog.String("hint", "set allowed_origins in config to enforce an explicit allowlist"))
+	}
+	return nil
+}
+
+// Stop flips running off. Live WebSocket connections + in-flight
+// HTTP requests are owned by the parent HTTP server — they close as
+// part of the server's graceful shutdown, not via any check inside
+// this component (we don't gate handlers on running.Load() — graph-
+// gateway and the http gateway follow the same convention).
+func (c *Component) Stop(_ time.Duration) error {
+	c.running.Store(false)
+	return nil
+}
+
+// Health reports gateway health. Healthy = running. ErrorCount maps
+// to failed-request count so operator dashboards see uniform
+// across-gateway metrics.
+func (c *Component) Health() component.HealthStatus {
+	c.mu.RLock()
+	start := c.startTime
+	lastErr := c.lastErr
+	c.mu.RUnlock()
+
+	running := c.running.Load()
+	healthy := running
+
+	return component.HealthStatus{
+		Healthy:    healthy,
+		LastError:  lastErr,
+		LastCheck:  time.Now(),
+		ErrorCount: int(c.requestsFailed.Load()),
+		Uptime:     time.Since(start),
+	}
+}
+
+// DataFlow reports gateway metrics. Throughput is averaged since
+// startup; sliding-window per-second is a future addition matching
+// the http gateway TODO.
+func (c *Component) DataFlow() component.FlowMetrics {
+	c.mu.RLock()
+	start := c.startTime
+	c.mu.RUnlock()
+
+	total := c.requestsTotal.Load()
+	failed := c.requestsFailed.Load()
+
+	var errorRate float64
+	if total > 0 {
+		errorRate = float64(failed) / float64(total)
+	}
+	var mps float64
+	if uptime := time.Since(start).Seconds(); uptime > 0 {
+		mps = float64(total) / uptime
+	}
+
+	return component.FlowMetrics{
+		MessagesPerSecond: mps,
+		ErrorRate:         errorRate,
+		LastActivity:      time.Now(),
+	}
+}
+
+// RegisterHTTPHandlers mounts the lifecycle gateway routes under
+// the parent prefix. The routing logic is intentionally
+// non-mux-based at the leaf — net/http.ServeMux only handles
+// prefix-based dispatch, so the gateway uses a single catch-all
+// HandleFunc rooted at `{prefix}{path_prefix}/` and parses the
+// remaining path segments inside the handler. This keeps the
+// ServeMux contract simple (one entry per gateway component
+// instance) and the path-parsing testable in isolation.
+func (c *Component) RegisterHTTPHandlers(prefix string, mux *http.ServeMux) {
+	root := strings.TrimSuffix(prefix, "/") + "/" + strings.Trim(c.config.PathPrefix, "/")
+	if !strings.HasPrefix(root, "/") {
+		root = "/" + root
+	}
+	c.setCachedRoot(root)
+	// Two patterns: root exact-match (GET /workflows) and root +
+	// slash for everything below. ServeMux dispatches by longest
+	// match so both registrations coexist cleanly.
+	mux.HandleFunc(root, c.serveHTTP)
+	mux.HandleFunc(root+"/", c.serveHTTP)
+
+	c.logger.Info("lifecycle-gateway routes registered",
+		slog.String("root", root),
+		slog.Bool("websocket_enabled", c.config.EnableWebSocket))
+}
+
+// recordRequest tracks a request outcome for metrics.
+func (c *Component) recordRequest(ok bool, errMsg string) {
+	c.requestsTotal.Add(1)
+	if ok {
+		c.requestsSuccess.Add(1)
+		return
+	}
+	c.requestsFailed.Add(1)
+	if errMsg != "" {
+		c.mu.Lock()
+		c.lastErr = errMsg
+		c.mu.Unlock()
+	}
+}

--- a/gateway/lifecycle-gateway/component.go
+++ b/gateway/lifecycle-gateway/component.go
@@ -40,8 +40,14 @@ type Config struct {
 	// EnableWebSocket toggles the WS upgrade path for
 	// {prefix}/{type}?stream=true. Default true. Operators that
 	// don't need live updates (purely poll-based dashboards) can
-	// disable it to remove the upgrade-handler surface.
-	EnableWebSocket bool `json:"enable_websocket" schema:"type:bool,description:Enable WebSocket streaming on GET {prefix}/{type}?stream=true via Manager.Watch. Default true. Set to false to disable live-update streaming and keep the gateway poll-only.,category:basic"`
+	// disable it by setting `"enable_websocket": false` in config.
+	//
+	// Pointer type (vs bare bool) so ApplyDefaults can distinguish
+	// "field absent from config" (→ default true) from "field
+	// explicitly set to false" (→ disable). Matches the
+	// MaxIterations precedent in processor/rule/actions.go.
+	// Callers read via the wsEnabled() helper, never field-direct.
+	EnableWebSocket *bool `json:"enable_websocket,omitempty" schema:"type:bool,description:Enable WebSocket streaming on GET {prefix}/{type}?stream=true via Manager.Watch. Default true when omitted. Set to false to disable live-update streaming and keep the gateway poll-only.,category:basic"`
 
 	// MaxBodyBytes caps the size of operator-supplied JSON bodies on
 	// POST {type}/{id}/state and POST {type}/{id}/transition (S2
@@ -85,6 +91,11 @@ const DefaultMaxBodyBytes int64 = 1 << 20
 // ApplyDefaults populates omitted fields. Called by the factory
 // before Validate so operator-provided values stay sticky and
 // unset fields fall back to framework conventions.
+//
+// EnableWebSocket is the only nullable field: nil means "operator
+// omitted the key" → resolve to true. A non-nil pointer (even to
+// false) is honored as-is. Same shape as MaxIterations in
+// processor/rule/actions.go.
 func (c *Config) ApplyDefaults() {
 	if c.PathPrefix == "" {
 		c.PathPrefix = "workflows"
@@ -92,25 +103,30 @@ func (c *Config) ApplyDefaults() {
 	if c.MaxBodyBytes <= 0 {
 		c.MaxBodyBytes = DefaultMaxBodyBytes
 	}
-	// EnableWebSocket defaults to true via inverted-default trick:
-	// the JSON unmarshal-default for a bool is false, but the
-	// framework convention is "WebSocket on by default" because the
-	// canonical operator-dashboard pattern uses live updates. Apps
-	// that genuinely want it off must set EnableWebSocket=false
-	// AND tag the config with a non-default marker (today, since
-	// false IS the JSON default, we can't distinguish "not set" from
-	// "set to false"). Operator-facing docs explicitly state the
-	// default-true convention; the `*bool` pointer-field upgrade is
-	// listed in `[[project_adr_047_048_bundle_progress]]` for a
-	// fast-follow after the bundle tag if operators surface confusion.
+	if c.EnableWebSocket == nil {
+		v := true
+		c.EnableWebSocket = &v
+	}
+}
+
+// wsEnabled returns the effective EnableWebSocket value. nil pointer
+// (operator omitted the key) is treated as true to match the
+// documented default; a non-nil pointer is dereferenced. Centralized
+// so callers never field-access the pointer directly.
+func (c *Config) wsEnabled() bool {
+	if c.EnableWebSocket == nil {
+		return true
+	}
+	return *c.EnableWebSocket
 }
 
 // DefaultConfig returns a Config ready for use in tests +
 // reasonable-default deployments.
 func DefaultConfig() Config {
+	t := true
 	return Config{
 		PathPrefix:      "workflows",
-		EnableWebSocket: true,
+		EnableWebSocket: &t,
 		MaxBodyBytes:    DefaultMaxBodyBytes,
 	}
 }
@@ -276,7 +292,7 @@ func (c *Component) Start(ctx context.Context) error {
 	// Loud-log the security-sensitive default-permissive origin
 	// policy so operators see the choice in their startup logs
 	// rather than discovering it after a cross-origin incident.
-	if c.config.EnableWebSocket && len(c.config.AllowedOrigins) == 0 {
+	if c.config.wsEnabled() && len(c.config.AllowedOrigins) == 0 {
 		c.logger.Warn("lifecycle-gateway: WebSocket origin check is default-permissive",
 			slog.String("policy", "AllowedOrigins is empty; cross-origin upgrades will be accepted"),
 			slog.String("hint", "set allowed_origins in config to enforce an explicit allowlist"))
@@ -364,7 +380,7 @@ func (c *Component) RegisterHTTPHandlers(prefix string, mux *http.ServeMux) {
 
 	c.logger.Info("lifecycle-gateway routes registered",
 		slog.String("root", root),
-		slog.Bool("websocket_enabled", c.config.EnableWebSocket))
+		slog.Bool("websocket_enabled", c.config.wsEnabled()))
 }
 
 // recordRequest tracks a request outcome for metrics.

--- a/gateway/lifecycle-gateway/component.go
+++ b/gateway/lifecycle-gateway/component.go
@@ -24,20 +24,24 @@ import (
 // literal.
 const ComponentName = "lifecycle-gateway"
 
-// Config is the operator-facing configuration surface.
+// Config is the operator-facing configuration surface. Field tags
+// populate the generated OpenAPI schema (`schemas/lifecycle-gateway.v1.json`)
+// — every field MUST carry `schema:"type:...,description:...,category:..."`
+// so operator dashboards can render the config surface. See
+// `component/schema_tags.go` for the conventions.
 type Config struct {
 	// PathPrefix is mounted under the parent component prefix (the
 	// arg to RegisterHTTPHandlers). Default "workflows" so the
 	// fully-resolved routes look like /lifecycle-gateway/workflows
 	// or /workflows when mounted at root. Leading slash is added
 	// automatically; trailing slash is normalized.
-	PathPrefix string `json:"path_prefix,omitempty"`
+	PathPrefix string `json:"path_prefix,omitempty" schema:"type:string,description:URL path prefix mounted under the parent component prefix (e.g. \"workflows\" → /lifecycle-gateway/workflows). Default \"workflows\". Must be non-empty after stripping leading/trailing slashes.,category:basic"`
 
 	// EnableWebSocket toggles the WS upgrade path for
 	// {prefix}/{type}?stream=true. Default true. Operators that
 	// don't need live updates (purely poll-based dashboards) can
 	// disable it to remove the upgrade-handler surface.
-	EnableWebSocket bool `json:"enable_websocket"`
+	EnableWebSocket bool `json:"enable_websocket" schema:"type:bool,description:Enable WebSocket streaming on GET {prefix}/{type}?stream=true via Manager.Watch. Default true. Set to false to disable live-update streaming and keep the gateway poll-only.,category:basic"`
 
 	// MaxBodyBytes caps the size of operator-supplied JSON bodies on
 	// POST {type}/{id}/state and POST {type}/{id}/transition (S2
@@ -45,7 +49,7 @@ type Config struct {
 	// Operators that genuinely need larger patch bodies (uncommon —
 	// operator_writable surface should be narrow) raise this
 	// explicitly. Zero or negative means "no override" → default.
-	MaxBodyBytes int64 `json:"max_body_bytes,omitempty"`
+	MaxBodyBytes int64 `json:"max_body_bytes,omitempty" schema:"type:int,description:Maximum bytes accepted in POST .../state and POST .../transition request bodies. Default 1048576 (1 MiB). Zero or negative means use default.,category:advanced"`
 
 	// AllowedOrigins is the WebSocket-upgrade origin allowlist
 	// (S7 reviewer fix — the gateway's POST surface mutates state,
@@ -55,7 +59,7 @@ type Config struct {
 	// "permit all" — the gateway emits a Warn log at Start time so
 	// operators see the policy choice in their logs. Wildcards are
 	// not supported; explicit origins only.
-	AllowedOrigins []string `json:"allowed_origins,omitempty"`
+	AllowedOrigins []string `json:"allowed_origins,omitempty" schema:"type:array,description:WebSocket upgrade Origin allowlist as exact-match strings. Empty list permits all origins and logs a Warn at Start; set explicitly to restrict cross-origin upgrades.,category:advanced"`
 }
 
 // Validate enforces operator-friendly constraints on the config.

--- a/gateway/lifecycle-gateway/component_test.go
+++ b/gateway/lifecycle-gateway/component_test.go
@@ -53,18 +53,19 @@ func (p *fakeParticipant) ParentEntityID() string       { return p.ParentMission
 // gateway path that doesn't require KV-revision-based History or
 // Watch behaviour.
 type fakeManager struct {
-	mu              sync.Mutex
-	entities        map[string]map[string]*fakeParticipant // workflow → id → state
-	defs            []lifecycle.WorkflowDef
-	historyByID     map[string][]lifecycle.TransitionEvent
-	writableFields  map[string]map[string]bool // workflow → field → allowed
-	updateCalls     int
-	transitionCalls int
-	transitionErr   error
-	updateErr       error
-	listErr         error
-	watchCh         chan lifecycle.Participant
-	watchErr        error
+	mu                sync.Mutex
+	entities          map[string]map[string]*fakeParticipant // workflow → id → state
+	defs              []lifecycle.WorkflowDef
+	historyByID       map[string][]lifecycle.TransitionEvent
+	writableFields    map[string]map[string]bool // workflow → field → allowed
+	updateCalls       int
+	transitionCalls   int
+	transitionErr     error
+	updateErr         error
+	listErr           error            // global List error (any workflow)
+	listErrByWorkflow map[string]error // per-workflow List error (overrides listErr when set)
+	watchCh           chan lifecycle.Participant
+	watchErr          error
 }
 
 func newFakeManager() *fakeManager {
@@ -104,6 +105,9 @@ func (m *fakeManager) ListWorkflows() []lifecycle.WorkflowDef {
 }
 
 func (m *fakeManager) List(_ context.Context, workflow string, opts lifecycle.ListOptions) ([]lifecycle.Participant, error) {
+	if perWorkflowErr, ok := m.listErrByWorkflow[workflow]; ok {
+		return nil, perWorkflowErr
+	}
 	if m.listErr != nil {
 		return nil, m.listErr
 	}
@@ -296,6 +300,62 @@ func TestListWorkflows_Success(t *testing.T) {
 	counts, _ := got[0]["counts_by_phase"].(map[string]any)
 	if counts["planning"] != float64(1) || counts["flying"] != float64(1) {
 		t.Errorf("phase counts: got %v", counts)
+	}
+}
+
+// TestListWorkflows_PartialListFailure exercises the B2 fix: when one
+// workflow's List call fails (e.g. KV unreachable), the gateway must
+// still render every workflow type but mark the failing one with a
+// `counts_error` field — silent fall-through to empty counts was the
+// original silent-fail bug. Regression-locks the loud-fail discipline
+// per [[feedback_no_clean_except_handwave]].
+func TestListWorkflows_PartialListFailure(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	// Register a second workflow so we can confirm one failure doesn't
+	// blow up the whole response.
+	mgr.registerWorkflow("calibration", lifecycle.Transitions{"idle": {"running"}, "running": {}})
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-1", PhaseF: "planning"})
+	mgr.seed("calibration", &fakeParticipant{EntityIDF: "c-1", PhaseF: "idle"})
+
+	mgr.listErrByWorkflow = map[string]error{
+		"mission": fmt.Errorf("simulated KV unreachable for MISSIONS bucket"),
+	}
+
+	resp, err := http.Get(srv.URL + "/gw/workflows")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d (partial List failure must NOT fail the whole response)", resp.StatusCode)
+	}
+	var got []map[string]any
+	mustDecodeJSON(t, resp, &got)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 workflow entries, got %d", len(got))
+	}
+	byName := map[string]map[string]any{}
+	for _, e := range got {
+		byName[e["workflow"].(string)] = e
+	}
+	mission := byName["mission"]
+	calib := byName["calibration"]
+	// The failing workflow must carry counts_error AND empty counts.
+	if mission["counts_error"] == nil || mission["counts_error"] == "" {
+		t.Errorf("mission entry missing counts_error: %v", mission)
+	}
+	if counts, ok := mission["counts_by_phase"].(map[string]any); !ok || len(counts) != 0 {
+		t.Errorf("mission counts_by_phase should be empty on failure, got %v", mission["counts_by_phase"])
+	}
+	// The healthy workflow must render normally (no counts_error,
+	// counts populated).
+	if _, hasErr := calib["counts_error"]; hasErr {
+		t.Errorf("calibration entry should have no counts_error, got %v", calib["counts_error"])
+	}
+	if counts, _ := calib["counts_by_phase"].(map[string]any); counts["idle"] != float64(1) {
+		t.Errorf("calibration counts_by_phase: got %v", calib["counts_by_phase"])
 	}
 }
 
@@ -670,6 +730,16 @@ func TestFactory_AcceptsRealManagerType(t *testing.T) {
 	// path passes deps.LifecycleManager which is *lifecycle.Manager;
 	// the factory must accept the concrete type (which implicitly
 	// satisfies our local LifecycleManager interface).
+	//
+	// SCOPE: this test verifies type-acceptance ONLY — the zero-value
+	// Manager passed here has no registered workflows + no store
+	// factory wired, so any operation against it would either return
+	// empty (ListWorkflows) or panic (List/Get/Update/etc). DO NOT
+	// extend this test to exercise behavior; use a fakeManager via
+	// newTestGateway or TestFactory_FullProductionWire for behavior
+	// coverage. The factory-accepts-concrete invariant is what's
+	// load-bearing here; the wired-and-functional invariant lives
+	// elsewhere.
 	deps := component.Dependencies{LifecycleManager: &lifecycle.Manager{}}
 	comp, err := CreateLifecycleGateway(nil, deps)
 	if err != nil {
@@ -746,6 +816,46 @@ func TestFactory_FullProductionWire(t *testing.T) {
 	// to upgrade since the field is set non-nil).
 	if comp.upgrade.CheckOrigin == nil {
 		t.Errorf("factory did not wire Upgrader.CheckOrigin")
+	}
+}
+
+// TestOpenAPISpec_DocumentsAllEndpoints locks the operator-facing
+// OpenAPI surface: the 7 HTTP endpoints (plus the WebSocket-upgrade
+// variant on /workflows/{type}) must appear in the spec so operator
+// dashboards auto-discover them. A regression that dropped an entry
+// would silently de-document an endpoint that still serves traffic.
+func TestOpenAPISpec_DocumentsAllEndpoints(t *testing.T) {
+	t.Parallel()
+	spec := lifecycleGatewayOpenAPISpec()
+	wantPaths := []string{
+		"/workflows",
+		"/workflows/{type}",
+		"/workflows/{type}/{id}",
+		"/workflows/{type}/{id}/history",
+		"/workflows/{type}/{id}/children",
+		"/workflows/{type}/{id}/state",
+		"/workflows/{type}/{id}/transition",
+	}
+	for _, p := range wantPaths {
+		if _, ok := spec.Paths[p]; !ok {
+			t.Errorf("spec missing path %q", p)
+		}
+	}
+	// Method coverage: state + transition must be POST-only; the rest GET-only.
+	for path, ps := range spec.Paths {
+		switch path {
+		case "/workflows/{type}/{id}/state", "/workflows/{type}/{id}/transition":
+			if ps.POST == nil {
+				t.Errorf("path %q missing POST operation", path)
+			}
+			if ps.GET != nil {
+				t.Errorf("path %q should not expose GET", path)
+			}
+		default:
+			if ps.GET == nil {
+				t.Errorf("path %q missing GET operation", path)
+			}
+		}
 	}
 }
 

--- a/gateway/lifecycle-gateway/component_test.go
+++ b/gateway/lifecycle-gateway/component_test.go
@@ -687,7 +687,8 @@ func TestWebSocket_DisabledReturns403(t *testing.T) {
 	mgr.registerWorkflow("mission", lifecycle.Transitions{"planning": {}})
 
 	cfg := DefaultConfig()
-	cfg.EnableWebSocket = false
+	f := false
+	cfg.EnableWebSocket = &f
 	comp := &Component{
 		name:    ComponentName,
 		config:  cfg,
@@ -706,6 +707,78 @@ func TestWebSocket_DisabledReturns403(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Errorf("expected 403 when WS disabled, got %d", resp.StatusCode)
+	}
+}
+
+// --- Config.EnableWebSocket pointer-field semantics (N9) ---
+
+// TestConfig_EnableWebSocket_UnsetResolvesTrue locks the
+// pointer-field invariant: an operator who omits `enable_websocket`
+// from config must get the framework-default (true), NOT a JSON-zero
+// false. ApplyDefaults distinguishes unset (nil) from explicit-false
+// via the pointer type.
+func TestConfig_EnableWebSocket_UnsetResolvesTrue(t *testing.T) {
+	t.Parallel()
+	var cfg Config // pointer is nil → "field absent from config"
+	cfg.ApplyDefaults()
+	if cfg.EnableWebSocket == nil {
+		t.Fatalf("ApplyDefaults should populate EnableWebSocket")
+	}
+	if !cfg.wsEnabled() {
+		t.Errorf("unset EnableWebSocket should resolve to true (framework default)")
+	}
+}
+
+func TestConfig_EnableWebSocket_ExplicitFalseHonored(t *testing.T) {
+	t.Parallel()
+	f := false
+	cfg := Config{EnableWebSocket: &f}
+	cfg.ApplyDefaults()
+	if cfg.EnableWebSocket == nil || *cfg.EnableWebSocket {
+		t.Errorf("explicit false must NOT be overridden by ApplyDefaults, got %v", cfg.EnableWebSocket)
+	}
+	if cfg.wsEnabled() {
+		t.Errorf("wsEnabled() should reflect explicit false")
+	}
+}
+
+func TestConfig_EnableWebSocket_ExplicitTrueHonored(t *testing.T) {
+	t.Parallel()
+	tr := true
+	cfg := Config{EnableWebSocket: &tr}
+	cfg.ApplyDefaults()
+	if cfg.EnableWebSocket == nil || !*cfg.EnableWebSocket {
+		t.Errorf("explicit true must survive ApplyDefaults, got %v", cfg.EnableWebSocket)
+	}
+}
+
+// TestConfig_EnableWebSocket_JSONUnmarshal_AbsentResolvesTrue exercises
+// the round-trip authors actually use: parse JSON config that omits
+// the key, then ApplyDefaults → wsEnabled() returns true.
+func TestConfig_EnableWebSocket_JSONUnmarshal_AbsentResolvesTrue(t *testing.T) {
+	t.Parallel()
+	var cfg Config
+	if err := json.Unmarshal([]byte(`{"path_prefix":"workflows"}`), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.EnableWebSocket != nil {
+		t.Errorf("absent key should unmarshal to nil pointer, got %v", *cfg.EnableWebSocket)
+	}
+	cfg.ApplyDefaults()
+	if !cfg.wsEnabled() {
+		t.Errorf("absent + ApplyDefaults should resolve true")
+	}
+}
+
+func TestConfig_EnableWebSocket_JSONUnmarshal_ExplicitFalseSurvivesDefaults(t *testing.T) {
+	t.Parallel()
+	var cfg Config
+	if err := json.Unmarshal([]byte(`{"enable_websocket":false}`), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cfg.ApplyDefaults()
+	if cfg.wsEnabled() {
+		t.Errorf("explicit false in JSON must survive ApplyDefaults")
 	}
 }
 

--- a/gateway/lifecycle-gateway/component_test.go
+++ b/gateway/lifecycle-gateway/component_test.go
@@ -1,0 +1,792 @@
+// Package lifecyclegateway — unit + integration tests.
+//
+// Production-wire discipline: every endpoint test drives the route
+// through `Component.RegisterHTTPHandlers` on a real
+// `http.ServeMux` mounted on `httptest.NewServer`. A regression
+// that broke path-prefix stripping, method dispatch, or response
+// envelope shape would fail these tests, not just the
+// helper-direct path. Per
+// [[feedback_integration_tests_must_drive_production_wire]].
+package lifecyclegateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+)
+
+// --- Mock LifecycleManager ---
+
+type fakeParticipant struct {
+	EntityIDF      string `json:"entity_id"`
+	WorkflowF      string `json:"workflow"`
+	PhaseF         string `json:"phase"`
+	TerminalF      bool   `json:"-"`
+	OwnerOrgIDF    string `json:"owner_org_id"`
+	ParentMissionF string `json:"parent_mission,omitempty"`
+}
+
+func (p *fakeParticipant) EntityID() string             { return p.EntityIDF }
+func (p *fakeParticipant) Workflow() string             { return p.WorkflowF }
+func (p *fakeParticipant) Phase() string                { return p.PhaseF }
+func (p *fakeParticipant) IsTerminal() bool             { return p.TerminalF }
+func (p *fakeParticipant) KVBucket() string             { return "MISSIONS" }
+func (p *fakeParticipant) KVKey(entityID string) string { return entityID }
+func (p *fakeParticipant) ParentEntityID() string       { return p.ParentMissionF }
+
+// fakeManager implements LifecycleManager. State lives in memory;
+// each method records its calls for assertion. Suitable for any
+// gateway path that doesn't require KV-revision-based History or
+// Watch behaviour.
+type fakeManager struct {
+	mu              sync.Mutex
+	entities        map[string]map[string]*fakeParticipant // workflow → id → state
+	defs            []lifecycle.WorkflowDef
+	historyByID     map[string][]lifecycle.TransitionEvent
+	writableFields  map[string]map[string]bool // workflow → field → allowed
+	updateCalls     int
+	transitionCalls int
+	transitionErr   error
+	updateErr       error
+	listErr         error
+	watchCh         chan lifecycle.Participant
+	watchErr        error
+}
+
+func newFakeManager() *fakeManager {
+	return &fakeManager{
+		entities:       make(map[string]map[string]*fakeParticipant),
+		historyByID:    make(map[string][]lifecycle.TransitionEvent),
+		writableFields: make(map[string]map[string]bool),
+	}
+}
+
+func (m *fakeManager) registerWorkflow(workflow string, transitions lifecycle.Transitions) {
+	m.defs = append(m.defs, lifecycle.WorkflowDef{
+		Workflow:               workflow,
+		KVBucket:               "MISSIONS",
+		Transitions:            transitions,
+		OperatorWritableFields: []string{"owner_org_id"},
+	})
+	m.writableFields[workflow] = map[string]bool{"owner_org_id": true}
+}
+
+func (m *fakeManager) seed(workflow string, p *fakeParticipant) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.entities[workflow] == nil {
+		m.entities[workflow] = make(map[string]*fakeParticipant)
+	}
+	p.WorkflowF = workflow
+	m.entities[workflow][p.EntityIDF] = p
+}
+
+func (m *fakeManager) ListWorkflows() []lifecycle.WorkflowDef {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]lifecycle.WorkflowDef, len(m.defs))
+	copy(out, m.defs)
+	return out
+}
+
+func (m *fakeManager) List(_ context.Context, workflow string, opts lifecycle.ListOptions) ([]lifecycle.Participant, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	byID, ok := m.entities[workflow]
+	if !ok {
+		return nil, fmt.Errorf("%w: workflow %q", lifecycle.ErrWorkflowNotRegistered, workflow)
+	}
+	out := make([]lifecycle.Participant, 0, len(byID))
+	for _, p := range byID {
+		if opts.Phase != "" && p.Phase() != opts.Phase {
+			continue
+		}
+		if opts.Active && p.IsTerminal() {
+			continue
+		}
+		if opts.Match != nil {
+			skip := false
+			for k, v := range opts.Match {
+				if k == "owner_org_id" && p.OwnerOrgIDF != fmt.Sprintf("%v", v) {
+					skip = true
+					break
+				}
+			}
+			if skip {
+				continue
+			}
+		}
+		out = append(out, p)
+	}
+	if opts.Offset > 0 && opts.Offset < len(out) {
+		out = out[opts.Offset:]
+	} else if opts.Offset >= len(out) {
+		out = nil
+	}
+	if opts.Limit > 0 && len(out) > opts.Limit {
+		out = out[:opts.Limit]
+	}
+	return out, nil
+}
+
+func (m *fakeManager) Get(_ context.Context, workflow, entityID string) (lifecycle.Participant, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.entities[workflow]; !ok {
+		return nil, fmt.Errorf("%w: workflow %q", lifecycle.ErrWorkflowNotRegistered, workflow)
+	}
+	p, ok := m.entities[workflow][entityID]
+	if !ok {
+		return nil, fmt.Errorf("%w: workflow=%q entity_id=%q", lifecycle.ErrEntityNotFound, workflow, entityID)
+	}
+	return p, nil
+}
+
+func (m *fakeManager) History(_ context.Context, workflow, entityID string) ([]lifecycle.TransitionEvent, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.entities[workflow]; !ok {
+		return nil, fmt.Errorf("%w: workflow %q", lifecycle.ErrWorkflowNotRegistered, workflow)
+	}
+	if _, ok := m.entities[workflow][entityID]; !ok {
+		return nil, fmt.Errorf("%w: workflow=%q entity_id=%q", lifecycle.ErrEntityNotFound, workflow, entityID)
+	}
+	return m.historyByID[entityID], nil
+}
+
+func (m *fakeManager) Children(_ context.Context, parentEntityID string) ([]lifecycle.Participant, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []lifecycle.Participant
+	for _, byID := range m.entities {
+		for _, p := range byID {
+			if p.ParentMissionF == parentEntityID {
+				out = append(out, p)
+			}
+		}
+	}
+	return out, nil
+}
+
+func (m *fakeManager) UpdateFromOperator(_ context.Context, workflow, entityID string, patch map[string]any) error {
+	m.updateCalls++
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.entities[workflow]; !ok {
+		return fmt.Errorf("%w: workflow %q", lifecycle.ErrWorkflowNotRegistered, workflow)
+	}
+	p, ok := m.entities[workflow][entityID]
+	if !ok {
+		return fmt.Errorf("%w: workflow=%q entity_id=%q", lifecycle.ErrEntityNotFound, workflow, entityID)
+	}
+	for field, val := range patch {
+		allowed := m.writableFields[workflow]
+		if allowed == nil || !allowed[field] {
+			return fmt.Errorf("%w: workflow=%q field=%q", lifecycle.ErrFieldNotOperatorWritable, workflow, field)
+		}
+		if field == "owner_org_id" {
+			p.OwnerOrgIDF = fmt.Sprintf("%v", val)
+		}
+	}
+	return nil
+}
+
+func (m *fakeManager) Transition(_ context.Context, workflow, entityID, newPhase string, _ lifecycle.TransitionSource, _ string) error {
+	m.transitionCalls++
+	if m.transitionErr != nil {
+		return m.transitionErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.entities[workflow]; !ok {
+		return fmt.Errorf("%w: workflow %q", lifecycle.ErrWorkflowNotRegistered, workflow)
+	}
+	p, ok := m.entities[workflow][entityID]
+	if !ok {
+		return fmt.Errorf("%w: workflow=%q entity_id=%q", lifecycle.ErrEntityNotFound, workflow, entityID)
+	}
+	p.PhaseF = newPhase
+	return nil
+}
+
+func (m *fakeManager) Watch(_ context.Context, _ string) (<-chan lifecycle.Participant, error) {
+	if m.watchErr != nil {
+		return nil, m.watchErr
+	}
+	if m.watchCh == nil {
+		m.watchCh = make(chan lifecycle.Participant, 8)
+	}
+	return m.watchCh, nil
+}
+
+// --- Production-wire setup ---
+
+// newTestGateway constructs a Component with a fakeManager, mounts
+// it on a real http.ServeMux, and serves via httptest.NewServer.
+// Returns the server (caller closes) + the fake manager so tests
+// can drive state + assert calls.
+func newTestGateway(t *testing.T, prefix string) (*httptest.Server, *fakeManager) {
+	t.Helper()
+	mgr := newFakeManager()
+	mgr.registerWorkflow("mission", lifecycle.Transitions{
+		"planning":  {"flying", "aborted"},
+		"flying":    {"completed", "failed"},
+		"completed": {},
+		"failed":    {},
+		"aborted":   {},
+	})
+	cfg := DefaultConfig()
+	comp := &Component{
+		name:    ComponentName,
+		config:  cfg,
+		manager: mgr,
+		logger:  slog.Default(),
+	}
+	mux := http.NewServeMux()
+	comp.RegisterHTTPHandlers(prefix, mux)
+	srv := httptest.NewServer(mux)
+	return srv, mgr
+}
+
+// --- Endpoint tests ---
+
+func TestListWorkflows_Success(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-1", PhaseF: "planning"})
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-2", PhaseF: "flying"})
+
+	resp, err := http.Get(srv.URL + "/gw/workflows")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d, body=%s", resp.StatusCode, mustBody(resp))
+	}
+	var got []map[string]any
+	mustDecodeJSON(t, resp, &got)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 workflow type, got %d", len(got))
+	}
+	if got[0]["workflow"] != "mission" {
+		t.Errorf("workflow name: got %v", got[0]["workflow"])
+	}
+	counts, _ := got[0]["counts_by_phase"].(map[string]any)
+	if counts["planning"] != float64(1) || counts["flying"] != float64(1) {
+		t.Errorf("phase counts: got %v", counts)
+	}
+}
+
+func TestListInstances_FiltersByPhase(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-1", PhaseF: "planning"})
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-2", PhaseF: "flying"})
+
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission?phase=flying")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	var got []map[string]any
+	mustDecodeJSON(t, resp, &got)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 instance, got %d", len(got))
+	}
+	if got[0]["entity_id"] != "m-1" && got[0]["entity_id"] != "m-2" {
+		t.Errorf("entity_id: got %v", got[0]["entity_id"])
+	}
+}
+
+func TestListInstances_LimitOffset(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	for i := 0; i < 5; i++ {
+		mgr.seed("mission", &fakeParticipant{EntityIDF: fmt.Sprintf("m-%d", i), PhaseF: "planning"})
+	}
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission?limit=2&offset=1")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var got []map[string]any
+	mustDecodeJSON(t, resp, &got)
+	if len(got) != 2 {
+		t.Errorf("limit=2 should return 2, got %d", len(got))
+	}
+}
+
+func TestListInstances_InvalidLimit(t *testing.T) {
+	t.Parallel()
+	srv, _ := newTestGateway(t, "/gw")
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission?limit=abc")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestListInstances_UnknownWorkflow_404(t *testing.T) {
+	t.Parallel()
+	srv, _ := newTestGateway(t, "/gw")
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/gw/workflows/no-such-workflow")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 (ErrWorkflowNotRegistered → 404), got %d", resp.StatusCode)
+	}
+}
+
+func TestGetInstance_Success(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-1", PhaseF: "flying", OwnerOrgIDF: "acme"})
+
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission/m-1")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	var got map[string]any
+	mustDecodeJSON(t, resp, &got)
+	if got["entity_id"] != "m-1" || got["phase"] != "flying" || got["owner_org_id"] != "acme" {
+		t.Errorf("instance state: got %v", got)
+	}
+}
+
+func TestGetInstance_NotFound_404(t *testing.T) {
+	t.Parallel()
+	srv, _ := newTestGateway(t, "/gw")
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission/missing")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestStatePatch_Success(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-1", PhaseF: "planning"})
+
+	body := bytes.NewBufferString(`{"owner_org_id": "acme"}`)
+	resp, err := http.Post(srv.URL+"/gw/workflows/mission/m-1/state", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d, body=%s", resp.StatusCode, mustBody(resp))
+	}
+	if mgr.updateCalls != 1 {
+		t.Errorf("UpdateFromOperator should be called once, got %d", mgr.updateCalls)
+	}
+	if mgr.entities["mission"]["m-1"].OwnerOrgIDF != "acme" {
+		t.Errorf("patch didn't land, owner_org_id=%q", mgr.entities["mission"]["m-1"].OwnerOrgIDF)
+	}
+}
+
+func TestStatePatch_FieldRejected_400(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-1", PhaseF: "planning"})
+
+	// "phase" isn't in writableFields → fake returns ErrFieldNotOperatorWritable.
+	body := bytes.NewBufferString(`{"phase": "completed"}`)
+	resp, err := http.Post(srv.URL+"/gw/workflows/mission/m-1/state", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestStatePatch_InvalidJSON_400(t *testing.T) {
+	t.Parallel()
+	srv, _ := newTestGateway(t, "/gw")
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/gw/workflows/mission/m-1/state", "application/json",
+		bytes.NewBufferString(`not json`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestStatePatch_MethodNotAllowed_405(t *testing.T) {
+	t.Parallel()
+	srv, _ := newTestGateway(t, "/gw")
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission/m-1/state")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestOperatorTransition_Success(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-1", PhaseF: "planning"})
+
+	body := bytes.NewBufferString(`{"phase": "flying", "note": "operator nudge"}`)
+	resp, err := http.Post(srv.URL+"/gw/workflows/mission/m-1/transition", "application/json", body)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d, body=%s", resp.StatusCode, mustBody(resp))
+	}
+	if mgr.entities["mission"]["m-1"].PhaseF != "flying" {
+		t.Errorf("transition didn't land, phase=%q", mgr.entities["mission"]["m-1"].PhaseF)
+	}
+	if mgr.transitionCalls != 1 {
+		t.Errorf("Transition should be called once, got %d", mgr.transitionCalls)
+	}
+}
+
+func TestOperatorTransition_MissingPhase_400(t *testing.T) {
+	t.Parallel()
+	srv, _ := newTestGateway(t, "/gw")
+	defer srv.Close()
+	resp, err := http.Post(srv.URL+"/gw/workflows/mission/m-1/transition",
+		"application/json", bytes.NewBufferString(`{}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for missing phase, got %d", resp.StatusCode)
+	}
+}
+
+func TestHistory_Success(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "m-1", PhaseF: "flying"})
+	mgr.historyByID["m-1"] = []lifecycle.TransitionEvent{
+		{From: "planning", To: "flying", At: time.Now(), Triggered: lifecycle.TransitionSourceRule, Note: ""},
+	}
+
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission/m-1/history")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	var got []map[string]any
+	mustDecodeJSON(t, resp, &got)
+	if len(got) != 1 || got[0]["from"] != "planning" {
+		t.Errorf("history: got %v", got)
+	}
+}
+
+func TestChildren_Success(t *testing.T) {
+	t.Parallel()
+	srv, mgr := newTestGateway(t, "/gw")
+	defer srv.Close()
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "parent", PhaseF: "planning"})
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "child-1", PhaseF: "planning", ParentMissionF: "parent"})
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "child-2", PhaseF: "flying", ParentMissionF: "parent"})
+
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission/parent/children")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	var got []map[string]any
+	mustDecodeJSON(t, resp, &got)
+	if len(got) != 2 {
+		t.Errorf("expected 2 children, got %d", len(got))
+	}
+}
+
+func TestUnknownSubresource_404(t *testing.T) {
+	t.Parallel()
+	srv, _ := newTestGateway(t, "/gw")
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission/m-1/garbage")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+// --- WebSocket ---
+
+func TestWebSocket_StreamsUpdates(t *testing.T) {
+	t.Parallel()
+	mgr := newFakeManager()
+	mgr.registerWorkflow("mission", lifecycle.Transitions{"planning": {"flying"}, "flying": {}})
+	mgr.watchCh = make(chan lifecycle.Participant, 4)
+
+	cfg := DefaultConfig()
+	comp := &Component{
+		name:    ComponentName,
+		config:  cfg,
+		manager: mgr,
+		logger:  slog.Default(),
+		upgrade: websocketUpgrader(),
+	}
+	mux := http.NewServeMux()
+	comp.RegisterHTTPHandlers("/gw", mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/gw/workflows/mission?stream=true"
+	conn, _, err := dialWS(wsURL)
+	if err != nil {
+		t.Fatalf("WS dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Push a Participant snapshot through the watch channel.
+	p := &fakeParticipant{EntityIDF: "m-ws-1", WorkflowF: "mission", PhaseF: "flying"}
+	mgr.watchCh <- p
+
+	// Read with deadline.
+	if err := conn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	var got map[string]any
+	if err := conn.ReadJSON(&got); err != nil {
+		t.Fatalf("ReadJSON: %v", err)
+	}
+	if got["entity_id"] != "m-ws-1" || got["phase"] != "flying" {
+		t.Errorf("WS payload: got %v", got)
+	}
+}
+
+func TestWebSocket_DisabledReturns403(t *testing.T) {
+	t.Parallel()
+	mgr := newFakeManager()
+	mgr.registerWorkflow("mission", lifecycle.Transitions{"planning": {}})
+
+	cfg := DefaultConfig()
+	cfg.EnableWebSocket = false
+	comp := &Component{
+		name:    ComponentName,
+		config:  cfg,
+		manager: mgr,
+		logger:  slog.Default(),
+	}
+	mux := http.NewServeMux()
+	comp.RegisterHTTPHandlers("/gw", mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/gw/workflows/mission?stream=true")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected 403 when WS disabled, got %d", resp.StatusCode)
+	}
+}
+
+// --- Component lifecycle ---
+
+func TestFactory_RejectsNilManager(t *testing.T) {
+	t.Parallel()
+	// Loud-fail: deps.LifecycleManager nil → factory MUST reject so
+	// the wiring gap surfaces at boot, not at the first endpoint hit.
+	_, err := CreateLifecycleGateway(nil, component.Dependencies{})
+	if err == nil {
+		t.Fatalf("expected factory to reject nil LifecycleManager")
+	}
+	if !strings.Contains(err.Error(), "LifecycleManager") {
+		t.Errorf("error should name the missing field, got %q", err.Error())
+	}
+}
+
+func TestFactory_AcceptsRealManagerType(t *testing.T) {
+	t.Parallel()
+	// Locks the interface-vs-concrete invariant: the production wiring
+	// path passes deps.LifecycleManager which is *lifecycle.Manager;
+	// the factory must accept the concrete type (which implicitly
+	// satisfies our local LifecycleManager interface).
+	deps := component.Dependencies{LifecycleManager: &lifecycle.Manager{}}
+	comp, err := CreateLifecycleGateway(nil, deps)
+	if err != nil {
+		t.Fatalf("expected factory to accept *lifecycle.Manager, got %v", err)
+	}
+	if comp == nil {
+		t.Fatalf("nil component returned")
+	}
+}
+
+// TestFactory_FullProductionWire goes through the exact construction
+// path production uses: CreateLifecycleGateway → Initialize → Start →
+// RegisterHTTPHandlers → httptest.NewServer → HTTP request. A
+// regression that broke `ApplyDefaults`, factory's CheckOrigin wiring,
+// or any field initialization missed by the test's direct-struct
+// constructor would surface here (B4 reviewer fix — earlier tests
+// bypassed the factory and zero-init'd Upgrader).
+func TestFactory_FullProductionWire(t *testing.T) {
+	t.Parallel()
+	// Bypass the nil-check by providing a (zero-value) Manager. The
+	// concrete *lifecycle.Manager satisfies our LifecycleManager
+	// interface; even though its operations would fail without
+	// registrations, we only need the factory + route wiring to
+	// succeed for this test.
+	deps := component.Dependencies{
+		LifecycleManager: &lifecycle.Manager{},
+		Logger:           slog.Default(),
+	}
+	disc, err := CreateLifecycleGateway(nil, deps)
+	if err != nil {
+		t.Fatalf("CreateLifecycleGateway: %v", err)
+	}
+	comp, ok := disc.(*Component)
+	if !ok {
+		t.Fatalf("expected *Component, got %T", disc)
+	}
+	// Swap in the fake manager AFTER construction so the gateway has
+	// real workflow registrations to read. The factory path is what
+	// we want to lock; the manager is the consumed dependency.
+	mgr := newFakeManager()
+	mgr.registerWorkflow("mission", lifecycle.Transitions{"planning": {"flying"}, "flying": {}})
+	mgr.seed("mission", &fakeParticipant{EntityIDF: "wire-1", PhaseF: "planning"})
+	comp.manager = mgr
+
+	if err := comp.Initialize(); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if err := comp.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = comp.Stop(0) }()
+
+	mux := http.NewServeMux()
+	comp.RegisterHTTPHandlers("/wire", mux)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/wire/workflows/mission/wire-1")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d, body=%s", resp.StatusCode, mustBody(resp))
+	}
+	var got map[string]any
+	mustDecodeJSON(t, resp, &got)
+	if got["entity_id"] != "wire-1" {
+		t.Errorf("entity_id: got %v", got["entity_id"])
+	}
+	// Confirm factory wired the Upgrader (zero-value Upgrader's
+	// CheckOrigin nil-panics on WS upgrade; if the factory dropped
+	// this, the WS test would crash — caught here without needing
+	// to upgrade since the field is set non-nil).
+	if comp.upgrade.CheckOrigin == nil {
+		t.Errorf("factory did not wire Upgrader.CheckOrigin")
+	}
+}
+
+func TestFactory_ValidatesPathPrefix(t *testing.T) {
+	t.Parallel()
+	// S4: "/" or "//" trim to "" → factory must reject so the
+	// gateway doesn't register a bogus mux pattern.
+	rawCfg := []byte(`{"path_prefix": "/"}`)
+	deps := component.Dependencies{LifecycleManager: &lifecycle.Manager{}}
+	_, err := CreateLifecycleGateway(rawCfg, deps)
+	if err == nil {
+		t.Fatalf("expected factory to reject path_prefix=\"/\"")
+	}
+	if !strings.Contains(err.Error(), "path_prefix") {
+		t.Errorf("error should name path_prefix, got %q", err.Error())
+	}
+}
+
+// --- helpers ---
+
+func websocketUpgrader() websocket.Upgrader {
+	return websocket.Upgrader{
+		CheckOrigin: func(_ *http.Request) bool { return true },
+	}
+}
+
+func dialWS(url string) (*websocket.Conn, *http.Response, error) {
+	return websocket.DefaultDialer.Dial(url, nil)
+}
+
+func mustBody(r *http.Response) string {
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		return "<read error: " + err.Error() + ">"
+	}
+	return string(b)
+}
+
+func mustDecodeJSON(t *testing.T, r *http.Response, into any) {
+	t.Helper()
+	if err := json.NewDecoder(r.Body).Decode(into); err != nil {
+		t.Fatalf("decode JSON: %v", err)
+	}
+}

--- a/gateway/lifecycle-gateway/doc.go
+++ b/gateway/lifecycle-gateway/doc.go
@@ -1,0 +1,43 @@
+// Package lifecyclegateway exposes the pkg/lifecycle.Manager's
+// read + operator-mutation surface over HTTP and WebSocket. ADR-047
+// PR 3. The endpoints are deliberately framework-shape — every
+// app's lifecycle-managed workflow types (drone missions, sensor
+// lifecycles, manufacturing batches, scenario executions, API
+// request lifecycles) become uniformly inspectable + operator-
+// patchable through one gateway component.
+//
+// Wiring contract:
+//
+//   - The component reads Dependencies.LifecycleManager. Apps that
+//     declare no lifecycle-managed entity types simply don't run
+//     this gateway; apps that DO run it pass the same Manager into
+//     Dependencies that the rule processor consumes for
+//     lifecycle_* actions + $entity.lifecycle.* substitutions.
+//   - RegisterHTTPHandlers mounts the routes under the configured
+//     PathPrefix (default "/workflows"). Each app deployment chooses
+//     where in its gateway placement to mount this — there's no
+//     hardcoded port or standalone binary.
+//
+// Endpoint surface (ADR-047 line 305-315):
+//
+//   - GET    {prefix}                                     → list registered workflow types + instance counts
+//   - GET    {prefix}/{type}                              → list instances (Phase/Active/Match/Limit/Offset query params)
+//   - GET    {prefix}/{type}/{id}                         → get full instance state
+//   - GET    {prefix}/{type}/{id}/history                 → phase transition history (KV revision replay)
+//   - GET    {prefix}/{type}/{id}/children                → child instance summaries
+//   - POST   {prefix}/{type}/{id}/state                   → operator patch (validates lifecycle:"operator_writable")
+//   - POST   {prefix}/{type}/{id}/transition              → operator-initiated transition (validates transitions table)
+//   - GET    {prefix}/{type}?stream=true (websocket)      → live updates via Manager.Watch
+//
+// All endpoints loud-fail on missing manager / unknown workflow /
+// unknown entity rather than silently returning empty results.
+// Error responses use a uniform JSON envelope {"error": "..."} so
+// operator dashboards can render the underlying cause without
+// per-endpoint parsing.
+//
+// Scaling cliffs documented at ADR-047 § "Scaling cliff (operator
+// guidance)" apply to the gateway's List/Watch/History/Children
+// paths since they are direct Manager pass-throughs. Operators
+// observing dashboard latency at high cardinality should file a
+// bottleneck issue per the ADR's v2 secondary-index upgrade path.
+package lifecyclegateway

--- a/gateway/lifecycle-gateway/handlers.go
+++ b/gateway/lifecycle-gateway/handlers.go
@@ -1,0 +1,523 @@
+// Package lifecyclegateway — HTTP + WebSocket handlers.
+//
+// Single catch-all `serveHTTP` dispatches by trimmed path + method.
+// Path-tree shape (ADR-047 § Operator API):
+//
+//	{root}                                  GET   → list workflow types + counts
+//	{root}/{type}                           GET   → list instances (query params for filters) — or WS upgrade when ?stream=true
+//	{root}/{type}/{id}                      GET   → instance state
+//	{root}/{type}/{id}/history              GET   → phase-transition history
+//	{root}/{type}/{id}/children             GET   → child instances
+//	{root}/{type}/{id}/state                POST  → operator patch
+//	{root}/{type}/{id}/transition           POST  → operator transition
+//
+// Error model: every non-2xx response is `{"error": "..."}` so
+// operator dashboards parse one envelope. The mapping from
+// pkg/lifecycle errors → HTTP status is centralized in
+// `errorToStatus`. Workflow-not-registered + entity-not-found map
+// to 404; field-not-operator-writable + invalid-transition +
+// terminal-phase map to 400 (client must fix); retries-exhausted
+// maps to 409 (race with another writer); anything else 500.
+package lifecyclegateway
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+)
+
+// errorResponse is the uniform error envelope. Single field is
+// intentional — dashboards render `error` directly without per-error
+// per-endpoint parsing logic. When pkg/errs gains structured codes
+// (post-v1), this envelope grows additively.
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// serveHTTP is the catch-all entrypoint registered on the parent
+// mux. Dispatches by trimmed-path + method.
+func (c *Component) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	// Trim the configured root prefix. The mux already routed us
+	// here because the prefix matched, so we just need the
+	// remainder.
+	root := strings.TrimSuffix(r.URL.Path, "/")
+	rootPrefix := c.routePrefix()
+	relative := strings.TrimPrefix(root, strings.TrimSuffix(rootPrefix, "/"))
+	relative = strings.Trim(relative, "/")
+
+	// Segment splitting. Empty `relative` means root path.
+	var segments []string
+	if relative != "" {
+		segments = strings.Split(relative, "/")
+	}
+
+	switch len(segments) {
+	case 0:
+		c.handleListWorkflows(w, r)
+	case 1:
+		// {type} — list instances OR WebSocket upgrade when
+		// ?stream=true. The WS path stays under the same URL for
+		// CORS and discovery parity (operator dashboards point at
+		// the workflow type, add ?stream=true to subscribe).
+		if r.URL.Query().Get("stream") == "true" {
+			c.handleWebSocket(w, r, segments[0])
+			return
+		}
+		c.handleListInstances(w, r, segments[0])
+	case 2:
+		// {type}/{id} → instance state
+		c.handleGetInstance(w, r, segments[0], segments[1])
+	case 3:
+		c.handleSubresource(w, r, segments[0], segments[1], segments[2])
+	default:
+		c.writeError(w, http.StatusNotFound,
+			fmt.Sprintf("no route for path %q (lifecycle gateway expects 0-3 segments under the root)", r.URL.Path))
+		c.recordRequest(false, "no route")
+	}
+}
+
+// routePrefix recomputes the mounted root for path stripping.
+// Mirrors the math in RegisterHTTPHandlers; kept duplicated rather
+// than stored to avoid a mu.RLock per request — the values are
+// configured once at startup and don't move.
+func (c *Component) routePrefix() string {
+	// The HTTP server passes us the URL.Path verbatim; we don't have
+	// access to the parent prefix here unless we cache it. Cache it
+	// at RegisterHTTPHandlers time via c.mu so serveHTTP can subtract
+	// it back out.
+	c.mu.RLock()
+	root := c.cachedRoot
+	c.mu.RUnlock()
+	if root == "" {
+		// Pre-RegisterHTTPHandlers calls (shouldn't happen in
+		// production but possible in test fixtures that wire raw):
+		// strip nothing and route from the bare URL.
+		return ""
+	}
+	return root
+}
+
+// --- Endpoint handlers ---
+
+// handleListWorkflows returns the registered workflow types with
+// per-phase instance counts. Phase counts are computed via a
+// best-effort List(workflow, ListOptions{}) — at high cardinality
+// this is O(N) per workflow type so dashboards should poll
+// sparingly. The structured counts give operators an "at a glance"
+// overview without hitting individual workflow endpoints.
+//
+// Per-workflow List errors surface as a per-entry `counts_error`
+// field rather than blowing up the whole response — a dashboard
+// rendering 12 workflow types shouldn't lose all of them because
+// one bucket is briefly unreachable. The loud signal is BOTH the
+// per-entry `counts_error` string in the response AND a Warn log
+// per failed workflow so operators see the partial-degradation
+// clearly (B2 reviewer fix — silent err=nil-fallthrough was
+// rendering "0 instances in every phase" with full operator
+// confidence, contradicting ADR-047's loud-fail discipline).
+func (c *Component) handleListWorkflows(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		c.writeError(w, http.StatusMethodNotAllowed, "GET only")
+		c.recordRequest(false, "method not allowed")
+		return
+	}
+	defs := c.manager.ListWorkflows()
+	type entry struct {
+		Workflow               string         `json:"workflow"`
+		KVBucket               string         `json:"kv_bucket"`
+		Phases                 []string       `json:"phases"`
+		TerminalPhases         []string       `json:"terminal_phases"`
+		OperatorWritableFields []string       `json:"operator_writable_fields"`
+		Counts                 map[string]int `json:"counts_by_phase"`
+		CountsError            string         `json:"counts_error,omitempty"`
+	}
+	out := make([]entry, 0, len(defs))
+	for _, def := range defs {
+		e := entry{
+			Workflow:               def.Workflow,
+			KVBucket:               def.KVBucket,
+			Phases:                 def.Transitions.Phases(),
+			TerminalPhases:         def.Transitions.TerminalPhases(),
+			OperatorWritableFields: def.OperatorWritableFields,
+			Counts:                 map[string]int{},
+		}
+		instances, err := c.manager.List(r.Context(), def.Workflow, lifecycle.ListOptions{})
+		if err != nil {
+			e.CountsError = err.Error()
+			c.logger.Warn("lifecycle-gateway: List failed for workflow during counts aggregation",
+				slog.String("workflow", def.Workflow),
+				slog.String("error", err.Error()))
+		} else {
+			for _, inst := range instances {
+				e.Counts[inst.Phase()]++
+			}
+		}
+		out = append(out, e)
+	}
+	c.writeJSON(w, http.StatusOK, out)
+	c.recordRequest(true, "")
+}
+
+// handleListInstances pages through Manager.List with query-param
+// filters. Field-equality Match values are accepted as `match.<field>=<value>`
+// query params. Values stay string-typed at the gateway boundary;
+// reflection-based comparison inside pkg/lifecycle handles type
+// coercion against the registered struct.
+func (c *Component) handleListInstances(w http.ResponseWriter, r *http.Request, workflow string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		c.writeError(w, http.StatusMethodNotAllowed, "GET only")
+		c.recordRequest(false, "method not allowed")
+		return
+	}
+	q := r.URL.Query()
+	opts := lifecycle.ListOptions{
+		Phase:  q.Get("phase"),
+		Active: q.Get("active") == "true",
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			c.writeError(w, http.StatusBadRequest, "invalid limit (must be a non-negative integer)")
+			c.recordRequest(false, "invalid limit")
+			return
+		}
+		opts.Limit = n
+	}
+	if v := q.Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			c.writeError(w, http.StatusBadRequest, "invalid offset (must be a non-negative integer)")
+			c.recordRequest(false, "invalid offset")
+			return
+		}
+		opts.Offset = n
+	}
+	// match.<field>=value query params populate ListOptions.Match.
+	for k, vs := range q {
+		if !strings.HasPrefix(k, "match.") || len(vs) == 0 {
+			continue
+		}
+		if opts.Match == nil {
+			opts.Match = make(map[string]any, 1)
+		}
+		opts.Match[strings.TrimPrefix(k, "match.")] = vs[0]
+	}
+
+	instances, err := c.manager.List(r.Context(), workflow, opts)
+	if err != nil {
+		c.writeErrorFromLifecycle(w, "list", err)
+		return
+	}
+	if instances == nil {
+		instances = []lifecycle.Participant{}
+	}
+	c.writeJSON(w, http.StatusOK, instances)
+	c.recordRequest(true, "")
+}
+
+// handleGetInstance returns the full state of one Participant.
+func (c *Component) handleGetInstance(w http.ResponseWriter, r *http.Request, workflow, entityID string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		c.writeError(w, http.StatusMethodNotAllowed, "GET only")
+		c.recordRequest(false, "method not allowed")
+		return
+	}
+	p, err := c.manager.Get(r.Context(), workflow, entityID)
+	if err != nil {
+		c.writeErrorFromLifecycle(w, "get", err)
+		return
+	}
+	c.writeJSON(w, http.StatusOK, p)
+	c.recordRequest(true, "")
+}
+
+// handleSubresource dispatches /{type}/{id}/{subresource} routes.
+func (c *Component) handleSubresource(w http.ResponseWriter, r *http.Request, workflow, entityID, sub string) {
+	switch sub {
+	case "history":
+		c.handleHistory(w, r, workflow, entityID)
+	case "children":
+		c.handleChildren(w, r, workflow, entityID)
+	case "state":
+		c.handleStatePatch(w, r, workflow, entityID)
+	case "transition":
+		c.handleOperatorTransition(w, r, workflow, entityID)
+	default:
+		c.writeError(w, http.StatusNotFound,
+			fmt.Sprintf("unknown subresource %q (supported: history, children, state, transition)", sub))
+		c.recordRequest(false, "unknown subresource")
+	}
+}
+
+// handleHistory returns the KV-revision-derived phase history.
+func (c *Component) handleHistory(w http.ResponseWriter, r *http.Request, workflow, entityID string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		c.writeError(w, http.StatusMethodNotAllowed, "GET only")
+		c.recordRequest(false, "method not allowed")
+		return
+	}
+	events, err := c.manager.History(r.Context(), workflow, entityID)
+	if err != nil {
+		c.writeErrorFromLifecycle(w, "history", err)
+		return
+	}
+	if events == nil {
+		events = []lifecycle.TransitionEvent{}
+	}
+	c.writeJSON(w, http.StatusOK, events)
+	c.recordRequest(true, "")
+}
+
+// handleChildren returns Participants whose ParentEntityID matches
+// the given entity, across all registered workflows.
+func (c *Component) handleChildren(w http.ResponseWriter, r *http.Request, _ /* workflow */, entityID string) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		c.writeError(w, http.StatusMethodNotAllowed, "GET only")
+		c.recordRequest(false, "method not allowed")
+		return
+	}
+	// Workflow is ignored: Children scans by ParentEntityID across
+	// all workflows. The route includes {workflow} for symmetry
+	// with the other endpoints; the value just isn't load-bearing
+	// for the underlying call. Documented in the OpenAPI/README.
+	kids, err := c.manager.Children(r.Context(), entityID)
+	if err != nil {
+		c.writeErrorFromLifecycle(w, "children", err)
+		return
+	}
+	if kids == nil {
+		kids = []lifecycle.Participant{}
+	}
+	c.writeJSON(w, http.StatusOK, kids)
+	c.recordRequest(true, "")
+}
+
+// handleStatePatch applies a JSON-body operator patch via
+// Manager.UpdateFromOperator. Validation against
+// lifecycle:"operator_writable" tags runs in pkg/lifecycle; the
+// gateway just shuttles the body.
+func (c *Component) handleStatePatch(w http.ResponseWriter, r *http.Request, workflow, entityID string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		c.writeError(w, http.StatusMethodNotAllowed, "POST only")
+		c.recordRequest(false, "method not allowed")
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, c.config.MaxBodyBytes)
+	var patch map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		c.writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("invalid JSON body: %s", err.Error()))
+		c.recordRequest(false, "invalid body")
+		return
+	}
+	if err := c.manager.UpdateFromOperator(r.Context(), workflow, entityID, patch); err != nil {
+		c.writeErrorFromLifecycle(w, "state_patch", err)
+		return
+	}
+	c.writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	c.recordRequest(true, "")
+}
+
+// transitionRequest is the body shape for POST .../transition.
+// Phase is required; Note is optional operator commentary that lands
+// in the TransitionEvent.Note for audit.
+type transitionRequest struct {
+	Phase string `json:"phase"`
+	Note  string `json:"note,omitempty"`
+}
+
+// handleOperatorTransition runs an explicit operator-initiated
+// transition. Phase must be declared in the registered transitions
+// table; current→target must be a declared edge.
+func (c *Component) handleOperatorTransition(w http.ResponseWriter, r *http.Request, workflow, entityID string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		c.writeError(w, http.StatusMethodNotAllowed, "POST only")
+		c.recordRequest(false, "method not allowed")
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, c.config.MaxBodyBytes)
+	var req transitionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		c.writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("invalid JSON body: %s", err.Error()))
+		c.recordRequest(false, "invalid body")
+		return
+	}
+	if strings.TrimSpace(req.Phase) == "" {
+		c.writeError(w, http.StatusBadRequest, "phase is required")
+		c.recordRequest(false, "missing phase")
+		return
+	}
+	if err := c.manager.Transition(r.Context(), workflow, entityID, req.Phase,
+		lifecycle.TransitionSourceOperator, req.Note); err != nil {
+		c.writeErrorFromLifecycle(w, "transition", err)
+		return
+	}
+	c.writeJSON(w, http.StatusOK, map[string]any{"ok": true, "phase": req.Phase})
+	c.recordRequest(true, "")
+}
+
+// handleWebSocket upgrades the connection and streams Participants
+// from Manager.Watch to the client. The Watch contract delivers a
+// bootstrap snapshot followed by live updates; this handler
+// JSON-encodes each Participant per-message.
+//
+// The client controls the lifetime: closing the WS or canceling
+// the request context cancels Watch's ctx, which closes Manager's
+// watcher goroutine + the underlying NATS subscription. Slow
+// consumers blow through the per-connection buffer
+// (c.config.WatchBufferSize); the gateway closes the connection
+// rather than blocking the watcher (slow consumer → loud close,
+// per ADR-047's loud-fail discipline).
+func (c *Component) handleWebSocket(w http.ResponseWriter, r *http.Request, workflow string) {
+	if !c.config.EnableWebSocket {
+		c.writeError(w, http.StatusForbidden,
+			"websocket streaming disabled (set enable_websocket=true in config)")
+		c.recordRequest(false, "websocket disabled")
+		return
+	}
+	conn, err := c.upgrade.Upgrade(w, r, nil)
+	if err != nil {
+		c.logger.Warn("websocket upgrade failed",
+			slog.String("workflow", workflow),
+			slog.String("error", err.Error()))
+		c.recordRequest(false, "ws upgrade failed")
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	c.wsConnections.Add(1)
+	defer c.wsConnections.Add(-1)
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	updates, err := c.manager.Watch(ctx, workflow)
+	if err != nil {
+		// Best-effort send the error frame before closing; if the
+		// client already dropped, the write fails silently.
+		_ = conn.WriteJSON(errorResponse{Error: err.Error()})
+		c.recordRequest(false, "watch error")
+		return
+	}
+	c.recordRequest(true, "")
+
+	// Reader goroutine: detect client-side close + drain control
+	// frames. We don't consume client messages but must keep the
+	// reader alive so gorilla/websocket processes pings.
+	go func() {
+		defer cancel()
+		for {
+			if _, _, err := conn.NextReader(); err != nil {
+				return
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case p, ok := <-updates:
+			if !ok {
+				return
+			}
+			if err := conn.WriteJSON(p); err != nil {
+				// Slow consumer or peer drop. Cancel + return.
+				return
+			}
+		}
+	}
+}
+
+// --- helpers ---
+
+func (c *Component) writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if body == nil {
+		return
+	}
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		c.logger.Warn("response write failed",
+			slog.String("error", err.Error()))
+	}
+}
+
+func (c *Component) writeError(w http.ResponseWriter, status int, msg string) {
+	c.writeJSON(w, status, errorResponse{Error: msg})
+}
+
+// writeErrorFromLifecycle maps a pkg/lifecycle error to the right
+// HTTP status and writes the envelope. Records the failure for
+// metrics.
+//
+// For mapped sentinels (status != 500), the underlying pkg/lifecycle
+// message ships through verbatim — operators NEED "field=X is not
+// operator_writable" / "transition from terminal" detail to fix
+// their request. For unmapped errors (status 500, infra-shaped), the
+// response carries a canned "internal error" + label so the wire
+// doesn't leak NATS subjects, KV keys, or trace IDs to potentially
+// untrusted operators; the full error is logged at Error level for
+// post-hoc inspection (S1 reviewer fix — verbose-leak on 500-class
+// was the trade-off space).
+func (c *Component) writeErrorFromLifecycle(w http.ResponseWriter, label string, err error) {
+	status := errorToStatus(err)
+	if status == http.StatusInternalServerError {
+		c.logger.Error("lifecycle-gateway: internal error",
+			slog.String("op", label),
+			slog.String("error", err.Error()))
+		c.writeError(w, status,
+			fmt.Sprintf("%s: internal error (operator details in server log)", label))
+		c.recordRequest(false, err.Error())
+		return
+	}
+	c.writeError(w, status, fmt.Sprintf("%s: %s", label, err.Error()))
+	c.recordRequest(false, err.Error())
+}
+
+// errorToStatus maps pkg/lifecycle sentinels to HTTP status codes.
+// The mapping is the operator-facing contract: when a 404 vs 400 vs
+// 409 distinction changes here, dashboards must follow. Anything
+// unrecognised maps to 500 — the gateway doesn't gloss errors.
+func errorToStatus(err error) int {
+	switch {
+	case errors.Is(err, lifecycle.ErrWorkflowNotRegistered):
+		return http.StatusNotFound
+	case errors.Is(err, lifecycle.ErrEntityNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, lifecycle.ErrFieldNotOperatorWritable):
+		return http.StatusBadRequest
+	case errors.Is(err, lifecycle.ErrInvalidTransition):
+		return http.StatusBadRequest
+	case errors.Is(err, lifecycle.ErrTerminalPhase):
+		return http.StatusBadRequest
+	case errors.Is(err, lifecycle.ErrUpdateRetriesExhausted):
+		return http.StatusConflict
+	}
+	return http.StatusInternalServerError
+}
+
+// setCachedRoot records the fully-resolved mount root for serveHTTP
+// to subtract when computing path segments. Called by
+// RegisterHTTPHandlers; protected by mu so a hot-reload of the
+// component can safely re-register without racing serveHTTP readers.
+func (c *Component) setCachedRoot(root string) {
+	c.mu.Lock()
+	c.cachedRoot = root
+	c.mu.Unlock()
+}

--- a/gateway/lifecycle-gateway/handlers.go
+++ b/gateway/lifecycle-gateway/handlers.go
@@ -83,15 +83,14 @@ func (c *Component) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// routePrefix recomputes the mounted root for path stripping.
-// Mirrors the math in RegisterHTTPHandlers; kept duplicated rather
-// than stored to avoid a mu.RLock per request — the values are
-// configured once at startup and don't move.
+// routePrefix returns the mounted root for path stripping. The root
+// is computed once in RegisterHTTPHandlers from the parent prefix +
+// config.PathPrefix and stored on c.cachedRoot; this getter reads
+// it under mu.RLock so a hot-reload of the component (re-running
+// RegisterHTTPHandlers with a different prefix) doesn't race
+// in-flight serveHTTP readers. The RLock is uncontended in steady
+// state.
 func (c *Component) routePrefix() string {
-	// The HTTP server passes us the URL.Path verbatim; we don't have
-	// access to the parent prefix here unless we cache it. Cache it
-	// at RegisterHTTPHandlers time via c.mu so serveHTTP can subtract
-	// it back out.
 	c.mu.RLock()
 	root := c.cachedRoot
 	c.mu.RUnlock()
@@ -379,10 +378,10 @@ func (c *Component) handleOperatorTransition(w http.ResponseWriter, r *http.Requ
 // The client controls the lifetime: closing the WS or canceling
 // the request context cancels Watch's ctx, which closes Manager's
 // watcher goroutine + the underlying NATS subscription. Slow
-// consumers blow through the per-connection buffer
-// (c.config.WatchBufferSize); the gateway closes the connection
-// rather than blocking the watcher (slow consumer → loud close,
-// per ADR-047's loud-fail discipline).
+// consumers exceed gorilla/websocket's internal write buffer; when
+// WriteJSON fails the gateway closes the connection rather than
+// blocking the watcher (slow consumer → loud close per ADR-047's
+// loud-fail discipline).
 func (c *Component) handleWebSocket(w http.ResponseWriter, r *http.Request, workflow string) {
 	if !c.config.EnableWebSocket {
 		c.writeError(w, http.StatusForbidden,

--- a/gateway/lifecycle-gateway/handlers.go
+++ b/gateway/lifecycle-gateway/handlers.go
@@ -383,7 +383,7 @@ func (c *Component) handleOperatorTransition(w http.ResponseWriter, r *http.Requ
 // blocking the watcher (slow consumer → loud close per ADR-047's
 // loud-fail discipline).
 func (c *Component) handleWebSocket(w http.ResponseWriter, r *http.Request, workflow string) {
-	if !c.config.EnableWebSocket {
+	if !c.config.wsEnabled() {
 		c.writeError(w, http.StatusForbidden,
 			"websocket streaming disabled (set enable_websocket=true in config)")
 		c.recordRequest(false, "websocket disabled")

--- a/gateway/lifecycle-gateway/openapi.go
+++ b/gateway/lifecycle-gateway/openapi.go
@@ -1,0 +1,184 @@
+// Package lifecyclegateway — OpenAPI spec.
+//
+// The lifecycle-gateway implements gateway.OpenAPIProvider so the
+// operator-facing endpoints show up in the framework's auto-
+// generated OpenAPI surface (specs/openapi.v3.yaml). Matches the
+// pattern from gateway/graph-gateway/openapi.go.
+//
+// Path templates use literal "{prefix}/{type}/{id}" placeholders —
+// the actual path prefix is operator-configurable per deployment,
+// so the spec advertises the shape, not the bound paths.
+package lifecyclegateway
+
+import (
+	"reflect"
+
+	"github.com/c360studio/semstreams/service"
+)
+
+// StatePatchRequest is the JSON body shape for POST {type}/{id}/state.
+// Reflective-typed schema; the actual content is a free-form
+// `map[string]any` field-name → value patch validated server-side
+// against `lifecycle:"operator_writable"` tags.
+type StatePatchRequest map[string]any
+
+// TransitionRequest is the JSON body shape for POST {type}/{id}/transition.
+// Phase is required; Note is operator commentary persisted into the
+// TransitionEvent.Note for audit.
+type TransitionRequest struct {
+	Phase string `json:"phase"`
+	Note  string `json:"note,omitempty"`
+}
+
+func init() {
+	service.RegisterOpenAPISpec(ComponentName, lifecycleGatewayOpenAPISpec())
+}
+
+// OpenAPISpec implements gateway.OpenAPIProvider.
+func (c *Component) OpenAPISpec() *service.OpenAPISpec {
+	return lifecycleGatewayOpenAPISpec()
+}
+
+// lifecycleGatewayOpenAPISpec returns the OpenAPI spec for the
+// 7 HTTP endpoints + WebSocket. Path templates use the
+// operator-facing shape from ADR-047 § Operator API.
+func lifecycleGatewayOpenAPISpec() *service.OpenAPISpec {
+	return &service.OpenAPISpec{
+		Tags: []service.TagSpec{
+			{Name: "Lifecycle", Description: "pkg/lifecycle.Manager operator read + mutation surface (ADR-047)"},
+		},
+		Paths: map[string]service.PathSpec{
+			"/workflows": {
+				GET: &service.OperationSpec{
+					Summary:     "List registered workflow types",
+					Description: "Returns the workflow types registered with the Manager + per-phase instance counts. Per-workflow List errors surface as a `counts_error` field on the failing entry so partial degradation is visible without breaking the whole response.",
+					Tags:        []string{"Lifecycle"},
+					Responses: map[string]service.ResponseSpec{
+						"200": {Description: "Workflow types with instance counts", ContentType: "application/json", IsArray: true},
+						"405": {Description: "Method not allowed (GET only)"},
+					},
+				},
+			},
+			"/workflows/{type}": {
+				GET: &service.OperationSpec{
+					Summary:     "List instances of a workflow type",
+					Description: "Lists Participant instances for the given workflow type with filter + pagination query parameters. When ?stream=true is set, the connection is upgraded to a WebSocket that streams bootstrap + live updates from Manager.Watch.",
+					Tags:        []string{"Lifecycle"},
+					Parameters: []service.ParameterSpec{
+						{Name: "type", In: "path", Required: true, Description: "Workflow type identifier (matches Participant.Workflow())", Schema: service.Schema{Type: "string"}},
+						{Name: "phase", In: "query", Description: "Filter to instances in this phase", Schema: service.Schema{Type: "string"}},
+						{Name: "active", In: "query", Description: "Filter to non-terminal instances when true", Schema: service.Schema{Type: "boolean"}},
+						{Name: "limit", In: "query", Description: "Maximum results returned (default unlimited)", Schema: service.Schema{Type: "integer"}},
+						{Name: "offset", In: "query", Description: "Skip the first N matching results for pagination", Schema: service.Schema{Type: "integer"}},
+						{Name: "match.<field>", In: "query", Description: "Field-equality filter (any number; one query param per field)", Schema: service.Schema{Type: "string"}},
+						{Name: "stream", In: "query", Description: "Set to 'true' to upgrade to a WebSocket carrying Manager.Watch updates", Schema: service.Schema{Type: "string"}},
+					},
+					Responses: map[string]service.ResponseSpec{
+						"200": {Description: "Instance array (or WebSocket frames when ?stream=true)", ContentType: "application/json", IsArray: true},
+						"400": {Description: "Invalid query parameter"},
+						"403": {Description: "WebSocket streaming disabled (enable_websocket=false)"},
+						"404": {Description: "Workflow type not registered"},
+						"405": {Description: "Method not allowed (GET only)"},
+					},
+				},
+			},
+			"/workflows/{type}/{id}": {
+				GET: &service.OperationSpec{
+					Summary:     "Get instance state",
+					Description: "Returns the full Participant state for the given workflow type + entity ID.",
+					Tags:        []string{"Lifecycle"},
+					Parameters: []service.ParameterSpec{
+						{Name: "type", In: "path", Required: true, Description: "Workflow type identifier", Schema: service.Schema{Type: "string"}},
+						{Name: "id", In: "path", Required: true, Description: "Entity ID (Participant.EntityID())", Schema: service.Schema{Type: "string"}},
+					},
+					Responses: map[string]service.ResponseSpec{
+						"200": {Description: "Participant state", ContentType: "application/json"},
+						"404": {Description: "Workflow or entity not found"},
+						"405": {Description: "Method not allowed (GET only)"},
+					},
+				},
+			},
+			"/workflows/{type}/{id}/history": {
+				GET: &service.OperationSpec{
+					Summary:     "List phase-transition history",
+					Description: "Returns the phase-transition history derived from KV revision replay. Each entry includes from/to phases, wallclock timestamp, the TransitionSource (rule/operator/component/framework), and any operator-supplied note.",
+					Tags:        []string{"Lifecycle"},
+					Parameters: []service.ParameterSpec{
+						{Name: "type", In: "path", Required: true, Description: "Workflow type identifier", Schema: service.Schema{Type: "string"}},
+						{Name: "id", In: "path", Required: true, Description: "Entity ID", Schema: service.Schema{Type: "string"}},
+					},
+					Responses: map[string]service.ResponseSpec{
+						"200": {Description: "TransitionEvent array", ContentType: "application/json", IsArray: true},
+						"404": {Description: "Workflow or entity not found"},
+						"405": {Description: "Method not allowed (GET only)"},
+					},
+				},
+			},
+			"/workflows/{type}/{id}/children": {
+				GET: &service.OperationSpec{
+					Summary:     "List child instances",
+					Description: "Returns Participants whose ParentEntityID matches the given entity, across all registered workflows. The {type} segment is required for routing symmetry with the other endpoints; the underlying Manager.Children call scans cross-workflow.",
+					Tags:        []string{"Lifecycle"},
+					Parameters: []service.ParameterSpec{
+						{Name: "type", In: "path", Required: true, Description: "Workflow type identifier (routing-only; cross-workflow scan ignores it)", Schema: service.Schema{Type: "string"}},
+						{Name: "id", In: "path", Required: true, Description: "Parent entity ID", Schema: service.Schema{Type: "string"}},
+					},
+					Responses: map[string]service.ResponseSpec{
+						"200": {Description: "Child Participant array", ContentType: "application/json", IsArray: true},
+						"405": {Description: "Method not allowed (GET only)"},
+					},
+				},
+			},
+			"/workflows/{type}/{id}/state": {
+				POST: &service.OperationSpec{
+					Summary:     "Operator patch (state mutation)",
+					Description: "Applies a JSON-body patch to the Participant. The body is a `{<field>: <value>}` map; every field MUST be tagged `lifecycle:\"operator_writable\"` on the registered state struct. Identity (`lifecycle:\"id\"`) and phase fields are protected by the same default-deny gate the rule layer enforces (ADR-047 § AssertRuleWritable).",
+					Tags:        []string{"Lifecycle"},
+					Parameters: []service.ParameterSpec{
+						{Name: "type", In: "path", Required: true, Description: "Workflow type identifier", Schema: service.Schema{Type: "string"}},
+						{Name: "id", In: "path", Required: true, Description: "Entity ID", Schema: service.Schema{Type: "string"}},
+					},
+					RequestBody: &service.RequestBodySpec{
+						Description: "Field-name → value patch map",
+						Required:    true,
+						SchemaRef:   "#/components/schemas/StatePatchRequest",
+					},
+					Responses: map[string]service.ResponseSpec{
+						"200": {Description: "Patch applied", ContentType: "application/json"},
+						"400": {Description: "Invalid body OR field is not operator_writable OR type mismatch"},
+						"404": {Description: "Workflow or entity not found"},
+						"405": {Description: "Method not allowed (POST only)"},
+						"409": {Description: "Optimistic-concurrency retries exhausted"},
+						"413": {Description: "Request body exceeds max_body_bytes"},
+					},
+				},
+			},
+			"/workflows/{type}/{id}/transition": {
+				POST: &service.OperationSpec{
+					Summary:     "Operator-initiated phase transition",
+					Description: "Transitions the Participant to the requested phase via Manager.Transition with TransitionSourceOperator. Phase must be declared in the workflow's Transitions table; current → target must be a declared edge; current must not be terminal.",
+					Tags:        []string{"Lifecycle"},
+					Parameters: []service.ParameterSpec{
+						{Name: "type", In: "path", Required: true, Description: "Workflow type identifier", Schema: service.Schema{Type: "string"}},
+						{Name: "id", In: "path", Required: true, Description: "Entity ID", Schema: service.Schema{Type: "string"}},
+					},
+					RequestBody: &service.RequestBodySpec{
+						Description: "Target phase + optional operator note for the audit trail",
+						Required:    true,
+						SchemaRef:   "#/components/schemas/TransitionRequest",
+					},
+					Responses: map[string]service.ResponseSpec{
+						"200": {Description: "Transition applied", ContentType: "application/json"},
+						"400": {Description: "Invalid body OR target phase undeclared OR edge undeclared OR current phase terminal"},
+						"404": {Description: "Workflow or entity not found"},
+						"405": {Description: "Method not allowed (POST only)"},
+						"413": {Description: "Request body exceeds max_body_bytes"},
+					},
+				},
+			},
+		},
+		RequestBodyTypes: []reflect.Type{
+			reflect.TypeOf(TransitionRequest{}),
+		},
+	}
+}

--- a/pkg/lifecycle/participant.go
+++ b/pkg/lifecycle/participant.go
@@ -135,27 +135,27 @@ const (
 type TransitionEvent struct {
 	// From is the phase the entity was in before the transition.
 	// Empty string for the Create event (entity didn't exist before).
-	From string
+	From string `json:"from"`
 
 	// To is the phase the entity entered. Equal to the entity's
 	// Phase() at the time of the transition.
-	To string
+	To string `json:"to"`
 
 	// At is the wallclock time the transition was committed to KV.
 	// Sourced from the KV revision's metadata, not from app code
 	// — so it's authoritative across restarts and clock skew.
-	At time.Time
+	At time.Time `json:"at"`
 
 	// Triggered identifies what caused the transition. Closed set
 	// of values defined by TransitionSource. Operator dashboards
 	// can filter / color-code by this field; audit trails
 	// distinguish operator-initiated from automated transitions.
-	Triggered TransitionSource
+	Triggered TransitionSource `json:"triggered"`
 
 	// Note is an optional free-text annotation. Manager.Fail uses
 	// this to carry the failure reason; Manager.Transition can pass
 	// arbitrary context. Empty by default.
-	Note string
+	Note string `json:"note,omitempty"`
 }
 
 // WorkflowDef describes a registered workflow type. Returned by
@@ -168,21 +168,21 @@ type TransitionEvent struct {
 type WorkflowDef struct {
 	// Workflow is the workflow type identifier (matches what was
 	// passed to Manager.Register and what Participant.Workflow returns).
-	Workflow string
+	Workflow string `json:"workflow"`
 
 	// Transitions is the declared phase-transition table registered
 	// for this workflow. The state-machine diagram is derivable
 	// directly from this map.
-	Transitions Transitions
+	Transitions Transitions `json:"transitions"`
 
 	// KVBucket is the NATS KV bucket this workflow's instances live
 	// in. Operator API uses this to route List/Watch operations.
-	KVBucket string
+	KVBucket string `json:"kv_bucket"`
 
 	// OperatorWritableFields lists the JSON field paths that are
 	// tagged `lifecycle:"operator_writable"` on the registered state
 	// struct. Used by UpdateFromOperator to enforce default-deny;
 	// also exposed in the operator API for clients to know which
 	// fields are patchable.
-	OperatorWritableFields []string
+	OperatorWritableFields []string `json:"operator_writable_fields"`
 }

--- a/processor/rule/factory.go
+++ b/processor/rule/factory.go
@@ -86,6 +86,16 @@ func CreateRuleProcessor(rawConfig json.RawMessage, deps component.Dependencies)
 	// unmarshal incoming envelopes against the shared payload registry.
 	processor.SetDecoder(message.NewDecoder(deps.PayloadRegistry))
 
+	// Propagate the Lifecycle harness Manager (ADR-047) so the
+	// lifecycle_* action family + $entity.lifecycle.* condition-field
+	// resolution can dispatch through it. Nil-safe: apps without
+	// lifecycle-managed entity types pass no Manager and the rule
+	// engine surfaces a wiring error if a rule references the
+	// harness anyway.
+	if deps.LifecycleManager != nil {
+		processor.SetLifecycleManager(deps.LifecycleManager)
+	}
+
 	// Set logger from dependencies
 	logger := deps.Logger
 	if logger == nil {

--- a/schemas/lifecycle-gateway.v1.json
+++ b/schemas/lifecycle-gateway.v1.json
@@ -15,7 +15,7 @@
     },
     "enable_websocket": {
       "type": "boolean",
-      "description": "Enable WebSocket streaming on GET {prefix}/{type}?stream=true via Manager.Watch. Default true. Set to false to disable live-update streaming and keep the gateway poll-only.",
+      "description": "Enable WebSocket streaming on GET {prefix}/{type}?stream=true via Manager.Watch. Default true when omitted. Set to false to disable live-update streaming and keep the gateway poll-only.",
       "category": "basic"
     },
     "max_body_bytes": {

--- a/schemas/lifecycle-gateway.v1.json
+++ b/schemas/lifecycle-gateway.v1.json
@@ -4,7 +4,31 @@
   "type": "object",
   "title": "lifecycle-gateway Configuration",
   "description": "Operator HTTP + WebSocket gateway over pkg/lifecycle.Manager (ADR-047)",
-  "properties": {},
+  "properties": {
+    "allowed_origins": {
+      "type": "array",
+      "description": "WebSocket upgrade Origin allowlist as exact-match strings. Empty list permits all origins and logs a Warn at Start; set explicitly to restrict cross-origin upgrades.",
+      "items": {
+        "type": "string"
+      },
+      "category": "advanced"
+    },
+    "enable_websocket": {
+      "type": "boolean",
+      "description": "Enable WebSocket streaming on GET {prefix}/{type}?stream=true via Manager.Watch. Default true. Set to false to disable live-update streaming and keep the gateway poll-only.",
+      "category": "basic"
+    },
+    "max_body_bytes": {
+      "type": "integer",
+      "description": "Maximum bytes accepted in POST .../state and POST .../transition request bodies. Default 1048576 (1 MiB). Zero or negative means use default.",
+      "category": "advanced"
+    },
+    "path_prefix": {
+      "type": "string",
+      "description": "URL path prefix mounted under the parent component prefix (e.g. \"workflows\" → /lifecycle-gateway/workflows). Default \"workflows\". Must be non-empty after stripping leading/trailing slashes.",
+      "category": "basic"
+    }
+  },
   "required": [],
   "x-component-metadata": {
     "name": "lifecycle-gateway",

--- a/schemas/lifecycle-gateway.v1.json
+++ b/schemas/lifecycle-gateway.v1.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "lifecycle-gateway.v1.json",
+  "type": "object",
+  "title": "lifecycle-gateway Configuration",
+  "description": "Operator HTTP + WebSocket gateway over pkg/lifecycle.Manager (ADR-047)",
+  "properties": {},
+  "required": [],
+  "x-component-metadata": {
+    "name": "lifecycle-gateway",
+    "type": "gateway",
+    "protocol": "http",
+    "domain": "lifecycle",
+    "version": "0.1.0"
+  }
+}

--- a/service/component_manager.go
+++ b/service/component_manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/c360studio/semstreams/model"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/payloadregistry"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
 	"github.com/c360studio/semstreams/pkg/retry"
 	"github.com/c360studio/semstreams/pkg/security"
 	"github.com/c360studio/semstreams/types"
@@ -40,6 +41,7 @@ type ComponentManager struct {
 	registry         *component.Registry
 	toolRegistry     component.ToolRegistryReader           // Shared tool registry plumbed via deps.ToolRegistry to managed components
 	payloadRegistry  *payloadregistry.Registry              // Shared payload registry plumbed via deps.PayloadRegistry to managed components
+	lifecycleManager *lifecycle.Manager                     // Shared Lifecycle harness Manager plumbed via deps.LifecycleManager (ADR-047). Nil when no app workflows are registered.
 	componentConfigs config.ComponentConfigs                // Component configurations
 	platform         types.PlatformMeta                     // Platform identity for components
 	components       map[string]*component.ManagedComponent // Track managed components
@@ -143,11 +145,13 @@ func NewComponentManager(rawConfig json.RawMessage, deps *Dependencies) (Service
 	var registry *component.Registry
 	var toolRegistry component.ToolRegistryReader
 	var payloadRegistry *payloadregistry.Registry
+	var lifecycleManager *lifecycle.Manager
 	if deps != nil {
 		platform = deps.Platform
 		registry = deps.ComponentRegistry
 		toolRegistry = deps.ToolRegistry
 		payloadRegistry = deps.PayloadRegistry
+		lifecycleManager = deps.LifecycleManager
 	}
 
 	// Fallback to creating a new registry if not provided
@@ -161,6 +165,7 @@ func NewComponentManager(rawConfig json.RawMessage, deps *Dependencies) (Service
 		registry:             registry,
 		toolRegistry:         toolRegistry,
 		payloadRegistry:      payloadRegistry,
+		lifecycleManager:     lifecycleManager,
 		componentConfigs:     componentsConfig,
 		platform:             platform,
 		components:           make(map[string]*component.ManagedComponent),
@@ -1536,6 +1541,7 @@ func (cm *ComponentManager) buildComponentDependencies() component.Dependencies 
 		ToolRegistry:      cm.toolRegistry,
 		PayloadRegistry:   cm.payloadRegistry,
 		ComponentRegistry: cm.registry,
+		LifecycleManager:  cm.lifecycleManager,
 	}
 
 	return deps

--- a/service/dependencies.go
+++ b/service/dependencies.go
@@ -10,6 +10,7 @@ import (
 	"github.com/c360studio/semstreams/metric"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/payloadregistry"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
 	"github.com/c360studio/semstreams/types"
 )
 
@@ -32,6 +33,7 @@ type Dependencies struct {
 	ComponentRegistry *component.Registry          // Component registry for ComponentManager
 	ToolRegistry      component.ToolRegistryReader // Shared tool executor registry plumbed to component deps
 	PayloadRegistry   *payloadregistry.Registry    // Shared payload registry plumbed to component deps
+	LifecycleManager  *lifecycle.Manager           // Shared Lifecycle harness Manager (ADR-047), plumbed to component deps (rule processor + lifecycle-gateway). Nil when no app workflows are registered.
 	ServiceManager    *Manager                     // Service manager for accessing other services
 }
 

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -917,6 +917,251 @@ paths:
                         application/json:
                             schema:
                                 type: object
+    /workflows:
+        get:
+            summary: List registered workflow types
+            description: Returns the workflow types registered with the Manager + per-phase instance counts. Per-workflow List errors surface as a `counts_error` field on the failing entry so partial degradation is visible without breaking the whole response.
+            tags:
+                - Lifecycle
+            responses:
+                "200":
+                    description: Workflow types with instance counts
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                "405":
+                    description: Method not allowed (GET only)
+    /workflows/{type}:
+        get:
+            summary: List instances of a workflow type
+            description: Lists Participant instances for the given workflow type with filter + pagination query parameters. When ?stream=true is set, the connection is upgraded to a WebSocket that streams bootstrap + live updates from Manager.Watch.
+            tags:
+                - Lifecycle
+            parameters:
+                - name: type
+                  in: path
+                  required: true
+                  description: Workflow type identifier (matches Participant.Workflow())
+                  schema:
+                    type: string
+                - name: phase
+                  in: query
+                  description: Filter to instances in this phase
+                  schema:
+                    type: string
+                - name: active
+                  in: query
+                  description: Filter to non-terminal instances when true
+                  schema:
+                    type: boolean
+                - name: limit
+                  in: query
+                  description: Maximum results returned (default unlimited)
+                  schema:
+                    type: integer
+                - name: offset
+                  in: query
+                  description: Skip the first N matching results for pagination
+                  schema:
+                    type: integer
+                - name: match.<field>
+                  in: query
+                  description: Field-equality filter (any number; one query param per field)
+                  schema:
+                    type: string
+                - name: stream
+                  in: query
+                  description: Set to 'true' to upgrade to a WebSocket carrying Manager.Watch updates
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: Instance array (or WebSocket frames when ?stream=true)
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                "400":
+                    description: Invalid query parameter
+                "403":
+                    description: WebSocket streaming disabled (enable_websocket=false)
+                "404":
+                    description: Workflow type not registered
+                "405":
+                    description: Method not allowed (GET only)
+    /workflows/{type}/{id}:
+        get:
+            summary: Get instance state
+            description: Returns the full Participant state for the given workflow type + entity ID.
+            tags:
+                - Lifecycle
+            parameters:
+                - name: type
+                  in: path
+                  required: true
+                  description: Workflow type identifier
+                  schema:
+                    type: string
+                - name: id
+                  in: path
+                  required: true
+                  description: Entity ID (Participant.EntityID())
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: Participant state
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                "404":
+                    description: Workflow or entity not found
+                "405":
+                    description: Method not allowed (GET only)
+    /workflows/{type}/{id}/children:
+        get:
+            summary: List child instances
+            description: Returns Participants whose ParentEntityID matches the given entity, across all registered workflows. The {type} segment is required for routing symmetry with the other endpoints; the underlying Manager.Children call scans cross-workflow.
+            tags:
+                - Lifecycle
+            parameters:
+                - name: type
+                  in: path
+                  required: true
+                  description: Workflow type identifier (routing-only; cross-workflow scan ignores it)
+                  schema:
+                    type: string
+                - name: id
+                  in: path
+                  required: true
+                  description: Parent entity ID
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: Child Participant array
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                "405":
+                    description: Method not allowed (GET only)
+    /workflows/{type}/{id}/history:
+        get:
+            summary: List phase-transition history
+            description: Returns the phase-transition history derived from KV revision replay. Each entry includes from/to phases, wallclock timestamp, the TransitionSource (rule/operator/component/framework), and any operator-supplied note.
+            tags:
+                - Lifecycle
+            parameters:
+                - name: type
+                  in: path
+                  required: true
+                  description: Workflow type identifier
+                  schema:
+                    type: string
+                - name: id
+                  in: path
+                  required: true
+                  description: Entity ID
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: TransitionEvent array
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                "404":
+                    description: Workflow or entity not found
+                "405":
+                    description: Method not allowed (GET only)
+    /workflows/{type}/{id}/state:
+        post:
+            summary: Operator patch (state mutation)
+            description: 'Applies a JSON-body patch to the Participant. The body is a `{<field>: <value>}` map; every field MUST be tagged `lifecycle:"operator_writable"` on the registered state struct. Identity (`lifecycle:"id"`) and phase fields are protected by the same default-deny gate the rule layer enforces (ADR-047 § AssertRuleWritable).'
+            tags:
+                - Lifecycle
+            parameters:
+                - name: type
+                  in: path
+                  required: true
+                  description: Workflow type identifier
+                  schema:
+                    type: string
+                - name: id
+                  in: path
+                  required: true
+                  description: Entity ID
+                  schema:
+                    type: string
+            requestBody:
+                description: Field-name → value patch map
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/StatePatchRequest'
+            responses:
+                "200":
+                    description: Patch applied
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                "400":
+                    description: Invalid body OR field is not operator_writable OR type mismatch
+                "404":
+                    description: Workflow or entity not found
+                "405":
+                    description: Method not allowed (POST only)
+                "409":
+                    description: Optimistic-concurrency retries exhausted
+                "413":
+                    description: Request body exceeds max_body_bytes
+    /workflows/{type}/{id}/transition:
+        post:
+            summary: Operator-initiated phase transition
+            description: Transitions the Participant to the requested phase via Manager.Transition with TransitionSourceOperator. Phase must be declared in the workflow's Transitions table; current → target must be a declared edge; current must not be terminal.
+            tags:
+                - Lifecycle
+            parameters:
+                - name: type
+                  in: path
+                  required: true
+                  description: Workflow type identifier
+                  schema:
+                    type: string
+                - name: id
+                  in: path
+                  required: true
+                  description: Entity ID
+                  schema:
+                    type: string
+            requestBody:
+                description: Target phase + optional operator note for the audit trail
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/TransitionRequest'
+            responses:
+                "200":
+                    description: Transition applied
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                "400":
+                    description: Invalid body OR target phase undeclared OR edge undeclared OR current phase terminal
+                "404":
+                    description: Workflow or entity not found
+                "405":
+                    description: Method not allowed (POST only)
+                "413":
+                    description: Request body exceeds max_body_bytes
 components:
     schemas:
         ActivityEvent:
@@ -2098,6 +2343,15 @@ components:
                 - step_type
                 - duration
             type: object
+        TransitionRequest:
+            properties:
+                note:
+                    type: string
+                phase:
+                    type: string
+            required:
+                - phase
+            type: object
 tags:
     - name: AgenticDispatch
       description: User message processing and command dispatch
@@ -2113,6 +2367,8 @@ tags:
       description: GraphQL query endpoint for knowledge graph operations
     - name: Inference
       description: Structural anomaly inference review API
+    - name: Lifecycle
+      description: pkg/lifecycle.Manager operator read + mutation surface (ADR-047)
     - name: MCP
       description: Model Context Protocol endpoint for AI tool integration
     - name: MessageLogger

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1014,6 +1014,7 @@ components:
                         - $ref: ../schemas/json_filter.v1.json
                         - $ref: ../schemas/json_generic.v1.json
                         - $ref: ../schemas/json_map.v1.json
+                        - $ref: ../schemas/lifecycle-gateway.v1.json
                         - $ref: ../schemas/oasf-generator.v1.json
                         - $ref: ../schemas/objectstore.v1.json
                         - $ref: ../schemas/otel-exporter.v1.json


### PR DESCRIPTION
## Summary

- Third and final PR in the **ADR-047 + ADR-048 framework primitives bundle**. PR 1 ([#154](https://github.com/C360Studio/semstreams/pull/154)), PR 2 ([#156](https://github.com/C360Studio/semstreams/pull/156)), PR 4 ([#155](https://github.com/C360Studio/semstreams/pull/155)) shipped earlier. **Bundle tag `v1.0.0-beta.85` follows this PR.**
- New `gateway/lifecycle-gateway` component exposes pkg/lifecycle.Manager's read + operator-mutation surface over HTTP + WebSocket.
- `component.Dependencies.LifecycleManager` field added; both binaries (`cmd/semstreams`, `cmd/e2e-semstreams`) construct + thread the Manager through. Closes the wiring gap reviewer flagged as a beta.18-shaped risk.

## Endpoint surface (matches ADR-047 § Operator API)

| Endpoint | Behavior |
|---|---|
| `GET {root}` | List workflow types + per-phase instance counts |
| `GET {root}/{type}` | List instances (phase / active / limit / offset / `match.<field>` filters) |
| `GET {root}/{type}?stream=true` | WebSocket upgrade via `Manager.Watch` |
| `GET {root}/{type}/{id}` | Get instance state |
| `GET {root}/{type}/{id}/history` | Phase-transition history |
| `GET {root}/{type}/{id}/children` | Child instances (cross-workflow scan) |
| `POST {root}/{type}/{id}/state` | Operator patch (`UpdateFromOperator` → `lifecycle:\"operator_writable\"` gate) |
| `POST {root}/{type}/{id}/transition` | Operator-initiated `Transition` (`TransitionSourceOperator`) |

## Review trail

Two go-reviewer passes. **All BLOCKERS + STRONG RECs + NITs + NEW-FINDINGS structurally closed in-PR — nothing deferred to fast-follow.**

### First-round review

| Item | Severity | Status |
|---|---|---|
| B1: no `main.go` wires `Dependencies.LifecycleManager` | Blocker | **Fixed** — both cmd binaries + componentregistry wired |
| B2: silent `List` error swallow in `handleListWorkflows` | Blocker | **Fixed** — `counts_error` per entry + Warn log |
| B3: dead `WatchBufferSize` config | Blocker | **Fixed** — removed; replaced with real `MaxBodyBytes` |
| B4: tests bypass factory | Blocker | **Fixed** — `TestFactory_FullProductionWire` drives full chain |
| S1: 500-class error verbose leak | Strong | **Fixed** — canned + log; mapped sentinels stay detailed |
| S2: unbounded body reads | Strong | **Fixed** — `http.MaxBytesReader` cap |
| S3: `recordRequest` missing on 405/404 | Strong | **Fixed** — metrics complete; `Allow:` header |
| S4: `path_prefix=\"/\"` trap | Strong | **Fixed** — `Validate` rejects empty-after-trim |
| S5: `OpenAPISpec` not implemented | Strong | **Fixed** — new `openapi.go` + endpoint-coverage test |
| S6: `TransitionEvent` PascalCase JSON | Strong | **Fixed** in `pkg/lifecycle` (snake_case tags) |
| S7: default-permissive WS origin | Strong | **Fixed** — `AllowedOrigins` config + Warn at Start |
| S8: `Stop` docstring lies | Strong | **Fixed** — matches graph-gateway convention |
| N1-N9: nits | Nit | **Fixed** — all addressed (dead code, stale comments, nil-slice normalization, `Allow:` header, `*bool` for EnableWebSocket) |

### Re-review (post-fixes)

| Item | Severity | Status |
|---|---|---|
| N-NEW-1: empty operator-facing schema | Medium | **Fixed** — `schema:` struct tags on all 4 Config fields |
| N-NEW-2: B2 fix had no asserting test | Low | **Fixed** — `TestListWorkflows_PartialListFailure` |
| N-NEW-3: `TestFactory_AcceptsRealManagerType` claim ambiguity | Low | **Fixed** — added SCOPE docstring |
| N-NEW-4: two stale comments | Low | **Fixed** — `handleWebSocket` + `routePrefix` rewritten |
| N-NEW-5: pre-flight checklist phrasing | Info | Non-code; doc-only |

Re-review verdict: **APPROVE for merge** with one MEDIUM "fix-before-merge" item (N-NEW-1). All items closed in subsequent commits on this branch.

## Test plan

- [x] `go test -race ./... | grep FAIL` — empty
- [x] `task lint` — clean (no revive warnings)
- [x] `go vet -tags=integration ./...` AND `go vet -tags=live_llm ./...` — clean
- [x] `go test ./test/contract/...` — clean after `task schema:generate`
- [x] Factory-driven production-wire integration test
- [x] WebSocket smoke test
- [x] OpenAPISpec endpoint-coverage test
- [x] B2 partial-failure regression test
- [x] N9 pointer-field semantic tests (5 cases covering unset / explicit-true / explicit-false / JSON-absent / JSON-explicit-false)
- [ ] Manual `task e2e:core` post-merge to verify rule-engine ↔ gateway round-trip with a registered workflow

## Bundle status

- [x] PR 1 (#154) — pkg/lifecycle substrate
- [x] PR 4 (#155) — BoundedDispatcher + `.triples`
- [x] PR 2 (#156) — rule integration + greenfield rip
- [x] **PR 3 (this PR)** — operator gateway + Dependencies wire
- [ ] Bundle tag `v1.0.0-beta.85` — after this merges

## Commits on this branch

1. \`1558c67\` — original PR (4 files: doc, component, handlers, component_test + Dependencies wiring)
2. \`3721a2b\` — N-NEW-1 fix (Config schema struct tags)
3. \`b8dd869\` — N-NEW-2/3/4 + S5 (test coverage, doc clarity, stale comments, OpenAPISpec)
4. \`f84aba4\` — N9 (*bool EnableWebSocket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)