### PR TITLE
agentic-tools: rename sandbox → runner to free name for substrate

### DIFF
--- a/docs/concepts/25-phased-agentic-chains.md
+++ b/docs/concepts/25-phased-agentic-chains.md
@@ -113,8 +113,8 @@ framework primitives:
 | Trajectory manager | ✅ shipped | KV-backed |
 | Loop lineage (`loop_id`, parent chain) | ✅ shipped | message metadata |
 | `read_loop_result` tool | ✅ shipped | inter-phase data passing |
-| `BashExecutor` (local + sandbox) | ✅ shipped | `processor/agentic-tools/executors/bash.go` |
-| Sandbox client | ✅ shipped | `processor/agentic-tools/sandbox/` |
+| `BashExecutor` (local + remote runner) | ✅ shipped | `processor/agentic-tools/executors/bash.go` |
+| Runner client (HTTP client for remote sandbox container) | ✅ shipped | `processor/agentic-tools/runner/` (renamed from `sandbox/` 2026-05-31 to free the `sandbox` term for the substrate primitive — see ADR-052) |
 | Chain-scoped worktree on `BashExecutor` | 🟡 gap | tracked, see issues |
 | Always-warm sandbox documented as default | 🟡 gap | tracked, see issues |
 | Preview-first output for large `bash` fetches | 🟡 gap | tracked, see issues |

--- a/processor/agentic-tools/executors/bash.go
+++ b/processor/agentic-tools/executors/bash.go
@@ -1,8 +1,9 @@
 // Package executors provides tool executor implementations for the agentic system.
 //
-// BashExecutor runs shell commands. When a sandbox is configured (SANDBOX_URL),
-// commands execute inside the sandbox container. Otherwise, they run locally
-// via os/exec with sensitive environment variables stripped.
+// BashExecutor runs shell commands. When a remote runner is configured (SANDBOX_URL),
+// commands execute inside the remote sandbox container via the runner client.
+// Otherwise, they run locally via os/exec with sensitive environment variables
+// stripped.
 //
 // Ported from semspec/tools/bash.
 package executors
@@ -18,7 +19,7 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
-	"github.com/c360studio/semstreams/processor/agentic-tools/sandbox"
+	"github.com/c360studio/semstreams/processor/agentic-tools/runner"
 )
 
 const (
@@ -26,10 +27,11 @@ const (
 	bashDefaultTimeout = 120 * time.Second
 )
 
-// BashExecutor runs shell commands locally or via sandbox.
+// BashExecutor runs shell commands locally or via the remote runner client
+// (which routes to a remote sandbox container — see SANDBOX_URL).
 type BashExecutor struct {
 	workDir string
-	sandbox *sandbox.Client
+	runner  *runner.Client
 	timeout time.Duration
 }
 
@@ -51,7 +53,7 @@ func NewBashExecutor(workDir, sandboxURL string, opts ...BashOption) *BashExecut
 		opt(e)
 	}
 	if sandboxURL != "" {
-		e.sandbox = sandbox.NewClient(sandboxURL)
+		e.runner = runner.NewClient(sandboxURL)
 	}
 	return e
 }
@@ -112,7 +114,7 @@ func (e *BashExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agen
 	readOnlyPaths := stringSliceArg(call.Arguments["read_only_paths"])
 	verifyClean, _ := call.Arguments["verify_clean"].(bool)
 
-	if e.sandbox != nil {
+	if e.runner != nil {
 		taskID := "default"
 		if m := call.Metadata; m != nil {
 			if tid, ok := m["task_id"].(string); ok && tid != "" {
@@ -122,13 +124,13 @@ func (e *BashExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agen
 			}
 		}
 		if verifyClean {
-			if violation, err := e.verifyCleanSandbox(ctx, taskID, readOnlyPaths); err != nil {
+			if violation, err := e.verifyCleanRemote(ctx, taskID, readOnlyPaths); err != nil {
 				return agentic.ToolResult{CallID: call.ID, Error: fmt.Sprintf("verify_clean precondition failed: %v", err)}, nil
 			} else if violation != "" {
 				return agentic.ToolResult{CallID: call.ID, Error: violation}, nil
 			}
 		}
-		return e.execSandbox(ctx, call.ID, command, taskID)
+		return e.execRemote(ctx, call.ID, command, taskID)
 	}
 
 	if verifyClean {
@@ -162,14 +164,14 @@ func stringSliceArg(raw any) []string {
 	return out
 }
 
-// verifyCleanSandbox runs `git status -z --porcelain --untracked-files=all` inside the sandbox and
-// returns a non-empty violation message if any dirty path matches
-// readOnlyPaths (or, when readOnlyPaths is empty, if any path is dirty).
-// Returns ("", nil) when the precondition passes; (msg, nil) when it
-// fails; ("", err) when the precondition itself errored (network,
-// non-zero exit from git status, malformed output).
-func (e *BashExecutor) verifyCleanSandbox(ctx context.Context, taskID string, readOnlyPaths []string) (string, error) {
-	res, err := e.sandbox.Exec(ctx, taskID, "git status -z --porcelain --untracked-files=all", int(e.effectiveTimeout().Milliseconds()))
+// verifyCleanRemote runs `git status -z --porcelain --untracked-files=all` inside
+// the remote runner's sandbox container and returns a non-empty violation
+// message if any dirty path matches readOnlyPaths (or, when readOnlyPaths is
+// empty, if any path is dirty). Returns ("", nil) when the precondition
+// passes; (msg, nil) when it fails; ("", err) when the precondition itself
+// errored (network, non-zero exit from git status, malformed output).
+func (e *BashExecutor) verifyCleanRemote(ctx context.Context, taskID string, readOnlyPaths []string) (string, error) {
+	res, err := e.runner.Exec(ctx, taskID, "git status -z --porcelain --untracked-files=all", int(e.effectiveTimeout().Milliseconds()))
 	if err != nil {
 		return "", err
 	}
@@ -183,7 +185,7 @@ func (e *BashExecutor) verifyCleanSandbox(ctx context.Context, taskID string, re
 }
 
 // verifyCleanLocal runs the same precondition against the local workdir.
-// Mirrors verifyCleanSandbox; kept separate so each path remains
+// Mirrors verifyCleanRemote; kept separate so each path remains
 // straightforward to read.
 func (e *BashExecutor) verifyCleanLocal(ctx context.Context, readOnlyPaths []string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, e.effectiveTimeout())
@@ -285,13 +287,13 @@ func pathMatchesAny(path string, patterns []string) bool {
 	return false
 }
 
-// execSandbox routes the command to the sandbox container.
-func (e *BashExecutor) execSandbox(ctx context.Context, callID, command, taskID string) (agentic.ToolResult, error) {
-	result, err := e.sandbox.Exec(ctx, taskID, command, int(e.effectiveTimeout().Milliseconds()))
+// execRemote routes the command to the remote runner's sandbox container.
+func (e *BashExecutor) execRemote(ctx context.Context, callID, command, taskID string) (agentic.ToolResult, error) {
+	result, err := e.runner.Exec(ctx, taskID, command, int(e.effectiveTimeout().Milliseconds()))
 	if err != nil {
 		return agentic.ToolResult{
 			CallID: callID,
-			Error:  fmt.Sprintf("sandbox exec failed: %v", err),
+			Error:  fmt.Sprintf("remote exec failed: %v", err),
 		}, nil
 	}
 

--- a/processor/agentic-tools/executors/bash_test.go
+++ b/processor/agentic-tools/executors/bash_test.go
@@ -76,14 +76,15 @@ func TestBashExecutor_StderrCaptured(t *testing.T) {
 	assert.Contains(t, result.Content, "stderr-text")
 }
 
-func TestBashExecutor_SandboxMode(t *testing.T) {
-	// When sandbox URL is set, sandbox client is created
+func TestBashExecutor_RemoteMode(t *testing.T) {
+	// When SANDBOX_URL is set, the runner client (HTTP client to the
+	// remote sandbox container) is created.
 	e := NewBashExecutor("/tmp", "http://sandbox:8080")
-	assert.NotNil(t, e.sandbox)
+	assert.NotNil(t, e.runner)
 
-	// Without sandbox URL, runs locally
+	// Without SANDBOX_URL, runs locally.
 	e2 := NewBashExecutor("/tmp", "")
-	assert.Nil(t, e2.sandbox)
+	assert.Nil(t, e2.runner)
 }
 
 func TestFilterEnv_StripsSecrets(t *testing.T) {

--- a/processor/agentic-tools/runner/client.go
+++ b/processor/agentic-tools/runner/client.go
@@ -1,9 +1,16 @@
-// Package sandbox provides an HTTP client for the sandbox server.
-// The sandbox server runs file, git, and command operations inside an isolated
+// Package runner is an HTTP client for a remote tool-execution sandbox server.
+// The remote server runs file, git, and command operations inside an isolated
 // container so that agent-generated code never touches the host process.
 //
+// Naming note: this package is the local Go client; the upstream service it
+// talks to is colloquially "the sandbox server" (operated by semspec via
+// SANDBOX_URL). The package was renamed from `sandbox` to `runner` to free
+// the `sandbox` term for the substrate-level primitive (see ADR-052 /
+// `pkg/sandbox` capability-aware execution environment substrate). External
+// surfaces unchanged: SANDBOX_URL env var, server-side wire protocol.
+//
 // Ported from semspec/tools/sandbox with task_id mapped to agent loop_id.
-package sandbox
+package runner
 
 import (
 	"bytes"

--- a/processor/agentic-tools/runner/client_test.go
+++ b/processor/agentic-tools/runner/client_test.go
@@ -1,4 +1,4 @@
-package sandbox
+package runner
 
 import (
 	"context"


### PR DESCRIPTION
## Summary

Industry has converged on **"sandbox"** as the term for capability-aware
execution environments (E2B, Anthropic computer use, Daytona, Modal,
Cloudflare Workers, OpenAI playground). The forthcoming `pkg/sandbox`
substrate primitive (see `docs/proposals/sandbox-substrate.md`) needs
that name. Renaming the existing tool-level HTTP client now — before
the substrate lands — avoids perpetual "which sandbox?" disambiguation
across the codebase.

The existing `processor/agentic-tools/sandbox` is a thin HTTP-client
wrapper used by the bash executor to call an out-of-process remote
runner. Renaming it `runner` matches what it actually is and clears
the `sandbox` namespace for the substrate.

## External surface (unchanged)

- `SANDBOX_URL` env var — kept (operator-facing)
- `sandboxURL` parameter name — kept (operator-facing)
- Remote-server wire protocol — kept

## Internal renames

- Package: `processor/agentic-tools/sandbox` → `processor/agentic-tools/runner`
- Field: `e.sandbox *sandbox.Client` → `e.runner *runner.Client`
- Method: `execSandbox` → `execRemote`
- Method: `verifyCleanSandbox` → `verifyCleanRemote`
- Test: `TestBashExecutor_SandboxMode` → `TestBashExecutor_RemoteMode`
- Doc: `docs/concepts/25-phased-agentic-chains.md` — references updated

5 files; 44 lines added, 34 removed (mostly file-rename surface).

## Pre-merge gate

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -race ./processor/agentic-tools/...` — green (executors, runner, root)
- `task lint` — clean (18 pre-existing revive warnings on main; same count after rename)

## Rationale doc

See `docs/proposals/sandbox-substrate.md` (the proposal that drives
this rename — landed in working tree separately, not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)