### PR TITLE
graph-ingest: merge-not-replace on jetstream consumer entity ingest

### DIFF
--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -834,9 +834,15 @@ func (c *Component) handleMessage(ctx context.Context, subject string, data []by
 		return
 	}
 
-	// Store entity in KV bucket
-	if err := c.CreateEntity(ctx, entity); err != nil {
-		c.logger.Error("Failed to create entity",
+	// Store entity in KV bucket — MERGE semantics (gh#177). Earlier code
+	// used CreateEntity (Put = full-replace) here, which clobbered any
+	// pre-existing triples on the entity. The atomic mutation handlers
+	// (create_with_triples, update_with_triples, triple.add) all merge;
+	// the jetstream consumer path was the lone outlier and silently
+	// erased lifecycle-managed entity state on every subsequent
+	// Graphable arrival.
+	if err := c.MergeEntity(ctx, entity); err != nil {
+		c.logger.Error("Failed to merge entity",
 			slog.String("entity_id", entity.ID),
 			slog.Any("error", err))
 		return
@@ -916,6 +922,125 @@ func validateEntityID(id string) error {
 // when the ID is already present.
 func (c *Component) CreateEntity(ctx context.Context, entity *graph.EntityState) error {
 	return c.createEntity(ctx, entity, false)
+}
+
+// MergeEntity ingests a streaming-consumer EntityState (typically built
+// by extractEntityFromMessage from a Graphable arriving on the
+// JetStream input) WITHOUT clobbering pre-existing triples on the
+// entity. First write behaves like CreateEntity (the entity didn't
+// exist; its fields land verbatim); subsequent writes append the
+// incoming triples to the existing slice and refresh latest-wins
+// metadata (MessageType, StorageRef, UpdatedAt) while monotonically
+// bumping Version.
+//
+// Closes gh#177: the prior code called CreateEntity (Put = full-
+// replace) from handleMessage, which erased any triples written via
+// the atomic mutation handlers (create_with_triples, update_with_
+// triples, triple.add) — all of which merge. The jetstream consumer
+// path was the lone outlier. Lifecycle-managed entities surfaced this
+// most loudly: Manager.Create stamped the phase triple, then the
+// first Graphable arrival via a downstream processor wiped it.
+//
+// Uses entityBucket.UpdateWithRetry for atomic CAS read-modify-write,
+// so concurrent arrivals on the same Subject converge without racing.
+func (c *Component) MergeEntity(ctx context.Context, entity *graph.EntityState) error {
+	if entity == nil {
+		return errs.WrapInvalid(errs.ErrInvalidData, "Component", "MergeEntity", "entity cannot be nil")
+	}
+	if err := validateEntityID(entity.ID); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return errs.Wrap(err, "Component", "MergeEntity", "context cancelled")
+	}
+
+	// Hierarchy inference is deterministic per entityID — calling it
+	// on every merge would APPEND the same hierarchy triples on each
+	// arrival (50 mission-command Graphables → 50 copies of
+	// type.container / system.container / etc. on the same entity).
+	// Gate to first-write only, applied inside the CAS callback so the
+	// fetch happens once per genuine create. See go-reviewer concern 5
+	// on the gh#177 fix.
+	var hierarchyTriples []message.Triple
+	if c.config.EnableHierarchy && c.hierarchyInference != nil {
+		// Probe-then-fetch: cheap pre-check avoids the inference cost
+		// on guaranteed-second-write paths. Even if the entity is
+		// concurrently created between probe and CAS, the callback's
+		// len(current) == 0 branch is the gate that actually applies
+		// the hierarchy triples — the probe is an optimization, not
+		// correctness.
+		if _, err := c.entityBucket.Get(ctx, entity.ID); err != nil && natsclient.IsKVNotFoundError(err) {
+			triples, herr := c.hierarchyInference.GetHierarchyTriples(ctx, entity.ID)
+			if herr != nil {
+				c.logger.Warn("Failed to get hierarchy triples",
+					slog.String("entity_id", entity.ID),
+					slog.Any("error", herr))
+			} else {
+				hierarchyTriples = triples
+			}
+		}
+	}
+
+	var bytesWritten int
+	err := c.entityBucket.UpdateWithRetry(ctx, entity.ID, func(current []byte) ([]byte, error) {
+		// First write: entity didn't exist. Apply hierarchy triples
+		// (deterministic-per-ID so safe to apply once on create),
+		// then store verbatim.
+		if len(current) == 0 {
+			if len(hierarchyTriples) > 0 {
+				entity.Triples = append(entity.Triples, hierarchyTriples...)
+			}
+			data, err := json.Marshal(entity)
+			if err == nil {
+				bytesWritten = len(data)
+			}
+			return data, err
+		}
+		// Existing entity: merge triples + refresh latest-wins metadata.
+		// Hierarchy triples are NOT re-applied — they landed on the
+		// original create and would only produce duplicates here.
+		var existing graph.EntityState
+		if err := json.Unmarshal(current, &existing); err != nil {
+			return nil, err // non-retryable
+		}
+		existing.Triples = append(existing.Triples, entity.Triples...)
+		existing.MessageType = entity.MessageType
+		if entity.StorageRef != nil {
+			existing.StorageRef = entity.StorageRef
+		}
+		existing.Version++
+		existing.UpdatedAt = time.Now()
+		data, err := json.Marshal(&existing)
+		if err == nil {
+			bytesWritten = len(data)
+		}
+		return data, err
+	})
+	if err != nil {
+		atomic.AddInt64(&c.errors, 1)
+		return errs.Wrap(err, "Component", "MergeEntity", "CAS update")
+	}
+
+	// Cache invalidation matches createEntity — readers must see the
+	// merged state on next Get.
+	if c.entityCache != nil {
+		c.entityCache.Delete(entity.ID) //nolint:errcheck
+	}
+
+	c.updateSuffixIndex(ctx, entity.ID)
+
+	atomic.AddInt64(&c.messagesProcessed, 1)
+	atomic.AddInt64(&c.bytesProcessed, int64(bytesWritten))
+	c.lastActivity.Store(time.Now())
+	c.entitiesUpdated.Inc()
+
+	c.logger.Debug("entity merged",
+		slog.String("entity_id", entity.ID),
+		slog.Int("triples_in", len(entity.Triples)))
+
+	c.ensureRelationshipTargetsExist(ctx, entity)
+
+	return nil
 }
 
 // CreateEntityStrict creates a new entity atomically — if the ID is

--- a/processor/graph-ingest/merge_entity_integration_test.go
+++ b/processor/graph-ingest/merge_entity_integration_test.go
@@ -1,0 +1,294 @@
+//go:build integration
+
+// Integration tests for MergeEntity — the merge-not-replace semantics
+// the JetStream consumer path uses (handleMessage) to ingest
+// Graphable arrivals without clobbering pre-existing triples written
+// via the atomic mutation handlers (create_with_triples,
+// update_with_triples, triple.add).
+//
+// gh#177 regression coverage: the canonical failure mode the issue
+// captures is "Manager.Create stamps phase triple; subsequent
+// mission-command Graphable arrives via jetstream; phase triple
+// vanishes." TestIntegration_MergeEntity_HandleMessageDoesNotClobber
+// pins that exact case.
+
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	payloadbuiltins "github.com/c360studio/semstreams/payloadbuiltins"
+	payloadregistry "github.com/c360studio/semstreams/payloadregistry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newSeedEntity(id string, triples ...message.Triple) *graph.EntityState {
+	now := time.Now()
+	return &graph.EntityState{
+		ID:          id,
+		Triples:     triples,
+		MessageType: message.Type{Domain: "test", Category: "seed", Version: "v1"},
+		Version:     1,
+		UpdatedAt:   now,
+	}
+}
+
+// TestIntegration_MergeEntity_FirstWriteCreatesAtomically pins the
+// fresh-entity case: MergeEntity on an absent ID writes the entity
+// verbatim, like CreateEntity but without the upsert footgun.
+func TestIntegration_MergeEntity_FirstWriteCreatesAtomically(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.merge.firstwrite.entity.001"
+	now := time.Now()
+	entity := newSeedEntity(entityID,
+		message.Triple{Subject: entityID, Predicate: "merge.kind", Object: "alpha", Timestamp: now, Confidence: 1.0},
+	)
+
+	require.NoError(t, c.MergeEntity(ctx, entity))
+
+	stored, _, err := c.fetchEntityState(ctx, entityID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Len(t, stored.Triples, 1)
+	assert.Equal(t, "merge.kind", stored.Triples[0].Predicate)
+	assert.Equal(t, "alpha", stored.Triples[0].Object)
+}
+
+// TestIntegration_MergeEntity_SecondWriteMergesTriples pins the load-
+// bearing fix: when an entity already exists, MergeEntity APPENDS the
+// new triples to the existing slice. Pre-fix code at component.go:838
+// used Put (full-replace) and would have wiped the first set of
+// triples.
+func TestIntegration_MergeEntity_SecondWriteMergesTriples(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.merge.secondwrite.entity.001"
+	now := time.Now()
+
+	// First write: phase triple (simulates Manager.Create's stamp).
+	first := newSeedEntity(entityID,
+		message.Triple{Subject: entityID, Predicate: "mission.phase", Object: "planning", Timestamp: now, Confidence: 1.0},
+	)
+	require.NoError(t, c.MergeEntity(ctx, first))
+
+	// Second write: command triple (simulates a mission-command Graphable arrival).
+	second := newSeedEntity(entityID,
+		message.Triple{Subject: entityID, Predicate: "mission.command", Object: "launch", Timestamp: now, Confidence: 1.0},
+	)
+	second.MessageType = message.Type{Domain: "mission", Category: "command", Version: "v1"}
+	require.NoError(t, c.MergeEntity(ctx, second))
+
+	stored, _, err := c.fetchEntityState(ctx, entityID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+
+	// Both triples must be present — pre-fix this assertion failed
+	// because the second MergeEntity (then CreateEntity → Put) wiped
+	// mission.phase.
+	predicates := make(map[string]any, len(stored.Triples))
+	for _, tr := range stored.Triples {
+		predicates[tr.Predicate] = tr.Object
+	}
+	assert.Equal(t, "planning", predicates["mission.phase"], "phase triple must survive the second arrival (gh#177)")
+	assert.Equal(t, "launch", predicates["mission.command"], "command triple must be present after the second arrival")
+
+	// Metadata: latest-wins on MessageType, monotonic Version.
+	assert.Equal(t, "mission", stored.MessageType.Domain)
+	assert.Equal(t, "command", stored.MessageType.Category)
+	assert.Equal(t, uint64(2), stored.Version, "Version should bump monotonically")
+}
+
+// TestIntegration_HandleMessage_DoesNotClobber is the gh#177
+// regression test driving through the actual jetstream-consumer entry
+// point. Seeds the entity via the atomic mutation handler shape
+// (analogous to Manager.Create), then drives a Graphable through
+// handleMessage and asserts the seeded triple survives.
+//
+// Why this test: TestIntegration_MergeEntity_SecondWriteMergesTriples
+// proves the helper merges; this test proves the production wire
+// actually calls the helper. The bug was specifically that the wire
+// called the wrong helper.
+func TestIntegration_HandleMessage_DoesNotClobber(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const entityID = "c360.test.handlemsg.gh177.entity.001"
+	now := time.Now()
+
+	// Step 1: seed the entity through the atomic mutation handler
+	// path — same shape Manager.Create produces.
+	seed := newSeedEntity(entityID,
+		message.Triple{Subject: entityID, Predicate: "mission.phase", Object: "planning", Timestamp: now, Confidence: 1.0},
+	)
+	require.NoError(t, c.CreateEntityStrict(ctx, seed))
+
+	// Step 2: build a BaseMessage carrying a Graphable that stamps
+	// one extra triple (mission.command=launch). This is the shape
+	// the mission-command processor publishes to mission.processed.entity.
+	graphablePayload := &mergeTestGraphable{
+		entityID: entityID,
+		triples: []message.Triple{
+			{Subject: entityID, Predicate: "mission.command", Object: "launch", Timestamp: now, Confidence: 1.0},
+		},
+	}
+	registerMergeTestPayload(t, c)
+	baseMsg := message.NewBaseMessage(graphablePayload.Schema(), graphablePayload, "test-source")
+	data, err := json.Marshal(baseMsg)
+	require.NoError(t, err)
+
+	// Step 3: drive the message through handleMessage — the exact
+	// production entry point the JetStream consumer uses.
+	c.handleMessage(ctx, "test.subject", data)
+
+	// Step 4: assert both triples are present. Pre-fix, only the
+	// second arrival's triple survived; the seeded mission.phase
+	// vanished. Post-fix, MergeEntity preserves both.
+	stored, _, err := c.fetchEntityState(ctx, entityID)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	predicates := make(map[string]any, len(stored.Triples))
+	for _, tr := range stored.Triples {
+		predicates[tr.Predicate] = tr.Object
+	}
+	assert.Equal(t, "planning", predicates["mission.phase"],
+		"seeded phase triple must survive a subsequent jetstream-consumer arrival (gh#177)")
+	assert.Equal(t, "launch", predicates["mission.command"],
+		"new Graphable's triple must also be present")
+}
+
+// TestIntegration_MergeEntity_HierarchyDoesNotDuplicate is the
+// targeted regression test for the go-reviewer concern 5 finding on
+// gh#177's first cut: hierarchy inference is deterministic per
+// entityID; running it on every merge would APPEND the same edges
+// repeatedly. The fix gates hierarchy fetch to the first-write arm
+// (probed via a KV existence check before the CAS callback, with the
+// callback's len(current) == 0 branch as the actual gate).
+//
+// Setup: spin up a component with EnableHierarchy=true; call
+// MergeEntity twice with the same entity ID; assert hierarchy
+// triples appear exactly once in the final merged state.
+func TestIntegration_MergeEntity_HierarchyDoesNotDuplicate(t *testing.T) {
+	ctx := context.Background()
+	streams := []natsclient.TestStreamConfig{
+		{Name: "ENTITY", Subjects: []string{"entity.>"}},
+	}
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+
+	cfg := DefaultConfig()
+	cfg.EnableHierarchy = true
+	cfgJSON, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	comp, err := CreateGraphIngest(cfgJSON, component.Dependencies{NATSClient: testClient.Client})
+	require.NoError(t, err)
+	c := comp.(*Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Stop(5 * time.Second) })
+
+	time.Sleep(100 * time.Millisecond)
+
+	const entityID = "c360.test.merge.hier.entity.001"
+	now := time.Now()
+
+	// First merge — entity is fresh; hierarchy inference runs and stamps edges.
+	first := newSeedEntity(entityID,
+		message.Triple{Subject: entityID, Predicate: "robotics.status", Object: "armed", Timestamp: now, Confidence: 1.0},
+	)
+	require.NoError(t, c.MergeEntity(ctx, first))
+
+	stored, _, err := c.fetchEntityState(ctx, entityID)
+	require.NoError(t, err)
+	tripleCountAfterFirst := len(stored.Triples)
+	require.Greater(t, tripleCountAfterFirst, 1,
+		"after first merge, expected hierarchy triples to land (got %d total)", tripleCountAfterFirst)
+
+	// Snapshot hierarchy triples (anything not the caller-supplied robotics.status).
+	hierarchyTripleCount := 0
+	for _, tr := range stored.Triples {
+		if tr.Predicate != "robotics.status" {
+			hierarchyTripleCount++
+		}
+	}
+	require.Greater(t, hierarchyTripleCount, 0, "hierarchy edges must be stamped on first merge")
+
+	// Second merge — same entity ID, one new caller-supplied triple.
+	// Pre-fix the hierarchy block ran again, doubling the hierarchy
+	// triple count (same edges appended verbatim).
+	second := newSeedEntity(entityID,
+		message.Triple{Subject: entityID, Predicate: "robotics.command", Object: "land", Timestamp: now, Confidence: 1.0},
+	)
+	require.NoError(t, c.MergeEntity(ctx, second))
+
+	stored2, _, err := c.fetchEntityState(ctx, entityID)
+	require.NoError(t, err)
+
+	// Final state: first-call payload + hierarchy + second-call payload.
+	// Hierarchy count must MATCH the snapshot, not double.
+	hierarchyAfterSecond := 0
+	for _, tr := range stored2.Triples {
+		if tr.Predicate != "robotics.status" && tr.Predicate != "robotics.command" {
+			hierarchyAfterSecond++
+		}
+	}
+	assert.Equal(t, hierarchyTripleCount, hierarchyAfterSecond,
+		"hierarchy triples must NOT duplicate on subsequent merges (gh#177 reviewer concern 5)")
+}
+
+// mergeTestGraphable is a minimal Graphable payload that stamps a
+// caller-supplied triple set on an entity ID. Used by the
+// HandleMessage regression test above to exercise the merge wire.
+type mergeTestGraphable struct {
+	entityID string
+	triples  []message.Triple
+}
+
+func (g *mergeTestGraphable) EntityID() string          { return g.entityID }
+func (g *mergeTestGraphable) Triples() []message.Triple { return g.triples }
+func (g *mergeTestGraphable) Schema() message.Type {
+	return message.Type{Domain: "test", Category: "merge", Version: "v1"}
+}
+
+func (g *mergeTestGraphable) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		EntityID string           `json:"entity_id"`
+		Triples  []message.Triple `json:"triples"`
+	}{g.entityID, g.triples})
+}
+
+func (g *mergeTestGraphable) UnmarshalJSON(data []byte) error {
+	var v struct {
+		EntityID string           `json:"entity_id"`
+		Triples  []message.Triple `json:"triples"`
+	}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	g.entityID = v.EntityID
+	g.triples = v.Triples
+	return nil
+}
+
+func (g *mergeTestGraphable) Validate() error { return nil }
+
+func registerMergeTestPayload(t *testing.T, c *Component) {
+	t.Helper()
+	reg := payloadregistry.New()
+	require.NoError(t, payloadbuiltins.Register(reg))
+	require.NoError(t, reg.Register(&payloadregistry.Registration{
+		Domain:      "test",
+		Category:    "merge",
+		Version:     "v1",
+		Description: "merge-entity integration-test payload",
+		Factory:     func() any { return &mergeTestGraphable{} },
+	}))
+	c.decoder = message.NewDecoder(reg)
+}


### PR DESCRIPTION
## Summary

Closes #177. The JetStream consumer entry point (`handleMessage` in
`processor/graph-ingest/component.go`) called `CreateEntity` (Put =
full-replace upsert) on every Graphable arrival, clobbering any
pre-existing triples on the entity. Lifecycle-managed entities
surfaced this most loudly: `Manager.Create` stamps the phase triple,
then the first downstream Graphable wipes it. Same code at beta.86
commit 895ec44 — surfaced by gh#170's fix (PR #179) letting
`task e2e:lifecycle` reach stage 5 for the first time.

**Depends on #179** (gh#170 e2e binary fix). End-to-end e2e:lifecycle
validation requires both — see "E2E validation" section below.

## Fix shape

- New `Component.MergeEntity` method using `entityBucket.UpdateWithRetry`
  for atomic CAS read-modify-write.
  - First write writes verbatim (CreateEntity-like).
  - Subsequent writes APPEND incoming triples to existing slice;
    refresh latest-wins entity-level fields (`MessageType`,
    `StorageRef`, `UpdatedAt`); monotonic `Version`.
- `handleMessage` switched from `CreateEntity` → `MergeEntity`.
- `CreateEntity` kept for callers that explicitly want Put semantics
  (graph/datamanager edge ops, test seeds, `entityManagerAdapter` for
  inference stub-fill).

## Hierarchy-inference gating (go-reviewer concern 5)

Hierarchy triples are deterministic-per-entityID. Pre-fix Put replaced
the slice so re-running the inference on every arrival was harmless;
post-fix merge would have APPENDED the same hierarchy edges every
arrival. `MergeEntity` now probes existence + fetches hierarchy
triples ONLY when the entity is fresh, with the UpdateWithRetry
callback's `len(current) == 0` branch as the actual gate that applies
them. CAS retries don't re-fetch.

## Integration tests (build-tagged `integration`)

`processor/graph-ingest/merge_entity_integration_test.go`:

1. `TestIntegration_MergeEntity_FirstWriteCreatesAtomically` — absent-entity case.
2. `TestIntegration_MergeEntity_SecondWriteMergesTriples` — gh#177 merge semantic via helper.
3. `TestIntegration_HandleMessage_DoesNotClobber` — drives actual production wire (handleMessage). Pins the wire, not just the helper.
4. `TestIntegration_MergeEntity_HierarchyDoesNotDuplicate` — concern-5 regression.

## Pre-merge gate

- `go test -race ./processor/graph-ingest/...` — green
- `go test -race -tags=integration ./processor/graph-ingest/... ./pkg/lifecycle/...` — green
- `task lint` — clean
- **E2E validation** on local combined branch (this PR + PR #179):
  `task e2e:lifecycle` **3/3 cold-rebuild PASSES** — all 8 scenario
  stages green; rule-driven-transition consistently ~155ms;
  websocket-live-update ~158ms; total scenario ~340ms.

## Reviewer-found bug fix

go-reviewer flagged the hierarchy-duplication bug on the first cut
(concern 5). Fixed in this PR via the probe-then-first-write-arm
pattern + dedicated regression test (test 4 above). Reviewer's
concerns 1-4, 6, 7 all checked out with code-cited verification.
Minor cleanups also applied: bytesProcessed metric added; dead
`_ = context.Background()` removed from test.

## Test plan

- [ ] `task lint` clean
- [ ] `go test -race ./...`
- [ ] `go test -race -tags=integration ./...`
- [ ] After #179 merges + rebase: `task e2e:lifecycle` 3x cold-rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)