### PR TITLE
natsclient: gh#93 Phase 1+2+3 — header-classified handler errors (additive, dual-encoded)

### DIFF
--- a/gateway/graph-gateway/component.go
+++ b/gateway/graph-gateway/component.go
@@ -21,6 +21,7 @@ package graphgateway
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -47,6 +48,11 @@ import (
 // *natsclient.Client satisfies this interface, and tests can provide mocks.
 type natsRequester interface {
 	Request(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
+	// RequestClassified is the gh#93 caller-side path that surfaces
+	// handler errors via the err return as classified errors.
+	// Used by the GraphQL → NATS request path so handler "not found",
+	// "invalid request", etc. map cleanly to GraphQL errors.
+	RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
 	Status() natsclient.ConnectionStatus
 }
 
@@ -1618,7 +1624,11 @@ func (c *Component) handleNATSResponse(w http.ResponseWriter, subject string, re
 // that optionally includes an extensions map (e.g. classification metadata). When extensions
 // is nil, behaviour is identical to handleNATSResponse.
 func (c *Component) handleNATSResponseWithExtensions(w http.ResponseWriter, subject string, resp []byte, extensions map[string]interface{}) {
-	// Check if response is a plain-text error from NATS handler (format: "error: <message>")
+	// gh#93 Phase 2: handler errors are now intercepted upstream by
+	// RequestClassified (the caller path), so by the time we get here
+	// resp is guaranteed not to start with "error: ". Defensive sniff
+	// retained as a belt-and-braces fallback during the dual-encoding
+	// window in case some caller bypasses RequestClassified.
 	respStr := string(resp)
 	if strings.HasPrefix(respStr, "error:") {
 		atomic.AddInt64(&c.errors, 1)
@@ -1752,13 +1762,29 @@ func (c *Component) handleGraphQL(w http.ResponseWriter, r *http.Request) {
 
 	payloadBytes, _ := json.Marshal(payload)
 
-	resp, err := c.natsRequester.Request(ctx, subject, payloadBytes, c.config.QueryTimeout)
+	// gh#93 Phase 2: RequestClassified surfaces handler-side errors
+	// via the err return. Transport failures (no responders, context
+	// deadline) arrive as raw errors; handler-side classified errors
+	// arrive as *errs.ClassifiedError. We preserve the historic HTTP
+	// status mapping: transport → 500, handler error → 200 with
+	// GraphQL errors envelope.
+	resp, err := c.natsRequester.RequestClassified(ctx, subject, payloadBytes, c.config.QueryTimeout)
 	if err != nil {
 		atomic.AddInt64(&c.errors, 1)
 		if err == context.DeadlineExceeded || ctx.Err() == context.DeadlineExceeded || ctx.Err() == context.Canceled {
 			c.writeGraphQLError(w, http.StatusGatewayTimeout, "request timeout")
 			return
 		}
+		// Classified handler error (server alive, reporting failure)
+		// → GraphQL 200 with errors envelope. Message text is the
+		// handler's original error.
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) {
+			c.writeGraphQLError(w, http.StatusOK, err.Error())
+			return
+		}
+		// Transport-layer failure (no responders, connection error)
+		// → 500 Internal Server Error. Component is unreachable.
 		c.writeGraphQLError(w, http.StatusInternalServerError, "query failed")
 		return
 	}

--- a/gateway/graph-gateway/component.go
+++ b/gateway/graph-gateway/component.go
@@ -1624,18 +1624,12 @@ func (c *Component) handleNATSResponse(w http.ResponseWriter, subject string, re
 // that optionally includes an extensions map (e.g. classification metadata). When extensions
 // is nil, behaviour is identical to handleNATSResponse.
 func (c *Component) handleNATSResponseWithExtensions(w http.ResponseWriter, subject string, resp []byte, extensions map[string]interface{}) {
-	// gh#93 Phase 2: handler errors are now intercepted upstream by
-	// RequestClassified (the caller path), so by the time we get here
-	// resp is guaranteed not to start with "error: ". Defensive sniff
-	// retained as a belt-and-braces fallback during the dual-encoding
-	// window in case some caller bypasses RequestClassified.
-	respStr := string(resp)
-	if strings.HasPrefix(respStr, "error:") {
-		atomic.AddInt64(&c.errors, 1)
-		errorMsg := strings.TrimSpace(strings.TrimPrefix(respStr, "error: "))
-		c.writeGraphQLError(w, http.StatusOK, errorMsg) // GraphQL convention: 200 with errors
-		return
-	}
+	// gh#93 Phase 2: handler errors are intercepted upstream by
+	// RequestClassified at the caller path; resp here is guaranteed
+	// not to start with "error: ". The legacy defensive body-prefix
+	// sniff was removed per CLAUDE.md ("don't add error handling for
+	// scenarios that can't happen"). If a future caller bypasses
+	// RequestClassified, that's a separate caller-side bug.
 
 	// Detect JetStream PubAck responses (indicates stream/subject overlap)
 	if isPubAckResponse(resp) {
@@ -1776,8 +1770,10 @@ func (c *Component) handleGraphQL(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// Classified handler error (server alive, reporting failure)
-		// → GraphQL 200 with errors envelope. Message text is the
-		// handler's original error.
+		// → GraphQL 200 with errors envelope. err.Error() returns
+		// the handler's clean inner message verbatim
+		// (classifiedFromHeader uses errs.Classified to preserve
+		// the wire text without framework attribution).
 		var ce *errs.ClassifiedError
 		if errors.As(err, &ce) {
 			c.writeGraphQLError(w, http.StatusOK, err.Error())

--- a/gateway/graph-gateway/query_test.go
+++ b/gateway/graph-gateway/query_test.go
@@ -16,9 +16,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/c360studio/semstreams/natsclient"
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/natsclient"
 )
 
 // ====================================================================================
@@ -44,6 +46,18 @@ func (m *mockNATSRequester) Request(ctx context.Context, subject string, data []
 		return m.requestFunc(ctx, subject, data, timeout)
 	}
 	return nil, errors.New("no mock response configured")
+}
+
+// RequestClassified routes through Request and ClassifyReply against
+// the response bytes (no headers — exercises the legacy-body-prefix
+// fallback). Matches how a pre-#93 handler appears on the wire.
+func (m *mockNATSRequester) RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error) {
+	body, err := m.Request(ctx, subject, data, timeout)
+	if err != nil {
+		return nil, err
+	}
+	msg := &nats.Msg{Data: body, Header: nats.Header{}}
+	return natsclient.ClassifyReply(msg)
 }
 
 func (m *mockNATSRequester) Status() natsclient.ConnectionStatus {

--- a/gateway/graph-gateway/query_test.go
+++ b/gateway/graph-gateway/query_test.go
@@ -600,6 +600,68 @@ func TestGateway_QueryErrorHandling_ComponentUnavailable(t *testing.T) {
 	assert.NotNil(t, errors)
 }
 
+// TestGateway_QueryErrorHandling_ClassifiedHandlerError pins the
+// gh#93 Phase 2 contract: when the upstream NATS handler returns
+// a classified error (legacy body "error: <msg>" OR header-stamped
+// X-Status), the gateway maps it to HTTP 200 with a GraphQL errors
+// envelope, and the envelope message is the handler's CLEAN inner
+// text — NOT the natsclient.ClassifyReply attribution wrap.
+//
+// The mock RequestClassified shim routes through Request +
+// natsclient.ClassifyReply against a header-less nats.Msg, so this
+// exercises ClassifyReply's legacy-body-prefix fallback path —
+// matches how a pre-#93 handler appears on the wire AND validates
+// the migration handles both shape paths uniformly.
+func TestGateway_QueryErrorHandling_ClassifiedHandlerError(t *testing.T) {
+	mock := newMockNATSRequester()
+
+	// Handler returns the legacy body-prefix error shape that
+	// graph-ingest's handleQueryEntityNATS emits on missing entity.
+	mock.requestFunc = func(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error) {
+		return []byte("error: not found: test.entity.001"), nil
+	}
+
+	comp := createTestGatewayWithMock(t, mock)
+	require.NoError(t, comp.Initialize())
+	require.NoError(t, comp.Start(context.Background()))
+	defer comp.Stop(5 * time.Second)
+
+	gqlRequest := map[string]interface{}{
+		"query": `query { entity(id: "test.entity.001") { id } }`,
+	}
+	body, err := json.Marshal(gqlRequest)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	comp.handleGraphQL(w, req)
+
+	// GraphQL convention: handler errors → 200 with errors envelope.
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response map[string]interface{}
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	errs, ok := response["errors"].([]interface{})
+	require.True(t, ok, "response must have errors array; got %v", response)
+	require.NotEmpty(t, errs, "errors array must be non-empty")
+
+	// The error message must surface the handler's CLEAN inner
+	// message — not the natsclient.ClassifyReply attribution wrap.
+	firstErr := errs[0].(map[string]interface{})
+	message, ok := firstErr["message"].(string)
+	require.True(t, ok, "first error must have message field; got %v", firstErr)
+	assert.Contains(t, message, "not found: test.entity.001",
+		"GraphQL error message must surface the handler text")
+	assert.NotContains(t, message, "natsclient",
+		"GraphQL error message must NOT leak natsclient attribution; got %q", message)
+	assert.NotContains(t, message, "ClassifyReply",
+		"GraphQL error message must NOT leak ClassifyReply attribution; got %q", message)
+}
+
 func TestGateway_QueryErrorHandling_GraphQLError(t *testing.T) {
 	mock := newMockNATSRequester()
 

--- a/natsclient/doc.go
+++ b/natsclient/doc.go
@@ -345,6 +345,52 @@
 //	childCtx := natsclient.ContextWithTrace(ctx, childTC)
 //	err := client.Request(childCtx, "service.action", data, timeout)
 //
+// # Header-Classified Handler Errors (gh#93)
+//
+// SubscribeForRequests handlers that return a Go error have that error
+// encoded on the wire in two redundant ways during the dual-encoding
+// window (Phase 1+2+3; Phase 4 retires the legacy body shape):
+//
+//   - Headers: X-Status: error + X-Error-Class: invalid|transient|fatal
+//   - Body: "error: <handler-error-text>" (the legacy convention)
+//
+// New callers should use RequestClassified which surfaces the
+// classified error via the err return — covers both transport and
+// handler failure modes uniformly:
+//
+//	data, err := c.RequestClassified(ctx, "subject", body, 5*time.Second)
+//	if err != nil {
+//	    if errs.IsInvalid(err)   { /* 400 — bad input */ }
+//	    if errs.IsTransient(err) { /* retry */ }
+//	    if errs.IsFatal(err)     { /* abort */ }
+//	}
+//
+// Legacy Request() callers continue to work — the err return remains
+// transport-only, and the response body still carries "error: <msg>".
+// However, plain Request() + json.Unmarshal is a silent-corruption
+// footgun: a handler error returns successfully with the prefix body,
+// and Unmarshal fails downstream pointing at the wrong layer. The
+// pkg-level audit pattern is at feedback_silent_handler_error_payload_audit
+// memory; the structural fix is to migrate callers to RequestClassified.
+//
+// Handler-side, return classified errors so the X-Error-Class header
+// carries truth (not the pkg/errs.Classify fallback default of
+// "transient"). For new code prefer errs.WrapTransient/Fatal/Invalid
+// which add Component/Method/Action attribution; for sites where
+// downstream consumers parse the body text (e.g. gateway-side HTTP
+// status mapping on substring matches), use errs.Classified to set
+// the class without rewriting the message:
+//
+//	// Producer side:
+//	return nil, errs.Classified(errs.ErrorInvalid,
+//	    fmt.Errorf("not found: %s", req.ID))
+//
+//	// Consumer side via RequestClassified — err.Error() returns
+//	// "not found: <id>" verbatim; errs.IsInvalid(err) == true.
+//
+// See gh#93 issue body for the full Phase 1+2+3 architecture and the
+// deferred Phase 4 (drop legacy body shape) follow-up.
+//
 // # Architecture Integration
 //
 // The natsclient package integrates with StreamKit components:

--- a/natsclient/errors.go
+++ b/natsclient/errors.go
@@ -1,0 +1,222 @@
+// Package natsclient — header-classified handler errors (gh#93).
+//
+// Handler errors from SubscribeForRequests handlers, and from direct
+// msg.Respond callers that opt in, travel as wire headers:
+//
+//	X-Status: error
+//	X-Error-Class: transient | invalid | fatal
+//
+// The reply body keeps the legacy "error: <msg>" shape unchanged so
+// existing prefix-sniffing callers (pathrag.go, graphrag.go, etc.) keep
+// working unmodified — dual encoding is the load-bearing
+// backward-compat contract. Phase 4 (deferred post-1.0) drops the
+// legacy body shape; until then headers are the new-callers signal,
+// body is the old-callers signal, and both carry the same information.
+//
+// Caller migration:
+//
+//	OLD: data, err := c.Request(ctx, subj, body, timeout)
+//	     if err != nil { /* transport */ }
+//	     if bytes.HasPrefix(data, []byte("error: ")) { /* handler */ }
+//
+//	NEW: data, err := c.RequestClassified(ctx, subj, body, timeout)
+//	     if err != nil {
+//	         // err may be transport OR classified handler error
+//	         if errs.IsInvalid(err) { /* 400 */ }
+//	         if errs.IsTransient(err) { /* retry */ }
+//	     }
+//
+// Handler migration:
+//
+//	OLD: msg.Respond([]byte("error: " + err.Error()))
+//	NEW: natsclient.RespondError(msg, err)
+//
+// HTTP semantics (400 vs 404) belong at the gateway layer, not the
+// wire layer — "not found" maps to ErrorClass=invalid at this layer;
+// gateways disambiguate with a small body-substring check or a
+// per-subject convention. See feedback_natsclient_error_payload_convention.md.
+package natsclient
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"time"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// Header keys for the header-classified error convention. New callers
+// branch on these; legacy callers fall through to the "error: " body
+// prefix as before.
+const (
+	// HeaderStatus is set to HeaderStatusError on reply messages that
+	// represent a handler-side failure. Absent on success replies.
+	HeaderStatus = "X-Status"
+
+	// HeaderErrorClass carries the pkg/errs.ErrorClass value as a
+	// lowercase string: "transient", "invalid", or "fatal". Set
+	// only when HeaderStatus == HeaderStatusError.
+	HeaderErrorClass = "X-Error-Class"
+)
+
+// Values used in HeaderStatus / HeaderErrorClass.
+const (
+	HeaderStatusError = "error"
+
+	ErrorClassTransient = "transient"
+	ErrorClassInvalid   = "invalid"
+	ErrorClassFatal     = "fatal"
+)
+
+// legacyErrorBodyPrefix is the body-prefix convention the framework
+// has used since pre-#93. Callers can still sniff this shape for the
+// duration of the dual-encoding window (Phase 4 retires it).
+var legacyErrorBodyPrefix = []byte("error: ")
+
+// errMissingReplySubject is returned by RespondError when the inbound
+// message had no reply subject — there's no one to respond to.
+var errMissingReplySubject = errors.New("natsclient: message has no reply subject")
+
+// RespondError writes a header-classified error reply to msg. The
+// reply body keeps the legacy "error: <msg>" shape; headers carry
+// the new X-Status / X-Error-Class signal.
+//
+// Used by SubscribeForRequests internally + by direct-msg.Respond
+// handlers that opt in to the convention.
+//
+// Returns nil + no-op when err is nil (treat as success — caller
+// should have used msg.Respond with success data). Returns
+// errMissingReplySubject when the inbound message has no reply
+// subject; caller can ignore (the request was fire-and-forget).
+func RespondError(msg *nats.Msg, err error) error {
+	if err == nil {
+		return nil
+	}
+	if msg.Reply == "" {
+		return errMissingReplySubject
+	}
+
+	reply := nats.NewMsg(msg.Reply)
+	reply.Header = make(nats.Header)
+	reply.Header.Set(HeaderStatus, HeaderStatusError)
+	reply.Header.Set(HeaderErrorClass, classForHeader(err))
+	reply.Data = []byte(legacyErrorBodyPrefix)
+	reply.Data = append(reply.Data, err.Error()...)
+
+	return msg.RespondMsg(reply)
+}
+
+// ReplyError sends a header-classified error reply via the
+// client's Publish path. Companion to Reply / ReplyWithHeaders for
+// handlers that don't have the inbound *nats.Msg in scope.
+//
+// Returns nil + no-op when err is nil OR replyTo is empty.
+func (c *Client) ReplyError(ctx context.Context, replyTo string, err error) error {
+	if err == nil || replyTo == "" {
+		return nil
+	}
+
+	body := append([]byte(legacyErrorBodyPrefix), err.Error()...)
+	headers := map[string]string{
+		HeaderStatus:     HeaderStatusError,
+		HeaderErrorClass: classForHeader(err),
+	}
+	return c.ReplyWithHeaders(ctx, replyTo, body, headers)
+}
+
+// ClassifyReply inspects a reply message and returns either the
+// success body (when no error signal is present) or a classified
+// error suitable for branching with errs.IsInvalid / IsTransient /
+// IsFatal.
+//
+// Detection order:
+//  1. X-Status: error header → reconstruct from X-Error-Class.
+//  2. Legacy "error: " body prefix → classify as invalid (the
+//     default for old handlers; gateways doing finer-grained mapping
+//     can substring-check the unwrapped message).
+//  3. Otherwise → success: return body, nil.
+//
+// The reconstructed classified error reads
+// "natsclient.ClassifyReply: handler error failed: <original>" so its
+// provenance is obvious in logs while errs.Is* still returns the
+// correct class.
+func ClassifyReply(msg *nats.Msg) ([]byte, error) {
+	if msg == nil {
+		return nil, nil
+	}
+
+	if msg.Header.Get(HeaderStatus) == HeaderStatusError {
+		body := bytes.TrimPrefix(msg.Data, legacyErrorBodyPrefix)
+		return nil, classifiedFromHeader(msg.Header.Get(HeaderErrorClass), string(body))
+	}
+
+	if bytes.HasPrefix(msg.Data, legacyErrorBodyPrefix) {
+		body := bytes.TrimPrefix(msg.Data, legacyErrorBodyPrefix)
+		return nil, classifiedFromHeader(ErrorClassInvalid, string(body))
+	}
+
+	return msg.Data, nil
+}
+
+// RequestClassified is the recommended caller-side replacement for
+// Request + body-prefix sniffing. It performs the request, then
+// runs the reply through ClassifyReply so the returned error covers
+// both transport and handler failure modes uniformly.
+//
+// Transport failures (no responders, timeout) are returned as the
+// underlying error and classify as ErrorTransient via pkg/errs.IsTransient
+// — caller's existing retry logic on IsTransient continues to fire.
+//
+// Handler failures arrive as a *errs.ClassifiedError reconstructed
+// from the X-Error-Class header (or the legacy body prefix as
+// fallback). Caller branches on errs.IsInvalid / IsTransient / IsFatal.
+func (c *Client) RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error) {
+	msg, err := c.RequestWithHeaders(ctx, subject, data, nil, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return ClassifyReply(msg)
+}
+
+// classForHeader returns the lowercase ErrorClass string that should
+// be stamped in the X-Error-Class header for the given error.
+func classForHeader(err error) string {
+	switch errs.Classify(err) {
+	case errs.ErrorInvalid:
+		return ErrorClassInvalid
+	case errs.ErrorFatal:
+		return ErrorClassFatal
+	case errs.ErrorTransient:
+		return ErrorClassTransient
+	default:
+		return ErrorClassTransient
+	}
+}
+
+// classifiedFromHeader reconstructs a *errs.ClassifiedError from the
+// X-Error-Class header value + the unwrapped body message. The
+// resulting error round-trips through errs.IsInvalid / IsTransient /
+// IsFatal correctly.
+//
+// Unknown class strings fall back to invalid (the conservative choice
+// — a caller seeing IsInvalid won't retry on a class they don't
+// recognize, vs IsTransient which would loop).
+func classifiedFromHeader(class, message string) error {
+	if message == "" {
+		message = "handler error"
+	}
+	inner := errors.New(message)
+	switch class {
+	case ErrorClassInvalid:
+		return errs.WrapInvalid(inner, "natsclient", "ClassifyReply", "handler error")
+	case ErrorClassFatal:
+		return errs.WrapFatal(inner, "natsclient", "ClassifyReply", "handler error")
+	case ErrorClassTransient:
+		return errs.WrapTransient(inner, "natsclient", "ClassifyReply", "handler error")
+	default:
+		return errs.WrapInvalid(inner, "natsclient", "ClassifyReply", "handler error (unknown class)")
+	}
+}

--- a/natsclient/errors.go
+++ b/natsclient/errors.go
@@ -35,6 +35,46 @@
 // wire layer — "not found" maps to ErrorClass=invalid at this layer;
 // gateways disambiguate with a small body-substring check or a
 // per-subject convention. See feedback_natsclient_error_payload_convention.md.
+//
+// # Footgun warning — plain Request() is still a silent-corruption surface
+//
+// Phase 1 is ADDITIVE. The plain Request() and RequestWithHeaders()
+// methods are UNCHANGED — they do NOT inspect X-Status / X-Error-Class
+// headers, and they return the legacy "error: <msg>" body verbatim
+// with err == nil when the handler errors. New code that does
+//
+//	data, err := c.Request(...)
+//	if err != nil { return err }
+//	json.Unmarshal(data, &resp)        // SILENT CORRUPTION on handler error
+//
+// will silently mis-decode handler errors as success data. This is
+// the exact bug class that shipped three times in the beta.86 cycle
+// (commit c626854 fixed FindSimilar + searchEntitiesSemantic; commit
+// 895ec44 fixed searchGraph's fallback adapter — different shape,
+// same class). New callers MUST use RequestClassified, OR explicitly
+// check bytes.HasPrefix(data, []byte("error: ")) before unmarshal.
+// See feedback_silent_handler_error_payload_audit.md for the audit
+// pattern.
+//
+// # Sentinel chains do not survive the wire boundary
+//
+// classifiedFromHeader reconstructs a fresh *errs.ClassifiedError
+// from the header value + body message. The original handler's
+// sentinel chain (e.g. an inner jetstream.ErrKeyNotFound, or any
+// custom errors.Is-friendly sentinel) is LOST in transit. Callers
+// that previously branched on errors.Is(err, sentinel) need to
+// substring-match the body message instead, OR move the
+// sentinel-distinction logic to the handler side and surface the
+// distinction through a different mechanism (separate subject,
+// distinct ErrorClass, response-payload field). The ErrorClass
+// taxonomy (invalid / transient / fatal) is the ONLY structured
+// signal that round-trips today.
+//
+// If a future consumer needs sentinel-Is parity across the wire,
+// the path is adding an X-Error-Sentinel header with a small
+// allowlist of framework-recognized sentinel IDs; classifiedFromHeader
+// would graft the real sentinel back into the wrap chain. Filed as
+// follow-up to gh#93 (out of Phase 1 scope).
 package natsclient
 
 import (
@@ -87,9 +127,17 @@ var errMissingReplySubject = errors.New("natsclient: message has no reply subjec
 // Used by SubscribeForRequests internally + by direct-msg.Respond
 // handlers that opt in to the convention.
 //
+// When to reach for RespondError vs (*Client).ReplyError:
+//   - Handler has *nats.Msg in scope (most common — direct Subscribe
+//     callback): use RespondError(msg, err). Free function; reads
+//     the reply subject off msg.
+//   - Handler has only a reply subject + *Client (e.g. deferred-reply
+//     forwarder): use c.ReplyError(ctx, replyTo, err). Method;
+//     publishes via the client connection.
+//
 // Returns nil + no-op when err is nil (treat as success — caller
 // should have used msg.Respond with success data). Returns
-// errMissingReplySubject when the inbound message has no reply
+// errMissingReplySubject when the inbound message had no reply
 // subject; caller can ignore (the request was fire-and-forget).
 func RespondError(msg *nats.Msg, err error) error {
 	if err == nil {
@@ -149,11 +197,23 @@ func ClassifyReply(msg *nats.Msg) ([]byte, error) {
 	}
 
 	if msg.Header.Get(HeaderStatus) == HeaderStatusError {
-		body := bytes.TrimPrefix(msg.Data, legacyErrorBodyPrefix)
+		// Header-driven path. Strip the legacy prefix only if
+		// present so the inner message is clean; future Phase 4
+		// handlers may stop emitting the prefix entirely, in which
+		// case this becomes a pure pass-through. Either way the
+		// reconstructed error carries the original handler text.
+		body := msg.Data
+		if bytes.HasPrefix(body, legacyErrorBodyPrefix) {
+			body = bytes.TrimPrefix(body, legacyErrorBodyPrefix)
+		}
 		return nil, classifiedFromHeader(msg.Header.Get(HeaderErrorClass), string(body))
 	}
 
 	if bytes.HasPrefix(msg.Data, legacyErrorBodyPrefix) {
+		// Pre-#93 handler — no header signal. Conservative default:
+		// classify as invalid so callers don't loop-retry on an
+		// unknown shape. Gateways doing finer-grained mapping can
+		// substring-check the unwrapped message.
 		body := bytes.TrimPrefix(msg.Data, legacyErrorBodyPrefix)
 		return nil, classifiedFromHeader(ErrorClassInvalid, string(body))
 	}

--- a/natsclient/errors.go
+++ b/natsclient/errors.go
@@ -257,13 +257,20 @@ func classForHeader(err error) string {
 }
 
 // classifiedFromHeader reconstructs a *errs.ClassifiedError from the
-// X-Error-Class header value + the unwrapped body message. The
-// resulting error round-trips through errs.IsInvalid / IsTransient /
-// IsFatal correctly.
+// X-Error-Class header value + the unwrapped body message. Uses
+// errs.Classified (the bare constructor) rather than the Wrap*
+// family so the inner message survives verbatim — external surfaces
+// (GraphQL responses, agent tool results) get the handler's clean
+// text via err.Error() instead of a leaky framework-attribution
+// prefix.
 //
-// Unknown class strings fall back to invalid (the conservative choice
-// — a caller seeing IsInvalid won't retry on a class they don't
-// recognize, vs IsTransient which would loop).
+// The resulting error round-trips through errs.IsInvalid /
+// IsTransient / IsFatal correctly because errs.Classified preserves
+// the class tag on the ClassifiedError struct.
+//
+// Unknown class strings fall back to invalid (the conservative
+// choice — a caller seeing IsInvalid won't retry on a class they
+// don't recognize, vs IsTransient which would loop).
 func classifiedFromHeader(class, message string) error {
 	if message == "" {
 		message = "handler error"
@@ -271,12 +278,12 @@ func classifiedFromHeader(class, message string) error {
 	inner := errors.New(message)
 	switch class {
 	case ErrorClassInvalid:
-		return errs.WrapInvalid(inner, "natsclient", "ClassifyReply", "handler error")
+		return errs.Classified(errs.ErrorInvalid, inner)
 	case ErrorClassFatal:
-		return errs.WrapFatal(inner, "natsclient", "ClassifyReply", "handler error")
+		return errs.Classified(errs.ErrorFatal, inner)
 	case ErrorClassTransient:
-		return errs.WrapTransient(inner, "natsclient", "ClassifyReply", "handler error")
+		return errs.Classified(errs.ErrorTransient, inner)
 	default:
-		return errs.WrapInvalid(inner, "natsclient", "ClassifyReply", "handler error (unknown class)")
+		return errs.Classified(errs.ErrorInvalid, inner)
 	}
 }

--- a/natsclient/errors_integration_test.go
+++ b/natsclient/errors_integration_test.go
@@ -3,6 +3,7 @@
 package natsclient
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"strings"
@@ -135,6 +136,39 @@ func TestIntegration_LegacyBodyPrefix_StillReadable(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "legacy compat case") {
 		t.Errorf("body missing original message; got %q", data)
+	}
+}
+
+// TestIntegration_LegacyRequest_SuccessBodyUnchanged is the
+// success-path counterpart to TestIntegration_LegacyBodyPrefix_StillReadable.
+// Pre-#93 callers using plain Request() against a Phase-1 handler
+// must see exactly the bytes the handler returned — Phase 1's
+// SubscribeForRequests change must NOT introduce headers or trace
+// the byte payload on the success path. Locks the byte invariant
+// that Phase 4 (legacy body drop) would otherwise break first here.
+func TestIntegration_LegacyRequest_SuccessBodyUnchanged(t *testing.T) {
+	ctx := context.Background()
+
+	natsContainer, natsURL := startNATSContainer(ctx, t)
+	defer natsContainer.Terminate(ctx)
+
+	client, err := NewClient(natsURL)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(ctx)
+
+	subject := "test.legacy.success.body"
+	want := []byte(`{"hello":"world","number":42}`)
+	_, err = client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+		return want, nil
+	})
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	data, err := client.Request(ctx, subject, []byte("ping"), 2*time.Second)
+	require.NoError(t, err)
+	if !bytes.Equal(data, want) {
+		t.Fatalf("Request success body diverged from handler bytes:\n  got  %q\n  want %q", data, want)
 	}
 }
 

--- a/natsclient/errors_integration_test.go
+++ b/natsclient/errors_integration_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+package natsclient
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// TestIntegration_RequestClassified_RoundTripPreservesClass is the
+// load-bearing gh#93 contract: a handler that returns
+// errs.WrapInvalid(...) MUST surface to the caller as a classified
+// error where errs.IsInvalid(err) == true. This is the regression
+// net that catches Phase 1 wire-format gaps.
+func TestIntegration_RequestClassified_RoundTripPreservesClass(t *testing.T) {
+	ctx := context.Background()
+
+	natsContainer, natsURL := startNATSContainer(ctx, t)
+	defer natsContainer.Terminate(ctx)
+
+	client, err := NewClient(natsURL)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(ctx)
+
+	cases := []struct {
+		name        string
+		handlerErr  error
+		isInvalid   bool
+		isTransient bool
+		isFatal     bool
+		wantInMsg   string
+	}{
+		{
+			name:       "invalid_class_round_trips",
+			handlerErr: errs.WrapInvalid(errors.New("bad request shape"), "Test", "Handle", "validate"),
+			isInvalid:  true,
+			wantInMsg:  "bad request shape",
+		},
+		{
+			name:        "transient_class_round_trips",
+			handlerErr:  errs.WrapTransient(errors.New("kv temporarily unavailable"), "Test", "Handle", "fetch"),
+			isTransient: true,
+			wantInMsg:   "kv temporarily unavailable",
+		},
+		{
+			name:       "fatal_class_round_trips",
+			handlerErr: errs.WrapFatal(errors.New("kv permanently unreachable"), "Test", "Handle", "fetch"),
+			isFatal:    true,
+			wantInMsg:  "kv permanently unreachable",
+		},
+		{
+			name:        "unclassified_plain_error_defaults_transient",
+			handlerErr:  errors.New("plain — pkg/errs Classify defaults to transient"),
+			isTransient: true,
+			wantInMsg:   "plain",
+		},
+	}
+
+	for i, tc := range cases {
+		tc := tc
+		i := i
+		t.Run(tc.name, func(t *testing.T) {
+			subject := "test.classified." + tc.name
+			_, err = client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+				return nil, tc.handlerErr
+			})
+			require.NoError(t, err)
+
+			// Give subscription time to be established. Pattern
+			// copied from sibling integration tests above; not a
+			// race — NATS interest propagation is fast but not
+			// instant.
+			time.Sleep(50 * time.Millisecond)
+
+			data, err := client.RequestClassified(ctx, subject, []byte("ping"), 2*time.Second)
+			if data != nil {
+				t.Errorf("data should be nil on classified error; got %q", data)
+			}
+			if err == nil {
+				t.Fatal("expected classified error")
+			}
+			if errs.IsInvalid(err) != tc.isInvalid {
+				t.Errorf("IsInvalid=%v, want %v (err=%v)", errs.IsInvalid(err), tc.isInvalid, err)
+			}
+			if errs.IsTransient(err) != tc.isTransient {
+				t.Errorf("IsTransient=%v, want %v (err=%v)", errs.IsTransient(err), tc.isTransient, err)
+			}
+			if errs.IsFatal(err) != tc.isFatal {
+				t.Errorf("IsFatal=%v, want %v (err=%v)", errs.IsFatal(err), tc.isFatal, err)
+			}
+			if !strings.Contains(err.Error(), tc.wantInMsg) {
+				t.Errorf("case %d err=%q, want substring %q", i, err.Error(), tc.wantInMsg)
+			}
+		})
+	}
+}
+
+// TestIntegration_LegacyBodyPrefix_StillReadable confirms the
+// backward-compat contract: a pre-#93 caller using plain Request +
+// bytes.HasPrefix("error: ") continues to see the legacy body shape
+// unchanged. This is the wire-compat lock on Phase 1.
+func TestIntegration_LegacyBodyPrefix_StillReadable(t *testing.T) {
+	ctx := context.Background()
+
+	natsContainer, natsURL := startNATSContainer(ctx, t)
+	defer natsContainer.Terminate(ctx)
+
+	client, err := NewClient(natsURL)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(ctx)
+
+	subject := "test.legacy.body.prefix"
+	handlerErr := errs.WrapInvalid(errors.New("legacy compat case"), "Test", "Handle", "validate")
+	_, err = client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, handlerErr
+	})
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	// Plain Request — pre-#93 path. Should see "error: " body
+	// prefix, unchanged from before.
+	data, err := client.Request(ctx, subject, []byte("ping"), 2*time.Second)
+	require.NoError(t, err) // Handler errors don't surface in err return per legacy contract.
+	if !strings.HasPrefix(string(data), "error: ") {
+		t.Fatalf("legacy body prefix missing; got %q", data)
+	}
+	if !strings.Contains(string(data), "legacy compat case") {
+		t.Errorf("body missing original message; got %q", data)
+	}
+}
+
+// TestIntegration_RequestClassified_SuccessPath confirms the
+// non-error path: handler returns (data, nil), caller gets the same
+// data, nil error.
+func TestIntegration_RequestClassified_SuccessPath(t *testing.T) {
+	ctx := context.Background()
+
+	natsContainer, natsURL := startNATSContainer(ctx, t)
+	defer natsContainer.Terminate(ctx)
+
+	client, err := NewClient(natsURL)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(ctx)
+
+	subject := "test.classified.success"
+	want := []byte(`{"ok":true}`)
+	_, err = client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+		return want, nil
+	})
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	data, err := client.RequestClassified(ctx, subject, []byte("ping"), 2*time.Second)
+	require.NoError(t, err)
+	if string(data) != string(want) {
+		t.Fatalf("data = %q, want %q", data, want)
+	}
+}

--- a/natsclient/errors_test.go
+++ b/natsclient/errors_test.go
@@ -1,0 +1,225 @@
+package natsclient
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+func TestClassForHeader_AllClasses(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "invalid",
+			err:  errs.WrapInvalid(errors.New("bad input"), "C", "M", "validate"),
+			want: ErrorClassInvalid,
+		},
+		{
+			name: "fatal",
+			err:  errs.WrapFatal(errors.New("kv gone"), "C", "M", "store"),
+			want: ErrorClassFatal,
+		},
+		{
+			name: "transient_explicit",
+			err:  errs.WrapTransient(errors.New("timeout"), "C", "M", "request"),
+			want: ErrorClassTransient,
+		},
+		{
+			name: "unclassified_defaults_transient",
+			err:  errors.New("plain error — pkg/errs Classify defaults to transient"),
+			want: ErrorClassTransient,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := classForHeader(tc.err); got != tc.want {
+				t.Fatalf("classForHeader(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifiedFromHeader_RoundTrips(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		class       string
+		msg         string
+		isInvalid   bool
+		isTransient bool
+		isFatal     bool
+	}{
+		{name: "invalid", class: ErrorClassInvalid, msg: "bad input", isInvalid: true},
+		{name: "fatal", class: ErrorClassFatal, msg: "kv gone", isFatal: true},
+		{name: "transient", class: ErrorClassTransient, msg: "timeout", isTransient: true},
+		{name: "unknown_class_falls_back_invalid", class: "weird", msg: "x", isInvalid: true},
+		{name: "empty_message_synthesized", class: ErrorClassInvalid, msg: "", isInvalid: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := classifiedFromHeader(tc.class, tc.msg)
+			if err == nil {
+				t.Fatal("expected non-nil error")
+			}
+			if errs.IsInvalid(err) != tc.isInvalid {
+				t.Errorf("IsInvalid = %v, want %v (err=%v)", errs.IsInvalid(err), tc.isInvalid, err)
+			}
+			if errs.IsTransient(err) != tc.isTransient {
+				t.Errorf("IsTransient = %v, want %v (err=%v)", errs.IsTransient(err), tc.isTransient, err)
+			}
+			if errs.IsFatal(err) != tc.isFatal {
+				t.Errorf("IsFatal = %v, want %v (err=%v)", errs.IsFatal(err), tc.isFatal, err)
+			}
+		})
+	}
+}
+
+func TestClassifyReply_NilMessage(t *testing.T) {
+	t.Parallel()
+	data, err := ClassifyReply(nil)
+	if err != nil || data != nil {
+		t.Fatalf("ClassifyReply(nil) = (%v, %v), want (nil, nil)", data, err)
+	}
+}
+
+func TestClassifyReply_SuccessBody(t *testing.T) {
+	t.Parallel()
+	msg := &nats.Msg{Data: []byte(`{"ok":true}`), Header: nats.Header{}}
+	data, err := ClassifyReply(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != `{"ok":true}` {
+		t.Fatalf("data = %q, want %q", data, `{"ok":true}`)
+	}
+}
+
+func TestClassifyReply_HeaderClassifiedError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		class       string
+		isInvalid   bool
+		isTransient bool
+		isFatal     bool
+	}{
+		{name: "invalid", class: ErrorClassInvalid, isInvalid: true},
+		{name: "transient", class: ErrorClassTransient, isTransient: true},
+		{name: "fatal", class: ErrorClassFatal, isFatal: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			msg := &nats.Msg{
+				Header: nats.Header{
+					HeaderStatus:     []string{HeaderStatusError},
+					HeaderErrorClass: []string{tc.class},
+				},
+				Data: []byte("error: original handler message"),
+			}
+			data, err := ClassifyReply(msg)
+			if data != nil {
+				t.Errorf("data should be nil on error reply; got %q", data)
+			}
+			if err == nil {
+				t.Fatal("expected non-nil error")
+			}
+			if errs.IsInvalid(err) != tc.isInvalid {
+				t.Errorf("IsInvalid = %v, want %v", errs.IsInvalid(err), tc.isInvalid)
+			}
+			if errs.IsTransient(err) != tc.isTransient {
+				t.Errorf("IsTransient = %v, want %v", errs.IsTransient(err), tc.isTransient)
+			}
+			if errs.IsFatal(err) != tc.isFatal {
+				t.Errorf("IsFatal = %v, want %v", errs.IsFatal(err), tc.isFatal)
+			}
+			// The original message should survive into the reconstructed error.
+			if !strings.Contains(err.Error(), "original handler message") {
+				t.Errorf("err = %q, expected to contain original message", err)
+			}
+		})
+	}
+}
+
+func TestClassifyReply_LegacyBodyPrefix_DefaultsInvalid(t *testing.T) {
+	t.Parallel()
+	// No X-Status header — caller is a pre-#93 handler. The body
+	// prefix sniff treats it as invalid (the conservative default,
+	// since pre-#93 has no class signal).
+	msg := &nats.Msg{
+		Header: nats.Header{},
+		Data:   []byte("error: not found: foo.bar.baz"),
+	}
+	data, err := ClassifyReply(msg)
+	if data != nil {
+		t.Errorf("data should be nil on error reply; got %q", data)
+	}
+	if !errs.IsInvalid(err) {
+		t.Errorf("legacy body-prefix should classify invalid; got err=%v IsInvalid=%v", err, errs.IsInvalid(err))
+	}
+	if !strings.Contains(err.Error(), "not found: foo.bar.baz") {
+		t.Errorf("expected body message to survive; got %q", err)
+	}
+}
+
+func TestRespondError_NilErr_NoOp(t *testing.T) {
+	t.Parallel()
+	msg := &nats.Msg{Reply: "_INBOX.fake"}
+	if err := RespondError(msg, nil); err != nil {
+		t.Fatalf("RespondError(_, nil) = %v, want nil no-op", err)
+	}
+}
+
+func TestRespondError_MissingReply_ReturnsSentinel(t *testing.T) {
+	t.Parallel()
+	msg := &nats.Msg{}
+	err := RespondError(msg, errors.New("any error"))
+	if !errors.Is(err, errMissingReplySubject) {
+		t.Fatalf("RespondError on msg without Reply = %v, want errMissingReplySubject", err)
+	}
+}
+
+func TestReplyError_NilErr_NoOp(t *testing.T) {
+	t.Parallel()
+	// Method receiver with nil client is fine because we short-circuit
+	// before touching c — no panic.
+	var c *Client
+	if err := c.ReplyError(nil, "any", nil); err != nil { //nolint:staticcheck // deliberately nil receiver
+		t.Fatalf("ReplyError(_, _, nil) = %v, want nil no-op", err)
+	}
+}
+
+func TestReplyError_EmptyReplyTo_NoOp(t *testing.T) {
+	t.Parallel()
+	var c *Client
+	if err := c.ReplyError(nil, "", errors.New("ignored")); err != nil { //nolint:staticcheck
+		t.Fatalf("ReplyError(_, \"\", _) = %v, want nil no-op", err)
+	}
+}
+
+// TestLegacyBodyPrefixStable pins the wire-format byte sequence —
+// any future change here is a wire break and must go through Phase 4.
+func TestLegacyBodyPrefixStable(t *testing.T) {
+	t.Parallel()
+	want := []byte("error: ")
+	if !bytes.Equal(legacyErrorBodyPrefix, want) {
+		t.Fatalf("legacyErrorBodyPrefix = %q, want %q — wire break!", legacyErrorBodyPrefix, want)
+	}
+}

--- a/natsclient/errors_test.go
+++ b/natsclient/errors_test.go
@@ -223,3 +223,32 @@ func TestLegacyBodyPrefixStable(t *testing.T) {
 		t.Fatalf("legacyErrorBodyPrefix = %q, want %q — wire break!", legacyErrorBodyPrefix, want)
 	}
 }
+
+// TestClassifyReply_ClassifiedErrorRecoversComponentFields confirms
+// the reconstructed *errs.ClassifiedError exposes its Component /
+// Operation fields via errors.As. Callers may use these for slog
+// attribution ("which natsclient call this came from").
+func TestClassifyReply_ClassifiedErrorRecoversComponentFields(t *testing.T) {
+	t.Parallel()
+	msg := &nats.Msg{
+		Header: nats.Header{
+			HeaderStatus:     []string{HeaderStatusError},
+			HeaderErrorClass: []string{ErrorClassInvalid},
+		},
+		Data: []byte("error: bad request"),
+	}
+	_, err := ClassifyReply(msg)
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	var ce *errs.ClassifiedError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected reconstructed error to be a *errs.ClassifiedError; got %T (%v)", err, err)
+	}
+	if ce.Component != "natsclient" {
+		t.Errorf("ce.Component = %q, want \"natsclient\"", ce.Component)
+	}
+	if ce.Operation != "ClassifyReply" {
+		t.Errorf("ce.Operation = %q, want \"ClassifyReply\"", ce.Operation)
+	}
+}

--- a/natsclient/errors_test.go
+++ b/natsclient/errors_test.go
@@ -224,31 +224,46 @@ func TestLegacyBodyPrefixStable(t *testing.T) {
 	}
 }
 
-// TestClassifyReply_ClassifiedErrorRecoversComponentFields confirms
-// the reconstructed *errs.ClassifiedError exposes its Component /
-// Operation fields via errors.As. Callers may use these for slog
-// attribution ("which natsclient call this came from").
-func TestClassifyReply_ClassifiedErrorRecoversComponentFields(t *testing.T) {
+// TestClassifyReply_ReconstructedErrorPreservesInnerMessage pins the
+// load-bearing Phase 2-polish contract: the reconstructed
+// *errs.ClassifiedError's Error() string is the handler's clean inner
+// message — NOT a leaky framework-attribution wrap. Phase 2's
+// reviewer R2/R3 surfaced that gateway/graph-gateway and
+// agentic-tools/executors were leaking
+// "natsclient.ClassifyReply: handler error failed: <real msg>" to
+// external surfaces; classifiedFromHeader now uses errs.Classified
+// (bare constructor) so the inner message round-trips verbatim.
+func TestClassifyReply_ReconstructedErrorPreservesInnerMessage(t *testing.T) {
 	t.Parallel()
 	msg := &nats.Msg{
 		Header: nats.Header{
 			HeaderStatus:     []string{HeaderStatusError},
 			HeaderErrorClass: []string{ErrorClassInvalid},
 		},
-		Data: []byte("error: bad request"),
+		Data: []byte("error: not found: test.entity.001"),
 	}
 	_, err := ClassifyReply(msg)
 	if err == nil {
 		t.Fatal("expected non-nil error")
 	}
+	// errors.As recovery still works (class round-trip is intact).
 	var ce *errs.ClassifiedError
 	if !errors.As(err, &ce) {
 		t.Fatalf("expected reconstructed error to be a *errs.ClassifiedError; got %T (%v)", err, err)
 	}
-	if ce.Component != "natsclient" {
-		t.Errorf("ce.Component = %q, want \"natsclient\"", ce.Component)
+	// Class survives.
+	if !errs.IsInvalid(err) {
+		t.Errorf("expected IsInvalid(err) == true; got false")
 	}
-	if ce.Operation != "ClassifyReply" {
-		t.Errorf("ce.Operation = %q, want \"ClassifyReply\"", ce.Operation)
+	// Inner message survives verbatim — no framework attribution.
+	if err.Error() != "not found: test.entity.001" {
+		t.Errorf("err.Error() = %q, want %q (no framework attribution)",
+			err.Error(), "not found: test.entity.001")
+	}
+	if strings.Contains(err.Error(), "natsclient") {
+		t.Errorf("err.Error() must NOT leak natsclient attribution; got %q", err.Error())
+	}
+	if strings.Contains(err.Error(), "ClassifyReply") {
+		t.Errorf("err.Error() must NOT leak ClassifyReply attribution; got %q", err.Error())
 	}
 }

--- a/natsclient/request.go
+++ b/natsclient/request.go
@@ -3,6 +3,7 @@ package natsclient
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -212,14 +213,26 @@ func (c *Client) SubscribeForRequests(
 			// headers carry the new caller signal. RespondError
 			// returns errMissingReplySubject when the inbound
 			// message had no reply subject — that's expected for
-			// fire-and-forget patterns, so swallow.
-			_ = RespondError(msg, err)
+			// fire-and-forget patterns, so swallow. Any other
+			// publish failure is operator-visible (queue full,
+			// connection torn down mid-reply, etc.) and needs to
+			// surface, not silently swallow.
+			if respErr := RespondError(msg, err); respErr != nil && !errors.Is(respErr, errMissingReplySubject) {
+				c.logger.Error("natsclient: failed to publish handler-error reply",
+					"subject", subject,
+					"handler_err", err.Error(),
+					"publish_err", respErr.Error())
+			}
 			return
 		}
 
 		// Send successful response
 		if msg.Reply != "" {
-			_ = msg.Respond(response)
+			if respErr := msg.Respond(response); respErr != nil {
+				c.logger.Error("natsclient: failed to publish handler success reply",
+					"subject", subject,
+					"err", respErr.Error())
+			}
 		}
 	})
 	if err != nil {

--- a/natsclient/request.go
+++ b/natsclient/request.go
@@ -206,11 +206,14 @@ func (c *Client) SubscribeForRequests(
 		// Call the handler
 		response, err := handler(msgCtx, msg.Data)
 		if err != nil {
-			// Send error response if there's a reply subject
-			if msg.Reply != "" {
-				// Use a simple error format - could be enhanced with structured errors
-				_ = msg.Respond([]byte("error: " + err.Error()))
-			}
+			// Send a header-classified error reply (gh#93). The
+			// reply body keeps the legacy "error: <msg>" shape for
+			// backward compatibility; X-Status / X-Error-Class
+			// headers carry the new caller signal. RespondError
+			// returns errMissingReplySubject when the inbound
+			// message had no reply subject — that's expected for
+			// fire-and-forget patterns, so swallow.
+			_ = RespondError(msg, err)
 			return
 		}
 

--- a/pkg/errs/errs.go
+++ b/pkg/errs/errs.go
@@ -244,6 +244,31 @@ func newClassified(class ErrorClass, err error, component, operation, message st
 	}
 }
 
+// Classified wraps err with the given class WITHOUT adding the
+// "<component>.<method>: <action> failed: " attribution prefix that
+// WrapTransient/WrapFatal/WrapInvalid layer on. Use when callers
+// downstream rely on the inner error's text being the verbatim
+// Error() string (e.g. wire-format consumers parsing the body for
+// a known prefix).
+//
+// Prefer WrapTransient/WrapFatal/WrapInvalid for new code — the
+// attribution prefix is operator-visible in logs and worth the cost
+// when no caller is parsing the message. This bare constructor exists
+// for the gh#93 dual-encoding window: handlers that need to preserve
+// the historic "<kind>: <detail>" body shape (e.g. "not found: <id>",
+// "invalid request: <reason>") so the body-prefix sniffers downstream
+// keep working while the X-Error-Class header layer rolls out. Once
+// Phase 4 retires the legacy body shape, the Wrap* family becomes
+// preferred uniformly.
+//
+// Returns nil when err is nil.
+func Classified(class ErrorClass, err error) *ClassifiedError {
+	if err == nil {
+		return nil
+	}
+	return newClassified(class, err, "", "", err.Error())
+}
+
 // Wrap creates a standardized error with context following the pattern:
 // "component.method: action failed: %w"
 func Wrap(err error, component, method, action string) error {

--- a/pkg/lifecycle/errors.go
+++ b/pkg/lifecycle/errors.go
@@ -16,6 +16,16 @@ var (
 	// indicates a wire-up bug, not a benign re-init.
 	ErrWorkflowAlreadyRegistered = errors.New("lifecycle: workflow already registered")
 
+	// ErrInvalidWorkflow is returned by Workflow.validate() at Register
+	// time when the declaration itself is malformed (missing required
+	// field, wrong-arity EntityIDPattern, duplicate ChildSpec
+	// LinkPredicate, etc.). Distinct from ErrWorkflowNotRegistered —
+	// that one fires at lookup time when a caller references a
+	// workflow type that was never registered. Callers branching on
+	// errors.Is(err, ErrInvalidWorkflow) can distinguish "you wrote
+	// a bad Workflow{}" from "you asked for an unknown workflow."
+	ErrInvalidWorkflow = errors.New("lifecycle: invalid workflow declaration")
+
 	// ErrEntityNotFound is returned by Manager.Get when no entity exists
 	// at the given EntityID in ENTITY_STATES. Distinct from
 	// ErrEntityNotLifecycleManaged — that one fires when the entity

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -370,6 +370,11 @@ func (m *Manager) Create(ctx context.Context, initial Participant) error {
 // buildInitialTriples constructs the triple slice for Manager.Create:
 // phase + audit (source=framework, at=now, note="created") + non-zero
 // projection fields.
+//
+// AuditPredicates.From is deliberately NOT stamped here — initial
+// creation has no prior phase. History reconstruction handles the
+// absent-From case by falling back to previousPhase="" for the first
+// revision (see Manager.History at manager_query.go:209).
 func buildInitialTriples(reg *registration, entityID string, initial Participant, now time.Time) []message.Triple {
 	delta := []message.Triple{
 		triple(entityID, reg.workflow.PhasePredicate, initial.Phase()),

--- a/pkg/lifecycle/manager_query.go
+++ b/pkg/lifecycle/manager_query.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/c360studio/semstreams/graph"
-	"github.com/c360studio/semstreams/message"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -206,6 +205,15 @@ func (m *Manager) History(ctx context.Context, workflow, entityID string) ([]Tra
 	}
 
 	events := make([]TransitionEvent, 0, len(entries))
+	// previousPhase tracks the last observed phase across revisions,
+	// including non-phase-changing intermediate revisions (e.g. an
+	// operator UpdateFromOperator that touches only Note). Such
+	// revisions are skipped at :233-235 because currentPhase ==
+	// previousPhase, so the next genuine transition's From still
+	// reflects the prior phase rather than the intervening no-op.
+	// During mid-rollout, revisions written before AuditPredicates.From
+	// existed fall back to this reconstruction; once .From is stamped
+	// the :253-256 read takes precedence.
 	previousPhase := ""
 	for _, entry := range entries {
 		if entry.Operation() == jetstream.KeyValueDelete ||
@@ -337,6 +345,12 @@ func (m *Manager) Children(ctx context.Context, parentEntityID string, opts Chil
 // triple on the entity. Stubs are light — Workflow + Phase are
 // populated only when the target itself is lifecycle-managed
 // (matches some registered EntityIDPattern).
+//
+// Cost model: 1 read for the source entity plus 1 additional read per
+// lifecycle-managed reference target (so a `Phase` peek can be filled
+// in). References pointing at non-lifecycle entities skip the second
+// read. References does NOT call References transitively — the returned
+// stubs are depth-1 only; following them is the caller's job.
 func (m *Manager) References(ctx context.Context, entityID string) ([]ReferenceStub, error) {
 	state, _, err := m.getEntity(ctx, entityID)
 	if err != nil {
@@ -594,8 +608,3 @@ func matchesActiveFilter(p Participant, active bool) bool {
 	}
 	return !p.IsTerminal()
 }
-
-// triplesEntity is the placeholder shape that signals projection
-// callers don't need the full EntityState. Kept here to make the
-// unused-import elimination cleaner — not referenced.
-var _ message.Triple

--- a/pkg/lifecycle/projection.go
+++ b/pkg/lifecycle/projection.go
@@ -206,7 +206,7 @@ func projectStructToTriples(sm *structMeta, entityID string, source Participant)
 	}
 	var out []message.Triple
 	for _, meta := range sm.FieldsByPredicate {
-		if meta.IsID || meta.ReadOnly && !meta.IsPhase {
+		if meta.IsID || (meta.ReadOnly && !meta.IsPhase) {
 			// Skip ID (no predicate target).
 			// Skip readonly non-phase fields (audit + reference
 			// targets are stamped by the framework / upstream

--- a/pkg/lifecycle/workflow.go
+++ b/pkg/lifecycle/workflow.go
@@ -160,14 +160,16 @@ type ReferenceSpec struct {
 
 // validate checks the Workflow declaration for structural correctness
 // at Register time. Catches typos and missing required fields before
-// the workflow goes live.
+// the workflow goes live. All failures wrap ErrInvalidWorkflow —
+// ErrWorkflowNotRegistered is reserved for lookup-time misses on the
+// Manager surface.
 func (w *Workflow) validate() error {
 	if w.Name == "" {
-		return fmt.Errorf("%w: workflow Name is required", ErrWorkflowNotRegistered)
+		return fmt.Errorf("%w: workflow Name is required", ErrInvalidWorkflow)
 	}
 	if w.EntityIDPattern == "" {
 		return fmt.Errorf("%w: workflow %q EntityIDPattern is required",
-			ErrWorkflowNotRegistered, w.Name)
+			ErrInvalidWorkflow, w.Name)
 	}
 	// EntityIDPattern must be 6-segment to match the federated EntityID
 	// contract (org.platform.domain.system.type.instance — pkg/types.EntityID
@@ -176,15 +178,15 @@ func (w *Workflow) validate() error {
 	// e2e mission pattern. Fail loudly at Register time.
 	if segs := strings.Split(w.EntityIDPattern, "."); len(segs) != 6 {
 		return fmt.Errorf("%w: workflow %q EntityIDPattern %q has %d segments (expected 6 per federated EntityID contract org.platform.domain.system.type.instance)",
-			ErrWorkflowNotRegistered, w.Name, w.EntityIDPattern, len(segs))
+			ErrInvalidWorkflow, w.Name, w.EntityIDPattern, len(segs))
 	}
 	if w.PhasePredicate == "" {
 		return fmt.Errorf("%w: workflow %q PhasePredicate is required",
-			ErrWorkflowNotRegistered, w.Name)
+			ErrInvalidWorkflow, w.Name)
 	}
 	if w.Schema == nil {
 		return fmt.Errorf("%w: workflow %q Schema is required",
-			ErrWorkflowNotRegistered, w.Name)
+			ErrInvalidWorkflow, w.Name)
 	}
 	if err := w.Transitions.Validate(); err != nil {
 		return err
@@ -195,22 +197,22 @@ func (w *Workflow) validate() error {
 	for _, ch := range w.ChildWorkflows {
 		if ch.Workflow == "" {
 			return fmt.Errorf("%w: workflow %q has ChildWorkflows entry with empty Workflow",
-				ErrWorkflowNotRegistered, w.Name)
+				ErrInvalidWorkflow, w.Name)
 		}
 		if ch.LinkPredicate == "" {
 			return fmt.Errorf("%w: workflow %q ChildSpec for %q has empty LinkPredicate",
-				ErrWorkflowNotRegistered, w.Name, ch.Workflow)
+				ErrInvalidWorkflow, w.Name, ch.Workflow)
 		}
 		if seen[ch.LinkPredicate] {
 			return fmt.Errorf("%w: workflow %q has duplicate ChildSpec LinkPredicate %q",
-				ErrWorkflowNotRegistered, w.Name, ch.LinkPredicate)
+				ErrInvalidWorkflow, w.Name, ch.LinkPredicate)
 		}
 		seen[ch.LinkPredicate] = true
 	}
 	for _, ref := range w.ReferencePredicates {
 		if ref.Predicate == "" {
 			return fmt.Errorf("%w: workflow %q has ReferenceSpec with empty Predicate",
-				ErrWorkflowNotRegistered, w.Name)
+				ErrInvalidWorkflow, w.Name)
 		}
 	}
 	return nil

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -3,6 +3,7 @@ package agenticloop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -1470,7 +1471,7 @@ func (c *Component) handleTrajectoryQuery(_ context.Context, data []byte) ([]byt
 		Limit  int    `json:"limit,omitempty"`
 	}
 	if err := json.Unmarshal(data, &req); err != nil || req.LoopID == "" {
-		return nil, fmt.Errorf("loopId required")
+		return nil, errs.WrapInvalid(errors.New("loopId required"), "Component", "handleTrajectoryQuery", "validate request")
 	}
 
 	// Try cache first (finalized trajectories).
@@ -1483,7 +1484,9 @@ func (c *Component) handleTrajectoryQuery(_ context.Context, data []byte) ([]byt
 	if traj == nil {
 		t, err := c.handler.trajectoryManager.GetTrajectory(req.LoopID)
 		if err != nil {
-			return nil, fmt.Errorf("trajectory not found: %w", err)
+			// "Not found" classifies as Invalid at the wire boundary
+			// per gh#93 — HTTP semantics (404) belong at the gateway.
+			return nil, errs.WrapInvalid(err, "Component", "handleTrajectoryQuery", "trajectory not found")
 		}
 		traj = &t
 	}

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -1470,8 +1470,15 @@ func (c *Component) handleTrajectoryQuery(_ context.Context, data []byte) ([]byt
 		LoopID string `json:"loopId"`
 		Limit  int    `json:"limit,omitempty"`
 	}
-	if err := json.Unmarshal(data, &req); err != nil || req.LoopID == "" {
-		return nil, errs.WrapInvalid(errors.New("loopId required"), "Component", "handleTrajectoryQuery", "validate request")
+	// Split unmarshal vs missing-loopId per Phase 3 reviewer R3 — both
+	// classify Invalid but log lines should distinguish them. errs.Classified
+	// preserves the historic "loopId required" / "trajectory not found: ..."
+	// wire body shape for downstream sniffers per gh#93 dual-encoding.
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, errs.Classified(errs.ErrorInvalid, fmt.Errorf("loopId required: %w", err))
+	}
+	if req.LoopID == "" {
+		return nil, errs.Classified(errs.ErrorInvalid, errors.New("loopId required"))
 	}
 
 	// Try cache first (finalized trajectories).
@@ -1486,7 +1493,7 @@ func (c *Component) handleTrajectoryQuery(_ context.Context, data []byte) ([]byt
 		if err != nil {
 			// "Not found" classifies as Invalid at the wire boundary
 			// per gh#93 — HTTP semantics (404) belong at the gateway.
-			return nil, errs.WrapInvalid(err, "Component", "handleTrajectoryQuery", "trajectory not found")
+			return nil, errs.Classified(errs.ErrorInvalid, fmt.Errorf("trajectory not found: %w", err))
 		}
 		traj = &t
 	}

--- a/processor/agentic-loop/todos.go
+++ b/processor/agentic-loop/todos.go
@@ -1,7 +1,6 @@
 package agenticloop
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,22 +12,9 @@ import (
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
-
-// notFoundPrefix is the prefix natsclient.SubscribeForRequests stamps
-// onto handler-side errors when the responder returns a Go error
-// instead of structured response data. graph-ingest's
-// handleQueryEntityNATS returns "not found: <id>" as a Go error on
-// missing entities; the client sees that as a *successful* NATS
-// response whose body starts with "error: not found:".
-//
-// We detect that prefix and treat it as an empty-list signal so a
-// fresh loop's first iteration doesn't emit a JSON-unmarshal Debug
-// log line per check. Any other "error: ..." payload (e.g.
-// "error: internal error: ...") falls through and surfaces as an
-// unmarshal error that the caller logs.
-var notFoundPrefix = []byte("error: not found")
 
 // queryEntitySubject is the NATS subject for single-entity reads from
 // graph-ingest. Mirrors processor/graph-ingest/query.go.
@@ -89,12 +75,18 @@ func (r *natsTodoReader) ReadTodos(ctx context.Context, loopEntityID string) ([]
 		return nil, fmt.Errorf("marshal query request: %w", err)
 	}
 
-	respData, err := r.client.Request(ctx, queryEntitySubject, reqData, readTodosTimeout)
+	respData, err := r.client.RequestClassified(ctx, queryEntitySubject, reqData, readTodosTimeout)
 	if err != nil {
-		// Transport-layer errors (timeout, no responders) — propagate.
-		// Handler-layer errors land in the response body via
-		// natsclient's "error: ..." payload convention, NOT in this
-		// err return; see notFoundPrefix above.
+		// gh#93: RequestClassified unifies transport AND handler
+		// errors behind one classified return. Handler-side
+		// "not found" classifies as Invalid (graph-ingest's
+		// handleQueryEntityNATS returns errs.Classified(ErrorInvalid,
+		// "not found: <id>") for missing entities) — fail-open with
+		// an empty list so a fresh loop's first iteration doesn't
+		// emit Debug noise. Transient/transport errors propagate.
+		if errs.IsInvalid(err) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("request %s: %w", queryEntitySubject, err)
 	}
 
@@ -102,17 +94,11 @@ func (r *natsTodoReader) ReadTodos(ctx context.Context, loopEntityID string) ([]
 }
 
 // parseQueryEntityTodos decodes a graph.ingest.query.entity response
-// payload into TodoState values. Treats the "error: not found"
-// payload prefix as an empty list (fresh-loop case) so callers don't
-// log a JSON-unmarshal Debug line on every first iteration. Other
-// "error: ..." payloads fall through and surface as unmarshal
-// errors. Factored out so the not-found contract is testable
-// without a NATS test cluster.
+// payload into TodoState values. As of gh#93 Phase 2 the caller
+// (ReadTodos) routes through natsclient.RequestClassified, which
+// surfaces handler-side errors via err return — this function only
+// sees success-path bytes.
 func parseQueryEntityTodos(respData []byte) ([]TodoState, error) {
-	if bytes.HasPrefix(respData, notFoundPrefix) {
-		return nil, nil
-	}
-
 	var entity graph.EntityState
 	if err := json.Unmarshal(respData, &entity); err != nil {
 		return nil, fmt.Errorf("unmarshal entity: %w", err)

--- a/processor/agentic-loop/todos_test.go
+++ b/processor/agentic-loop/todos_test.go
@@ -163,44 +163,34 @@ func TestBuildTodoStateMessage_EmptyReturnsZeroValue(t *testing.T) {
 	}
 }
 
-// TestParseQueryEntityTodos_NotFoundIsEmptyList pins the fresh-loop
-// fail-open contract. graph-ingest's handler returns a Go error on
-// missing entity, but natsclient.SubscribeForRequests wraps it as a
-// successful NATS response whose body is "error: not found: <id>".
-// We must detect that prefix and return an empty list rather than
-// emit a JSON-unmarshal Debug log per iteration of every fresh loop.
-// Regression: the prior implementation checked err.Error() on the
-// Request return, which never fires on this protocol path.
-func TestParseQueryEntityTodos_NotFoundIsEmptyList(t *testing.T) {
+// TestParseQueryEntityTodos_UnmarshalFailureSurfaces pins the
+// remaining contract for parseQueryEntityTodos after the gh#93
+// Phase 2 migration: ReadTodos now routes through
+// natsclient.RequestClassified, so handler errors arrive via the err
+// return and the fresh-loop fail-open contract is enforced one level
+// up. parseQueryEntityTodos only sees success-path bytes; if they
+// aren't valid EntityState JSON, return the unmarshal error.
+//
+// The not-found / fresh-loop fail-open contract is now wire-driven
+// by the integration test in todos_wire_integration_test.go.
+func TestParseQueryEntityTodos_UnmarshalFailureSurfaces(t *testing.T) {
 	tests := []struct {
 		name      string
 		payload   string
-		wantNil   bool
 		wantError bool
 	}{
-		{"exact prefix", "error: not found", true, false},
-		{"with id suffix", "error: not found: acme.test.foo.bar.loop.001", true, false},
-		// Other "error: ..." payloads fall through and surface as
-		// unmarshal failures — the caller logs Debug, the model just
-		// doesn't see the block this iteration. Tested here so a
-		// future protocol change that broadens the not-found prefix
-		// (e.g. to "error:" alone) trips this case.
-		{"other handler error", "error: internal error: db down", false, true},
+		{"empty body", "", true},
+		{"non-JSON", "garbage data", true},
+		{"empty triples", `{"id":"x","triples":[]}`, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			todos, err := parseQueryEntityTodos([]byte(tt.payload))
-			if tt.wantNil {
-				if err != nil {
-					t.Errorf("payload %q: got err %v, want nil", tt.payload, err)
-				}
-				if todos != nil {
-					t.Errorf("payload %q: got todos %v, want nil", tt.payload, todos)
-				}
-				return
-			}
+			_, err := parseQueryEntityTodos([]byte(tt.payload))
 			if tt.wantError && err == nil {
-				t.Errorf("payload %q: expected unmarshal error, got nil", tt.payload)
+				t.Errorf("payload %q: expected error, got nil", tt.payload)
+			}
+			if !tt.wantError && err != nil {
+				t.Errorf("payload %q: got err %v, want nil", tt.payload, err)
 			}
 		})
 	}

--- a/processor/agentic-tools/executors/search_graph.go
+++ b/processor/agentic-tools/executors/search_graph.go
@@ -142,7 +142,7 @@ func (e *SearchGraphExecutor) Execute(ctx context.Context, call agentic.ToolCall
 	if err != nil {
 		return agentic.ToolResult{
 			CallID:    call.ID,
-			Error:     fmt.Sprintf("search_graph failed: %v", err),
+			Error:     fmt.Sprintf("search_graph: %s", err.Error()),
 			ErrorKind: classifyRequestError(err),
 		}, nil
 	}

--- a/processor/agentic-tools/executors/search_graph.go
+++ b/processor/agentic-tools/executors/search_graph.go
@@ -134,23 +134,16 @@ func (e *SearchGraphExecutor) Execute(ctx context.Context, call agentic.ToolCall
 		}, nil
 	}
 
-	respData, err := e.natsClient.Request(ctx, searchGraphSubject, reqPayload, e.timeout)
+	// gh#93 Phase 2: RequestClassified unifies transport + handler
+	// errors behind one classified return. classifyRequestError maps
+	// transport failures to ToolErrorNetwork and handler-side
+	// classified errors to ToolErrorExternal.
+	respData, err := e.natsClient.RequestClassified(ctx, searchGraphSubject, reqPayload, e.timeout)
 	if err != nil {
 		return agentic.ToolResult{
 			CallID:    call.ID,
-			Error:     fmt.Sprintf("search_graph NATS request failed: %v", err),
-			ErrorKind: agentic.ToolErrorNetwork,
-		}, nil
-	}
-
-	// natsclient convention: handler-side Go errors come back in the
-	// body as "error: <msg>" rather than the err return. Check FIRST.
-	// See feedback_natsclient_error_payload_convention.md.
-	if msg, ok := extractNATSHandlerError(respData); ok {
-		return agentic.ToolResult{
-			CallID:    call.ID,
-			Error:     fmt.Sprintf("search_graph server error: %s", msg),
-			ErrorKind: agentic.ToolErrorExternal,
+			Error:     fmt.Sprintf("search_graph failed: %v", err),
+			ErrorKind: classifyRequestError(err),
 		}, nil
 	}
 

--- a/processor/agentic-tools/executors/summarize_graph.go
+++ b/processor/agentic-tools/executors/summarize_graph.go
@@ -1,9 +1,9 @@
 package executors
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -11,34 +11,28 @@ import (
 
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/pkg/errs"
 )
 
-// natsErrorPrefix is the convention natsclient.SubscribeForRequests
-// uses to surface handler-side Go errors back to callers — the
-// response body is `error: <msg>`, NOT a transport-level error.
-// Every NATS Request caller must check for this prefix before
-// attempting to decode the body as the expected response shape,
-// otherwise a downstream component failure surfaces to the LLM as
-// an opaque "parse response" error pointing at the wrong fix.
+// classifyRequestError maps a natsclient.RequestClassified failure
+// into the agentic ToolError taxonomy:
 //
-// See memory feedback_natsclient_error_payload_convention.md —
-// this convention bit PR #48 twice (todos.go H1 + pathrag.go
-// sister-bug). Every new NATS query caller in this PR follows the
-// same pattern.
-var natsErrorPrefix = []byte("error: ")
-
-// extractNATSHandlerError inspects raw NATS response bytes for the
-// natsclient "error: <msg>" handler-error envelope. Returns
-// (extracted-message, true) when the body matches the convention,
-// otherwise ("", false). Callers should propagate the extracted
-// message as ToolErrorExternal (downstream component is alive but
-// reporting failure) rather than ToolErrorInternal (we can't parse
-// the response).
-func extractNATSHandlerError(data []byte) (string, bool) {
-	if bytes.HasPrefix(data, natsErrorPrefix) {
-		return string(data[len(natsErrorPrefix):]), true
+//   - Transport failures (no responders, timeout, ctx cancelled)
+//     arrive as raw errors → ToolErrorNetwork.
+//   - Handler-side failures arrive as *errs.ClassifiedError
+//     reconstructed from the X-Status / X-Error-Class wire headers
+//     (or legacy body-prefix fallback) → ToolErrorExternal.
+//
+// Replaces the per-callsite extractNATSHandlerError helper that
+// sniffed the body-prefix shape — gh#93 Phase 2 unified the
+// transport + handler error paths behind RequestClassified, so the
+// caller now branches on the reconstructed-classified shape.
+func classifyRequestError(err error) agentic.ToolErrorKind {
+	var ce *errs.ClassifiedError
+	if errors.As(err, &ce) {
+		return agentic.ToolErrorExternal
 	}
-	return "", false
+	return agentic.ToolErrorNetwork
 }
 
 const (
@@ -74,6 +68,12 @@ const (
 // memory recorder.
 type NATSQuerier interface {
 	Request(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
+	// RequestClassified is the gh#93 path that surfaces handler
+	// errors via err return as *errs.ClassifiedError. Test mocks
+	// can synthesize via Request + natsclient.ClassifyReply against
+	// a nats.Msg{Data: ...} (matches the legacy-body-prefix
+	// fallback path).
+	RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
 }
 
 // SummarizeGraphExecutor implements the summarize_graph tool. Thin
@@ -162,25 +162,17 @@ func (e *SummarizeGraphExecutor) Execute(ctx context.Context, call agentic.ToolC
 		}, nil
 	}
 
-	respData, err := e.natsClient.Request(ctx, summarizeGraphSubject, reqPayload, e.timeout)
+	// gh#93 Phase 2: RequestClassified unifies transport + handler
+	// errors behind one classified return. classifyRequestError maps
+	// transport failures to ToolErrorNetwork (retryable from agent's
+	// view) and handler-side classified errors to ToolErrorExternal
+	// (server alive, reporting failure — different agent recovery).
+	respData, err := e.natsClient.RequestClassified(ctx, summarizeGraphSubject, reqPayload, e.timeout)
 	if err != nil {
 		return agentic.ToolResult{
 			CallID:    call.ID,
-			Error:     fmt.Sprintf("summarize_graph NATS request failed: %v", err),
-			ErrorKind: agentic.ToolErrorNetwork,
-		}, nil
-	}
-
-	// natsclient convention: handler-side Go errors come back in the
-	// body as "error: <msg>" rather than the err return. Check FIRST,
-	// before json.Unmarshal — otherwise downstream failures surface
-	// as opaque "parse response" errors and the LLM tries to fix the
-	// wrong thing. See feedback_natsclient_error_payload_convention.md.
-	if msg, ok := extractNATSHandlerError(respData); ok {
-		return agentic.ToolResult{
-			CallID:    call.ID,
-			Error:     fmt.Sprintf("summarize_graph server error: %s", msg),
-			ErrorKind: agentic.ToolErrorExternal,
+			Error:     fmt.Sprintf("summarize_graph failed: %v", err),
+			ErrorKind: classifyRequestError(err),
 		}, nil
 	}
 

--- a/processor/agentic-tools/executors/summarize_graph.go
+++ b/processor/agentic-tools/executors/summarize_graph.go
@@ -27,6 +27,9 @@ import (
 // sniffed the body-prefix shape — gh#93 Phase 2 unified the
 // transport + handler error paths behind RequestClassified, so the
 // caller now branches on the reconstructed-classified shape.
+//
+// Same-package helper used by both summarize_graph and search_graph
+// executors; lift to a shared package if a third caller appears.
 func classifyRequestError(err error) agentic.ToolErrorKind {
 	var ce *errs.ClassifiedError
 	if errors.As(err, &ce) {
@@ -171,7 +174,7 @@ func (e *SummarizeGraphExecutor) Execute(ctx context.Context, call agentic.ToolC
 	if err != nil {
 		return agentic.ToolResult{
 			CallID:    call.ID,
-			Error:     fmt.Sprintf("summarize_graph failed: %v", err),
+			Error:     fmt.Sprintf("summarize_graph: %s", err.Error()),
 			ErrorKind: classifyRequestError(err),
 		}, nil
 	}

--- a/processor/agentic-tools/executors/summarize_graph_test.go
+++ b/processor/agentic-tools/executors/summarize_graph_test.go
@@ -8,8 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go"
+
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
 )
 
 // recordingNATSQuerier captures the last request and returns a
@@ -29,6 +32,21 @@ func (r *recordingNATSQuerier) Request(_ context.Context, subject string, data [
 	r.gotPayload = data
 	r.gotTimeout = timeout
 	return r.resp, r.err
+}
+
+// RequestClassified routes through Request and then runs ClassifyReply
+// against the response bytes. The mock has no headers, so this
+// exercises ClassifyReply's legacy-body-prefix fallback path —
+// matches how a pre-#93 handler would behave today AND how a
+// header-stamping Phase-1 handler appears once the response bytes
+// land on the wire.
+func (r *recordingNATSQuerier) RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error) {
+	body, err := r.Request(ctx, subject, data, timeout)
+	if err != nil {
+		return nil, err
+	}
+	msg := &nats.Msg{Data: body, Header: nats.Header{}}
+	return natsclient.ClassifyReply(msg)
 }
 
 func successSummaryResponse(t *testing.T, data graph.SummaryData) []byte {

--- a/processor/graph-clustering/similarity.go
+++ b/processor/graph-clustering/similarity.go
@@ -2,7 +2,6 @@
 package graphclustering
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -84,27 +83,18 @@ func (f *querySimilarityFinder) FindSimilar(
 		return nil, errs.WrapInvalid(err, "querySimilarityFinder", "FindSimilar", "marshal request")
 	}
 
-	// Send request with timeout
-	respData, err := f.natsClient.Request(ctx, similarQuerySubject, reqData, similarQueryTimeout)
+	// gh#93 Phase 2: RequestClassified unifies transport + handler
+	// errors behind one classified return. The similarity finder is
+	// optional — fail-open on any error so the caller
+	// (SemanticGapDetector) keeps walking other entities. Most common
+	// handler error here is "source entity has no embedding yet"
+	// (aggregation/group entities never projected through the
+	// embedder).
+	respData, err := f.natsClient.RequestClassified(ctx, similarQuerySubject, reqData, similarQueryTimeout)
 	if err != nil {
-		// Log but don't fail - similarity finder is optional
-		f.logger.Debug("similarity query failed",
+		f.logger.Debug("similarity query failed (transport or handler)",
 			slog.String("entity_id", entityID),
 			slog.Any("error", err))
-		return nil, nil
-	}
-
-	// Handler-layer failure surfaces in the response body via natsclient's
-	// "error: <msg>" payload convention (most common case here: source
-	// entity has no embedding yet, e.g. aggregation/group entities never
-	// projected through the embedder). Treat as "no similar found" so the
-	// caller (SemanticGapDetector) keeps walking other entities. Per
-	// feedback_natsclient_error_payload_convention; gh#93 tracks the
-	// header-classified replacement (breaking change, deferred).
-	if bytes.HasPrefix(respData, []byte("error: ")) {
-		f.logger.Debug("similarity query returned handler error",
-			slog.String("entity_id", entityID),
-			slog.String("body", string(respData)))
 		return nil, nil
 	}
 

--- a/processor/graph-index/query.go
+++ b/processor/graph-index/query.go
@@ -211,6 +211,20 @@ func (c *Component) handleQueryPredicateNATS(ctx context.Context, data []byte) (
 	}))
 }
 
+// queryMsg + the handleQuery* methods + respondError + respondJSON
+// below form a parallel msg-style handler family that is NEVER
+// registered for production traffic. Only the *NATS-suffixed
+// handlers above are wired via SubscribeForRequests; the msg-style
+// handlers exist solely for the in-process unit tests in this
+// package and emit a `{"error": "..."}` JSON envelope (a third
+// divergent error shape, distinct from both the legacy `error: `
+// body prefix and the gh#93 X-Status header convention).
+//
+// This duplication is a refactoring debt — the *NATS handlers
+// should be exercised directly by tests. Out of scope for gh#93's
+// wire-format fix (no production wire impact). Tracked as a separate
+// followup; see the gh#93 PR description's "Deferred" section.
+//
 // queryMsg is an interface for query request messages.
 // This accommodates both real NATS messages and test mocks.
 type queryMsg interface {

--- a/processor/graph-index/query.go
+++ b/processor/graph-index/query.go
@@ -211,22 +211,12 @@ func (c *Component) handleQueryPredicateNATS(ctx context.Context, data []byte) (
 	}))
 }
 
-// queryMsg + the handleQuery* methods + respondError + respondJSON
-// below form a parallel msg-style handler family that is NEVER
-// registered for production traffic. Only the *NATS-suffixed
-// handlers above are wired via SubscribeForRequests; the msg-style
-// handlers exist solely for the in-process unit tests in this
-// package and emit a `{"error": "..."}` JSON envelope (a third
-// divergent error shape, distinct from both the legacy `error: `
-// body prefix and the gh#93 X-Status header convention).
-//
-// This duplication is a refactoring debt — the *NATS handlers
-// should be exercised directly by tests. Out of scope for gh#93's
-// wire-format fix (no production wire impact). Tracked as a separate
-// followup; see the gh#93 PR description's "Deferred" section.
-//
-// queryMsg is an interface for query request messages.
-// This accommodates both real NATS messages and test mocks.
+// queryMsg + the handleQuery* methods + respondError/respondJSON below
+// are a parallel handler family used ONLY by in-package unit tests
+// (the *NATS-suffixed handlers above are the production wire). Emit
+// a third error shape — `{"error": "..."}` JSON envelopes — distinct
+// from the legacy body prefix and gh#93 X-Status headers. Refactoring
+// debt; out of scope for gh#93. See PR description.
 type queryMsg interface {
 	Data() []byte
 	Respond(data []byte) error

--- a/processor/graph-ingest/query.go
+++ b/processor/graph-ingest/query.go
@@ -4,6 +4,7 @@ package graphingest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 )
 
 // defaultMaxConcurrent is the default bounded concurrency for entity fetches
@@ -63,21 +65,24 @@ func (c *Component) handleQueryEntityNATS(ctx context.Context, data []byte) ([]b
 		ID string `json:"id"`
 	}
 	if err := json.Unmarshal(data, &req); err != nil {
-		return nil, fmt.Errorf("invalid request: %w", err)
+		return nil, errs.WrapInvalid(err, "Component", "handleQueryEntityNATS", "unmarshal request")
 	}
 
 	// Validate request
 	if req.ID == "" {
-		return nil, fmt.Errorf("invalid request: empty id")
+		return nil, errs.WrapInvalid(errors.New("empty id"), "Component", "handleQueryEntityNATS", "validate request")
 	}
 
 	// Get entity from KV bucket
 	entry, err := c.entityBucket.Get(ctx, req.ID)
 	if err != nil {
 		if natsclient.IsKVNotFoundError(err) {
-			return nil, fmt.Errorf("not found: %s", req.ID)
+			// HTTP semantics (400 vs 404) live at the gateway —
+			// "not found" classifies as Invalid at the wire boundary;
+			// callers can substring-match the body for 404 routing.
+			return nil, errs.WrapInvalid(errors.New(req.ID), "Component", "handleQueryEntityNATS", "entity not found")
 		}
-		return nil, fmt.Errorf("internal error: %w", err)
+		return nil, errs.WrapTransient(err, "Component", "handleQueryEntityNATS", "kv get")
 	}
 
 	return entry.Value, nil
@@ -94,7 +99,7 @@ func (c *Component) handleQueryBatchNATS(ctx context.Context, data []byte) ([]by
 		IDs []string `json:"ids"`
 	}
 	if err := json.Unmarshal(data, &req); err != nil {
-		return nil, fmt.Errorf("invalid request: %w", err)
+		return nil, errs.WrapInvalid(err, "Component", "handleQueryBatchNATS", "unmarshal request")
 	}
 
 	// Handle empty IDs (return empty entities)
@@ -123,7 +128,7 @@ func (c *Component) handleQueryPrefixNATS(ctx context.Context, data []byte) ([]b
 		Limit  int    `json:"limit"`
 	}
 	if err := json.Unmarshal(data, &req); err != nil {
-		return nil, fmt.Errorf("invalid request: %w", err)
+		return nil, errs.WrapInvalid(err, "Component", "handleQueryPrefixNATS", "unmarshal request")
 	}
 
 	// Build prefix for server-side filtering
@@ -135,7 +140,7 @@ func (c *Component) handleQueryPrefixNATS(ctx context.Context, data []byte) ([]b
 	// Use server-side prefix filtering instead of loading all keys
 	keys, err := c.entityBucket.KeysByPrefix(ctx, prefixDot)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get keys: %w", err)
+		return nil, errs.WrapTransient(err, "Component", "handleQueryPrefixNATS", "kv keys by prefix")
 	}
 
 	// Also check exact match for full entity ID queries (6-part IDs
@@ -179,13 +184,13 @@ func (c *Component) handleQuerySuffixNATS(ctx context.Context, data []byte) ([]b
 	}
 	if err := json.Unmarshal(data, &req); err != nil {
 		c.logger.Error("suffix query unmarshal failed", "error", err)
-		return nil, fmt.Errorf("invalid request: %w", err)
+		return nil, errs.WrapInvalid(err, "Component", "handleQuerySuffixNATS", "unmarshal request")
 	}
 
 	c.logger.Debug("suffix query received", "suffix", req.Suffix)
 
 	if req.Suffix == "" {
-		return nil, fmt.Errorf("invalid request: empty suffix")
+		return nil, errs.WrapInvalid(errors.New("empty suffix"), "Component", "handleQuerySuffixNATS", "validate request")
 	}
 
 	// Tier 1: Check TTL cache (O(1) memory lookup)
@@ -260,6 +265,20 @@ func (c *Component) suffixFallbackScan(ctx context.Context, suffix string) strin
 	return ""
 }
 
+// queryMsg + the handleQueryEntity / handleQueryBatch methods +
+// respondError + respondJSON below form a parallel msg-style handler
+// family that is NEVER registered for production traffic. Only the
+// *NATS-suffixed handlers above are wired via SubscribeForRequests;
+// the msg-style handlers exist solely for the in-process unit tests
+// in this package and emit a `{"error": "..."}` JSON envelope
+// (a third divergent error shape, distinct from both the legacy
+// `error: ` body prefix and the gh#93 X-Status header convention).
+//
+// This duplication is a refactoring debt — the *NATS handlers
+// should be exercised directly by tests. Out of scope for gh#93's
+// wire-format fix (no production wire impact). Tracked as a separate
+// followup; see the gh#93 PR description's "Deferred" section.
+//
 // queryMsg is an interface for query request messages.
 // This accommodates both real NATS messages and test mocks.
 type queryMsg interface {

--- a/processor/graph-ingest/query.go
+++ b/processor/graph-ingest/query.go
@@ -65,12 +65,18 @@ func (c *Component) handleQueryEntityNATS(ctx context.Context, data []byte) ([]b
 		ID string `json:"id"`
 	}
 	if err := json.Unmarshal(data, &req); err != nil {
-		return nil, errs.WrapInvalid(err, "Component", "handleQueryEntityNATS", "unmarshal request")
+		// Preserve historic wire body shape "error: invalid request: <inner>"
+		// for downstream consumers (semconnect's classifyEntityQueryError
+		// HasPrefix-matches "invalid request:", todos.go matches
+		// "error: not found", etc.) until Phase 2 retires the sniffers.
+		// errs.Classified carries the X-Error-Class header without the
+		// Wrap formula's attribution prefix.
+		return nil, errs.Classified(errs.ErrorInvalid, fmt.Errorf("invalid request: %w", err))
 	}
 
 	// Validate request
 	if req.ID == "" {
-		return nil, errs.WrapInvalid(errors.New("empty id"), "Component", "handleQueryEntityNATS", "validate request")
+		return nil, errs.Classified(errs.ErrorInvalid, errors.New("invalid request: empty id"))
 	}
 
 	// Get entity from KV bucket
@@ -79,10 +85,13 @@ func (c *Component) handleQueryEntityNATS(ctx context.Context, data []byte) ([]b
 		if natsclient.IsKVNotFoundError(err) {
 			// HTTP semantics (400 vs 404) live at the gateway —
 			// "not found" classifies as Invalid at the wire boundary;
-			// callers can substring-match the body for 404 routing.
-			return nil, errs.WrapInvalid(errors.New(req.ID), "Component", "handleQueryEntityNATS", "entity not found")
+			// the "not found: <id>" body prefix is the contract
+			// downstream consumers HasPrefix-match for 404 routing
+			// (semconnect:cs-api/systems.go:596,
+			// agentic-loop/todos.go:31).
+			return nil, errs.Classified(errs.ErrorInvalid, fmt.Errorf("not found: %s", req.ID))
 		}
-		return nil, errs.WrapTransient(err, "Component", "handleQueryEntityNATS", "kv get")
+		return nil, errs.Classified(errs.ErrorTransient, fmt.Errorf("internal error: %w", err))
 	}
 
 	return entry.Value, nil
@@ -99,7 +108,7 @@ func (c *Component) handleQueryBatchNATS(ctx context.Context, data []byte) ([]by
 		IDs []string `json:"ids"`
 	}
 	if err := json.Unmarshal(data, &req); err != nil {
-		return nil, errs.WrapInvalid(err, "Component", "handleQueryBatchNATS", "unmarshal request")
+		return nil, errs.Classified(errs.ErrorInvalid, fmt.Errorf("invalid request: %w", err))
 	}
 
 	// Handle empty IDs (return empty entities)
@@ -128,7 +137,7 @@ func (c *Component) handleQueryPrefixNATS(ctx context.Context, data []byte) ([]b
 		Limit  int    `json:"limit"`
 	}
 	if err := json.Unmarshal(data, &req); err != nil {
-		return nil, errs.WrapInvalid(err, "Component", "handleQueryPrefixNATS", "unmarshal request")
+		return nil, errs.Classified(errs.ErrorInvalid, fmt.Errorf("invalid request: %w", err))
 	}
 
 	// Build prefix for server-side filtering
@@ -140,7 +149,7 @@ func (c *Component) handleQueryPrefixNATS(ctx context.Context, data []byte) ([]b
 	// Use server-side prefix filtering instead of loading all keys
 	keys, err := c.entityBucket.KeysByPrefix(ctx, prefixDot)
 	if err != nil {
-		return nil, errs.WrapTransient(err, "Component", "handleQueryPrefixNATS", "kv keys by prefix")
+		return nil, errs.Classified(errs.ErrorTransient, fmt.Errorf("failed to get keys: %w", err))
 	}
 
 	// Also check exact match for full entity ID queries (6-part IDs
@@ -184,13 +193,13 @@ func (c *Component) handleQuerySuffixNATS(ctx context.Context, data []byte) ([]b
 	}
 	if err := json.Unmarshal(data, &req); err != nil {
 		c.logger.Error("suffix query unmarshal failed", "error", err)
-		return nil, errs.WrapInvalid(err, "Component", "handleQuerySuffixNATS", "unmarshal request")
+		return nil, errs.Classified(errs.ErrorInvalid, fmt.Errorf("invalid request: %w", err))
 	}
 
 	c.logger.Debug("suffix query received", "suffix", req.Suffix)
 
 	if req.Suffix == "" {
-		return nil, errs.WrapInvalid(errors.New("empty suffix"), "Component", "handleQuerySuffixNATS", "validate request")
+		return nil, errs.Classified(errs.ErrorInvalid, errors.New("invalid request: empty suffix"))
 	}
 
 	// Tier 1: Check TTL cache (O(1) memory lookup)
@@ -265,22 +274,13 @@ func (c *Component) suffixFallbackScan(ctx context.Context, suffix string) strin
 	return ""
 }
 
-// queryMsg + the handleQueryEntity / handleQueryBatch methods +
-// respondError + respondJSON below form a parallel msg-style handler
-// family that is NEVER registered for production traffic. Only the
-// *NATS-suffixed handlers above are wired via SubscribeForRequests;
-// the msg-style handlers exist solely for the in-process unit tests
-// in this package and emit a `{"error": "..."}` JSON envelope
-// (a third divergent error shape, distinct from both the legacy
-// `error: ` body prefix and the gh#93 X-Status header convention).
-//
-// This duplication is a refactoring debt — the *NATS handlers
-// should be exercised directly by tests. Out of scope for gh#93's
-// wire-format fix (no production wire impact). Tracked as a separate
-// followup; see the gh#93 PR description's "Deferred" section.
-//
-// queryMsg is an interface for query request messages.
-// This accommodates both real NATS messages and test mocks.
+// queryMsg + handleQueryEntity/handleQueryBatch methods + respondError/
+// respondJSON below are a parallel handler family used ONLY by
+// in-package unit tests (the *NATS-suffixed handlers above are the
+// production wire). Emit a third error shape — `{"error": "..."}`
+// JSON envelopes — distinct from the legacy body prefix and gh#93
+// X-Status headers. Refactoring debt; out of scope for gh#93. See
+// PR description.
 type queryMsg interface {
 	Data() []byte
 	Respond(data []byte) error

--- a/processor/graph-ingest/query_wire_contract_integration_test.go
+++ b/processor/graph-ingest/query_wire_contract_integration_test.go
@@ -1,0 +1,191 @@
+//go:build integration
+
+package graphingest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// TestIntegration_QueryEntityNATS_WireContract drives the registered
+// graph.ingest.query.entity handler end-to-end and asserts on BOTH
+// the X-Error-Class header AND the legacy body prefix shape that
+// downstream consumers depend on. Closes the gh#93 Phase 3 reviewer
+// B1/B2 regression class — the previous Phase 3 commit changed the
+// body message text and broke production HasPrefix sniffers in
+// processor/agentic-loop/todos.go and semconnect's
+// classifyEntityQueryError; this test would have caught both because
+// it asserts on the actual wire bytes, not synthetic fakes.
+func TestIntegration_QueryEntityNATS_WireContract(t *testing.T) {
+	ctx := context.Background()
+
+	streams := []natsclient.TestStreamConfig{
+		{Name: "ENTITY", Subjects: []string{"entity.>"}},
+	}
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+	natsClient := testClient.Client
+
+	config := DefaultConfig()
+	deps := component.Dependencies{NATSClient: natsClient}
+
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := CreateGraphIngest(configJSON, deps)
+	require.NoError(t, err)
+
+	c := comp.(*Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	defer func() { _ = c.Stop(5 * time.Second) }()
+	time.Sleep(100 * time.Millisecond)
+
+	t.Run("not_found_path", func(t *testing.T) {
+		// The wire-shape contracts this case pins:
+		//   - Body has prefix "error: not found:" so downstream
+		//     HasPrefix sniffers (agentic-loop/todos.go,
+		//     semconnect/cs-api/systems.go) keep routing correctly.
+		//   - The entity ID survives in the body tail for HTTP 404
+		//     payload context.
+		//   - X-Error-Class header is "invalid" so Phase 2 callers
+		//     using RequestClassified see errs.IsInvalid(err) == true.
+		req, _ := json.Marshal(map[string]string{"id": "no.such.entity.does.not.exist.xyz"})
+
+		msg, err := natsClient.RequestWithHeaders(ctx, "graph.ingest.query.entity", req, nil, 2*time.Second)
+		require.NoError(t, err, "transport must succeed")
+		require.NotNil(t, msg)
+
+		// 1. Header: X-Error-Class must be "invalid".
+		gotClass := msg.Header.Get(natsclient.HeaderErrorClass)
+		if gotClass != natsclient.ErrorClassInvalid {
+			t.Errorf("X-Error-Class = %q, want %q (Phase 2 callers depend on this)",
+				gotClass, natsclient.ErrorClassInvalid)
+		}
+
+		// 2. Body prefix: legacy "error: " present.
+		if !bytes.HasPrefix(msg.Data, []byte("error: ")) {
+			t.Fatalf("body missing legacy 'error: ' prefix; got %q", msg.Data)
+		}
+
+		// 3. Body has "not found:" right after the legacy prefix
+		//    — agentic-loop/todos.go:31 HasPrefix-matches
+		//    []byte("error: not found"), and semconnect's
+		//    classifyEntityQueryError HasPrefix-matches "not found:"
+		//    after stripping the "error: " prefix.
+		if !bytes.HasPrefix(msg.Data, []byte("error: not found:")) {
+			t.Errorf("body does not match downstream sniffer contract\n"+
+				"  got:  %q\n"+
+				"  want prefix: %q (agentic-loop/todos.go + semconnect/cs-api/systems.go)",
+				msg.Data, "error: not found:")
+		}
+
+		// 4. Entity ID survives in the body for 404 payload context.
+		if !bytes.Contains(msg.Data, []byte("no.such.entity.does.not.exist.xyz")) {
+			t.Errorf("entity ID missing from body; got %q", msg.Data)
+		}
+
+		// 5. RequestClassified round-trip — Phase 2 callers using
+		//    this path must see errs.IsInvalid(err) == true.
+		_, classifiedErr := natsClient.RequestClassified(ctx, "graph.ingest.query.entity", req, 2*time.Second)
+		if classifiedErr == nil {
+			t.Fatal("RequestClassified must surface classified error")
+		}
+		if !errs.IsInvalid(classifiedErr) {
+			t.Errorf("RequestClassified err class wrong: IsInvalid=%v want true; err=%v",
+				errs.IsInvalid(classifiedErr), classifiedErr)
+		}
+	})
+
+	t.Run("invalid_request_path", func(t *testing.T) {
+		// The wire-shape contract this case pins:
+		//   - Body has prefix "error: invalid request:" so
+		//     semconnect's classifyEntityQueryError HasPrefix-matches
+		//     after stripping the "error: " prefix → HTTP 400.
+		//   - X-Error-Class header is "invalid".
+		req := []byte("this is not valid JSON {{{")
+
+		msg, err := natsClient.RequestWithHeaders(ctx, "graph.ingest.query.entity", req, nil, 2*time.Second)
+		require.NoError(t, err)
+		require.NotNil(t, msg)
+
+		gotClass := msg.Header.Get(natsclient.HeaderErrorClass)
+		if gotClass != natsclient.ErrorClassInvalid {
+			t.Errorf("X-Error-Class = %q, want %q", gotClass, natsclient.ErrorClassInvalid)
+		}
+
+		if !bytes.HasPrefix(msg.Data, []byte("error: invalid request:")) {
+			t.Errorf("body does not match semconnect's HasPrefix(\"invalid request:\") contract\n"+
+				"  got: %q\n"+
+				"  want prefix: %q",
+				msg.Data, "error: invalid request:")
+		}
+	})
+
+	t.Run("empty_id_path", func(t *testing.T) {
+		// Validation error before KV lookup. Body must read
+		// "error: invalid request: empty id" — semconnect's
+		// classifyEntityQueryError treats the "invalid request:"
+		// prefix as HTTP 400.
+		req, _ := json.Marshal(map[string]string{"id": ""})
+
+		msg, err := natsClient.RequestWithHeaders(ctx, "graph.ingest.query.entity", req, nil, 2*time.Second)
+		require.NoError(t, err)
+
+		gotClass := msg.Header.Get(natsclient.HeaderErrorClass)
+		if gotClass != natsclient.ErrorClassInvalid {
+			t.Errorf("X-Error-Class = %q, want %q", gotClass, natsclient.ErrorClassInvalid)
+		}
+
+		want := []byte("error: invalid request: empty id")
+		if !bytes.Equal(msg.Data, want) {
+			t.Errorf("body = %q, want %q", msg.Data, want)
+		}
+	})
+
+	t.Run("success_path_unchanged", func(t *testing.T) {
+		// Success body byte invariant — Phase 3 must NOT introduce
+		// any header on the success path, NOT change the success
+		// body bytes. Closes the Phase 1 reviewer R1 lock at this
+		// handler.
+		entityID := "test.org.platform.domain.system.entity.success-fixture"
+		seedEntity(t, ctx, c, entityID, []byte(`{"id":"`+entityID+`","triples":[]}`))
+
+		req, _ := json.Marshal(map[string]string{"id": entityID})
+		msg, err := natsClient.RequestWithHeaders(ctx, "graph.ingest.query.entity", req, nil, 2*time.Second)
+		require.NoError(t, err)
+
+		if msg.Header.Get(natsclient.HeaderStatus) != "" {
+			t.Errorf("X-Status must be absent on success path; got %q",
+				msg.Header.Get(natsclient.HeaderStatus))
+		}
+		if bytes.HasPrefix(msg.Data, []byte("error: ")) {
+			t.Errorf("success body must NOT carry legacy error prefix; got %q", msg.Data)
+		}
+		// Body should be the seeded entity JSON.
+		if !strings.Contains(string(msg.Data), entityID) {
+			t.Errorf("success body missing entity ID; got %q", msg.Data)
+		}
+	})
+}
+
+// seedEntity writes a raw entity JSON to the ENTITY_STATES KV bucket
+// so the not-found path tests can be distinguished from the success
+// path. Uses the bucket directly to bypass mutation handler complexity.
+func seedEntity(t *testing.T, ctx context.Context, c *Component, id string, body []byte) {
+	t.Helper()
+	if c.entityBucket == nil {
+		t.Fatal("entityBucket not initialized")
+	}
+	_, err := c.entityBucket.Put(ctx, id, body)
+	require.NoError(t, err)
+}

--- a/processor/graph-query/component.go
+++ b/processor/graph-query/component.go
@@ -31,6 +31,11 @@ import (
 // *natsclient.Client satisfies this interface, and tests can provide mocks.
 type natsRequester interface {
 	Request(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
+	// RequestClassified is the gh#93 caller-side path: handler errors
+	// surface via the err return as classified errors, transport
+	// errors remain on err too. Prefer over Request+body-sniff for
+	// new callers.
+	RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
 	SubscribeForRequests(ctx context.Context, subject string, handler func(ctx context.Context, data []byte) ([]byte, error)) (*natsclient.Subscription, error)
 	Status() natsclient.ConnectionStatus
 	Connect(ctx context.Context) error

--- a/processor/graph-query/component_test.go
+++ b/processor/graph-query/component_test.go
@@ -49,6 +49,22 @@ func (m *mockNATSClient) Request(ctx context.Context, subject string, data []byt
 	return nil, errors.New("no mock response configured")
 }
 
+// RequestClassified routes through Request and then ClassifyReply
+// against the response bytes. The mock has no headers, so this
+// exercises the legacy-body-prefix fallback path — matches how a
+// pre-#93 handler would behave today.
+func (m *mockNATSClient) RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error) {
+	body, err := m.Request(ctx, subject, data, timeout)
+	if err != nil {
+		return nil, err
+	}
+	// Synthesize a *nats.Msg with no headers and the body bytes so
+	// ClassifyReply runs against the same shape it would see from
+	// the wire. Avoids depending on a real connection.
+	msg := &nats.Msg{Data: body, Header: nats.Header{}}
+	return natsclient.ClassifyReply(msg)
+}
+
 func (m *mockNATSClient) SubscribeForRequests(_ context.Context, subject string, _ func(ctx context.Context, data []byte) ([]byte, error)) (*natsclient.Subscription, error) {
 	m.subscribed[subject] = true
 	// Return a nil subscription since the mock doesn't actually subscribe

--- a/processor/graph-query/graphrag.go
+++ b/processor/graph-query/graphrag.go
@@ -2,7 +2,6 @@
 package graphquery
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1258,24 +1257,18 @@ func (c *Component) searchEntitiesSemantic(ctx context.Context, query string, li
 		return nil, errs.Wrap(err, "GraphQuery", "searchEntitiesSemantic", "marshal request")
 	}
 
-	resp, err := c.natsClient.Request(ctx, "graph.embedding.query.search", data, 30*time.Second)
+	// gh#93 Phase 2: RequestClassified unifies transport + handler
+	// errors. Most common handler error here: graph-embedding's
+	// embedder isn't initialized yet, or the embedder (semembed HTTP
+	// / BM25 cache) couldn't produce a vector for the query text.
+	// Treat any classified handler error as "no semantic hits" so
+	// globalSearch's caller falls through to the tier-2 text-based
+	// community search instead of hard-failing.
+	resp, err := c.natsClient.RequestClassified(ctx, "graph.embedding.query.search", data, 30*time.Second)
 	if err != nil {
-		return nil, errs.WrapTransient(err, "GraphQuery", "searchEntitiesSemantic", "semantic search request")
-	}
-
-	// Handler-layer failure surfaces in the response body via natsclient's
-	// "error: <msg>" payload convention — most common cause here:
-	// graph-embedding's embedder isn't initialized yet, or the embedder
-	// (semembed HTTP / BM25 cache) couldn't produce a vector for the
-	// query text. Treat as "no semantic hits" so globalSearch's caller
-	// falls through to the tier-2 text-based community search instead of
-	// hard-failing. Per feedback_natsclient_error_payload_convention;
-	// gh#93 tracks the header-classified replacement (breaking change,
-	// deferred — quick site-local fix here to unblock pre-tag e2e).
-	if bytes.HasPrefix(resp, []byte("error: ")) {
-		c.logger.Debug("semantic search returned handler error",
+		c.logger.Debug("semantic search failed (transport or handler)",
 			slog.String("query", query),
-			slog.String("body", string(resp)))
+			slog.Any("error", err))
 		return nil, nil
 	}
 

--- a/processor/graph-query/graphrag.go
+++ b/processor/graph-query/graphrag.go
@@ -1258,18 +1258,26 @@ func (c *Component) searchEntitiesSemantic(ctx context.Context, query string, li
 	}
 
 	// gh#93 Phase 2: RequestClassified unifies transport + handler
-	// errors. Most common handler error here: graph-embedding's
-	// embedder isn't initialized yet, or the embedder (semembed HTTP
-	// / BM25 cache) couldn't produce a vector for the query text.
-	// Treat any classified handler error as "no semantic hits" so
-	// globalSearch's caller falls through to the tier-2 text-based
-	// community search instead of hard-failing.
+	// errors behind one classified return. Distinguish with errors.As:
+	//   - Handler-side classified error (embedder not ready, no vector
+	//     for query text) → fail-open with nil so globalSearch falls
+	//     to tier-2 text-based community search. Server reported
+	//     "I couldn't help with this query," which is a legitimate
+	//     fall-through signal.
+	//   - Transport-layer failure (no responders, timeout) → propagate
+	//     as Transient. The embedding service is unreachable; the
+	//     caller should know vs silently degrading to text search on
+	//     every query.
 	resp, err := c.natsClient.RequestClassified(ctx, "graph.embedding.query.search", data, 30*time.Second)
 	if err != nil {
-		c.logger.Debug("semantic search failed (transport or handler)",
-			slog.String("query", query),
-			slog.Any("error", err))
-		return nil, nil
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) {
+			c.logger.Debug("semantic search handler error",
+				slog.String("query", query),
+				slog.Any("error", err))
+			return nil, nil
+		}
+		return nil, errs.WrapTransient(err, "GraphQuery", "searchEntitiesSemantic", "semantic search request")
 	}
 
 	// Response format from graph-embedding/query.go:SearchResponse

--- a/processor/graph-query/pathrag.go
+++ b/processor/graph-query/pathrag.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/pkg/errs"
 )
 
 // Direction constants for path traversal
@@ -87,7 +89,10 @@ func NewPathSearcher(nats natsRequester, timeout time.Duration, maxDepth int, lo
 // Search performs BFS traversal with path tracking
 func (p *PathSearcher) Search(ctx context.Context, req PathSearchRequest) (*PathSearchResponse, error) {
 	if req.StartEntity == "" {
-		return nil, fmt.Errorf("invalid request: empty start_entity")
+		// Classified at source so the handleGlobalSearch wire emits
+		// X-Error-Class: invalid instead of defaulting to transient.
+		// errs.Classified preserves the historic body shape.
+		return nil, errs.Classified(errs.ErrorInvalid, errors.New("invalid request: empty start_entity"))
 	}
 
 	// Apply request-level timeout if specified

--- a/processor/graph-query/pathrag.go
+++ b/processor/graph-query/pathrag.go
@@ -2,7 +2,6 @@
 package graphquery
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -202,25 +201,29 @@ func (p *PathSearcher) applyLimits(reqDepth, reqNodes int) (maxDepth, maxNodes i
 //
 // Protocol note: graph-ingest's handleQueryEntityNATS returns a Go
 // error on missing-entity, but natsclient.SubscribeForRequests wraps
-// handler errors as a successful NATS response whose body starts with
-// "error: ". The previous implementation only branched on the Go err
-// return — which never fires on this protocol path — so a missing
-// entity silently passed verification. We detect the "error: " prefix
-// on the response payload to surface the not-found case correctly.
-// Same fix as ADR-036 Stage 4 H1 in processor/agentic-loop/todos.go.
+// gh#93 Phase 2: RequestClassified unifies transport and handler
+// errors. Handler-side "not found" classifies as Invalid and surfaces
+// as *errs.ClassifiedError; transport failures (no responders,
+// context.DeadlineExceeded) arrive as raw errors. We distinguish so
+// callers know whether the entity is genuinely absent vs we couldn't
+// ask. Previous implementation only branched on the Go err return —
+// which never fired on the legacy protocol path — so a missing entity
+// silently passed verification. Same fix as ADR-036 Stage 4 H1 in
+// processor/agentic-loop/todos.go.
 func (p *PathSearcher) verifyEntityExists(ctx context.Context, entityID string) error {
 	entityReq := map[string]string{"id": entityID}
 	entityReqData, _ := json.Marshal(entityReq)
-	respData, err := p.nats.Request(ctx, "graph.ingest.query.entity", entityReqData, p.timeout)
+	_, err := p.nats.RequestClassified(ctx, "graph.ingest.query.entity", entityReqData, p.timeout)
 	if err != nil {
-		// Transport-layer failure (timeout, no responders).
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) {
+			// Handler-side classified error — most commonly
+			// Invalid+"not found: <id>". Entity is genuinely absent.
+			return fmt.Errorf("entity not found: %w", err)
+		}
+		// Transport-layer failure (no responders, timeout). We
+		// couldn't ask; the entity may or may not exist.
 		return fmt.Errorf("query entity: %w", err)
-	}
-	// Handler-layer failure surfaces in the response body via
-	// natsclient's "error: <msg>" payload convention. The most
-	// common case is "error: not found: <id>" for missing entities.
-	if bytes.HasPrefix(respData, []byte("error: ")) {
-		return fmt.Errorf("entity not found: %s", string(respData))
 	}
 	return nil
 }

--- a/processor/graph-query/pathrag.go
+++ b/processor/graph-query/pathrag.go
@@ -217,9 +217,13 @@ func (p *PathSearcher) verifyEntityExists(ctx context.Context, entityID string) 
 	if err != nil {
 		var ce *errs.ClassifiedError
 		if errors.As(err, &ce) {
-			// Handler-side classified error — most commonly
-			// Invalid+"not found: <id>". Entity is genuinely absent.
-			return fmt.Errorf("entity not found: %w", err)
+			// Handler-side classified error — propagate verbatim.
+			// Producer side has already emitted a self-describing
+			// message (e.g. "not found: <id>", "internal error: ...")
+			// via errs.Classified, so wrapping here would
+			// double-prefix the wire body. Caller-facing GraphQL
+			// surface shows the handler's clean message directly.
+			return err
 		}
 		// Transport-layer failure (no responders, timeout). We
 		// couldn't ask; the entity may or may not exist.

--- a/processor/research-graph-classify/adapters.go
+++ b/processor/research-graph-classify/adapters.go
@@ -134,8 +134,15 @@ func (r *searchGraphRetriever) FetchCandidates(ctx context.Context, topic string
 	}
 	// gh#93 Phase 2: RequestClassified unifies transport + handler
 	// errors. Both arrive via err return; caller wraps as a single
-	// "search_graph failed" error so the upstream retriever decides
-	// whether to fall back or surface the failure.
+	// "search_graph" error. The upstream retriever drives fall-back
+	// off the CandidateSet.Degraded field, not err class — so
+	// flattening here is OK today.
+	//
+	// TODO(phase-4): consider surfacing the err class via
+	// CandidateSet.DegradedReason so callers can distinguish
+	// "search subsystem unreachable" from "search returned no
+	// candidates legitimately" once header-classified errors are
+	// the canonical path.
 	respData, err := r.client.RequestClassified(ctx, searchGraphSubject, reqData, r.timeout)
 	if err != nil {
 		return CandidateSet{}, fmt.Errorf("search_graph: %w", err)

--- a/processor/research-graph-classify/adapters.go
+++ b/processor/research-graph-classify/adapters.go
@@ -32,26 +32,6 @@ func (a *classifierChainAdapter) ClassifyQuery(ctx context.Context, topic string
 	return a.chain.ClassifyQuery(ctx, topic)
 }
 
-// natsErrorPrefix is the body-prefix convention natsclient handlers
-// use to surface Go errors as response payloads (see
-// feedback_natsclient_error_payload_convention). One named constant
-// instead of `len("error: ")` magic numbers across call sites.
-const natsErrorPrefix = "error: "
-
-// extractNATSBodyError returns the trimmed error message if respData
-// carries the natsErrorPrefix shape; the bool flags whether a match
-// happened. Mirrors processor/agentic-tools/executors helper of the
-// same intent, kept local until natsclient grows a shared helper.
-func extractNATSBodyError(respData []byte) (string, bool) {
-	if len(respData) < len(natsErrorPrefix) {
-		return "", false
-	}
-	if string(respData[:len(natsErrorPrefix)]) != natsErrorPrefix {
-		return "", false
-	}
-	return string(respData[len(natsErrorPrefix):]), true
-}
-
 // searchGraphSubject is the existing graph-query NATS surface for
 // natural-language search. PR 2 reuses it (rather than introducing a
 // new endpoint) so the candidate-retrieval path shares wiring with
@@ -152,20 +132,13 @@ func (r *searchGraphRetriever) FetchCandidates(ctx context.Context, topic string
 	if err != nil {
 		return CandidateSet{}, fmt.Errorf("marshal search request: %w", err)
 	}
-	respData, err := r.client.Request(ctx, searchGraphSubject, reqData, r.timeout)
+	// gh#93 Phase 2: RequestClassified unifies transport + handler
+	// errors. Both arrive via err return; caller wraps as a single
+	// "search_graph failed" error so the upstream retriever decides
+	// whether to fall back or surface the failure.
+	respData, err := r.client.RequestClassified(ctx, searchGraphSubject, reqData, r.timeout)
 	if err != nil {
-		return CandidateSet{}, fmt.Errorf("request %s: %w", searchGraphSubject, err)
-	}
-	// natsclient handler-error convention (body-prefix "error: ...")
-	// per feedback_natsclient_error_payload_convention. The check is
-	// inlined here because pulling in the agentic-tools helper would
-	// invert the dependency graph. Follow-up: lifting
-	// natsclient.ExtractHandlerError into natsclient itself, so
-	// summarize_graph + search_graph + this adapter share one helper
-	// — file alongside the planned #93 header-classified-errors
-	// migration.
-	if errMsg, ok := extractNATSBodyError(respData); ok {
-		return CandidateSet{}, fmt.Errorf("search_graph server error: %s", errMsg)
+		return CandidateSet{}, fmt.Errorf("search_graph: %w", err)
 	}
 
 	var resp searchGraphResponse


### PR DESCRIPTION
## Summary

Closes (partially) #93 — header-classified handler errors at the natsclient request/reply boundary. Phase 1+2+3 are **fully additive**; Phase 4 (drop legacy body shape) deferred post-1.0 as **#161**.

Seven commits on this branch:

| Commit | Phase |
|---|---|
| `eb94710` | Phase 1 — helpers + dual-encoding |
| `b44566e` | Phase 1 polish (B1b/B2a + R1-R4 + N2) |
| `0d9c323` | Phase 3 — handler classification |
| `afece48` | Phase 3 polish (`pkg/errs.Classified` + 4 reviewer blockers + wire-contract integration test) |
| `5221a56` | Phase 2 — 7 sniffer migrations |
| `c89213f` | Phase 2 polish (message-leak fix + R1 test + R5 dead-code delete + R6 transport/handler split) |
| `f08e339` | doc note + pathrag double-prefix fix |

## What ships

**New natsclient surface** (`natsclient/errors.go`):
- `RespondError(msg, err)` — free function for `SubscribeForRequests` handlers + direct `msg.Respond` callers
- `(*Client).ReplyError(ctx, replyTo, err)` — companion for `c.Reply` path
- `ClassifyReply(msg) ([]byte, error)` — caller-side header inspection with legacy body-prefix fallback
- `(*Client).RequestClassified(ctx, subject, data, timeout)` — recommended caller pattern; unifies transport + handler failure modes behind one classified return

**New pkg/errs surface**:
- `errs.Classified(class, err) *ClassifiedError` — bare classification constructor (no `<component>.<method>: <action> failed:` attribution prefix). Used by handlers that need to preserve verbatim wire body text for downstream HasPrefix consumers (semconnect's `classifyEntityQueryError`, etc.) during the dual-encoding window.

**11 handler-side migrations**: `processor/graph-ingest/query.go` (9 sites) + `processor/agentic-loop/component.go` (2 sites) + `processor/graph-query/pathrag.go` (1 site) — raw `fmt.Errorf` → classified via `errs.Classified` so X-Error-Class header carries truth.

**7 caller-side migrations**: agentic-loop/todos, graph-clustering/similarity, graph-query/{graphrag,pathrag}, agentic-tools/executors/{search,summarize}_graph, research-graph-classify/adapters, gateway/graph-gateway — all retired from body-prefix sniffing to `RequestClassified` / `ClassifyReply`.

**Wire-driving integration test**: `processor/graph-ingest/query_wire_contract_integration_test.go` (4 sub-cases) drives the registered `graph.ingest.query.entity` handler end-to-end and asserts both X-Status / X-Error-Class headers AND legacy body prefix shape. This is the structural lock that would have caught the two production-wire regressions the Phase 3 reviewer surfaced (`agentic-loop/todos.go` notFoundPrefix sniffer + semconnect's `classifyEntityQueryError`).

**Gateway header-path test**: `TestGateway_QueryErrorHandling_ClassifiedHandlerError` asserts the gateway maps classified handler errors to HTTP 200 with GraphQL errors envelope, AND that `errors[0].message` does NOT leak `"natsclient"` or `"ClassifyReply"` attribution — the structural lock on the Phase 2 polish R2/R3 fix.

## What this does NOT change

- Wire format on the success path unchanged.
- Wire body on the error path still carries the legacy `"error: <msg>"` prefix (Phase 3 polish locked this via `errs.Classified` at the producer side). New callers use header signal; legacy prefix is dual-encoding compat.
- pkg/errs preserves `WrapTransient/WrapFatal/WrapInvalid` (with attribution) as the preferred path for new code; `Classified` is the wire-stability tool.
- The msg-style dead-code handlers in `graph-index/query.go` and `graph-ingest/query.go` are UNTOUCHED (annotated in-place) — see follow-up #164.
- The `*NATS` envelope-style handlers in `graph-index/query.go` (7 sites) and `graph-ingest/mutations.go` (8 sites) still use NewQueryError / MutationResponse JSON envelopes — see follow-up #164.

## E2E gate

All five tiers green:

| Tier | Result |
|---|---|
| `task e2e:core` | 2/2 pass |
| `task e2e:structural` | validation_errors:0 |
| `task e2e:statistical` | validation_errors:0, known_answer_tests 7/7, 1m37s |
| `task e2e:semantic` | validation_errors:0, known_answer_failures:0, search_quality 0.76, gateway_hits 33, 7m05s |
| `task e2e:agentic` | passed |

Plus full `go test -race ./...` clean, `go vet -tags=integration` clean, revive clean.

## Follow-up issues filed at PR time

- **#161** — **Phase 4: drop legacy `"error: <msg>"` body shape (BREAKING, post-1.0)**. The compat-layer removal.
- **#162** — R7 AST-walker lint rule for new `Request` + `json.Unmarshal` callers (machine-side counterpart to `feedback_silent_handler_error_payload_audit`).
- **#163** — R4 `pathrag.verifyEntityExists` Invalid-vs-Transient/Fatal sharpening.
- **#164** — `graph-index/query.go` + `graph-ingest/mutations.go` JSON-envelope handler migration + msg-style dead-code cleanup (~1200 LOC).

## Sister-project impact (semconnect)

- During dual-encoding window: NO migration required. `classifyEntityQueryError` keeps working unchanged.
- At Phase 4 (#161): migration to `RequestClassified` / `ClassifyReply` required; `classifyEntityQueryError` shrinks to `errs.IsInvalid` + substring sniff for HTTP 400/404 routing.

## Test plan

- [x] Unit suite: `go test -race ./...` green
- [x] Integration: `go test -race -tags=integration ./natsclient/... ./processor/graph-ingest/...` green (round-trip + wire-contract tests)
- [x] E2E core / structural / statistical / semantic / agentic — all green per above
- [x] Lint: `task lint` clean
- [ ] Reviewer pass (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)