### PR TITLE
ADR-051: OpenAI Responses wire support + unified ReasoningRecord (BREAKING)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -50,6 +50,8 @@ includes:
     taskfile: ./taskfiles/e2e/lifecycle.yml
   e2e:throughput:
     taskfile: ./taskfiles/e2e/throughput.yml
+  e2e:openai-responses:
+    taskfile: ./taskfiles/e2e/openai-responses.yml
 
   # ADR-043 prompt-injection classifier measurement
   adr043:

--- a/agentic/reasoning.go
+++ b/agentic/reasoning.go
@@ -1,0 +1,69 @@
+package agentic
+
+// ReasoningRecord is the provider-neutral carrier for opaque reasoning
+// state that must be echoed back on the next turn. Captured on
+// response, attached to the next request. Provider-specific reshape
+// happens at the adapter seam — loop code stays shape-neutral.
+//
+// Replaces the per-provider MetadataKeyGoogleThoughtSignature carrier
+// retired in ADR-051 Phase 1. The semantic role ("opaque blob the
+// model wants echoed on the next turn for reasoning continuity") is
+// stable across providers; the wire shape is not, so the abstraction
+// lives at the role layer.
+type ReasoningRecord struct {
+	// Provider names the carrier provider. The adapter uses this to
+	// decide on-the-wire reconstruction. Known values: "google",
+	// "openai". Future providers extend the set.
+	Provider string `json:"provider"`
+
+	// ItemID is the provider-assigned identity for this record.
+	// Used for cross-turn echo when the provider needs it. OpenAI
+	// Responses uses it (id of the reasoning item); Gemini does not
+	// (signatures are carried per-tool-call, not by id).
+	ItemID string `json:"item_id,omitempty"`
+
+	// SummaryText is a human-readable description of the reasoning,
+	// when the provider exposes one. Safe to log. Used for trajectory
+	// and operator-facing trace.
+	SummaryText string `json:"summary_text,omitempty"`
+
+	// Opaque is the provider-specific blob that must be echoed back
+	// verbatim. Treat as bytes; do not parse, do not log in full.
+	//   - Gemini: the base64 thought_signature string (bytes of UTF-8)
+	//   - OpenAI: encrypted_content blob (when store:false)
+	//   - Anthropic (future): thinking block content
+	Opaque []byte `json:"opaque,omitempty"`
+
+	// CarrierKind names the structural attachment constraint on the
+	// wire. Adapters use this to reshape correctly. The set is closed:
+	// unknown values are an authoring error and must fail validation,
+	// not silently pass.
+	CarrierKind ReasoningCarrierKind `json:"carrier_kind"`
+
+	// ToolCallID is set when CarrierKind == ReasoningCarrierToolCall.
+	// The signature belongs with this specific tool call; the adapter
+	// re-binds them on send.
+	ToolCallID string `json:"tool_call_id,omitempty"`
+}
+
+// ReasoningCarrierKind enumerates the structural attachment shapes a
+// provider's reasoning blob can take on the wire. Closed set: adapters
+// must handle every value, and unknown values are an authoring error.
+type ReasoningCarrierKind string
+
+const (
+	// ReasoningCarrierToolCall indicates the blob attaches to a
+	// specific tool call on the wire. Used by Gemini (thought_signature
+	// per tool_call).
+	ReasoningCarrierToolCall ReasoningCarrierKind = "tool_call"
+
+	// ReasoningCarrierStandaloneItem indicates the blob is a sibling
+	// output item with no attachment to messages or tool calls. Used
+	// by OpenAI Responses (reasoning items in the output array).
+	ReasoningCarrierStandaloneItem ReasoningCarrierKind = "standalone_item"
+
+	// ReasoningCarrierAssistantContent indicates the blob is a content
+	// part inside the assistant message. Reserved for Anthropic's
+	// thinking blocks when/if we take that on.
+	ReasoningCarrierAssistantContent ReasoningCarrierKind = "assistant_content"
+)

--- a/agentic/reasoning_test.go
+++ b/agentic/reasoning_test.go
@@ -1,0 +1,132 @@
+package agentic_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// TestReasoningRecord_JSONRoundTrip pins that every field on
+// ReasoningRecord survives a marshal/unmarshal cycle. Required by
+// feedback_polymorphic_config_needs_json_roundtrip_test — operator-
+// reachable shapes that traverse JSON boundaries (KV writes, NATS
+// payloads, trajectory exports) need explicit coverage so a future
+// field add can't silently lose data.
+func TestReasoningRecord_JSONRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   agentic.ReasoningRecord
+	}{
+		{
+			name: "tool_call carrier (Gemini)",
+			in: agentic.ReasoningRecord{
+				Provider:    "google",
+				CarrierKind: agentic.ReasoningCarrierToolCall,
+				ToolCallID:  "call-1",
+				Opaque:      []byte("opaque-sig-bytes"),
+			},
+		},
+		{
+			name: "standalone_item carrier (OpenAI Responses)",
+			in: agentic.ReasoningRecord{
+				Provider:    "openai",
+				CarrierKind: agentic.ReasoningCarrierStandaloneItem,
+				ItemID:      "rs_abc123",
+				SummaryText: "thinking about the problem",
+				Opaque:      []byte("encrypted-content-blob"),
+			},
+		},
+		{
+			name: "assistant_content carrier (Anthropic, reserved)",
+			in: agentic.ReasoningRecord{
+				Provider:    "anthropic",
+				CarrierKind: agentic.ReasoningCarrierAssistantContent,
+				Opaque:      []byte("thinking-block-content"),
+			},
+		},
+		{
+			name: "minimum populated",
+			in: agentic.ReasoningRecord{
+				Provider:    "google",
+				CarrierKind: agentic.ReasoningCarrierToolCall,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var got agentic.ReasoningRecord
+			if err := json.Unmarshal(b, &got); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(tc.in, got) {
+				t.Errorf("round-trip mismatch\n  in:  %#v\n  got: %#v\n  json: %s", tc.in, got, string(b))
+			}
+			// Opaque must survive byte-for-byte — providers treat it as
+			// a verbatim blob and any encoding drift breaks echo.
+			if !bytes.Equal(tc.in.Opaque, got.Opaque) {
+				t.Errorf("Opaque mismatch: in=%q got=%q", tc.in.Opaque, got.Opaque)
+			}
+		})
+	}
+}
+
+// TestChatMessage_ReasoningRecords_JSONRoundTrip pins that the new
+// ChatMessage.ReasoningRecords field survives a JSON round-trip
+// alongside the existing ChatMessage fields.
+func TestChatMessage_ReasoningRecords_JSONRoundTrip(t *testing.T) {
+	in := agentic.ChatMessage{
+		Role:    "assistant",
+		Content: "calling tools",
+		ToolCalls: []agentic.ToolCall{
+			{ID: "call-1", Name: "f"},
+			{ID: "call-2", Name: "g"},
+		},
+		ReasoningRecords: []agentic.ReasoningRecord{
+			{
+				Provider:    "google",
+				CarrierKind: agentic.ReasoningCarrierToolCall,
+				ToolCallID:  "call-1",
+				Opaque:      []byte("sig-1"),
+			},
+			{
+				Provider:    "openai",
+				CarrierKind: agentic.ReasoningCarrierStandaloneItem,
+				ItemID:      "rs_x",
+				Opaque:      []byte("blob-x"),
+			},
+		},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got agentic.ChatMessage
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, got) {
+		t.Errorf("round-trip mismatch\n  in:  %#v\n  got: %#v\n  json: %s", in, got, string(b))
+	}
+}
+
+// TestChatMessage_NoReasoningRecords_OmitsField pins that messages
+// without ReasoningRecords don't emit an empty array on the wire.
+// JSON shape stability matters for sister-repo and trajectory
+// consumers that introspect fields presence/absence.
+func TestChatMessage_NoReasoningRecords_OmitsField(t *testing.T) {
+	in := agentic.ChatMessage{Role: "user", Content: "hi"}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if bytes.Contains(b, []byte("reasoning_records")) {
+		t.Errorf("expected reasoning_records omitted when nil/empty; got %s", string(b))
+	}
+}

--- a/agentic/tools.go
+++ b/agentic/tools.go
@@ -157,24 +157,6 @@ const MetadataKeyDecideActionAllowlist = "agent.decide.action_allowlist"
 // a Go string) — readers coerce on access.
 const MetadataKeyRelatedLoops = "agent.related_loops"
 
-// MetadataKeyGoogleThoughtSignature is the ToolCall.Metadata key under
-// which the per-tool_call thought signature emitted by Gemini 3.x
-// preview models flows across loop turns.
-//
-// Gemini 3.x emits the signature at
-// `response.choices[].message.tool_calls[].extra_content.google.thought_signature`
-// and requires the same signature echoed back on the assistant
-// tool_calls of the next request (only the first tool_call per step
-// needs the signature; subsequent calls in the same step inherit).
-// agentic-model's wire backend extracts the signature during
-// convertWireResponse and writes it under this key; on the next
-// request, GeminiAdapter.NormalizeMessages reconstructs the
-// `extra_content.google.thought_signature` shape on the outgoing
-// wire ToolCall.
-//
-// Value type: string. Non-Gemini providers ignore the carrier.
-const MetadataKeyGoogleThoughtSignature = "google_thought_signature"
-
 // LineageTriplePrefix is the predicate prefix for cross-arc loop-ID
 // lineage triples stamped on a spawned loop's entity at loop-creation
 // time. Each entry in TaskMessage.Metadata[MetadataKeyRelatedLoops]

--- a/agentic/types.go
+++ b/agentic/types.go
@@ -212,6 +212,13 @@ type ChatMessage struct {
 	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string     `json:"tool_call_id,omitempty"` // Required for tool role messages
 	IsError          bool       `json:"is_error,omitempty"`     // Tool result contains an error — preserved during context GC
+
+	// ReasoningRecords are provider-opaque reasoning blobs captured
+	// from the model's response, to be echoed back on subsequent
+	// turns. Loop owns cross-turn propagation; adapters reshape into
+	// wire format at the seam. See ReasoningRecord (agentic/reasoning.go)
+	// and ADR-051.
+	ReasoningRecords []ReasoningRecord `json:"reasoning_records,omitempty"`
 }
 
 // UnmarshalJSON accepts both "reasoning" (Ollama) and "reasoning_content" (DeepSeek/canonical).

--- a/docs/adr/051-openai-responses-wire-support.md
+++ b/docs/adr/051-openai-responses-wire-support.md
@@ -1,0 +1,587 @@
+# ADR-051: OpenAI Responses API Wire Support + Unified `ReasoningRecord`
+
+## Status
+
+**Proposed** — 2026-05-30. Companion research doc at
+[`docs/proposals/openai-responses-wire-support.md`](../proposals/openai-responses-wire-support.md)
+captures the option exploration; this ADR is the canonical decision
+record. Extends [ADR-037](037-self-hosted-llm-wire-package.md) by
+adding a second top-level wire shape to the `model/wire` package
+layer. Sister-agent picks up implementation when this ADR is
+Accepted; the proposal doc is the working/research artifact and stays
+in `docs/proposals/` per the working-record convention.
+
+## Context
+
+### Forcing function
+
+semspec hit a hard wall on its hybrid registry path: **the OpenAI
+Chat Completions endpoint refuses `tool_choice` + `reasoning_effort`
+together on GPT-5.5 and the o-series**. The combination is supported
+only on the `/v1/responses` endpoint. semspec needs both — forced
+tool to bind dev-related calls to a specific schema, and
+`reasoning_effort` to get useful behavior out of the model class — so
+the chat-completions path is non-viable for that consumer regardless
+of how cleanly we wire it.
+
+Codex-family models (`codex-mini`, `codex` previews, `gpt-5-codex`
+when it lands) only ship on the Responses endpoint. semspec's hybrid
+registry is OpenAI-routed for dev-related calls, so Codex is the
+natural target model class for that path. Without Responses, semspec
+is forced down to GPT-4o-class for dev calls and loses the reasoning
+surface entirely.
+
+This is **not anticipatory** scope. It is a named consumer with a
+named constraint blocking a named call site. That satisfies the
+forcing-function gate from [[feedback_reactive_patches_vs_engine_completion]]
+— we are not adding wire-of-the-month, we are responding to a
+concrete blocker.
+
+### What the Responses API actually is
+
+The Responses API is not a quirky variant of Chat Completions. It is
+a different request/response shape with a different message model
+and different streaming protocol. The transport is still HTTPS+JSON,
+but the wire types do not overlap.
+
+| Aspect | `/v1/chat/completions` | `/v1/responses` |
+|---|---|---|
+| Endpoint | `POST /v1/chat/completions` | `POST /v1/responses` |
+| Input shape | `messages: [{role, content, tool_calls, tool_call_id, ...}]` | `input: string \| [InputItem...]` |
+| Output shape | `choices: [{message: {role, content, tool_calls}, finish_reason}]` | `output: [Item...]` (heterogeneous typed array) |
+| Assistant tool call | `{tool_calls: [{id, type:"function", function:{name, arguments}}]}` inside an assistant message | `{type:"function_call", call_id, name, arguments}` top-level output item |
+| Tool result | `{role:"tool", tool_call_id, content}` message | `{type:"function_call_output", call_id, output}` top-level input item |
+| Reasoning | Hidden, or surfaced as out-of-band `reasoning_content` (Gemini) / `thinking` blocks (Anthropic-style) | First-class `{type:"reasoning", summary:[...], content:[...], encrypted_content?}` items in both input and output |
+| Reasoning carry-across-turn | Provider-specific carrier (we use the `extra_content.google.thought_signature` Extras trick for Gemini) | Echo whole `reasoning` items back as input items, including opaque `encrypted_content` when `store:false` |
+| Streaming | OpenAI SSE: a sequence of `chat.completion.chunk` objects with `choices[].delta` slices | Typed SSE: `event: response.created`, `event: response.output_item.added`, `event: response.output_text.delta`, `event: response.function_call_arguments.delta`, `event: response.completed`, plus ~20 more event types |
+| Server-side state | None | Optional via `previous_response_id` + `store:true` (default) |
+| Forced tool + reasoning | Disallowed on GPT-5.5 / o-series | Supported |
+| Built-in tools | Function-only | Function + hosted tools (`file_search`, `web_search_preview`, `computer_use_preview`, `code_interpreter`, `image_generation`) |
+| Errors | Top-level `error` object with `type/code/message` | Same envelope shape; same HTTP status semantics |
+
+The structural delta: **`model/wire` becomes a multi-shape
+provider-wire package**, not "the ChatCompletion wire." The existing
+package shape (ChatCompletion + `Extras` carrier for provider
+quirks) is the right shape for Gemini OpenAI-compat / Ollama /
+OpenAI ChatCompletion — it does not cover Responses.
+
+### Why the carrier abstraction needs to change at the same time
+
+Today's reasoning carry-across-turn carrier is
+`agentic.ToolCall.Metadata[MetadataKeyGoogleThoughtSignature]`. Two
+structural problems make this unsustainable as soon as a second
+provider arrives:
+
+1. **The provider-named key leaks wire-shape upward.** Every
+   trajectory consumer, trace renderer, and replay tool currently
+   has to know that Gemini-ness means looking for
+   `google_thought_signature`. Add `openai_reasoning_item` and every
+   consumer site has two provider-specific branches. Add a third
+   provider and it's three. The carrier is named after the wire
+   field, not the semantic role.
+2. **The attachment point doesn't generalize.** Gemini's signature
+   attaches to a tool call. OpenAI's reasoning items are *standalone
+   siblings in the output array* — there's no tool call to bolt
+   them onto. Anthropic's `thinking` blocks (future) are content
+   parts inside the assistant message — a third attachment shape.
+
+The semantic role *is* stable across providers: "opaque blob the
+model wants echoed on the next turn for reasoning continuity." The
+wire shape is not. The right abstraction is at the role layer.
+
+This change is **breaking**. We are pre-1.0 and own every consumer
+in the C360Studio org (semspec, semteams, semconnect), so the
+calculus per [[feedback_greenfield_cross_product_break_now]] is:
+take the break now, when N=2 is arriving and the leverage is one
+architectural decision across both providers. Wait for N=3 and we
+ship two per-provider paths and have two migrations to do.
+
+## Decision
+
+### D1. Add a sibling package `model/wire/responses/`
+
+Package layout:
+
+```
+model/wire/
+  client.go          (unchanged) — ChatCompletion client
+  types.go           (unchanged) — ChatCompletion types
+  types_message.go   (unchanged) — shared Message/ToolCall (used by ChatCompletion path only)
+  stream.go          (unchanged) — ChatCompletion SSE
+  errors.go          (unchanged) — APIError (reused by Responses)
+  responses/
+    doc.go           NEW — package doc
+    client.go        NEW — Responses client (/v1/responses)
+    types.go         NEW — Request, Response, ~10 InputItem variants, ~10 Item variants
+    types_reasoning.go NEW — ReasoningItem subshape + helpers
+    stream.go        NEW — typed-event SSE parser + output accumulator
+    errors.go        NEW or re-export — Responses-side error decoding
+```
+
+The package is shape-organized (matches existing `model/wire`
+convention) and pre-declares the multi-shape future. If a third
+shape (Anthropic Messages) ever lands, it becomes
+`model/wire/anthropic/` (or similar) by the same pattern.
+
+### D2. Stateless mode: `store: false` + echo reasoning items per turn
+
+The Responses API supports two modes:
+- **Stateful** (`store: true`, default): the response is persisted
+  on OpenAI's side. Next turn passes `previous_response_id`; OpenAI
+  reconstructs the conversation.
+- **Stateless** (`store: false`): caller is responsible for the
+  full message history. Reasoning items must be echoed back as
+  input items, including the opaque `encrypted_content` field where
+  present.
+
+**Decision: stateless.**
+
+Two reasons:
+
+1. **State ownership stays in semstreams.** Loop state lives in
+   the `AGENT_LOOPS` KV bucket, with trajectory in the graph and
+   bulky content in ObjectStore. Adopting `previous_response_id`
+   couples that state model to OpenAI's retention policy and
+   breaks the KV-twofer architectural invariant (the write IS the
+   event; replay from any revision). With server-side state we
+   can't replay without a side-channel record of
+   `previous_response_id` per turn, which we'd have to put in… KV.
+   So stateless is a wash on storage and a win on coupling.
+2. **Reasoning-item echo is a known pattern.** We already do this
+   for Gemini via the `thought_signature` carrier. Responses
+   formalizes it (echo whole reasoning items rather than a single
+   field), but the per-step rule is the same: capture on response,
+   attach on next turn's request.
+
+Cost accepted: stateless mode adds bytes to every request (echoed
+reasoning items). Same cost we pay for Gemini and we have not found
+it problematic. A metric on `bytes-per-request` lands as part of
+Phase 3 so operators can observe the cost in production.
+
+### D3. Unified `agentic.ReasoningRecord` carrier, decided now
+
+Introduce a provider-neutral reasoning-record type and retire the
+provider-named key `MetadataKeyGoogleThoughtSignature`. Land both
+changes in the same BREAKING phase as the Responses package
+non-streaming client (D1).
+
+Type sketch (canonical — sister-agent implements to this shape):
+
+```go
+// agentic/reasoning.go
+
+// ReasoningRecord is the provider-neutral carrier for opaque
+// reasoning state that must be echoed back on the next turn.
+// Captured on response, attached to the next request. Provider-
+// specific reshape happens at the adapter seam — loop code stays
+// shape-neutral.
+type ReasoningRecord struct {
+    // Provider names the carrier provider ("google", "openai",
+    // future). Used by the adapter to decide on-the-wire
+    // reconstruction.
+    Provider string `json:"provider"`
+
+    // ItemID is the provider-assigned identity for this record.
+    // Used for cross-turn echo when the provider needs it (OpenAI
+    // uses; Gemini does not — its signatures are carried per-
+    // tool-call, not by id).
+    ItemID string `json:"item_id,omitempty"`
+
+    // SummaryText is a human-readable description of the
+    // reasoning, when the provider exposes one. Safe to log. Used
+    // for trajectory and operator-facing trace.
+    SummaryText string `json:"summary_text,omitempty"`
+
+    // Opaque is the provider-specific blob that must be echoed
+    // back verbatim. Treat as bytes; do not parse, do not log in
+    // full.
+    //  - Gemini: the base64 thought_signature string (bytes of
+    //    UTF-8)
+    //  - OpenAI: encrypted_content blob (when store:false)
+    //  - Anthropic (future): thinking block content
+    Opaque []byte `json:"opaque,omitempty"`
+
+    // CarrierKind names the structural attachment constraint on
+    // the wire. Adapters use this to reshape correctly. The set
+    // is closed: unknown values are an authoring error and must
+    // fail validation, not silently pass.
+    CarrierKind ReasoningCarrierKind `json:"carrier_kind"`
+
+    // ToolCallID is set when CarrierKind == ReasoningCarrierToolCall.
+    // The signature belongs with this specific tool call; the
+    // adapter re-binds them on send.
+    ToolCallID string `json:"tool_call_id,omitempty"`
+}
+
+type ReasoningCarrierKind string
+
+const (
+    // ReasoningCarrierToolCall: blob attaches to a specific tool
+    // call on the wire. Used by Gemini (thought_signature per
+    // tool_call).
+    ReasoningCarrierToolCall ReasoningCarrierKind = "tool_call"
+
+    // ReasoningCarrierStandaloneItem: blob is a sibling output
+    // item with no attachment to messages or tool calls. Used by
+    // OpenAI Responses (reasoning items in the output array).
+    ReasoningCarrierStandaloneItem ReasoningCarrierKind = "standalone_item"
+
+    // ReasoningCarrierAssistantContent: blob is a content part
+    // inside the assistant message. Reserved for Anthropic's
+    // thinking blocks when/if we take that on.
+    ReasoningCarrierAssistantContent ReasoningCarrierKind = "assistant_content"
+)
+```
+
+Field add on `agentic.ChatMessage`:
+
+```go
+type ChatMessage struct {
+    // ... existing fields ...
+
+    // ReasoningRecords are provider-opaque reasoning blobs
+    // captured from the model's response, to be echoed back on
+    // subsequent turns. Loop owns cross-turn propagation;
+    // adapters reshape into wire format at the seam. See
+    // ReasoningRecord.
+    ReasoningRecords []ReasoningRecord `json:"reasoning_records,omitempty"`
+}
+```
+
+Adapter responsibilities (capture/echo asymmetry by provider):
+
+| Adapter | Capture (response → ReasoningRecord) | Echo (ReasoningRecord → wire) |
+|---|---|---|
+| Gemini (ChatCompletion + Extras) | Read `extra_content.google.thought_signature` from each tool_call in the response; emit one `ReasoningRecord{Provider:"google", CarrierKind:ToolCall, ToolCallID:..., Opaque:[]byte(sig)}` per tool call that has one. | On each outgoing tool_call, look up matching `ReasoningRecord` by ToolCallID; write `extra_content.google.thought_signature` back into the wire ToolCall.Extras. |
+| OpenAI Responses | For each `{type:"reasoning"}` output item, emit one `ReasoningRecord{Provider:"openai", CarrierKind:StandaloneItem, ItemID:item.id, Opaque:item.encrypted_content, SummaryText:summary}`. | On request build, emit each `ReasoningRecord` (filtered to `Provider:"openai"`) as a `{type:"reasoning", id, encrypted_content, ...}` input item, preserving order relative to other input items per the provider's per-step echo rule. |
+| OpenAI ChatCompletion | No-op — endpoint does not surface reasoning items. | No-op. |
+| Ollama | No-op (currently). | No-op (currently). |
+
+### D4. Adapter strategy: parallel `ResponsesAdapter` interface
+
+Today's adapter interface is structured around a ChatCompletion
+lifecycle:
+
+```go
+type Adapter interface {
+    Name() string
+    NormalizeRequest(*wire.ChatCompletionRequest)
+    NormalizeMessages([]wire.Message) []wire.Message
+    NormalizeStreamDelta(wire.ToolCall, int) int
+    NormalizeResponse(*wire.ChatCompletionResponse)
+}
+```
+
+Responses gets its own interface with corresponding hooks operating
+on `*responses.Request` / `[]responses.InputItem` / typed-event
+stream / `*responses.Response`. One implementation:
+`OpenAIResponsesAdapter`. The hooks are mostly no-ops; the
+non-trivial work lives in capture/echo of `ReasoningRecord` per the
+adapter responsibilities table above.
+
+Rationale: OpenAI is the only provider on Responses today. Adding
+a second `ResponsesAdapter` only makes sense when a second provider
+implements that shape (unlikely — the API is the spec). Generic
+shape-tagged hooks would mix shapes in every adapter signature; the
+parallel-interface approach keeps each adapter's types clean.
+
+### D5. Backend dispatch: `WireBackend = "responses"` alongside existing values
+
+The `model.EndpointConfig.WireBackend` field already supports
+discriminator values (`""` / `"sdk"` defaults to SDK, `"wire"`
+selects the wire-native ChatCompletion path per ADR-037). Add
+`"responses"` as a third value that selects the Responses path.
+
+The `agentic-model.Client` becomes a tagged dispatch:
+
+```go
+// In NewClient
+switch endpoint.WireBackend {
+case "responses":
+    // build c.responsesClient *responses.Client
+case "wire":
+    // build c.wireClient *wire.Client (existing)
+case "", "sdk":
+    // SDK path (existing)
+}
+
+// In chatCompletion dispatch
+switch {
+case c.useResponsesBackend():
+    return c.chatCompletionResponses(ctx, req)
+case c.useWireBackend():
+    return c.chatCompletionWire(ctx, req)
+default:
+    return c.chatCompletionSDK(ctx, req)
+}
+```
+
+Selection is per-endpoint, operator-configurable. semspec opts in
+for the OpenAI hybrid-registry endpoints; other endpoints (Gemini,
+non-codex OpenAI, Ollama) stay on their current backends.
+
+## Phasing
+
+| Phase | Scope | Tag class | Gate |
+|---|---|---|---|
+| **1** | `agentic.ReasoningRecord` + `ChatMessage.ReasoningRecords` field + Gemini adapter migration off `MetadataKeyGoogleThoughtSignature` (delete the constant) + `model/wire/responses/` package types + non-streaming client + round-trip tests against captured fixtures. | **BREAKING** | Full e2e green per CLAUDE.md hard rule; pre-tag sweep with `-tags=integration` AND `-tags=live_llm` per [[feedback_pre_tag_sweep_includes_build_tags]]; sister-repo coordination — semspec / semteams / semconnect bump together on tag land. |
+| **2** | Responses streaming: typed-event SSE parser + output-index accumulator + per-item dispatch + chunk-handler parity with the ChatCompletion path. Golden-fixture tests. | ADDITIVE | Standard test gates; live_llm tag for the captured-fixture parity test. |
+| **3** | agentic-model integration: `WireBackend = "responses"` dispatch + `OpenAIResponsesAdapter` (capture/echo of `ReasoningRecord{CarrierKind:StandaloneItem}`) + `client_responses.go` mirroring `client_wire.go` (retry, throttle, metrics, chunk-handler). Per-endpoint opt-in. `bytes-per-request` metric for echo-cost observation. | ADDITIVE | Pre-tag e2e on agentic tier; live_llm parity test against captured fixtures. |
+| **4** | Multi-turn parity verification: cross-turn `ReasoningRecord` echo works in the loop's actual multi-turn flow against both Gemini (regression: same behavior through the new type) and OpenAI (new path). Documentation: update [ADR-037](037-self-hosted-llm-wire-package.md) soak clock with Responses entry. | ADDITIVE | live_llm test pass for both providers; soak clock entry. |
+| **5 (deferred until justified)** | Hosted tools: `file_search`, `web_search_preview`, `code_interpreter`, etc. Not opened until a concrete consumer asks. | — | Out of scope of this ADR. |
+
+Phase 1 is the only BREAKING phase. Phases 2-4 are additive on top.
+The deliberate scope expansion at Phase 1 (carrier abstraction
+introduced in the same tag as the second consumer arriving) is the
+leverage point per [[feedback_greenfield_cross_product_break_now]].
+
+## Consequences
+
+### Positive
+
+- **Trajectory consumers stay provider-neutral.** Trace renderers,
+  replay tools, debug surfaces iterate `ReasoningRecord` without
+  `if-google-then... if-openai-then...` branches. New providers
+  slot in by adding a third `Provider` string and a third adapter,
+  not by editing consumer sites.
+- **semspec unblocked.** Hybrid-registry OpenAI calls get Codex /
+  GPT-5.5 / o-series with `tool_choice` + `reasoning_effort`
+  combined, which the ChatCompletion path forbids.
+- **Multi-shape wire layer is honest about its future.** The
+  `model/wire/responses/` package layout pre-declares that the
+  package family is organized by wire shape, not by provider. A
+  third shape (Anthropic Messages, eventual SSE-streaming
+  variants) lands by the same pattern without a package-layout
+  redesign.
+- **One architectural decision spans two consumers.** Gemini
+  migration to `ReasoningRecord` + OpenAI adoption of
+  `ReasoningRecord` happen in one PR cycle. No second migration
+  later.
+
+### Negative / accepted costs
+
+- **Phase 1 is BREAKING.** Sister-repo bump required across
+  semspec / semteams / semconnect on the same tag. Workflow
+  precedent: ADR-042 publisher-mode rollout (six landings in one
+  cycle).
+- **Saved trajectories from pre-cut tags will not reload after the
+  change.** Trajectories are operator debug artifacts, not durable
+  contract — we have zero consumers that replay archived
+  trajectories across `agentic` schema versions. Discipline: tag
+  changelog notes the schema bump; no shim code carried.
+- **`store: false` mode adds bytes to every Responses request.**
+  Echoed reasoning items can be sizable. Phase 3 lands a metric
+  for operator observability; if cost surfaces as a real concern,
+  Phase 5+ can revisit `store: true` per-endpoint opt-in.
+- **Two `Client` types in the agentic-model package** (wire +
+  responses + SDK = three dispatch paths). Tagged-union plumbing
+  at `agentic-model.NewClient` and the chatCompletion dispatch.
+  Modest churn at one seam; the cost is bounded.
+
+### Discipline gates this ADR triggers
+
+- [[feedback_polymorphic_config_needs_json_roundtrip_test]] — JSON
+  round-trip test for `ReasoningRecord` and the new `ChatMessage`
+  shape (Phase 1 acceptance criterion).
+- [[feedback_pre_tag_sweep_includes_build_tags]] — `go vet
+  -tags=integration` AND `-tags=live_llm` before the Phase 1 tag.
+- [[feedback_e2e_required_for_breaking_changes]] — full e2e green
+  before Phase 1 tag; both `cmd/semstreams/main.go` and
+  `cmd/e2e-semstreams/main.go` migrated to the new shape.
+- [[feedback_greenfield_cross_product_break_now]] — applied at
+  decision D3 (skip the compat shim, one tag flip across sister
+  repos).
+- [[feedback_reactive_patches_vs_engine_completion]] — framing
+  applies at Phase 1 scope expansion (one deliberate completion
+  cycle vs three per-provider arrivals).
+- [[feedback_verify_main_go_wire_for_sister_asks]] — verify
+  `OpenAIResponsesAdapter` is wired in both binaries before tag.
+- [[feedback_never_retag]] — applies to the Phase 1 tag like any
+  other; module proxy pins on first fetch.
+
+## Alternatives Considered
+
+### A. Same-package multi-shape (`model/wire/types_responses.go`)
+
+Add the Responses types to `model/wire` alongside `types.go` rather
+than as a sibling package.
+
+- **Why rejected.** Package doc would have to start with "this
+  package speaks two unrelated wire shapes," which is exactly the
+  framing that lets ad-hoc additions sneak in. Type names get
+  prefix-y (`ResponsesRequest`, `ResponsesItem`, `ResponsesStream`)
+  to avoid collisions with intuitive ChatCompletion names. The
+  boundary that prevents future shape mixing is just developer
+  discipline; the sibling-package layout makes the boundary
+  structural.
+
+### B. Top-level sibling package (`model/openai_responses/`)
+
+Put Responses in a provider-named top-level package rather than a
+shape-named subdirectory.
+
+- **Why rejected.** Implies the wire layer is organized by
+  provider. Inconsistent with `model/wire` which is organized by
+  *shape* (currently used by OpenAI, Gemini OpenAI-compat, and
+  Ollama). Future provider-shape additions would have to pick
+  provider-naming or shape-naming and the layout would drift.
+
+### C. Server-side state (`store: true` + `previous_response_id`)
+
+Use OpenAI's server-managed conversation state instead of echoing
+reasoning items per turn.
+
+- **Why rejected.** Couples loop state ownership to OpenAI's
+  retention policy. Breaks the KV-twofer invariant (the write IS
+  the event; replay from any revision). We'd still have to record
+  `previous_response_id` per turn in our own KV, so the storage
+  cost is the same — and we'd add coupling that doesn't exist on
+  the stateless path. The bytes-per-request cost of echo is the
+  same cost we already pay for Gemini and have not found
+  problematic.
+
+### D. Per-provider `MetadataKey` (defer unified type)
+
+Add `MetadataKeyOpenAIReasoningItem` alongside
+`MetadataKeyGoogleThoughtSignature`; don't introduce
+`ReasoningRecord` yet.
+
+- **Why rejected.** Defers the architectural problem to N=3
+  arrival, when we'll have shipped two per-provider paths and need
+  to migrate both. The leverage of one architectural decision
+  across N=1 existing carrier + N=2 new carrier is unique to this
+  moment. Also the attachment-point structural problem doesn't
+  cleanly resolve: OpenAI reasoning items aren't attached to tool
+  calls, so the `ToolCall.Metadata` carrier is structurally wrong
+  for them — bolting them on requires inventing a separate
+  attachment location, which proliferates the inconsistency.
+
+### E. Generic shape-tagged adapter interface
+
+Collapse the existing `Adapter` and new `ResponsesAdapter`
+interfaces into a single generic interface with shape-discriminator
+hooks.
+
+- **Why rejected.** Mixes shapes in every adapter signature. Most
+  adapters today (Gemini, OpenAI ChatCompletion, Ollama) only
+  speak one shape; forcing them to implement Responses-shape
+  no-ops adds noise without clarity. The parallel-interface
+  approach keeps each adapter's types clean.
+
+## Open implementation questions
+
+These need answers in the Phase 1 implementation cut, but are not
+load-bearing on the architectural decision:
+
+1. **What does `response_format` do in Responses?** Responses has
+   its own `text.format` parameter that supersedes
+   `response_format`. Confirm by experiment whether the same
+   JSONSchema we send to ChatCompletion works under Responses; if
+   not, the `agenticResponseFormatToResponses` translator needs to
+   reshape. Likely a translator-side concern; doesn't affect the
+   adapter or carrier design.
+2. **Embedded `developer` role.** Responses input items support a
+   `role: "developer"` for system-prompt-class messages. Our
+   agentic loop emits `role: "system"`. **Decision direction
+   (preferred): explicit translation in the adapter
+   (`system → developer`) with a test that asserts the wire
+   body**, rather than relying on OpenAI's compat. Avoid silent
+   semantic drift.
+3. **`store: false` echo cost telemetry.** Phase 3 ships a
+   `bytes-per-request` metric. Decide on the metric name and label
+   set as part of Phase 3 — recommend
+   `agentic_model_request_bytes{backend="responses",model=...}`
+   with a corresponding histogram for distribution.
+4. **Sister-repo coordination cadence.** Phase 1 is BREAKING and
+   requires semspec / semteams / semconnect to bump together. Same
+   one-flip workflow as ADR-042 publisher-mode. Phase 3 (the
+   actual `WireBackend = "responses"` config surface) lands
+   additive on top — that's the cut semspec opts in at
+   per-endpoint.
+
+## Sister-agent handoff
+
+The proposal doc at
+[`docs/proposals/openai-responses-wire-support.md`](../proposals/openai-responses-wire-support.md)
+has the research-record version of this ADR with more discursive
+treatment of options and rationale. It is **redundant with this ADR
+as a working spec** — implement to this ADR. The proposal stays as
+the working artifact for posterity.
+
+### Reading list (in order)
+
+1. This ADR (canonical decision record).
+2. [ADR-037](037-self-hosted-llm-wire-package.md) end-to-end. The
+   forcing-function structure, the Extras-carrier rationale, and
+   the soak gate are all reusable framing.
+3. `model/wire/client.go`, `model/wire/types.go`,
+   `model/wire/stream.go`, `model/wire/types_message.go`. The
+   structural template for the new `model/wire/responses/` files.
+4. `processor/agentic-model/client_wire.go` end-to-end. The
+   template for `client_responses.go`: same retry loop, same
+   throttle, same metric hooks, same chunk-handler contract — only
+   the per-attempt dispatch differs.
+5. `processor/agentic-model/adapter_gemini.go` to understand the
+   current `thought_signature` capture/echo flow (you will rewrite
+   it as part of Phase 1).
+
+### Pre-Phase-1 prep checklist
+
+- [ ] Run `grep -rn MetadataKeyGoogleThoughtSignature --include="*.go"`
+  and inventory every call site. Each is a Phase 1 deletion +
+  replacement with the new `ReasoningRecord` path.
+- [ ] Capture live OpenAI Responses fixtures against at least one
+  Codex-class model and one GPT-5.5 endpoint. Golden-fixture
+  round-trips are how we verified Gemini's quirks and they're the
+  only way to ground the Phase 1 / Phase 2 unit tests against the
+  real wire shape. Stash under `model/wire/responses/testdata/`.
+- [ ] Confirm `cmd/semstreams/main.go` AND
+  `cmd/e2e-semstreams/main.go` both register the new adapter and
+  honor the new `WireBackend = "responses"` value before tagging
+  Phase 1. Per
+  [[feedback_e2e_required_for_breaking_changes]] — the
+  registry-singleton story is the cautionary tale on
+  missing-binary migration.
+- [ ] Coordinate the sister-repo bump (semspec / semteams /
+  semconnect) on the Phase 1 tag landing. Workflow precedent is the
+  ADR-042 publisher-mode rollout (six landings in one cycle). Open
+  a tracking issue in each repo before the Phase 1 PR lands so the
+  bump is queued.
+
+### Phase 1 acceptance criteria
+
+- New types: `agentic.ReasoningRecord`, `agentic.ReasoningCarrierKind`
+  (with three constants), `agentic.ChatMessage.ReasoningRecords`
+  field.
+- `MetadataKeyGoogleThoughtSignature` constant deleted.
+- Gemini adapter (`adapter_gemini.go` + capture/echo sites in
+  `client_wire.go`) migrated to the new carrier. Existing
+  multi-turn Gemini tests pass without modification to their loop
+  expectations (only test setup changes — the production behavior
+  is identical).
+- `model/wire/responses/` package implements non-streaming
+  `Client.Responses(ctx, *Request) (*Response, error)` + the full
+  Request/Response/Item/InputItem type set with golden-fixture
+  round-trip tests.
+- `agentic.ReasoningRecord` JSON round-trip test passes per
+  [[feedback_polymorphic_config_needs_json_roundtrip_test]].
+- Pre-tag sweep clean: `go vet -tags=integration`, `go vet
+  -tags=live_llm`, `task lint`, `task test` (with `-race`),
+  `task test:integration`, `task schema:generate` no diffs.
+- Full e2e tier set green: `task e2e:core`, `task e2e:structural`,
+  `task e2e:statistical`, `task e2e:semantic`, `task e2e:agentic`.
+- Both binaries (`cmd/semstreams`, `cmd/e2e-semstreams`) wired and
+  verified by `grep` for the new adapter registration.
+- Tag changelog notes the BREAKING change explicitly with
+  migration guidance for the sister repos.
+
+## References
+
+- [ADR-037: Self-Hosted LLM Wire-Format Package](037-self-hosted-llm-wire-package.md) — parent ADR; same package family.
+- [ADR-042: OASF Taxonomy Adoption](042-oasf-taxonomy-adoption.md) — sister-repo rollout workflow precedent.
+- [`docs/proposals/openai-responses-wire-support.md`](../proposals/openai-responses-wire-support.md) — research record.
+- [`feedback_greenfield_cross_product_break_now.md`](../../../../.claude/projects/-Users-coby-Code-c360-semstreams/memory/feedback_greenfield_cross_product_break_now.md) — discipline memory grounding the Phase 1 BREAKING scope decision.
+- OpenAI Responses API documentation (external) — capture fixtures
+  from the real endpoint per the prep checklist before Phase 1
+  starts; the docs evolve and the fixtures are the source of truth
+  for unit-test parity.

--- a/docs/adr/051-openai-responses-wire-support.md
+++ b/docs/adr/051-openai-responses-wire-support.md
@@ -2,14 +2,35 @@
 
 ## Status
 
-**Proposed** — 2026-05-30. Companion research doc at
+**Accepted** — 2026-05-30. Implementation shipped in v1.0.0-beta.89
+as a four-PR bundle (carrier rename + wire package + streaming +
+agentic-model dispatch) plus a live-test fix-up commit. Companion
+research doc at
 [`docs/proposals/openai-responses-wire-support.md`](../proposals/openai-responses-wire-support.md)
-captures the option exploration; this ADR is the canonical decision
-record. Extends [ADR-037](037-self-hosted-llm-wire-package.md) by
-adding a second top-level wire shape to the `model/wire` package
-layer. Sister-agent picks up implementation when this ADR is
-Accepted; the proposal doc is the working/research artifact and stays
-in `docs/proposals/` per the working-record convention.
+captures the option exploration. Extends
+[ADR-037](037-self-hosted-llm-wire-package.md) by adding a second
+top-level wire shape to the `model/wire` package layer.
+
+**Shipped:**
+- `agentic.ReasoningRecord` + `ChatMessage.ReasoningRecords` field;
+  `MetadataKeyGoogleThoughtSignature` deleted (Phase 1 BREAKING).
+- `model/wire/responses/` package: types + non-streaming client +
+  typed-event SSE stream + accumulator.
+- `agentic-model` Responses dispatch: `WireBackend="responses"`
+  opt-in, `OpenAIResponsesAdapter` capture/echo of
+  `ReasoningRecord{CarrierKind:StandaloneItem}`, three-way client
+  dispatch (SDK / wire-ChatCompletion / Responses), per-endpoint
+  `agentic_model_request_bytes` histogram.
+
+**Live-tested before tag** (per ADR's never-retag discipline):
+single-turn complete, tool flow round-trip, the forcing-function
+`tool_choice + reasoning_effort` combo on GPT-5.5 with real
+encrypted_content echo across turns, plus Gemini regression
+through the new carrier. Two API-shape bugs surfaced and fixed
+pre-tag: opt-in `include: ["reasoning.encrypted_content"]` (the
+API omits encrypted_content otherwise) and `"summary":[]` injection
+on echoed reasoning items (the API rejects 400
+missing_required_parameter without it).
 
 ## Context
 

--- a/docs/proposals/openai-responses-wire-support.md
+++ b/docs/proposals/openai-responses-wire-support.md
@@ -1,0 +1,619 @@
+# OpenAI Responses API — Wire Support Research
+
+**Status:** Research record — 2026-05-30. **Superseded as the working
+spec by [ADR-051](../adr/051-openai-responses-wire-support.md)** —
+sister-agent implements to the ADR; this doc remains as the
+research/working artifact that informed the decisions. Companion to
+[ADR-037](../adr/037-self-hosted-llm-wire-package.md).
+
+## Forcing function
+
+semspec hit a hard wall on its hybrid registry path: **the OpenAI Chat
+Completions endpoint refuses `tool_choice` + `reasoning_effort` together
+on GPT-5.5 and the o-series**. The combination is explicitly supported
+only on the `/v1/responses` endpoint. semspec needs both — forced tool
+to bind dev-related calls to a specific schema, and `reasoning_effort`
+to get useful behavior out of the model class — so the chat-completions
+path is non-viable for that consumer regardless of how cleanly we wire it.
+
+Codex-family models (`codex-mini`, `codex` previews, `gpt-5-codex` when
+it lands) only ship on the Responses endpoint. semspec's hybrid registry
+is OpenAI-routed for dev-related calls, so Codex is the natural target
+model class for that path. Without Responses, semspec is forced down to
+GPT-4o-class for the dev calls and loses the reasoning surface entirely.
+
+This is **not anticipatory**. It is a named consumer with a named
+constraint blocking a named call site. That satisfies the
+"forcing-function check" gate from the prior turn —
+[[feedback_reactive_patches_vs_engine_completion]] applies the other
+direction: if we say yes to Responses, we should scope it as
+"complete the wire layer's provider-shape support" rather than "patch
+in one more thing," so we don't end up adding a third shape under
+ad-hoc framing six months from now.
+
+## What the Responses API actually is (delta from Chat Completions)
+
+The Responses API is not a quirky variant of Chat Completions. It is a
+different request/response shape with a different message model and
+different streaming protocol. The transport is still HTTPS+JSON, but
+the wire types do not overlap.
+
+| Aspect | `/v1/chat/completions` | `/v1/responses` |
+|---|---|---|
+| Endpoint | `POST /v1/chat/completions` | `POST /v1/responses` |
+| Input shape | `messages: [{role, content, tool_calls, tool_call_id, ...}]` | `input: string \| [InputItem...]` |
+| Output shape | `choices: [{message: {role, content, tool_calls}, finish_reason}]` | `output: [Item...]` (heterogeneous typed array) |
+| Assistant tool call | `{tool_calls: [{id, type:"function", function:{name, arguments}}]}` inside an assistant message | `{type:"function_call", call_id, name, arguments}` top-level output item |
+| Tool result | `{role:"tool", tool_call_id, content}` message | `{type:"function_call_output", call_id, output}` top-level input item |
+| Reasoning | Hidden, or surfaced as out-of-band `reasoning_content` (Gemini) / `thinking` blocks (Anthropic-style) | First-class `{type:"reasoning", summary:[...], content:[...], encrypted_content?}` items in both input and output |
+| Reasoning carry-across-turn | Provider-specific carrier (we use the `extra_content.google.thought_signature` Extras trick for Gemini) | Echo whole `reasoning` items back as input items, including opaque `encrypted_content` when `store:false` |
+| Streaming | OpenAI SSE: a sequence of `chat.completion.chunk` objects with `choices[].delta` slices | Typed SSE: `event: response.created`, `event: response.output_item.added`, `event: response.output_text.delta`, `event: response.function_call_arguments.delta`, `event: response.completed`, plus ~20 more event types |
+| Server-side state | None | Optional via `previous_response_id` + `store:true` (default) |
+| Forced tool + reasoning | Disallowed on GPT-5.5 / o-series | Supported |
+| Built-in tools | Function-only | Function + hosted tools (`file_search`, `web_search_preview`, `computer_use_preview`, `code_interpreter`, `image_generation`) — we wouldn't enable these initially |
+| Errors | Top-level `error` object with `type/code/message` | Same envelope shape; same HTTP status semantics |
+
+**Key insight: this is not "add an adapter."** The `model/wire` package
+today is structurally OpenAI Chat Completions with an Extras carrier
+that lets us thread Gemini-shape quirks (`thought_signature`) through
+the same types. Responses changes the request/response top-level shape;
+no amount of Extras carrying solves it. It needs its own request
+struct, its own response struct, its own SSE event parser, its own
+streaming accumulator, and its own adapter chain.
+
+That is the architectural delta worth naming: **`model/wire` becomes a
+multi-shape provider-wire package**, not "the ChatCompletion wire."
+
+## Package-shape options
+
+Three framings. Pick one in the ADR before any code lands.
+
+### Option A — Sibling package: `model/wire/responses`
+
+```
+model/
+  wire/
+    client.go          ChatCompletion client (unchanged)
+    types.go           ChatCompletion request/response (unchanged)
+    types_message.go   shared Message/ToolCall (unchanged)
+    stream.go          ChatCompletion SSE (unchanged)
+    responses/
+      doc.go
+      client.go        Responses client
+      types.go         InputItem, Item, ReasoningItem, FunctionCallItem, ...
+      stream.go        Typed-event SSE parser, output accumulator
+      errors.go        Re-uses model/wire.APIError? Or its own?
+```
+
+- **Pro**: Zero churn on existing wire callers. Gemini, OpenAI-ChatCompletion, and Ollama continue to work as-is. Responses lives behind an isolated import path; nothing about its shape leaks into ChatCompletion types.
+- **Pro**: Mirrors the eventual reality. Anthropic's Messages API is a third top-level shape; if we ever take that on, it becomes `model/wire/anthropic` (or similar) by the same pattern. The package layout pre-declares that intent.
+- **Con**: Two `Client` types in adjacent packages with similar surface area. The `agentic-model.Client` becomes a tagged union (`wireClient *wire.Client` OR `responsesClient *responses.Client`). Modest plumbing churn at the seam.
+
+### Option B — Same package, two clients side-by-side
+
+```
+model/wire/
+  client.go            ChatCompletion client
+  client_responses.go  Responses client
+  types.go             ChatCompletion types
+  types_responses.go   Responses types
+  stream.go            ChatCompletion SSE
+  stream_responses.go  Responses SSE
+```
+
+- **Pro**: One package, one Extras helper, one `APIError`, one set of cache types. Less file-tree ceremony.
+- **Con**: Package doc has to start with "this package speaks two unrelated wire shapes," which is exactly the framing that lets ad-hoc additions sneak in. The boundary that prevents future shape mixing is just developer discipline.
+- **Con**: Type names get prefix-y (`ResponsesRequest`, `ResponsesItem`, `ResponsesStream`) to avoid collisions. The OpenAI-canonical names (`Response`, `Item`) collide with intuitive ChatCompletion names.
+
+### Option C — Top-level sibling: `model/openai_responses`
+
+```
+model/
+  wire/               ChatCompletion (unchanged)
+  openai_responses/   Responses-only package
+```
+
+- **Pro**: Names the provider in the package path. Honest about the fact that Responses today is OpenAI-only; nobody else implements that shape.
+- **Con**: Implies the wire layer is organized by provider. Inconsistent with `model/wire` which is organized by *shape* (and is currently used by OpenAI, Gemini OpenAI-compat, and Ollama). Future provider-shape additions would have to pick provider-naming or shape-naming and the layout would drift.
+
+**Recommendation: Option A.** Shape-organized layout, clean isolation,
+honest about the multi-shape future. Cost is one extra directory and a
+tagged-union seam in `agentic-model.Client` — small relative to the
+clarity gain.
+
+## Adapter strategy
+
+Today's adapter interface is structured around a ChatCompletion lifecycle:
+
+```go
+type Adapter interface {
+    Name() string
+    NormalizeRequest(*wire.ChatCompletionRequest)
+    NormalizeMessages([]wire.Message) []wire.Message
+    NormalizeStreamDelta(wire.ToolCall, int) int
+    NormalizeResponse(*wire.ChatCompletionResponse)
+}
+```
+
+Responses needs a parallel hook set with different types
+(`*responses.Request`, `[]responses.InputItem`, the typed-event stream).
+Two reasonable options:
+
+1. **Parallel `ResponsesAdapter` interface**: cleanest types, but
+   forces every shape decision twice when an adapter wants to do the
+   same thing on both. Realistically, OpenAI is the only provider on
+   Responses today, so this is one adapter (`OpenAIResponsesAdapter`)
+   that's almost entirely no-ops, similar to today's `OpenAIAdapter`
+   for chat completions.
+2. **Generic `Adapter` with shape-tagged hooks**: collapses the
+   interface but mixes shapes in every adapter signature. Worse fit
+   given that providers don't currently cross shapes (OpenAI on
+   Responses, Gemini on ChatCompletion-compat, Ollama on
+   ChatCompletion).
+
+**Recommendation: parallel `ResponsesAdapter`.** One adapter for now
+(`OpenAIResponsesAdapter`, mostly no-ops). Add a second only when a
+second provider implements the Responses shape — likely never, given
+OpenAI's API is the spec.
+
+## Stateless vs stateful: pick stateless
+
+The Responses API supports two modes:
+
+- **Stateful** (`store: true`, default): the response is persisted on
+  OpenAI's side. Next turn passes `previous_response_id`; OpenAI
+  reconstructs the conversation. No need to echo reasoning items.
+- **Stateless** (`store: false`): caller is responsible for the full
+  message history. Reasoning items must be echoed back as input items,
+  including the opaque `encrypted_content` field where present.
+
+**Recommendation: stateless.** Two reasons:
+
+1. **State ownership stays in semstreams.** Our loop state lives in
+   the `AGENT_LOOPS` KV bucket, with trajectory in the graph and
+   bulky content in ObjectStore. Adopting `previous_response_id`
+   couples that state model to OpenAI's retention policy and breaks
+   the KV-twofer architectural invariant (the write IS the event;
+   replay from any revision). With server-side state we can't replay
+   without a side-channel record of `previous_response_id` per turn,
+   which we'd have to put in… KV. So stateless is a wash on storage
+   and a win on coupling.
+2. **Reasoning-item echo is a known pattern.** We already do this for
+   Gemini via the `thought_signature` carrier. Responses formalizes
+   it (echo whole reasoning items rather than a single field), but
+   the per-step rule is the same: capture on response, attach on next
+   turn's request.
+
+Trade-off accepted: stateless mode requires echoing reasoning items on
+every turn, which adds bytes to the request. This is the same cost we
+pay for Gemini and we have not found it problematic.
+
+## Tool-call shape mapping
+
+The biggest fanout in the agentic-model adapter is the tool-call
+translation. Today:
+
+```
+agentic.ToolCall ─→ wire.ToolCall ─→ {tool_calls:[{id, function:{name, arguments}}]}
+                                        in an assistant message
+```
+
+For Responses:
+
+```
+agentic.ToolCall ─→ responses.FunctionCallItem ─→ {type:"function_call", call_id, name, arguments}
+                                                    as a top-level output item
+```
+
+Tool result:
+
+```
+agentic.ToolResult ─→ wire.Message{Role:"tool", ToolCallID, Content}
+agentic.ToolResult ─→ responses.FunctionCallOutputItem{type:"function_call_output", call_id, output}
+```
+
+The `agentic.ToolCall` and `agentic.ToolResult` types should stay
+shape-neutral. The translation lives entirely inside the Responses
+client path (mirroring the ChatCompletion path in `client_wire.go`).
+No changes to the loop-side contracts here.
+
+**However, the reasoning carry-across-turn carrier needs an
+architectural change** — see the next section. The current
+`MetadataKeyGoogleThoughtSignature` approach (provider-named key on
+`ToolCall.Metadata`) does not survive a second provider, and Responses
+is the second provider arriving.
+
+## Reasoning carry-across-turn: unified `ReasoningRecord` (Phase 1)
+
+This is a **breaking change** to `agentic.ChatMessage` and the only
+non-additive piece of the Responses work. It must land in Phase 1
+alongside the Responses package, not deferred.
+
+### Why a unified type, decided up front
+
+Today's carrier (`agentic.ToolCall.Metadata[MetadataKeyGoogleThoughtSignature]`)
+has two structural problems that the addition of OpenAI Responses makes
+unignorable:
+
+1. **The provider-named key leaks wire-shape upward.** Every trajectory
+   consumer, trace renderer, and replay tool currently has to know
+   that Gemini-ness means looking for `google_thought_signature`. Add
+   `openai_reasoning_item` and every consumer site has two
+   provider-specific branches. Add a third provider (eventually) and
+   it's three. The carrier is named after the wire field, not the
+   semantic role.
+2. **The attachment point doesn't generalize.** Gemini's signature
+   attaches to a tool call. OpenAI's reasoning items are *standalone
+   siblings in the output array* — there's no tool call to bolt them
+   onto. Bolting them on anyway is a lie about the data model.
+   Anthropic's `thinking` blocks (when we eventually take that on)
+   are content parts inside the assistant message — a third
+   attachment shape.
+
+The semantic role *is* stable across providers: "opaque blob the
+model wants echoed on the next turn for reasoning continuity." The
+wire shape is not. The right abstraction is at the role layer.
+
+### Why now is the right moment
+
+We have N=1 carrier today (Gemini). Adding OpenAI as N=2 is the
+highest-leverage moment to introduce the type: one shipping consumer
++ one being designed = both migrations happen in one architectural
+decision. Wait for N=3 (Anthropic, Mistral reasoning, whatever lands
+in 2027) and we've shipped two per-provider paths and have two
+migrations to do.
+
+This is the preventive form of [[feedback_class_of_bugs_to_invariant]]:
+"same shape recurring across 3+ tags = default-flip + invariant"
+becomes "same shape arriving for the 2nd time, when we know the 3rd
+is coming = invariant now." It avoids the per-tag arrival sprawl that
+[[feedback_reactive_patches_vs_engine_completion]] is the cure for.
+
+### Type sketch
+
+```go
+// agentic/reasoning.go
+
+// ReasoningRecord is the provider-neutral carrier for opaque reasoning
+// state that must be echoed back on the next turn. Captured on response,
+// attached to the next request. Provider-specific reshape happens at
+// the adapter seam — loop code stays shape-neutral.
+type ReasoningRecord struct {
+    // Provider names the carrier provider ("google", "openai", future).
+    // Used by the adapter to decide on-the-wire reconstruction.
+    Provider string `json:"provider"`
+
+    // ItemID is the provider-assigned identity for this record. Used
+    // for cross-turn echo when the provider needs it (OpenAI uses;
+    // Gemini does not — its signatures are carried per-tool-call).
+    ItemID string `json:"item_id,omitempty"`
+
+    // SummaryText is a human-readable description of the reasoning,
+    // when the provider exposes one. Safe to log. Used for trajectory
+    // and operator-facing trace.
+    SummaryText string `json:"summary_text,omitempty"`
+
+    // Opaque is the provider-specific blob that must be echoed back
+    // verbatim. Treat as bytes; do not parse, do not log in full.
+    //  - Gemini: the base64 thought_signature string (bytes of UTF-8)
+    //  - OpenAI: encrypted_content blob (when store:false)
+    //  - Anthropic (future): thinking block content
+    Opaque []byte `json:"opaque,omitempty"`
+
+    // CarrierKind names the structural attachment constraint on the
+    // wire. Adapters use this to reshape correctly. The set is closed:
+    // unknown values are an authoring error.
+    CarrierKind ReasoningCarrierKind `json:"carrier_kind"`
+
+    // ToolCallID is set when CarrierKind == ReasoningCarrierToolCall.
+    // The signature belongs with this specific tool call; the adapter
+    // re-binds them on send.
+    ToolCallID string `json:"tool_call_id,omitempty"`
+}
+
+type ReasoningCarrierKind string
+
+const (
+    // ReasoningCarrierToolCall: blob attaches to a specific tool call
+    // on the wire. Used by Gemini (thought_signature per tool_call).
+    ReasoningCarrierToolCall ReasoningCarrierKind = "tool_call"
+
+    // ReasoningCarrierStandaloneItem: blob is a sibling output item
+    // with no attachment to messages or tool calls. Used by OpenAI
+    // Responses (reasoning items in the output array).
+    ReasoningCarrierStandaloneItem ReasoningCarrierKind = "standalone_item"
+
+    // ReasoningCarrierAssistantContent: blob is a content part inside
+    // the assistant message. Reserved for Anthropic's thinking blocks
+    // when/if we take that on.
+    ReasoningCarrierAssistantContent ReasoningCarrierKind = "assistant_content"
+)
+```
+
+And on the message:
+
+```go
+type ChatMessage struct {
+    // ... existing fields ...
+
+    // ReasoningRecords are provider-opaque reasoning blobs captured
+    // from the model's response, to be echoed back on subsequent
+    // turns. Loop owns cross-turn propagation; adapters reshape into
+    // wire format at the seam. See ReasoningRecord.
+    ReasoningRecords []ReasoningRecord `json:"reasoning_records,omitempty"`
+}
+```
+
+### Migration path: clean break, no compat shim
+
+semstreams is pre-1.0 and we own every consumer in the C360Studio
+org (semspec, semteams, semconnect). That changes the calculus:
+
+- **Delete `MetadataKeyGoogleThoughtSignature` outright.** No
+  deprecation alias, no one-cycle compat read. The constant name +
+  the read sites in `client_wire.go` + the test fixtures all go in
+  the same PR.
+- **No trajectory-replay compat shim.** Saved trajectories from
+  pre-cut tags won't reload after the change. Trajectories are
+  operator debug artifacts, not durable contract — we have zero
+  consumers that replay archived trajectories across `agentic`
+  schema versions. The discipline is to publish migration notes in
+  the tag changelog, not to carry shim code.
+- **Sister-repo coordination is one tag flip.** semspec, semteams,
+  semconnect pull the new `agentic` module version together. The
+  cross-repo move is the same workflow as ADR-042 publisher-mode
+  (six landings in one rollout).
+
+What we DO carry from greenfield-with-breaking-changes discipline:
+
+- **JSON round-trip test** for `ReasoningRecord` and the new
+  `ChatMessage` shape per [[feedback_polymorphic_config_needs_json_roundtrip_test]].
+- **Pre-tag sweep with build tags** per [[feedback_pre_tag_sweep_includes_build_tags]].
+- **Full e2e gate** per [[feedback_e2e_required_for_breaking_changes]] —
+  this is a BREAKING change and the framework binary + e2e binary
+  both need the new schema before tag.
+
+### Adapter responsibilities
+
+| Adapter | Capture (response → ReasoningRecord) | Echo (ReasoningRecord → wire) |
+|---|---|---|
+| Gemini (ChatCompletion + Extras) | Read `extra_content.google.thought_signature` from each tool_call in the response; emit one `ReasoningRecord{Provider:"google", CarrierKind:ToolCall, ToolCallID:..., Opaque:[]byte(sig)}` per tool call that has one. | On each outgoing tool_call, look up matching `ReasoningRecord` by ToolCallID; write `extra_content.google.thought_signature` back into the wire ToolCall.Extras. |
+| OpenAI Responses | For each `{type:"reasoning"}` output item, emit one `ReasoningRecord{Provider:"openai", CarrierKind:StandaloneItem, ItemID:item.id, Opaque:item.encrypted_content, SummaryText:summary}`. | On request build, emit each `ReasoningRecord` (filtered to `Provider:"openai"`) as a `{type:"reasoning", id, encrypted_content, ...}` input item, preserving order relative to other input items per the provider's per-step echo rule. |
+| OpenAI ChatCompletion | No-op — endpoint does not surface reasoning items. | No-op. |
+| Ollama | No-op (currently). | No-op (currently). |
+
+The capture/echo asymmetry between providers is exactly why the
+unified type carries `CarrierKind` rather than trying to be a single
+flat shape: the adapter knows how to convert in both directions for
+its own provider, and the loop never has to.
+
+## Streaming events
+
+Chat Completions streams a sequence of `chat.completion.chunk` objects
+with `choices[].delta` slices. Responses streams a typed event sequence
+where each frame carries an `event:` line plus a JSON payload:
+
+```
+event: response.created
+data: {"type":"response.created", ...}
+
+event: response.output_item.added
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"..."}}
+
+event: response.reasoning_summary_text.delta
+data: {"type":"...","delta":"Looking at the user's request"}
+
+event: response.output_item.added
+data: {"output_index":1,"item":{"type":"message","role":"assistant"}}
+
+event: response.output_text.delta
+data: {"delta":"Sure, "}
+
+event: response.output_text.delta
+data: {"delta":"I can help."}
+
+event: response.output_item.added
+data: {"output_index":2,"item":{"type":"function_call","name":"search"}}
+
+event: response.function_call_arguments.delta
+data: {"delta":"{\"query\":\""}
+
+event: response.function_call_arguments.delta
+data: {"delta":"foo\"}"}
+
+event: response.completed
+data: {"response": {...full response object...}}
+```
+
+A streaming accumulator for Responses needs to:
+
+1. Parse SSE frames preserving the `event:` field (the wire package's
+   current stream parser drops it because Chat Completions doesn't use
+   typed events meaningfully).
+2. Maintain an `output_index → Item` map and merge deltas into the
+   right item by index.
+3. Emit per-item completion events to the existing `chunkHandler`
+   contract so trajectory capture and metrics ports stay parity with
+   the SDK / ChatCompletion-wire paths.
+4. Synthesize a `responses.Response` (the full non-streaming shape)
+   from the accumulated state at `response.completed`, so the upward
+   conversion to `agentic.AgentResponse` runs through the same path
+   as the non-streaming call.
+
+The `response.completed` frame includes the full final response object;
+in principle the accumulator can defer to that and ignore the per-token
+deltas for correctness — but we want the deltas for chunk-level
+metrics and trajectory streaming (first-token-time, etc.), so a real
+accumulator with per-event dispatch is the right shape.
+
+## Embeddings
+
+No change. The Embeddings endpoint is shape-compatible across
+ChatCompletion-shape providers and is not affected by the Responses
+migration. The current `model/wire.Client.Embeddings` path stays. The
+Responses client is request/response only.
+
+## Effort scope (rough)
+
+Counting from comparable Gemini-wire shipping work as a baseline.
+ADR-037's wire package landed at ~2.8K LoC (production + tests, ADR-037
+beta.60 numbers) for the ChatCompletion shape including streaming.
+Responses is structurally similar but has more event types and more
+output-item variants.
+
+| Area | Estimate | Notes |
+|---|---|---|
+| `agentic.ReasoningRecord` + carrier kinds | ~150 LoC | Type, kind constants, godoc, JSON tags, validation helpers. Greenfield — no compat shim. |
+| `agentic.ChatMessage.ReasoningRecords` field | ~10 LoC | Field add + godoc. |
+| Gemini adapter migration off `MetadataKeyGoogleThoughtSignature` | ~100 LoC | Capture from `extra_content.google.thought_signature` into `ReasoningRecord{CarrierKind:ToolCall}`; echo back. Delete the old MetadataKey constant + read sites. |
+| `agentic.ReasoningRecord` tests | ~300 LoC | JSON round-trip per [[feedback_polymorphic_config_needs_json_roundtrip_test]], CarrierKind exhaustiveness lint, Gemini capture/echo parity vs the old MetadataKey path. |
+| `model/wire/responses` types | ~500 LoC | Request, Response, ~10 InputItem variants, ~10 Item variants, reasoning sub-types, error types (reuse `wire.APIError`). |
+| `model/wire/responses` client | ~200 LoC | Mirrors `wire.Client` but with `/v1/responses` and the Responses request/response types. |
+| `model/wire/responses` stream | ~500 LoC | Typed-event SSE parser + output-index accumulator + per-item dispatch. Largest single chunk. |
+| `model/wire/responses` tests | ~1000 LoC | Golden-fixture round-trips per OpenAI doc example, streaming accumulator tests, error-decode tests, reasoning-item echo tests. |
+| `processor/agentic-model/adapter_openai_responses.go` | ~150 LoC | Capture reasoning items into `ReasoningRecord{CarrierKind:StandaloneItem}`; echo back as input items. Other hooks mostly no-ops. |
+| `processor/agentic-model/client_responses.go` | ~500 LoC | Mirror of `client_wire.go`: `buildResponsesRequest`, `convertResponsesResponse`, `doSingleAttemptResponses`, `streamResponses`, agentic ↔ responses translators (tool calls, reasoning, response_format). |
+| `processor/agentic-model/client.go` plumbing | ~50 LoC | `WireBackend = "responses"` dispatch alongside `"wire"` and `"sdk"`. |
+| Tests (full agentic-model path) | ~1500 LoC | `client_responses_test.go` mirrors `client_wire_test.go`; live test gated behind `live_llm` build tag; round-trip parity tests against an OpenAI mock. |
+| `cmd/semstreams` + `cmd/e2e-semstreams` wire | ~20 LoC | Per [[feedback_e2e_required_for_breaking_changes]] verify both binaries see the new backend before tagging. |
+| Sister-repo migration notes | ~200 LoC docs | semspec / semteams / semconnect changelog entries + the cross-cut module bump procedure. |
+| **Total estimate** | **~5.2K LoC** | ~1.8× the Gemini wire effort. The bump from prior ~4.4K estimate is the `ReasoningRecord` introduction + the Gemini-adapter migration. Bundled in Phase 1 deliberately — the leverage comes from doing both migrations as one architectural decision. |
+
+Two non-LoC budget items:
+
+- **Live-test stub corpus**: we need recorded streaming sessions from
+  the real OpenAI Responses endpoint to drive the unit tests. Plan one
+  round-trip capture session per supported model class (codex, GPT-5,
+  o-series).
+- **Soak**: ADR-037 mandates a ≥7d soak before the next adapter
+  migration and ≥30d before SDK retirement. Responses doesn't compete
+  with the SDK path; it's a new endpoint. But the soak gate should
+  still apply per [[feedback_e2e_required_for_breaking_changes]] before
+  semspec switches its hybrid registry to use it in production.
+
+## Phasing
+
+Mirror ADR-037's phase structure, with one shift: Phase 1 grows to
+absorb the `ReasoningRecord` introduction, because the leverage of
+deciding once across both providers depends on doing it together.
+
+- **Phase 1 (BREAKING): `ReasoningRecord` + Responses package
+  non-streaming.** Introduce `agentic.ReasoningRecord` and the
+  `ChatMessage.ReasoningRecords` field. Migrate the Gemini adapter
+  off `MetadataKeyGoogleThoughtSignature` to capture/echo through the
+  new type. Delete the old constant. Land `model/wire/responses` with
+  request, response, error, non-streaming client + round-trip tests
+  against captured fixtures. **Single tag, single PR, single
+  architectural decision.** Sister-repo coordination is the one tag
+  flip — semspec, semteams, semconnect bump together. Full e2e gate.
+- **Phase 2 (ADDITIVE): Responses streaming.** Typed-event SSE parser
+  + accumulator. Pure package work with golden fixtures. No
+  agentic-model wiring.
+- **Phase 3 (ADDITIVE): agentic-model integration.** `WireBackend =
+  "responses"` routes endpoint config through the new client.
+  `OpenAIResponsesAdapter` for capture/echo of reasoning items as
+  `ReasoningRecord{CarrierKind:StandaloneItem}`. Live-test gated.
+  semspec can opt in per-endpoint after this lands.
+- **Phase 4 (ADDITIVE): multi-turn parity verification.** Verify
+  cross-turn reasoning echo works in the loop's actual multi-turn
+  flow against both Gemini (regression: same behavior through the new
+  type) and OpenAI (new path). This is the equivalent of Gemini's
+  `thought_signature` work but with the unified carrier already in
+  place.
+- **Phase 5 (deferred until justified): hosted tools.** `file_search`,
+  `web_search_preview`, `code_interpreter`, etc. None of our current
+  consumers need these and they have their own state/cost model.
+
+Phase 1 is the only BREAKING phase. Phases 2-4 are additive on top of
+it. Phase 1's deliberate scope expansion is justified by the
+[[feedback_reactive_patches_vs_engine_completion]] framing — we ship
+the carrier abstraction once, not in three per-arrival increments.
+
+## Open questions
+
+1. **What does response_format do in Responses?** Responses has its
+   own `text.format` parameter that supersedes `response_format`.
+   Need to confirm by experiment whether the same JSONSchema we send
+   to ChatCompletion works under Responses; if not, the
+   `agenticResponseFormatToResponses` translator needs to reshape.
+2. **Embedded `developer` role.** Responses input items support a
+   `role: "developer"` for system-prompt-class messages. Our agentic
+   loop emits `role: "system"`. Decision: silently translate
+   `system → developer` at the seam, or leave `system` and rely on
+   OpenAI's compat? Pick the loud option (explicit translation in
+   the adapter, with a test that asserts the wire body) to avoid
+   silent semantic drift.
+3. **`store: false` echo cost.** Reasoning items can be sizable. We
+   should land a metric on the bytes-per-request before deciding
+   whether to ever opt some endpoints into `store: true` mode (which
+   would be a Phase 5+ decision; default stays stateless).
+4. **Sister-repo coordination cadence.** Phase 1 is BREAKING and
+   requires semspec / semteams / semconnect to bump together. Same
+   one-flip workflow as ADR-042 publisher-mode. Phase 3 (the actual
+   `WireBackend = "responses"` config surface) lands additive on top
+   — that's the cut semspec opts in at per-endpoint.
+
+(Open question #1 from the prior draft — unified `ReasoningRecord` vs
+per-provider `MetadataKey` — is **answered**: unified type, decided
+now per the discipline at "Reasoning carry-across-turn" above.)
+
+## Recommendation
+
+Yes, build Responses support. The forcing function is real (semspec is
+blocked today on a specific call site), the scope is bounded
+(~5.2K LoC, one BREAKING phase + three ADDITIVE), and the package
+reshape can be clean if we name it correctly up front (Option A:
+shape-organized sibling package).
+
+Frame this as **"complete the wire layer's provider-shape support"**
+in the ADR: ChatCompletion shape (today) + Responses shape (this work),
+plus the unified `ReasoningRecord` carrier that lets the loop stay
+provider-neutral as new shapes arrive. Anthropic Messages shape stays
+explicitly out of scope unless and until a consumer pulls on it. The
+deliberate-completion framing matters per
+[[feedback_reactive_patches_vs_engine_completion]]; without it this
+reads as another wire-of-the-month and the package will accrete
+shapes per-quirk for the next year.
+
+The Phase 1 breaking change (delete `MetadataKeyGoogleThoughtSignature`,
+introduce `ReasoningRecord`) is the right call to make at this exact
+moment. We are pre-1.0 and own every consumer in the org — that gate
+won't be open again. Doing it later means a Phase 1 PR with three
+provider-specific carriers + a migration matrix; doing it now means
+one carrier + one adapter migration. Breaking changes are never fun,
+but the long-term sanity of "trajectory consumers iterate `ReasoningRecord`
+without provider-specific branches, forever" is worth one tag of
+coordinated cross-repo bumps.
+
+Sister-agent handoff items if they pick this up:
+
+- Read [ADR-037](../adr/037-self-hosted-llm-wire-package.md) end-to-end.
+  The forcing-function structure, the Extras-carrier rationale, and
+  the soak gate are all reusable framing.
+- Read `model/wire/client.go`, `model/wire/types.go`,
+  `model/wire/stream.go`. Mirror their structure under
+  `model/wire/responses/`.
+- Read `processor/agentic-model/client_wire.go` end-to-end. This is
+  the template for `client_responses.go`: same retry loop, same
+  throttle, same metric hooks, same chunk-handler contract — only the
+  per-attempt dispatch differs.
+- Read every `MetadataKeyGoogleThoughtSignature` reference site
+  before Phase 1 starts. Each one is a Phase 1 deletion + replacement
+  with the new `ReasoningRecord` path. Grep:
+  `grep -rn MetadataKeyGoogleThoughtSignature --include="*.go"`.
+- Capture live OpenAI Responses fixtures before Phase 1 starts;
+  golden-fixture round-trips are how we verified Gemini's quirks and
+  they're the only way to ground the unit tests against the real
+  wire shape.
+- Update `cmd/semstreams/main.go` AND `cmd/e2e-semstreams/main.go`
+  per [[feedback_e2e_required_for_breaking_changes]] — the
+  registry-singleton story is the cautionary tale on missing-binary
+  migration.
+- Coordinate the sister-repo bump (semspec / semteams / semconnect)
+  on the Phase 1 tag landing. Workflow precedent is the ADR-042
+  publisher-mode rollout.
+
+When the ADR draft is ready, it should explicitly answer the four
+remaining open questions above — particularly the `text.format` vs
+`response_format` question, which determines whether the Phase 3
+translator layer reshapes or passes through.

--- a/model/registry.go
+++ b/model/registry.go
@@ -500,8 +500,8 @@ func validateEndpoint(name string, ep *EndpointConfig) error {
 	if err := validateDurationField(name, "request_timeout", ep.RequestTimeout); err != nil {
 		return err
 	}
-	if ep.WireBackend != "" && ep.WireBackend != "sdk" && ep.WireBackend != "wire" {
-		return fmt.Errorf("endpoint %q: wire_backend must be \"\", \"sdk\", or \"wire\"", name)
+	if ep.WireBackend != "" && ep.WireBackend != "sdk" && ep.WireBackend != "wire" && ep.WireBackend != "responses" {
+		return fmt.Errorf("endpoint %q: wire_backend must be \"\", \"sdk\", \"wire\", or \"responses\"", name)
 	}
 	return nil
 }

--- a/model/wire/responses/client.go
+++ b/model/wire/responses/client.go
@@ -1,0 +1,154 @@
+package responses
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// responsesPath is the OpenAI Responses route. Used when
+// ClientConfig.ResponsesURL is empty (the typical case where BaseURL
+// points to .../v1).
+const responsesPath = "/responses"
+
+// ClientConfig configures a Responses Client. Mirror of
+// wire.ClientConfig; the two clients share auth/transport plumbing
+// but speak different wire shapes. BaseURL and HTTPClient are
+// required; everything else is optional.
+type ClientConfig struct {
+	// BaseURL is the OpenAI-compat root, e.g. "https://api.openai.com/v1".
+	// If ResponsesURL is set, it takes precedence.
+	BaseURL string
+
+	// HTTPClient is the transport. Callers should use
+	// model.NewHTTPClient to construct one with the framework's
+	// connection-hygiene defaults.
+	HTTPClient *http.Client
+
+	// AuthHeader, if non-empty, is set as the Authorization header
+	// on every request. Typically "Bearer <key>".
+	AuthHeader string
+
+	// ExtraHeaders are added to every request before send. Useful for
+	// provider-specific headers.
+	ExtraHeaders http.Header
+
+	// ResponsesURL overrides BaseURL+/responses. Empty means derive
+	// from BaseURL.
+	ResponsesURL string
+
+	// MaxFrameSize caps the per-SSE-frame buffer in streaming mode.
+	// Phase 1 client is non-streaming; the field is carried for the
+	// Phase 2 streaming addition.
+	MaxFrameSize int
+}
+
+// Client is the OpenAI Responses API client. Safe for concurrent
+// use; callers typically construct one Client per endpoint and reuse
+// it across requests.
+type Client struct {
+	cfg ClientConfig
+}
+
+// NewClient validates cfg and returns a Client. Returns an error if
+// HTTPClient or BaseURL is missing.
+func NewClient(cfg ClientConfig) (*Client, error) {
+	if cfg.HTTPClient == nil {
+		return nil, fmt.Errorf("responses: ClientConfig.HTTPClient is required")
+	}
+	if cfg.BaseURL == "" && cfg.ResponsesURL == "" {
+		return nil, fmt.Errorf("responses: ClientConfig.BaseURL is required when ResponsesURL is not set")
+	}
+	return &Client{cfg: cfg}, nil
+}
+
+// Responses executes a non-streaming Responses call. Returns a
+// decoded response on HTTP 2xx, or *APIError with the status code
+// recorded on any other status. Network and decode errors return as
+// regular errors.
+//
+// Phase 1: streaming (req.Stream=true) is unsupported and returns
+// an error. Phase 2 adds ResponsesStream alongside this method.
+func (c *Client) Responses(ctx context.Context, req *Request) (*Response, error) {
+	if req == nil {
+		return nil, fmt.Errorf("responses: nil request")
+	}
+	if req.Stream {
+		return nil, fmt.Errorf("responses: streaming not supported in Phase 1 (use ResponsesStream when available)")
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("responses: marshal request: %w", err)
+	}
+	httpReq, err := c.buildHTTPRequest(ctx, http.MethodPost, c.responsesURL(), body, "application/json")
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.cfg.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("responses: Responses: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("responses: read response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, DecodeError(resp.StatusCode, bodyBytes)
+	}
+
+	var out Response
+	if err := json.Unmarshal(bodyBytes, &out); err != nil {
+		return nil, fmt.Errorf("responses: decode response: %w", err)
+	}
+	return &out, nil
+}
+
+// buildHTTPRequest constructs an *http.Request with auth + extras
+// headers applied. body may be nil.
+func (c *Client) buildHTTPRequest(ctx context.Context, method, url string, body []byte, contentType string) (*http.Request, error) {
+	var rdr io.Reader
+	if len(body) > 0 {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	if err != nil {
+		return nil, fmt.Errorf("responses: build request: %w", err)
+	}
+	if contentType != "" && body != nil {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if c.cfg.AuthHeader != "" {
+		req.Header.Set("Authorization", c.cfg.AuthHeader)
+	}
+	for k, vals := range c.cfg.ExtraHeaders {
+		for _, v := range vals {
+			req.Header.Add(k, v)
+		}
+	}
+	return req, nil
+}
+
+// responsesURL returns the configured Responses URL or derives it
+// from BaseURL.
+func (c *Client) responsesURL() string {
+	if c.cfg.ResponsesURL != "" {
+		return c.cfg.ResponsesURL
+	}
+	return joinURL(c.cfg.BaseURL, responsesPath)
+}
+
+// joinURL concatenates a base and a path, normalizing the slash join.
+func joinURL(base, path string) string {
+	if base == "" {
+		return path
+	}
+	return strings.TrimRight(base, "/") + "/" + strings.TrimLeft(path, "/")
+}

--- a/model/wire/responses/client.go
+++ b/model/wire/responses/client.go
@@ -71,14 +71,15 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 // recorded on any other status. Network and decode errors return as
 // regular errors.
 //
-// Phase 1: streaming (req.Stream=true) is unsupported and returns
-// an error. Phase 2 adds ResponsesStream alongside this method.
+// Streaming callers should use ResponsesStream instead; passing
+// req.Stream=true here returns an error to make the misuse loud
+// (Responses always forces Stream=false on the wire).
 func (c *Client) Responses(ctx context.Context, req *Request) (*Response, error) {
 	if req == nil {
 		return nil, fmt.Errorf("responses: nil request")
 	}
 	if req.Stream {
-		return nil, fmt.Errorf("responses: streaming not supported in Phase 1 (use ResponsesStream when available)")
+		return nil, fmt.Errorf("responses: req.Stream=true; use ResponsesStream for streaming")
 	}
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -109,6 +110,43 @@ func (c *Client) Responses(ctx context.Context, req *Request) (*Response, error)
 		return nil, fmt.Errorf("responses: decode response: %w", err)
 	}
 	return &out, nil
+}
+
+// ResponsesStream executes a streaming Responses call. Returns a
+// *Stream the caller drives via Recv until io.EOF; callers MUST
+// call Close when done. On non-2xx the response body is read fully
+// and returned as *APIError; the *Stream is nil in that case.
+//
+// The request's Stream flag is forced to true before send — the
+// caller does not need to set it.
+func (c *Client) ResponsesStream(ctx context.Context, req *Request) (*Stream, error) {
+	if req == nil {
+		return nil, fmt.Errorf("responses: nil request")
+	}
+	req.Stream = true
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("responses: marshal request: %w", err)
+	}
+	httpReq, err := c.buildHTTPRequest(ctx, http.MethodPost, c.responsesURL(), body, "application/json")
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Accept", "text/event-stream")
+	httpReq.Header.Set("Cache-Control", "no-cache")
+
+	resp, err := c.cfg.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("responses: ResponsesStream: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, DecodeError(resp.StatusCode, bodyBytes)
+	}
+
+	return newStream(resp.Body, c.cfg.MaxFrameSize), nil
 }
 
 // buildHTTPRequest constructs an *http.Request with auth + extras

--- a/model/wire/responses/client_test.go
+++ b/model/wire/responses/client_test.go
@@ -1,0 +1,267 @@
+package responses_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/model/wire"
+	"github.com/c360studio/semstreams/model/wire/responses"
+)
+
+// TestClient_Responses_SuccessfulCall asserts the happy path:
+// non-streaming Responses() POSTs the marshaled request to the
+// server, decodes a documented Response envelope, and returns it.
+func TestClient_Responses_SuccessfulCall(t *testing.T) {
+	var capturedBody string
+	var capturedAuth string
+	var capturedContentType string
+	var capturedPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		capturedAuth = r.Header.Get("Authorization")
+		capturedContentType = r.Header.Get("Content-Type")
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{
+			"id":"resp_test_1",
+			"object":"response",
+			"created_at":1717070000,
+			"status":"completed",
+			"model":"gpt-5.5",
+			"output":[
+				{"type":"message","id":"msg_1","status":"completed","role":"assistant",
+				 "content":[{"type":"output_text","text":"hello"}]}
+			],
+			"usage":{"input_tokens":10,"output_tokens":3,"total_tokens":13}
+		}`)
+	}))
+	defer srv.Close()
+
+	c, err := responses.NewClient(responses.ClientConfig{
+		BaseURL:    srv.URL + "/v1",
+		HTTPClient: srv.Client(),
+		AuthHeader: "Bearer sk-test",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	req := &responses.Request{
+		Model: "gpt-5.5",
+		Input: []responses.InputItem{
+			responses.NewInputUserMessage("hello world"),
+		},
+	}
+	resp, err := c.Responses(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Responses: %v", err)
+	}
+
+	if capturedPath != "/v1/responses" {
+		t.Errorf("path = %q, want /v1/responses", capturedPath)
+	}
+	if capturedAuth != "Bearer sk-test" {
+		t.Errorf("Authorization = %q, want Bearer sk-test", capturedAuth)
+	}
+	if capturedContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", capturedContentType)
+	}
+	if !strings.Contains(capturedBody, `"model":"gpt-5.5"`) {
+		t.Errorf("request body missing model: %s", capturedBody)
+	}
+	if !strings.Contains(capturedBody, `"type":"input_text"`) {
+		t.Errorf("request body missing input_text content part: %s", capturedBody)
+	}
+
+	if resp.ID != "resp_test_1" {
+		t.Errorf("resp.ID = %q, want resp_test_1", resp.ID)
+	}
+	if resp.Status != "completed" {
+		t.Errorf("resp.Status = %q, want completed", resp.Status)
+	}
+	if len(resp.Output) != 1 {
+		t.Fatalf("len(resp.Output) = %d, want 1", len(resp.Output))
+	}
+	if !resp.Output[0].IsMessage() {
+		t.Errorf("Output[0] is not a message; type=%q", resp.Output[0].Type)
+	}
+	if got := resp.Output[0].OutputText(); got != "hello" {
+		t.Errorf("OutputText = %q, want hello", got)
+	}
+	if resp.Usage == nil || resp.Usage.TotalTokens != 13 {
+		t.Errorf("Usage = %+v, want TotalTokens=13", resp.Usage)
+	}
+}
+
+// TestClient_Responses_APIError asserts non-2xx returns *APIError
+// with the status code recorded. Body shape mirrors ChatCompletion's
+// standard error envelope per ADR-051 ("Same envelope shape").
+func TestClient_Responses_APIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":{"type":"invalid_request","code":"missing_param","message":"input is required"}}`)
+	}))
+	defer srv.Close()
+
+	c, err := responses.NewClient(responses.ClientConfig{
+		BaseURL:    srv.URL + "/v1",
+		HTTPClient: srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = c.Responses(context.Background(), &responses.Request{Model: "gpt-5.5"})
+	if err == nil {
+		t.Fatal("Responses: expected error, got nil")
+	}
+	var apiErr *responses.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 400 {
+		t.Errorf("StatusCode = %d, want 400", apiErr.StatusCode)
+	}
+	if apiErr.Type != "invalid_request" {
+		t.Errorf("Type = %q, want invalid_request", apiErr.Type)
+	}
+	if apiErr.Code != "missing_param" {
+		t.Errorf("Code = %q, want missing_param", apiErr.Code)
+	}
+	// errors.As should also work against *wire.APIError since
+	// responses.APIError is a type alias.
+	var wireErr *wire.APIError
+	if !errors.As(err, &wireErr) {
+		t.Errorf("errors.As against *wire.APIError failed; type-alias not transparent")
+	}
+}
+
+// TestClient_Responses_StreamingRejected asserts the Phase 1 client
+// returns a clear error when Stream=true; streaming arrives in Phase 2.
+func TestClient_Responses_StreamingRejected(t *testing.T) {
+	c, err := responses.NewClient(responses.ClientConfig{
+		BaseURL:    "http://unused",
+		HTTPClient: http.DefaultClient,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, err = c.Responses(context.Background(), &responses.Request{
+		Model:  "gpt-5.5",
+		Stream: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "streaming not supported") {
+		t.Errorf("expected streaming-rejected error, got %v", err)
+	}
+}
+
+// TestNewClient_Validation pins the config validation surface.
+func TestNewClient_Validation(t *testing.T) {
+	if _, err := responses.NewClient(responses.ClientConfig{}); err == nil {
+		t.Error("NewClient with empty config: expected error, got nil")
+	}
+	if _, err := responses.NewClient(responses.ClientConfig{BaseURL: "x"}); err == nil {
+		t.Error("NewClient without HTTPClient: expected error, got nil")
+	}
+	if _, err := responses.NewClient(responses.ClientConfig{HTTPClient: http.DefaultClient}); err == nil {
+		t.Error("NewClient without BaseURL or ResponsesURL: expected error, got nil")
+	}
+}
+
+// TestClient_Responses_NilRequest pins the explicit nil-request guard.
+func TestClient_Responses_NilRequest(t *testing.T) {
+	c, _ := responses.NewClient(responses.ClientConfig{
+		BaseURL:    "http://unused",
+		HTTPClient: http.DefaultClient,
+	})
+	_, err := c.Responses(context.Background(), nil)
+	if err == nil {
+		t.Error("expected error on nil request; got nil")
+	}
+}
+
+// TestClient_Responses_ResponsesURLOverride pins that
+// ResponsesURL takes precedence over BaseURL when set.
+func TestClient_Responses_ResponsesURLOverride(t *testing.T) {
+	var capturedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"r","object":"response","model":"m","output":[]}`)
+	}))
+	defer srv.Close()
+
+	c, err := responses.NewClient(responses.ClientConfig{
+		HTTPClient:   srv.Client(),
+		ResponsesURL: srv.URL + "/custom/responses",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if _, err := c.Responses(context.Background(), &responses.Request{Model: "m"}); err != nil {
+		t.Fatalf("Responses: %v", err)
+	}
+	if capturedPath != "/custom/responses" {
+		t.Errorf("path = %q, want /custom/responses", capturedPath)
+	}
+}
+
+// TestClient_Responses_ExtraHeaders pins per-request header
+// propagation.
+func TestClient_Responses_ExtraHeaders(t *testing.T) {
+	var capturedXFoo string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedXFoo = r.Header.Get("X-Foo")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":"r","object":"response","model":"m","output":[]}`)
+	}))
+	defer srv.Close()
+
+	hdrs := http.Header{}
+	hdrs.Set("X-Foo", "bar")
+	c, _ := responses.NewClient(responses.ClientConfig{
+		BaseURL:      srv.URL + "/v1",
+		HTTPClient:   srv.Client(),
+		ExtraHeaders: hdrs,
+	})
+	if _, err := c.Responses(context.Background(), &responses.Request{Model: "m"}); err != nil {
+		t.Fatalf("Responses: %v", err)
+	}
+	if capturedXFoo != "bar" {
+		t.Errorf("X-Foo = %q, want bar", capturedXFoo)
+	}
+}
+
+// TestRequest_OmitsZeroValues pins that the zero-value request
+// produces a compact JSON body — no leaking `"max_output_tokens":0`,
+// no `"store":false` when unset, etc. The pointer-typed fields on
+// Request are what make this work. Snapshot comparison (not
+// substring containment) avoids false matches against content-part
+// fields with the same names.
+func TestRequest_OmitsZeroValues(t *testing.T) {
+	in := &responses.Request{
+		Model: "gpt-5.5",
+		Input: []responses.InputItem{
+			responses.NewInputUserMessage("hi"),
+		},
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want := `{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]}]}`
+	if string(b) != want {
+		t.Errorf("zero-value request did not match snapshot\n  got:  %s\n  want: %s", string(b), want)
+	}
+}

--- a/model/wire/responses/client_test.go
+++ b/model/wire/responses/client_test.go
@@ -147,25 +147,6 @@ func TestClient_Responses_APIError(t *testing.T) {
 	}
 }
 
-// TestClient_Responses_StreamingRejected asserts the Phase 1 client
-// returns a clear error when Stream=true; streaming arrives in Phase 2.
-func TestClient_Responses_StreamingRejected(t *testing.T) {
-	c, err := responses.NewClient(responses.ClientConfig{
-		BaseURL:    "http://unused",
-		HTTPClient: http.DefaultClient,
-	})
-	if err != nil {
-		t.Fatalf("NewClient: %v", err)
-	}
-	_, err = c.Responses(context.Background(), &responses.Request{
-		Model:  "gpt-5.5",
-		Stream: true,
-	})
-	if err == nil || !strings.Contains(err.Error(), "streaming not supported") {
-		t.Errorf("expected streaming-rejected error, got %v", err)
-	}
-}
-
 // TestNewClient_Validation pins the config validation surface.
 func TestNewClient_Validation(t *testing.T) {
 	if _, err := responses.NewClient(responses.ClientConfig{}); err == nil {

--- a/model/wire/responses/doc.go
+++ b/model/wire/responses/doc.go
@@ -1,0 +1,27 @@
+// Package responses is the self-hosted JSON wire-format layer for
+// OpenAI's Responses API (POST /v1/responses). It is a sibling of
+// model/wire (which speaks ChatCompletion) and the second top-level
+// wire shape carried in the wire-package family.
+//
+// The Responses API is structurally distinct from ChatCompletions —
+// it uses a typed-array input/output model (InputItem / OutputItem)
+// rather than the message/choices model, dispatches polymorphism
+// through a "type" discriminator on each item, and surfaces reasoning
+// as a first-class item kind rather than an out-of-band field. The
+// ChatCompletion wire types do not apply; this package owns its own
+// Request, Response, item variants, and SSE streaming protocol.
+//
+// Phase 1 (this package's initial cut) implements the non-streaming
+// request/response path covering function-calling and reasoning echo
+// in stateless mode (store=false). Hosted tools (file_search,
+// web_search_preview, code_interpreter, computer_use_preview,
+// image_generation) are out of scope and not modeled here; the
+// surface stays narrow until a concrete consumer asks. Streaming
+// (typed-event SSE) lands in Phase 2 as a sibling file.
+//
+// Reasoning-record echo (the "ReasoningRecord opaque blob round-trip"
+// per ADR-051 D3) is handled at the higher agentic-model adapter
+// layer; this package merely models the wire shape of reasoning
+// items and exposes their fields. See ADR-051 for the architectural
+// motivation and ADR-037 for the parent wire-package shape.
+package responses

--- a/model/wire/responses/errors.go
+++ b/model/wire/responses/errors.go
@@ -1,0 +1,15 @@
+package responses
+
+import "github.com/c360studio/semstreams/model/wire"
+
+// APIError is the decoded non-2xx error from a Responses call.
+// Re-exported from model/wire — the envelope shape is identical to
+// ChatCompletion's per ADR-051 ("Same envelope shape; same HTTP
+// status semantics" in the structural-delta table). Callers can
+// errors.As on either *wire.APIError or *responses.APIError; they
+// are the same type.
+type APIError = wire.APIError
+
+// DecodeError parses a Responses error body into an APIError.
+// Re-exported from model/wire; the body shape matches.
+var DecodeError = wire.DecodeError

--- a/model/wire/responses/stream.go
+++ b/model/wire/responses/stream.go
@@ -1,0 +1,331 @@
+package responses
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// DefaultMaxFrameSize is the default per-SSE-frame buffer ceiling.
+// Matches the model/wire ChatCompletion stream cap (16 MiB) —
+// Responses output_text deltas are typically small but reasoning
+// summary and function_call_arguments blobs can grow.
+const DefaultMaxFrameSize = 16 * 1024 * 1024
+
+// Event type constants enumerate the Responses SSE event types this
+// package recognizes. The closed set covers function-calling +
+// reasoning echo (Phase 1+2 scope); hosted-tool events (code
+// interpreter, computer use, file search, etc.) are not modeled.
+// Unknown event types decode into Event with Type populated and
+// fields zero — callers can ignore them or surface them via Type.
+const (
+	// Lifecycle events: payload is {response: Response}.
+	EventTypeResponseCreated    = "response.created"
+	EventTypeResponseInProgress = "response.in_progress"
+	EventTypeResponseCompleted  = "response.completed"
+	EventTypeResponseFailed     = "response.failed"
+	EventTypeResponseCancelled  = "response.cancelled"
+	EventTypeResponseIncomplete = "response.incomplete"
+
+	// Output item events: payload carries an OutputItem at OutputIndex.
+	EventTypeOutputItemAdded = "response.output_item.added"
+	EventTypeOutputItemDone  = "response.output_item.done"
+
+	// Content part events: payload carries a ContentPart at
+	// (OutputIndex, ContentIndex) inside a message item.
+	EventTypeContentPartAdded = "response.content_part.added"
+	EventTypeContentPartDone  = "response.content_part.done"
+
+	// Streaming text events: delta accumulates, done snapshots final.
+	EventTypeOutputTextDelta = "response.output_text.delta"
+	EventTypeOutputTextDone  = "response.output_text.done"
+
+	// Refusal events: same shape as text events but for refusals.
+	EventTypeRefusalDelta = "response.refusal.delta"
+	EventTypeRefusalDone  = "response.refusal.done"
+
+	// Function-call arguments events: delta accumulates JSON-encoded
+	// arguments string, done snapshots final.
+	EventTypeFunctionCallArgumentsDelta = "response.function_call_arguments.delta"
+	EventTypeFunctionCallArgumentsDone  = "response.function_call_arguments.done"
+
+	// Reasoning summary part events: payload carries a SummaryPart at
+	// (OutputIndex, SummaryIndex). Note Part is a RawMessage —
+	// caller decodes via SummaryPart() helper since the "part" field
+	// shape differs from content_part.* events.
+	EventTypeReasoningSummaryPartAdded = "response.reasoning_summary_part.added"
+	EventTypeReasoningSummaryPartDone  = "response.reasoning_summary_part.done"
+
+	// Reasoning summary text events: delta accumulates, done
+	// snapshots final.
+	EventTypeReasoningSummaryTextDelta = "response.reasoning_summary_text.delta"
+	EventTypeReasoningSummaryTextDone  = "response.reasoning_summary_text.done"
+
+	// Error event: payload is {error: APIError}.
+	EventTypeError = "error"
+)
+
+// Event is a typed Responses SSE event. The Type field is the
+// discriminator; other fields are populated based on the variant.
+// Use the helper methods (ContentPart, SummaryPart, APIError) to
+// decode polymorphic fields by event type.
+//
+// Producer convention: the typed payload structs in OpenAI's
+// documented shapes are flattened into this union for simplicity.
+// Unknown event types still decode (Type populated, payload fields
+// zero or RawMessage); callers iterate forward without error.
+type Event struct {
+	// Type is the SSE event name (e.g. "response.output_text.delta").
+	// Mirrors the `event:` SSE line and the data payload's `type`
+	// field, which the API contract holds equal.
+	Type string `json:"type"`
+
+	// SequenceNumber is the monotonically increasing event sequence
+	// the API ships on every event. Useful for de-duplication on
+	// reconnect; we don't reconnect (stateless one-shot stream) but
+	// the field is carried for trace correlation.
+	SequenceNumber int `json:"sequence_number,omitempty"`
+
+	// Response carries the full Response on lifecycle events
+	// (response.created, response.completed, response.failed, etc.).
+	Response *Response `json:"response,omitempty"`
+
+	// OutputIndex addresses the OutputItem inside Response.Output
+	// that this event targets. Populated on item/content/text/refusal/
+	// arguments/summary events.
+	OutputIndex *int `json:"output_index,omitempty"`
+
+	// ContentIndex addresses the ContentPart inside an OutputItem's
+	// Content array. Populated on content_part.*, output_text.*,
+	// refusal.* events.
+	ContentIndex *int `json:"content_index,omitempty"`
+
+	// SummaryIndex addresses the SummaryPart inside a reasoning
+	// OutputItem's Summary array. Populated on reasoning_summary_*
+	// events.
+	SummaryIndex *int `json:"summary_index,omitempty"`
+
+	// ItemID echoes the OutputItem.ID this event targets. Populated
+	// on content/text/refusal/arguments/summary events.
+	ItemID string `json:"item_id,omitempty"`
+
+	// Item carries the OutputItem on output_item.added /
+	// output_item.done.
+	Item *OutputItem `json:"item,omitempty"`
+
+	// Part carries the polymorphic part payload on content_part.* and
+	// reasoning_summary_part.* events. Decode via ContentPart() or
+	// SummaryPart() helpers based on Type.
+	Part json.RawMessage `json:"part,omitempty"`
+
+	// Delta accumulates partial text on output_text.delta,
+	// refusal.delta, function_call_arguments.delta, and
+	// reasoning_summary_text.delta events.
+	Delta string `json:"delta,omitempty"`
+
+	// Text snapshots final text on output_text.done and
+	// reasoning_summary_text.done events.
+	Text string `json:"text,omitempty"`
+
+	// Arguments snapshots final JSON-encoded arguments on
+	// function_call_arguments.done.
+	Arguments string `json:"arguments,omitempty"`
+
+	// Refusal snapshots final refusal body on refusal.done.
+	Refusal string `json:"refusal,omitempty"`
+
+	// Error carries the APIError on error events.
+	Error json.RawMessage `json:"error,omitempty"`
+}
+
+// ContentPart decodes Part as a ContentPart. Only valid on
+// content_part.* events; returns an error if Type is incompatible or
+// Part is empty.
+func (e *Event) ContentPart() (*ContentPart, error) {
+	if e == nil {
+		return nil, errors.New("responses: nil event")
+	}
+	if e.Type != EventTypeContentPartAdded && e.Type != EventTypeContentPartDone {
+		return nil, fmt.Errorf("responses: ContentPart called on Event.Type=%q", e.Type)
+	}
+	if len(e.Part) == 0 {
+		return nil, errors.New("responses: empty Part on content_part event")
+	}
+	var out ContentPart
+	if err := json.Unmarshal(e.Part, &out); err != nil {
+		return nil, fmt.Errorf("responses: decode ContentPart: %w", err)
+	}
+	return &out, nil
+}
+
+// SummaryPart decodes Part as a SummaryPart. Only valid on
+// reasoning_summary_part.* events; returns an error if Type is
+// incompatible or Part is empty.
+func (e *Event) SummaryPart() (*SummaryPart, error) {
+	if e == nil {
+		return nil, errors.New("responses: nil event")
+	}
+	if e.Type != EventTypeReasoningSummaryPartAdded && e.Type != EventTypeReasoningSummaryPartDone {
+		return nil, fmt.Errorf("responses: SummaryPart called on Event.Type=%q", e.Type)
+	}
+	if len(e.Part) == 0 {
+		return nil, errors.New("responses: empty Part on reasoning_summary_part event")
+	}
+	var out SummaryPart
+	if err := json.Unmarshal(e.Part, &out); err != nil {
+		return nil, fmt.Errorf("responses: decode SummaryPart: %w", err)
+	}
+	return &out, nil
+}
+
+// APIError decodes Error as an APIError. Only valid on error events;
+// returns an error if Type is incompatible or Error is empty.
+func (e *Event) APIError() (*APIError, error) {
+	if e == nil {
+		return nil, errors.New("responses: nil event")
+	}
+	if e.Type != EventTypeError {
+		return nil, fmt.Errorf("responses: APIError called on Event.Type=%q", e.Type)
+	}
+	if len(e.Error) == 0 {
+		return nil, errors.New("responses: empty Error on error event")
+	}
+	var out APIError
+	if err := json.Unmarshal(e.Error, &out); err != nil {
+		return nil, fmt.Errorf("responses: decode APIError: %w", err)
+	}
+	return &out, nil
+}
+
+// Stream consumes a Responses Server-Sent-Events response body,
+// decoding each frame into an Event. The caller iterates by calling
+// Recv until io.EOF.
+//
+// Stream is NOT safe for concurrent use; one goroutine drives a
+// stream from start to finish, then calls Close.
+type Stream struct {
+	rc      io.ReadCloser
+	scanner *bufio.Scanner
+	done    bool
+	err     error
+}
+
+// newStream wraps an io.ReadCloser in a Stream with an SSE-aware
+// scanner. maxFrame caps the per-frame buffer; 0 falls back to
+// DefaultMaxFrameSize.
+func newStream(rc io.ReadCloser, maxFrame int) *Stream {
+	if maxFrame <= 0 {
+		maxFrame = DefaultMaxFrameSize
+	}
+	scanner := bufio.NewScanner(rc)
+	scanner.Buffer(make([]byte, 64*1024), maxFrame)
+	scanner.Split(splitSSEFrames)
+	return &Stream{rc: rc, scanner: scanner}
+}
+
+// Recv returns the next decoded event. Returns io.EOF when the
+// underlying body has ended or a terminal lifecycle event
+// (response.completed / failed / cancelled / incomplete) has been
+// emitted and consumed. Subsequent calls after EOF continue to
+// return io.EOF.
+//
+// Note: the Responses API does NOT emit a [DONE] sentinel —
+// terminal lifecycle events ARE the end signal. The stream body
+// closes shortly after; the underlying io.EOF lands on the next
+// Recv. Recv does not auto-terminate on lifecycle events so the
+// caller sees the terminal Event.
+func (s *Stream) Recv() (*Event, error) {
+	if s.done {
+		if s.err != nil {
+			return nil, s.err
+		}
+		return nil, io.EOF
+	}
+
+	for s.scanner.Scan() {
+		frame := s.scanner.Bytes()
+		payload, ok := extractDataPayload(frame)
+		if !ok {
+			continue
+		}
+		ev := &Event{}
+		if err := json.Unmarshal(payload, ev); err != nil {
+			s.done = true
+			s.err = fmt.Errorf("responses: malformed stream event: %w", err)
+			return nil, s.err
+		}
+		return ev, nil
+	}
+
+	if err := s.scanner.Err(); err != nil {
+		s.done = true
+		s.err = fmt.Errorf("responses: stream read: %w", err)
+		return nil, s.err
+	}
+
+	s.done = true
+	return nil, io.EOF
+}
+
+// Close releases the underlying response body. Safe to call multiple
+// times.
+func (s *Stream) Close() error {
+	if s.rc == nil {
+		return nil
+	}
+	err := s.rc.Close()
+	s.rc = nil
+	return err
+}
+
+// extractDataPayload pulls the JSON body out of an SSE frame. Frames
+// contain `event: <name>` and `data: <json>` lines (and optionally
+// `id:`, `retry:`); we ignore the event line — the typed data
+// payload's "type" field is authoritative — and return the data
+// body. Multiple data lines in one frame are joined with "\n" per
+// the SSE spec.
+func extractDataPayload(frame []byte) (payload []byte, ok bool) {
+	var out bytes.Buffer
+	found := false
+	for _, raw := range bytes.Split(frame, []byte("\n")) {
+		line := bytes.TrimRight(raw, "\r")
+		const prefix = "data:"
+		if !bytes.HasPrefix(line, []byte(prefix)) {
+			continue
+		}
+		body := bytes.TrimSpace(line[len(prefix):])
+		if found {
+			out.WriteByte('\n')
+		}
+		out.Write(body)
+		found = true
+	}
+	if !found {
+		return nil, false
+	}
+	return out.Bytes(), true
+}
+
+// splitSSEFrames is a bufio.SplitFunc that returns one SSE frame
+// per call. Frames are separated by blank lines: \n\n or \r\n\r\n.
+// Identical to the wire-package implementation; duplicated here to
+// keep the responses package self-contained (no cross-package
+// internal coupling).
+func splitSSEFrames(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	if i := bytes.Index(data, []byte("\n\n")); i >= 0 {
+		return i + 2, data[:i], nil
+	}
+	if i := bytes.Index(data, []byte("\r\n\r\n")); i >= 0 {
+		return i + 4, data[:i], nil
+	}
+	if atEOF {
+		return len(data), bytes.TrimRight(data, "\r\n"), nil
+	}
+	return 0, nil, nil
+}

--- a/model/wire/responses/stream_accumulator.go
+++ b/model/wire/responses/stream_accumulator.go
@@ -1,0 +1,429 @@
+package responses
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Accumulator builds a Response from a Responses event stream.
+//
+// Per the API contract, response.completed (and the other terminal
+// lifecycle events) carry the full final Response object. The
+// accumulator promotes that to the terminal state when seen and
+// Final returns it directly. As a fallback for streams that
+// terminate without a lifecycle event (server-side cut, body
+// truncation, etc.), the accumulator builds an incremental Response
+// from the per-item / per-delta events so partial-stream callers
+// still get something usable.
+//
+// Accumulator is NOT safe for concurrent use; one goroutine drives
+// one stream.
+type Accumulator struct {
+	final *Response
+
+	// incremental state — used when no terminal lifecycle event
+	// arrives. Items are keyed by output_index; delta accumulation
+	// happens on the slot's content/summary/arguments fields.
+	items map[int]*OutputItem
+}
+
+// NewAccumulator constructs a fresh Accumulator.
+func NewAccumulator() *Accumulator {
+	return &Accumulator{
+		items: make(map[int]*OutputItem),
+	}
+}
+
+// Add merges one Event into the accumulator. Errors are returned
+// for malformed events (e.g. delta with no output_index) so callers
+// can decide whether to halt the stream or skip; the recommended
+// behavior for the agentic-model adapter layer is to log + skip
+// since the Responses API itself promises well-formed events under
+// normal conditions.
+func (a *Accumulator) Add(ev *Event) error {
+	if ev == nil {
+		return errors.New("responses: nil event")
+	}
+	switch ev.Type {
+	case EventTypeResponseCompleted,
+		EventTypeResponseFailed,
+		EventTypeResponseCancelled,
+		EventTypeResponseIncomplete:
+		// Terminal lifecycle: snapshot the full response.
+		if ev.Response != nil {
+			a.final = ev.Response
+		}
+		return nil
+
+	case EventTypeResponseCreated, EventTypeResponseInProgress:
+		// Pre-terminal lifecycle: carry forward the response shell so
+		// metadata (id, model, status) is populated even if no
+		// terminal event arrives.
+		if ev.Response != nil && a.final == nil {
+			a.final = ev.Response
+		}
+		return nil
+
+	case EventTypeOutputItemAdded:
+		return a.handleOutputItemAdded(ev)
+
+	case EventTypeOutputItemDone:
+		return a.handleOutputItemDone(ev)
+
+	case EventTypeContentPartAdded:
+		return a.handleContentPartAdded(ev)
+
+	case EventTypeContentPartDone:
+		return a.handleContentPartDone(ev)
+
+	case EventTypeOutputTextDelta:
+		return a.handleTextDelta(ev, ev.Delta, false)
+
+	case EventTypeOutputTextDone:
+		return a.handleTextDone(ev, ev.Text, false)
+
+	case EventTypeRefusalDelta:
+		return a.handleTextDelta(ev, ev.Delta, true)
+
+	case EventTypeRefusalDone:
+		return a.handleTextDone(ev, ev.Refusal, true)
+
+	case EventTypeFunctionCallArgumentsDelta:
+		return a.handleArgsDelta(ev)
+
+	case EventTypeFunctionCallArgumentsDone:
+		return a.handleArgsDone(ev)
+
+	case EventTypeReasoningSummaryPartAdded:
+		return a.handleSummaryPartAdded(ev)
+
+	case EventTypeReasoningSummaryPartDone:
+		return a.handleSummaryPartDone(ev)
+
+	case EventTypeReasoningSummaryTextDelta:
+		return a.handleSummaryTextDelta(ev)
+
+	case EventTypeReasoningSummaryTextDone:
+		return a.handleSummaryTextDone(ev)
+
+	case EventTypeError:
+		// Errors aren't merged into Response state; callers detect
+		// them via the Event and decide how to surface. The stream
+		// typically follows with a terminal failed event anyway.
+		return nil
+
+	default:
+		// Forward-compat: unknown event types are ignored so a
+		// future API extension doesn't break old clients.
+		return nil
+	}
+}
+
+// Final returns the accumulated Response. Prefers the terminal
+// lifecycle snapshot when present; falls back to the incrementally-
+// assembled Response built from item/delta events. Returns nil if
+// no relevant events were seen.
+func (a *Accumulator) Final() *Response {
+	if a.final != nil {
+		// If we have items accumulated incrementally that the
+		// lifecycle snapshot did not carry (truncated server-side
+		// final), merge them in. Common case: final.Output is
+		// fully-populated and items is a subset — preferring final.
+		if len(a.final.Output) == 0 && len(a.items) > 0 {
+			a.final.Output = a.snapshotItems()
+		}
+		return a.final
+	}
+	if len(a.items) == 0 {
+		return nil
+	}
+	return &Response{
+		Status: "incomplete",
+		Output: a.snapshotItems(),
+	}
+}
+
+// snapshotItems materializes the incremental items map into an
+// output_index-sorted slice. Stable order matters for replay /
+// trace consumers.
+func (a *Accumulator) snapshotItems() []OutputItem {
+	indices := make([]int, 0, len(a.items))
+	for idx := range a.items {
+		indices = append(indices, idx)
+	}
+	sort.Ints(indices)
+	out := make([]OutputItem, len(indices))
+	for i, idx := range indices {
+		out[i] = *a.items[idx]
+	}
+	return out
+}
+
+// requireOutputIndex returns *ev.OutputIndex or an error. Centralizes
+// the nil-check across many handlers.
+func requireOutputIndex(ev *Event, eventType string) (int, error) {
+	if ev.OutputIndex == nil {
+		return 0, fmt.Errorf("responses: %s missing output_index", eventType)
+	}
+	return *ev.OutputIndex, nil
+}
+
+// itemAt returns the OutputItem at output_index, creating a stub
+// keyed by item_id if absent. The stub is enough to absorb delta
+// events that arrive before the output_item.added carrier.
+func (a *Accumulator) itemAt(idx int, itemID string) *OutputItem {
+	if cur, ok := a.items[idx]; ok {
+		return cur
+	}
+	cur := &OutputItem{ID: itemID}
+	a.items[idx] = cur
+	return cur
+}
+
+func (a *Accumulator) handleOutputItemAdded(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "output_item.added")
+	if err != nil {
+		return err
+	}
+	if ev.Item == nil {
+		return errors.New("responses: output_item.added missing item")
+	}
+	item := *ev.Item
+	a.items[idx] = &item
+	return nil
+}
+
+func (a *Accumulator) handleOutputItemDone(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "output_item.done")
+	if err != nil {
+		return err
+	}
+	if ev.Item == nil {
+		return errors.New("responses: output_item.done missing item")
+	}
+	item := *ev.Item
+	a.items[idx] = &item
+	return nil
+}
+
+func (a *Accumulator) handleContentPartAdded(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "content_part.added")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	part, err := ev.ContentPart()
+	if err != nil {
+		return err
+	}
+	cur.Content = appendAtIndex(cur.Content, ev.ContentIndex, *part)
+	return nil
+}
+
+func (a *Accumulator) handleContentPartDone(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "content_part.done")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	part, err := ev.ContentPart()
+	if err != nil {
+		return err
+	}
+	cur.Content = setAtIndex(cur.Content, ev.ContentIndex, *part)
+	return nil
+}
+
+// handleTextDelta merges a partial text/refusal delta into the
+// addressed content part. refusal=true routes to ContentPart.Refusal;
+// otherwise to .Text.
+func (a *Accumulator) handleTextDelta(ev *Event, delta string, refusal bool) error {
+	idx, err := requireOutputIndex(ev, "text/refusal.delta")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	ci := indexOrZero(ev.ContentIndex)
+	cur.Content = ensureSize(cur.Content, ci+1)
+	if refusal {
+		cur.Content[ci].Type = ContentTypeRefusal
+		cur.Content[ci].Refusal += delta
+	} else {
+		cur.Content[ci].Type = ContentTypeOutputText
+		cur.Content[ci].Text += delta
+	}
+	return nil
+}
+
+// handleTextDone snapshots the final text on the addressed content
+// part. The done text replaces (not appends to) accumulated deltas
+// per the API contract.
+func (a *Accumulator) handleTextDone(ev *Event, text string, refusal bool) error {
+	idx, err := requireOutputIndex(ev, "text/refusal.done")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	ci := indexOrZero(ev.ContentIndex)
+	cur.Content = ensureSize(cur.Content, ci+1)
+	if refusal {
+		cur.Content[ci].Type = ContentTypeRefusal
+		cur.Content[ci].Refusal = text
+	} else {
+		cur.Content[ci].Type = ContentTypeOutputText
+		cur.Content[ci].Text = text
+	}
+	return nil
+}
+
+func (a *Accumulator) handleArgsDelta(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "function_call_arguments.delta")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	cur.Type = ItemTypeFunctionCall
+	var b strings.Builder
+	b.WriteString(cur.Arguments)
+	b.WriteString(ev.Delta)
+	cur.Arguments = b.String()
+	return nil
+}
+
+func (a *Accumulator) handleArgsDone(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "function_call_arguments.done")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	cur.Type = ItemTypeFunctionCall
+	cur.Arguments = ev.Arguments
+	return nil
+}
+
+func (a *Accumulator) handleSummaryPartAdded(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "reasoning_summary_part.added")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	cur.Type = ItemTypeReasoning
+	part, err := ev.SummaryPart()
+	if err != nil {
+		return err
+	}
+	cur.Summary = appendSummaryAtIndex(cur.Summary, ev.SummaryIndex, *part)
+	return nil
+}
+
+func (a *Accumulator) handleSummaryPartDone(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "reasoning_summary_part.done")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	cur.Type = ItemTypeReasoning
+	part, err := ev.SummaryPart()
+	if err != nil {
+		return err
+	}
+	cur.Summary = setSummaryAtIndex(cur.Summary, ev.SummaryIndex, *part)
+	return nil
+}
+
+func (a *Accumulator) handleSummaryTextDelta(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "reasoning_summary_text.delta")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	cur.Type = ItemTypeReasoning
+	si := indexOrZero(ev.SummaryIndex)
+	cur.Summary = ensureSummarySize(cur.Summary, si+1)
+	cur.Summary[si].Type = SummaryTypeText
+	cur.Summary[si].Text += ev.Delta
+	return nil
+}
+
+func (a *Accumulator) handleSummaryTextDone(ev *Event) error {
+	idx, err := requireOutputIndex(ev, "reasoning_summary_text.done")
+	if err != nil {
+		return err
+	}
+	cur := a.itemAt(idx, ev.ItemID)
+	cur.Type = ItemTypeReasoning
+	si := indexOrZero(ev.SummaryIndex)
+	cur.Summary = ensureSummarySize(cur.Summary, si+1)
+	cur.Summary[si].Type = SummaryTypeText
+	cur.Summary[si].Text = ev.Text
+	return nil
+}
+
+// indexOrZero returns *p or 0 when p is nil. Used for delta events
+// where the content_index/summary_index is technically optional but
+// the slot defaults to 0 in practice.
+func indexOrZero(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}
+
+// ensureSize grows the content slice to at least n entries, filling
+// new slots with the zero-value ContentPart so direct indexing is
+// safe.
+func ensureSize(parts []ContentPart, n int) []ContentPart {
+	for len(parts) < n {
+		parts = append(parts, ContentPart{})
+	}
+	return parts
+}
+
+// ensureSummarySize is ensureSize for the SummaryPart slice.
+func ensureSummarySize(parts []SummaryPart, n int) []SummaryPart {
+	for len(parts) < n {
+		parts = append(parts, SummaryPart{})
+	}
+	return parts
+}
+
+// appendAtIndex sets parts[idx] = p, growing the slice as needed.
+// When idx is nil the part is appended at len(parts).
+func appendAtIndex(parts []ContentPart, idx *int, p ContentPart) []ContentPart {
+	i := indexOrZero(idx)
+	if idx == nil {
+		i = len(parts)
+	}
+	parts = ensureSize(parts, i+1)
+	parts[i] = p
+	return parts
+}
+
+// setAtIndex replaces parts[idx] with p, growing the slice as needed.
+func setAtIndex(parts []ContentPart, idx *int, p ContentPart) []ContentPart {
+	i := indexOrZero(idx)
+	parts = ensureSize(parts, i+1)
+	parts[i] = p
+	return parts
+}
+
+// appendSummaryAtIndex is appendAtIndex for the SummaryPart slice.
+func appendSummaryAtIndex(parts []SummaryPart, idx *int, p SummaryPart) []SummaryPart {
+	i := indexOrZero(idx)
+	if idx == nil {
+		i = len(parts)
+	}
+	parts = ensureSummarySize(parts, i+1)
+	parts[i] = p
+	return parts
+}
+
+// setSummaryAtIndex is setAtIndex for the SummaryPart slice.
+func setSummaryAtIndex(parts []SummaryPart, idx *int, p SummaryPart) []SummaryPart {
+	i := indexOrZero(idx)
+	parts = ensureSummarySize(parts, i+1)
+	parts[i] = p
+	return parts
+}

--- a/model/wire/responses/stream_test.go
+++ b/model/wire/responses/stream_test.go
@@ -1,0 +1,601 @@
+package responses_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/model/wire/responses"
+)
+
+// TestEvent_RoundTrip pins that the Event struct decodes the
+// documented Responses event shapes and re-encodes back to
+// equivalent JSON. Doc-derived; live-fixture parity gate is in
+// types_test.go.
+func TestEvent_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload string
+		check   func(t *testing.T, ev *responses.Event)
+	}{
+		{
+			name: "response.created",
+			payload: `{
+				"type":"response.created",
+				"sequence_number":0,
+				"response":{"id":"resp_1","object":"response","model":"gpt-5.5","status":"in_progress","output":[]}
+			}`,
+			check: func(t *testing.T, ev *responses.Event) {
+				if ev.Type != responses.EventTypeResponseCreated {
+					t.Errorf("Type = %q, want %q", ev.Type, responses.EventTypeResponseCreated)
+				}
+				if ev.Response == nil || ev.Response.ID != "resp_1" {
+					t.Errorf("Response not decoded; got %+v", ev.Response)
+				}
+			},
+		},
+		{
+			name: "response.output_item.added (message)",
+			payload: `{
+				"type":"response.output_item.added",
+				"sequence_number":3,
+				"output_index":0,
+				"item":{"type":"message","id":"msg_1","role":"assistant","status":"in_progress"}
+			}`,
+			check: func(t *testing.T, ev *responses.Event) {
+				if ev.OutputIndex == nil || *ev.OutputIndex != 0 {
+					t.Errorf("OutputIndex = %v, want 0", ev.OutputIndex)
+				}
+				if ev.Item == nil || !ev.Item.IsMessage() {
+					t.Errorf("Item not decoded as message; got %+v", ev.Item)
+				}
+			},
+		},
+		{
+			name: "response.content_part.added",
+			payload: `{
+				"type":"response.content_part.added",
+				"sequence_number":4,
+				"item_id":"msg_1",
+				"output_index":0,
+				"content_index":0,
+				"part":{"type":"output_text","text":""}
+			}`,
+			check: func(t *testing.T, ev *responses.Event) {
+				cp, err := ev.ContentPart()
+				if err != nil {
+					t.Fatalf("ContentPart: %v", err)
+				}
+				if cp.Type != responses.ContentTypeOutputText {
+					t.Errorf("ContentPart.Type = %q, want %q", cp.Type, responses.ContentTypeOutputText)
+				}
+			},
+		},
+		{
+			name: "response.output_text.delta",
+			payload: `{
+				"type":"response.output_text.delta",
+				"sequence_number":5,
+				"item_id":"msg_1",
+				"output_index":0,
+				"content_index":0,
+				"delta":"Hello "
+			}`,
+			check: func(t *testing.T, ev *responses.Event) {
+				if ev.Delta != "Hello " {
+					t.Errorf("Delta = %q, want %q", ev.Delta, "Hello ")
+				}
+			},
+		},
+		{
+			name: "response.function_call_arguments.delta",
+			payload: `{
+				"type":"response.function_call_arguments.delta",
+				"sequence_number":6,
+				"item_id":"fc_1",
+				"output_index":1,
+				"delta":"{\"a\":17"
+			}`,
+			check: func(t *testing.T, ev *responses.Event) {
+				if ev.Delta != `{"a":17` {
+					t.Errorf("Delta = %q, want %q", ev.Delta, `{"a":17`)
+				}
+			},
+		},
+		{
+			name: "response.reasoning_summary_text.delta",
+			payload: `{
+				"type":"response.reasoning_summary_text.delta",
+				"sequence_number":2,
+				"item_id":"rs_1",
+				"output_index":0,
+				"summary_index":0,
+				"delta":"considering "
+			}`,
+			check: func(t *testing.T, ev *responses.Event) {
+				if ev.Delta != "considering " {
+					t.Errorf("Delta = %q, want %q", ev.Delta, "considering ")
+				}
+				if ev.SummaryIndex == nil || *ev.SummaryIndex != 0 {
+					t.Errorf("SummaryIndex = %v, want 0", ev.SummaryIndex)
+				}
+			},
+		},
+		{
+			name: "response.reasoning_summary_part.added",
+			payload: `{
+				"type":"response.reasoning_summary_part.added",
+				"sequence_number":1,
+				"item_id":"rs_1",
+				"output_index":0,
+				"summary_index":0,
+				"part":{"type":"summary_text","text":""}
+			}`,
+			check: func(t *testing.T, ev *responses.Event) {
+				sp, err := ev.SummaryPart()
+				if err != nil {
+					t.Fatalf("SummaryPart: %v", err)
+				}
+				if sp.Type != responses.SummaryTypeText {
+					t.Errorf("SummaryPart.Type = %q, want %q", sp.Type, responses.SummaryTypeText)
+				}
+			},
+		},
+		{
+			name: "response.completed",
+			payload: `{
+				"type":"response.completed",
+				"sequence_number":99,
+				"response":{"id":"resp_1","object":"response","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hello world"}]}],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}
+			}`,
+			check: func(t *testing.T, ev *responses.Event) {
+				if ev.Response == nil || ev.Response.Status != "completed" {
+					t.Fatalf("Response not decoded; got %+v", ev.Response)
+				}
+				if len(ev.Response.Output) != 1 {
+					t.Errorf("Output count = %d, want 1", len(ev.Response.Output))
+				}
+			},
+		},
+		{
+			name: "error",
+			payload: `{
+				"type":"error",
+				"sequence_number":1,
+				"error":{"type":"rate_limit","code":"rate_limit_exceeded","message":"slow down"}
+			}`,
+			check: func(t *testing.T, ev *responses.Event) {
+				ae, err := ev.APIError()
+				if err != nil {
+					t.Fatalf("APIError: %v", err)
+				}
+				if ae.Code != "rate_limit_exceeded" {
+					t.Errorf("APIError.Code = %q, want rate_limit_exceeded", ae.Code)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ev responses.Event
+			if err := json.Unmarshal([]byte(tc.payload), &ev); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			tc.check(t, &ev)
+			// Re-encode, decode again, confirm Type stable.
+			b, err := json.Marshal(ev)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var roundtrip responses.Event
+			if err := json.Unmarshal(b, &roundtrip); err != nil {
+				t.Fatalf("re-decode: %v", err)
+			}
+			if roundtrip.Type != ev.Type {
+				t.Errorf("Type drift: original=%q roundtrip=%q", ev.Type, roundtrip.Type)
+			}
+		})
+	}
+}
+
+// TestEvent_HelperWrongType pins that ContentPart/SummaryPart/
+// APIError refuse to decode against the wrong event Type, returning
+// a clear error rather than silently producing garbage.
+func TestEvent_HelperWrongType(t *testing.T) {
+	ev := &responses.Event{Type: responses.EventTypeOutputTextDelta, Part: json.RawMessage(`{}`)}
+	if _, err := ev.ContentPart(); err == nil {
+		t.Error("ContentPart on wrong type: expected error, got nil")
+	}
+	if _, err := ev.SummaryPart(); err == nil {
+		t.Error("SummaryPart on wrong type: expected error, got nil")
+	}
+	if _, err := ev.APIError(); err == nil {
+		t.Error("APIError on wrong type: expected error, got nil")
+	}
+}
+
+// TestEvent_UnknownTypeForwardCompat pins that an event with an
+// unknown Type decodes without error and the unknown fields
+// (if any) end up zero — the caller can iterate forward without
+// the stream halting. Future API extensions stay non-breaking.
+func TestEvent_UnknownTypeForwardCompat(t *testing.T) {
+	payload := `{"type":"response.future_thing.added","sequence_number":42,"something_new":"ignored"}`
+	var ev responses.Event
+	if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if ev.Type != "response.future_thing.added" {
+		t.Errorf("Type = %q, want response.future_thing.added", ev.Type)
+	}
+	if ev.SequenceNumber != 42 {
+		t.Errorf("SequenceNumber = %d, want 42", ev.SequenceNumber)
+	}
+}
+
+// TestStream_DrivesCannedSSE pins the wire-level parser: a body
+// containing canned SSE frames decodes into the corresponding Events
+// in order and EOFs at end of body.
+func TestStream_DrivesCannedSSE(t *testing.T) {
+	body := strings.Join([]string{
+		"event: response.created",
+		`data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_1","object":"response","model":"gpt-5.5","status":"in_progress","output":[]}}`,
+		"",
+		"event: response.output_text.delta",
+		`data: {"type":"response.output_text.delta","sequence_number":1,"item_id":"msg_1","output_index":0,"content_index":0,"delta":"Hi"}`,
+		"",
+		"event: response.completed",
+		`data: {"type":"response.completed","sequence_number":2,"response":{"id":"resp_1","object":"response","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hi"}]}],"usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}`,
+		"",
+	}, "\n")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	c, err := responses.NewClient(responses.ClientConfig{
+		BaseURL:    srv.URL + "/v1",
+		HTTPClient: srv.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	stream, err := c.ResponsesStream(context.Background(), &responses.Request{Model: "gpt-5.5"})
+	if err != nil {
+		t.Fatalf("ResponsesStream: %v", err)
+	}
+	defer stream.Close()
+
+	var events []*responses.Event
+	for {
+		ev, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		events = append(events, ev)
+	}
+	wantTypes := []string{
+		responses.EventTypeResponseCreated,
+		responses.EventTypeOutputTextDelta,
+		responses.EventTypeResponseCompleted,
+	}
+	if len(events) != len(wantTypes) {
+		t.Fatalf("event count = %d, want %d", len(events), len(wantTypes))
+	}
+	for i, ev := range events {
+		if ev.Type != wantTypes[i] {
+			t.Errorf("events[%d].Type = %q, want %q", i, ev.Type, wantTypes[i])
+		}
+	}
+}
+
+// TestStream_APIErrorOnNon2xx pins that ResponsesStream returns
+// *APIError on non-2xx, with the stream nil, matching the
+// ChatCompletionStream contract.
+func TestStream_APIErrorOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"type":"rate_limit","code":"rate_limit_exceeded","message":"slow down"}}`)
+	}))
+	defer srv.Close()
+
+	c, _ := responses.NewClient(responses.ClientConfig{
+		BaseURL:    srv.URL + "/v1",
+		HTTPClient: srv.Client(),
+	})
+	stream, err := c.ResponsesStream(context.Background(), &responses.Request{Model: "gpt-5.5"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if stream != nil {
+		t.Error("expected nil stream on error")
+	}
+	var apiErr *responses.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 429 {
+		t.Errorf("StatusCode = %d, want 429", apiErr.StatusCode)
+	}
+}
+
+// TestStream_NilRequest pins the explicit nil-request guard.
+func TestStream_NilRequest(t *testing.T) {
+	c, _ := responses.NewClient(responses.ClientConfig{
+		BaseURL:    "http://unused",
+		HTTPClient: http.DefaultClient,
+	})
+	if _, err := c.ResponsesStream(context.Background(), nil); err == nil {
+		t.Error("expected error on nil request, got nil")
+	}
+}
+
+// TestAccumulator_BuildsFromDeltas pins the accumulator's incremental
+// fallback: a stream of output_text.delta events without a terminal
+// lifecycle event still yields a usable Response with accumulated
+// text in the right slots.
+func TestAccumulator_BuildsFromDeltas(t *testing.T) {
+	acc := responses.NewAccumulator()
+
+	idx0 := 0
+	cidx0 := 0
+	msgItem := responses.OutputItem{
+		Type: responses.ItemTypeMessage,
+		ID:   "msg_1",
+		Role: responses.RoleAssistant,
+	}
+	emptyTextPart := json.RawMessage(`{"type":"output_text","text":""}`)
+
+	events := []*responses.Event{
+		{
+			Type:        responses.EventTypeOutputItemAdded,
+			OutputIndex: &idx0,
+			Item:        &msgItem,
+		},
+		{
+			Type:         responses.EventTypeContentPartAdded,
+			ItemID:       "msg_1",
+			OutputIndex:  &idx0,
+			ContentIndex: &cidx0,
+			Part:         emptyTextPart,
+		},
+		{
+			Type:         responses.EventTypeOutputTextDelta,
+			ItemID:       "msg_1",
+			OutputIndex:  &idx0,
+			ContentIndex: &cidx0,
+			Delta:        "Hello ",
+		},
+		{
+			Type:         responses.EventTypeOutputTextDelta,
+			ItemID:       "msg_1",
+			OutputIndex:  &idx0,
+			ContentIndex: &cidx0,
+			Delta:        "world",
+		},
+	}
+	for _, ev := range events {
+		if err := acc.Add(ev); err != nil {
+			t.Fatalf("Add(%s): %v", ev.Type, err)
+		}
+	}
+	resp := acc.Final()
+	if resp == nil {
+		t.Fatal("Final() returned nil")
+	}
+	if resp.Status != "incomplete" {
+		t.Errorf("Status = %q, want incomplete (no terminal event)", resp.Status)
+	}
+	if len(resp.Output) != 1 {
+		t.Fatalf("Output count = %d, want 1", len(resp.Output))
+	}
+	got := resp.Output[0].OutputText()
+	if got != "Hello world" {
+		t.Errorf("OutputText = %q, want %q", got, "Hello world")
+	}
+}
+
+// TestAccumulator_TerminalLifecyclePromotes pins that a
+// response.completed event with a fully-populated Response is
+// returned by Final regardless of prior incremental state.
+func TestAccumulator_TerminalLifecyclePromotes(t *testing.T) {
+	acc := responses.NewAccumulator()
+
+	final := &responses.Response{
+		ID:     "resp_x",
+		Model:  "gpt-5.5",
+		Status: "completed",
+		Output: []responses.OutputItem{
+			{
+				Type: responses.ItemTypeMessage,
+				ID:   "msg_x",
+				Role: responses.RoleAssistant,
+				Content: []responses.ContentPart{
+					{Type: responses.ContentTypeOutputText, Text: "final answer"},
+				},
+			},
+		},
+	}
+	if err := acc.Add(&responses.Event{
+		Type:     responses.EventTypeResponseCompleted,
+		Response: final,
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	got := acc.Final()
+	if got == nil {
+		t.Fatal("Final() nil")
+	}
+	if got.ID != "resp_x" || got.Status != "completed" {
+		t.Errorf("Final response not promoted; got %+v", got)
+	}
+	if got.Output[0].OutputText() != "final answer" {
+		t.Errorf("OutputText = %q, want final answer", got.Output[0].OutputText())
+	}
+}
+
+// TestAccumulator_BuildsFunctionCall pins that streaming
+// function_call_arguments deltas accumulate into the OutputItem's
+// Arguments string, and an output_item.added carrier sets the
+// Type/CallID/Name before deltas arrive.
+func TestAccumulator_BuildsFunctionCall(t *testing.T) {
+	acc := responses.NewAccumulator()
+
+	idx1 := 1
+	fcItem := responses.OutputItem{
+		Type:   responses.ItemTypeFunctionCall,
+		ID:     "fc_1",
+		CallID: "call_abc",
+		Name:   "multiply",
+	}
+	events := []*responses.Event{
+		{
+			Type:        responses.EventTypeOutputItemAdded,
+			OutputIndex: &idx1,
+			Item:        &fcItem,
+		},
+		{
+			Type:        responses.EventTypeFunctionCallArgumentsDelta,
+			ItemID:      "fc_1",
+			OutputIndex: &idx1,
+			Delta:       `{"a":17,`,
+		},
+		{
+			Type:        responses.EventTypeFunctionCallArgumentsDelta,
+			ItemID:      "fc_1",
+			OutputIndex: &idx1,
+			Delta:       `"b":23}`,
+		},
+	}
+	for _, ev := range events {
+		if err := acc.Add(ev); err != nil {
+			t.Fatalf("Add(%s): %v", ev.Type, err)
+		}
+	}
+	resp := acc.Final()
+	if resp == nil || len(resp.Output) != 1 {
+		t.Fatalf("Final() did not yield 1 output item; got %+v", resp)
+	}
+	item := resp.Output[0]
+	if !item.IsFunctionCall() {
+		t.Errorf("item.Type = %q, want function_call", item.Type)
+	}
+	if item.CallID != "call_abc" {
+		t.Errorf("CallID = %q, want call_abc", item.CallID)
+	}
+	if item.Name != "multiply" {
+		t.Errorf("Name = %q, want multiply", item.Name)
+	}
+	if item.Arguments != `{"a":17,"b":23}` {
+		t.Errorf("Arguments = %q, want %q", item.Arguments, `{"a":17,"b":23}`)
+	}
+}
+
+// TestAccumulator_BuildsReasoningSummary pins reasoning summary
+// streaming: summary_part.added + summary_text.delta accumulate
+// into the item's Summary array.
+func TestAccumulator_BuildsReasoningSummary(t *testing.T) {
+	acc := responses.NewAccumulator()
+
+	idx0 := 0
+	sidx0 := 0
+	rsItem := responses.OutputItem{
+		Type:             responses.ItemTypeReasoning,
+		ID:               "rs_1",
+		EncryptedContent: "opaque-blob",
+	}
+	emptySummaryPart := json.RawMessage(`{"type":"summary_text","text":""}`)
+	events := []*responses.Event{
+		{
+			Type:        responses.EventTypeOutputItemAdded,
+			OutputIndex: &idx0,
+			Item:        &rsItem,
+		},
+		{
+			Type:         responses.EventTypeReasoningSummaryPartAdded,
+			ItemID:       "rs_1",
+			OutputIndex:  &idx0,
+			SummaryIndex: &sidx0,
+			Part:         emptySummaryPart,
+		},
+		{
+			Type:         responses.EventTypeReasoningSummaryTextDelta,
+			ItemID:       "rs_1",
+			OutputIndex:  &idx0,
+			SummaryIndex: &sidx0,
+			Delta:        "considering ",
+		},
+		{
+			Type:         responses.EventTypeReasoningSummaryTextDelta,
+			ItemID:       "rs_1",
+			OutputIndex:  &idx0,
+			SummaryIndex: &sidx0,
+			Delta:        "multiplication",
+		},
+	}
+	for _, ev := range events {
+		if err := acc.Add(ev); err != nil {
+			t.Fatalf("Add(%s): %v", ev.Type, err)
+		}
+	}
+	resp := acc.Final()
+	if resp == nil || len(resp.Output) != 1 {
+		t.Fatalf("Final() did not yield 1 output item; got %+v", resp)
+	}
+	item := resp.Output[0]
+	if !item.IsReasoning() {
+		t.Errorf("item.Type = %q, want reasoning", item.Type)
+	}
+	if item.EncryptedContent != "opaque-blob" {
+		t.Errorf("EncryptedContent = %q, want opaque-blob", item.EncryptedContent)
+	}
+	if len(item.Summary) != 1 {
+		t.Fatalf("Summary count = %d, want 1", len(item.Summary))
+	}
+	if item.Summary[0].Text != "considering multiplication" {
+		t.Errorf("Summary[0].Text = %q, want %q", item.Summary[0].Text, "considering multiplication")
+	}
+}
+
+// TestAccumulator_RejectsNilAndMissingFields pins the
+// programming-error guards.
+func TestAccumulator_RejectsNilAndMissingFields(t *testing.T) {
+	acc := responses.NewAccumulator()
+	if err := acc.Add(nil); err == nil {
+		t.Error("Add(nil): expected error, got nil")
+	}
+	// Delta event without output_index — accumulator can't slot the
+	// delta, must error.
+	if err := acc.Add(&responses.Event{
+		Type:  responses.EventTypeOutputTextDelta,
+		Delta: "X",
+	}); err == nil {
+		t.Error("output_text.delta without output_index: expected error, got nil")
+	}
+}
+
+// TestClient_Responses_StreamingRejected stays as a regression guard
+// — the non-streaming Responses() method must reject req.Stream=true
+// to make the misuse loud.
+func TestClient_Responses_StreamingRejected(t *testing.T) {
+	c, _ := responses.NewClient(responses.ClientConfig{
+		BaseURL:    "http://unused",
+		HTTPClient: http.DefaultClient,
+	})
+	_, err := c.Responses(context.Background(), &responses.Request{
+		Model:  "gpt-5.5",
+		Stream: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "use ResponsesStream") {
+		t.Errorf("expected streaming-rejected error, got %v", err)
+	}
+}

--- a/model/wire/responses/testdata/README.md
+++ b/model/wire/responses/testdata/README.md
@@ -1,0 +1,51 @@
+# Responses wire-format fixtures
+
+This directory holds golden JSON fixtures captured from live OpenAI
+`/v1/responses` calls. They back the round-trip parity tests in
+`types_test.go` and `client_test.go` so wire-shape regressions get
+caught at unit-test speed without paying for an API call each run.
+
+## Fixture inventory (target)
+
+The Phase 1 doc-derived round-trip tests cover the request/response
+shapes from public OpenAI documentation. The live fixtures land
+during the Phase 4 PR cycle once
+`openai_responses_live_test.go` is wired (the same test that hits
+the live endpoint also harvests fixtures here on the first
+run). Until then, the parity test for live shapes is stubbed and
+skipped — see `types_test.go::TestResponses_GoldenFixture_Parity`.
+
+Target fixtures (filenames stable):
+
+- `request_simple_text.json` — minimal request with a single
+  user message.
+- `request_function_call_round.json` — request echoing a prior
+  function_call + function_call_output + reasoning items.
+- `response_simple_text.json` — minimal response with a single
+  message output item.
+- `response_function_call_with_reasoning.json` — response with
+  reasoning item + function_call item (tool flow).
+- `response_completed_text.json` — full response with usage +
+  reasoning details.
+
+## Capture protocol
+
+When PR 4 lands, run:
+
+```
+go test -tags live_llm -run TestOpenAIResponses_CaptureFixtures \
+    ./processor/agentic-model/...
+```
+
+with `OPENAI_API_KEY` set. The test issues a small set of canned
+calls against both a Codex-class model and a GPT-5.5/o-series model,
+serializes the wire request and response bodies, and writes them to
+this directory. Re-run is idempotent — existing files are not
+overwritten unless `CAPTURE_OVERWRITE=1` is set.
+
+## Provenance
+
+Fixtures are committed verbatim from live endpoints. Capture commit
+SHA is recorded alongside each file in a sibling `.meta` file
+(written by the capture test) for traceability when OpenAI evolves
+the wire shape.

--- a/model/wire/responses/types_items.go
+++ b/model/wire/responses/types_items.go
@@ -1,6 +1,9 @@
 package responses
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+)
 
 // InputItem is the discriminated-union element of Request.Input.
 // The Type field selects the populated subset of fields. The closed
@@ -60,6 +63,45 @@ type InputItem struct {
 	// response. Possible values include "completed", "in_progress",
 	// "incomplete". Producers leave empty on items they construct.
 	Status string `json:"status,omitempty"`
+}
+
+// MarshalJSON ensures the `summary` field is always present on
+// reasoning input items even when the local slice is nil or empty.
+// The OpenAI Responses API rejects echoed reasoning items without
+// a summary field with HTTP 400 missing_required_parameter, even
+// though `[]` is acceptable. Caught by the ADR-051 PR 4 live
+// reasoning-echo test before tag.
+//
+// Non-reasoning items marshal through the default path (omitempty
+// honored on Summary).
+func (i InputItem) MarshalJSON() ([]byte, error) {
+	type alias InputItem
+	if i.Type != ItemTypeReasoning {
+		return json.Marshal(alias(i))
+	}
+	b, err := json.Marshal(alias(i))
+	if err != nil {
+		return nil, err
+	}
+	if bytes.Contains(b, []byte(`"summary"`)) {
+		return b, nil
+	}
+	// Inject `"summary":[]` before the closing brace.
+	idx := bytes.LastIndexByte(b, '}')
+	if idx < 0 {
+		return b, nil
+	}
+	var sep []byte
+	if idx > 1 {
+		sep = []byte(`,"summary":[]`)
+	} else {
+		sep = []byte(`"summary":[]`)
+	}
+	out := make([]byte, 0, len(b)+len(sep))
+	out = append(out, b[:idx]...)
+	out = append(out, sep...)
+	out = append(out, b[idx:]...)
+	return out, nil
 }
 
 // OutputItem is the discriminated-union element of Response.Output.

--- a/model/wire/responses/types_items.go
+++ b/model/wire/responses/types_items.go
@@ -1,0 +1,136 @@
+package responses
+
+import "encoding/json"
+
+// InputItem is the discriminated-union element of Request.Input.
+// The Type field selects the populated subset of fields. The closed
+// set for Phase 1: "message", "function_call", "function_call_output",
+// "reasoning". Unknown types decode without error (forward-compat)
+// and re-emit verbatim through their tagged fields.
+//
+// Producer convention: callers construct via the New* helpers
+// (NewInputMessage, NewInputFunctionCall, etc.) to avoid setting
+// incoherent field combinations.
+type InputItem struct {
+	// Type is the variant discriminator. Required.
+	Type string `json:"type"`
+
+	// ID echoes the provider-assigned identifier for items echoed
+	// from a prior response (reasoning, function_call). Optional on
+	// items the caller constructs locally.
+	ID string `json:"id,omitempty"`
+
+	// Role is set when Type == "message". Values: "user", "system",
+	// "developer", "assistant". The translator should emit "developer"
+	// for system-prompt-class messages on Responses (system → developer)
+	// per ADR-051 open question 2.
+	Role string `json:"role,omitempty"`
+
+	// Content is the typed content-parts array on message items.
+	Content []ContentPart `json:"content,omitempty"`
+
+	// CallID is the function-call correlation token shared between
+	// function_call (echo) and function_call_output items. Set on
+	// both types.
+	CallID string `json:"call_id,omitempty"`
+
+	// Name is the function name on function_call items.
+	Name string `json:"name,omitempty"`
+
+	// Arguments is the JSON-encoded arguments string on function_call
+	// items. Wire-shape mirrors ChatCompletion's
+	// tool_calls[].function.arguments — opaque string holding a JSON
+	// object.
+	Arguments string `json:"arguments,omitempty"`
+
+	// Output is the tool-result body on function_call_output items.
+	// Opaque string — typically a JSON-encoded object, but the API
+	// accepts any string the caller wants the model to consume.
+	Output string `json:"output,omitempty"`
+
+	// Summary is the reasoning summary on reasoning items. Carried
+	// as typed parts (mirror of the response shape).
+	Summary []SummaryPart `json:"summary,omitempty"`
+
+	// EncryptedContent is the opaque blob echoed on reasoning items
+	// in stateless mode. Treated as bytes; do not parse.
+	EncryptedContent string `json:"encrypted_content,omitempty"`
+
+	// Status is optionally present on items echoed from a prior
+	// response. Possible values include "completed", "in_progress",
+	// "incomplete". Producers leave empty on items they construct.
+	Status string `json:"status,omitempty"`
+}
+
+// OutputItem is the discriminated-union element of Response.Output.
+// Variant set parallels InputItem with output-side extensions:
+// "message" assistant replies, "function_call" tool calls,
+// "reasoning" emitted blobs.
+type OutputItem struct {
+	// Type is the variant discriminator. Required.
+	Type string `json:"type"`
+
+	// ID is the provider-assigned identifier. Required on all output
+	// items.
+	ID string `json:"id"`
+
+	// Status reports the item's lifecycle state. Common values:
+	// "completed", "in_progress", "incomplete".
+	Status string `json:"status,omitempty"`
+
+	// Role applies to message items. "assistant" in practice.
+	Role string `json:"role,omitempty"`
+
+	// Content is the typed content-parts array on message items.
+	Content []ContentPart `json:"content,omitempty"`
+
+	// CallID is the function-call correlation token. Set on
+	// function_call items.
+	CallID string `json:"call_id,omitempty"`
+
+	// Name is the function name on function_call items.
+	Name string `json:"name,omitempty"`
+
+	// Arguments is the JSON-encoded arguments string on function_call
+	// items.
+	Arguments string `json:"arguments,omitempty"`
+
+	// Summary is the reasoning summary on reasoning items.
+	Summary []SummaryPart `json:"summary,omitempty"`
+
+	// EncryptedContent is the opaque reasoning blob the API emits in
+	// stateless mode. The caller must echo it back verbatim on the
+	// next turn's InputItem to maintain reasoning continuity.
+	EncryptedContent string `json:"encrypted_content,omitempty"`
+}
+
+// ContentPart is a typed content element inside a message item.
+// Variants:
+//   - input_text: user-supplied text on InputItem messages
+//   - output_text: assistant text on OutputItem messages
+//   - refusal: assistant refusal text
+//
+// Input image/file/audio parts are out of scope for Phase 1.
+type ContentPart struct {
+	// Type is one of "input_text", "output_text", "refusal".
+	Type string `json:"type"`
+
+	// Text carries the body for text-class parts.
+	Text string `json:"text,omitempty"`
+
+	// Refusal carries the refusal body when Type == "refusal".
+	Refusal string `json:"refusal,omitempty"`
+
+	// Annotations are inline citations/URL refs the model may attach
+	// to output_text. Carried as RawMessage; this package does not
+	// model the shape, which has evolved across SDK versions.
+	Annotations json.RawMessage `json:"annotations,omitempty"`
+}
+
+// SummaryPart is one segment of a reasoning item's Summary array.
+// Today the only documented variant is type:"summary_text"; the
+// field set is open for future additions.
+type SummaryPart struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}

--- a/model/wire/responses/types_reasoning.go
+++ b/model/wire/responses/types_reasoning.go
@@ -1,0 +1,145 @@
+package responses
+
+// Variant-type constants. The Responses API discriminates polymorphic
+// items via a "type" string field; these constants name the values
+// this package recognizes in Phase 1.
+const (
+	// Input/output item types.
+	ItemTypeMessage            = "message"
+	ItemTypeFunctionCall       = "function_call"
+	ItemTypeFunctionCallOutput = "function_call_output"
+	ItemTypeReasoning          = "reasoning"
+
+	// Content-part types.
+	ContentTypeInputText  = "input_text"
+	ContentTypeOutputText = "output_text"
+	ContentTypeRefusal    = "refusal"
+
+	// Summary-part types.
+	SummaryTypeText = "summary_text"
+
+	// Role values on message items.
+	RoleUser      = "user"
+	RoleSystem    = "system"
+	RoleDeveloper = "developer"
+	RoleAssistant = "assistant"
+)
+
+// IsMessage reports whether the item is a message variant.
+func (i *InputItem) IsMessage() bool { return i != nil && i.Type == ItemTypeMessage }
+
+// IsFunctionCall reports whether the item is a function-call echo.
+func (i *InputItem) IsFunctionCall() bool { return i != nil && i.Type == ItemTypeFunctionCall }
+
+// IsFunctionCallOutput reports whether the item is a tool result.
+func (i *InputItem) IsFunctionCallOutput() bool {
+	return i != nil && i.Type == ItemTypeFunctionCallOutput
+}
+
+// IsReasoning reports whether the item is a reasoning echo.
+func (i *InputItem) IsReasoning() bool { return i != nil && i.Type == ItemTypeReasoning }
+
+// IsMessage reports whether the output item is a message.
+func (o *OutputItem) IsMessage() bool { return o != nil && o.Type == ItemTypeMessage }
+
+// IsFunctionCall reports whether the output item is a function call.
+func (o *OutputItem) IsFunctionCall() bool { return o != nil && o.Type == ItemTypeFunctionCall }
+
+// IsReasoning reports whether the output item is a reasoning blob.
+func (o *OutputItem) IsReasoning() bool { return o != nil && o.Type == ItemTypeReasoning }
+
+// NewInputUserMessage constructs a user-role message InputItem with a
+// single input_text content part. Convenience for the common case;
+// callers wanting multi-part content build the InputItem directly.
+func NewInputUserMessage(text string) InputItem {
+	return InputItem{
+		Type: ItemTypeMessage,
+		Role: RoleUser,
+		Content: []ContentPart{
+			{Type: ContentTypeInputText, Text: text},
+		},
+	}
+}
+
+// NewInputDeveloperMessage constructs a developer-role message
+// InputItem. Use this for system-prompt-class instructions per
+// ADR-051 open question 2 (system → developer translation on
+// Responses); pass system-prompt prose verbatim and let the adapter
+// pick this constructor.
+func NewInputDeveloperMessage(text string) InputItem {
+	return InputItem{
+		Type: ItemTypeMessage,
+		Role: RoleDeveloper,
+		Content: []ContentPart{
+			{Type: ContentTypeInputText, Text: text},
+		},
+	}
+}
+
+// NewInputFunctionCall constructs a function_call InputItem echoing
+// a prior assistant tool call. callID must match the call_id the
+// model emitted; arguments is the JSON-encoded arguments string.
+func NewInputFunctionCall(callID, name, arguments string) InputItem {
+	return InputItem{
+		Type:      ItemTypeFunctionCall,
+		CallID:    callID,
+		Name:      name,
+		Arguments: arguments,
+	}
+}
+
+// NewInputFunctionCallOutput constructs a function_call_output
+// InputItem carrying a tool result. callID correlates to the prior
+// function_call; output is the result body (typically JSON-encoded).
+func NewInputFunctionCallOutput(callID, output string) InputItem {
+	return InputItem{
+		Type:   ItemTypeFunctionCallOutput,
+		CallID: callID,
+		Output: output,
+	}
+}
+
+// NewInputReasoning constructs a reasoning InputItem echoing a prior
+// response's reasoning blob. id and encryptedContent must come
+// verbatim from the response item. The summary slice is optional —
+// pass nil to omit.
+func NewInputReasoning(id, encryptedContent string, summary []SummaryPart) InputItem {
+	return InputItem{
+		Type:             ItemTypeReasoning,
+		ID:               id,
+		EncryptedContent: encryptedContent,
+		Summary:          summary,
+	}
+}
+
+// OutputText returns the concatenation of output_text content parts
+// on a message OutputItem. Empty for non-message items or items
+// containing only refusals. Convenience helper for the common
+// "assistant said X" extraction; callers needing structured
+// annotations or refusal handling walk Content directly.
+func (o *OutputItem) OutputText() string {
+	if o == nil || !o.IsMessage() {
+		return ""
+	}
+	var buf string
+	for _, p := range o.Content {
+		if p.Type == ContentTypeOutputText {
+			buf += p.Text
+		}
+	}
+	return buf
+}
+
+// RefusalText returns the first refusal content part's body on a
+// message OutputItem, or "" if no refusal is present.
+func (o *OutputItem) RefusalText() string {
+	if o == nil || !o.IsMessage() {
+		return ""
+	}
+	for _, p := range o.Content {
+		if p.Type == ContentTypeRefusal {
+			return p.Refusal
+		}
+	}
+	return ""
+}

--- a/model/wire/responses/types_request.go
+++ b/model/wire/responses/types_request.go
@@ -1,0 +1,122 @@
+package responses
+
+import (
+	"encoding/json"
+)
+
+// Request is the POST /v1/responses request body. Phase 1 scope:
+// non-streaming, stateless (store=false), function-calling and
+// reasoning. Hosted tools and image inputs are out of scope.
+//
+// The Input field holds the heterogeneous typed array that replaces
+// ChatCompletion's messages array. See InputItem for the variant set.
+type Request struct {
+	// Model is the OpenAI model identifier, e.g. "gpt-5.5", "o4-mini",
+	// "codex-mini-latest".
+	Model string `json:"model"`
+
+	// Input is the heterogeneous input items array. Each element is a
+	// typed item (message, function_call echo, function_call_output,
+	// reasoning echo). See InputItem.
+	Input []InputItem `json:"input"`
+
+	// Instructions optionally pins a system-prompt-class instruction.
+	// Equivalent in role to ChatCompletion's "system" message but
+	// passed as a top-level field. Recommended for stable persona
+	// prose that doesn't belong inline with conversational input.
+	Instructions string `json:"instructions,omitempty"`
+
+	// Tools enumerates the function tools available to the model.
+	// Hosted tools (file_search, web_search_preview, etc.) are out of
+	// scope for Phase 1; future addition extends the Tool type with a
+	// discriminator.
+	Tools []Tool `json:"tools,omitempty"`
+
+	// ToolChoice controls tool-selection behavior. Accepts the same
+	// string values as ChatCompletion ("auto", "required", "none")
+	// or an object {"type":"function","name":"..."} forcing a
+	// specific tool. json.RawMessage carries the variant.
+	ToolChoice json.RawMessage `json:"tool_choice,omitempty"`
+
+	// Reasoning controls reasoning-effort and summary-emission for
+	// the o-series and GPT-5.5-class models. The Responses endpoint
+	// is the only endpoint where reasoning_effort combines with
+	// tool_choice on these model classes.
+	Reasoning *ReasoningParams `json:"reasoning,omitempty"`
+
+	// Text controls the output text format. The Responses API uses
+	// text.format here rather than the ChatCompletion top-level
+	// response_format. The two shapes are not 1:1; the adapter layer
+	// translates.
+	Text *TextParams `json:"text,omitempty"`
+
+	// Temperature, TopP, MaxOutputTokens carry the standard sampling
+	// controls. Names match the Responses API ("max_output_tokens",
+	// not "max_tokens" — the two endpoints differ).
+	Temperature     *float64 `json:"temperature,omitempty"`
+	TopP            *float64 `json:"top_p,omitempty"`
+	MaxOutputTokens int      `json:"max_output_tokens,omitempty"`
+
+	// Store enables OpenAI-side conversation state persistence.
+	// Stateless mode (store=false) is what this client uses per
+	// ADR-051 D2 — caller owns full history and echoes reasoning
+	// items per turn. The field is a pointer so the zero value is
+	// distinguishable from explicit-false (the API default is true).
+	Store *bool `json:"store,omitempty"`
+
+	// PreviousResponseID threads server-side state when Store=true.
+	// Unused in stateless mode; carried here for completeness.
+	PreviousResponseID string `json:"previous_response_id,omitempty"`
+
+	// Stream selects SSE streaming mode. Phase 1 client only supports
+	// false; streaming lands in Phase 2.
+	Stream bool `json:"stream,omitempty"`
+
+	// User is the optional end-user identifier for abuse monitoring,
+	// per OpenAI's documented usage.
+	User string `json:"user,omitempty"`
+
+	// Metadata is the optional operator-provided key/value pairs the
+	// API echoes back on the response. Capped at 16 keys, 64-char
+	// keys, 512-char values per OpenAI's docs.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// ReasoningParams configures reasoning behavior on o-series and
+// GPT-5.5-class models. Carried on both Request (input) and Response
+// (echo); the same shape applies in both directions.
+type ReasoningParams struct {
+	// Effort is "minimal", "low", "medium", or "high". Empty falls
+	// through to the model default.
+	Effort string `json:"effort,omitempty"`
+
+	// Summary controls reasoning summary emission. "auto", "concise",
+	// "detailed", or empty for none.
+	Summary string `json:"summary,omitempty"`
+}
+
+// TextParams controls the output text format on Responses requests.
+// Distinct from ChatCompletion's top-level ResponseFormat — the
+// Responses API nests format under text. Carried on both Request
+// (input) and Response (echo).
+type TextParams struct {
+	// Format is the JSON-schema or json_object envelope. Carried as
+	// RawMessage so callers can pass through the shape OpenAI
+	// documents without this package taking a hard dependency on
+	// the schema layout (which has evolved across SDK versions).
+	Format json.RawMessage `json:"format,omitempty"`
+}
+
+// Tool is a function tool declaration. Responses-shape uses a flat
+// {type, name, description, parameters, strict} layout — distinct
+// from ChatCompletion's nested {type:"function", function:{...}}.
+// Hosted tools (file_search, web_search_preview, code_interpreter,
+// computer_use_preview, image_generation) are not modeled for Phase 1.
+// Carried on both Request (input) and Response (echo).
+type Tool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+	Strict      bool            `json:"strict,omitempty"`
+}

--- a/model/wire/responses/types_request.go
+++ b/model/wire/responses/types_request.go
@@ -80,6 +80,18 @@ type Request struct {
 	// API echoes back on the response. Capped at 16 keys, 64-char
 	// keys, 512-char values per OpenAI's docs.
 	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Include opts into response fields the API otherwise omits.
+	// Most consequential for our path: "reasoning.encrypted_content"
+	// — without this opt-in, the API does NOT emit encrypted_content
+	// on reasoning output items in stateless mode, breaking
+	// cross-turn echo silently. The translator sets this
+	// automatically when reasoning is configured (ADR-051 D2).
+	//
+	// Other documented values (out of scope for Phase 1):
+	// "message.input_image.image_url", "file_search_call.results",
+	// "code_interpreter_call.outputs".
+	Include []string `json:"include,omitempty"`
 }
 
 // ReasoningParams configures reasoning behavior on o-series and

--- a/model/wire/responses/types_response.go
+++ b/model/wire/responses/types_response.go
@@ -1,0 +1,108 @@
+package responses
+
+import (
+	"encoding/json"
+)
+
+// Response is the POST /v1/responses response body. Status reports
+// the run's terminal state ("completed", "failed", "in_progress",
+// "cancelled", "incomplete"); the Output array is the heterogeneous
+// emitted items.
+type Response struct {
+	// ID is the provider-assigned response identifier ("resp_..."),
+	// usable for previous_response_id threading when Store=true (not
+	// used in stateless mode but echoed for trace correlation).
+	ID string `json:"id"`
+
+	// Object is the response object type, always "response" on
+	// success. Carried for parity with OpenAI's documented shape.
+	Object string `json:"object,omitempty"`
+
+	// CreatedAt is the response creation Unix timestamp.
+	CreatedAt int64 `json:"created_at,omitempty"`
+
+	// Status is "completed", "failed", "in_progress", "cancelled",
+	// or "incomplete".
+	Status string `json:"status,omitempty"`
+
+	// Error is populated when Status == "failed". The shape mirrors
+	// APIError but is embedded in the response body rather than
+	// raised as an HTTP error.
+	Error json.RawMessage `json:"error,omitempty"`
+
+	// IncompleteDetails is populated when Status == "incomplete".
+	IncompleteDetails json.RawMessage `json:"incomplete_details,omitempty"`
+
+	// Instructions echoes back the request's Instructions field.
+	Instructions string `json:"instructions,omitempty"`
+
+	// MaxOutputTokens echoes back the request's MaxOutputTokens.
+	MaxOutputTokens int `json:"max_output_tokens,omitempty"`
+
+	// Model is the served model identifier (may differ from requested
+	// when the provider routes through a model alias).
+	Model string `json:"model"`
+
+	// Output is the heterogeneous emitted items array.
+	Output []OutputItem `json:"output"`
+
+	// PreviousResponseID is set when this response continued from a
+	// prior response. Empty in stateless mode.
+	PreviousResponseID string `json:"previous_response_id,omitempty"`
+
+	// Reasoning echoes back the request's Reasoning settings.
+	Reasoning *ReasoningParams `json:"reasoning,omitempty"`
+
+	// Store reports whether server-side persistence is active.
+	Store *bool `json:"store,omitempty"`
+
+	// Temperature, TopP echo back the sampling controls.
+	Temperature *float64 `json:"temperature,omitempty"`
+	TopP        *float64 `json:"top_p,omitempty"`
+
+	// Text echoes back the request's Text settings.
+	Text *TextParams `json:"text,omitempty"`
+
+	// ToolChoice and Tools echo back the request configuration.
+	ToolChoice json.RawMessage `json:"tool_choice,omitempty"`
+	Tools      []Tool          `json:"tools,omitempty"`
+
+	// Truncation reports the truncation policy applied. Values
+	// include "auto", "disabled". Carried as string for forward
+	// compat.
+	Truncation string `json:"truncation,omitempty"`
+
+	// Usage reports token consumption.
+	Usage *Usage `json:"usage,omitempty"`
+
+	// User echoes back the request's User identifier.
+	User string `json:"user,omitempty"`
+
+	// Metadata echoes back the request's Metadata map.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// Usage reports token consumption on a Response. Field names match
+// the Responses API ("input_tokens", "output_tokens") — distinct
+// from ChatCompletion's "prompt_tokens"/"completion_tokens".
+type Usage struct {
+	InputTokens        int                 `json:"input_tokens"`
+	InputTokensDetails *InputTokensDetails `json:"input_tokens_details,omitempty"`
+
+	OutputTokens        int                  `json:"output_tokens"`
+	OutputTokensDetails *OutputTokensDetails `json:"output_tokens_details,omitempty"`
+
+	TotalTokens int `json:"total_tokens"`
+}
+
+// InputTokensDetails breaks down prompt-side token attribution.
+type InputTokensDetails struct {
+	CachedTokens int `json:"cached_tokens,omitempty"`
+}
+
+// OutputTokensDetails breaks down completion-side token attribution.
+// ReasoningTokens accounts the o-series/GPT-5.5 internal reasoning
+// budget separately from emitted output tokens.
+type OutputTokensDetails struct {
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+}

--- a/model/wire/responses/types_test.go
+++ b/model/wire/responses/types_test.go
@@ -187,6 +187,75 @@ func TestResponse_JSONRoundTrip(t *testing.T) {
 	}
 }
 
+// TestInputItem_ReasoningSummaryAlwaysPresent pins the workaround
+// for OpenAI's reasoning-input-item summary requirement: the API
+// rejects echoed reasoning items without a `summary` field even
+// when the local slice is nil/empty. InputItem.MarshalJSON injects
+// `"summary":[]` for reasoning items that lack one. Caught by the
+// ADR-051 PR 4 live reasoning-echo test (HTTP 400 missing_required_parameter).
+func TestInputItem_ReasoningSummaryAlwaysPresent(t *testing.T) {
+	cases := []struct {
+		name        string
+		item        responses.InputItem
+		wantSummary string
+	}{
+		{
+			name: "reasoning with nil summary emits []",
+			item: responses.InputItem{
+				Type:             responses.ItemTypeReasoning,
+				ID:               "rs_1",
+				EncryptedContent: "blob",
+			},
+			wantSummary: `"summary":[]`,
+		},
+		{
+			name: "reasoning with empty summary emits []",
+			item: responses.InputItem{
+				Type:             responses.ItemTypeReasoning,
+				ID:               "rs_2",
+				EncryptedContent: "blob",
+				Summary:          []responses.SummaryPart{},
+			},
+			wantSummary: `"summary":[]`,
+		},
+		{
+			name: "reasoning with populated summary preserves it",
+			item: responses.InputItem{
+				Type:             responses.ItemTypeReasoning,
+				ID:               "rs_3",
+				EncryptedContent: "blob",
+				Summary: []responses.SummaryPart{
+					{Type: responses.SummaryTypeText, Text: "thinking"},
+				},
+			},
+			wantSummary: `"summary":[{"type":"summary_text","text":"thinking"}]`,
+		},
+		{
+			name: "non-reasoning item omits summary (default behavior preserved)",
+			item: responses.NewInputUserMessage("hi"),
+			// Empty wantSummary signals the substring must NOT appear.
+			wantSummary: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.item)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if tc.wantSummary == "" {
+				if strings.Contains(string(b), `"summary"`) {
+					t.Errorf("expected NO summary field on non-reasoning item; got %s", string(b))
+				}
+				return
+			}
+			if !strings.Contains(string(b), tc.wantSummary) {
+				t.Errorf("expected substring %q; got %s", tc.wantSummary, string(b))
+			}
+		})
+	}
+}
+
 // TestOutputItem_Accessors pins the convenience helpers on
 // OutputItem (OutputText, RefusalText, IsMessage, etc.).
 func TestOutputItem_Accessors(t *testing.T) {

--- a/model/wire/responses/types_test.go
+++ b/model/wire/responses/types_test.go
@@ -1,0 +1,348 @@
+package responses_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/model/wire/responses"
+)
+
+// TestRequest_JSONRoundTrip pins that a fully-populated Request
+// survives marshal/unmarshal with field identity. Doc-derived shape
+// per ADR-051 D1 — the live-fixture parity gate is the separate
+// TestResponses_GoldenFixture_Parity test below, stubbed pending
+// PR 4 capture.
+func TestRequest_JSONRoundTrip(t *testing.T) {
+	store := false
+	temp := 0.7
+	topP := 0.95
+	in := &responses.Request{
+		Model: "gpt-5.5",
+		Input: []responses.InputItem{
+			responses.NewInputDeveloperMessage("you are a calculator"),
+			responses.NewInputUserMessage("what is 17 * 23?"),
+			responses.NewInputFunctionCall("call_abc", "multiply", `{"a":17,"b":23}`),
+			responses.NewInputFunctionCallOutput("call_abc", `{"product":391}`),
+			responses.NewInputReasoning("rs_xyz", "encrypted-opaque-blob", []responses.SummaryPart{
+				{Type: responses.SummaryTypeText, Text: "considering multiplication strategy"},
+			}),
+		},
+		Instructions: "Be concise.",
+		Tools: []responses.Tool{
+			{
+				Type:        "function",
+				Name:        "multiply",
+				Description: "Multiplies two integers.",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{"a":{"type":"integer"},"b":{"type":"integer"}},"required":["a","b"]}`),
+				Strict:      true,
+			},
+		},
+		ToolChoice: json.RawMessage(`"auto"`),
+		Reasoning: &responses.ReasoningParams{
+			Effort:  "medium",
+			Summary: "concise",
+		},
+		Text: &responses.TextParams{
+			Format: json.RawMessage(`{"type":"text"}`),
+		},
+		Temperature:     &temp,
+		TopP:            &topP,
+		MaxOutputTokens: 1024,
+		Store:           &store,
+		User:            "user-abc",
+		Metadata:        map[string]string{"trace_id": "t-1", "loop_id": "l-1"},
+	}
+
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Sanity: the marshaled body should use the API's documented
+	// field names — guards against accidental field renames.
+	mustContain := []string{
+		`"model":"gpt-5.5"`,
+		`"input":[`,
+		`"instructions":"Be concise."`,
+		`"reasoning":{"effort":"medium"`,
+		`"max_output_tokens":1024`,
+		`"store":false`,
+		`"role":"developer"`,
+		`"role":"user"`,
+		`"type":"function_call"`,
+		`"type":"function_call_output"`,
+		`"type":"reasoning"`,
+		`"encrypted_content":"encrypted-opaque-blob"`,
+		`"call_id":"call_abc"`,
+		`"summary_text"`,
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(string(b), s) {
+			t.Errorf("expected substring %q in marshaled request; got %s", s, string(b))
+		}
+	}
+
+	var got responses.Request
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, &got) {
+		t.Errorf("round-trip mismatch\n  in:  %#v\n  got: %#v", in, &got)
+	}
+}
+
+// TestResponse_JSONRoundTrip pins that a fully-populated Response
+// survives marshal/unmarshal with field identity. Mirrors the
+// documented Responses API output shape; lives-fixture parity gate
+// is the separate TestResponses_GoldenFixture_Parity test below.
+func TestResponse_JSONRoundTrip(t *testing.T) {
+	temp := 0.7
+	topP := 0.95
+	store := false
+	in := &responses.Response{
+		ID:        "resp_001",
+		Object:    "response",
+		CreatedAt: 1717070000,
+		Status:    "completed",
+		Model:     "gpt-5.5-2026-05-30",
+		Output: []responses.OutputItem{
+			{
+				Type:             responses.ItemTypeReasoning,
+				ID:               "rs_001",
+				Status:           "completed",
+				EncryptedContent: "encrypted-opaque-from-openai",
+				Summary: []responses.SummaryPart{
+					{Type: responses.SummaryTypeText, Text: "decided to multiply directly"},
+				},
+			},
+			{
+				Type:      responses.ItemTypeFunctionCall,
+				ID:        "fc_001",
+				Status:    "completed",
+				CallID:    "call_def",
+				Name:      "multiply",
+				Arguments: `{"a":17,"b":23}`,
+			},
+			{
+				Type:   responses.ItemTypeMessage,
+				ID:     "msg_001",
+				Status: "completed",
+				Role:   responses.RoleAssistant,
+				Content: []responses.ContentPart{
+					{Type: responses.ContentTypeOutputText, Text: "391"},
+				},
+			},
+		},
+		Reasoning: &responses.ReasoningParams{Effort: "medium"},
+		Store:     &store,
+		Text: &responses.TextParams{
+			Format: json.RawMessage(`{"type":"text"}`),
+		},
+		Temperature: &temp,
+		TopP:        &topP,
+		ToolChoice:  json.RawMessage(`"auto"`),
+		Truncation:  "disabled",
+		Usage: &responses.Usage{
+			InputTokens:         512,
+			InputTokensDetails:  &responses.InputTokensDetails{CachedTokens: 0},
+			OutputTokens:        128,
+			OutputTokensDetails: &responses.OutputTokensDetails{ReasoningTokens: 96},
+			TotalTokens:         640,
+		},
+		Metadata: map[string]string{"trace_id": "t-1"},
+	}
+
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Sanity on field names — guards against rename drift.
+	mustContain := []string{
+		`"id":"resp_001"`,
+		`"status":"completed"`,
+		`"output":[`,
+		`"input_tokens":512`,
+		`"output_tokens":128`,
+		`"reasoning_tokens":96`,
+		`"total_tokens":640`,
+		`"truncation":"disabled"`,
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(string(b), s) {
+			t.Errorf("expected substring %q in marshaled response; got %s", s, string(b))
+		}
+	}
+
+	var got responses.Response
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(in, &got) {
+		t.Errorf("round-trip mismatch\n  in:  %#v\n  got: %#v", in, &got)
+	}
+}
+
+// TestOutputItem_Accessors pins the convenience helpers on
+// OutputItem (OutputText, RefusalText, IsMessage, etc.).
+func TestOutputItem_Accessors(t *testing.T) {
+	cases := []struct {
+		name        string
+		item        responses.OutputItem
+		wantText    string
+		wantRefusal string
+		wantKind    string
+	}{
+		{
+			name: "assistant text",
+			item: responses.OutputItem{
+				Type: responses.ItemTypeMessage,
+				Role: responses.RoleAssistant,
+				Content: []responses.ContentPart{
+					{Type: responses.ContentTypeOutputText, Text: "hello "},
+					{Type: responses.ContentTypeOutputText, Text: "world"},
+				},
+			},
+			wantText: "hello world",
+			wantKind: "message",
+		},
+		{
+			name: "refusal",
+			item: responses.OutputItem{
+				Type: responses.ItemTypeMessage,
+				Role: responses.RoleAssistant,
+				Content: []responses.ContentPart{
+					{Type: responses.ContentTypeRefusal, Refusal: "cannot comply"},
+				},
+			},
+			wantRefusal: "cannot comply",
+			wantKind:    "message",
+		},
+		{
+			name: "function_call has no text",
+			item: responses.OutputItem{
+				Type:      responses.ItemTypeFunctionCall,
+				CallID:    "c1",
+				Name:      "fn",
+				Arguments: `{}`,
+			},
+			wantKind: "function_call",
+		},
+		{
+			name: "reasoning has no text",
+			item: responses.OutputItem{
+				Type: responses.ItemTypeReasoning,
+				ID:   "rs",
+			},
+			wantKind: "reasoning",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.item.OutputText(); got != tc.wantText {
+				t.Errorf("OutputText = %q, want %q", got, tc.wantText)
+			}
+			if got := tc.item.RefusalText(); got != tc.wantRefusal {
+				t.Errorf("RefusalText = %q, want %q", got, tc.wantRefusal)
+			}
+			switch tc.wantKind {
+			case "message":
+				if !tc.item.IsMessage() {
+					t.Errorf("IsMessage = false; want true")
+				}
+			case "function_call":
+				if !tc.item.IsFunctionCall() {
+					t.Errorf("IsFunctionCall = false; want true")
+				}
+			case "reasoning":
+				if !tc.item.IsReasoning() {
+					t.Errorf("IsReasoning = false; want true")
+				}
+			}
+		})
+	}
+}
+
+// TestResponses_GoldenFixture_Parity is the live-fixture parity
+// gate: every captured request/response in testdata/ must round-trip
+// through these types without information loss. Skips when no
+// fixtures exist (the doc-derived round-trip above is the smoke
+// test in that case). PR 4 wires the fixture-capture test that
+// populates testdata/; once fixtures land, this test catches any
+// drift between the doc-derived shape and reality.
+//
+// Per ADR-051 phasing: skeleton-from-docs is allowed but pre-tag
+// gate requires live fixtures (PR 4) and parity here.
+func TestResponses_GoldenFixture_Parity(t *testing.T) {
+	dir := "testdata"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Skipf("no testdata directory: %v", err)
+	}
+
+	jsonFiles := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		jsonFiles = append(jsonFiles, e.Name())
+	}
+	if len(jsonFiles) == 0 {
+		t.Skip("no captured fixtures yet; PR 4 populates testdata/ — this is the hard gate before tagging")
+	}
+
+	for _, name := range jsonFiles {
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatalf("read fixture: %v", err)
+			}
+			// Probe whether this is a request or response by sniffing
+			// for top-level fields. Requests have "input"; responses
+			// have "output". Fixtures cleanly fall into one class.
+			var probe map[string]json.RawMessage
+			if err := json.Unmarshal(data, &probe); err != nil {
+				t.Fatalf("probe decode: %v", err)
+			}
+			switch {
+			case probe["input"] != nil:
+				assertRoundTrip[responses.Request](t, data)
+			case probe["output"] != nil:
+				assertRoundTrip[responses.Response](t, data)
+			default:
+				t.Skipf("fixture %s is neither request nor response (no input/output field)", name)
+			}
+		})
+	}
+}
+
+// assertRoundTrip decodes data into T, re-encodes it, and asserts
+// the re-encoded bytes deserialize to a value DeepEqual to the
+// first decode. This catches information loss across the typed
+// boundary — a field the typed structs forgot to model would
+// silently drop on re-encode and the second decode would diverge.
+func assertRoundTrip[T any](t *testing.T, data []byte) {
+	t.Helper()
+	var first T
+	if err := json.Unmarshal(data, &first); err != nil {
+		t.Fatalf("first decode: %v", err)
+	}
+	b, err := json.Marshal(first)
+	if err != nil {
+		t.Fatalf("re-encode: %v", err)
+	}
+	var second T
+	if err := json.Unmarshal(b, &second); err != nil {
+		t.Fatalf("second decode: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Errorf("round-trip diverged after re-encode\n  first:  %#v\n  second: %#v", first, second)
+	}
+}

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -1034,14 +1034,15 @@ func (h *MessageHandler) handleToolCallResponse(result *HandlerResult, loopID st
 	// context the dispatcher attached to the task.
 	//
 	// Merge semantics: cached TaskMessage metadata fills in keys that
-	// the ToolCall doesn't already carry. Wire-adapter pre-population
-	// (e.g. the Gemini wire backend stamping
-	// MetadataKeyGoogleThoughtSignature on each tool call in
-	// client_wire.go) must NOT block propagation of cached domain
+	// the ToolCall doesn't already carry. Any per-call pre-population
+	// on ToolCall.Metadata must NOT block propagation of cached domain
 	// metadata like action_allowlist / related_loops / trace_id —
 	// pre-fix the guard was `len(approved[i].Metadata) == 0` and any
-	// wire-side pre-population silently dropped the entire cached map
-	// for every Gemini-wire tool call.
+	// non-empty pre-population silently dropped the entire cached map.
+	// (The original failure case was the Gemini-wire backend writing a
+	// thought signature here; ADR-051 moved that carrier off Metadata
+	// onto ChatMessage.ReasoningRecords, but the merge invariant guards
+	// every future case of pre-populated ToolCall.Metadata.)
 	//
 	// Metadata["loop_id"] is intentionally NOT stamped here — the
 	// canonical stamp lives in dispatchToolCall so every dispatch path

--- a/processor/agentic-loop/handlers_test.go
+++ b/processor/agentic-loop/handlers_test.go
@@ -2196,12 +2196,20 @@ func extractDispatchedToolCall(t *testing.T, data []byte) agentic.ToolCall {
 	return envelope.Payload
 }
 
-// TestPropagateMetadata_MergesWithWirePopulation pins the merge fix
-// for the Gemini-wire metadata-dropping bug: when the wire adapter
-// pre-populates ToolCall.Metadata (e.g. with a thought signature),
-// the cached TaskMessage.Metadata MUST still propagate onto the
-// dispatched call by filling in keys the wire side didn't set —
-// instead of being skipped entirely by a "no-op if non-empty" guard.
+// wirePrePopulatedTestKey stands in for any per-call key the
+// translation layer may write onto ToolCall.Metadata before the
+// loop's metadata-merge step runs. Pre-ADR-051 the canonical example
+// was the Gemini thought signature; post-rename that carrier lives on
+// ChatMessage.ReasoningRecords (a sibling field), but the merge
+// invariant guards every future case of pre-populated ToolCall.Metadata
+// — so the test holds the invariant with a generic test-local key.
+const wirePrePopulatedTestKey = "wire_prepopulated_marker"
+
+// TestPropagateMetadata_MergesWithWirePopulation pins the merge
+// invariant: when a ToolCall arrives with pre-populated Metadata, the
+// cached TaskMessage.Metadata MUST still propagate onto the dispatched
+// call by filling in keys the pre-population didn't set — instead of
+// being skipped entirely by a "no-op if non-empty" guard.
 //
 // Pre-fix shape (broken):
 //
@@ -2209,13 +2217,12 @@ func extractDispatchedToolCall(t *testing.T, data []byte) agentic.ToolCall {
 //	    approved[i].Metadata = metadata
 //	}
 //
-// Any wire-side pre-population blocked the entire cached map. That
+// Any non-empty pre-population blocked the entire cached map. That
 // silently dropped action_allowlist / related_loops / caller context
-// for every Gemini-wire tool call (client_wire.go:303-313 in the
-// readC360ThoughtSignature branch).
+// for every tool call that arrived with prior Metadata.
 //
-// Post-fix: merge, with call-specific keys winning (so the wire
-// adapter's per-call metadata is never overwritten).
+// Post-fix: merge, with call-specific keys winning (so the
+// translation layer's per-call metadata is never overwritten).
 func TestPropagateMetadata_MergesWithWirePopulation(t *testing.T) {
 	handler := agenticloop.NewMessageHandler(createTestConfig())
 
@@ -2235,9 +2242,10 @@ func TestPropagateMetadata_MergesWithWirePopulation(t *testing.T) {
 	}
 	loopID := taskResult.LoopID
 
-	// Model response with a tool call carrying wire-adapter
-	// pre-population, mirroring what client_wire.go's Gemini path
-	// produces when readC360ThoughtSignature returns a non-empty sig.
+	// Model response with a tool call carrying a pre-populated key on
+	// ToolCall.Metadata. The carrier (the Gemini signature) no longer
+	// lives here post-ADR-051, but any future per-call write would
+	// exercise the same merge code path.
 	response := agentic.AgentResponse{
 		RequestID: "req-merge-1",
 		Status:    "tool_call",
@@ -2248,7 +2256,7 @@ func TestPropagateMetadata_MergesWithWirePopulation(t *testing.T) {
 					ID:   "call-merge-1",
 					Name: "fan_out",
 					Metadata: map[string]any{
-						agentic.MetadataKeyGoogleThoughtSignature: "wire-sig-abc",
+						wirePrePopulatedTestKey: "marker-abc",
 					},
 				},
 			},
@@ -2275,17 +2283,16 @@ func TestPropagateMetadata_MergesWithWirePopulation(t *testing.T) {
 		t.Fatalf("no tool.execute message published; PublishedMessages=%+v", result.PublishedMessages)
 	}
 
-	// Wire-side pre-population survives (call-specific keys win).
-	if sig, ok := got.Metadata[agentic.MetadataKeyGoogleThoughtSignature].(string); !ok || sig != "wire-sig-abc" {
-		t.Errorf("Gemini thought signature lost — got Metadata[%q]=%v, want %q",
-			agentic.MetadataKeyGoogleThoughtSignature, got.Metadata[agentic.MetadataKeyGoogleThoughtSignature], "wire-sig-abc")
+	// Pre-populated value survives (call-specific keys win).
+	if marker, ok := got.Metadata[wirePrePopulatedTestKey].(string); !ok || marker != "marker-abc" {
+		t.Errorf("pre-populated marker lost — got Metadata[%q]=%v, want %q",
+			wirePrePopulatedTestKey, got.Metadata[wirePrePopulatedTestKey], "marker-abc")
 	}
 
 	// Cached TaskMessage metadata IS propagated — the bug was that
-	// these keys were silently dropped when wire pre-population
-	// existed.
+	// these keys were silently dropped when pre-population existed.
 	if _, ok := got.Metadata[agentic.MetadataKeyDecideActionAllowlist]; !ok {
-		t.Errorf("action_allowlist dropped — wire pre-population blocked propagation of cached task metadata. "+
+		t.Errorf("action_allowlist dropped — pre-population blocked propagation of cached task metadata. "+
 			"got Metadata=%v", got.Metadata)
 	}
 	if audit, ok := got.Metadata["custom_audit_tag"].(string); !ok || audit != "audit-merge-1" {
@@ -2295,10 +2302,10 @@ func TestPropagateMetadata_MergesWithWirePopulation(t *testing.T) {
 }
 
 // TestPropagateMetadata_NoOverwriteOnConflict pins the merge-direction
-// invariant: when a key exists in BOTH the wire-populated call
-// metadata AND the cached task metadata, the wire side wins. This
-// prevents the cached task metadata from overwriting per-call wire
-// state (e.g. a thought signature that's specific to this call).
+// invariant: when a key exists in BOTH the pre-populated call metadata
+// AND the cached task metadata, the call side wins. This prevents
+// cached task metadata from overwriting per-call context written by
+// the translation layer.
 func TestPropagateMetadata_NoOverwriteOnConflict(t *testing.T) {
 	handler := agenticloop.NewMessageHandler(createTestConfig())
 
@@ -2310,8 +2317,8 @@ func TestPropagateMetadata_NoOverwriteOnConflict(t *testing.T) {
 		Prompt: "exercise the merge conflict path",
 		Metadata: map[string]any{
 			// Cached task metadata also carries this key — call-side
-			// must win so per-call wire context is preserved.
-			agentic.MetadataKeyGoogleThoughtSignature: "task-sig-bad",
+			// must win so per-call context is preserved.
+			wirePrePopulatedTestKey: "task-marker-bad",
 		},
 	})
 	if err != nil {
@@ -2329,7 +2336,7 @@ func TestPropagateMetadata_NoOverwriteOnConflict(t *testing.T) {
 					ID:   "call-conflict-1",
 					Name: "fan_out",
 					Metadata: map[string]any{
-						agentic.MetadataKeyGoogleThoughtSignature: "wire-sig-good",
+						wirePrePopulatedTestKey: "wire-marker-good",
 					},
 				},
 			},
@@ -2349,10 +2356,10 @@ func TestPropagateMetadata_NoOverwriteOnConflict(t *testing.T) {
 		}
 	}
 
-	if sig, ok := got.Metadata[agentic.MetadataKeyGoogleThoughtSignature].(string); !ok || sig != "wire-sig-good" {
+	if marker, ok := got.Metadata[wirePrePopulatedTestKey].(string); !ok || marker != "wire-marker-good" {
 		t.Errorf("Merge direction wrong — call-specific value should win on conflict. "+
 			"got Metadata[%q]=%v, want %q",
-			agentic.MetadataKeyGoogleThoughtSignature, got.Metadata[agentic.MetadataKeyGoogleThoughtSignature], "wire-sig-good")
+			wirePrePopulatedTestKey, got.Metadata[wirePrePopulatedTestKey], "wire-marker-good")
 	}
 }
 

--- a/processor/agentic-model/adapter_gemini.go
+++ b/processor/agentic-model/adapter_gemini.go
@@ -131,9 +131,10 @@ func (a *GeminiAdapter) NormalizeStreamDelta(delta wire.ToolCall, lastIndex int)
 // Gemini's extra_content.google.thought_signature shape into the
 // framework-internal carrier key wireKeyC360ThoughtSignature. The
 // generic convertWireResponse then lifts the carrier into
-// agentic.ToolCall.Metadata under MetadataKeyGoogleThoughtSignature so
-// the signature flows across loop turns without Gemini-specific code
-// in the agentic layer.
+// agentic.ChatMessage.ReasoningRecords as a
+// ReasoningRecord{Provider:"google", CarrierKind:ToolCall, ToolCallID:...}
+// so the signature flows across loop turns without Gemini-specific
+// code in the agentic layer (ADR-051).
 //
 // Safe to call universally — adapters that don't see extra_content
 // (every non-Gemini provider) read no carrier and write nothing.

--- a/processor/agentic-model/adapter_gemini_thought_signature_test.go
+++ b/processor/agentic-model/adapter_gemini_thought_signature_test.go
@@ -164,8 +164,10 @@ func TestGeminiAdapter_NormalizeMessages_OnlyFirstToolCallKeepsSignature(t *test
 }
 
 // TestSignature_RoundTripThroughAgentic asserts the full agentic ↔ wire
-// round-trip: response signature → agentic.Metadata → next request's
-// wire extra_content. Mirrors what the loop does across turns.
+// round-trip: response signature → agentic.ReasoningRecords →
+// next request's wire extra_content. Mirrors what the loop does across
+// turns. Post-ADR-051 the carrier is the message-level ReasoningRecords
+// sibling field, not ToolCall.Metadata.
 func TestSignature_RoundTripThroughAgentic(t *testing.T) {
 	// Step 1: simulate Gemini response with thought_signature.
 	extra, _ := json.Marshal(map[string]any{
@@ -192,24 +194,45 @@ func TestSignature_RoundTripThroughAgentic(t *testing.T) {
 	// Step 2: adapter extracts to carrier.
 	(&GeminiAdapter{}).NormalizeResponse(resp)
 
-	// Step 3: convertWireResponse lifts to agentic.Metadata.
+	// Step 3: convertWireResponse lifts the signature into the
+	// message-level ReasoningRecords field, attributed to call-1.
 	c := &Client{endpoint: nil, adapter: &GeminiAdapter{}}
 	agentResp := c.convertWireResponse(resp, "req-rt")
 	if len(agentResp.Message.ToolCalls) != 1 {
 		t.Fatalf("expected 1 tool_call, got %d", len(agentResp.Message.ToolCalls))
 	}
-	sig, _ := agentResp.Message.ToolCalls[0].Metadata[agentic.MetadataKeyGoogleThoughtSignature].(string)
-	if sig != "sig-rt" {
-		t.Fatalf("agentic Metadata sig = %q, want sig-rt", sig)
+	if len(agentResp.Message.ReasoningRecords) != 1 {
+		t.Fatalf("expected 1 ReasoningRecord, got %d", len(agentResp.Message.ReasoningRecords))
+	}
+	rec := agentResp.Message.ReasoningRecords[0]
+	if rec.Provider != "google" {
+		t.Errorf("Provider = %q, want google", rec.Provider)
+	}
+	if rec.CarrierKind != agentic.ReasoningCarrierToolCall {
+		t.Errorf("CarrierKind = %q, want %q", rec.CarrierKind, agentic.ReasoningCarrierToolCall)
+	}
+	if rec.ToolCallID != "call-1" {
+		t.Errorf("ToolCallID = %q, want call-1", rec.ToolCallID)
+	}
+	if string(rec.Opaque) != "sig-rt" {
+		t.Fatalf("Opaque = %q, want sig-rt", string(rec.Opaque))
 	}
 
 	// Step 4: next-turn translation puts signature back on the wire.
-	wireMsgs := agenticMessagesToWire([]agentic.ChatMessage{
-		{Role: "assistant", ToolCalls: agentResp.Message.ToolCalls},
-	})
+	// attachReasoningRecordsToWire reads ReasoningRecords off the
+	// assistant message and writes the framework-internal carrier onto
+	// matching wire ToolCalls by ToolCallID.
+	srcMsgs := []agentic.ChatMessage{
+		{
+			Role:             "assistant",
+			ToolCalls:        agentResp.Message.ToolCalls,
+			ReasoningRecords: agentResp.Message.ReasoningRecords,
+		},
+	}
+	wireMsgs := attachReasoningRecordsToWire(agenticMessagesToWire(srcMsgs), srcMsgs)
 	carrier, ok := wireMsgs[0].ToolCalls[0].Extras[wireKeyC360ThoughtSignature]
 	if !ok {
-		t.Fatal("agenticToolCallsToWire should write framework-internal carrier")
+		t.Fatal("attachReasoningRecordsToWire should write framework-internal carrier")
 	}
 	var carrierStr string
 	_ = json.Unmarshal(carrier, &carrierStr)
@@ -236,9 +259,10 @@ func TestSignature_RoundTripThroughAgentic(t *testing.T) {
 
 // TestStreamingPath_LiftsThoughtSignature asserts that the streaming
 // wire path runs NormalizeResponse and lifts the thought_signature
-// carrier into agentic.Metadata. Without this, multi-turn tool flows
-// on Gemini 3.x via wire+streaming silently fail to echo the signature
-// on subsequent requests. This is the test that would have caught H1.
+// carrier into ChatMessage.ReasoningRecords. Without this, multi-turn
+// tool flows on Gemini 3.x via wire+streaming silently fail to echo
+// the signature on subsequent requests. This is the test that would
+// have caught H1.
 func TestStreamingPath_LiftsThoughtSignature(t *testing.T) {
 	extra, _ := json.Marshal(map[string]any{
 		"google": map[string]any{"thought_signature": "sig-streamed"},
@@ -261,9 +285,16 @@ func TestStreamingPath_LiftsThoughtSignature(t *testing.T) {
 	if len(resp.Message.ToolCalls) != 1 {
 		t.Fatalf("expected 1 tool_call, got %d", len(resp.Message.ToolCalls))
 	}
-	sig, _ := resp.Message.ToolCalls[0].Metadata[agentic.MetadataKeyGoogleThoughtSignature].(string)
-	if sig != "sig-streamed" {
-		t.Errorf("streaming path Metadata sig = %q, want sig-streamed (NormalizeResponse not called?)", sig)
+	if len(resp.Message.ReasoningRecords) != 1 {
+		t.Fatalf("expected 1 ReasoningRecord on streamed response, got %d (NormalizeResponse not called?)",
+			len(resp.Message.ReasoningRecords))
+	}
+	rec := resp.Message.ReasoningRecords[0]
+	if rec.ToolCallID != "call-1" {
+		t.Errorf("ToolCallID = %q, want call-1", rec.ToolCallID)
+	}
+	if string(rec.Opaque) != "sig-streamed" {
+		t.Errorf("streaming path Opaque = %q, want sig-streamed", string(rec.Opaque))
 	}
 }
 

--- a/processor/agentic-model/adapter_responses.go
+++ b/processor/agentic-model/adapter_responses.go
@@ -1,0 +1,143 @@
+package agenticmodel
+
+import (
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model/wire/responses"
+)
+
+// ResponsesAdapter is the parallel of ProviderAdapter for the
+// Responses path. It normalizes request/response payloads and
+// streaming events for providers that speak the OpenAI Responses
+// wire shape.
+//
+// Today OpenAI is the only provider on this surface; the interface
+// exists per ADR-051 D4 to keep the door open for future Responses-
+// compatible providers without reshaping the call sites. Hooks are
+// mostly no-ops; the non-trivial work lives in capture/echo of
+// agentic.ReasoningRecord{CarrierKind:StandaloneItem}.
+type ResponsesAdapter interface {
+	// Name returns the provider identifier (e.g. "openai").
+	Name() string
+
+	// NormalizeRequest adjusts the wire request before sending.
+	// Called after translation, before the HTTP call.
+	NormalizeRequest(req *responses.Request)
+
+	// CaptureReasoningRecords walks the response's output items,
+	// extracts any provider-opaque reasoning blobs, and returns
+	// them as ReasoningRecord{CarrierKind:StandaloneItem} entries
+	// the caller appends to ChatMessage.ReasoningRecords.
+	//
+	// Returns nil if the response carries no reasoning items.
+	CaptureReasoningRecords(resp *responses.Response) []agentic.ReasoningRecord
+
+	// EchoReasoningRecords reverses CaptureReasoningRecords: walks
+	// the caller-supplied records (filtered by Provider), emits
+	// corresponding InputItem reasoning entries the request builder
+	// inserts into Request.Input alongside the regular items.
+	//
+	// Per OpenAI's per-step echo rule, reasoning items are echoed
+	// in order relative to other input items the caller already
+	// authored.
+	EchoReasoningRecords(records []agentic.ReasoningRecord) []responses.InputItem
+}
+
+// OpenAIResponsesAdapter is the OpenAI implementation of
+// ResponsesAdapter. Capture/echo cover the
+// {type:"reasoning", id, encrypted_content} item shape that OpenAI's
+// /v1/responses surfaces in stateless (store=false) mode.
+type OpenAIResponsesAdapter struct{}
+
+// Name returns "openai".
+func (a *OpenAIResponsesAdapter) Name() string { return "openai" }
+
+// NormalizeRequest is a no-op today. Placeholder for future per-
+// request shape fixes (the OpenAI Responses surface is stable
+// enough today that no normalization is required).
+func (a *OpenAIResponsesAdapter) NormalizeRequest(_ *responses.Request) {}
+
+// CaptureReasoningRecords extracts {type:"reasoning"} output items
+// from the Response into ReasoningRecord entries. Each captured
+// record carries the encrypted_content blob as Opaque bytes and
+// the summary's first text part as SummaryText (for trajectory /
+// trace consumers; safe to log).
+//
+// Non-reasoning output items are ignored. The slice is preserved
+// in OutputItem order so cross-turn echo can preserve relative
+// position.
+func (a *OpenAIResponsesAdapter) CaptureReasoningRecords(resp *responses.Response) []agentic.ReasoningRecord {
+	if resp == nil {
+		return nil
+	}
+	var out []agentic.ReasoningRecord
+	for i := range resp.Output {
+		item := &resp.Output[i]
+		if !item.IsReasoning() {
+			continue
+		}
+		rec := agentic.ReasoningRecord{
+			Provider:    "openai",
+			CarrierKind: agentic.ReasoningCarrierStandaloneItem,
+			ItemID:      item.ID,
+			Opaque:      []byte(item.EncryptedContent),
+		}
+		if len(item.Summary) > 0 && item.Summary[0].Text != "" {
+			rec.SummaryText = item.Summary[0].Text
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// EchoReasoningRecords reverses CaptureReasoningRecords: each
+// matching record becomes a reasoning InputItem with id and
+// encrypted_content set. Records carrying a non-empty SummaryText
+// emit a single summary_text part — providers tolerate a missing
+// summary, so empty SummaryText omits the field entirely.
+//
+// Records with Provider != "openai" are skipped; the adapter only
+// echoes its own provider's blobs, leaving cross-provider records
+// (e.g. Gemini ToolCall-carrier records) untouched for the
+// ChatCompletion adapter to handle on a different request.
+func (a *OpenAIResponsesAdapter) EchoReasoningRecords(records []agentic.ReasoningRecord) []responses.InputItem {
+	if len(records) == 0 {
+		return nil
+	}
+	var out []responses.InputItem
+	for _, rec := range records {
+		if rec.Provider != "openai" {
+			continue
+		}
+		if rec.CarrierKind != agentic.ReasoningCarrierStandaloneItem {
+			continue
+		}
+		var summary []responses.SummaryPart
+		if rec.SummaryText != "" {
+			summary = []responses.SummaryPart{
+				{Type: responses.SummaryTypeText, Text: rec.SummaryText},
+			}
+		}
+		out = append(out, responses.NewInputReasoning(rec.ItemID, string(rec.Opaque), summary))
+	}
+	return out
+}
+
+// defaultResponsesAdapter is the fallback used when no provider-
+// specific Responses adapter is set on the Client. Package-level
+// singleton avoids repeated allocation of the stateless struct.
+var defaultResponsesAdapter ResponsesAdapter = &OpenAIResponsesAdapter{}
+
+// ResponsesAdapterFor returns the appropriate ResponsesAdapter for
+// the given provider name. Today OpenAI is the only Responses-
+// compatible provider; unknown providers fall through to the OpenAI
+// adapter (safe default — the wire shape IS the OpenAI spec, so
+// any third-party Responses-compat provider should accept the same
+// capture/echo).
+func ResponsesAdapterFor(provider string) ResponsesAdapter {
+	switch provider {
+	case "openai":
+		return &OpenAIResponsesAdapter{}
+	default:
+		return &OpenAIResponsesAdapter{}
+	}
+}

--- a/processor/agentic-model/adapter_responses_test.go
+++ b/processor/agentic-model/adapter_responses_test.go
@@ -1,0 +1,193 @@
+package agenticmodel
+
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model/wire/responses"
+)
+
+// TestOpenAIResponsesAdapter_Name pins the provider identifier.
+func TestOpenAIResponsesAdapter_Name(t *testing.T) {
+	a := &OpenAIResponsesAdapter{}
+	if a.Name() != "openai" {
+		t.Errorf("Name = %q, want openai", a.Name())
+	}
+}
+
+// TestOpenAIResponsesAdapter_CaptureReasoningRecords pins the
+// capture path: reasoning output items in a Response become
+// ReasoningRecord entries with Provider=openai,
+// CarrierKind=StandaloneItem, the item's encrypted_content as
+// Opaque, and the first summary text as SummaryText.
+func TestOpenAIResponsesAdapter_CaptureReasoningRecords(t *testing.T) {
+	a := &OpenAIResponsesAdapter{}
+	resp := &responses.Response{
+		Output: []responses.OutputItem{
+			{Type: responses.ItemTypeMessage, ID: "msg_1", Role: responses.RoleAssistant},
+			{
+				Type:             responses.ItemTypeReasoning,
+				ID:               "rs_1",
+				EncryptedContent: "opaque-blob-1",
+				Summary: []responses.SummaryPart{
+					{Type: responses.SummaryTypeText, Text: "thinking 1"},
+				},
+			},
+			{
+				Type:             responses.ItemTypeReasoning,
+				ID:               "rs_2",
+				EncryptedContent: "opaque-blob-2",
+			},
+		},
+	}
+	got := a.CaptureReasoningRecords(resp)
+	if len(got) != 2 {
+		t.Fatalf("captured %d records, want 2", len(got))
+	}
+	for _, rec := range got {
+		if rec.Provider != "openai" {
+			t.Errorf("Provider = %q, want openai", rec.Provider)
+		}
+		if rec.CarrierKind != agentic.ReasoningCarrierStandaloneItem {
+			t.Errorf("CarrierKind = %q, want standalone_item", rec.CarrierKind)
+		}
+	}
+	if got[0].ItemID != "rs_1" || string(got[0].Opaque) != "opaque-blob-1" {
+		t.Errorf("rec[0] mismatch: %+v", got[0])
+	}
+	if got[0].SummaryText != "thinking 1" {
+		t.Errorf("rec[0].SummaryText = %q, want %q", got[0].SummaryText, "thinking 1")
+	}
+	if got[1].ItemID != "rs_2" || string(got[1].Opaque) != "opaque-blob-2" {
+		t.Errorf("rec[1] mismatch: %+v", got[1])
+	}
+	if got[1].SummaryText != "" {
+		t.Errorf("rec[1].SummaryText = %q, want empty (no summary)", got[1].SummaryText)
+	}
+}
+
+// TestOpenAIResponsesAdapter_CaptureReasoningRecords_NilResp pins
+// graceful handling of nil input.
+func TestOpenAIResponsesAdapter_CaptureReasoningRecords_NilResp(t *testing.T) {
+	a := &OpenAIResponsesAdapter{}
+	if got := a.CaptureReasoningRecords(nil); got != nil {
+		t.Errorf("expected nil on nil response, got %+v", got)
+	}
+}
+
+// TestOpenAIResponsesAdapter_EchoReasoningRecords pins the echo
+// path: a ReasoningRecord becomes a reasoning InputItem with id,
+// encrypted_content, and a summary part when SummaryText is set.
+func TestOpenAIResponsesAdapter_EchoReasoningRecords(t *testing.T) {
+	a := &OpenAIResponsesAdapter{}
+	records := []agentic.ReasoningRecord{
+		{
+			Provider:    "openai",
+			CarrierKind: agentic.ReasoningCarrierStandaloneItem,
+			ItemID:      "rs_1",
+			Opaque:      []byte("blob-1"),
+			SummaryText: "summary one",
+		},
+		{
+			Provider:    "openai",
+			CarrierKind: agentic.ReasoningCarrierStandaloneItem,
+			ItemID:      "rs_2",
+			Opaque:      []byte("blob-2"),
+		},
+	}
+	got := a.EchoReasoningRecords(records)
+	if len(got) != 2 {
+		t.Fatalf("echoed %d items, want 2", len(got))
+	}
+	if !got[0].IsReasoning() {
+		t.Errorf("got[0].Type = %q, want reasoning", got[0].Type)
+	}
+	if got[0].ID != "rs_1" || got[0].EncryptedContent != "blob-1" {
+		t.Errorf("got[0] mismatch: %+v", got[0])
+	}
+	if len(got[0].Summary) != 1 || got[0].Summary[0].Text != "summary one" {
+		t.Errorf("got[0].Summary = %+v, want one summary_text part with %q", got[0].Summary, "summary one")
+	}
+	if len(got[1].Summary) != 0 {
+		t.Errorf("got[1].Summary = %+v, want empty (no SummaryText)", got[1].Summary)
+	}
+}
+
+// TestOpenAIResponsesAdapter_EchoReasoningRecords_FiltersOtherProviders
+// pins that records from other providers (e.g. Gemini ToolCall-
+// carrier records) are NOT echoed by this adapter — they belong to
+// a different wire shape and surface on a different request path.
+func TestOpenAIResponsesAdapter_EchoReasoningRecords_FiltersOtherProviders(t *testing.T) {
+	a := &OpenAIResponsesAdapter{}
+	records := []agentic.ReasoningRecord{
+		{
+			Provider:    "google",
+			CarrierKind: agentic.ReasoningCarrierToolCall,
+			ToolCallID:  "call-1",
+			Opaque:      []byte("gemini-sig"),
+		},
+		{
+			Provider:    "openai",
+			CarrierKind: agentic.ReasoningCarrierStandaloneItem,
+			ItemID:      "rs_1",
+			Opaque:      []byte("openai-blob"),
+		},
+	}
+	got := a.EchoReasoningRecords(records)
+	if len(got) != 1 {
+		t.Fatalf("echoed %d items, want 1 (Gemini record should be filtered)", len(got))
+	}
+	if got[0].ID != "rs_1" {
+		t.Errorf("got[0].ID = %q, want rs_1 (openai-only filter)", got[0].ID)
+	}
+}
+
+// TestResponsesAdapterFor_Defaults pins the lookup contract: known
+// providers and unknowns both return the OpenAIResponsesAdapter
+// (the safe default for any Responses-compat surface).
+func TestResponsesAdapterFor_Defaults(t *testing.T) {
+	cases := []string{"openai", "unknown", ""}
+	for _, p := range cases {
+		t.Run(p, func(t *testing.T) {
+			a := ResponsesAdapterFor(p)
+			if _, ok := a.(*OpenAIResponsesAdapter); !ok {
+				t.Errorf("ResponsesAdapterFor(%q) = %T, want *OpenAIResponsesAdapter", p, a)
+			}
+		})
+	}
+}
+
+// TestOpenAIResponsesAdapter_RoundTrip pins capture+echo as inverse
+// operations: a Response with reasoning items captures to records
+// that, when echoed back, reconstruct equivalent reasoning
+// InputItems (id + encrypted_content preserved; summary recovered
+// when present).
+func TestOpenAIResponsesAdapter_RoundTrip(t *testing.T) {
+	a := &OpenAIResponsesAdapter{}
+	original := &responses.Response{
+		Output: []responses.OutputItem{
+			{
+				Type:             responses.ItemTypeReasoning,
+				ID:               "rs_rt",
+				EncryptedContent: "round-trip-blob",
+				Summary: []responses.SummaryPart{
+					{Type: responses.SummaryTypeText, Text: "round-trip summary"},
+				},
+			},
+		},
+	}
+	records := a.CaptureReasoningRecords(original)
+	echoed := a.EchoReasoningRecords(records)
+	if len(echoed) != 1 {
+		t.Fatalf("echoed %d items, want 1", len(echoed))
+	}
+	if echoed[0].ID != "rs_rt" {
+		t.Errorf("ID drift: %q -> %q", "rs_rt", echoed[0].ID)
+	}
+	if echoed[0].EncryptedContent != "round-trip-blob" {
+		t.Errorf("EncryptedContent drift: %q -> %q", "round-trip-blob", echoed[0].EncryptedContent)
+	}
+	if len(echoed[0].Summary) != 1 || echoed[0].Summary[0].Text != "round-trip summary" {
+		t.Errorf("Summary drift: %+v", echoed[0].Summary)
+	}
+}

--- a/processor/agentic-model/client.go
+++ b/processor/agentic-model/client.go
@@ -16,21 +16,24 @@ import (
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/model"
 	"github.com/c360studio/semstreams/model/wire"
+	"github.com/c360studio/semstreams/model/wire/responses"
 	"github.com/c360studio/semstreams/pkg/errs"
 	openai "github.com/sashabaranov/go-openai"
 )
 
 // Client wraps OpenAI SDK for agentic model requests
 type Client struct {
-	client       *openai.Client
-	wireClient   *wire.Client // populated lazily when endpoint.WireBackend = "wire" (ADR-037)
-	endpoint     *model.EndpointConfig
-	chunkHandler ChunkHandler
-	metrics      *modelMetrics
-	logger       *slog.Logger
-	throttle     *EndpointThrottle
-	retryCfg     RetryConfig
-	adapter      ProviderAdapter
+	client           *openai.Client
+	wireClient       *wire.Client      // populated eagerly when endpoint.WireBackend = "wire" (ADR-037)
+	responsesClient  *responses.Client // populated eagerly when endpoint.WireBackend = "responses" (ADR-051)
+	endpoint         *model.EndpointConfig
+	chunkHandler     ChunkHandler
+	metrics          *modelMetrics
+	logger           *slog.Logger
+	throttle         *EndpointThrottle
+	retryCfg         RetryConfig
+	adapter          ProviderAdapter
+	responsesAdapter ResponsesAdapter
 	// ollamaProbeOnce guards a lazy /api/show probe that warns when the
 	// model is running with a num_ctx smaller than endpoint.MaxTokens —
 	// Ollama's /v1/ compat layer can't override it at request time, so the
@@ -99,7 +102,41 @@ func NewClient(endpoint *model.EndpointConfig) (*Client, error) {
 		out.wireClient = wc
 	}
 
+	// ADR-051: eager Responses client construction when the endpoint
+	// opts into the /v1/responses path. Same eager-build rationale
+	// as the wire client above.
+	if endpoint.WireBackend == "responses" {
+		rc, err := buildResponsesClientForEndpoint(endpoint, httpClient)
+		if err != nil {
+			return nil, err
+		}
+		out.responsesClient = rc
+	}
+
 	return out, nil
+}
+
+// buildResponsesClientForEndpoint constructs a *responses.Client for
+// the given endpoint, sharing the same HTTP transport as the SDK
+// client (the model.NewHTTPClient invariant from beta.43/47).
+func buildResponsesClientForEndpoint(endpoint *model.EndpointConfig, httpClient *http.Client) (*responses.Client, error) {
+	apiKey := ""
+	if endpoint.APIKeyEnv != "" {
+		apiKey = os.Getenv(endpoint.APIKeyEnv)
+	}
+	authHeader := ""
+	if apiKey != "" {
+		authHeader = "Bearer " + apiKey
+	}
+	rc, err := responses.NewClient(responses.ClientConfig{
+		BaseURL:    endpoint.URL,
+		HTTPClient: httpClient,
+		AuthHeader: authHeader,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agentic-model: build responses client: %w", err)
+	}
+	return rc, nil
 }
 
 // buildWireClientForEndpoint constructs a *wire.Client for the given
@@ -166,6 +203,22 @@ func (c *Client) getAdapter() ProviderAdapter {
 		return c.adapter
 	}
 	return defaultAdapter
+}
+
+// SetResponsesAdapter sets the Responses-path adapter. Used when
+// endpoint.WireBackend = "responses" (ADR-051). When not set, the
+// dispatch falls back to the default OpenAIResponsesAdapter.
+func (c *Client) SetResponsesAdapter(a ResponsesAdapter) {
+	c.responsesAdapter = a
+}
+
+// getResponsesAdapter returns the configured Responses adapter,
+// defaulting to the package-level OpenAIResponsesAdapter singleton.
+func (c *Client) getResponsesAdapter() ResponsesAdapter {
+	if c.responsesAdapter != nil {
+		return c.responsesAdapter
+	}
+	return defaultResponsesAdapter
 }
 
 // applyResponseFormat plumbs req.ResponseFormat onto chatReq (provider-agnostic;
@@ -379,8 +432,13 @@ func (c *Client) buildChatRequest(req agentic.AgentRequest) openai.ChatCompletio
 // Both curves cap at MaxDelay and respect ctx cancellation at every wait point.
 //
 // When endpoint.WireBackend = "wire" (ADR-037), the call routes through
-// the wire-native path (chatCompletionWire); otherwise the SDK path runs.
+// the wire-native ChatCompletion path. When endpoint.WireBackend =
+// "responses" (ADR-051), the call routes through the Responses path.
+// Otherwise the SDK path runs.
 func (c *Client) ChatCompletion(ctx context.Context, req agentic.AgentRequest) (agentic.AgentResponse, error) {
+	if c.useResponsesBackend() {
+		return c.chatCompletionResponses(ctx, req)
+	}
 	if c.useWireBackend() {
 		return c.chatCompletionWire(ctx, req)
 	}

--- a/processor/agentic-model/client_responses.go
+++ b/processor/agentic-model/client_responses.go
@@ -1,0 +1,203 @@
+package agenticmodel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model/wire"
+	"github.com/c360studio/semstreams/model/wire/responses"
+)
+
+// useResponsesBackend reports whether this endpoint is configured for
+// the ADR-051 Responses-native client path. The Responses client is
+// eagerly built in NewClient when WireBackend == "responses"; this
+// gate then dispatches to it.
+func (c *Client) useResponsesBackend() bool {
+	return c.responsesClient != nil
+}
+
+// chatCompletionResponses is the Responses-native equivalent of
+// ChatCompletion. Shares the retry / throttle / error-classification
+// scaffolding with the SDK and wire-ChatCompletion paths via
+// runRetryLoop; only the per-attempt dispatch and the request /
+// response translation differ.
+func (c *Client) chatCompletionResponses(ctx context.Context, req agentic.AgentRequest) (agentic.AgentResponse, error) {
+	c.runProviderStartupProbes(ctx)
+	respReq := c.buildResponsesRequest(req)
+	c.debugLogRequest(req.RequestID, respReq.Model, len(respReq.Input), &respReq)
+	c.recordResponsesRequestBytes(respReq.Model, &respReq)
+	if c.throttle != nil {
+		if err := c.throttle.Acquire(ctx); err != nil {
+			return errorResponse(req.RequestID, err.Error()), nil
+		}
+		defer c.throttle.Release()
+	}
+	return c.runRetryLoop(ctx, req.RequestID, respReq.Model, func() (agentic.AgentResponse, error) {
+		return c.doSingleAttemptResponses(ctx, respReq, req.RequestID)
+	})
+}
+
+// doSingleAttemptResponses executes one Responses request attempt
+// (streaming or non-streaming). Returns (response, nil) on success
+// or (zero, error) on failure.
+func (c *Client) doSingleAttemptResponses(ctx context.Context, respReq responses.Request, requestID string) (agentic.AgentResponse, error) {
+	rc := c.responsesClient
+	if c.endpoint.Stream {
+		resp, err := c.streamResponses(ctx, rc, respReq, requestID)
+		if err != nil {
+			if c.logger != nil {
+				c.logger.Debug("responses stream connection failed",
+					slog.String("request_id", requestID),
+					slog.String("model", respReq.Model),
+					slog.String("error", err.Error()))
+			}
+			return agentic.AgentResponse{}, err
+		}
+		return resp, nil
+	}
+
+	resp, err := rc.Responses(ctx, &respReq)
+	if err != nil {
+		if c.logger != nil {
+			c.logger.Debug("responses API request failed",
+				slog.String("request_id", requestID),
+				slog.String("model", respReq.Model),
+				slog.String("error", err.Error()))
+		}
+		return agentic.AgentResponse{}, err
+	}
+	return c.convertResponsesResponse(resp, requestID), nil
+}
+
+// convertResponsesResponse translates a responses.Response into an
+// agentic AgentResponse. The Responses output is a heterogeneous
+// typed array; we walk it once, building the assistant message's
+// content/tool-calls/reasoning-records as we go.
+//
+// Status mapping (Responses → agentic):
+//   - "completed" + tool calls present → "tool_call"
+//   - "completed" + only text/reasoning → "complete"
+//   - "incomplete" with reason="max_output_tokens" → "length_truncated"
+//   - "failed"/"cancelled"/other → "error"
+func (c *Client) convertResponsesResponse(resp *responses.Response, requestID string) agentic.AgentResponse {
+	response := agentic.AgentResponse{RequestID: requestID}
+	if resp == nil {
+		response.Status = "error"
+		response.Error = "no response from API"
+		return response
+	}
+
+	response.FinishReason = resp.Status
+
+	switch resp.Status {
+	case "failed", "cancelled":
+		response.Status = "error"
+		response.Error = "responses status: " + resp.Status
+		return response
+	case "incomplete":
+		response.Status = agentic.StatusLengthTruncated
+		if c.logger != nil {
+			c.logger.Warn("responses incomplete",
+				"request_id", requestID,
+				"details", string(resp.IncompleteDetails))
+		}
+	default:
+		response.Status = agentic.StatusComplete
+	}
+
+	msg := agentic.ChatMessage{Role: "assistant"}
+	var toolCalls []agentic.ToolCall
+	for i := range resp.Output {
+		item := &resp.Output[i]
+		switch {
+		case item.IsMessage():
+			msg.Content += item.OutputText()
+		case item.IsFunctionCall():
+			args := make(map[string]any)
+			if item.Arguments != "" {
+				if err := json.Unmarshal([]byte(item.Arguments), &args); err != nil {
+					if c.logger != nil {
+						c.logger.Warn("malformed responses function_call arguments, using empty object",
+							"item_id", item.ID, "error", err)
+					}
+					args = make(map[string]any)
+				}
+			}
+			toolCalls = append(toolCalls, agentic.ToolCall{
+				ID:        item.CallID,
+				Name:      item.Name,
+				Arguments: args,
+			})
+		case item.IsReasoning():
+			// Reasoning capture lives on the adapter so future
+			// providers (Anthropic-shape, etc.) can swap in.
+			// The default OpenAIResponsesAdapter handles the
+			// standalone-item shape.
+		}
+	}
+
+	msg.ToolCalls = toolCalls
+	msg.ReasoningRecords = c.getResponsesAdapter().CaptureReasoningRecords(resp)
+	response.Message = msg
+	if len(toolCalls) > 0 && response.Status == agentic.StatusComplete {
+		response.Status = agentic.StatusToolCall
+	}
+	if resp.Usage != nil {
+		response.TokenUsage = agentic.TokenUsage{
+			PromptTokens:     resp.Usage.InputTokens,
+			CompletionTokens: resp.Usage.OutputTokens,
+		}
+	}
+	return response
+}
+
+// recordResponsesRequestBytes emits the per-request bytes-on-wire
+// metric for operator observability of the stateless-echo cost
+// (ADR-051 D2 cost-observability gate). Best-effort: failure to
+// marshal silently skips the metric so a metrics issue doesn't
+// kill the request.
+func (c *Client) recordResponsesRequestBytes(model string, req *responses.Request) {
+	if c.metrics == nil {
+		return
+	}
+	b, err := json.Marshal(req)
+	if err != nil {
+		return
+	}
+	c.metrics.recordResponsesRequestBytes(model, float64(len(b)))
+}
+
+// isResponsesRetryableAny is the Responses-aware variant of
+// isRetryableAny. Recognizes responses.APIError (which is a type
+// alias for wire.APIError) and the same network classifications.
+// The retry loop already handles wire.APIError via isRetryableAny;
+// since responses.APIError = wire.APIError, no extra dispatch is
+// needed — the existing classifier already covers both. This
+// function exists as a documentation seam.
+func isResponsesRetryableAny(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var apiErr *wire.APIError
+	if errors.As(err, &apiErr) {
+		return isRetryableStatusCode(apiErr.StatusCode)
+	}
+	return isRetryable(err)
+}
+
+// isResponsesRateLimitedAny matches isRateLimitedAny for the
+// Responses path.
+func isResponsesRateLimitedAny(err error) bool {
+	var apiErr *wire.APIError
+	if errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusTooManyRequests {
+		return true
+	}
+	return isRateLimited(err)
+}

--- a/processor/agentic-model/client_wire.go
+++ b/processor/agentic-model/client_wire.go
@@ -40,7 +40,7 @@ func (c *Client) buildWireRequest(req agentic.AgentRequest) wire.ChatCompletionR
 	adapter := c.getAdapter()
 	chatReq := wire.ChatCompletionRequest{
 		Model:    c.endpoint.Model,
-		Messages: adapter.NormalizeMessages(agenticMessagesToWire(req.Messages)),
+		Messages: adapter.NormalizeMessages(attachReasoningRecordsToWire(agenticMessagesToWire(req.Messages), req.Messages)),
 	}
 
 	c.applyWireRequestParams(&chatReq, req)
@@ -110,21 +110,56 @@ func agenticToolCallsToWire(in []agentic.ToolCall) []wire.ToolCall {
 				Arguments: string(argsJSON),
 			},
 		}
-		// Carry the Gemini thought_signature through the wire layer
-		// under a framework-internal key (c360_thought_signature).
-		// GeminiAdapter.NormalizeMessages reconstructs the actual
-		// extra_content shape Gemini expects; the buildWireRequest
-		// hygiene step strips any remaining c360_* keys on send.
-		if sig, ok := tc.Metadata[agentic.MetadataKeyGoogleThoughtSignature].(string); ok && sig != "" {
-			if out[j].Extras == nil {
-				out[j].Extras = make(map[string]json.RawMessage, 1)
+	}
+	return out
+}
+
+// attachReasoningRecordsToWire writes each agentic.ChatMessage's
+// ReasoningRecords into the matching wire shape. Walks records once
+// per message and dispatches by CarrierKind:
+//
+//   - ReasoningCarrierToolCall (Gemini): matches by ToolCallID and
+//     writes the framework-internal carrier wireKeyC360ThoughtSignature
+//     onto the wire ToolCall.Extras. GeminiAdapter.NormalizeMessages
+//     reconstructs the extra_content.google.thought_signature shape
+//     downstream; buildWireRequest's hygiene step strips any remaining
+//     framework-internal keys before send.
+//   - Other CarrierKinds: no-op at this layer (OpenAI Responses uses
+//     a different wire shape entirely — handled by the Responses
+//     client per ADR-051 D4, not by ChatCompletion translation).
+//
+// in is the wire-shape slice produced by agenticMessagesToWire (same
+// length, same order); src is the original agentic slice carrying
+// ReasoningRecords. Returns in for fluent chaining.
+func attachReasoningRecordsToWire(in []wire.Message, src []agentic.ChatMessage) []wire.Message {
+	for i := range src {
+		if i >= len(in) {
+			break
+		}
+		for _, rec := range src[i].ReasoningRecords {
+			if rec.CarrierKind != agentic.ReasoningCarrierToolCall {
+				continue
 			}
-			if b, err := json.Marshal(sig); err == nil {
-				out[j].Extras[wireKeyC360ThoughtSignature] = b
+			if rec.ToolCallID == "" || len(rec.Opaque) == 0 {
+				continue
+			}
+			for j := range in[i].ToolCalls {
+				if in[i].ToolCalls[j].ID != rec.ToolCallID {
+					continue
+				}
+				b, err := json.Marshal(string(rec.Opaque))
+				if err != nil {
+					continue
+				}
+				if in[i].ToolCalls[j].Extras == nil {
+					in[i].ToolCalls[j].Extras = make(map[string]json.RawMessage, 1)
+				}
+				in[i].ToolCalls[j].Extras[wireKeyC360ThoughtSignature] = b
+				break
 			}
 		}
 	}
-	return out
+	return in
 }
 
 // wireKeyC360ThoughtSignature is the framework-internal carrier key on
@@ -306,10 +341,12 @@ func (c *Client) convertWireResponse(resp *wire.ChatCompletionResponse, requestI
 				Arguments: args,
 			}
 			if sig := readC360ThoughtSignature(tc); sig != "" {
-				if toolCalls[i].Metadata == nil {
-					toolCalls[i].Metadata = make(map[string]any, 1)
-				}
-				toolCalls[i].Metadata[agentic.MetadataKeyGoogleThoughtSignature] = sig
+				response.Message.ReasoningRecords = append(response.Message.ReasoningRecords, agentic.ReasoningRecord{
+					Provider:    "google",
+					CarrierKind: agentic.ReasoningCarrierToolCall,
+					ToolCallID:  tc.ID,
+					Opaque:      []byte(sig),
+				})
 			}
 		}
 		response.Message.ToolCalls = toolCalls

--- a/processor/agentic-model/component.go
+++ b/processor/agentic-model/component.go
@@ -703,6 +703,12 @@ func (c *Component) getClientForRequest(req agentic.AgentRequest) (*Client, *mod
 
 	// Wire provider adapter for request/response normalization.
 	client.SetAdapter(AdapterFor(ep.Provider))
+	// ADR-051: when the endpoint opts into the Responses path,
+	// also wire the Responses-side adapter so capture/echo of
+	// ReasoningRecord{CarrierKind:StandaloneItem} runs at the seam.
+	if ep.WireBackend == "responses" {
+		client.SetResponsesAdapter(ResponsesAdapterFor(ep.Provider))
+	}
 
 	// Wire logger, streaming chunk handler, and metrics
 	client.SetLogger(c.logger)

--- a/processor/agentic-model/gemini_thought_signature_live_test.go
+++ b/processor/agentic-model/gemini_thought_signature_live_test.go
@@ -14,14 +14,18 @@ import (
 )
 
 // ADR-037 chunk 8 live_llm smoke against Gemini 3.x preview.
+// Post-ADR-051: carrier is ChatMessage.ReasoningRecords; field
+// matched by ToolCallID on echo.
 //
 // Asserts the end-to-end thought_signature round trip:
 //  1. First request elicits a tool_call from the model.
 //  2. The wire response carries extra_content.google.thought_signature
-//     and convertWireResponse lifts it into agentic.ToolCall.Metadata.
-//  3. The second request (with tool result + replayed assistant tool_call)
-//     is accepted — Gemini 3.x rejects multi-turn tool flows where the
-//     signature isn't echoed.
+//     and convertWireResponse lifts it into
+//     ChatMessage.ReasoningRecords as a ReasoningRecord{Provider:"google",
+//     CarrierKind:ToolCall, ToolCallID:...}.
+//  3. The second request (with tool result + replayed assistant
+//     message including its ReasoningRecords) is accepted — Gemini 3.x
+//     rejects multi-turn tool flows where the signature isn't echoed.
 //
 // Requires:
 //   - GEMINI_API_KEY environment variable (sourced from secrets manager).
@@ -118,21 +122,24 @@ func TestGemini3x_ThoughtSignature_RoundTrip(t *testing.T) {
 			resp1.Status, resp1.Message.Content)
 	}
 	tc := resp1.Message.ToolCalls[0]
-	sig, _ := tc.Metadata[agentic.MetadataKeyGoogleThoughtSignature].(string)
+	sig := signatureForToolCall(resp1.Message.ReasoningRecords, tc.ID)
 	t.Logf("turn 1 toolcall[0]: id=%q name=%q args=%v sig_len=%d sig_preview=%q",
 		tc.ID, tc.Name, tc.Arguments, len(sig), previewSig(sig))
 	if sig == "" {
 		t.Logf("turn 1: thought_signature is empty — model is not a 3.x preview build OR the API stripped it. Continuing to turn 2 to see whether the round-trip still succeeds without it.")
 	}
 
-	// Turn 2: replay the assistant tool_call + supply the tool result.
+	// Turn 2: replay the assistant message + supply the tool result.
+	// ReasoningRecords ride alongside the ToolCalls on the assistant
+	// message; attachReasoningRecordsToWire rebinds them by ToolCallID.
 	turn2 := agentic.AgentRequest{
 		RequestID: "req-gemini-rt-2",
 		Messages: []agentic.ChatMessage{
 			{Role: "user", Content: "What is 17 * 23? Use the multiply tool."},
 			{
-				Role:      "assistant",
-				ToolCalls: resp1.Message.ToolCalls, // carries signature in Metadata
+				Role:             "assistant",
+				ToolCalls:        resp1.Message.ToolCalls,
+				ReasoningRecords: resp1.Message.ReasoningRecords,
 			},
 			{
 				Role:       "tool",
@@ -165,4 +172,16 @@ func previewSig(s string) string {
 		return s
 	}
 	return s[:16] + "..."
+}
+
+// signatureForToolCall extracts the Gemini thought signature from a
+// message's ReasoningRecords for a specific tool_call. Returns "" if
+// no matching record is found.
+func signatureForToolCall(records []agentic.ReasoningRecord, toolCallID string) string {
+	for _, rec := range records {
+		if rec.Provider == "google" && rec.CarrierKind == agentic.ReasoningCarrierToolCall && rec.ToolCallID == toolCallID {
+			return string(rec.Opaque)
+		}
+	}
+	return ""
 }

--- a/processor/agentic-model/metrics.go
+++ b/processor/agentic-model/metrics.go
@@ -37,6 +37,11 @@ type modelMetrics struct {
 
 	// Endpoint health (circuit-breaker observability)
 	endpointHealthState *prometheus.GaugeVec
+
+	// Per-request bytes-on-wire by backend. Used to observe the
+	// stateless-echo cost on the Responses backend (ADR-051 D2),
+	// where echoed reasoning items add bytes to every request.
+	requestBytes *prometheus.HistogramVec
 }
 
 // Package-level metrics (registered once to avoid duplicate registration errors)
@@ -135,6 +140,14 @@ func getMetrics(registry *metric.MetricsRegistry) *modelMetrics {
 				Name:      "endpoint_health_state",
 				Help:      "Circuit-breaker state for each endpoint (1 if endpoint is in this state, 0 otherwise). state label: closed, open, half_open.",
 			}, []string{"endpoint", "state"}),
+
+			requestBytes: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Namespace: "semstreams",
+				Subsystem: "agentic_model",
+				Name:      "request_bytes",
+				Help:      "Distribution of outgoing request body sizes by backend and model. Used to observe the stateless reasoning-echo cost on the Responses backend (ADR-051).",
+				Buckets:   prometheus.ExponentialBuckets(1024, 2, 14), // 1 KiB to ~16 MiB
+			}, []string{"backend", "model"}),
 		}
 
 		// Register metrics with the metrics registry if available
@@ -151,6 +164,7 @@ func getMetrics(registry *metric.MetricsRegistry) *modelMetrics {
 			_ = registry.RegisterCounterVec("agentic-model", "rate_limit_retries_total", metrics.rateLimitRetries)
 			_ = registry.RegisterCounterVec("agentic-model", "length_truncations_total", metrics.lengthTruncationsTotal)
 			_ = registry.RegisterGaugeVec("agentic-model", "endpoint_health_state", metrics.endpointHealthState)
+			_ = registry.RegisterHistogramVec("agentic-model", "request_bytes", metrics.requestBytes)
 		} else {
 			// Fallback to default prometheus registry for testing
 			_ = prometheus.DefaultRegisterer.Register(metrics.requestsTotal)
@@ -165,9 +179,18 @@ func getMetrics(registry *metric.MetricsRegistry) *modelMetrics {
 			_ = prometheus.DefaultRegisterer.Register(metrics.rateLimitRetries)
 			_ = prometheus.DefaultRegisterer.Register(metrics.lengthTruncationsTotal)
 			_ = prometheus.DefaultRegisterer.Register(metrics.endpointHealthState)
+			_ = prometheus.DefaultRegisterer.Register(metrics.requestBytes)
 		}
 	})
 	return metrics
+}
+
+// recordResponsesRequestBytes observes the outgoing wire-bytes size
+// for a Responses request. Labels backend="responses" so the metric
+// can be split per-backend (operators can compare against wire/SDK
+// baselines).
+func (m *modelMetrics) recordResponsesRequestBytes(model string, bytes float64) {
+	m.requestBytes.WithLabelValues("responses", model).Observe(bytes)
 }
 
 // recordEndpointHealthState sets the gauge for one endpoint to indicate

--- a/processor/agentic-model/openai_responses_live_test.go
+++ b/processor/agentic-model/openai_responses_live_test.go
@@ -33,6 +33,17 @@ import (
 
 const openAIResponsesDefaultModel = "gpt-5.5"
 
+// openAIResponsesReasoningModel picks the model used for the
+// reasoning-explicit test. Defaults to gpt-5.5 (which supports
+// reasoning_effort when wired through /v1/responses); override with
+// OPENAI_RESPONSES_REASONING_MODEL for o-series / Codex / GPT-5.5-mini.
+func openAIResponsesReasoningModel() string {
+	if m := os.Getenv("OPENAI_RESPONSES_REASONING_MODEL"); m != "" {
+		return m
+	}
+	return "gpt-5.5"
+}
+
 func requireOpenAIAPIKey(t *testing.T) string {
 	t.Helper()
 	key := os.Getenv("OPENAI_API_KEY")
@@ -181,6 +192,148 @@ func TestOpenAIResponses_ToolFlow_WithReasoningEcho(t *testing.T) {
 	t.Logf("turn 2: status=%q content=%q", resp2.Status, resp2.Message.Content)
 	if !strings.Contains(resp2.Message.Content, "391") {
 		t.Errorf("expected 391 in turn 2 response, got %q", resp2.Message.Content)
+	}
+}
+
+// TestOpenAIResponses_ReasoningEcho is the ADR-051 forcing-function
+// gate: exercises tool_choice + reasoning_effort combined (the combo
+// ChatCompletion forbids on GPT-5.5 / o-series, which is the entire
+// reason this work exists). Asserts:
+//
+//  1. Turn 1 elicits BOTH a tool_call AND at least one
+//     ReasoningRecord{Provider:"openai", CarrierKind:StandaloneItem}
+//     with non-empty Opaque bytes (the encrypted_content blob).
+//  2. Turn 2 replays the assistant message WITH ReasoningRecords +
+//     supplies the tool result, and the API accepts it. If the echo
+//     is broken (records not flowing through ChatMessage.ReasoningRecords,
+//     adapter not rebuilding the reasoning InputItem shape, or the
+//     translator not interleaving them with messages correctly),
+//     turn 2 either fails outright or the model re-thinks instead
+//     of continuing — both are failure modes this test catches.
+//
+// Override model with OPENAI_RESPONSES_REASONING_MODEL when the
+// default doesn't emit reasoning items in your account.
+func TestOpenAIResponses_ReasoningEcho(t *testing.T) {
+	requireOpenAIAPIKey(t)
+
+	chosenModel := openAIResponsesReasoningModel()
+	client, err := agenticmodel.NewClient(&model.EndpointConfig{
+		Provider:        "openai",
+		URL:             "https://api.openai.com/v1",
+		Model:           chosenModel,
+		APIKeyEnv:       "OPENAI_API_KEY",
+		WireBackend:     "responses",
+		ReasoningEffort: "medium", // forcing-function combo with tool_choice
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	client.SetResponsesAdapter(agenticmodel.ResponsesAdapterFor("openai"))
+
+	ctx := context.Background()
+	tools := []agentic.ToolDefinition{
+		{
+			Name:        "multiply",
+			Description: "Multiplies two integers and returns the product.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"a": map[string]any{"type": "integer"},
+					"b": map[string]any{"type": "integer"},
+				},
+				"required": []string{"a", "b"},
+			},
+		},
+	}
+
+	t.Logf("Reasoning-explicit test against model=%q with reasoning.effort=medium", chosenModel)
+
+	turn1 := agentic.AgentRequest{
+		RequestID: "req-resp-reasoning-1",
+		Messages: []agentic.ChatMessage{
+			{Role: "user", Content: "What is 47 * 89? Think carefully, then use the multiply tool."},
+		},
+		Tools: tools,
+	}
+	ctx1, cancel1 := context.WithTimeout(ctx, 90*time.Second)
+	resp1, err := client.ChatCompletion(ctx1, turn1)
+	cancel1()
+	if err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if resp1.Status == "error" {
+		t.Fatalf("turn 1 error: %s", resp1.Error)
+	}
+	t.Logf("turn 1: status=%q toolcalls=%d reasoning_records=%d",
+		resp1.Status, len(resp1.Message.ToolCalls), len(resp1.Message.ReasoningRecords))
+
+	if len(resp1.Message.ToolCalls) == 0 {
+		t.Fatalf("turn 1: expected at least one tool_call, got status=%q content=%q",
+			resp1.Status, resp1.Message.Content)
+	}
+	if len(resp1.Message.ReasoningRecords) == 0 {
+		t.Fatalf("turn 1: expected at least one ReasoningRecord (model=%s, reasoning_effort=medium); "+
+			"the API didn't emit reasoning items. Try a Codex-class or o-series model via "+
+			"OPENAI_RESPONSES_REASONING_MODEL.", chosenModel)
+	}
+
+	// Inspect the first ReasoningRecord: provider, carrier kind,
+	// non-empty Opaque, non-empty ItemID.
+	rec := resp1.Message.ReasoningRecords[0]
+	t.Logf("turn 1 reasoning_record[0]: provider=%q carrier=%q item_id=%q opaque_len=%d summary=%q",
+		rec.Provider, rec.CarrierKind, rec.ItemID, len(rec.Opaque), rec.SummaryText)
+	if rec.Provider != "openai" {
+		t.Errorf("ReasoningRecord[0].Provider = %q, want openai", rec.Provider)
+	}
+	if string(rec.CarrierKind) != "standalone_item" {
+		t.Errorf("ReasoningRecord[0].CarrierKind = %q, want standalone_item", rec.CarrierKind)
+	}
+	if rec.ItemID == "" {
+		t.Error("ReasoningRecord[0].ItemID empty (capture path broken?)")
+	}
+	if len(rec.Opaque) == 0 {
+		t.Error("ReasoningRecord[0].Opaque empty (encrypted_content not captured?)")
+	}
+
+	tc := resp1.Message.ToolCalls[0]
+	t.Logf("turn 1 tool_call: id=%q name=%q args=%v", tc.ID, tc.Name, tc.Arguments)
+
+	// Turn 2: replay the assistant message INCLUDING ReasoningRecords,
+	// supply the tool result. If the echo path is correctly threading
+	// the encrypted_content blob back as an input reasoning item,
+	// OpenAI accepts the request and continues; if not, it errors or
+	// the model re-thinks visibly.
+	turn2 := agentic.AgentRequest{
+		RequestID: "req-resp-reasoning-2",
+		Messages: []agentic.ChatMessage{
+			{Role: "user", Content: "What is 47 * 89? Think carefully, then use the multiply tool."},
+			{
+				Role:             "assistant",
+				ToolCalls:        resp1.Message.ToolCalls,
+				ReasoningRecords: resp1.Message.ReasoningRecords,
+			},
+			{
+				Role:       "tool",
+				ToolCallID: tc.ID,
+				Name:       tc.Name,
+				Content:    `{"product":4183}`,
+			},
+		},
+		Tools: tools,
+	}
+	ctx2, cancel2 := context.WithTimeout(ctx, 90*time.Second)
+	resp2, err := client.ChatCompletion(ctx2, turn2)
+	cancel2()
+	if err != nil {
+		t.Fatalf("turn 2 (reasoning echo): %v", err)
+	}
+	if resp2.Status == "error" {
+		t.Fatalf("turn 2 reasoning echo error: %s — likely ReasoningRecord echo path broken "+
+			"(records didn't reconstruct on the wire correctly)", resp2.Error)
+	}
+	t.Logf("turn 2 (reasoning echo): status=%q content=%q", resp2.Status, resp2.Message.Content)
+	if !strings.Contains(resp2.Message.Content, "4183") {
+		t.Errorf("expected 4183 in turn 2 response, got %q", resp2.Message.Content)
 	}
 }
 

--- a/processor/agentic-model/openai_responses_live_test.go
+++ b/processor/agentic-model/openai_responses_live_test.go
@@ -1,0 +1,239 @@
+//go:build live_llm
+
+package agenticmodel_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model"
+	agenticmodel "github.com/c360studio/semstreams/processor/agentic-model"
+)
+
+// ADR-051 live_llm parity test against OpenAI's /v1/responses
+// endpoint. Doubles as the fixture-capture mechanism for the
+// model/wire/responses/testdata/ golden round-trip tests.
+//
+// Requires:
+//   - OPENAI_API_KEY environment variable
+//   - Model defaults to "gpt-5.5"; override with OPENAI_RESPONSES_MODEL
+//
+// Run: go test -tags live_llm -run TestOpenAIResponses \
+//              ./processor/agentic-model/...
+//
+// Set CAPTURE_FIXTURES=1 to write request/response bodies to
+// model/wire/responses/testdata/ (overwrites existing fixtures).
+
+const openAIResponsesDefaultModel = "gpt-5.5"
+
+func requireOpenAIAPIKey(t *testing.T) string {
+	t.Helper()
+	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		t.Skip("OPENAI_API_KEY not set; skipping OpenAI Responses live_llm test")
+	}
+	return key
+}
+
+func openAIResponsesTestModel() string {
+	if m := os.Getenv("OPENAI_RESPONSES_MODEL"); m != "" {
+		return m
+	}
+	return openAIResponsesDefaultModel
+}
+
+func newOpenAIResponsesLiveClient(t *testing.T) *agenticmodel.Client {
+	t.Helper()
+	requireOpenAIAPIKey(t)
+	client, err := agenticmodel.NewClient(&model.EndpointConfig{
+		Provider:    "openai",
+		URL:         "https://api.openai.com/v1",
+		Model:       openAIResponsesTestModel(),
+		APIKeyEnv:   "OPENAI_API_KEY",
+		WireBackend: "responses",
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	client.SetResponsesAdapter(agenticmodel.ResponsesAdapterFor("openai"))
+	return client
+}
+
+// TestOpenAIResponses_SingleTurn pins a simple end-to-end call:
+// user prompt → assistant text response. Smoke test for dispatch
+// + translation + adapter wiring.
+func TestOpenAIResponses_SingleTurn(t *testing.T) {
+	client := newOpenAIResponsesLiveClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	resp, err := client.ChatCompletion(ctx, agentic.AgentRequest{
+		RequestID: "req-resp-1",
+		Messages: []agentic.ChatMessage{
+			{Role: "user", Content: "Reply with only the word 'pong'."},
+		},
+		MaxTokens: 64,
+	})
+	if err != nil {
+		t.Fatalf("ChatCompletion: %v", err)
+	}
+	if resp.Status == "error" {
+		t.Fatalf("status=error: %s", resp.Error)
+	}
+	t.Logf("single-turn response: status=%q content=%q", resp.Status, resp.Message.Content)
+	if !strings.Contains(strings.ToLower(resp.Message.Content), "pong") {
+		t.Errorf("expected 'pong' in response, got %q", resp.Message.Content)
+	}
+}
+
+// TestOpenAIResponses_ToolFlow_WithReasoningEcho exercises the full
+// multi-turn tool flow: turn 1 elicits a function_call + reasoning
+// echo; turn 2 replays the assistant message (with ReasoningRecords)
+// plus the tool result and expects a coherent terminal response.
+//
+// This is the parity gate for the carrier abstraction: if echo is
+// broken (records not flowing through ChatMessage.ReasoningRecords,
+// adapter not rebuilding the wire shape), turn 2 fails or the model
+// re-thinks instead of continuing.
+func TestOpenAIResponses_ToolFlow_WithReasoningEcho(t *testing.T) {
+	client := newOpenAIResponsesLiveClient(t)
+	ctx := context.Background()
+
+	tools := []agentic.ToolDefinition{
+		{
+			Name:        "multiply",
+			Description: "Multiplies two integers and returns the product.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"a": map[string]any{"type": "integer"},
+					"b": map[string]any{"type": "integer"},
+				},
+				"required": []string{"a", "b"},
+			},
+		},
+	}
+
+	turn1 := agentic.AgentRequest{
+		RequestID: "req-resp-tool-1",
+		Messages: []agentic.ChatMessage{
+			{Role: "user", Content: "What is 17 * 23? Use the multiply tool."},
+		},
+		Tools: tools,
+	}
+	ctx1, cancel1 := context.WithTimeout(ctx, 90*time.Second)
+	resp1, err := client.ChatCompletion(ctx1, turn1)
+	cancel1()
+	if err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if resp1.Status == "error" {
+		t.Fatalf("turn 1 error: %s", resp1.Error)
+	}
+	t.Logf("turn 1: status=%q toolcalls=%d reasoning_records=%d",
+		resp1.Status, len(resp1.Message.ToolCalls), len(resp1.Message.ReasoningRecords))
+	if len(resp1.Message.ToolCalls) == 0 {
+		t.Fatalf("turn 1: expected tool_call, got status=%q content=%q",
+			resp1.Status, resp1.Message.Content)
+	}
+	tc := resp1.Message.ToolCalls[0]
+	t.Logf("turn 1 tool_call: id=%q name=%q args=%v", tc.ID, tc.Name, tc.Arguments)
+	t.Logf("turn 1 reasoning_records: %d items", len(resp1.Message.ReasoningRecords))
+	for i, rec := range resp1.Message.ReasoningRecords {
+		t.Logf("  record[%d]: provider=%q carrier=%q item_id=%q opaque_len=%d",
+			i, rec.Provider, rec.CarrierKind, rec.ItemID, len(rec.Opaque))
+	}
+
+	turn2 := agentic.AgentRequest{
+		RequestID: "req-resp-tool-2",
+		Messages: []agentic.ChatMessage{
+			{Role: "user", Content: "What is 17 * 23? Use the multiply tool."},
+			{
+				Role:             "assistant",
+				ToolCalls:        resp1.Message.ToolCalls,
+				ReasoningRecords: resp1.Message.ReasoningRecords,
+			},
+			{
+				Role:       "tool",
+				ToolCallID: tc.ID,
+				Name:       tc.Name,
+				Content:    `{"product":391}`,
+			},
+		},
+		Tools: tools,
+	}
+	ctx2, cancel2 := context.WithTimeout(ctx, 90*time.Second)
+	resp2, err := client.ChatCompletion(ctx2, turn2)
+	cancel2()
+	if err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	if resp2.Status == "error" {
+		t.Fatalf("turn 2 error: %s — likely reasoning_records not echoed correctly", resp2.Error)
+	}
+	t.Logf("turn 2: status=%q content=%q", resp2.Status, resp2.Message.Content)
+	if !strings.Contains(resp2.Message.Content, "391") {
+		t.Errorf("expected 391 in turn 2 response, got %q", resp2.Message.Content)
+	}
+}
+
+// TestOpenAIResponses_CaptureFixtures harvests live request/response
+// bodies into model/wire/responses/testdata/ for the unit-level
+// round-trip parity tests. Skips by default; enable with
+// CAPTURE_FIXTURES=1. Overwrites existing files unconditionally
+// when enabled — caller decides when to re-capture.
+func TestOpenAIResponses_CaptureFixtures(t *testing.T) {
+	if os.Getenv("CAPTURE_FIXTURES") != "1" {
+		t.Skip("CAPTURE_FIXTURES != 1; skipping fixture capture")
+	}
+	requireOpenAIAPIKey(t)
+
+	testdataDir, err := filepath.Abs(filepath.Join("..", "..", "model", "wire", "responses", "testdata"))
+	if err != nil {
+		t.Fatalf("resolve testdata dir: %v", err)
+	}
+	if _, err := os.Stat(testdataDir); err != nil {
+		t.Fatalf("testdata dir not found: %v", err)
+	}
+
+	// We can't easily intercept the wire body from inside the
+	// agentic-model client; instead, we drive the responses.Client
+	// directly here and serialize the request/response pair.
+	// This is the same shape the agentic-model client constructs;
+	// the captured fixtures back the round-trip tests in
+	// model/wire/responses/.
+
+	// NOTE: the implementation of this capture is intentionally a
+	// future seam. Set CAPTURE_FIXTURES=1 to run, but the test will
+	// emit a TODO log line until the seam is filled. The TODO does
+	// not fail the test — it's a known gap tracked in the PR.
+	t.Logf("TODO: fixture capture implementation pending — see ADR-051 pre-tag gate")
+	_ = testdataDir
+}
+
+// outputJSONToFile is a helper for fixture capture (kept for the
+// scaffold even if TestOpenAIResponses_CaptureFixtures defers the
+// real capture).
+func outputJSONToFile(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	t.Logf("wrote %s (%d bytes)", filepath.Base(path), len(b))
+}
+
+// _ = silences the unused-function lint when the fixture capture
+// seam hasn't been filled.
+var _ = fmt.Stringer(nil)
+var _ = outputJSONToFile

--- a/processor/agentic-model/stream_responses.go
+++ b/processor/agentic-model/stream_responses.go
@@ -1,0 +1,119 @@
+package agenticmodel
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model/wire/responses"
+)
+
+// streamResponses handles the Responses-native streaming path.
+// Connection errors return a Go error (retryable); mid-stream
+// errors return AgentResponse{Status:"error"} (not retryable).
+// Mirrors streamChatCompletionWire's contract.
+func (c *Client) streamResponses(ctx context.Context, rc *responses.Client, req responses.Request, requestID string) (agentic.AgentResponse, error) {
+	stream, err := rc.ResponsesStream(ctx, &req)
+	if err != nil {
+		return agentic.AgentResponse{}, err
+	}
+	defer stream.Close()
+
+	acc := responses.NewAccumulator()
+	streamStart := time.Now()
+	firstTokenRecorded := false
+
+	for {
+		ev, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			// Mid-stream decode/IO error: surface as an error
+			// AgentResponse with whatever was accumulated so the
+			// loop can observe partial progress. Not retryable
+			// (the retry loop classifies on Go errors, not on
+			// error-status responses).
+			final := acc.Final()
+			resp := c.convertResponsesResponse(final, requestID)
+			resp.Status = "error"
+			resp.Error = err.Error()
+			return resp, nil
+		}
+
+		if accErr := acc.Add(ev); accErr != nil && c.logger != nil {
+			c.logger.Debug("responses accumulator: skipping malformed event",
+				slog.String("request_id", requestID),
+				slog.String("event_type", ev.Type),
+				slog.Any("err", accErr))
+		}
+
+		c.dispatchResponsesChunk(ev, requestID)
+
+		if c.metrics != nil {
+			c.metrics.recordStreamChunk(req.Model)
+			if !firstTokenRecorded && responsesEventCarriesText(ev) {
+				c.metrics.recordStreamTTFT(req.Model, time.Since(streamStart).Seconds())
+				firstTokenRecorded = true
+			}
+		}
+	}
+
+	if c.chunkHandler != nil {
+		c.chunkHandler(StreamChunk{RequestID: requestID, Done: true})
+	}
+
+	final := acc.Final()
+	return c.convertResponsesResponse(final, requestID), nil
+}
+
+// dispatchResponsesChunk forwards the per-event text deltas to the
+// chunk handler. Translates the typed Responses event into the
+// flat StreamChunk shape the rest of the agentic stack consumes.
+// Non-text events (lifecycle, item lifecycle) are not forwarded —
+// they don't carry visible content.
+func (c *Client) dispatchResponsesChunk(ev *responses.Event, requestID string) {
+	if c.chunkHandler == nil {
+		return
+	}
+	switch ev.Type {
+	case responses.EventTypeOutputTextDelta:
+		c.chunkHandler(StreamChunk{
+			RequestID:    requestID,
+			ContentDelta: ev.Delta,
+		})
+	case responses.EventTypeReasoningSummaryTextDelta:
+		c.chunkHandler(StreamChunk{
+			RequestID:      requestID,
+			ReasoningDelta: ev.Delta,
+		})
+	case responses.EventTypeFunctionCallArgumentsDelta:
+		// Function-call arguments deltas flow through as content for
+		// trace observability. The terminal accumulator still
+		// reconstructs the full ToolCall from the .done snapshot.
+		c.chunkHandler(StreamChunk{
+			RequestID:    requestID,
+			ContentDelta: ev.Delta,
+		})
+	}
+}
+
+// responsesEventCarriesText reports whether an event has non-empty
+// delta text — used to gate the time-to-first-token metric so it
+// fires on the first visible content rather than the first lifecycle
+// event.
+func responsesEventCarriesText(ev *responses.Event) bool {
+	if ev == nil {
+		return false
+	}
+	switch ev.Type {
+	case responses.EventTypeOutputTextDelta,
+		responses.EventTypeReasoningSummaryTextDelta,
+		responses.EventTypeFunctionCallArgumentsDelta:
+		return ev.Delta != ""
+	}
+	return false
+}

--- a/processor/agentic-model/stream_wire.go
+++ b/processor/agentic-model/stream_wire.go
@@ -329,12 +329,15 @@ func (a *wireStreamAccumulator) toAgentResponse(requestID string) agentic.AgentR
 			}
 			// Read the carrier off the post-NormalizeResponse wire shape
 			// (synth.Choices[0].Message.ToolCalls[i] mirrors the SDK-side
-			// extraction in convertWireResponse).
+			// extraction in convertWireResponse). Lift into the message-
+			// level ReasoningRecords sibling field per ADR-051.
 			if sig := readC360ThoughtSignature(synth.Choices[0].Message.ToolCalls[i]); sig != "" {
-				if out.Metadata == nil {
-					out.Metadata = make(map[string]any, 1)
-				}
-				out.Metadata[agentic.MetadataKeyGoogleThoughtSignature] = sig
+				resp.Message.ReasoningRecords = append(resp.Message.ReasoningRecords, agentic.ReasoningRecord{
+					Provider:    "google",
+					CarrierKind: agentic.ReasoningCarrierToolCall,
+					ToolCallID:  tc.ID,
+					Opaque:      []byte(sig),
+				})
 			}
 			toolCalls = append(toolCalls, out)
 		}

--- a/processor/agentic-model/translate_responses.go
+++ b/processor/agentic-model/translate_responses.go
@@ -138,7 +138,22 @@ func (c *Client) applyResponsesRequestParams(out *responses.Request, req agentic
 	}
 	if c.endpoint.ReasoningEffort != "" {
 		out.Reasoning = &responses.ReasoningParams{Effort: c.endpoint.ReasoningEffort}
+		// Opt into encrypted_content emission on reasoning output
+		// items. Without this, the API omits encrypted_content and
+		// cross-turn echo loses the opaque blob — a silent break
+		// caught by the ADR-051 PR 4 live reasoning-echo test.
+		out.Include = appendUnique(out.Include, "reasoning.encrypted_content")
 	}
+}
+
+// appendUnique appends v to dst if not already present.
+func appendUnique(dst []string, v string) []string {
+	for _, s := range dst {
+		if s == v {
+			return dst
+		}
+	}
+	return append(dst, v)
 }
 
 // agenticResponseFormatToResponsesText translates agentic.ResponseFormat

--- a/processor/agentic-model/translate_responses.go
+++ b/processor/agentic-model/translate_responses.go
@@ -1,0 +1,231 @@
+package agenticmodel
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model/wire/responses"
+)
+
+// buildResponsesRequest converts an AgentRequest into a responses.Request,
+// translating the ChatCompletion-shaped message conversation into the
+// Responses typed-array input shape and reshaping reasoning records
+// for echo. Adapter NormalizeRequest runs after translation; the
+// echo step lives at this seam so adapter hooks operate on a fully-
+// formed request.
+//
+// Translation table:
+//
+//   - role=system → role=developer InputItem (explicit translation
+//     per ADR-051 open question 2; avoids relying on silent provider
+//     compat).
+//   - role=user → role=user InputItem with input_text content.
+//   - role=assistant with content → role=assistant InputItem with
+//     output_text content.
+//   - role=assistant with tool_calls → emit each tool_call as a
+//     standalone function_call InputItem (echoes the OpenAI
+//     Responses shape where assistant tool calls are top-level items,
+//     not nested inside a message).
+//   - role=tool → function_call_output InputItem keyed by
+//     ToolCallID.
+//   - ReasoningRecords from the agentic message → reasoning
+//     InputItems via the ResponsesAdapter's EchoReasoningRecords
+//     hook. Echoed AFTER the message they were captured from, in
+//     the order the API recommends.
+func (c *Client) buildResponsesRequest(req agentic.AgentRequest) responses.Request {
+	if len(req.Messages) == 0 {
+		if c.logger != nil {
+			c.logger.Warn("buildResponsesRequest called with empty messages",
+				slog.String("request_id", req.RequestID),
+				slog.String("loop_id", req.LoopID))
+		}
+		return responses.Request{Model: c.endpoint.Model}
+	}
+
+	adapter := c.getResponsesAdapter()
+	out := responses.Request{
+		Model: c.endpoint.Model,
+	}
+
+	// Stateless mode (ADR-051 D2): always set Store=false so the
+	// caller owns full history and echoes reasoning items per turn.
+	storeFalse := false
+	out.Store = &storeFalse
+
+	for _, msg := range req.Messages {
+		input := agenticMessageToResponses(msg)
+		out.Input = append(out.Input, input...)
+		echoed := adapter.EchoReasoningRecords(msg.ReasoningRecords)
+		out.Input = append(out.Input, echoed...)
+	}
+
+	c.applyResponsesRequestParams(&out, req)
+	if req.ResponseFormat != nil {
+		out.Text = agenticResponseFormatToResponsesText(req.ResponseFormat, req.RequestID, c.logger)
+	}
+	if len(req.Tools) > 0 {
+		out.Tools = agenticToolsToResponses(req.Tools)
+	}
+	if req.ToolChoice != nil {
+		out.ToolChoice = agenticToolChoiceToResponses(req.ToolChoice)
+	}
+
+	adapter.NormalizeRequest(&out)
+	return out
+}
+
+// agenticMessageToResponses translates one agentic ChatMessage into
+// zero or more Responses InputItems per the table above. Tool
+// messages produce a single function_call_output; assistant
+// messages with tool_calls produce one function_call per call (and
+// optionally a message InputItem if there's also content).
+func agenticMessageToResponses(msg agentic.ChatMessage) []responses.InputItem {
+	switch msg.Role {
+	case "system":
+		// Explicit translation: avoid silent provider compat.
+		return []responses.InputItem{responses.NewInputDeveloperMessage(msg.Content)}
+
+	case "user":
+		return []responses.InputItem{responses.NewInputUserMessage(msg.Content)}
+
+	case "assistant":
+		var out []responses.InputItem
+		if msg.Content != "" {
+			out = append(out, responses.InputItem{
+				Type: responses.ItemTypeMessage,
+				Role: responses.RoleAssistant,
+				Content: []responses.ContentPart{
+					{Type: responses.ContentTypeOutputText, Text: msg.Content},
+				},
+			})
+		}
+		for _, tc := range msg.ToolCalls {
+			argsJSON := ""
+			if len(tc.Arguments) > 0 {
+				if b, err := json.Marshal(tc.Arguments); err == nil {
+					argsJSON = string(b)
+				}
+			}
+			out = append(out, responses.NewInputFunctionCall(tc.ID, tc.Name, argsJSON))
+		}
+		return out
+
+	case "tool":
+		return []responses.InputItem{responses.NewInputFunctionCallOutput(msg.ToolCallID, msg.Content)}
+
+	default:
+		// Forward-compat: emit a developer message so the model sees
+		// the content rather than dropping it silently.
+		return []responses.InputItem{responses.NewInputDeveloperMessage(msg.Content)}
+	}
+}
+
+// applyResponsesRequestParams writes the scalar sampling controls
+// from AgentRequest + endpoint config onto the responses.Request.
+// Mirrors applyWireRequestParams. Field names are the Responses-API
+// names ("max_output_tokens", not "max_tokens").
+func (c *Client) applyResponsesRequestParams(out *responses.Request, req agentic.AgentRequest) {
+	switch {
+	case req.MaxTokens > 0:
+		out.MaxOutputTokens = req.MaxTokens
+	case c.endpoint.MaxOutputTokens > 0:
+		out.MaxOutputTokens = c.endpoint.MaxOutputTokens
+	}
+	if req.Temperature > 0 {
+		t := req.Temperature
+		out.Temperature = &t
+	}
+	if c.endpoint.ReasoningEffort != "" {
+		out.Reasoning = &responses.ReasoningParams{Effort: c.endpoint.ReasoningEffort}
+	}
+}
+
+// agenticResponseFormatToResponsesText translates agentic.ResponseFormat
+// into the Responses-shape text.format envelope. Distinct from
+// ChatCompletion's top-level response_format — Responses nests
+// format under text.
+//
+// Phase 1 supports json_schema and json_object via a minimal hand-
+// shaped envelope; the schema bytes flow through json.RawMessage.
+// A marshal failure on rf.Schema is surfaced via Warn — silent
+// drop would surface as an upstream generic 400 with "schema must
+// be object" instead of the real root cause.
+func agenticResponseFormatToResponsesText(rf *agentic.ResponseFormat, requestID string, logger *slog.Logger) *responses.TextParams {
+	if rf == nil {
+		return nil
+	}
+	switch rf.Type {
+	case agentic.ResponseFormatJSONObject:
+		return &responses.TextParams{
+			Format: json.RawMessage(`{"type":"json_object"}`),
+		}
+	case agentic.ResponseFormatJSONSchema:
+		envelope := map[string]any{
+			"type":   "json_schema",
+			"name":   rf.Name,
+			"strict": rf.Strict,
+		}
+		if len(rf.Schema) > 0 {
+			envelope["schema"] = rf.Schema
+		}
+		b, err := json.Marshal(envelope)
+		if err != nil {
+			if logger != nil {
+				logger.Warn("response_format schema failed to marshal; upstream will reject with a generic schema error",
+					slog.String("request_id", requestID),
+					slog.String("name", rf.Name),
+					slog.Any("err", err))
+			}
+			return nil
+		}
+		return &responses.TextParams{Format: b}
+	default:
+		return nil
+	}
+}
+
+// agenticToolsToResponses translates agentic tool definitions to
+// the Responses-shape flat layout ({type, name, description,
+// parameters, strict}). Distinct from ChatCompletion's nested
+// {type:"function", function:{...}}.
+func agenticToolsToResponses(in []agentic.ToolDefinition) []responses.Tool {
+	out := make([]responses.Tool, len(in))
+	for i, t := range in {
+		params, _ := json.Marshal(t.Parameters)
+		out[i] = responses.Tool{
+			Type:        "function",
+			Name:        t.Name,
+			Description: t.Description,
+			Parameters:  params,
+			Strict:      t.Strict,
+		}
+	}
+	return out
+}
+
+// agenticToolChoiceToResponses translates agentic.ToolChoice to the
+// Responses-shape JSON. The string values are identical to
+// ChatCompletion ("auto", "required", "none"); the forced-function
+// shape uses {type:"function", name:"..."} (no nested function
+// object).
+func agenticToolChoiceToResponses(tc *agentic.ToolChoice) json.RawMessage {
+	if tc == nil {
+		return nil
+	}
+	switch tc.Mode {
+	case "auto", "required", "none":
+		if b, err := json.Marshal(tc.Mode); err == nil {
+			return b
+		}
+	case "function":
+		envelope := map[string]any{
+			"type": "function",
+			"name": tc.FunctionName,
+		}
+		if b, err := json.Marshal(envelope); err == nil {
+			return b
+		}
+	}
+	return nil
+}

--- a/processor/agentic-model/translate_responses_test.go
+++ b/processor/agentic-model/translate_responses_test.go
@@ -243,7 +243,10 @@ func TestBuildResponsesRequest_ToolChoiceForced(t *testing.T) {
 
 // TestBuildResponsesRequest_ReasoningEffortFromEndpoint pins that
 // the endpoint's reasoning_effort flows into the Responses
-// reasoning.effort field.
+// reasoning.effort field AND that include is set to opt into
+// encrypted_content emission (without it the API silently omits
+// the blob, breaking cross-turn echo). Both invariants caught by
+// the ADR-051 PR 4 live reasoning-echo test.
 func TestBuildResponsesRequest_ReasoningEffortFromEndpoint(t *testing.T) {
 	c := newResponsesTestClient(t)
 	c.endpoint.ReasoningEffort = "medium"
@@ -252,6 +255,18 @@ func TestBuildResponsesRequest_ReasoningEffortFromEndpoint(t *testing.T) {
 	})
 	if got.Reasoning == nil || got.Reasoning.Effort != "medium" {
 		t.Errorf("Reasoning = %+v, want Effort=medium", got.Reasoning)
+	}
+	wantInclude := "reasoning.encrypted_content"
+	found := false
+	for _, s := range got.Include {
+		if s == wantInclude {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Include = %v, want to contain %q (silent encrypted_content omission risk)",
+			got.Include, wantInclude)
 	}
 }
 

--- a/processor/agentic-model/translate_responses_test.go
+++ b/processor/agentic-model/translate_responses_test.go
@@ -1,0 +1,310 @@
+package agenticmodel
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/model"
+	"github.com/c360studio/semstreams/model/wire/responses"
+)
+
+// newResponsesTestClient builds a minimal Client with a Responses
+// adapter wired so translate calls have something to invoke.
+func newResponsesTestClient(t *testing.T) *Client {
+	t.Helper()
+	c := &Client{
+		endpoint: &model.EndpointConfig{
+			Provider:    "openai",
+			Model:       "gpt-5.5",
+			WireBackend: "responses",
+		},
+		responsesAdapter: &OpenAIResponsesAdapter{},
+	}
+	return c
+}
+
+// TestBuildResponsesRequest_RoleTranslation pins ADR-051 open
+// question 2: system messages translate to role:developer InputItems.
+func TestBuildResponsesRequest_RoleTranslation(t *testing.T) {
+	c := newResponsesTestClient(t)
+	req := agentic.AgentRequest{
+		Messages: []agentic.ChatMessage{
+			{Role: "system", Content: "you are X"},
+			{Role: "user", Content: "do Y"},
+		},
+	}
+	got := c.buildResponsesRequest(req)
+	if len(got.Input) != 2 {
+		t.Fatalf("Input count = %d, want 2", len(got.Input))
+	}
+	if got.Input[0].Role != responses.RoleDeveloper {
+		t.Errorf("system → role = %q, want %q", got.Input[0].Role, responses.RoleDeveloper)
+	}
+	if got.Input[1].Role != responses.RoleUser {
+		t.Errorf("user → role = %q, want %q", got.Input[1].Role, responses.RoleUser)
+	}
+}
+
+// TestBuildResponsesRequest_StatelessByDefault pins ADR-051 D2:
+// the translator always sets Store=false.
+func TestBuildResponsesRequest_StatelessByDefault(t *testing.T) {
+	c := newResponsesTestClient(t)
+	got := c.buildResponsesRequest(agentic.AgentRequest{
+		Messages: []agentic.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	if got.Store == nil || *got.Store != false {
+		t.Errorf("Store = %v, want explicit false", got.Store)
+	}
+}
+
+// TestBuildResponsesRequest_AssistantToolCalls pins that an
+// assistant message with tool_calls produces a function_call
+// InputItem per call, in order.
+func TestBuildResponsesRequest_AssistantToolCalls(t *testing.T) {
+	c := newResponsesTestClient(t)
+	req := agentic.AgentRequest{
+		Messages: []agentic.ChatMessage{
+			{
+				Role: "assistant",
+				ToolCalls: []agentic.ToolCall{
+					{ID: "call_a", Name: "fn_a", Arguments: map[string]any{"x": 1.0}},
+					{ID: "call_b", Name: "fn_b", Arguments: map[string]any{"y": 2.0}},
+				},
+			},
+		},
+	}
+	got := c.buildResponsesRequest(req)
+	if len(got.Input) != 2 {
+		t.Fatalf("Input count = %d, want 2 (one per tool_call, no content message)", len(got.Input))
+	}
+	for i, want := range []struct{ callID, name string }{
+		{"call_a", "fn_a"},
+		{"call_b", "fn_b"},
+	} {
+		if !got.Input[i].IsFunctionCall() {
+			t.Errorf("Input[%d].Type = %q, want function_call", i, got.Input[i].Type)
+		}
+		if got.Input[i].CallID != want.callID {
+			t.Errorf("Input[%d].CallID = %q, want %q", i, got.Input[i].CallID, want.callID)
+		}
+		if got.Input[i].Name != want.name {
+			t.Errorf("Input[%d].Name = %q, want %q", i, got.Input[i].Name, want.name)
+		}
+	}
+}
+
+// TestBuildResponsesRequest_ToolMessage pins that role:tool messages
+// translate to function_call_output InputItems with the tool result
+// in the Output field.
+func TestBuildResponsesRequest_ToolMessage(t *testing.T) {
+	c := newResponsesTestClient(t)
+	req := agentic.AgentRequest{
+		Messages: []agentic.ChatMessage{
+			{
+				Role:       "tool",
+				ToolCallID: "call_a",
+				Name:       "fn_a",
+				Content:    `{"result":42}`,
+			},
+		},
+	}
+	got := c.buildResponsesRequest(req)
+	if len(got.Input) != 1 {
+		t.Fatalf("Input count = %d, want 1", len(got.Input))
+	}
+	if !got.Input[0].IsFunctionCallOutput() {
+		t.Errorf("Type = %q, want function_call_output", got.Input[0].Type)
+	}
+	if got.Input[0].CallID != "call_a" {
+		t.Errorf("CallID = %q, want call_a", got.Input[0].CallID)
+	}
+	if got.Input[0].Output != `{"result":42}` {
+		t.Errorf("Output = %q, want %q", got.Input[0].Output, `{"result":42}`)
+	}
+}
+
+// TestBuildResponsesRequest_ReasoningRecordEcho pins ADR-051 D3
+// echo: ReasoningRecords on an assistant message become reasoning
+// InputItems emitted right after the message's items.
+func TestBuildResponsesRequest_ReasoningRecordEcho(t *testing.T) {
+	c := newResponsesTestClient(t)
+	req := agentic.AgentRequest{
+		Messages: []agentic.ChatMessage{
+			{
+				Role: "assistant",
+				ToolCalls: []agentic.ToolCall{
+					{ID: "call_a", Name: "fn_a"},
+				},
+				ReasoningRecords: []agentic.ReasoningRecord{
+					{
+						Provider:    "openai",
+						CarrierKind: agentic.ReasoningCarrierStandaloneItem,
+						ItemID:      "rs_echo",
+						Opaque:      []byte("echo-blob"),
+						SummaryText: "echo summary",
+					},
+				},
+			},
+		},
+	}
+	got := c.buildResponsesRequest(req)
+	if len(got.Input) != 2 {
+		t.Fatalf("Input count = %d, want 2 (one function_call + one reasoning echo)", len(got.Input))
+	}
+	if !got.Input[0].IsFunctionCall() {
+		t.Errorf("Input[0].Type = %q, want function_call", got.Input[0].Type)
+	}
+	if !got.Input[1].IsReasoning() {
+		t.Errorf("Input[1].Type = %q, want reasoning", got.Input[1].Type)
+	}
+	if got.Input[1].ID != "rs_echo" {
+		t.Errorf("Input[1].ID = %q, want rs_echo", got.Input[1].ID)
+	}
+	if got.Input[1].EncryptedContent != "echo-blob" {
+		t.Errorf("Input[1].EncryptedContent = %q, want echo-blob", got.Input[1].EncryptedContent)
+	}
+}
+
+// TestBuildResponsesRequest_NonOpenAIRecordsSkipped pins that
+// records from other providers (e.g. Gemini ToolCall-carrier) are
+// not echoed onto Responses input — they belong to a different wire
+// path.
+func TestBuildResponsesRequest_NonOpenAIRecordsSkipped(t *testing.T) {
+	c := newResponsesTestClient(t)
+	req := agentic.AgentRequest{
+		Messages: []agentic.ChatMessage{
+			{
+				Role:    "assistant",
+				Content: "hi",
+				ReasoningRecords: []agentic.ReasoningRecord{
+					{
+						Provider:    "google",
+						CarrierKind: agentic.ReasoningCarrierToolCall,
+						ToolCallID:  "call-1",
+						Opaque:      []byte("gemini-sig"),
+					},
+				},
+			},
+		},
+	}
+	got := c.buildResponsesRequest(req)
+	for _, item := range got.Input {
+		if item.IsReasoning() {
+			t.Errorf("unexpected reasoning InputItem from Gemini record: %+v", item)
+		}
+	}
+}
+
+// TestBuildResponsesRequest_ToolDefinitionsFlatShape pins that
+// tool definitions translate to the Responses flat shape, not the
+// ChatCompletion nested {function:{...}} shape.
+func TestBuildResponsesRequest_ToolDefinitionsFlatShape(t *testing.T) {
+	c := newResponsesTestClient(t)
+	req := agentic.AgentRequest{
+		Messages: []agentic.ChatMessage{{Role: "user", Content: "hi"}},
+		Tools: []agentic.ToolDefinition{
+			{
+				Name:        "multiply",
+				Description: "Multiplies",
+				Parameters:  map[string]any{"type": "object"},
+				Strict:      true,
+			},
+		},
+	}
+	got := c.buildResponsesRequest(req)
+	if len(got.Tools) != 1 {
+		t.Fatalf("Tools count = %d, want 1", len(got.Tools))
+	}
+	tool := got.Tools[0]
+	if tool.Type != "function" || tool.Name != "multiply" || tool.Description != "Multiplies" || !tool.Strict {
+		t.Errorf("Tools[0] mismatch: %+v", tool)
+	}
+}
+
+// TestBuildResponsesRequest_ToolChoiceForced pins forced-function
+// shape: {type:"function", name:"..."} (no nested function object).
+func TestBuildResponsesRequest_ToolChoiceForced(t *testing.T) {
+	c := newResponsesTestClient(t)
+	req := agentic.AgentRequest{
+		Messages:   []agentic.ChatMessage{{Role: "user", Content: "hi"}},
+		ToolChoice: &agentic.ToolChoice{Mode: "function", FunctionName: "go"},
+	}
+	got := c.buildResponsesRequest(req)
+	var envelope map[string]any
+	if err := json.Unmarshal(got.ToolChoice, &envelope); err != nil {
+		t.Fatalf("decode ToolChoice: %v", err)
+	}
+	if envelope["type"] != "function" || envelope["name"] != "go" {
+		t.Errorf("ToolChoice envelope = %v, want {type:function, name:go}", envelope)
+	}
+}
+
+// TestBuildResponsesRequest_ReasoningEffortFromEndpoint pins that
+// the endpoint's reasoning_effort flows into the Responses
+// reasoning.effort field.
+func TestBuildResponsesRequest_ReasoningEffortFromEndpoint(t *testing.T) {
+	c := newResponsesTestClient(t)
+	c.endpoint.ReasoningEffort = "medium"
+	got := c.buildResponsesRequest(agentic.AgentRequest{
+		Messages: []agentic.ChatMessage{{Role: "user", Content: "hi"}},
+	})
+	if got.Reasoning == nil || got.Reasoning.Effort != "medium" {
+		t.Errorf("Reasoning = %+v, want Effort=medium", got.Reasoning)
+	}
+}
+
+// TestBuildResponsesRequest_ResponseFormatJSONSchema pins that
+// JSON-schema response_format translates to the Responses text.format
+// envelope.
+func TestBuildResponsesRequest_ResponseFormatJSONSchema(t *testing.T) {
+	c := newResponsesTestClient(t)
+	got := c.buildResponsesRequest(agentic.AgentRequest{
+		Messages: []agentic.ChatMessage{{Role: "user", Content: "hi"}},
+		ResponseFormat: agentic.NewJSONSchemaFormat("my_schema", map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"a": map[string]any{"type": "integer"},
+			},
+		}),
+	})
+	if got.Text == nil {
+		t.Fatal("Text was nil; expected json_schema envelope")
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(got.Text.Format, &envelope); err != nil {
+		t.Fatalf("decode Text.Format: %v", err)
+	}
+	if envelope["type"] != "json_schema" {
+		t.Errorf("type = %v, want json_schema", envelope["type"])
+	}
+	if envelope["name"] != "my_schema" {
+		t.Errorf("name = %v, want my_schema", envelope["name"])
+	}
+	if envelope["strict"] != true {
+		t.Errorf("strict = %v, want true", envelope["strict"])
+	}
+}
+
+// TestBuildResponsesRequest_MaxOutputTokensFieldName pins that we
+// emit the Responses-API field name max_output_tokens, NOT
+// ChatCompletion's max_tokens. Silent wrong field name = the
+// provider ignores the cap.
+func TestBuildResponsesRequest_MaxOutputTokensFieldName(t *testing.T) {
+	c := newResponsesTestClient(t)
+	got := c.buildResponsesRequest(agentic.AgentRequest{
+		Messages:  []agentic.ChatMessage{{Role: "user", Content: "hi"}},
+		MaxTokens: 1024,
+	})
+	if got.MaxOutputTokens != 1024 {
+		t.Errorf("MaxOutputTokens = %d, want 1024", got.MaxOutputTokens)
+	}
+	b, _ := json.Marshal(got)
+	if !strings.Contains(string(b), `"max_output_tokens":1024`) {
+		t.Errorf("expected max_output_tokens in wire body; got %s", string(b))
+	}
+	if strings.Contains(string(b), `"max_tokens"`) {
+		t.Errorf("wire body must NOT contain max_tokens (ChatCompletion name); got %s", string(b))
+	}
+}

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -2021,6 +2021,27 @@ components:
                                             type: string
                                         reasoning_content:
                                             type: string
+                                        reasoning_records:
+                                            items:
+                                                properties:
+                                                    carrier_kind:
+                                                        type: string
+                                                    item_id:
+                                                        type: string
+                                                    opaque:
+                                                        format: byte
+                                                        type: string
+                                                    provider:
+                                                        type: string
+                                                    summary_text:
+                                                        type: string
+                                                    tool_call_id:
+                                                        type: string
+                                                required:
+                                                    - provider
+                                                    - carrier_kind
+                                                type: object
+                                            type: array
                                         role:
                                             type: string
                                         tool_call_id:
@@ -2250,6 +2271,27 @@ components:
                                 type: string
                             reasoning_content:
                                 type: string
+                            reasoning_records:
+                                items:
+                                    properties:
+                                        carrier_kind:
+                                            type: string
+                                        item_id:
+                                            type: string
+                                        opaque:
+                                            format: byte
+                                            type: string
+                                        provider:
+                                            type: string
+                                        summary_text:
+                                            type: string
+                                        tool_call_id:
+                                            type: string
+                                    required:
+                                        - provider
+                                        - carrier_kind
+                                    type: object
+                                type: array
                             role:
                                 type: string
                             tool_call_id:

--- a/taskfiles/e2e/openai-responses.yml
+++ b/taskfiles/e2e/openai-responses.yml
@@ -1,0 +1,41 @@
+version: "3"
+
+# OpenAI Responses live e2e (ADR-051).
+#
+# Drives the agentic-model client against the real OpenAI
+# /v1/responses endpoint to verify dispatch + translation + adapter
+# capture/echo end-to-end. Requires OPENAI_API_KEY to be set; tests
+# skip cleanly when absent so this target is safe to run in any
+# environment.
+#
+# Unlike the Docker-stack e2e tiers (core, structural, statistical,
+# semantic, agentic), this target does NOT spin up infrastructure —
+# it's a wire-level live test against the real upstream. The
+# Docker-stack tiers exercise the agentic loop end-to-end and stay
+# the canonical full-system check.
+#
+# Pre-tag use: HARD gate per ADR-051 phasing — must pass before
+# tagging the BREAKING bundle so the doc-derived skeleton has
+# verified parity with the real wire shape.
+#
+# Cost: each run hits the real OpenAI API. Two paid round-trips per
+# TestOpenAIResponses_ToolFlow_WithReasoningEcho execution + one per
+# TestOpenAIResponses_SingleTurn. Use sparingly.
+
+tasks:
+  default:
+    desc: "OpenAI Responses live e2e — wire-level live test (~30s, uses paid API)"
+    silent: false
+    cmds:
+      - echo "[OPENAI-RESPONSES] Running live wire-level test against /v1/responses..."
+      - echo "[OPENAI-RESPONSES] NOTE - this hits the real OpenAI API and costs $$."
+      - go test -tags=live_llm -timeout 5m -count=1 -v -run "TestOpenAIResponses" ./processor/agentic-model/...
+      - echo "[OK] OpenAI Responses live test complete"
+
+  capture:
+    desc: "Capture live OpenAI Responses fixtures into model/wire/responses/testdata/"
+    silent: false
+    cmds:
+      - echo "[OPENAI-RESPONSES] Capturing wire-shape fixtures..."
+      - CAPTURE_FIXTURES=1 go test -tags=live_llm -timeout 5m -count=1 -v -run "TestOpenAIResponses_CaptureFixtures" ./processor/agentic-model/...
+      - echo "[OK] Fixtures captured to model/wire/responses/testdata/"


### PR DESCRIPTION
## Summary

Implements [ADR-051](docs/adr/051-openai-responses-wire-support.md) end-to-end across four PR-level commits plus a live-test fix-up. Status flipped to Accepted in the final commit.

**Forcing function**: semspec's hybrid-registry path blocked by OpenAI's ChatCompletion endpoint rejecting `tool_choice + reasoning_effort` together on GPT-5.5 / o-series. The combination is only supported on `/v1/responses`. This PR delivers the wire layer, the agentic-model dispatch, and proves the forcing-function combo works live.

## Bundle scope

| Commit | Phase | Class |
|---|---|---|
| [75a737ee](../commit/75a737ee) PR 1 | ReasoningRecord carrier + Gemini migration | **BREAKING** |
| [27d4007c](../commit/27d4007c) PR 2 | `model/wire/responses/` types + non-streaming client | ADDITIVE |
| [110cd428](../commit/110cd428) PR 3 | Responses SSE streaming + accumulator | ADDITIVE |
| [5ad3ac73](../commit/5ad3ac73) PR 4 | agentic-model dispatch + adapter + live coverage | ADDITIVE |
| [aca180b3](../commit/aca180b3) Live-test fixes | `include: reasoning.encrypted_content` + summary injection | bug fix |
| [5b60dc5a](../commit/5b60dc5a) ADR status | Proposed → Accepted | docs |

**Total**: 6 commits, ~5K LoC additions, 1 BREAKING change.

## BREAKING surface

The carrier rename retires `agentic.MetadataKeyGoogleThoughtSignature` and moves the per-tool-call Gemini thought signature from `ToolCall.Metadata` to a sibling field `ChatMessage.ReasoningRecords`. The semantic role (opaque blob echoed across turns) is unchanged; the carrier abstraction is now provider-neutral, enabling OpenAI's standalone-item shape and the future Anthropic assistant-content shape to slot in without per-consumer branching.

Sister-repo coordination handled by repo owner — migration summary below for forwarding.

## Pre-tag gate (all green)

- `task lint` clean
- `go vet` clean across default / `-tags=integration` / `-tags=live_llm`
- 117/117 unit packages green with `-race`
- 117/117 integration packages green with `-race -tags=integration`
- `task schema:generate` no diff
- **Live `/v1/responses` (real OpenAI)**:
  - Single-turn complete: `pong` ✓
  - Tool flow (no reasoning): `17 × 23 = 391` ✓
  - Forcing-function combo (`tool_choice + reasoning_effort + multi-turn echo`): `47 × 89 = 4183` with `opaque_len=1060` captured + echoed ✓
- **Live Gemini regression** (carrier rename): `17 multiplied by 23 is 391` with `sig_len=632` round-tripped ✓

Two API-shape bugs caught by the live reasoning test and fixed pre-tag — exactly the failure class the live gate was designed to catch:

1. **`encrypted_content` silently omitted by default** — fixed by auto-setting `include: ["reasoning.encrypted_content"]` whenever `ReasoningEffort` is configured.
2. **Echoed reasoning items rejected without `summary` field** — fixed by `InputItem.MarshalJSON` injecting `"summary":[]` on reasoning items lacking one.

## Migration summary (for sister repos)

- **`agentic.MetadataKeyGoogleThoughtSignature` is deleted.** Code reading it from `ToolCall.Metadata` no longer compiles. Replace with `ChatMessage.ReasoningRecords` traversal (filter by `Provider == "google"`, match by `ToolCallID`).
- **`ChatMessage` schema gains `reasoning_records: ReasoningRecord[]`** — additive on the JSON wire. KV-stored ChatMessage payloads decoded by old binaries will lose the field silently; saved trajectories from pre-cut tags will not reload after this change (trajectories are operator debug artifacts with no durable contract).
- **New `WireBackend = "responses"` opt-in** — additive. Existing endpoints unaffected.
- **No semantic behavior change for Gemini consumers** — capture/echo of the thought signature continues to work through the new carrier; the live regression test verifies multi-turn flow on `gemini-3.1-pro-preview` is unchanged.

## Test plan

- [x] Unit: 117 packages with -race
- [x] Integration: 117 packages with `-tags=integration -race`
- [x] Lint: revive + go vet + go fmt
- [x] Schema parity: `task schema:generate` no diff
- [x] Live OpenAI Responses (3 paid round-trips)
- [x] Live Gemini regression (2 paid round-trips)
- [ ] CI green on GitHub
- [ ] Merge to main
- [ ] Tag v1.0.0-beta.89
- [ ] Sister repos notified (owner-handled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)