### PR TITLE
vocabulary/csapi: dual-surface predicates — dotted internal + IRI export (closes #182)

### DIFF
--- a/docs/concepts/26-typed-artifact-entities.md
+++ b/docs/concepts/26-typed-artifact-entities.md
@@ -33,23 +33,32 @@ entities.
 
 ```text
 Parent entity (Datastream, System, ControlStream, ...)
-  rdf:type                csapi:Datastream
-  csapi:producedBy        system:<systemEntityID>
-  csapi:hasResultSchema   artifact:<schemaEntityID>     ← typed-artifact link
-  csapi:hasSource         artifact:<sensormlEntityID>   ← typed-artifact link
+  rdf:type                          csapi:Datastream             ← IRI (export-only, rdf:type stays IRI-shaped)
+  csapi.datastream.producedBy       system:<systemEntityID>      ← dotted predicate
+  csapi.datastream.resultSchema     artifact:<schemaEntityID>    ← typed-artifact link
+  csapi.artifact.source             artifact:<sensormlEntityID>  ← typed-artifact link
 
 artifact:<schemaEntityID>
-  rdf:type                csapi:SWESchemaDocument
+  rdf:type                csapi:SWESchemaDocument                ← IRI (export-only)
   StorageRef              { Instance: "csapi-artifacts",
                             Key: "swe/schemas/temp-celsius-v1.json",
                             ContentType: "application/swe+json" }
 
 artifact:<sensormlEntityID>
-  rdf:type                csapi:SensorMLDocument
+  rdf:type                csapi:SensorMLDocument                 ← IRI (export-only)
   StorageRef              { Instance: "csapi-artifacts",
                             Key: "sml/systems/weather-station-42.xml",
                             ContentType: "application/sml+xml" }
 ```
+
+**Predicate form (gh#182)**: triples carry the dotted-notation
+predicate constants (`csapi.HasSource`, `csapi.HasResultSchema`,
+`csapi.ProducedBy`, etc. — all expand to `csapi.<category>.<property>`)
+per the framework convention. The IRI forms (`csapi.HasSourceIRI`,
+etc.) live alongside them for JSON-LD / RDF export. The framework
+registry auto-binds dotted → IRI on package import so exporters can
+resolve in either direction. See `vocabulary/csapi/doc.go`
+§Dual-surface predicates.
 
 EntityID convention for artifacts: the `instance` segment of the
 6-part ID encodes identity in a content-addressable way — schema name
@@ -92,9 +101,12 @@ every other storage-ref-bearing entity.
 
 ## Cross-references
 
-- `vocabulary/csapi/` — `HasSource`, `HasResultSchema`,
-  `HasCommandSchema` predicates; `SensorMLDocument`,
-  `SWESchemaDocument` class IRIs.
+- `vocabulary/csapi/` — `HasSource`/`HasSourceIRI`,
+  `HasResultSchema`/`HasResultSchemaIRI`,
+  `HasCommandSchema`/`HasCommandSchemaIRI` dotted + IRI dual forms
+  (gh#182). All csapi predicates expose the same `{dotted, IRI}`
+  shape; `SensorMLDocument` and `SWESchemaDocument` are class IRIs
+  (rdf:type values; no dotted form).
 - [Rule-Driven Artifacts](18-rule-driven-artifacts.md) — the sister
   pattern for *external-facing* rendered artifacts (markdown, CSV,
   HTTP payloads). Different shape; complementary.

--- a/vocabulary/csapi/doc.go
+++ b/vocabulary/csapi/doc.go
@@ -54,6 +54,30 @@
 // are exported strings; no OWL inferencing, no SPARQL, no operator-
 // authored RDF. Prefix registration is automatic on import.
 //
+// # Dual-surface predicates (gh#182)
+//
+// Predicates expose two constants each — a dotted-notation form for
+// internal use in [message.Triple.Predicate] values and an IRI form
+// for JSON-LD / RDF export. Both share a Go identifier base; the IRI
+// form carries the `IRI` suffix:
+//
+//   - csapi.HasSource       = "csapi.artifact.source"    // dotted, for triples
+//   - csapi.HasSourceIRI    = "http://...hasSource"      // IRI, for export
+//   - csapi.ProducedBy      = "csapi.datastream.producedBy"
+//   - csapi.ProducedByIRI   = "http://...producedBy"
+//
+// Use the dotted form when constructing triples (the framework's NATS
+// wildcard semantics, predicate-index, and rule-engine all rely on the
+// dotted convention). Use the IRI form when serializing for boundary
+// export (JSON-LD `@context`, RDF/Turtle, OGC API responses). The
+// dotted-→-IRI mapping is registered automatically on package import
+// via [vocabulary.Register]; consumers can also resolve via
+// [vocabulary.GetPredicateMetadata].
+//
+// Class IRIs (Datastream, ControlStream, SensorMLDocument, etc.) have
+// no dotted counterpart — rdf:type values stay IRI-shaped on export
+// and aren't graph predicates themselves.
+//
 // # External references
 //
 //   - Spec (working draft): https://docs.ogc.org/DRAFTS/23-001r0.html

--- a/vocabulary/csapi/iris.go
+++ b/vocabulary/csapi/iris.go
@@ -70,6 +70,11 @@ const (
 // by their compact form. Adding a constant in iris.go or
 // predicates.go requires adding it here too; the contract test in
 // iris_test.go fails loud if these drift apart.
+//
+// Predicate IRI entries use the `*IRI` constants from predicates.go
+// (the dotted forms are framework-internal and don't appear in IRI
+// tables). Class IRIs have no parallel dotted form — RDF type
+// references stay IRI-shaped on export.
 var iris = map[string]string{
 	// Classes
 	Prefix + ":Datastream":        Datastream,
@@ -79,17 +84,17 @@ var iris = map[string]string{
 	Prefix + ":SensorMLDocument":  SensorMLDocument,
 	Prefix + ":SWESchemaDocument": SWESchemaDocument,
 
-	// Predicates
-	Prefix + ":producedBy":          ProducedBy,
-	Prefix + ":resultTimeRange":     ResultTimeRange,
-	Prefix + ":phenomenonTimeRange": PhenomenonTimeRange,
-	Prefix + ":resultType":          ResultType,
-	Prefix + ":controlsSystem":      ControlsSystem,
-	Prefix + ":partOfControlStream": PartOfControlStream,
-	Prefix + ":eventForSystem":      EventForSystem,
-	Prefix + ":hasSource":           HasSource,
-	Prefix + ":hasResultSchema":     HasResultSchema,
-	Prefix + ":hasCommandSchema":    HasCommandSchema,
+	// Predicates — `*IRI` form (export/import boundary).
+	Prefix + ":producedBy":          ProducedByIRI,
+	Prefix + ":resultTimeRange":     ResultTimeRangeIRI,
+	Prefix + ":phenomenonTimeRange": PhenomenonTimeRangeIRI,
+	Prefix + ":resultType":          ResultTypeIRI,
+	Prefix + ":controlsSystem":      ControlsSystemIRI,
+	Prefix + ":partOfControlStream": PartOfControlStreamIRI,
+	Prefix + ":eventForSystem":      EventForSystemIRI,
+	Prefix + ":hasSource":           HasSourceIRI,
+	Prefix + ":hasResultSchema":     HasResultSchemaIRI,
+	Prefix + ":hasCommandSchema":    HasCommandSchemaIRI,
 }
 
 var reverseIRIs = func() map[string]string {

--- a/vocabulary/csapi/iris_test.go
+++ b/vocabulary/csapi/iris_test.go
@@ -14,16 +14,16 @@ func TestIRIsCoverConstants(t *testing.T) {
 		Prefix + ":SensorMLDocument":  SensorMLDocument,
 		Prefix + ":SWESchemaDocument": SWESchemaDocument,
 
-		Prefix + ":producedBy":          ProducedBy,
-		Prefix + ":resultTimeRange":     ResultTimeRange,
-		Prefix + ":phenomenonTimeRange": PhenomenonTimeRange,
-		Prefix + ":resultType":          ResultType,
-		Prefix + ":controlsSystem":      ControlsSystem,
-		Prefix + ":partOfControlStream": PartOfControlStream,
-		Prefix + ":eventForSystem":      EventForSystem,
-		Prefix + ":hasSource":           HasSource,
-		Prefix + ":hasResultSchema":     HasResultSchema,
-		Prefix + ":hasCommandSchema":    HasCommandSchema,
+		Prefix + ":producedBy":          ProducedByIRI,
+		Prefix + ":resultTimeRange":     ResultTimeRangeIRI,
+		Prefix + ":phenomenonTimeRange": PhenomenonTimeRangeIRI,
+		Prefix + ":resultType":          ResultTypeIRI,
+		Prefix + ":controlsSystem":      ControlsSystemIRI,
+		Prefix + ":partOfControlStream": PartOfControlStreamIRI,
+		Prefix + ":eventForSystem":      EventForSystemIRI,
+		Prefix + ":hasSource":           HasSourceIRI,
+		Prefix + ":hasResultSchema":     HasResultSchemaIRI,
+		Prefix + ":hasCommandSchema":    HasCommandSchemaIRI,
 	}
 	got := IRIs()
 	if len(got) != len(wantPairs) {
@@ -38,17 +38,45 @@ func TestIRIsCoverConstants(t *testing.T) {
 	}
 }
 
-func TestConstantsLiveInDeclaredNamespace(t *testing.T) {
+// TestIRIConstantsLiveInDeclaredNamespace ensures every `*IRI`
+// constant lands under the spec-rooted Namespace. The dotted
+// predicate constants (ProducedBy, HasSource, etc.) DO NOT live in
+// the IRI namespace — they're internal dotted-notation strings —
+// so they're excluded from this check (gh#182).
+func TestIRIConstantsLiveInDeclaredNamespace(t *testing.T) {
 	all := []string{
 		Datastream, ControlStream, Command, SystemEvent,
 		SensorMLDocument, SWESchemaDocument,
-		ProducedBy, ResultTimeRange, PhenomenonTimeRange, ResultType,
-		ControlsSystem, PartOfControlStream, EventForSystem,
-		HasSource, HasResultSchema, HasCommandSchema,
+		ProducedByIRI, ResultTimeRangeIRI, PhenomenonTimeRangeIRI, ResultTypeIRI,
+		ControlsSystemIRI, PartOfControlStreamIRI, EventForSystemIRI,
+		HasSourceIRI, HasResultSchemaIRI, HasCommandSchemaIRI,
 	}
 	for _, c := range all {
 		if !strings.HasPrefix(c, Namespace) {
 			t.Errorf("%q does not start with CS API namespace %q", c, Namespace)
+		}
+	}
+}
+
+// TestPredicateConstantsUseDottedNotation ensures the dotted predicate
+// constants follow the framework convention `domain.category.property`
+// (vocabulary/predicates.go) — i.e. NOT IRI-shaped (gh#182). Three
+// dotted segments, lowercase domain, no IRI-namespace prefix.
+func TestPredicateConstantsUseDottedNotation(t *testing.T) {
+	predicates := []string{
+		ProducedBy, ResultTimeRange, PhenomenonTimeRange, ResultType,
+		ControlsSystem, PartOfControlStream, EventForSystem,
+		HasSource, HasResultSchema, HasCommandSchema,
+	}
+	for _, p := range predicates {
+		if strings.HasPrefix(p, Namespace) {
+			t.Errorf("%q must be dotted-notation, not IRI-shaped", p)
+		}
+		if strings.Count(p, ".") != 2 {
+			t.Errorf("%q must be three-level dotted (domain.category.property), got %d dots", p, strings.Count(p, "."))
+		}
+		if !strings.HasPrefix(p, "csapi.") {
+			t.Errorf("%q must start with `csapi.` domain", p)
 		}
 	}
 }
@@ -59,8 +87,8 @@ func TestIsKnown(t *testing.T) {
 		want bool
 	}{
 		{Datastream, true},
-		{ProducedBy, true},
-		{ResultTimeRange, true},
+		{ProducedByIRI, true},
+		{ResultTimeRangeIRI, true},
 		{Namespace + "unmappedButValidCSAPI", false},
 		{"http://example.org/not-csapi", false},
 		{"", false},
@@ -78,8 +106,8 @@ func TestLocalName(t *testing.T) {
 		want string
 	}{
 		{Datastream, "Datastream"},
-		{ProducedBy, "producedBy"},
-		{ResultTimeRange, "resultTimeRange"},
+		{ProducedByIRI, "producedBy"},
+		{ResultTimeRangeIRI, "resultTimeRange"},
 		{Namespace + "unmappedButValidCSAPI", "unmappedButValidCSAPI"},
 		{"http://example.org/not-csapi", ""},
 		{"", ""},

--- a/vocabulary/csapi/predicates.go
+++ b/vocabulary/csapi/predicates.go
@@ -1,40 +1,60 @@
 package csapi
 
-// CS API predicate IRIs.
+// CS API predicate constants — internal dotted-notation form.
+//
+// Per the framework convention (vocabulary/predicates.go), values
+// flowing through message.Triple.Predicate use three-level dotted
+// notation (`domain.category.property`). IRIs are reserved for
+// export/import boundary serialization. The constants below carry
+// the dotted form; the `*IRI` constants in this file carry the IRI
+// form for JSON-LD / RDF export. Both are exported because callers
+// have legitimate use cases for each:
+//
+//   - Triples: `triple := message.Triple{Predicate: csapi.HasSource, ...}`
+//   - JSON-LD export: `iri := csapi.HasSourceIRI`
+//
+// The mapping internal → IRI is registered in register.go's init via
+// vocabulary.Register(..., WithIRI(...)) so the framework's export
+// pipeline can resolve either direction.
+//
+// gh#171 added the artifact-relationship predicates (HasSource,
+// HasResultSchema, HasCommandSchema). gh#182 audited the full set
+// and split each into the dual {dotted, IRI} form.
 const (
 	// ProducedBy binds a Datastream to the entity ID of the System
 	// (sensor or system of systems) that produces its Observations.
 	// Inverse of a forthcoming `producesDatastream` predicate.
-	ProducedBy = Namespace + "producedBy"
+	// CS API §10.
+	ProducedBy = "csapi.datastream.producedBy"
 
 	// ResultTimeRange is the ISO 8601 time-interval representation
 	// of the temporal bounds during which the Datastream produced
 	// result values (clock time of the measurements). CS API §10.4.
-	ResultTimeRange = Namespace + "resultTimeRange"
+	ResultTimeRange = "csapi.datastream.resultTimeRange"
 
 	// PhenomenonTimeRange is the ISO 8601 time-interval representation
 	// of the temporal bounds of the observed phenomena. May differ
 	// from ResultTimeRange for processed or back-dated observations.
 	// CS API §10.4.
-	PhenomenonTimeRange = Namespace + "phenomenonTimeRange"
+	PhenomenonTimeRange = "csapi.datastream.phenomenonTimeRange"
 
 	// ResultType discriminates the structure of the Datastream's
 	// Observations — om:Measurement, om:Category, om:CountObservation,
 	// etc. Consumers branch on this to decode the result payload.
-	ResultType = Namespace + "resultType"
+	ResultType = "csapi.datastream.resultType"
 
 	// ControlsSystem binds a ControlStream to the entity ID of the
 	// System it targets with Commands. Inverse counterpart to a
 	// forthcoming `hasControlStream`. CS API v1.0 Part 2 §14.
-	ControlsSystem = Namespace + "controlsSystem"
+	ControlsSystem = "csapi.controlstream.controlsSystem"
 
 	// PartOfControlStream binds a Command to the entity ID of the
 	// ControlStream it was issued through. CS API v1.0 Part 2 §15.
-	PartOfControlStream = Namespace + "partOfControlStream"
+	PartOfControlStream = "csapi.command.partOfControlStream"
 
 	// EventForSystem binds a SystemEvent to the entity ID of the
 	// System the event is about. CS API v1.0 Part 2 §16.
-	EventForSystem = Namespace + "eventForSystem"
+	EventForSystem = "csapi.systemevent.forSystem"
 
 	// HasSource binds a System or Datastream to the entity ID of
 	// the SensorMLDocument artifact that carries its lossless
@@ -43,18 +63,62 @@ const (
 	// ObjectStore. Lets parent resources stay graph-shaped
 	// (queryable facts) while the heavy document payload is fetched
 	// on demand via the ObjectStore reference. gh#171.
-	HasSource = Namespace + "hasSource"
+	HasSource = "csapi.artifact.source"
 
 	// HasResultSchema binds a Datastream to the entity ID of the
 	// SWESchemaDocument artifact describing its observation result
 	// structure. Reusable across N Datastreams that share a schema —
 	// the artifact entity holds the canonical schema, the
 	// Datastreams reference it. gh#171.
-	HasResultSchema = Namespace + "hasResultSchema"
+	HasResultSchema = "csapi.datastream.resultSchema"
 
 	// HasCommandSchema binds a ControlStream to the entity ID of
 	// the SWESchemaDocument artifact describing the structure of
 	// commands it accepts. Same reuse model as HasResultSchema.
 	// gh#171.
-	HasCommandSchema = Namespace + "hasCommandSchema"
+	HasCommandSchema = "csapi.controlstream.commandSchema"
+)
+
+// CS API predicate IRIs — export/import boundary form.
+//
+// Use these for JSON-LD export, RDF serialization, and any wire
+// shape that addresses predicates by their canonical OGC IRI. For
+// `message.Triple.Predicate` values inside the framework, use the
+// dotted constants above; the framework's export pipeline resolves
+// dotted → IRI via the registry binding in register.go.
+//
+// IRI strings are spec-rooted at vocabulary/csapi.Namespace. The CS
+// API is still a working draft; when canonical IRIs publish, only
+// these constants need a one-shot swap (the dotted predicates above
+// are framework-internal and don't change).
+const (
+	// ProducedByIRI — CS API IRI for csapi.ProducedBy.
+	ProducedByIRI = Namespace + "producedBy"
+
+	// ResultTimeRangeIRI — CS API IRI for csapi.ResultTimeRange.
+	ResultTimeRangeIRI = Namespace + "resultTimeRange"
+
+	// PhenomenonTimeRangeIRI — CS API IRI for csapi.PhenomenonTimeRange.
+	PhenomenonTimeRangeIRI = Namespace + "phenomenonTimeRange"
+
+	// ResultTypeIRI — CS API IRI for csapi.ResultType.
+	ResultTypeIRI = Namespace + "resultType"
+
+	// ControlsSystemIRI — CS API IRI for csapi.ControlsSystem.
+	ControlsSystemIRI = Namespace + "controlsSystem"
+
+	// PartOfControlStreamIRI — CS API IRI for csapi.PartOfControlStream.
+	PartOfControlStreamIRI = Namespace + "partOfControlStream"
+
+	// EventForSystemIRI — CS API IRI for csapi.EventForSystem.
+	EventForSystemIRI = Namespace + "eventForSystem"
+
+	// HasSourceIRI — CS API IRI for csapi.HasSource.
+	HasSourceIRI = Namespace + "hasSource"
+
+	// HasResultSchemaIRI — CS API IRI for csapi.HasResultSchema.
+	HasResultSchemaIRI = Namespace + "hasResultSchema"
+
+	// HasCommandSchemaIRI — CS API IRI for csapi.HasCommandSchema.
+	HasCommandSchemaIRI = Namespace + "hasCommandSchema"
 )

--- a/vocabulary/csapi/register.go
+++ b/vocabulary/csapi/register.go
@@ -3,16 +3,94 @@ package csapi
 import (
 	"fmt"
 
+	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/c360studio/semstreams/vocabulary/export"
 )
 
-// Register binds the csapi: prefix into the export prefix table.
-// Importing the package triggers this from init(); idempotent.
+// Register binds the csapi: prefix into the export prefix table AND
+// registers each dotted predicate in the global vocabulary registry
+// with its IRI mapping for boundary export. Importing the package
+// triggers this from init(); idempotent.
 func Register() error {
 	if err := export.Register(Prefix, Namespace); err != nil {
 		return fmt.Errorf("vocabulary/csapi: register csapi prefix: %w", err)
 	}
+	registerDatastreamPredicates()
+	registerControlStreamPredicates()
+	registerCommandPredicates()
+	registerSystemEventPredicates()
+	registerArtifactPredicates()
 	return nil
+}
+
+// registerDatastreamPredicates binds the Datastream-domain dotted
+// predicates to their canonical CS API IRIs. Internal triples carry
+// the dotted form; JSON-LD/RDF export resolves via the IRI mapping.
+func registerDatastreamPredicates() {
+	vocabulary.Register(ProducedBy,
+		vocabulary.WithDescription("Datastream → producing System entity ID. CS API §10. Inverse of forthcoming producesDatastream."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(ProducedByIRI))
+
+	vocabulary.Register(ResultTimeRange,
+		vocabulary.WithDescription("ISO 8601 time-interval bounds for when result values were produced (clock time). CS API §10.4."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(ResultTimeRangeIRI))
+
+	vocabulary.Register(PhenomenonTimeRange,
+		vocabulary.WithDescription("ISO 8601 time-interval bounds for the observed phenomena (may differ from ResultTimeRange for processed/back-dated data). CS API §10.4."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(PhenomenonTimeRangeIRI))
+
+	vocabulary.Register(ResultType,
+		vocabulary.WithDescription("Discriminates Observation structure (om:Measurement, om:Category, om:CountObservation, etc). Consumers branch on this to decode the result payload."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(ResultTypeIRI))
+
+	vocabulary.Register(HasResultSchema,
+		vocabulary.WithDescription("Datastream → SWESchemaDocument artifact entity ID. Reusable across N Datastreams sharing a schema; the artifact entity holds the canonical schema content. gh#171."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(HasResultSchemaIRI))
+}
+
+// registerControlStreamPredicates binds the ControlStream-domain
+// dotted predicates to their CS API IRIs.
+func registerControlStreamPredicates() {
+	vocabulary.Register(ControlsSystem,
+		vocabulary.WithDescription("ControlStream → target System entity ID (the System receiving Commands). CS API v1.0 Part 2 §14."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(ControlsSystemIRI))
+
+	vocabulary.Register(HasCommandSchema,
+		vocabulary.WithDescription("ControlStream → SWESchemaDocument artifact entity ID describing accepted command structure. Same reuse model as HasResultSchema. gh#171."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(HasCommandSchemaIRI))
+}
+
+// registerCommandPredicates binds Command-domain dotted predicates.
+func registerCommandPredicates() {
+	vocabulary.Register(PartOfControlStream,
+		vocabulary.WithDescription("Command → owning ControlStream entity ID. CS API v1.0 Part 2 §15."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(PartOfControlStreamIRI))
+}
+
+// registerSystemEventPredicates binds SystemEvent-domain dotted predicates.
+func registerSystemEventPredicates() {
+	vocabulary.Register(EventForSystem,
+		vocabulary.WithDescription("SystemEvent → subject System entity ID. CS API v1.0 Part 2 §16."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(EventForSystemIRI))
+}
+
+// registerArtifactPredicates binds the typed-artifact-entity dotted
+// predicates (gh#171 pattern). HasSource crosses System and Datastream
+// resources; HasResultSchema/HasCommandSchema are domain-scoped above.
+func registerArtifactPredicates() {
+	vocabulary.Register(HasSource,
+		vocabulary.WithDescription("System or Datastream → SensorMLDocument artifact entity ID. Artifact has its own StorageRef pointing to the SensorML XML/JSON in ObjectStore. gh#171."),
+		vocabulary.WithDataType("string"),
+		vocabulary.WithIRI(HasSourceIRI))
 }
 
 func init() {

--- a/vocabulary/csapi/register_test.go
+++ b/vocabulary/csapi/register_test.go
@@ -1,6 +1,10 @@
 package csapi
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/vocabulary"
+)
 
 // End-to-end integration with vocabulary/export's prefix compaction
 // is covered by the smoke test suite that iterates over registered
@@ -11,5 +15,39 @@ func TestRegisterIsIdempotent(t *testing.T) {
 	}
 	if err := Register(); err != nil {
 		t.Fatalf("Register() second call: %v", err)
+	}
+}
+
+// TestPredicatesRegisteredWithIRIMappings pins the gh#182 contract:
+// every dotted predicate constant in this package must be registered
+// in the global vocabulary registry with its `*IRI` counterpart as
+// StandardIRI metadata. Without this binding, exporters lose the
+// dotted→IRI mapping and JSON-LD output drops the spec-rooted IRIs.
+func TestPredicatesRegisteredWithIRIMappings(t *testing.T) {
+	cases := []struct {
+		dotted string
+		iri    string
+	}{
+		{ProducedBy, ProducedByIRI},
+		{ResultTimeRange, ResultTimeRangeIRI},
+		{PhenomenonTimeRange, PhenomenonTimeRangeIRI},
+		{ResultType, ResultTypeIRI},
+		{ControlsSystem, ControlsSystemIRI},
+		{PartOfControlStream, PartOfControlStreamIRI},
+		{EventForSystem, EventForSystemIRI},
+		{HasSource, HasSourceIRI},
+		{HasResultSchema, HasResultSchemaIRI},
+		{HasCommandSchema, HasCommandSchemaIRI},
+	}
+	for _, c := range cases {
+		meta := vocabulary.GetPredicateMetadata(c.dotted)
+		if meta == nil {
+			t.Errorf("predicate %q not registered in vocabulary registry", c.dotted)
+			continue
+		}
+		if meta.StandardIRI != c.iri {
+			t.Errorf("predicate %q registered with IRI %q, want %q",
+				c.dotted, meta.StandardIRI, c.iri)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

semconnect's beta.90 validation pass caught a vocabulary contract
violation: every `csapi` predicate constant is an IRI string. The
framework's convention (`vocabulary/predicates.go`) reserves IRIs for
export/import boundary serialization; values flowing through
`message.Triple.Predicate` use three-level dotted notation
(`domain.category.property`) so NATS wildcard semantics, the
predicate-index, and the rule-engine all match correctly. The
canonical implementation pattern is `vocabulary/agentic` (e.g.
`IntentGoal = \"agent.intent.goal\"`, registered with `WithIRI(...)`
at init).

## Fix shape

Split each csapi predicate into a `{dotted, IRI}` pair. The dotted
form keeps the existing Go identifier (`HasSource`,
`HasResultSchema`, `HasCommandSchema`, `ProducedBy`, etc.); the IRI
form takes the `IRI` suffix (`HasSourceIRI`, `ProducedByIRI`, etc.).
Both exported because callers have legitimate use cases for each:

```go
// Triples:
triple := message.Triple{Predicate: csapi.HasSource, ...}

// JSON-LD / RDF export:
ld := JSONLD{Context: map[string]string{\"hasSource\": csapi.HasSourceIRI}}
```

`vocabulary/csapi/register.go` now binds every dotted predicate to
its IRI counterpart via `vocabulary.Register(..., WithIRI(...))` at
init, with `WithDescription` + `WithDataType` for export polish.

## Scope (all 10 csapi predicates)

Audited the full set per the issue's \"audit older CS API relationship
predicates\" ask:

| Dotted (Triple.Predicate)                  | IRI (export)            |
|--------------------------------------------|-------------------------|
| `csapi.datastream.producedBy`              | `ProducedByIRI`           |
| `csapi.datastream.resultTimeRange`         | `ResultTimeRangeIRI`      |
| `csapi.datastream.phenomenonTimeRange`     | `PhenomenonTimeRangeIRI`  |
| `csapi.datastream.resultType`              | `ResultTypeIRI`           |
| `csapi.controlstream.controlsSystem`       | `ControlsSystemIRI`       |
| `csapi.command.partOfControlStream`        | `PartOfControlStreamIRI`  |
| `csapi.systemevent.forSystem`              | `EventForSystemIRI`       |
| `csapi.artifact.source`                    | `HasSourceIRI`            |
| `csapi.datastream.resultSchema`            | `HasResultSchemaIRI`      |
| `csapi.controlstream.commandSchema`        | `HasCommandSchemaIRI`     |

Class IRIs (Datastream, ControlStream, SensorMLDocument, etc.) have
no dotted counterpart — `rdf:type` values stay IRI-shaped on export
and aren't graph predicates themselves.

## Tests added

- `TestPredicateConstantsUseDottedNotation` — asserts every dotted
  const is three-segment, `csapi.`-prefixed, NOT IRI-shaped.
- `TestPredicatesRegisteredWithIRIMappings` — asserts every dotted
  predicate is in the vocabulary registry with the matching IRI in
  `StandardIRI` metadata.
- `TestIRIConstantsLiveInDeclaredNamespace` (renamed from
  `TestConstantsLiveInDeclaredNamespace`) — now only checks IRI
  consts; the dotted predicates are intentionally NOT IRI-shaped.
- Existing `TestIRIsCoverConstants` updated — the iris map now binds
  compact CURIE keys (`csapi:hasSource`) to the `*IRI` constants.

## In-tree impact

Zero. The csapi constants had no external consumers in the in-tree
codebase (semconnect is the sister-repo consumer still validating
beta.90); this PR sets up the right shape for their adoption.

## Docs

- `vocabulary/csapi/doc.go` — new §Dual-surface predicates explaining
  when to use each form, with usage examples.
- `docs/concepts/26-typed-artifact-entities.md` — example triples now
  show the dotted-predicate form; IRI uses noted as export-only.

## Pre-merge gate

- `task lint` — clean (18 pre-existing revive warnings unchanged)
- `go build ./...` — clean
- `go test -race ./vocabulary/csapi/...` — green
- `go test -race -tags=integration ./vocabulary/...` — green

## Sister-repo migration (semconnect)

When pinning to the tag this lands on, switch
`message.Triple.Predicate` writes from the IRI form to the dotted
form:

```go
// before (incorrect — gh#182):
triple.Predicate = csapi.HasSource  // was: \"http://...hasSource\"

// after — same Go identifier, now the dotted value:
triple.Predicate = csapi.HasSource  // now: \"csapi.artifact.source\"
```

Boundary-export code that needs the IRI form switches to the new
`*IRI` constants:

```go
ldContext[\"hasSource\"] = csapi.HasSourceIRI
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)