### PR TITLE
fix(e2e,natsclient): structural fixes for testcontainers + e2e:semantic flake classes

### DIFF
--- a/cmd/e2e/main.go
+++ b/cmd/e2e/main.go
@@ -376,7 +376,16 @@ func createScenario(
 		// Set GraphQL URL based on variant — via ServiceManager shared mux
 		if cfg.Variant == "semantic" {
 			cfg.GraphQLURL = "http://localhost:38180/graph-gateway/graphql"
-			cfg.ValidationTimeout = 60 * time.Second // Neural embeddings need more time
+			// Semantic tier has the slowest entity-load pipeline:
+			// neural embeddings, multiple ML services (semembed +
+			// 3 seminstruct instances), and the longest file-loader
+			// path. Under Docker pressure (parallel projects on the
+			// host), the verify-entity-count critical-entity check
+			// can need >60s before all PathRAG-test entities land.
+			// 120s gives 2× the historical budget; steady-state
+			// entity load on idle hosts is still well under 5s, so
+			// this only matters on contended hosts.
+			cfg.ValidationTimeout = 120 * time.Second
 		} else {
 			cfg.GraphQLURL = "http://localhost:38080/graph-gateway/graphql"
 		}

--- a/natsclient/test_client.go
+++ b/natsclient/test_client.go
@@ -123,16 +123,16 @@ func NewSharedTestClient(opts ...TestOption) (*TestClient, error) {
 	cfg := &testConfig{
 		natsVersion: "2.12-alpine",
 		timeout:     5 * time.Second,
-		// 60s startup timeout: comfortable headroom for full
-		// `go test -race -tags=integration ./...` sweeps where Docker
-		// can be under contention from dozens of parallel container
-		// spinups. Steady-state startup is well under 5s; the
-		// generous default only matters when the host is loaded.
-		// Beta.78 sweep showed 30s occasionally insufficient for
-		// hierarchy_sync_integration_test.go and
-		// entity_mutation_integration_test.go (port-not-found within
-		// the deadline). See issue #107.
-		startTimeout: 60 * time.Second,
+		// 180s startup timeout: the wait strategy's MappedPort polls
+		// take hundreds of ms each under heavy Docker pressure (parallel
+		// projects spinning up containers — beta.91 case study). The
+		// prior 60s budget consistently exhausted at ~237 retries
+		// before the port mapping resolved (gh#107 flake class). The
+		// strategy's per-poll overhead means actual port-resolution
+		// wall time can balloon way past the steady-state ~5s. 180s
+		// keeps tests fast on idle hosts and gives 3x headroom under
+		// contention. Steady-state startup is unchanged.
+		startTimeout: 180 * time.Second,
 	}
 
 	// Apply options
@@ -160,17 +160,21 @@ func NewSharedTestClient(opts ...TestOption) (*TestClient, error) {
 		Image:        "nats:" + cfg.natsVersion,
 		ExposedPorts: []string{"4222/tcp", "8222/tcp"},
 		Cmd:          args,
-		// Startup timeout applied at the ForAll level so it bounds BOTH
-		// strategies. Prior pattern only set it on ForHTTP, leaving
-		// ForListeningPort with its own (shorter) default — under Docker
-		// API pressure the port-listening check would burn through retries
-		// before the HTTP timeout could engage. Symptom:
-		//   "retries: 532, port: '', last err: port '4222/tcp' not found,
-		//   ctx err: context deadline exceeded"
-		WaitingFor: wait.ForAll(
-			wait.ForListeningPort("4222/tcp"),
-			wait.ForHTTP("/").WithPort("8222/tcp"),
-		).WithStartupTimeoutDefault(cfg.startTimeout),
+		// NATS HTTP healthcheck at /healthz on the monitoring port is
+		// the load-bearing readiness signal — it returns 200 only when
+		// the server is accepting client connections on :4222. Prior
+		// pattern used both `ForListeningPort("4222/tcp")` and
+		// `ForHTTP("/")` strategies; under Docker pressure the
+		// strategies run sequentially (per ForAll's contract), and
+		// each calls MappedPort internally to figure out where to
+		// connect. Two strategies = double the MappedPort polling
+		// stress on Docker's API. Single ForHTTP strategy halves the
+		// pressure while keeping a stronger readiness signal (HTTP 200
+		// strictly implies port is listening). Caught during beta.91
+		// flake investigation (gh#107).
+		WaitingFor: wait.ForHTTP("/healthz").
+			WithPort("8222/tcp").
+			WithStartupTimeout(cfg.startTimeout),
 	}
 
 	// Start container
@@ -267,16 +271,16 @@ func NewTestClient(t testing.TB, opts ...TestOption) *TestClient {
 	cfg := &testConfig{
 		natsVersion: "2.12-alpine",
 		timeout:     5 * time.Second,
-		// 60s startup timeout: comfortable headroom for full
-		// `go test -race -tags=integration ./...` sweeps where Docker
-		// can be under contention from dozens of parallel container
-		// spinups. Steady-state startup is well under 5s; the
-		// generous default only matters when the host is loaded.
-		// Beta.78 sweep showed 30s occasionally insufficient for
-		// hierarchy_sync_integration_test.go and
-		// entity_mutation_integration_test.go (port-not-found within
-		// the deadline). See issue #107.
-		startTimeout: 60 * time.Second,
+		// 180s startup timeout: the wait strategy's MappedPort polls
+		// take hundreds of ms each under heavy Docker pressure (parallel
+		// projects spinning up containers — beta.91 case study). The
+		// prior 60s budget consistently exhausted at ~237 retries
+		// before the port mapping resolved (gh#107 flake class). The
+		// strategy's per-poll overhead means actual port-resolution
+		// wall time can balloon way past the steady-state ~5s. 180s
+		// keeps tests fast on idle hosts and gives 3x headroom under
+		// contention. Steady-state startup is unchanged.
+		startTimeout: 180 * time.Second,
 	}
 
 	// Apply options
@@ -304,17 +308,21 @@ func NewTestClient(t testing.TB, opts ...TestOption) *TestClient {
 		Image:        "nats:" + cfg.natsVersion,
 		ExposedPorts: []string{"4222/tcp", "8222/tcp"},
 		Cmd:          args,
-		// Startup timeout applied at the ForAll level so it bounds BOTH
-		// strategies. Prior pattern only set it on ForHTTP, leaving
-		// ForListeningPort with its own (shorter) default — under Docker
-		// API pressure the port-listening check would burn through retries
-		// before the HTTP timeout could engage. Symptom:
-		//   "retries: 532, port: '', last err: port '4222/tcp' not found,
-		//   ctx err: context deadline exceeded"
-		WaitingFor: wait.ForAll(
-			wait.ForListeningPort("4222/tcp"),
-			wait.ForHTTP("/").WithPort("8222/tcp"),
-		).WithStartupTimeoutDefault(cfg.startTimeout),
+		// NATS HTTP healthcheck at /healthz on the monitoring port is
+		// the load-bearing readiness signal — it returns 200 only when
+		// the server is accepting client connections on :4222. Prior
+		// pattern used both `ForListeningPort("4222/tcp")` and
+		// `ForHTTP("/")` strategies; under Docker pressure the
+		// strategies run sequentially (per ForAll's contract), and
+		// each calls MappedPort internally to figure out where to
+		// connect. Two strategies = double the MappedPort polling
+		// stress on Docker's API. Single ForHTTP strategy halves the
+		// pressure while keeping a stronger readiness signal (HTTP 200
+		// strictly implies port is listening). Caught during beta.91
+		// flake investigation (gh#107).
+		WaitingFor: wait.ForHTTP("/healthz").
+			WithPort("8222/tcp").
+			WithStartupTimeout(cfg.startTimeout),
 	}
 
 	// Start container

--- a/test/e2e/scenarios/tiered.go
+++ b/test/e2e/scenarios/tiered.go
@@ -105,10 +105,18 @@ func DefaultTieredConfig() *TieredConfig {
 		Variant:         "", // Auto-detect from environment
 		MessageCount:    20,
 		MessageInterval: 50 * time.Millisecond,
-		// Event-driven validation timeouts
-		// 10s default - structural tier should complete quickly
-		// Semantic tier may need to override this for ML processing
-		ValidationTimeout:    10 * time.Second,
+		// Event-driven validation timeouts.
+		// 30s default — entity stabilization needs headroom for Docker
+		// pressure on the host (parallel projects spinning containers
+		// can slow graph-ingest's pipeline meaningfully). Steady-state
+		// stabilization completes in ~100ms; the generous budget only
+		// matters under contention. Prior 10s budget consistently flaked
+		// in the beta.91 sweep when host was loaded — the SSE path
+		// would return `TimedOut: false, FinalCount: 0` before entities
+		// landed, and the silent-pass downstream surfaced as
+		// "entity not found" in stage 14 (test-pathrag-document).
+		// Semantic tier may still override this for ML processing.
+		ValidationTimeout:    30 * time.Second,
 		PollInterval:         100 * time.Millisecond, // Fast polling for responsiveness
 		MinProcessed:         10,                     // At least 50% should make it through
 		MinExpectedEntities:  50,                     // Test data has 74 entities, expect at least 50 indexed

--- a/test/e2e/scenarios/validate_entity.go
+++ b/test/e2e/scenarios/validate_entity.go
@@ -89,9 +89,20 @@ func (s *TieredScenario) executeWaitForEntityStabilization(ctx context.Context, 
 		"used_sse":      stabilization.UsedSSE,
 	}
 
-	if stabilization.TimedOut && stabilization.FinalCount < expectedEntities {
-		result.Warnings = append(result.Warnings,
-			fmt.Sprintf("Entity stabilization: got %d, expected %d", stabilization.FinalCount, expectedEntities))
+	// Fail the stage if entities didn't stabilize. Prior code only
+	// warned-and-returned-nil when `TimedOut && FinalCount < expected`,
+	// which left a silent-pass hole on the SSE path (which returns
+	// `TimedOut: false` unconditionally even when sourceCount=0). That
+	// hole let downstream stages (test-pathrag-document, etc.) fire
+	// against an empty graph under Docker pressure and surface as
+	// "entity not found" with no useful diagnosis. Caught in the
+	// v1.0.0-beta.91 pre-tag e2e:semantic flake. Per
+	// [[feedback_warning_not_fail_masks_integration_drift]], the
+	// stabilization gate is exactly the case where warning is wrong.
+	if !stabilization.Stabilized {
+		return fmt.Errorf("entity stabilization failed: got %d, expected %d (timed_out=%v used_sse=%v wait_duration=%s)",
+			stabilization.FinalCount, expectedEntities, stabilization.TimedOut, stabilization.UsedSSE,
+			stabilization.WaitDuration)
 	}
 
 	return nil
@@ -136,14 +147,38 @@ func (s *TieredScenario) getMinRequiredEntities() int {
 	}
 }
 
+// getCriticalEntities returns entity IDs that downstream stages will
+// query by exact ID. The pollForEntities gate (executeVerifyEntityCount)
+// waits until ALL of these exist in ENTITY_STATES before proceeding,
+// closing the cold-start race the v1.0.0-beta.91 sweep surfaced:
+// testdata loads 99 entities; the bare `count >= 74` stabilization
+// gate could trigger before file-loader processed every file (e.g.
+// maintenance.jsonl might load last, after the count threshold is
+// hit by sensors + observations + documents alone). Subsequent
+// PathRAG test stages then queried `maint-001` and got "not found"
+// despite the count gate passing. Each PathRAG test entity below is
+// queried by exact ID at stage 12+; missing any of them = stage 14
+// flake. Sensor and document entities included for both PathRAG
+// shapes (sensor + document).
 func (s *TieredScenario) getCriticalEntities() []string {
 	switch s.config.Variant {
 	case "structural":
-		return []string{"c360.logistics.environmental.sensor.temperature.temp-sensor-001"}
+		return []string{
+			"c360.logistics.environmental.sensor.temperature.temp-sensor-001",
+			"c360.logistics.maintenance.work.completed.maint-001",
+		}
 	case "statistical", "semantic":
-		return []string{"c360.logistics.content.document.operations.doc-ops-001"}
+		return []string{
+			"c360.logistics.content.document.operations.doc-ops-001",
+			"c360.logistics.environmental.sensor.temperature.temp-sensor-001",
+			"c360.logistics.maintenance.work.completed.maint-001",
+		}
 	default:
-		return []string{"c360.logistics.content.document.operations.doc-ops-001"}
+		return []string{
+			"c360.logistics.content.document.operations.doc-ops-001",
+			"c360.logistics.environmental.sensor.temperature.temp-sensor-001",
+			"c360.logistics.maintenance.work.completed.maint-001",
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Two long-standing flake classes that user flagged \"continue to haunt
us\" during the v1.0.0-beta.91 pre-tag gate. Both fixed structurally
(diagnosed root causes, not retry-wrapped).

## Flake class 1: testcontainers port-not-found (gh#107)

**Symptom:** `mapped port: retries: N, port: \"\", last err: port \"4222/tcp\" not found, ctx err: context deadline exceeded` on integration tests under Docker pressure.

**Root cause:** `natsclient.NewTestClient` used `wait.ForAll(ForListeningPort, ForHTTP)` — TWO sequential wait strategies, each with its own 60s startup-timeout budget. Each strategy calls Docker's MappedPort API to figure out where to connect; under Docker API pressure, each MappedPort call takes hundreds of ms (not the typical ~10ms). The budget runs out before resolution.

**Fix:**
- Drop redundant `ForListeningPort`. NATS HTTP healthcheck at `/healthz` on :8222 is a STRONGER readiness signal (HTTP 200 strictly implies :4222 is listening). Single `ForHTTP` strategy halves the MappedPort polling stress.
- Bump startup timeout 60s → 180s for 3× contention headroom. Steady-state startup unchanged (~5s).

## Flake class 2: e2e:semantic cold-start race

**Symptom:** `[14/46] test-pathrag-document FAILED after 2.4ms: PathRAG GraphQL error: not found: c360.logistics.maintenance.work.completed.maint-001` at scenario duration 488ms.

**Root cause chain (three stacked issues):**

1. `executeWaitForEntityStabilization` only failed when `TimedOut && FinalCount < expected`. The SSE path sets `TimedOut: false` even with sourceCount=0 — function silently returned success on an empty bucket. Downstream stages fired against an empty graph.
2. Once stabilization correctly gates count, the source-entity check (≥74) can still pass before all REQUIRED entities load. Testdata has 99 entities across 5 files; the file-loader can hit 74 with sensors+observations+documents alone, while maintenance.jsonl (containing `maint-001`) hasn't been processed. The `getCriticalEntities` gate was the right structural mechanism but its list only included `doc-ops-001`, not the PathRAG test entities.
3. Semantic-tier `ValidationTimeout` (60s) was tight for the full pipeline under Docker pressure.

**Fix:**
- `executeWaitForEntityStabilization` returns error on `!Stabilized` (the actual semantic) instead of warning-and-returning-nil. Per `[[feedback_warning_not_fail_masks_integration_drift]]`.
- Extend `getCriticalEntities` with sensor + maintenance PathRAG test entity IDs across all variants.
- Bump non-semantic `ValidationTimeout` 10s → 30s and semantic-override 60s → 120s for contention headroom.

## Verification

- `task lint` — clean (18 pre-existing revive warnings unchanged)
- `go test -race -tags=integration -timeout=15m ./...` — 117 packages ok. Same-class testcontainers port-not-found flake from prior sweep DID NOT recur. One unrelated timing-assertion flake (`TestIntegration_ToolConcurrentExecution 915ms < 800ms`) verified pass-in-isolation; separate class, filed as follow-up.
- `task e2e:core` — green (89 envelopes, 2.0s verify-websocket-stream)
- `task e2e:semantic` — **green** (7m07s, search_quality 0.7617, 7/7 known answers, `verify-entity-count: 7ms`, `test-pathrag-document: 1ms` — both prior failure stages now pass with full pipeline)

## Followups

- `TestIntegration_ToolConcurrentExecution` timing-assertion flake (parallel execution `915ms < 800ms` under contention). Separate class — needs different fix (looser duration or order-based assertion). Not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)