### PR TITLE
graph-query: graph.query.batch passthrough + gateway-layer prefix-limit cap

### DIFF
--- a/gateway/graph-gateway/README.md
+++ b/gateway/graph-gateway/README.md
@@ -118,7 +118,7 @@ Empty prefix forces a full KV scan (`KeysByPrefix("")` walks every key in `ENTIT
 
 ### Choose `limit` deliberately
 
-Default is 1000 when `limit` is 0 or omitted. Keep it at the smallest value your UI actually needs to render. A 5K-entity response wastes bandwidth and JSON decode time for no gain if the user sees 200 rows.
+Default is **100** when `limit` is 0 or omitted. The gateway caps the default to keep replies under NATS's default 1MB `max_payload` ceiling for entities with substantial triple sets (gh#172). For larger result sets, set `limit` explicitly up to the internal cap. Keep it at the smallest value your UI actually needs to render — a 5K-entity response wastes bandwidth and JSON decode time for no gain if the user sees 200 rows.
 
 ### Exhaustive enumeration has no API
 

--- a/gateway/graph-gateway/component.go
+++ b/gateway/graph-gateway/component.go
@@ -960,8 +960,20 @@ func (c *Component) transformVariablesToNATSPayload(variables map[string]interfa
 		return extractVars(variables, "id")
 	case "graph.query.relationships":
 		return c.transformRelationshipVars(variables)
-	case "graph.query.hierarchyStats", "graph.query.prefix":
+	case "graph.query.hierarchyStats":
 		return extractVars(variables, "prefix", "limit")
+	case "graph.query.prefix":
+		// gh#172: cap the default at 100 to keep replies under NATS's
+		// default 1MB max_payload for entities with substantial triple
+		// sets. graph-ingest's internal default stays at 1000 for non-
+		// gateway callers (handleQueryHierarchyStats passes 10000 and
+		// other in-tree callers set Limit explicitly). The gateway is
+		// the user-facing surface where the safety floor matters.
+		payload := extractVars(variables, "prefix", "limit")
+		if _, ok := payload["limit"]; !ok {
+			payload["limit"] = 100
+		}
+		return payload
 	case "graph.query.spatial":
 		return extractVars(variables, "north", "south", "east", "west", "limit")
 	case "graph.query.temporal":

--- a/gateway/graph-gateway/query_test.go
+++ b/gateway/graph-gateway/query_test.go
@@ -1348,6 +1348,79 @@ func TestGateway_InlineArgs_PrefixQuery(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+// TestGateway_PrefixQuery_DefaultsLimitTo100 pins gh#172's gateway-
+// layer cap. When the GraphQL client omits `limit`, the gateway
+// injects 100 into the NATS payload before forwarding. graph-ingest's
+// internal default stays 1000 (non-gateway callers can still hit that
+// ceiling explicitly); the gateway layer is the user-facing surface
+// where the 1MB max_payload safety floor matters.
+func TestGateway_PrefixQuery_DefaultsLimitTo100(t *testing.T) {
+	mock := newMockNATSRequester()
+
+	mock.requestFunc = func(_ context.Context, subject string, data []byte, _ time.Duration) ([]byte, error) {
+		assert.Equal(t, "graph.query.prefix", subject)
+
+		var payload map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &payload))
+
+		assert.Equal(t, float64(100), payload["limit"],
+			"omitted limit should be capped at the gateway-layer default of 100 (gh#172)")
+
+		return []byte(`{"entities":[]}`), nil
+	}
+
+	comp := createTestGatewayWithMock(t, mock)
+	require.NoError(t, comp.Initialize())
+	require.NoError(t, comp.Start(context.Background()))
+	defer comp.Stop(5 * time.Second)
+
+	gqlRequest := map[string]interface{}{
+		"query": `{ entitiesByPrefix(prefix: "test.") { id } }`,
+	}
+	body, err := json.Marshal(gqlRequest)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	comp.handleGraphQL(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestGateway_PrefixQuery_ExplicitLimitOverridesDefault pins the
+// inverse — when the caller sets `limit` explicitly, the gateway must
+// NOT clobber it with the default. Up to graph-ingest's internal cap.
+func TestGateway_PrefixQuery_ExplicitLimitOverridesDefault(t *testing.T) {
+	mock := newMockNATSRequester()
+
+	mock.requestFunc = func(_ context.Context, _ string, data []byte, _ time.Duration) ([]byte, error) {
+		var payload map[string]interface{}
+		require.NoError(t, json.Unmarshal(data, &payload))
+		assert.Equal(t, float64(500), payload["limit"],
+			"explicit caller limit must override the gateway default")
+		return []byte(`{"entities":[]}`), nil
+	}
+
+	comp := createTestGatewayWithMock(t, mock)
+	require.NoError(t, comp.Initialize())
+	require.NoError(t, comp.Start(context.Background()))
+	defer comp.Stop(5 * time.Second)
+
+	gqlRequest := map[string]interface{}{
+		"query": `{ entitiesByPrefix(prefix: "test.", limit: 500) { id } }`,
+	}
+	body, err := json.Marshal(gqlRequest)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	comp.handleGraphQL(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestGateway_InlineArgs_ExplicitVariablesOverrideInline(t *testing.T) {
 	mock := newMockNATSRequester()
 

--- a/processor/graph-query/batch_passthrough_integration_test.go
+++ b/processor/graph-query/batch_passthrough_integration_test.go
@@ -1,0 +1,151 @@
+//go:build integration
+
+// Integration test for the graph.query.batch passthrough (gh#172
+// Phase 1). The internal graph.ingest.query.batch handler in
+// graph-ingest already exists with bounded concurrency + cache-aware
+// reads + partial-success semantics; this test confirms the public
+// passthrough at graph-query lands a request on it and forwards the
+// reply verbatim.
+
+package graphquery
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_BatchQueryPassthrough_ForwardsToGraphIngest pins
+// the load-bearing wire: a client requesting graph.query.batch must
+// arrive at graph.ingest.query.batch with the same request body, and
+// the responder's reply must come back unmodified. semconnect's
+// collection-hydration path depends on this passthrough; the test
+// exists so the convention can't silently drift (e.g. a future
+// refactor swapping the subject mapping in the StaticRouter).
+func TestIntegration_BatchQueryPassthrough_ForwardsToGraphIngest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	natsClient, cleanup := setupTestNATS(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Stub graph.ingest.query.batch responder. Echoes the IDs back
+	// as minimal entity records so the test can verify both the
+	// forwarded request shape AND that the reply passes through
+	// unmodified.
+	var stubHits atomic.Int32
+	_, err := natsClient.SubscribeForRequests(ctx, "graph.ingest.query.batch",
+		func(_ context.Context, data []byte) ([]byte, error) {
+			stubHits.Add(1)
+			var req struct {
+				IDs []string `json:"ids"`
+			}
+			require.NoError(t, json.Unmarshal(data, &req))
+			entities := make([]map[string]any, 0, len(req.IDs))
+			for _, id := range req.IDs {
+				entities = append(entities, map[string]any{
+					"id":      id,
+					"triples": []map[string]any{},
+				})
+			}
+			return json.Marshal(map[string]any{"entities": entities})
+		})
+	require.NoError(t, err)
+
+	// Start the graph-query component.
+	config := DefaultConfig()
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+	comp, err := CreateGraphQuery(configJSON, component.Dependencies{NATSClient: natsClient})
+	require.NoError(t, err)
+	gq := comp.(*Component)
+	require.NoError(t, gq.Initialize())
+	require.NoError(t, gq.Start(ctx))
+	t.Cleanup(func() { _ = gq.Stop(5 * time.Second) })
+
+	// Fire a request at the PUBLIC graph.query.batch subject — exactly
+	// what semconnect's collection-hydration path would do.
+	ids := []string{
+		"acme.ops.robotics.gcs.drone.001",
+		"acme.ops.robotics.gcs.drone.002",
+		"acme.ops.robotics.gcs.drone.003",
+	}
+	reqBody, err := json.Marshal(map[string]any{"ids": ids})
+	require.NoError(t, err)
+
+	respBody, err := natsClient.Request(ctx, "graph.query.batch", reqBody, 5*time.Second)
+	require.NoError(t, err)
+
+	// Responder must have been hit exactly once.
+	assert.Equal(t, int32(1), stubHits.Load(), "stub responder should have received the forwarded request once")
+
+	// Response must contain all three echoed entities — proves the
+	// stub's reply passed back through the passthrough unmodified.
+	var resp struct {
+		Entities []map[string]any `json:"entities"`
+	}
+	require.NoError(t, json.Unmarshal(respBody, &resp))
+	require.Len(t, resp.Entities, 3)
+	for i, id := range ids {
+		assert.Equal(t, id, resp.Entities[i]["id"])
+	}
+}
+
+// TestIntegration_BatchQueryPassthrough_RejectsMalformedRequest pins
+// the early-validation behavior — malformed JSON must NOT reach
+// graph-ingest. The handler validates the request shape before
+// forwarding; this test asserts on the stub-responder hit count to
+// catch the validation regression (rather than asserting on the
+// natsclient.Request error path, which is the gh#93 classified-error
+// surface — a separate concern).
+func TestIntegration_BatchQueryPassthrough_RejectsMalformedRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	natsClient, cleanup := setupTestNATS(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Stub graph.ingest.query.batch — should NOT be invoked. If it
+	// is, the passthrough is forwarding malformed bodies, which we
+	// want to catch.
+	var stubHits atomic.Int32
+	_, err := natsClient.SubscribeForRequests(ctx, "graph.ingest.query.batch",
+		func(_ context.Context, _ []byte) ([]byte, error) {
+			stubHits.Add(1)
+			return []byte(`{}`), nil
+		})
+	require.NoError(t, err)
+
+	config := DefaultConfig()
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+	comp, err := CreateGraphQuery(configJSON, component.Dependencies{NATSClient: natsClient})
+	require.NoError(t, err)
+	gq := comp.(*Component)
+	require.NoError(t, gq.Initialize())
+	require.NoError(t, gq.Start(ctx))
+	t.Cleanup(func() { _ = gq.Stop(5 * time.Second) })
+
+	// Fire a malformed JSON request. The natsclient.Request call
+	// itself may not surface an error (gh#93 dual-encoding window
+	// returns the error body as a successful NATS reply); the
+	// load-bearing assertion is that the stub was not hit.
+	_, _ = natsClient.Request(ctx, "graph.query.batch", []byte("not json"), 2*time.Second)
+
+	// Stub responder must NOT have been hit — passthrough rejected
+	// the malformed body at validation, before any forward.
+	assert.Equal(t, int32(0), stubHits.Load(),
+		"malformed requests must not reach graph-ingest")
+}

--- a/processor/graph-query/component.go
+++ b/processor/graph-query/component.go
@@ -92,6 +92,7 @@ func DefaultConfig() Config {
 		Ports: &component.PortConfig{
 			Inputs: []component.PortDefinition{
 				{Name: "query_entity", Type: "nats-request", Subject: "graph.query.entity"},
+				{Name: "query_batch", Type: "nats-request", Subject: "graph.query.batch"},
 				{Name: "query_relationships", Type: "nats-request", Subject: "graph.query.relationships"},
 				{Name: "query_path_search", Type: "nats-request", Subject: "graph.query.pathSearch"},
 			},

--- a/processor/graph-query/query.go
+++ b/processor/graph-query/query.go
@@ -28,6 +28,7 @@ func (c *Component) setupQueryHandlers(ctx context.Context) error {
 	registrations := []subRegistration{
 		{"graph.query.entity", c.handleQueryEntity},
 		{"graph.query.entityByAlias", c.handleQueryEntityByAlias},
+		{"graph.query.batch", c.handleQueryBatch},
 		{"graph.query.relationships", c.handleQueryRelationships},
 		{"graph.query.pathSearch", c.handlePathSearch},
 		{"graph.query.hierarchyStats", c.handleQueryHierarchyStats},
@@ -145,6 +146,55 @@ func (c *Component) handleQueryEntityByAlias(ctx context.Context, data []byte) (
 			return nil, errs.WrapTransient(err, "GraphQuery", "handleQueryEntityByAlias", "request timeout")
 		}
 		return nil, errs.WrapTransient(err, "GraphQuery", "handleQueryEntityByAlias", "query entity")
+	}
+
+	c.recordSuccess(len(data), len(response))
+	return response, nil
+}
+
+// handleQueryBatch handles batch entity query requests (passthrough to
+// graph-ingest). Removes the N+1 collection-read pattern semconnect
+// (and other CS API gateway consumers) hit when hydrating predicate-
+// query results: instead of `predicate query → N entity queries`, the
+// flow becomes `predicate query → 1 batch query` — two NATS round-
+// trips total, regardless of result set size. gh#172 Phase 1.
+//
+// The internal graph.ingest.query.batch handler this forwards to
+// already does bounded concurrency (default 10 parallel KV gets),
+// cache-aware reads, and partial-success (skips missing IDs without
+// failing the whole batch). This passthrough simply lifts that
+// internal subject to the public graph.query.* surface.
+//
+// Chunking guidance: batches above ~100 IDs with substantial triple
+// sets risk exceeding NATS's default 1MB max_payload on the reply.
+// Callers expecting unbounded result-set sizes should chunk client-
+// side. Streaming/pagination for unbounded collections is a separate
+// design question (filed as a follow-up if the threshold actually
+// bites in practice).
+func (c *Component) handleQueryBatch(ctx context.Context, data []byte) ([]byte, error) {
+	c.reportQuerying(ctx)
+
+	// Validate request shape early — empty IDs is a no-op at the
+	// graph-ingest side, but malformed JSON should surface as
+	// ErrorInvalid at the caller (matches handleQueryEntity).
+	var req struct {
+		IDs []string `json:"ids"`
+	}
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, errs.WrapInvalid(err, "GraphQuery", "handleQueryBatch", "parse request")
+	}
+
+	subject := c.router.Route("entityBatch")
+	if subject == "" {
+		return nil, errs.WrapTransient(errors.New("entityBatch query routing not available"), "GraphQuery", "handleQueryBatch", "route query")
+	}
+	response, err := c.natsClient.Request(ctx, subject, data, c.config.QueryTimeout)
+	if err != nil {
+		c.recordError(err)
+		if errors.Is(err, nats.ErrTimeout) {
+			return nil, errs.WrapTransient(err, "GraphQuery", "handleQueryBatch", "request timeout")
+		}
+		return nil, errs.WrapTransient(err, "GraphQuery", "handleQueryBatch", "query batch")
 	}
 
 	c.recordSuccess(len(data), len(response))


### PR DESCRIPTION
## Summary

Closes #172 Phase 1. Lifts the existing internal `graph.ingest.query.batch`
handler to a public `graph.query.batch` passthrough so CS API gateway
collection-hydration paths (semconnect's `/systems`, `/samplingFeatures`,
`/controlstreams`, `/systemEvents`) can collapse predicate-query → N
entity-query into two NATS round-trips. Per the sister-agent's triage
on the issue, that's the load-bearing change; the predicate-hydrated
endpoint (Phase 2) is deferred until measured pressure, and the
predicate-with-projection alternative was explicitly rejected as
Goodhart risk without a forcing function.

Bundled with the gateway-layer prefix-limit cap (sister-agent
add-on) that addresses the latent NATS 1MB max_payload risk the
issue thread flagged.

**No dependency on PR #179 or #180.**

## What this PR does

### graph.query.batch passthrough

- `processor/graph-query/query.go` — new `handleQueryBatch` handler;
  registered in `setupQueryHandlers`. Mirrors `handleQueryEntity`:
  parse request → route via existing `"entityBatch"` StaticRouter
  mapping (→ `graph.ingest.query.batch`) → forward → return reply.
- `processor/graph-query/component.go` — `query_batch` port definition.
- `processor/graph-query/batch_passthrough_integration_test.go` —
  forwarding wire test + malformed-request rejection test (asserts
  on stub-hit count, not on the natsclient.Request error path —
  gh#93's domain).

### Gateway-layer prefix-limit cap

go-reviewer found a correctness bug on first cut: changing
graph-ingest's `handleQueryPrefixNATS` default 1000→100 would have
silently broken `gateway/graph-gateway/README.md`'s public
"Default is 1000" contract. Fix applied per reviewer's preferred
option — push the cap to the gateway layer where the user-facing
safety floor matters; graph-ingest's internal contract stays 1000
for non-gateway callers.

- `gateway/graph-gateway/component.go` — per-subject branch for
  `graph.query.prefix` that injects `limit: 100` when the GraphQL
  client omits it. Explicit caller limits pass through up to the
  internal cap.
- `gateway/graph-gateway/README.md` — contract updated with the
  gh#172 rationale.
- `gateway/graph-gateway/query_test.go` — two new tests locking the
  contract structurally:
  - `TestGateway_PrefixQuery_DefaultsLimitTo100` — omitted limit → 100
  - `TestGateway_PrefixQuery_ExplicitLimitOverridesDefault` — caller 500 passes through

## gh#178 status (NOT in this PR)

Attempted the `Manager.Create` probe-on-`ErrAlreadyExists` pattern
mid-PR using phase + audit-source as the discriminator. Broke
ADR-049 reviewer B2's atomic-create-or-fail semantic (existing
`TestManager_ConcurrentCreateOnlyOneWins` fails because N=8
identical-Participant Creates all "look like ours" via the probe).

Reverted. Commented on gh#178 with the design insight: probe needs
a stronger discriminator than phase + source (per-call
caller-identity stamp via a request UUID or callerID arg). Filed
as needing an ADR-shaped design pass on the identity model. Not
bundled here.

## Pre-merge gate

- `task lint` — clean
- `go test -race ./gateway/graph-gateway/... ./processor/graph-query/... ./processor/graph-ingest/...` — green
- `go test -race -tags=integration ./processor/graph-query/... ./processor/graph-ingest/...` — green
- **go-reviewer pass**: one correctness bug found (gateway README contract violation), fix applied + structural lock-in tests added.

## semconnect migration

After this PR + the existing `graph.index.query.predicate` endpoint,
the canonical CS API collection-read pattern becomes:

```
1. graph.index.query.predicate {predicate, value} → [N entity IDs]
2. graph.query.batch {ids: [...]} → {entities: [N full EntityStates]}
```

Two NATS round-trips regardless of result size. Chunking guidance
documented in the new `handleQueryBatch` docstring: batches above
~100 IDs with substantial triple sets risk exceeding NATS's default
1MB max_payload on the reply.

## Test plan

- [ ] `task lint` clean
- [ ] `go test -race ./...`
- [ ] `go test -race -tags=integration ./...`
- [ ] Manual: GraphQL `entitiesByPrefix(prefix: "test.")` (no limit)
      returns ≤100 entities; `entitiesByPrefix(prefix: "test.", limit: 500)`
      returns ≤500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)