### PR TITLE
docker/compose: per-target image tags to eliminate cross-compose cache contamination

### DIFF
--- a/docker/compose/agentic.yml
+++ b/docker/compose/agentic.yml
@@ -61,6 +61,8 @@ services:
 
   # SemStreams Application with Agentic Components
   semstreams:
+    # Per-target image tag — see docker/compose/e2e.yml for rationale.
+    image: c360studio/semstreams:e2e-production
     build:
       context: ../..
       dockerfile: docker/Dockerfile

--- a/docker/compose/crud-tools.yml
+++ b/docker/compose/crud-tools.yml
@@ -58,6 +58,8 @@ services:
       start_period: 5s
 
   semstreams:
+    # Per-target image tag — see docker/compose/e2e.yml for rationale.
+    image: c360studio/semstreams:e2e-production
     build:
       context: ../..
       dockerfile: docker/Dockerfile

--- a/docker/compose/deep-research.yml
+++ b/docker/compose/deep-research.yml
@@ -61,6 +61,8 @@ services:
       start_period: 5s
 
   semstreams:
+    # Per-target image tag — see docker/compose/e2e.yml for rationale.
+    image: c360studio/semstreams:e2e-production
     build:
       context: ../..
       dockerfile: docker/Dockerfile

--- a/docker/compose/e2e.yml
+++ b/docker/compose/e2e.yml
@@ -42,6 +42,14 @@ services:
 
   # SemStreams Application (core components only)
   semstreams:
+    # Explicit image tag is load-bearing — docker compose's default name
+    # ({project}_{service}) collides across compose files in this dir,
+    # so whoever built last wins regardless of `target:`. Per-target
+    # tags eliminate cross-compose contamination. Caught during the
+    # v1.0.0-beta.90 pre-tag gate: a target:e2e build from lifecycle.yml
+    # leaked into target:production for e2e.yml and the websocket-stream
+    # scenario silently ran against the wrong binary for 36s.
+    image: c360studio/semstreams:e2e-production
     build:
       context: ../..
       dockerfile: docker/Dockerfile

--- a/docker/compose/lifecycle.yml
+++ b/docker/compose/lifecycle.yml
@@ -47,6 +47,9 @@ services:
 
   # E2E SemStreams Application (mission workflow registered)
   semstreams:
+    # Per-target image tag — see docker/compose/e2e.yml for the rationale
+    # (cross-compose cache contamination caught in beta.90 pre-tag gate).
+    image: c360studio/semstreams:e2e-test
     build:
       context: ../..
       dockerfile: docker/Dockerfile

--- a/docker/compose/ops.yml
+++ b/docker/compose/ops.yml
@@ -65,6 +65,8 @@ services:
       start_period: 5s
 
   semstreams:
+    # Per-target image tag — see docker/compose/e2e.yml for rationale.
+    image: c360studio/semstreams:e2e-production
     build:
       context: ../..
       dockerfile: docker/Dockerfile

--- a/docker/compose/tiered.yml
+++ b/docker/compose/tiered.yml
@@ -187,6 +187,8 @@ services:
   # Statistical variant - runs without ML services (uses BM25 fallback for search)
   # PROFILE: statistical - Only started when --profile statistical is specified
   semstreams:
+    # Per-target image tag — see docker/compose/e2e.yml for rationale.
+    image: c360studio/semstreams:e2e-production
     build:
       context: ../..
       dockerfile: docker/Dockerfile
@@ -235,6 +237,8 @@ services:
   # Structural variant - uses e2e-semstreams binary with reactive workflow engine
   # PROFILE: structural - Only started when --profile structural is specified
   semstreams-structural:
+    # Per-target image tag — see docker/compose/e2e.yml for rationale.
+    image: c360studio/semstreams:e2e-test
     build:
       context: ../..
       dockerfile: docker/Dockerfile
@@ -280,6 +284,8 @@ services:
   # SemStreams Application with ML services enabled
   # PROFILE: semantic - Only started when --profile semantic is specified
   semstreams-ml:
+    # Per-target image tag — see docker/compose/e2e.yml for rationale.
+    image: c360studio/semstreams:e2e-production
     build:
       context: ../..
       dockerfile: docker/Dockerfile


### PR DESCRIPTION
## Summary

Closes the e2e:core `verify-websocket-stream` failure that v1.0.0-beta.90's
pre-tag gate documented as "pre-existing, verified identical at beta.89."
Root cause was a quiet docker compose default-naming collision that had
been latent for an unknown duration.

## Root cause

Every compose file in `docker/compose/` ran `build:` without an explicit
`image:` tag, so docker compose's default naming (`{project}_{service}`)
collided across files — all seven ended up sharing
`compose-semstreams:latest`. Concretely:

- `lifecycle.yml` builds with `target: e2e` → e2e-semstreams binary
- `e2e.yml` builds with `target: production` → cmd/semstreams binary
- Both compose files tag the result as `compose-semstreams:latest`

`docker compose up` sees the existing image tag and **skips rebuild
even when `target:` in the compose file differs from the current
image**. Whoever built last won. After a lifecycle run, e2e:core
would silently launch the e2e binary; the production binary's
flow-status / component-health / component-metrics / log_entry
publishers were therefore missing, the websocket client connected
+ subscribed to all 4 types, and received nothing within the 36s
timeout. Test failed under "context deadline exceeded" with no
useful signal pointing at the cache collision.

## Fix shape

Explicit per-target `image:` tag on every `semstreams` service in
the seven compose files. Same target = same image (legitimate cache
reuse across compose files); different target = different image
(no cross-contamination):

- `target: production` → `c360studio/semstreams:e2e-production`
- `target: e2e` → `c360studio/semstreams:e2e-test`

Files: `e2e.yml`, `lifecycle.yml`, `agentic.yml`, `crud-tools.yml`,
`deep-research.yml`, `ops.yml`, `tiered.yml` (3 services with both
targets).

25 net lines added (all `image:` declarations + load-bearing
comments explaining why).

## Verification

Two gates run locally on this branch:

1. **Cross-target round-trip** — lifecycle (e2e target) → e2e:core
   (production target) → lifecycle (e2e target). All 3 green; each
   built its own image independently. Confirms no cross-pollination
   in either direction.
2. **3x cold-rebuild on e2e:core** (gh#170-style acceptance pattern)
   — image deleted between each run; 3/3 PASS with identical metrics:
   - 89 envelopes received
   - 15 component_health, 42 component_metrics, 1 flow_status, 31 log_entry
   - verify-websocket-stream: ~2.0s (previously: 36s timeout)

## Discipline anchor

When N compose files share a tier-spanning image-build context,
default name collisions are a silent latent bug. Explicit `image:`
tags scoped to the build dimension (`target:`) isolate them. The
failure mode here matches the BuildKit stale-target-cache class
captured in `project_beta90_shipped` under discipline lessons — but
the root cause is one layer deeper (docker compose's image naming),
not the BuildKit layer cache itself.

## Test plan

- [ ] `task lint` — clean (only YAML changes; not in lint scope)
- [ ] `task e2e:core` — passes on first run
- [ ] `task e2e:lifecycle` after running e2e:core — passes (no
      cross-target cache leak)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)