### PR TITLE
feat(swecommon): ADR-050 — schema-bound SWE Common encodings (closes #116)

### DIFF
--- a/docs/adr/050-swe-common-schema-bound-encodings.md
+++ b/docs/adr/050-swe-common-schema-bound-encodings.md
@@ -1,0 +1,192 @@
+# ADR-050: SWE Common Schema-Bound Encodings as Framework Primitive
+
+## Status
+
+**Accepted** — 2026-05-29 with the next tag bundle (Phase 1 of
+ADR-050 lands as an additive framework primitive; tag will be cut
+once any sibling work in flight has cleared). Closes
+[#116](https://github.com/C360Studio/semstreams/issues/116) and
+the corresponding upstream-ask
+`semstreams-swe-schema-bound-encodings.md` in semconnect's
+`docs/upstream-asks/` directory.
+
+## Context
+
+### What semconnect Stage 27 shipped
+
+semconnect Stage 27 added CS API observation-read with three SWE
+Common media types negotiable on the `GET /datastreams/{id}/observations`
+endpoint: `application/swe+json`, `application/swe+csv`, and
+`application/swe+binary`. Every response is tagged
+`X-CS-SWE-Subset: observation-values` because the framework did not
+yet expose schema-bound SWE Common record encodings; the gateway
+projects each observation down to `{time, result}` and serializes
+that two-column shape per the requested format.
+
+That value-only projection is enough to round-trip primitive
+sensor readings (a Quantity per observation), but it loses every
+piece of structural information SWE Common is designed to carry —
+field labels, units of measure, multi-field records, controlled-
+vocabulary tokens, nil reasons, command-side parity. The
+`X-CS-SWE-Subset` header is the explicit "we know this is not
+SWE Common conformance" hedge: semconnect cannot claim the SWE
+Common JSON / SWE Common Text / SWE Common Binary conformance
+classes from CS API Part 2 §A.7.x with this subset.
+
+### What every CS API consumer eventually needs
+
+Both sides of the CS API contract need schema-bound encoders:
+
+- **Observation read** (`GET /observations`) — a multi-field
+  record per observation result, with the schema advertised on
+  the datastream and the values streamed in the negotiated media
+  type. The producer guarantees structural fidelity (UoMs survive,
+  Time stays ISO 8601, Category tokens stay scoped to their code
+  list, nil readings are tagged with the schema's `nilValue`).
+- **Command payload** (`POST /controlstreams` once CS API Part 2
+  command posting lands) — same encoding pipeline run in reverse:
+  the consumer decodes the posted bytes against the controlstream's
+  declared schema, validates structural conformance, and dispatches
+  the typed command payload.
+
+These two paths need the same model. Letting the gateway own one
+shape and a future command processor own a different one
+guarantees the SemSpec lifecycle case study repeats: parallel
+hand-rolled conventions that have to be re-converged at v2 cost.
+
+## Decision
+
+Add a new framework package `pkg/swecommon` providing:
+
+1. **Sealed component model.** A `DataComponent` interface with
+   one concrete type per SWE Common scalar (`Quantity`, `Count`,
+   `Time`, `Boolean`, `Text`, `Category`) plus the composite
+   `DataRecord`. The interface is sealed by an unexported method
+   so adding a new kind requires changing this package — every
+   encoder dispatch table fails to compile until the new kind is
+   handled.
+2. **Schema marshal / unmarshal** in OGC SWE Common JSON Encoding
+   (22-022) shape. Operators advertise a datastream's schema by
+   serving this metadata document; consumers parse it back to a
+   typed `*DataRecord` and drive the encoders.
+3. **Three schema-bound encoder/decoder pairs:**
+   - `application/swe+json` — JSON array of objects, one per row,
+     field names as keys, RFC 3339 for Time.
+   - `application/swe+csv` — SWE TextEncoding with configurable
+     token + block separators (default comma + newline), decimal
+     separator pinned to `.`, optional header row.
+   - `application/swe+binary` — packed primitives with a
+     per-record nil bitmap, big-endian by default, length-prefixed
+     UTF-8 for variable-width fields.
+4. **Media-type constants.** `MediaSWEJSON`, `MediaSWECSV`,
+   `MediaSWEBinary` so consumers reference one declaration site.
+
+### Why the sealed-interface shape
+
+The same SWE-Common-XML-parser-evolution issue every other
+implementation has hit: someone adds a new component kind
+(`Vector`, `DataArray`, `DataChoice`) and the encoders silently
+fall back to a generic shape that loses the new type's invariants.
+A sealed interface with kind-exhaustive switches in each encoder
+forces the maintainer to handle the new kind everywhere or fail
+the build — the same pattern that has kept the orchestration
+layer's `OperatorKind` table consistent through three rule-engine
+expansions.
+
+### Why the Phase 1 scope cut
+
+Phase 1 covers everything CS API consumers need to drop
+`X-CS-SWE-Subset: observation-values`:
+
+- Three encoders + decoders end-to-end
+- Scalar components + DataRecord
+- UoMs, nil values, time, typed quantities, categories
+- Round-trip tests covering each shape
+
+Deferred (filed for follow-up, not blocking the conformance claim):
+
+- DataArray (homogeneous element record) — useful for waveform /
+  spectrum results, not in CS API Phase 1 observation use cases.
+- DataChoice (discriminated union) — rare in CS API contexts.
+- Vector (axis-frame-bound values) — specialized to geometry
+  observations.
+- Per-component constraints (`allowedValues`, ranges) — validation
+  layer; producers can validate independently for now.
+- Multi-reason NilValues block — Phase 1 supports a single
+  `nilValue` stand-in token per field, which covers the "no
+  reading" case CS API streams hit.
+- Nested DataRecord values — the framework MVP is one flat record
+  per row, matching every CS API observation/command body.
+- SWE XML encoding — CS API does not require it.
+
+### Why `pkg/swecommon` (not `message/swecommon`, not `encoding/swecommon`)
+
+The package follows the `pkg/lifecycle` / `pkg/dispatch` /
+`pkg/errs` shape: self-contained framework substrate that
+multiple consumers import. It is not a payload type (no
+`Schema()` / `Validate()` / `Payload` interface — it does not flow
+through JetStream envelopes), so `message/` would mis-label it.
+It is not the only `encoding/`-shaped subpackage we will ever
+need but the `pkg/` location is consistent with every other
+framework substrate package, and consumers grep for `pkg/` when
+they want to find "framework-level shared primitives."
+
+## Consequences
+
+### Positive
+
+- **semconnect drops `X-CS-SWE-Subset: observation-values`.** The
+  gateway parses each datastream's advertised SWE schema, hands
+  the schema + the unwrapped observation results to
+  `swecommon.Encode{JSON,Text,Binary}`, and serves the response.
+  CS API Part 2 SWE Common conformance classes become claimable.
+- **One encoding contract for read and command paths.** When CS
+  API Part 2 command posting lands, the same package's decoders
+  validate the posted bytes against the controlstream schema.
+- **Future framework consumers get the contract for free.** Other
+  CS API frontends, MCP tools that surface observation
+  collections, internal processors emitting SWE-shaped fixtures —
+  all import the same package and dispatch through the same
+  encoders.
+
+### Negative
+
+- **One more framework package to maintain.** Mitigated by the
+  sealed-interface design — the scope of each kind is small and
+  changes localize to one switch table per encoder.
+- **Phase 1 deferrals (DataArray, DataChoice, Vector, etc.) leave
+  some SWE Common shapes unencoded.** Operators with waveform or
+  multi-element observation needs would have to extend the
+  package before they can claim full SWE Common conformance.
+  Reasonable cost: every CS API consumer using the framework
+  today produces flat record observations.
+
+### Migration path for semconnect
+
+1. semconnect imports `github.com/c360studio/semstreams/pkg/swecommon`.
+2. The datastream resource gains a `resultSchema` field carrying
+   the marshaled SWE schema document. Stage 27 already accepts
+   the field as opaque JSON; the new behavior is to parse it
+   through `swecommon.UnmarshalSchema` at datastream-create time
+   and reject bad shapes.
+3. `gateway/cs-api/observations_get.go`'s three subset writers
+   (`writeObservationsSWEJSON` / `writeObservationsSWECSV` /
+   `writeObservationsSWEBinary`) replace their value-only
+   projection with `swecommon.Encode{JSON,Text,Binary}` calls.
+4. `X-CS-SWE-Subset: observation-values` header writes are
+   removed. The conformance claim is filed.
+
+The migration is the next semconnect stage, gated on this tag
+landing on a published semstreams release.
+
+## References
+
+- OGC SWE Common Data Model 2.0 (08-094r1)
+- OGC SWE Common JSON Encoding (22-022)
+- OGC CS API Part 2 §A.7 (SWE Common conformance classes)
+- [#116](https://github.com/C360Studio/semstreams/issues/116)
+- semconnect upstream-ask
+  `docs/upstream-asks/semstreams-swe-schema-bound-encodings.md`
+- [ADR-044](044-ogc-connected-systems-framework-split.md) —
+  framework / sister-repo split that established `pkg/swecommon`
+  as the right home for this primitive.

--- a/docs/adr/050-swe-common-schema-bound-encodings.md
+++ b/docs/adr/050-swe-common-schema-bound-encodings.md
@@ -103,7 +103,7 @@ Phase 1 covers everything CS API consumers need to drop
 - UoMs, nil values, time, typed quantities, categories
 - Round-trip tests covering each shape
 
-Deferred (filed for follow-up, not blocking the conformance claim):
+Deferred (tracked in [#167](https://github.com/C360Studio/semstreams/issues/167), not blocking the conformance claim):
 
 - DataArray (homogeneous element record) — useful for waveform /
   spectrum results, not in CS API Phase 1 observation use cases.

--- a/docs/operations/21-adr044-framework-primitives-reference.md
+++ b/docs/operations/21-adr044-framework-primitives-reference.md
@@ -223,8 +223,9 @@ Added by [ADR-050](../adr/050-swe-common-schema-bound-encodings.md). Closes [#11
 | [`pkg/swecommon.MediaSWEJSON / MediaSWECSV / MediaSWEBinary`](../../pkg/swecommon/media_types.go) | CS API media-type strings | Content negotiation in CS API gateways |
 
 ADR-050 covers the scope cuts (DataArray / DataChoice / Vector /
-constraints / nested records / XML encoding all deferred) and the
-semconnect migration path.
+constraints / nested records / XML encoding all deferred,
+tracked as [#167](https://github.com/C360Studio/semstreams/issues/167))
+and the semconnect migration path.
 
 ## Scope cut — what's deferred to follow-up tags
 

--- a/docs/operations/21-adr044-framework-primitives-reference.md
+++ b/docs/operations/21-adr044-framework-primitives-reference.md
@@ -207,6 +207,25 @@ The CS API server's job is endpoint routing, content negotiation,
 auth, and conformance-class declaration. The data shape work is
 done by the framework primitives.
 
+## Phase 7 follow-up — SWE Common schema-bound encodings
+
+Added by [ADR-050](../adr/050-swe-common-schema-bound-encodings.md). Closes [#116](https://github.com/C360Studio/semstreams/issues/116) — the semconnect Stage 27 upstream-ask carrying the `X-CS-SWE-Subset: observation-values` workaround.
+
+| Primitive | What it provides | Use it for |
+|-----------|------------------|------------|
+| [`pkg/swecommon.DataComponent`](../../pkg/swecommon/component.go) | Sealed supertype for SWE Common data components | Type-switching across kinds in encoder dispatch |
+| [`pkg/swecommon.DataRecord`](../../pkg/swecommon/schema.go) | Composite record of named typed fields | Result-schema + command-payload model |
+| [`pkg/swecommon.Quantity / Count / Time / Boolean / Text / Category`](../../pkg/swecommon/component.go) | Scalar components with UoM / codeSpace / referenceFrame | Field-level typed values |
+| [`pkg/swecommon.MarshalSchema / UnmarshalSchema`](../../pkg/swecommon/schema.go) | Round-trip OGC SWE Common JSON Encoding (22-022) schema document | Advertising a datastream's result schema |
+| [`pkg/swecommon.EncodeJSON / DecodeJSON`](../../pkg/swecommon/json.go) | Schema-bound `application/swe+json` | Observation-collection responses + command JSON payloads |
+| [`pkg/swecommon.EncodeText / DecodeText`](../../pkg/swecommon/text.go) | Schema-bound `application/swe+csv` (configurable separators) | CSV-shaped observation streams |
+| [`pkg/swecommon.EncodeBinary / DecodeBinary`](../../pkg/swecommon/binary.go) | Schema-bound `application/swe+binary` (packed primitives + nil bitmap) | Binary observation streams + command payloads |
+| [`pkg/swecommon.MediaSWEJSON / MediaSWECSV / MediaSWEBinary`](../../pkg/swecommon/media_types.go) | CS API media-type strings | Content negotiation in CS API gateways |
+
+ADR-050 covers the scope cuts (DataArray / DataChoice / Vector /
+constraints / nested records / XML encoding all deferred) and the
+semconnect migration path.
+
 ## Scope cut — what's deferred to follow-up tags
 
 ADR-044 explicitly defers these to future phases / ADRs (post-Phase 6):

--- a/pkg/swecommon/binary.go
+++ b/pkg/swecommon/binary.go
@@ -1,0 +1,291 @@
+package swecommon
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+)
+
+// BinaryByteOrder is the wire byte order for the binary encoding.
+// Default and recommendation: big-endian (network byte order). The
+// producer and consumer must agree; the schema's BinaryEncoding
+// metadata block carries the choice on the wire.
+type BinaryByteOrder uint8
+
+const (
+	// BigEndian — default. Matches network byte order.
+	BigEndian BinaryByteOrder = iota
+	// LittleEndian — opt-in for producers that want to skip the
+	// host-to-network byte swap on x86/ARM.
+	LittleEndian
+)
+
+func (b BinaryByteOrder) order() binary.ByteOrder {
+	if b == LittleEndian {
+		return binary.LittleEndian
+	}
+	return binary.BigEndian
+}
+
+// BinaryEncoding configures the SWE BinaryEncoding (SWE Common
+// §7.4.4) options. The framework Phase 1 supports the
+// "packed primitives" variant: each field is encoded back-to-back
+// with no padding, types per the wire format below.
+//
+// Per-field wire format:
+//
+//   - Quantity → 8 bytes IEEE 754 float64
+//   - Count    → 8 bytes int64
+//   - Time     → uint32 length prefix + UTF-8 RFC 3339 bytes
+//   - Boolean  → 1 byte (0 = false, 1 = true)
+//   - Text     → uint32 length prefix + UTF-8 bytes
+//   - Category → uint32 length prefix + UTF-8 bytes
+//
+// Nil values: a separate nil bitmap precedes each record. The
+// bitmap is ceil(nfields/8) bytes, big-endian bit order (high bit
+// = field 0). A 1 bit means the field is nil; the value bytes are
+// skipped for nil fields.
+type BinaryEncoding struct {
+	ByteOrder BinaryByteOrder
+}
+
+// DefaultBinaryEncoding returns the network-byte-order packed
+// primitives encoding.
+func DefaultBinaryEncoding() BinaryEncoding {
+	return BinaryEncoding{ByteOrder: BigEndian}
+}
+
+// EncodeBinary writes the rows as SWE BinaryEncoding bytes per the
+// schema and encoding configuration. Field order follows the
+// schema's field declaration order. Each record is preceded by a
+// nil bitmap (see [BinaryEncoding] for the bitmap layout).
+//
+// No record-count prefix is emitted — consumers read until EOF.
+// This matches the streaming-friendly shape CS API uses for
+// chunked observation responses.
+func EncodeBinary(w io.Writer, schema *DataRecord, rows []Values, enc BinaryEncoding) error {
+	if err := schema.Validate(); err != nil {
+		return fmt.Errorf("swecommon: encode binary: %w", err)
+	}
+	order := enc.ByteOrder.order()
+	bw := &binaryWriter{w: w, order: order}
+	for ri, row := range rows {
+		if err := binaryWriteRow(bw, schema, row); err != nil {
+			return fmt.Errorf("swecommon: encode binary row %d: %w", ri, err)
+		}
+	}
+	return bw.err
+}
+
+// MarshalBinaryRows is the bytes-returning convenience wrapper around
+// [EncodeBinary].
+func MarshalBinaryRows(schema *DataRecord, rows []Values, enc BinaryEncoding) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := EncodeBinary(&buf, schema, rows, enc); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func binaryWriteRow(bw *binaryWriter, schema *DataRecord, row Values) error {
+	nilBitmap := make([]byte, (len(schema.Fields)+7)/8)
+	canonValues := make([]any, len(schema.Fields))
+	for i, f := range schema.Fields {
+		v := fieldValue(row, f.Name)
+		if matchesNilToken(f.Component, v) {
+			v = nil
+		}
+		canon, isNil, err := normalizeValue(f.Component, v)
+		if err != nil {
+			return fmt.Errorf("field %q: %w", f.Name, err)
+		}
+		if isNil {
+			nilBitmap[i/8] |= 1 << uint(7-(i%8))
+			continue
+		}
+		canonValues[i] = canon
+	}
+	bw.writeBytes(nilBitmap)
+	if bw.err != nil {
+		return bw.err
+	}
+	for i, f := range schema.Fields {
+		if nilBitmap[i/8]&(1<<uint(7-(i%8))) != 0 {
+			continue
+		}
+		if err := binaryWriteField(bw, f.Component, canonValues[i]); err != nil {
+			return fmt.Errorf("field %q: %w", f.Name, err)
+		}
+	}
+	return bw.err
+}
+
+func binaryWriteField(bw *binaryWriter, c DataComponent, v any) error {
+	switch c.Kind() {
+	case KindQuantity:
+		bw.writeUint64(math.Float64bits(v.(float64)))
+	case KindCount:
+		bw.writeUint64(uint64(v.(int64)))
+	case KindBoolean:
+		if v.(bool) {
+			bw.writeBytes([]byte{1})
+		} else {
+			bw.writeBytes([]byte{0})
+		}
+	case KindTime, KindText, KindCategory:
+		s := v.(string)
+		if uint64(len(s)) > math.MaxUint32 {
+			return fmt.Errorf("%s length %d exceeds uint32 prefix max (4 GiB)", c.Kind(), len(s))
+		}
+		bw.writeUint32(uint32(len(s)))
+		bw.writeBytes([]byte(s))
+	default:
+		return fmt.Errorf("unsupported kind %q", c.Kind())
+	}
+	return bw.err
+}
+
+// DecodeBinary reads SWE BinaryEncoding bytes into typed rows
+// against the schema. EOF after a complete record terminates the
+// stream cleanly; EOF mid-record surfaces as
+// [io.ErrUnexpectedEOF].
+func DecodeBinary(r io.Reader, schema *DataRecord, enc BinaryEncoding) ([]Values, error) {
+	if err := schema.Validate(); err != nil {
+		return nil, fmt.Errorf("swecommon: decode binary: %w", err)
+	}
+	order := enc.ByteOrder.order()
+	br := &binaryReader{r: r, order: order}
+	bitmapLen := (len(schema.Fields) + 7) / 8
+	out := make([]Values, 0)
+	for {
+		bitmap := make([]byte, bitmapLen)
+		n, err := io.ReadFull(br.r, bitmap)
+		if errors.Is(err, io.EOF) && n == 0 {
+			return out, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("swecommon: decode binary nil-bitmap: %w", err)
+		}
+		row := make(Values, len(schema.Fields))
+		for i, f := range schema.Fields {
+			if bitmap[i/8]&(1<<uint(7-(i%8))) != 0 {
+				row[f.Name] = nil
+				continue
+			}
+			v, err := binaryReadField(br, f.Component)
+			if err != nil {
+				return nil, fmt.Errorf("swecommon: decode binary row %d field %q: %w", len(out), f.Name, err)
+			}
+			row[f.Name] = v
+		}
+		out = append(out, row)
+	}
+}
+
+// UnmarshalBinaryRows is the bytes-taking convenience wrapper around
+// [DecodeBinary].
+func UnmarshalBinaryRows(data []byte, schema *DataRecord, enc BinaryEncoding) ([]Values, error) {
+	return DecodeBinary(bytes.NewReader(data), schema, enc)
+}
+
+func binaryReadField(br *binaryReader, c DataComponent) (any, error) {
+	switch c.Kind() {
+	case KindQuantity:
+		bits, err := br.readUint64()
+		if err != nil {
+			return nil, fmt.Errorf("Quantity: %w", err)
+		}
+		return math.Float64frombits(bits), nil
+	case KindCount:
+		u, err := br.readUint64()
+		if err != nil {
+			return nil, fmt.Errorf("Count: %w", err)
+		}
+		return int64(u), nil
+	case KindBoolean:
+		b, err := br.readByte()
+		if err != nil {
+			return nil, fmt.Errorf("Boolean: %w", err)
+		}
+		return b != 0, nil
+	case KindTime, KindText, KindCategory:
+		n, err := br.readUint32()
+		if err != nil {
+			return nil, fmt.Errorf("%s length: %w", c.Kind(), err)
+		}
+		buf := make([]byte, n)
+		if _, err := io.ReadFull(br.r, buf); err != nil {
+			return nil, fmt.Errorf("%s bytes: %w", c.Kind(), err)
+		}
+		return string(buf), nil
+	default:
+		return nil, fmt.Errorf("unsupported kind %q", c.Kind())
+	}
+}
+
+// binaryWriter is a sticky-error wrapper around io.Writer; once an
+// error is set, further writes are no-ops so the caller can check
+// the err once at the end.
+type binaryWriter struct {
+	w     io.Writer
+	order binary.ByteOrder
+	err   error
+}
+
+func (b *binaryWriter) writeBytes(p []byte) {
+	if b.err != nil {
+		return
+	}
+	_, b.err = b.w.Write(p)
+}
+
+func (b *binaryWriter) writeUint32(v uint32) {
+	if b.err != nil {
+		return
+	}
+	var buf [4]byte
+	b.order.PutUint32(buf[:], v)
+	_, b.err = b.w.Write(buf[:])
+}
+
+func (b *binaryWriter) writeUint64(v uint64) {
+	if b.err != nil {
+		return
+	}
+	var buf [8]byte
+	b.order.PutUint64(buf[:], v)
+	_, b.err = b.w.Write(buf[:])
+}
+
+// binaryReader mirrors binaryWriter on the read side.
+type binaryReader struct {
+	r     io.Reader
+	order binary.ByteOrder
+}
+
+func (b *binaryReader) readByte() (byte, error) {
+	var buf [1]byte
+	if _, err := io.ReadFull(b.r, buf[:]); err != nil {
+		return 0, err
+	}
+	return buf[0], nil
+}
+
+func (b *binaryReader) readUint32() (uint32, error) {
+	var buf [4]byte
+	if _, err := io.ReadFull(b.r, buf[:]); err != nil {
+		return 0, err
+	}
+	return b.order.Uint32(buf[:]), nil
+}
+
+func (b *binaryReader) readUint64() (uint64, error) {
+	var buf [8]byte
+	if _, err := io.ReadFull(b.r, buf[:]); err != nil {
+		return 0, err
+	}
+	return b.order.Uint64(buf[:]), nil
+}

--- a/pkg/swecommon/component.go
+++ b/pkg/swecommon/component.go
@@ -1,0 +1,154 @@
+package swecommon
+
+// ComponentKind is the SWE Common data-component discriminator. Every
+// concrete [DataComponent] reports one of these so encoders and
+// decoders can dispatch without reflection. The string values match
+// the `type` discriminator field in OGC SWE Common JSON Encoding
+// (22-022), so they double as the wire-format type tag.
+type ComponentKind string
+
+// SWE Common data-component kinds. KindRecord is the only composite
+// kind covered in Phase 1; DataArray and DataChoice are deferred.
+const (
+	KindRecord   ComponentKind = "DataRecord"
+	KindQuantity ComponentKind = "Quantity"
+	KindCount    ComponentKind = "Count"
+	KindTime     ComponentKind = "Time"
+	KindBoolean  ComponentKind = "Boolean"
+	KindText     ComponentKind = "Text"
+	KindCategory ComponentKind = "Category"
+)
+
+// DataComponent is the sealed supertype for SWE Common data
+// components. Implementations live in this package only — adding a
+// new kind requires updating the encoders, decoders, and the
+// register tables in schema.go, which would not compile otherwise.
+type DataComponent interface {
+	// Kind reports which SWE Common component this is.
+	Kind() ComponentKind
+
+	// Label is the human-readable name; empty when unset.
+	Label() string
+
+	// Definition is the IRI of the controlled concept that defines
+	// this component's semantics (e.g. a QUDT QuantityKind or a
+	// SWEET property concept). Empty when unset.
+	Definition() string
+
+	// sealed is unexported so external packages cannot implement
+	// DataComponent. The sealed pattern is load-bearing for the
+	// encoder dispatch table: every kind must be handled in this
+	// package.
+	sealed()
+}
+
+// CommonFields is the embedded base for every concrete component. It
+// carries the label + definition + nilValue stand-in that every SWE
+// component may optionally declare. JSON tag rules: omit when empty
+// so a minimal Quantity{} round-trips to `{"type":"Quantity"}`.
+type CommonFields struct {
+	LabelValue      string `json:"label,omitempty"`
+	DefinitionValue string `json:"definition,omitempty"`
+
+	// NilValue is the wire-side stand-in token a producer emits when
+	// the field is absent. Decoders treat any value equal to this
+	// token (after format-specific normalization) as Go `nil`.
+	// Per SWE Common §7.5 NilValues — Phase 1 supports a single
+	// stand-in; the multi-reason NilValues block is deferred.
+	NilValue string `json:"nilValue,omitempty"`
+}
+
+// Label implements [DataComponent].
+func (c CommonFields) Label() string { return c.LabelValue }
+
+// Definition implements [DataComponent].
+func (c CommonFields) Definition() string { return c.DefinitionValue }
+
+// Nil returns the optional wire-side nil-stand-in token.
+func (c CommonFields) Nil() string { return c.NilValue }
+
+// Quantity is a numeric value with a unit of measure (SWE Common
+// §7.6.4). Round-trips through float64; producers needing higher
+// precision (int64-fidelity counts, decimal-fixed) should declare a
+// [Count] or carry the value as [Text] instead.
+type Quantity struct {
+	CommonFields
+
+	// UoM is the unit of measure. Carry a UCUM symbol (e.g. "Cel",
+	// "m/s") via Code OR a QUDT/OGC unit IRI via Href. Both empty
+	// = dimensionless quantity, which is legal but lossy through
+	// the SWE+csv encoding.
+	UoMCode string `json:"uomCode,omitempty"`
+	UoMHref string `json:"uomHref,omitempty"`
+}
+
+// Kind reports [KindQuantity].
+func (Quantity) Kind() ComponentKind { return KindQuantity }
+func (Quantity) sealed()             {}
+
+// Count is a discrete integer count with no unit of measure (SWE
+// Common §7.6.6). Round-trips through int64.
+type Count struct {
+	CommonFields
+}
+
+// Kind reports [KindCount].
+func (Count) Kind() ComponentKind { return KindCount }
+func (Count) sealed()             {}
+
+// Time is a temporal instant (SWE Common §7.6.5). Round-trips
+// through ISO 8601 / RFC 3339 strings — Phase 1 does not encode
+// epoch-seconds doubles. Time-zone-frame and reference-frame are
+// carried as IRIs; missing frame is treated as UTC by convention.
+type Time struct {
+	CommonFields
+
+	// UoMHref carries the temporal reference IRI (e.g.
+	// "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian"). The
+	// SWE JSON encoding emits this as uom.href on the wire.
+	UoMHref string `json:"uomHref,omitempty"`
+
+	// ReferenceFrame is the optional temporal frame IRI for
+	// non-UTC time values. Empty = UTC.
+	ReferenceFrame string `json:"referenceFrame,omitempty"`
+}
+
+// Kind reports [KindTime].
+func (Time) Kind() ComponentKind { return KindTime }
+func (Time) sealed()             {}
+
+// Boolean is a true/false value (SWE Common §7.6.2). Round-trips
+// through Go bool.
+type Boolean struct {
+	CommonFields
+}
+
+// Kind reports [KindBoolean].
+func (Boolean) Kind() ComponentKind { return KindBoolean }
+func (Boolean) sealed()             {}
+
+// Text is a free-text string (SWE Common §7.6.3). Round-trips
+// through Go string; binary encoding length-prefixes the UTF-8
+// bytes with a uint32.
+type Text struct {
+	CommonFields
+}
+
+// Kind reports [KindText].
+func (Text) Kind() ComponentKind { return KindText }
+func (Text) sealed()             {}
+
+// Category is a controlled-vocabulary token (SWE Common §7.6.7).
+// CodeSpace is the IRI of the code list; values are short tokens
+// drawn from that list. Round-trips through Go string.
+type Category struct {
+	CommonFields
+
+	// CodeSpace is the IRI of the code list this category draws
+	// from. Empty = free-form token (legal but limits validation).
+	CodeSpace string `json:"codeSpace,omitempty"`
+}
+
+// Kind reports [KindCategory].
+func (Category) Kind() ComponentKind { return KindCategory }
+func (Category) sealed()             {}

--- a/pkg/swecommon/doc.go
+++ b/pkg/swecommon/doc.go
@@ -1,0 +1,59 @@
+// Package swecommon provides schema-bound encoders and decoders
+// for the OGC SWE Common data model, covering the JSON, text, and
+// binary encodings the OGC Connected Systems API negotiates for
+// observation results and command payloads.
+//
+// # Why this package exists
+//
+// CS API gateways (semconnect and friends) need to advertise a
+// per-datastream result schema and stream observation values
+// against that schema in three media types:
+//
+//   - application/swe+json
+//   - application/swe+csv
+//   - application/swe+binary
+//
+// Without a schema-bound model, gateways fall back to projecting
+// value-only views (time + result), tagging the response with a
+// non-conformant subset header. This package lets gateways drop
+// the subset header and claim the SWE Common conformance classes.
+//
+// # Model
+//
+// A schema is a [DataRecord] of named [Field]s. Each field carries
+// a typed [DataComponent] — Quantity, Count, Time, Boolean, Text,
+// Category. The scalar types are sealed; adding a new kind
+// requires extending this package (and is a compile-time error in
+// every consumer until they handle it).
+//
+// Values are carried as [Values] maps keyed by field name. The
+// encoders are tolerant on input — a Quantity field accepts any
+// Go numeric type, a Time accepts time.Time or RFC 3339 string.
+// Decoders always populate the canonical Go type per the schema.
+//
+// # Encoding choices
+//
+//   - JSON values: array of objects, one per row, field names as keys.
+//   - Text values: producer-configurable token + block separators
+//     (default CSV). Decimal separator must be ".". Optional header.
+//   - Binary values: per-record nil bitmap (ceil(nfields/8) bytes,
+//     high bit = field 0) + packed primitives. Big-endian by
+//     default. No record-count prefix; consumers read until EOF.
+//
+// # Round-trip stability
+//
+// Every encoding has a corresponding decoder in the same file and
+// every type/kind combination is exercised by the round-trip
+// table-driven tests in *_test.go. Producers that depend on a
+// shape that does not appear in the test table should add a row.
+//
+// # Phase 1 scope (this package as introduced by [ADR-050])
+//
+// Implemented: scalar components + DataRecord + JSON/text/binary
+// encoders + decoders + schema marshal/unmarshal + media-type
+// constants. Deferred: DataArray (homogeneous element record),
+// DataChoice (discriminated union), Vector (axis-frame-bound
+// values), per-component constraints (allowedValues, ranges),
+// multi-reason NilValues block, nested DataRecord values, SWE
+// XML encoding (CS API does not require it).
+package swecommon

--- a/pkg/swecommon/doc.go
+++ b/pkg/swecommon/doc.go
@@ -51,9 +51,10 @@
 //
 // Implemented: scalar components + DataRecord + JSON/text/binary
 // encoders + decoders + schema marshal/unmarshal + media-type
-// constants. Deferred: DataArray (homogeneous element record),
-// DataChoice (discriminated union), Vector (axis-frame-bound
-// values), per-component constraints (allowedValues, ranges),
-// multi-reason NilValues block, nested DataRecord values, SWE
-// XML encoding (CS API does not require it).
+// constants. Deferred (tracked in
+// https://github.com/C360Studio/semstreams/issues/167): DataArray
+// (homogeneous element record), DataChoice (discriminated union),
+// Vector (axis-frame-bound values), per-component constraints
+// (allowedValues, ranges), multi-reason NilValues block, nested
+// DataRecord values, SWE XML encoding (CS API does not require it).
 package swecommon

--- a/pkg/swecommon/json.go
+++ b/pkg/swecommon/json.go
@@ -1,0 +1,212 @@
+package swecommon
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// EncodeJSON writes the rows as a SWE Common JSON Encoding (22-022)
+// document bound to the given schema. The output shape is a JSON
+// array of objects, one per row, with field names matching the
+// schema's field declarations.
+//
+// Per-field value encoding:
+//
+//   - Quantity → JSON number (float64)
+//   - Count    → JSON number (int64)
+//   - Time     → JSON string (RFC 3339)
+//   - Boolean  → JSON boolean
+//   - Text     → JSON string
+//   - Category → JSON string
+//
+// nilValue rule: when a value is Go nil OR exactly equal to the
+// schema's nilValue for the field, the output is JSON null.
+// Decoders honor the same rule.
+func EncodeJSON(w io.Writer, schema *DataRecord, rows []Values) error {
+	if err := schema.Validate(); err != nil {
+		return fmt.Errorf("swecommon: encode JSON: %w", err)
+	}
+	enc := json.NewEncoder(w)
+	out := make([]map[string]any, 0, len(rows))
+	for i, row := range rows {
+		obj, err := jsonRow(schema, row)
+		if err != nil {
+			return fmt.Errorf("swecommon: encode JSON row %d: %w", i, err)
+		}
+		out = append(out, obj)
+	}
+	if err := enc.Encode(out); err != nil {
+		return fmt.Errorf("swecommon: encode JSON: %w", err)
+	}
+	return nil
+}
+
+// MarshalJSONRows is the bytes-returning convenience wrapper around
+// [EncodeJSON]. The result has no trailing newline.
+func MarshalJSONRows(schema *DataRecord, rows []Values) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := EncodeJSON(&buf, schema, rows); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+func jsonRow(schema *DataRecord, row Values) (map[string]any, error) {
+	out := make(map[string]any, len(schema.Fields))
+	for _, f := range schema.Fields {
+		v := fieldValue(row, f.Name)
+		if matchesNilToken(f.Component, v) {
+			v = nil
+		}
+		canon, isNil, err := normalizeValue(f.Component, v)
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", f.Name, err)
+		}
+		if isNil {
+			out[f.Name] = nil
+			continue
+		}
+		out[f.Name] = canon
+	}
+	return out, nil
+}
+
+// DecodeJSON reads a SWE Common JSON Encoding document into typed
+// row values bound to the schema. Unknown fields in the JSON input
+// are ignored — operators evolving the schema can add fields
+// without breaking old payloads. Missing fields decode to absent
+// keys (NOT to nil values, so callers can distinguish "the
+// producer omitted this" from "the producer asserted null").
+func DecodeJSON(r io.Reader, schema *DataRecord) ([]Values, error) {
+	if err := schema.Validate(); err != nil {
+		return nil, fmt.Errorf("swecommon: decode JSON: %w", err)
+	}
+	var raw []map[string]json.RawMessage
+	dec := json.NewDecoder(r)
+	dec.UseNumber()
+	if err := dec.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("swecommon: decode JSON: %w", err)
+	}
+	out := make([]Values, 0, len(raw))
+	for i, rawRow := range raw {
+		row, err := jsonDecodeRow(schema, rawRow)
+		if err != nil {
+			return nil, fmt.Errorf("swecommon: decode JSON row %d: %w", i, err)
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}
+
+// UnmarshalJSONRows is the bytes-taking convenience wrapper around
+// [DecodeJSON].
+func UnmarshalJSONRows(data []byte, schema *DataRecord) ([]Values, error) {
+	return DecodeJSON(bytes.NewReader(data), schema)
+}
+
+func jsonDecodeRow(schema *DataRecord, raw map[string]json.RawMessage) (Values, error) {
+	out := make(Values, len(schema.Fields))
+	for _, f := range schema.Fields {
+		rawVal, present := raw[f.Name]
+		if !present {
+			// Missing field — leave the key absent.
+			continue
+		}
+		if isJSONNull(rawVal) {
+			out[f.Name] = nil
+			continue
+		}
+		v, err := jsonDecodeField(f.Component, rawVal)
+		if err != nil {
+			return nil, fmt.Errorf("field %q: %w", f.Name, err)
+		}
+		out[f.Name] = v
+	}
+	return out, nil
+}
+
+func jsonDecodeField(c DataComponent, raw json.RawMessage) (any, error) {
+	switch c.Kind() {
+	case KindQuantity:
+		var n json.Number
+		if err := json.Unmarshal(raw, &n); err != nil {
+			return nil, fmt.Errorf("Quantity: %w", err)
+		}
+		f, err := n.Float64()
+		if err != nil {
+			return nil, fmt.Errorf("Quantity: %w", err)
+		}
+		return f, nil
+	case KindCount:
+		var n json.Number
+		if err := json.Unmarshal(raw, &n); err != nil {
+			return nil, fmt.Errorf("Count: %w", err)
+		}
+		i, err := n.Int64()
+		if err != nil {
+			return nil, fmt.Errorf("Count: %w", err)
+		}
+		return i, nil
+	case KindTime:
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, fmt.Errorf("Time: %w", err)
+		}
+		return s, nil
+	case KindBoolean:
+		var b bool
+		if err := json.Unmarshal(raw, &b); err != nil {
+			return nil, fmt.Errorf("Boolean: %w", err)
+		}
+		return b, nil
+	case KindText:
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, fmt.Errorf("Text: %w", err)
+		}
+		return s, nil
+	case KindCategory:
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return nil, fmt.Errorf("Category: %w", err)
+		}
+		return s, nil
+	default:
+		return nil, fmt.Errorf("unknown component kind %q", c.Kind())
+	}
+}
+
+func isJSONNull(raw json.RawMessage) bool {
+	t := bytes.TrimSpace(raw)
+	return len(t) == 4 && string(t) == "null"
+}
+
+// nilValueOf returns the nilValue token of a component, or empty.
+// Mirrors the embedded CommonFields.Nil() accessor — needed
+// because Go's type switch on DataComponent doesn't reach the
+// embedded method directly without a per-kind branch.
+func nilValueOf(c DataComponent) string {
+	switch v := c.(type) {
+	case Quantity:
+		return v.Nil()
+	case Count:
+		return v.Nil()
+	case Time:
+		return v.Nil()
+	case Boolean:
+		return v.Nil()
+	case Text:
+		return v.Nil()
+	case Category:
+		return v.Nil()
+	case *DataRecord:
+		if v == nil {
+			return ""
+		}
+		return v.Nil()
+	default:
+		return ""
+	}
+}

--- a/pkg/swecommon/media_types.go
+++ b/pkg/swecommon/media_types.go
@@ -1,0 +1,28 @@
+package swecommon
+
+// CS API media type identifiers for SWE Common encodings. These
+// match the strings the OGC Connected Systems API uses in Accept /
+// Content-Type negotiation. Importing consumers (e.g. CS API
+// gateways) should reference these constants rather than redeclare
+// the strings, so a future OGC errata that changes a suffix lands
+// in exactly one place.
+const (
+	// MediaSWEJSON — schema-bound JSON encoding.
+	MediaSWEJSON = "application/swe+json"
+
+	// MediaSWECSV — schema-bound text encoding using CSV-shaped
+	// separators (comma token, newline block).
+	MediaSWECSV = "application/swe+csv"
+
+	// MediaSWEBinary — schema-bound packed primitives binary
+	// encoding.
+	MediaSWEBinary = "application/swe+binary"
+)
+
+// SubsetObservationValues is the legacy semconnect-side header
+// value used to flag the value-only projection subset (no schema
+// binding). Consumers that have migrated to this package's
+// schema-bound encoders should drop the header entirely; the
+// constant is provided so the migration code path can grep for one
+// canonical token while it removes the workaround.
+const SubsetObservationValues = "observation-values"

--- a/pkg/swecommon/roundtrip_test.go
+++ b/pkg/swecommon/roundtrip_test.go
@@ -1,0 +1,694 @@
+package swecommon_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/pkg/swecommon"
+)
+
+// observationSchema is the canonical worked example: a 3-field
+// record covering Time + Quantity (with UoM) + Category. Used by
+// every encoding's round-trip table.
+func observationSchema() *swecommon.DataRecord {
+	return &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "time", Component: swecommon.Time{
+				UoMHref: "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
+			}},
+			{Name: "temperature", Component: swecommon.Quantity{
+				UoMCode: "Cel",
+			}},
+			{Name: "status", Component: swecommon.Category{
+				CodeSpace: "http://example.com/codes/sensor-status",
+			}},
+		},
+	}
+}
+
+// observationRows is the canonical row set: ordinary row,
+// nil-result row, boundary-numeric row.
+func observationRows() []swecommon.Values {
+	return []swecommon.Values{
+		{"time": "2026-05-29T13:00:00Z", "temperature": 23.5, "status": "normal"},
+		{"time": "2026-05-29T13:01:00Z", "temperature": nil, "status": "warning"},
+		{"time": "2026-05-29T13:02:00Z", "temperature": -40.125, "status": "critical"},
+	}
+}
+
+func TestSchema_RoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	bytesOut, err := swecommon.MarshalSchema(schema)
+	if err != nil {
+		t.Fatalf("MarshalSchema: %v", err)
+	}
+	t.Logf("schema bytes: %s", bytesOut)
+	got, err := swecommon.UnmarshalSchema(bytesOut)
+	if err != nil {
+		t.Fatalf("UnmarshalSchema: %v", err)
+	}
+	if len(got.Fields) != len(schema.Fields) {
+		t.Fatalf("field count: got %d, want %d", len(got.Fields), len(schema.Fields))
+	}
+	for i, f := range schema.Fields {
+		if got.Fields[i].Name != f.Name {
+			t.Errorf("field %d name: got %q, want %q", i, got.Fields[i].Name, f.Name)
+		}
+		if got.Fields[i].Component.Kind() != f.Component.Kind() {
+			t.Errorf("field %d kind: got %q, want %q", i, got.Fields[i].Component.Kind(), f.Component.Kind())
+		}
+	}
+	// Spot-check UoM round-trip on the Quantity.
+	q, ok := got.Fields[1].Component.(swecommon.Quantity)
+	if !ok {
+		t.Fatalf("field 1 component: got %T, want Quantity", got.Fields[1].Component)
+	}
+	if q.UoMCode != "Cel" {
+		t.Errorf("quantity UoMCode: got %q, want %q", q.UoMCode, "Cel")
+	}
+	// Spot-check CodeSpace round-trip on the Category.
+	cat, ok := got.Fields[2].Component.(swecommon.Category)
+	if !ok {
+		t.Fatalf("field 2 component: got %T, want Category", got.Fields[2].Component)
+	}
+	if cat.CodeSpace == "" {
+		t.Errorf("category CodeSpace lost in round-trip")
+	}
+}
+
+func TestEncodeJSON_RoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	rows := observationRows()
+	out, err := swecommon.MarshalJSONRows(schema, rows)
+	if err != nil {
+		t.Fatalf("MarshalJSONRows: %v", err)
+	}
+	t.Logf("JSON: %s", out)
+	got, err := swecommon.UnmarshalJSONRows(out, schema)
+	if err != nil {
+		t.Fatalf("UnmarshalJSONRows: %v", err)
+	}
+	assertRowsEqual(t, rows, got)
+}
+
+func TestEncodeText_RoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	rows := observationRows()
+	enc := swecommon.DefaultTextEncoding()
+	out, err := swecommon.MarshalTextRows(schema, rows, enc)
+	if err != nil {
+		t.Fatalf("MarshalTextRows: %v", err)
+	}
+	t.Logf("text:\n%s", out)
+	got, err := swecommon.UnmarshalTextRows(out, schema, enc)
+	if err != nil {
+		t.Fatalf("UnmarshalTextRows: %v", err)
+	}
+	assertRowsEqual(t, rows, got)
+}
+
+func TestEncodeText_WithHeader_RoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	rows := observationRows()
+	enc := swecommon.DefaultTextEncoding()
+	enc.EmitHeader = true
+	out, err := swecommon.MarshalTextRows(schema, rows, enc)
+	if err != nil {
+		t.Fatalf("MarshalTextRows: %v", err)
+	}
+	t.Logf("text with header:\n%s", out)
+	if !strings.HasPrefix(string(out), "time,temperature,status") {
+		t.Errorf("header missing or wrong: %s", out)
+	}
+	got, err := swecommon.UnmarshalTextRows(out, schema, enc)
+	if err != nil {
+		t.Fatalf("UnmarshalTextRows: %v", err)
+	}
+	assertRowsEqual(t, rows, got)
+}
+
+func TestEncodeText_CustomSeparators_RoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	rows := observationRows()
+	enc := swecommon.TextEncoding{
+		TokenSeparator:   "|",
+		BlockSeparator:   ";",
+		DecimalSeparator: ".",
+	}
+	out, err := swecommon.MarshalTextRows(schema, rows, enc)
+	if err != nil {
+		t.Fatalf("MarshalTextRows: %v", err)
+	}
+	t.Logf("custom-sep text: %s", out)
+	got, err := swecommon.UnmarshalTextRows(out, schema, enc)
+	if err != nil {
+		t.Fatalf("UnmarshalTextRows: %v", err)
+	}
+	assertRowsEqual(t, rows, got)
+}
+
+func TestEncodeBinary_RoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	rows := observationRows()
+	enc := swecommon.DefaultBinaryEncoding()
+	out, err := swecommon.MarshalBinaryRows(schema, rows, enc)
+	if err != nil {
+		t.Fatalf("MarshalBinaryRows: %v", err)
+	}
+	t.Logf("binary length: %d", len(out))
+	got, err := swecommon.UnmarshalBinaryRows(out, schema, enc)
+	if err != nil {
+		t.Fatalf("UnmarshalBinaryRows: %v", err)
+	}
+	assertRowsEqual(t, rows, got)
+}
+
+func TestEncodeBinary_LittleEndian_RoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	rows := observationRows()
+	enc := swecommon.BinaryEncoding{ByteOrder: swecommon.LittleEndian}
+	out, err := swecommon.MarshalBinaryRows(schema, rows, enc)
+	if err != nil {
+		t.Fatalf("MarshalBinaryRows: %v", err)
+	}
+	got, err := swecommon.UnmarshalBinaryRows(out, schema, enc)
+	if err != nil {
+		t.Fatalf("UnmarshalBinaryRows: %v", err)
+	}
+	assertRowsEqual(t, rows, got)
+}
+
+// TestEncodeBinary_ByteOrderRefusedCross asserts that little-endian
+// bytes decoded with the big-endian setting do NOT round-trip
+// cleanly. The assertion is shape-independent: either the decode
+// errors, OR the decoded rows differ from the input. (We don't
+// fix to one of the two so the test stays robust against schema
+// reordering — Time-first happens to produce an error; a
+// Quantity-first schema would produce garbage float64s but no
+// error.)
+func TestEncodeBinary_ByteOrderRefusedCross(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	rows := observationRows()
+	out, err := swecommon.MarshalBinaryRows(schema, rows, swecommon.BinaryEncoding{ByteOrder: swecommon.LittleEndian})
+	if err != nil {
+		t.Fatalf("MarshalBinaryRows: %v", err)
+	}
+	got, decErr := swecommon.UnmarshalBinaryRows(out, schema, swecommon.DefaultBinaryEncoding())
+	if decErr != nil {
+		// Decode errored — the byte-order mismatch was caught at
+		// the length-prefix / read-bounds layer. Acceptable signal.
+		return
+	}
+	// Decode succeeded but the values must differ from the input.
+	if len(got) != len(rows) {
+		return // row count mismatch is also acceptable evidence.
+	}
+	for i := range rows {
+		for k, want := range rows[i] {
+			if !valuesMatch(want, got[i][k]) {
+				return // any differing field is acceptable evidence.
+			}
+		}
+	}
+	t.Fatalf("expected byte-order disagreement to fail or produce different values; got identical round-trip: %+v", got)
+}
+
+func TestEncodeJSON_NilRoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "reading", Component: swecommon.Text{}},
+		},
+	}
+	rows := []swecommon.Values{
+		{"reading": "alpha"},
+		{"reading": nil},
+		{"reading": "beta"},
+	}
+	out, err := swecommon.MarshalJSONRows(schema, rows)
+	if err != nil {
+		t.Fatalf("MarshalJSONRows: %v", err)
+	}
+	t.Logf("JSON: %s", out)
+	if !bytes.Contains(out, []byte(`"reading":null`)) {
+		t.Errorf("expected JSON null for nil reading, got %s", out)
+	}
+	got, err := swecommon.UnmarshalJSONRows(out, schema)
+	if err != nil {
+		t.Fatalf("UnmarshalJSONRows: %v", err)
+	}
+	if got[1]["reading"] != nil {
+		t.Errorf("row 1 reading: got %v, want nil", got[1]["reading"])
+	}
+}
+
+func TestEncodeJSON_NumericNilStandIn(t *testing.T) {
+	t.Parallel()
+	// Quantity with a numeric nilValue stand-in. Regression test
+	// for B2: matching used to be string-only, so a numeric input
+	// equal to the nil token would silently round-trip as a real
+	// reading.
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "temp", Component: swecommon.Quantity{
+				CommonFields: swecommon.CommonFields{NilValue: "-9999"},
+				UoMCode:      "Cel",
+			}},
+		},
+	}
+	rows := []swecommon.Values{
+		{"temp": 23.5},
+		{"temp": float64(-9999)},
+		{"temp": "-9999"},
+		{"temp": int64(-9999)},
+	}
+	out, err := swecommon.MarshalJSONRows(schema, rows)
+	if err != nil {
+		t.Fatalf("MarshalJSONRows: %v", err)
+	}
+	t.Logf("JSON: %s", out)
+	got, err := swecommon.UnmarshalJSONRows(out, schema)
+	if err != nil {
+		t.Fatalf("UnmarshalJSONRows: %v", err)
+	}
+	if v := got[0]["temp"]; v != 23.5 {
+		t.Errorf("row 0: got %v, want 23.5", v)
+	}
+	for i := 1; i <= 3; i++ {
+		if v := got[i]["temp"]; v != nil {
+			t.Errorf("row %d: got %v, want nil (matched nilValue stand-in)", i, v)
+		}
+	}
+}
+
+func TestEncodeJSON_QuantityFromInt(t *testing.T) {
+	t.Parallel()
+	// Tolerance: a Go int feeding a Quantity field should encode
+	// as a float64. Catches regressions in coerceFloat.
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "n", Component: swecommon.Quantity{}},
+		},
+	}
+	rows := []swecommon.Values{{"n": int(42)}}
+	out, err := swecommon.MarshalJSONRows(schema, rows)
+	if err != nil {
+		t.Fatalf("MarshalJSONRows: %v", err)
+	}
+	t.Logf("JSON: %s", out)
+	got, err := swecommon.UnmarshalJSONRows(out, schema)
+	if err != nil {
+		t.Fatalf("UnmarshalJSONRows: %v", err)
+	}
+	if v, ok := got[0]["n"].(float64); !ok || v != 42 {
+		t.Errorf("row 0 n: got %v (%T), want 42 (float64)", got[0]["n"], got[0]["n"])
+	}
+}
+
+func TestEncodeJSON_TimeFromTimeTime(t *testing.T) {
+	t.Parallel()
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "t", Component: swecommon.Time{}},
+		},
+	}
+	tm := time.Date(2026, 5, 29, 13, 0, 0, 0, time.UTC)
+	rows := []swecommon.Values{{"t": tm}}
+	out, err := swecommon.MarshalJSONRows(schema, rows)
+	if err != nil {
+		t.Fatalf("MarshalJSONRows: %v", err)
+	}
+	if !bytes.Contains(out, []byte("2026-05-29T13:00:00Z")) {
+		t.Errorf("expected RFC3339 in output, got %s", out)
+	}
+}
+
+func TestEncodeBinary_BooleanRoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "online", Component: swecommon.Boolean{}},
+		},
+	}
+	rows := []swecommon.Values{{"online": true}, {"online": false}, {"online": nil}}
+	out, err := swecommon.MarshalBinaryRows(schema, rows, swecommon.DefaultBinaryEncoding())
+	if err != nil {
+		t.Fatalf("MarshalBinaryRows: %v", err)
+	}
+	got, err := swecommon.UnmarshalBinaryRows(out, schema, swecommon.DefaultBinaryEncoding())
+	if err != nil {
+		t.Fatalf("UnmarshalBinaryRows: %v", err)
+	}
+	if got[0]["online"] != true {
+		t.Errorf("row 0: got %v, want true", got[0]["online"])
+	}
+	if got[1]["online"] != false {
+		t.Errorf("row 1: got %v, want false", got[1]["online"])
+	}
+	if got[2]["online"] != nil {
+		t.Errorf("row 2: got %v, want nil", got[2]["online"])
+	}
+}
+
+func TestEncodeBinary_CountRoundTrip(t *testing.T) {
+	t.Parallel()
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "n", Component: swecommon.Count{}},
+		},
+	}
+	rows := []swecommon.Values{
+		{"n": int64(0)},
+		{"n": int64(42)},
+		{"n": int64(-7)},
+		{"n": int64(math.MaxInt64)},
+		{"n": int64(math.MinInt64)},
+	}
+	out, err := swecommon.MarshalBinaryRows(schema, rows, swecommon.DefaultBinaryEncoding())
+	if err != nil {
+		t.Fatalf("MarshalBinaryRows: %v", err)
+	}
+	got, err := swecommon.UnmarshalBinaryRows(out, schema, swecommon.DefaultBinaryEncoding())
+	if err != nil {
+		t.Fatalf("UnmarshalBinaryRows: %v", err)
+	}
+	for i, row := range rows {
+		if got[i]["n"] != row["n"] {
+			t.Errorf("row %d: got %v, want %v", i, got[i]["n"], row["n"])
+		}
+	}
+}
+
+func TestSchema_Validate_RejectsBadShapes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		schema *swecommon.DataRecord
+	}{
+		{"nil record", nil},
+		{"empty fields", &swecommon.DataRecord{}},
+		{"empty field name", &swecommon.DataRecord{
+			Fields: []swecommon.Field{{Name: "", Component: swecommon.Text{}}},
+		}},
+		{"nil component", &swecommon.DataRecord{
+			Fields: []swecommon.Field{{Name: "x", Component: nil}},
+		}},
+		{"duplicate names", &swecommon.DataRecord{
+			Fields: []swecommon.Field{
+				{Name: "x", Component: swecommon.Text{}},
+				{Name: "x", Component: swecommon.Text{}},
+			},
+		}},
+		{"nested DataRecord rejected at schema time", &swecommon.DataRecord{
+			Fields: []swecommon.Field{
+				{Name: "outer", Component: &swecommon.DataRecord{
+					Fields: []swecommon.Field{
+						{Name: "inner", Component: swecommon.Text{}},
+					},
+				}},
+			},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tc.schema.Validate(); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+// TestEncodeText_EmptyStringRoundTripsAsNil pins the documented
+// behavior: with no nilValue declared, an empty Text input encodes
+// as empty token and decodes as Go nil. Operators who need to
+// preserve empty-string readings as distinct from "absent" must
+// set a non-empty nilValue on the field. Regression test for S2.
+func TestEncodeText_EmptyStringRoundTripsAsNil(t *testing.T) {
+	t.Parallel()
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "note", Component: swecommon.Text{}},
+		},
+	}
+	rows := []swecommon.Values{
+		{"note": "alpha"},
+		{"note": ""},
+		{"note": "beta"},
+	}
+	enc := swecommon.DefaultTextEncoding()
+	out, err := swecommon.MarshalTextRows(schema, rows, enc)
+	if err != nil {
+		t.Fatalf("MarshalTextRows: %v", err)
+	}
+	t.Logf("text:\n%s", out)
+	got, err := swecommon.UnmarshalTextRows(out, schema, enc)
+	if err != nil {
+		t.Fatalf("UnmarshalTextRows: %v", err)
+	}
+	if v := got[1]["note"]; v != nil {
+		t.Errorf("row 1 note: got %v (%T), want nil (Phase 1 contract: empty Text token decodes to Go nil)", v, v)
+	}
+}
+
+// TestEncodeText_EmptyStringPreservedWithNilToken complements the
+// above: when nilValue is non-empty, an empty string input
+// preserves its value through the round-trip.
+func TestEncodeText_EmptyStringPreservedWithNilToken(t *testing.T) {
+	t.Parallel()
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "note", Component: swecommon.Text{
+				CommonFields: swecommon.CommonFields{NilValue: "<MISSING>"},
+			}},
+		},
+	}
+	rows := []swecommon.Values{
+		{"note": "alpha"},
+		{"note": ""},
+		{"note": nil},
+		{"note": "beta"},
+	}
+	enc := swecommon.DefaultTextEncoding()
+	out, err := swecommon.MarshalTextRows(schema, rows, enc)
+	if err != nil {
+		t.Fatalf("MarshalTextRows: %v", err)
+	}
+	t.Logf("text:\n%s", out)
+	got, err := swecommon.UnmarshalTextRows(out, schema, enc)
+	if err != nil {
+		t.Fatalf("UnmarshalTextRows: %v", err)
+	}
+	if v := got[1]["note"]; v != "" {
+		t.Errorf("row 1 note: got %v, want empty string (preserved by nilValue token discipline)", v)
+	}
+	if v := got[2]["note"]; v != nil {
+		t.Errorf("row 2 note: got %v, want nil", v)
+	}
+}
+
+func TestEncodeText_TokenAndBlockSeparatorMustDiffer(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	enc := swecommon.TextEncoding{TokenSeparator: ",", BlockSeparator: ",", DecimalSeparator: "."}
+	_, err := swecommon.MarshalTextRows(schema, observationRows(), enc)
+	if err == nil {
+		t.Error("expected separator-collision error, got nil")
+	}
+}
+
+func TestEncodeText_DecimalSeparatorMustBeDot(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	enc := swecommon.TextEncoding{TokenSeparator: ";", BlockSeparator: "\n", DecimalSeparator: ","}
+	_, err := swecommon.MarshalTextRows(schema, observationRows(), enc)
+	if err == nil {
+		t.Error("expected decimal-separator error, got nil")
+	}
+}
+
+func TestUnmarshalSchema_RejectsNonRecordRoot(t *testing.T) {
+	t.Parallel()
+	// A bare Quantity at the root — legal SWE Common component
+	// but not a complete schema for a stream of records.
+	bytesIn := []byte(`{"type":"Quantity","uomCode":"Cel"}`)
+	_, err := swecommon.UnmarshalSchema(bytesIn)
+	if err == nil {
+		t.Error("expected non-record-root error, got nil")
+	}
+}
+
+// assertRowsEqual compares two row slices field-by-field with the
+// per-kind tolerance the encoders apply (e.g. numeric round-trip
+// through float64). t.Errorf-and-continue so a single bad row
+// doesn't hide later mismatches.
+func assertRowsEqual(t *testing.T, want, got []swecommon.Values) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("row count: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		for k, w := range want[i] {
+			g, ok := got[i][k]
+			if !ok {
+				t.Errorf("row %d field %q: missing from decoded", i, k)
+				continue
+			}
+			if !valuesMatch(w, g) {
+				t.Errorf("row %d field %q: got %v (%T), want %v (%T)", i, k, g, g, w, w)
+			}
+		}
+	}
+}
+
+func valuesMatch(want, got any) bool {
+	if want == nil && got == nil {
+		return true
+	}
+	if want == nil || got == nil {
+		return false
+	}
+	switch w := want.(type) {
+	case float64:
+		g, ok := got.(float64)
+		return ok && math.Abs(w-g) < 1e-9
+	case int:
+		// Tolerance: int input may decode as float64 (Quantity) or
+		// int64 (Count).
+		if g, ok := got.(int64); ok {
+			return int64(w) == g
+		}
+		if g, ok := got.(float64); ok {
+			return float64(w) == g
+		}
+		return false
+	case time.Time:
+		g, ok := got.(string)
+		if !ok {
+			return false
+		}
+		// Compare against RFC 3339 nano form.
+		return g == w.UTC().Format(time.RFC3339Nano) || g == w.UTC().Format(time.RFC3339)
+	default:
+		// Use JSON serialization as the equality oracle for
+		// strings, bools, and anything else — works because the
+		// encoders canonicalize through JSON shapes anyway.
+		wj, werr := json.Marshal(want)
+		gj, gerr := json.Marshal(got)
+		if werr != nil || gerr != nil {
+			return false
+		}
+		return bytes.Equal(wj, gj)
+	}
+}
+
+// TestDecodeJSON_RefusesNilSchema asserts that the validate-on-
+// entry short-circuit catches a nil schema before json.Unmarshal
+// reaches it. Helps catch regressions if the validate call is
+// ever removed.
+func TestDecodeJSON_RefusesNilSchema(t *testing.T) {
+	t.Parallel()
+	_, err := swecommon.UnmarshalJSONRows([]byte("[]"), nil)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+// TestDecodeJSON_RejectsObjectAtRoot pins the contract: SWE JSON
+// row collections are JSON arrays, not objects. An object at the
+// root must surface as a decode error so producers don't silently
+// truncate to no rows.
+func TestDecodeJSON_RejectsObjectAtRoot(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	bytesIn := []byte(`{"time":"2026-05-29T13:00:00Z","temperature":23.5,"status":"normal"}`)
+	_, err := swecommon.UnmarshalJSONRows(bytesIn, schema)
+	if err == nil {
+		t.Error("expected decode error for object-at-root, got nil")
+	}
+}
+
+// TestDecodeText_RejectsRowWithTooFewTokens pins the column-count
+// check: a row whose tokens don't match the schema's field count
+// must error.
+func TestDecodeText_RejectsRowWithTooFewTokens(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	enc := swecommon.DefaultTextEncoding()
+	// Three fields, but the second row carries only two tokens.
+	bytesIn := []byte("2026-05-29T13:00:00Z,23.5,normal\n2026-05-29T13:01:00Z,24.0\n")
+	_, err := swecommon.UnmarshalTextRows(bytesIn, schema, enc)
+	if err == nil {
+		t.Error("expected token-count error, got nil")
+	}
+}
+
+// TestDecodeBinary_TruncatedStreamSurfacesUnexpectedEOF pins the
+// streaming contract: a partial record mid-stream must surface
+// as io.ErrUnexpectedEOF (or wrap it), not return partial rows
+// with garbage values.
+func TestDecodeBinary_TruncatedStreamSurfacesUnexpectedEOF(t *testing.T) {
+	t.Parallel()
+	schema := observationSchema()
+	rows := observationRows()
+	enc := swecommon.DefaultBinaryEncoding()
+	out, err := swecommon.MarshalBinaryRows(schema, rows, enc)
+	if err != nil {
+		t.Fatalf("MarshalBinaryRows: %v", err)
+	}
+	if len(out) < 5 {
+		t.Fatalf("binary output unexpectedly small: %d", len(out))
+	}
+	truncated := out[:len(out)-3]
+	_, err = swecommon.UnmarshalBinaryRows(truncated, schema, enc)
+	if err == nil {
+		t.Fatal("expected truncation error, got nil")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("expected io.ErrUnexpectedEOF wrap, got %T: %v", err, err)
+	}
+}
+
+// TestEncodeText_RejectsFieldNameWithSeparator pins S3 enforcement
+// on the schema side.
+func TestEncodeText_RejectsFieldNameWithSeparator(t *testing.T) {
+	t.Parallel()
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "temperature,celsius", Component: swecommon.Quantity{}},
+		},
+	}
+	_, err := swecommon.MarshalTextRows(schema, []swecommon.Values{{"temperature,celsius": 23.5}}, swecommon.DefaultTextEncoding())
+	if err == nil {
+		t.Error("expected separator-in-field-name error, got nil")
+	}
+}
+
+// TestEncodeText_RejectsValueWithSeparator pins S3 enforcement on
+// the value-emission seam.
+func TestEncodeText_RejectsValueWithSeparator(t *testing.T) {
+	t.Parallel()
+	schema := &swecommon.DataRecord{
+		Fields: []swecommon.Field{
+			{Name: "note", Component: swecommon.Text{}},
+		},
+	}
+	_, err := swecommon.MarshalTextRows(schema, []swecommon.Values{{"note": "alpha,beta"}}, swecommon.DefaultTextEncoding())
+	if err == nil {
+		t.Error("expected separator-in-value error, got nil")
+	}
+}

--- a/pkg/swecommon/schema.go
+++ b/pkg/swecommon/schema.go
@@ -1,0 +1,266 @@
+package swecommon
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Field is a named member of a [DataRecord]. The name is the
+// dictionary key in the record's value map (and the column header
+// in CSV / position index in binary). Component carries the typed
+// schema for the field's values.
+type Field struct {
+	// Name is the field's identifier within its parent record. Must
+	// be unique across the record's fields, non-empty, and (for
+	// CSV/text encoding) free of the configured token separator.
+	Name string
+
+	// Component is the typed schema for this field's values.
+	Component DataComponent
+}
+
+// DataRecord is the schema for a heterogeneous record of named
+// typed fields (SWE Common §7.6.8). It is the framework's
+// observation-result and command-payload model.
+type DataRecord struct {
+	CommonFields
+
+	// Fields are the record's typed members, in declaration order.
+	// Order is wire-significant for CSV and binary encodings.
+	Fields []Field
+}
+
+// Kind reports [KindRecord].
+func (*DataRecord) Kind() ComponentKind { return KindRecord }
+func (*DataRecord) sealed()             {}
+
+// FieldByName returns the field with the given name and reports
+// whether it was found. O(n) — DataRecords are typically small (a
+// handful of fields).
+func (r *DataRecord) FieldByName(name string) (Field, bool) {
+	if r == nil {
+		return Field{}, false
+	}
+	for _, f := range r.Fields {
+		if f.Name == name {
+			return f, true
+		}
+	}
+	return Field{}, false
+}
+
+// Validate enforces the structural invariants the encoders rely on:
+// non-empty record, non-empty unique field names, non-nil scalar
+// component per field. Phase 1 rejects nested DataRecord fields at
+// schema-validate time so consumers do not learn about the
+// unsupported shape per-row at first encode.
+func (r *DataRecord) Validate() error {
+	if r == nil {
+		return fmt.Errorf("swecommon: DataRecord is nil")
+	}
+	if len(r.Fields) == 0 {
+		return fmt.Errorf("swecommon: DataRecord has no fields")
+	}
+	seen := make(map[string]struct{}, len(r.Fields))
+	for i, f := range r.Fields {
+		if f.Name == "" {
+			return fmt.Errorf("swecommon: field %d has empty name", i)
+		}
+		if _, dup := seen[f.Name]; dup {
+			return fmt.Errorf("swecommon: duplicate field name %q", f.Name)
+		}
+		seen[f.Name] = struct{}{}
+		if f.Component == nil {
+			return fmt.Errorf("swecommon: field %q has nil component", f.Name)
+		}
+		if _, nested := f.Component.(*DataRecord); nested {
+			return fmt.Errorf("swecommon: field %q: nested DataRecord not supported in Phase 1", f.Name)
+		}
+	}
+	return nil
+}
+
+// schemaEnvelope is the wire shape of a serialized [DataRecord]
+// schema in SWE Common JSON Encoding (22-022). Composite types
+// embed a Fields slice; scalar types do not.
+type schemaEnvelope struct {
+	Type ComponentKind `json:"type"`
+
+	Label      string `json:"label,omitempty"`
+	Definition string `json:"definition,omitempty"`
+	NilValue   string `json:"nilValue,omitempty"`
+
+	// Quantity / Time fields
+	UoMCode        string `json:"uomCode,omitempty"`
+	UoMHref        string `json:"uomHref,omitempty"`
+	ReferenceFrame string `json:"referenceFrame,omitempty"`
+
+	// Category fields
+	CodeSpace string `json:"codeSpace,omitempty"`
+
+	// DataRecord fields
+	Fields []fieldEnvelope `json:"fields,omitempty"`
+}
+
+// fieldEnvelope is the JSON shape of a DataRecord field — name plus
+// the nested schema envelope of the field's component.
+type fieldEnvelope struct {
+	Name      string         `json:"name"`
+	Component schemaEnvelope `json:"-"`
+}
+
+// MarshalJSON splats the nested component shape onto the field
+// envelope (per OGC 22-022) so a Quantity field reads as
+// `{"name":"temperature","type":"Quantity","uomCode":"Cel"}`
+// instead of nesting the component under a sub-key.
+func (f fieldEnvelope) MarshalJSON() ([]byte, error) {
+	type fieldAlias struct {
+		Name string `json:"name"`
+		schemaEnvelope
+	}
+	return json.Marshal(fieldAlias{Name: f.Name, schemaEnvelope: f.Component})
+}
+
+// UnmarshalJSON is the inverse: read the splatted shape into a
+// fieldEnvelope.
+func (f *fieldEnvelope) UnmarshalJSON(data []byte) error {
+	type fieldAlias struct {
+		Name string `json:"name"`
+		schemaEnvelope
+	}
+	var a fieldAlias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	f.Name = a.Name
+	f.Component = a.schemaEnvelope
+	return nil
+}
+
+// envelopeFromComponent builds the wire envelope for a single
+// component. Used by both schema-marshal and the field encoder.
+func envelopeFromComponent(c DataComponent) (schemaEnvelope, error) {
+	if c == nil {
+		return schemaEnvelope{}, fmt.Errorf("swecommon: nil component")
+	}
+	env := schemaEnvelope{
+		Type:       c.Kind(),
+		Label:      c.Label(),
+		Definition: c.Definition(),
+	}
+	switch v := c.(type) {
+	case Quantity:
+		env.NilValue = v.Nil()
+		env.UoMCode = v.UoMCode
+		env.UoMHref = v.UoMHref
+	case Count:
+		env.NilValue = v.Nil()
+	case Time:
+		env.NilValue = v.Nil()
+		env.UoMHref = v.UoMHref
+		env.ReferenceFrame = v.ReferenceFrame
+	case Boolean:
+		env.NilValue = v.Nil()
+	case Text:
+		env.NilValue = v.Nil()
+	case Category:
+		env.NilValue = v.Nil()
+		env.CodeSpace = v.CodeSpace
+	case *DataRecord:
+		if v == nil {
+			return schemaEnvelope{}, fmt.Errorf("swecommon: nil *DataRecord")
+		}
+		env.NilValue = v.Nil()
+		env.Fields = make([]fieldEnvelope, 0, len(v.Fields))
+		for _, f := range v.Fields {
+			sub, err := envelopeFromComponent(f.Component)
+			if err != nil {
+				return schemaEnvelope{}, fmt.Errorf("field %q: %w", f.Name, err)
+			}
+			env.Fields = append(env.Fields, fieldEnvelope{Name: f.Name, Component: sub})
+		}
+	default:
+		return schemaEnvelope{}, fmt.Errorf("swecommon: unknown component kind %q", c.Kind())
+	}
+	return env, nil
+}
+
+// componentFromEnvelope is the inverse — reconstruct a typed
+// [DataComponent] from a wire envelope. Used by schema unmarshal
+// and the field decoder.
+func componentFromEnvelope(env schemaEnvelope) (DataComponent, error) {
+	base := CommonFields{
+		LabelValue:      env.Label,
+		DefinitionValue: env.Definition,
+		NilValue:        env.NilValue,
+	}
+	switch env.Type {
+	case KindQuantity:
+		return Quantity{CommonFields: base, UoMCode: env.UoMCode, UoMHref: env.UoMHref}, nil
+	case KindCount:
+		return Count{CommonFields: base}, nil
+	case KindTime:
+		return Time{CommonFields: base, UoMHref: env.UoMHref, ReferenceFrame: env.ReferenceFrame}, nil
+	case KindBoolean:
+		return Boolean{CommonFields: base}, nil
+	case KindText:
+		return Text{CommonFields: base}, nil
+	case KindCategory:
+		return Category{CommonFields: base, CodeSpace: env.CodeSpace}, nil
+	case KindRecord:
+		rec := &DataRecord{CommonFields: base, Fields: make([]Field, 0, len(env.Fields))}
+		for _, f := range env.Fields {
+			sub, err := componentFromEnvelope(f.Component)
+			if err != nil {
+				return nil, fmt.Errorf("field %q: %w", f.Name, err)
+			}
+			rec.Fields = append(rec.Fields, Field{Name: f.Name, Component: sub})
+		}
+		return rec, nil
+	default:
+		return nil, fmt.Errorf("swecommon: unknown component type %q", env.Type)
+	}
+}
+
+// MarshalSchema serializes a [DataRecord] schema to OGC SWE Common
+// JSON Encoding (22-022). Round-trips through [UnmarshalSchema].
+//
+// This is the metadata document — a datastream advertises its
+// observation-result schema by serving this on a `/schema` endpoint
+// (or embedding it in the datastream resource). The schema then
+// drives the JSON / CSV / binary encoders for the values.
+func MarshalSchema(r *DataRecord) ([]byte, error) {
+	if err := r.Validate(); err != nil {
+		return nil, fmt.Errorf("swecommon: marshal schema: %w", err)
+	}
+	env, err := envelopeFromComponent(r)
+	if err != nil {
+		return nil, fmt.Errorf("swecommon: marshal schema: %w", err)
+	}
+	return json.Marshal(env)
+}
+
+// UnmarshalSchema parses a SWE Common JSON Encoding schema document
+// into a typed [DataRecord]. The result is structurally validated
+// (non-empty record, unique field names).
+func UnmarshalSchema(data []byte) (*DataRecord, error) {
+	var env schemaEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("swecommon: unmarshal schema: %w", err)
+	}
+	if env.Type != KindRecord {
+		return nil, fmt.Errorf("swecommon: expected DataRecord at root, got %q", env.Type)
+	}
+	c, err := componentFromEnvelope(env)
+	if err != nil {
+		return nil, fmt.Errorf("swecommon: unmarshal schema: %w", err)
+	}
+	rec, ok := c.(*DataRecord)
+	if !ok {
+		return nil, fmt.Errorf("swecommon: root component is not *DataRecord")
+	}
+	if err := rec.Validate(); err != nil {
+		return nil, fmt.Errorf("swecommon: unmarshal schema: %w", err)
+	}
+	return rec, nil
+}

--- a/pkg/swecommon/text.go
+++ b/pkg/swecommon/text.go
@@ -1,0 +1,336 @@
+package swecommon
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// TextEncoding configures the SWE TextEncoding (SWE Common §7.4.3)
+// separators. CS API requires the producer/consumer to agree on
+// these; the framework defaults match the CSV media type and are
+// safe round-trip targets.
+//
+// Token separator splits values within one record (column
+// delimiter). Block separator splits records (row delimiter).
+// Decimal separator must be "." to round-trip JSON-compatible
+// floats; encoders surface a configuration error otherwise.
+type TextEncoding struct {
+	// TokenSeparator separates values within a record. Default ",".
+	TokenSeparator string
+
+	// BlockSeparator separates records. Default "\n".
+	BlockSeparator string
+
+	// DecimalSeparator is the decimal point. Must be ".".
+	DecimalSeparator string
+
+	// CollapseWhiteSpace controls whether the decoder trims
+	// leading/trailing whitespace from each token. Defaults true.
+	CollapseWhiteSpace bool
+
+	// EmitHeader controls whether the encoder emits the field-name
+	// header row before the first record. CS API SWE text streams
+	// typically omit it (the schema is advertised separately); the
+	// framework default is false to match.
+	EmitHeader bool
+}
+
+// DefaultTextEncoding is the CSV-shaped default used when no
+// per-datastream encoding is configured.
+func DefaultTextEncoding() TextEncoding {
+	return TextEncoding{
+		TokenSeparator:     ",",
+		BlockSeparator:     "\n",
+		DecimalSeparator:   ".",
+		CollapseWhiteSpace: true,
+		EmitHeader:         false,
+	}
+}
+
+func (te TextEncoding) resolve() (TextEncoding, error) {
+	if te.TokenSeparator == "" {
+		te.TokenSeparator = ","
+	}
+	if te.BlockSeparator == "" {
+		te.BlockSeparator = "\n"
+	}
+	if te.DecimalSeparator == "" {
+		te.DecimalSeparator = "."
+	}
+	if te.DecimalSeparator != "." {
+		return te, fmt.Errorf("swecommon: decimal separator %q not supported (use \".\")", te.DecimalSeparator)
+	}
+	if te.TokenSeparator == te.BlockSeparator {
+		return te, fmt.Errorf("swecommon: token and block separators must differ")
+	}
+	return te, nil
+}
+
+// EncodeText writes the rows as SWE TextEncoding bytes per the
+// given encoding (separators + optional header row). Field order
+// follows the schema's field declaration order.
+//
+// Nil values are emitted as the schema's nilValue token when set,
+// otherwise as the empty string. The empty string is a legal
+// "absent value" stand-in for SWE text streams but operators are
+// strongly encouraged to set a nilValue for fields where a real
+// reading could be empty (Text, Category) so decoders can tell
+// "absent" from "empty string reading."
+func EncodeText(w io.Writer, schema *DataRecord, rows []Values, enc TextEncoding) error {
+	if err := schema.Validate(); err != nil {
+		return fmt.Errorf("swecommon: encode text: %w", err)
+	}
+	resolved, err := enc.resolve()
+	if err != nil {
+		return err
+	}
+	if err := validateFieldNamesAgainstSeparators(schema, resolved); err != nil {
+		return err
+	}
+	bw := bufio.NewWriter(w)
+	if resolved.EmitHeader {
+		for i, f := range schema.Fields {
+			if i > 0 {
+				if _, err := bw.WriteString(resolved.TokenSeparator); err != nil {
+					return err
+				}
+			}
+			if _, err := bw.WriteString(f.Name); err != nil {
+				return err
+			}
+		}
+		if _, err := bw.WriteString(resolved.BlockSeparator); err != nil {
+			return err
+		}
+	}
+	for ri, row := range rows {
+		for fi, f := range schema.Fields {
+			if fi > 0 {
+				if _, err := bw.WriteString(resolved.TokenSeparator); err != nil {
+					return err
+				}
+			}
+			token, err := textEncodeField(f.Component, fieldValue(row, f.Name))
+			if err != nil {
+				return fmt.Errorf("swecommon: encode text row %d field %q: %w", ri, f.Name, err)
+			}
+			if err := validateTokenAgainstSeparators(token, resolved); err != nil {
+				return fmt.Errorf("swecommon: encode text row %d field %q: %w", ri, f.Name, err)
+			}
+			if _, err := bw.WriteString(token); err != nil {
+				return err
+			}
+		}
+		if _, err := bw.WriteString(resolved.BlockSeparator); err != nil {
+			return err
+		}
+	}
+	return bw.Flush()
+}
+
+// MarshalTextRows is the bytes-returning convenience wrapper around
+// [EncodeText].
+func MarshalTextRows(schema *DataRecord, rows []Values, enc TextEncoding) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := EncodeText(&buf, schema, rows, enc); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func textEncodeField(c DataComponent, v any) (string, error) {
+	if matchesNilToken(c, v) {
+		v = nil
+	}
+	canon, isNil, err := normalizeValue(c, v)
+	if err != nil {
+		return "", err
+	}
+	if isNil {
+		return nilValueOf(c), nil
+	}
+	switch c.Kind() {
+	case KindQuantity:
+		return strconv.FormatFloat(canon.(float64), 'f', -1, 64), nil
+	case KindCount:
+		return strconv.FormatInt(canon.(int64), 10), nil
+	case KindTime, KindText, KindCategory:
+		return canon.(string), nil
+	case KindBoolean:
+		return strconv.FormatBool(canon.(bool)), nil
+	default:
+		return "", fmt.Errorf("unsupported kind %q", c.Kind())
+	}
+}
+
+// DecodeText parses SWE TextEncoding bytes back into typed rows
+// against the schema. Field count per row must match the schema's
+// field count exactly; mismatched rows surface as errors.
+//
+// Header handling: when enc.EmitHeader is true, the first
+// non-empty block is consumed as the header and validated against
+// the schema's field names. When false, no header is expected.
+func DecodeText(r io.Reader, schema *DataRecord, enc TextEncoding) ([]Values, error) {
+	if err := schema.Validate(); err != nil {
+		return nil, fmt.Errorf("swecommon: decode text: %w", err)
+	}
+	resolved, err := enc.resolve()
+	if err != nil {
+		return nil, err
+	}
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("swecommon: decode text: %w", err)
+	}
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	blocks := strings.Split(string(raw), resolved.BlockSeparator)
+	// A trailing block separator yields an empty final element —
+	// drop it. Interior empty blocks ARE NOT skipped: for a
+	// single-field schema an empty block is a single empty-token
+	// row (which decodes to nil unless the schema declares a
+	// nilValue); for multi-field schemas the token-count check
+	// below catches them as malformed rows.
+	if len(blocks) > 0 && blocks[len(blocks)-1] == "" {
+		blocks = blocks[:len(blocks)-1]
+	}
+	out := make([]Values, 0, len(blocks))
+	headerConsumed := !resolved.EmitHeader
+	for bi, block := range blocks {
+		if !headerConsumed {
+			if err := validateHeader(block, schema, resolved); err != nil {
+				return nil, fmt.Errorf("swecommon: decode text header: %w", err)
+			}
+			headerConsumed = true
+			continue
+		}
+		tokens := strings.Split(block, resolved.TokenSeparator)
+		if len(tokens) != len(schema.Fields) {
+			return nil, fmt.Errorf("swecommon: decode text block %d: got %d tokens, want %d",
+				bi, len(tokens), len(schema.Fields))
+		}
+		row := make(Values, len(schema.Fields))
+		for fi, f := range schema.Fields {
+			tok := tokens[fi]
+			if resolved.CollapseWhiteSpace {
+				tok = strings.TrimSpace(tok)
+			}
+			v, err := textDecodeField(f.Component, tok)
+			if err != nil {
+				return nil, fmt.Errorf("swecommon: decode text block %d field %q: %w", bi, f.Name, err)
+			}
+			row[f.Name] = v
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}
+
+// UnmarshalTextRows is the bytes-taking convenience wrapper around
+// [DecodeText].
+func UnmarshalTextRows(data []byte, schema *DataRecord, enc TextEncoding) ([]Values, error) {
+	return DecodeText(bytes.NewReader(data), schema, enc)
+}
+
+// validateFieldNamesAgainstSeparators rejects schemas whose field
+// names contain the configured token or block separators. SWE
+// TextEncoding does not specify quoting, so a separator inside a
+// field name silently corrupts the header row and breaks the
+// downstream decoder's column-count check. Failing fast at encode
+// time surfaces the conflict before bad bytes hit the wire.
+func validateFieldNamesAgainstSeparators(schema *DataRecord, enc TextEncoding) error {
+	for _, f := range schema.Fields {
+		if strings.Contains(f.Name, enc.TokenSeparator) {
+			return fmt.Errorf("swecommon: encode text: field name %q contains token separator %q", f.Name, enc.TokenSeparator)
+		}
+		if strings.Contains(f.Name, enc.BlockSeparator) {
+			return fmt.Errorf("swecommon: encode text: field name %q contains block separator %q", f.Name, enc.BlockSeparator)
+		}
+	}
+	return nil
+}
+
+// validateTokenAgainstSeparators rejects emitted string tokens
+// (Text / Category values, Time strings) that contain the
+// configured separators. Mirrors the field-name check at the
+// value-emission seam — preserves the same fail-loud-at-encode
+// discipline.
+func validateTokenAgainstSeparators(token string, enc TextEncoding) error {
+	if strings.Contains(token, enc.TokenSeparator) {
+		return fmt.Errorf("token %q contains token separator %q", token, enc.TokenSeparator)
+	}
+	if strings.Contains(token, enc.BlockSeparator) {
+		return fmt.Errorf("token %q contains block separator %q", token, enc.BlockSeparator)
+	}
+	return nil
+}
+
+func validateHeader(block string, schema *DataRecord, enc TextEncoding) error {
+	tokens := strings.Split(block, enc.TokenSeparator)
+	if len(tokens) != len(schema.Fields) {
+		return fmt.Errorf("header has %d columns, schema has %d fields", len(tokens), len(schema.Fields))
+	}
+	for i, tok := range tokens {
+		if enc.CollapseWhiteSpace {
+			tok = strings.TrimSpace(tok)
+		}
+		if tok != schema.Fields[i].Name {
+			return fmt.Errorf("column %d: header %q does not match field name %q", i, tok, schema.Fields[i].Name)
+		}
+	}
+	return nil
+}
+
+func textDecodeField(c DataComponent, tok string) (any, error) {
+	// Nil-stand-in semantics on decode side:
+	//   1. If the schema declares a nilValue token, ONLY that
+	//      exact token decodes to Go nil — empty Text/Category
+	//      tokens preserve as empty strings, so a producer can
+	//      distinguish "no reading" from "empty reading."
+	//   2. If no nilValue is declared, an empty token decodes to
+	//      Go nil for non-string kinds (no other reading is
+	//      possible). For Text/Category an empty token also
+	//      decodes to nil — operators wanting to round-trip empty
+	//      string readings must declare a nilValue token.
+	nilStr := nilValueOf(c)
+	if nilStr != "" {
+		if tok == nilStr {
+			return nil, nil //nolint:nilnil // SWE text nil-stand-in: nil value is the schema-sanctioned answer for a nil-encoded token
+		}
+		// Fall through — empty tokens for Text/Category are real
+		// empty strings when a distinct nilValue is declared.
+	} else if tok == "" {
+		return nil, nil //nolint:nilnil // SWE text empty token without nilValue: framework treats as nil per Phase 1 contract
+	}
+	switch c.Kind() {
+	case KindQuantity:
+		f, err := strconv.ParseFloat(tok, 64)
+		if err != nil {
+			return nil, fmt.Errorf("Quantity: %w", err)
+		}
+		return f, nil
+	case KindCount:
+		i, err := strconv.ParseInt(tok, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("Count: %w", err)
+		}
+		return i, nil
+	case KindTime:
+		return tok, nil
+	case KindBoolean:
+		b, err := strconv.ParseBool(tok)
+		if err != nil {
+			return nil, fmt.Errorf("Boolean: %w", err)
+		}
+		return b, nil
+	case KindText, KindCategory:
+		return tok, nil
+	default:
+		return nil, fmt.Errorf("unsupported kind %q", c.Kind())
+	}
+}

--- a/pkg/swecommon/values.go
+++ b/pkg/swecommon/values.go
@@ -1,0 +1,270 @@
+package swecommon
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// Values is one record's worth of typed field values, keyed by
+// field name. Missing keys are treated as nil (encoders emit the
+// schema's nilValue or JSON null). Per-field Go types:
+//
+//   - Quantity → float64
+//   - Count    → int64
+//   - Time     → time.Time (or RFC 3339 string — encoders convert)
+//   - Boolean  → bool
+//   - Text     → string
+//   - Category → string
+//
+// Encoders are tolerant on input: a Quantity field accepts any
+// numeric type (int, int32, int64, float32, float64) and rounds
+// through float64; a Time field accepts either time.Time or an
+// RFC 3339 string. Decoders always populate the canonical type.
+type Values map[string]any
+
+// normalizeValue coerces a Go value into the canonical Go type for
+// the given component, returning (canonicalValue, isNil, error).
+// Used by every encoder so input-shape tolerance lives in one
+// place. isNil true means the value should be emitted as the
+// schema's nilValue token (or wire null when no nilValue is set).
+func normalizeValue(c DataComponent, v any) (any, bool, error) {
+	if v == nil {
+		return nil, true, nil
+	}
+	switch c.Kind() {
+	case KindQuantity:
+		f, err := coerceFloat(v)
+		if err != nil {
+			return nil, false, fmt.Errorf("Quantity: %w", err)
+		}
+		return f, false, nil
+	case KindCount:
+		i, err := coerceInt(v)
+		if err != nil {
+			return nil, false, fmt.Errorf("Count: %w", err)
+		}
+		return i, false, nil
+	case KindTime:
+		s, err := coerceTime(v)
+		if err != nil {
+			return nil, false, fmt.Errorf("Time: %w", err)
+		}
+		return s, false, nil
+	case KindBoolean:
+		b, err := coerceBool(v)
+		if err != nil {
+			return nil, false, fmt.Errorf("Boolean: %w", err)
+		}
+		return b, false, nil
+	case KindText:
+		s, ok := v.(string)
+		if !ok {
+			return nil, false, fmt.Errorf("Text: want string, got %T", v)
+		}
+		return s, false, nil
+	case KindCategory:
+		s, ok := v.(string)
+		if !ok {
+			return nil, false, fmt.Errorf("Category: want string, got %T", v)
+		}
+		return s, false, nil
+	case KindRecord:
+		// Nested records are not supported in Phase 1 value flow —
+		// the framework MVP carries one flat record per row, which
+		// is what every CS API observation/command consumer needs.
+		// Nested-record support is straightforward to add later by
+		// recursing through normalizeValue.
+		return nil, false, fmt.Errorf("nested DataRecord values not supported in Phase 1")
+	default:
+		return nil, false, fmt.Errorf("unknown component kind %q", c.Kind())
+	}
+}
+
+// coerceFloat converts any numeric Go type to float64. Strings are
+// parsed (so the CSV/binary decoders can route through here too).
+func coerceFloat(v any) (float64, error) {
+	switch n := v.(type) {
+	case float64:
+		return n, nil
+	case float32:
+		return float64(n), nil
+	case int:
+		return float64(n), nil
+	case int8:
+		return float64(n), nil
+	case int16:
+		return float64(n), nil
+	case int32:
+		return float64(n), nil
+	case int64:
+		return float64(n), nil
+	case uint:
+		return float64(n), nil
+	case uint8:
+		return float64(n), nil
+	case uint16:
+		return float64(n), nil
+	case uint32:
+		return float64(n), nil
+	case uint64:
+		return float64(n), nil
+	case string:
+		f, err := strconv.ParseFloat(n, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse float %q: %w", n, err)
+		}
+		return f, nil
+	default:
+		return 0, fmt.Errorf("want number, got %T", v)
+	}
+}
+
+// coerceInt converts any integer Go type (or numerically-integer
+// float) to int64. Float inputs are accepted when they round-trip
+// losslessly to int64.
+func coerceInt(v any) (int64, error) {
+	switch n := v.(type) {
+	case int64:
+		return n, nil
+	case int:
+		return int64(n), nil
+	case int8:
+		return int64(n), nil
+	case int16:
+		return int64(n), nil
+	case int32:
+		return int64(n), nil
+	case uint:
+		return int64(n), nil
+	case uint8:
+		return int64(n), nil
+	case uint16:
+		return int64(n), nil
+	case uint32:
+		return int64(n), nil
+	case uint64:
+		return int64(n), nil
+	case float32:
+		i := int64(n)
+		if float32(i) != n {
+			return 0, fmt.Errorf("float %v not exactly representable as int64", n)
+		}
+		return i, nil
+	case float64:
+		i := int64(n)
+		if float64(i) != n {
+			return 0, fmt.Errorf("float %v not exactly representable as int64", n)
+		}
+		return i, nil
+	case string:
+		i, err := strconv.ParseInt(n, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse int %q: %w", n, err)
+		}
+		return i, nil
+	default:
+		return 0, fmt.Errorf("want integer, got %T", v)
+	}
+}
+
+// coerceTime converts a Go time.Time or RFC 3339 string to its
+// canonical RFC 3339 Nano string for the wire. RFC 3339 is the
+// JSON-friendly subset of ISO 8601 the SWE Common JSON encoding
+// uses for Time values.
+func coerceTime(v any) (string, error) {
+	switch n := v.(type) {
+	case time.Time:
+		return n.UTC().Format(time.RFC3339Nano), nil
+	case string:
+		// Validate by re-parsing — round-trip-stable strings only.
+		if _, err := time.Parse(time.RFC3339Nano, n); err != nil {
+			if _, err2 := time.Parse(time.RFC3339, n); err2 != nil {
+				return "", fmt.Errorf("parse time %q: %w", n, err)
+			}
+		}
+		return n, nil
+	default:
+		return "", fmt.Errorf("want time.Time or RFC 3339 string, got %T", v)
+	}
+}
+
+// coerceBool converts a Go bool or canonical SWE bool string
+// ("true"/"false") to bool.
+func coerceBool(v any) (bool, error) {
+	switch n := v.(type) {
+	case bool:
+		return n, nil
+	case string:
+		b, err := strconv.ParseBool(n)
+		if err != nil {
+			return false, fmt.Errorf("parse bool %q: %w", n, err)
+		}
+		return b, nil
+	default:
+		return false, fmt.Errorf("want bool, got %T", v)
+	}
+}
+
+// fieldValue retrieves the value for a field name, treating an
+// absent key as nil.
+func fieldValue(row Values, name string) any {
+	if row == nil {
+		return nil
+	}
+	v, ok := row[name]
+	if !ok {
+		return nil
+	}
+	return v
+}
+
+// matchesNilToken reports whether the given input value should be
+// treated as Go nil for emission, given the component's declared
+// nilValue token. Returns false when nilValue is empty (no
+// stand-in declared) or v is already nil.
+//
+// String inputs match verbatim. Numeric inputs are formatted to
+// their canonical wire form (the same form the encoder would
+// otherwise emit) and compared — so a Quantity field with
+// nilValue "-9999" matches an input of float64(-9999), int(-9999),
+// and the string "-9999" identically. Boolean inputs are formatted
+// via strconv.FormatBool. Time inputs match against the canonical
+// RFC 3339 nano string.
+func matchesNilToken(c DataComponent, v any) bool {
+	nilStr := nilValueOf(c)
+	if nilStr == "" || v == nil {
+		return false
+	}
+	if asStr, ok := v.(string); ok {
+		return asStr == nilStr
+	}
+	switch c.Kind() {
+	case KindQuantity:
+		f, err := coerceFloat(v)
+		if err != nil {
+			return false
+		}
+		return strconv.FormatFloat(f, 'f', -1, 64) == nilStr
+	case KindCount:
+		i, err := coerceInt(v)
+		if err != nil {
+			return false
+		}
+		return strconv.FormatInt(i, 10) == nilStr
+	case KindTime:
+		s, err := coerceTime(v)
+		if err != nil {
+			return false
+		}
+		return s == nilStr
+	case KindBoolean:
+		b, err := coerceBool(v)
+		if err != nil {
+			return false
+		}
+		return strconv.FormatBool(b) == nilStr
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary

- New framework package \`pkg/swecommon\` providing schema-bound encoders/decoders for the three CS API SWE Common media types: \`application/swe+json\`, \`application/swe+csv\`, \`application/swe+binary\`.
- Closes #116 and unblocks the semconnect upstream-ask carrying the \`X-CS-SWE-Subset: observation-values\` workaround — CS API Part 2 SWE Common conformance becomes claimable.
- All ADDITIVE; no existing wire format or API contract changes.

## What's in Phase 1

- Sealed \`DataComponent\` interface + scalars (Quantity, Count, Time, Boolean, Text, Category) + composite DataRecord.
- Schema metadata in OGC SWE Common JSON Encoding (22-022) shape — \`MarshalSchema\` / \`UnmarshalSchema\`.
- Three schema-bound encoder/decoder pairs:
  - **JSON**: array of objects, one per row, RFC 3339 for Time.
  - **Text**: SWE TextEncoding with configurable separators (default CSV); decimal separator pinned to \".\"; optional header row.
  - **Binary**: packed primitives, per-record nil bitmap, big-endian default, length-prefixed UTF-8 for variable-width fields.
- Media-type constants matching CS API negotiation strings.
- 24 round-trip tests covering UoMs, nil values (incl. numeric stand-ins), custom separators, byte-order disagreement, empty-token semantics, separator-collision rejection, truncated streams.

## go-reviewer pass

Findings folded in (B1, B2, S1-S4, N3-N5):

- **B1** — DataRecord.Validate rejects nested record fields at schema time, not per-row.
- **B2** — Numeric nilValue stand-ins now match numeric inputs via canonical stringification (was string-only — silent fidelity bug).
- **S1** — Byte-order test asserts \`!valuesMatch\` OR decode error, robust to schema reordering.
- **S2** — Empty-Text-token decode contract pinned with two tests; decoder now preserves empty strings when nilValue is declared.
- **S3** — EncodeText rejects field names and emitted string values containing the configured separators.
- **S4** — \`errors.Is(err, io.EOF)\` per post-gh#93 discipline.
- **N3** — uint32 length-prefix overflow surfaces explicit error.
- **N4** — ADR/doc references converted to \"Phase 1 of ADR-050\" so they don't drift on tag bump.
- **N5** — Three decode-side error path tests added (truncated binary, object-at-root JSON, too-few text tokens).

## Deferred (out of scope for Phase 1)

- DataArray, DataChoice, Vector
- Per-component constraints (allowedValues, ranges)
- Multi-reason NilValues block
- Nested DataRecord values
- SWE XML encoding (CS API does not require)

## semconnect migration

The gateway parses each datastream's advertised SWE schema, hands the schema + unwrapped observation results to \`swecommon.Encode{JSON,Text,Binary}\`, drops the \`X-CS-SWE-Subset\` header. Migration is the next semconnect stage, gated on this tag landing.

## Test plan

- [x] \`task lint\` — vet + fmt + revive clean
- [x] \`go vet -tags=integration ./...\` — clean
- [x] \`go vet -tags=live_llm ./...\` — clean
- [x] \`go test -race ./...\` — full repo green; 24 swecommon tests pass
- [x] \`task schema:generate\` — no drift
- [ ] semconnect migration PR exercises the package end-to-end against a CS API conformance test fixture

## Tag

Goes into the next bundle. No BREAKING markers — purely additive framework primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)