### PR TITLE
feat(processor): route_search component + intent-shaped RouteDecision args (ADR-045 Phase 1 PR 3)

### DIFF
--- a/agentic/research/constants.go
+++ b/agentic/research/constants.go
@@ -51,15 +51,21 @@ const (
 	// at MaxIterations=2 on R2's retighten branch.
 	ActionRetighten = "retighten"
 
-	// ActionWalkSeeds dispatches execute_subqueries with the entity IDs
-	// the classifier surfaced. Multi-hop expansion from concrete seeds —
-	// structurally different from topic-wide decompose.
+	// ActionWalkSeeds dispatches execute_subqueries with seed
+	// REFERENCES (names, partial IDs, or candidate-list indices) the
+	// classifier surfaced. Per ADR-045 Amendment 2026-05-23
+	// (intent-not-structure), the model emits references; the backend
+	// resolves to full 6-part entity IDs via the entity index. Multi-
+	// hop expansion from concrete seeds — structurally different from
+	// topic-wide decompose. See WalkSeedsArgs.
 	ActionWalkSeeds = "walk_seeds"
 
-	// ActionDecompose dispatches execute_subqueries with a typed
-	// sub-query list (entity_state / predicate_walk / temporal_range /
-	// spatial_polygon). The v1 default-path now used only when the
-	// classifier shows it's necessary.
+	// ActionDecompose dispatches execute_subqueries with the
+	// decomposition INTENT (axes, focus, scope). Per ADR-045
+	// Amendment 2026-05-23 (intent-not-structure), the model emits
+	// intent; the backend constructs the typed sub-queries from
+	// templates. The v1 default-path now used only when the
+	// classifier shows it's necessary. See DecomposeArgs.
 	ActionDecompose = "decompose"
 )
 

--- a/agentic/research/roundtrip_test.go
+++ b/agentic/research/roundtrip_test.go
@@ -257,15 +257,16 @@ func TestClassifierOutput_ValidateRejectsInvalid(t *testing.T) {
 }
 
 func TestRouteDecision_RoundTripThroughDecoder(t *testing.T) {
+	// Intent-shaped args per ADR-045 Amendment 2026-05-23: model
+	// emits axes/focus/scope, backend constructs typed sub-queries.
 	original := &research.RouteDecision{
 		Action: research.ActionDecompose,
 		Args: map[string]any{
-			"sub_queries": []any{
-				map[string]any{"type": "predicate_walk", "predicate": "sosa.observes"},
-				map[string]any{"type": "temporal_range", "start": "2026-05-22T00:00:00Z", "end": "2026-05-22T23:59:59Z"},
-			},
+			"axes":  []any{"entity_type", "time"},
+			"focus": "sensor maintenance events",
+			"scope": research.DecomposeScopeMedium,
 		},
-		Rationale: "Topic spans multiple entity kinds and a 24h window; decompose into a predicate walk plus a temporal range and fuse.",
+		Rationale: "Topic spans multiple entity kinds and a 24h window; decompose along entity_type and time.",
 	}
 
 	envelope := message.NewBaseMessage(original.Schema(), original, "research-roundtrip-test")
@@ -459,5 +460,294 @@ func TestSearchResult_ValidateRejectsInvalidEvidence(t *testing.T) {
 				t.Errorf("Validate error = %q, want substring %q", err, c.wantSub)
 			}
 		})
+	}
+}
+
+// --- ParseDecomposeArgs ---
+
+func TestParseDecomposeArgs_HappyPath(t *testing.T) {
+	d := &research.RouteDecision{
+		Action: research.ActionDecompose,
+		Args: map[string]any{
+			"axes":  []any{"entity_type", "time"},
+			"focus": "drone telemetry anomalies",
+			"scope": research.DecomposeScopeNarrow,
+		},
+	}
+	got, err := d.ParseDecomposeArgs()
+	if err != nil {
+		t.Fatalf("ParseDecomposeArgs error: %v", err)
+	}
+	if len(got.Axes) != 2 || got.Axes[0] != "entity_type" || got.Axes[1] != "time" {
+		t.Errorf("axes drift: got %v", got.Axes)
+	}
+	if got.Focus != "drone telemetry anomalies" {
+		t.Errorf("focus drift: got %q", got.Focus)
+	}
+	if got.Scope != research.DecomposeScopeNarrow {
+		t.Errorf("scope drift: got %q", got.Scope)
+	}
+}
+
+func TestParseDecomposeArgs_EmptyScopeIsValid(t *testing.T) {
+	d := &research.RouteDecision{
+		Action: research.ActionDecompose,
+		Args: map[string]any{
+			"axes":  []any{"entity_type"},
+			"focus": "x",
+		},
+	}
+	got, err := d.ParseDecomposeArgs()
+	if err != nil {
+		t.Fatalf("ParseDecomposeArgs error: %v", err)
+	}
+	if got.Scope != "" {
+		t.Errorf("scope: got %q, want empty", got.Scope)
+	}
+}
+
+func TestParseDecomposeArgs_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    map[string]any
+		action  string
+		wantSub string
+	}{
+		{
+			name:    "wrong action",
+			action:  research.ActionWalkSeeds,
+			args:    map[string]any{"axes": []any{"x"}, "focus": "y"},
+			wantSub: "action is",
+		},
+		{
+			name:    "missing axes",
+			action:  research.ActionDecompose,
+			args:    map[string]any{"focus": "x"},
+			wantSub: "axes required",
+		},
+		{
+			name:    "empty axis",
+			action:  research.ActionDecompose,
+			args:    map[string]any{"axes": []any{"x", "   "}, "focus": "f"},
+			wantSub: "axes[1] is empty",
+		},
+		{
+			name:    "missing focus",
+			action:  research.ActionDecompose,
+			args:    map[string]any{"axes": []any{"x"}},
+			wantSub: "focus required",
+		},
+		{
+			name:    "invalid scope",
+			action:  research.ActionDecompose,
+			args:    map[string]any{"axes": []any{"x"}, "focus": "f", "scope": "wide"},
+			wantSub: "scope",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := &research.RouteDecision{Action: c.action, Args: c.args}
+			_, err := d.ParseDecomposeArgs()
+			if err == nil {
+				t.Fatalf("ParseDecomposeArgs = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("error = %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
+// --- ParseWalkSeedsArgs ---
+
+func TestParseWalkSeedsArgs_HappyPath(t *testing.T) {
+	d := &research.RouteDecision{
+		Action: research.ActionWalkSeeds,
+		Args: map[string]any{
+			"seeds": []any{
+				map[string]any{"ref": "drone-001", "ref_type": research.SeedRefTypeName},
+				map[string]any{"ref": "robotics.gcs.drone", "ref_type": research.SeedRefTypePartialID},
+				map[string]any{"ref": "0", "ref_type": research.SeedRefTypeCandidateIndex},
+			},
+		},
+	}
+	got, err := d.ParseWalkSeedsArgs()
+	if err != nil {
+		t.Fatalf("ParseWalkSeedsArgs error: %v", err)
+	}
+	if len(got.Seeds) != 3 {
+		t.Fatalf("want 3 seeds, got %d", len(got.Seeds))
+	}
+	if got.Seeds[0].Ref != "drone-001" || got.Seeds[0].RefType != research.SeedRefTypeName {
+		t.Errorf("seed[0] drift: %+v", got.Seeds[0])
+	}
+	if got.Seeds[2].RefType != research.SeedRefTypeCandidateIndex {
+		t.Errorf("seed[2] ref_type drift: %q", got.Seeds[2].RefType)
+	}
+}
+
+func TestParseWalkSeedsArgs_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		action  string
+		args    map[string]any
+		wantSub string
+	}{
+		{
+			name:    "wrong action",
+			action:  research.ActionDecompose,
+			args:    map[string]any{"seeds": []any{map[string]any{"ref": "x", "ref_type": "name"}}},
+			wantSub: "action is",
+		},
+		{
+			name:    "empty seeds",
+			action:  research.ActionWalkSeeds,
+			args:    map[string]any{"seeds": []any{}},
+			wantSub: "seeds required",
+		},
+		{
+			name:    "missing seeds key",
+			action:  research.ActionWalkSeeds,
+			args:    map[string]any{},
+			wantSub: "seeds required",
+		},
+		{
+			name:    "empty ref",
+			action:  research.ActionWalkSeeds,
+			args:    map[string]any{"seeds": []any{map[string]any{"ref": "   ", "ref_type": "name"}}},
+			wantSub: "ref is empty",
+		},
+		{
+			name:    "bad ref_type",
+			action:  research.ActionWalkSeeds,
+			args:    map[string]any{"seeds": []any{map[string]any{"ref": "x", "ref_type": "full_id"}}},
+			wantSub: "ref_type",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := &research.RouteDecision{Action: c.action, Args: c.args}
+			_, err := d.ParseWalkSeedsArgs()
+			if err == nil {
+				t.Fatalf("ParseWalkSeedsArgs = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("error = %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
+// --- ParseRetightenArgs ---
+
+func TestParseRetightenArgs_HappyPath(t *testing.T) {
+	d := &research.RouteDecision{
+		Action: research.ActionRetighten,
+		Args: map[string]any{
+			"topic": "drone-001 maintenance events in the last 24 hours",
+			"hints": map[string]any{"entity_type": "drone", "time": "24h"},
+		},
+	}
+	got, err := d.ParseRetightenArgs()
+	if err != nil {
+		t.Fatalf("ParseRetightenArgs error: %v", err)
+	}
+	if got.Topic != "drone-001 maintenance events in the last 24 hours" {
+		t.Errorf("topic drift: %q", got.Topic)
+	}
+	if got.Hints["entity_type"] != "drone" || got.Hints["time"] != "24h" {
+		t.Errorf("hints drift: %v", got.Hints)
+	}
+}
+
+func TestParseRetightenArgs_NoHintsIsValid(t *testing.T) {
+	d := &research.RouteDecision{
+		Action: research.ActionRetighten,
+		Args:   map[string]any{"topic": "refined topic"},
+	}
+	got, err := d.ParseRetightenArgs()
+	if err != nil {
+		t.Fatalf("ParseRetightenArgs error: %v", err)
+	}
+	if len(got.Hints) != 0 {
+		t.Errorf("hints: got %v, want empty", got.Hints)
+	}
+}
+
+func TestParseRetightenArgs_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		action  string
+		args    map[string]any
+		wantSub string
+	}{
+		{
+			name:    "wrong action",
+			action:  research.ActionDecompose,
+			args:    map[string]any{"topic": "x"},
+			wantSub: "action is",
+		},
+		{
+			name:    "missing topic",
+			action:  research.ActionRetighten,
+			args:    map[string]any{"hints": map[string]any{"k": "v"}},
+			wantSub: "topic required",
+		},
+		{
+			name:    "whitespace topic",
+			action:  research.ActionRetighten,
+			args:    map[string]any{"topic": "   "},
+			wantSub: "topic required",
+		},
+		{
+			name:    "empty hint value",
+			action:  research.ActionRetighten,
+			args:    map[string]any{"topic": "x", "hints": map[string]any{"k": ""}},
+			wantSub: "is empty",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := &research.RouteDecision{Action: c.action, Args: c.args}
+			_, err := d.ParseRetightenArgs()
+			if err == nil {
+				t.Fatalf("ParseRetightenArgs = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("error = %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
+// --- enum guards ---
+
+func TestIsValidSeedRefType(t *testing.T) {
+	for _, v := range []string{
+		research.SeedRefTypeName, research.SeedRefTypePartialID, research.SeedRefTypeCandidateIndex,
+	} {
+		if !research.IsValidSeedRefType(v) {
+			t.Errorf("IsValidSeedRefType(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"", "full_id", "Name", "candidate-index"} {
+		if research.IsValidSeedRefType(v) {
+			t.Errorf("IsValidSeedRefType(%q) = true, want false", v)
+		}
+	}
+}
+
+func TestIsValidDecomposeScope(t *testing.T) {
+	for _, v := range []string{
+		"", research.DecomposeScopeNarrow, research.DecomposeScopeMedium, research.DecomposeScopeBroad,
+	} {
+		if !research.IsValidDecomposeScope(v) {
+			t.Errorf("IsValidDecomposeScope(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"wide", "Narrow", "small"} {
+		if research.IsValidDecomposeScope(v) {
+			t.Errorf("IsValidDecomposeScope(%q) = true, want false", v)
+		}
 	}
 }

--- a/agentic/research/route.go
+++ b/agentic/research/route.go
@@ -24,16 +24,20 @@ type RouteDecision struct {
 	// constants. UnmarshalJSON and Validate both enforce the enum.
 	Action string `json:"action"`
 
-	// Args carries the action-specific argument map. Schemas per
-	// action (PR 3 finalizes the per-action shapes):
-	//   - synthesize_directly: empty (uses classifier output)
-	//   - retighten:           {"topic": string, "hints": map[string]string}
-	//   - walk_seeds:          {"seed_entity_ids": []string}
-	//   - decompose:           {"sub_queries": [{...typed...}]}
-	// The map is intentionally loose at the wire level — strict
-	// per-action shapes are enforced by the consuming component, not
-	// at decode time, so Phase 1 ships without a separate per-action
-	// payload type per action arg shape.
+	// Args carries the action-specific argument map. Per-action shapes
+	// (intent-not-structure per ADR-045 Amendment 2026-05-23 — model
+	// emits intent, backend constructs typed structures):
+	//   - synthesize_directly: empty (uses classifier output as-is)
+	//   - retighten:           RetightenArgs   {topic, hints}
+	//   - walk_seeds:          WalkSeedsArgs   {seeds: [{ref, ref_type}]}
+	//                          ref_type ∈ {"name","partial_id","candidate_index"};
+	//                          backend resolves to full 6-part entity IDs
+	//   - decompose:           DecomposeArgs   {axes, focus, scope}
+	//                          backend constructs typed sub-queries
+	// The map is intentionally loose at the wire level so the payload
+	// stays uniform; strict per-action shape checks live in the
+	// Parse*Args helpers below, called by the consuming component
+	// after a successful Validate() of the action enum.
 	Args map[string]any `json:"args,omitempty"`
 
 	// Rationale is the LLM's natural-language justification for the
@@ -101,6 +105,223 @@ func (p *RouteDecision) UnmarshalJSON(data []byte) error {
 	// invalid-action drift on real wire data.
 	if p.Action != "" && !IsValidRouteAction(p.Action) {
 		return fmt.Errorf("route decision: action %q is not a canonical router action", p.Action)
+	}
+	return nil
+}
+
+// SeedRefType constants for WalkSeedsArgs.Seeds[*].RefType. Closed
+// enum enforced by ParseWalkSeedsArgs. The backend
+// (execute_subqueries) interprets the ref string differently per
+// type: a "name" matches the entity's display name, a "partial_id"
+// matches any suffix of the 6-part federated ID, a
+// "candidate_index" indexes into the upstream ClassifierOutput
+// candidate list.
+const (
+	SeedRefTypeName           = "name"
+	SeedRefTypePartialID      = "partial_id"
+	SeedRefTypeCandidateIndex = "candidate_index"
+)
+
+// DecomposeScope constants for DecomposeArgs.Scope. Closed enum;
+// empty resolves to ScopeMedium at the backend so a model that
+// omits the field still routes deterministically.
+const (
+	DecomposeScopeNarrow = "narrow"
+	DecomposeScopeMedium = "medium"
+	DecomposeScopeBroad  = "broad"
+)
+
+// DecomposeArgs is the typed view of RouteDecision.Args when
+// Action == ActionDecompose. Intent-shaped per ADR-045 Amendment
+// 2026-05-23: the model emits decomposition INTENT (what to
+// decompose along, the central concept, the breadth); the backend
+// (execute_subqueries) constructs the typed sub-queries from
+// templates keyed on Axes + Focus. The model isn't asked to spell
+// sub-query types it can't reliably produce.
+type DecomposeArgs struct {
+	// Axes lists the dimensions of decomposition (e.g.
+	// "entity_type", "time", "spatial", "relationship"). Free-form
+	// strings; backend matches against its known decomposition
+	// templates.
+	Axes []string `json:"axes"`
+
+	// Focus is the central concept to decompose around. Anchors the
+	// backend's template selection — e.g. "sensor maintenance
+	// events" or "drone telemetry anomalies".
+	Focus string `json:"focus"`
+
+	// Scope is the breadth of decomposition. One of the
+	// DecomposeScope* constants. Empty resolves to "medium" at the
+	// backend.
+	Scope string `json:"scope,omitempty"`
+}
+
+// SeedRef carries one seed reference for WalkSeedsArgs. RefType is
+// one of SeedRefType*.
+type SeedRef struct {
+	// Ref is the reference itself — a display name, a partial
+	// federated ID, or a stringified index into the upstream
+	// classifier candidate list. Interpretation depends on RefType.
+	Ref string `json:"ref"`
+
+	// RefType disambiguates how the backend resolves Ref. Closed
+	// enum.
+	RefType string `json:"ref_type"`
+}
+
+// WalkSeedsArgs is the typed view of RouteDecision.Args when
+// Action == ActionWalkSeeds. Intent-shaped per ADR-045 Amendment
+// 2026-05-23: the model emits SEED REFERENCES (names, partial IDs,
+// or indices into the classifier candidate list); the backend
+// resolves to full 6-part entity IDs via the entity index. The
+// model isn't asked to spell full IDs it can't reliably produce.
+type WalkSeedsArgs struct {
+	Seeds []SeedRef `json:"seeds"`
+}
+
+// RetightenArgs is the typed view of RouteDecision.Args when
+// Action == ActionRetighten. The refined topic + hints feed back
+// into a second nl_classify run; R2's retighten branch caps the
+// loop at MaxIterations=2.
+type RetightenArgs struct {
+	// Topic is the refined topic string. Required.
+	Topic string `json:"topic"`
+
+	// Hints is the refined hint set. Optional; empty map and absent
+	// field both treated as no hints.
+	Hints map[string]string `json:"hints,omitempty"`
+}
+
+// IsValidSeedRefType reports whether s is one of the closed seed
+// reference types. Exported so component validators can reuse the
+// set.
+func IsValidSeedRefType(s string) bool {
+	switch s {
+	case SeedRefTypeName, SeedRefTypePartialID, SeedRefTypeCandidateIndex:
+		return true
+	}
+	return false
+}
+
+// IsValidDecomposeScope reports whether s is one of the closed
+// decompose-scope values. Empty string is treated as valid (it
+// resolves to "medium" at the backend); callers that want to
+// reject empty should test before calling.
+func IsValidDecomposeScope(s string) bool {
+	switch s {
+	case "", DecomposeScopeNarrow, DecomposeScopeMedium, DecomposeScopeBroad:
+		return true
+	}
+	return false
+}
+
+// ParseDecomposeArgs decodes p.Args into DecomposeArgs and
+// validates shape. Returns an error if p.Action != ActionDecompose,
+// if required fields are missing, or if Scope is non-empty and
+// outside the closed enum.
+func (p *RouteDecision) ParseDecomposeArgs() (DecomposeArgs, error) {
+	var zero DecomposeArgs
+	if p == nil {
+		return zero, fmt.Errorf("route decision is nil")
+	}
+	if p.Action != ActionDecompose {
+		return zero, fmt.Errorf("ParseDecomposeArgs: action is %q, want %q", p.Action, ActionDecompose)
+	}
+	var args DecomposeArgs
+	if err := remarshalArgs(p.Args, &args); err != nil {
+		return zero, fmt.Errorf("decompose args: %w", err)
+	}
+	if len(args.Axes) == 0 {
+		return zero, fmt.Errorf("decompose args: axes required (at least one decomposition dimension)")
+	}
+	for i, a := range args.Axes {
+		if strings.TrimSpace(a) == "" {
+			return zero, fmt.Errorf("decompose args: axes[%d] is empty", i)
+		}
+	}
+	if strings.TrimSpace(args.Focus) == "" {
+		return zero, fmt.Errorf("decompose args: focus required")
+	}
+	if !IsValidDecomposeScope(args.Scope) {
+		return zero, fmt.Errorf("decompose args: scope %q is not a canonical value (want one of %q, %q, %q, or empty)",
+			args.Scope, DecomposeScopeNarrow, DecomposeScopeMedium, DecomposeScopeBroad)
+	}
+	return args, nil
+}
+
+// ParseWalkSeedsArgs decodes p.Args into WalkSeedsArgs and
+// validates shape. Returns an error if p.Action != ActionWalkSeeds,
+// if Seeds is empty, or if any seed has an empty Ref or an
+// out-of-enum RefType.
+func (p *RouteDecision) ParseWalkSeedsArgs() (WalkSeedsArgs, error) {
+	var zero WalkSeedsArgs
+	if p == nil {
+		return zero, fmt.Errorf("route decision is nil")
+	}
+	if p.Action != ActionWalkSeeds {
+		return zero, fmt.Errorf("ParseWalkSeedsArgs: action is %q, want %q", p.Action, ActionWalkSeeds)
+	}
+	var args WalkSeedsArgs
+	if err := remarshalArgs(p.Args, &args); err != nil {
+		return zero, fmt.Errorf("walk_seeds args: %w", err)
+	}
+	if len(args.Seeds) == 0 {
+		return zero, fmt.Errorf("walk_seeds args: seeds required (at least one)")
+	}
+	for i, s := range args.Seeds {
+		if strings.TrimSpace(s.Ref) == "" {
+			return zero, fmt.Errorf("walk_seeds args: seeds[%d].ref is empty", i)
+		}
+		if !IsValidSeedRefType(s.RefType) {
+			return zero, fmt.Errorf("walk_seeds args: seeds[%d].ref_type %q is not a canonical value (want one of %q, %q, %q)",
+				i, s.RefType, SeedRefTypeName, SeedRefTypePartialID, SeedRefTypeCandidateIndex)
+		}
+	}
+	return args, nil
+}
+
+// ParseRetightenArgs decodes p.Args into RetightenArgs and
+// validates shape. Returns an error if p.Action != ActionRetighten,
+// if Topic is empty, or if any Hints value is empty.
+func (p *RouteDecision) ParseRetightenArgs() (RetightenArgs, error) {
+	var zero RetightenArgs
+	if p == nil {
+		return zero, fmt.Errorf("route decision is nil")
+	}
+	if p.Action != ActionRetighten {
+		return zero, fmt.Errorf("ParseRetightenArgs: action is %q, want %q", p.Action, ActionRetighten)
+	}
+	var args RetightenArgs
+	if err := remarshalArgs(p.Args, &args); err != nil {
+		return zero, fmt.Errorf("retighten args: %w", err)
+	}
+	if strings.TrimSpace(args.Topic) == "" {
+		return zero, fmt.Errorf("retighten args: topic required")
+	}
+	for k, v := range args.Hints {
+		if strings.TrimSpace(v) == "" {
+			return zero, fmt.Errorf("retighten args: hints[%q] is empty", k)
+		}
+	}
+	return args, nil
+}
+
+// remarshalArgs converts a loose map[string]any to a typed struct
+// via JSON round-trip. Keeps the Parse*Args helpers from depending
+// on a reflection library and matches the wire shape exactly.
+func remarshalArgs(in map[string]any, out any) error {
+	if in == nil {
+		// Decode the empty case as zero-value of out — caller's
+		// downstream "required field" checks will surface a missing
+		// field with a typed error rather than a marshal failure.
+		return nil
+	}
+	buf, err := json.Marshal(in)
+	if err != nil {
+		return fmt.Errorf("remarshal: %w", err)
+	}
+	if err := json.Unmarshal(buf, out); err != nil {
+		return fmt.Errorf("decode: %w", err)
 	}
 	return nil
 }

--- a/componentregistry/register.go
+++ b/componentregistry/register.go
@@ -38,6 +38,7 @@ import (
 	jsonmap "github.com/c360studio/semstreams/processor/json_map"
 	oasfgenerator "github.com/c360studio/semstreams/processor/oasf-generator"
 	researchclassify "github.com/c360studio/semstreams/processor/research-graph-classify"
+	researchroute "github.com/c360studio/semstreams/processor/research-graph-route"
 	"github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/storage/objectstore"
 )
@@ -199,11 +200,14 @@ func registerSemanticLayer(registry *component.Registry) error {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "graph-query component registration")
 	}
 
-	// Research graph chain (ADR-045): nl_classify stage. Subsequent
-	// PRs add route_search, execute_subqueries, assess_sufficiency,
-	// and synthesize_answer.
+	// Research graph chain (ADR-045): nl_classify + route_search
+	// stages. Subsequent PRs add execute_subqueries,
+	// assess_sufficiency, and synthesize_answer.
 	if err := researchclassify.Register(registry); err != nil {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-classify component registration")
+	}
+	if err := researchroute.Register(registry); err != nil {
+		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-route component registration")
 	}
 
 	// Statistical/Semantic tier components (enabled via config)

--- a/model/registry.go
+++ b/model/registry.go
@@ -38,6 +38,15 @@ const (
 	// deployments fall back to the community_summary endpoint (the legacy
 	// piggyback behavior preserved for backward compatibility).
 	CapabilityAnomalyReview = "anomaly_review"
+	// CapabilityResearchRouting is used by the route_search component
+	// (ADR-045 Phase 1 PR 3) to make a single structured-emit routing
+	// decision per research operation: one of synthesize_directly /
+	// retighten / walk_seeds / decompose. First of the three research
+	// LLM-wrapping capabilities; assess_sufficiency (PR 5) and
+	// synthesize_answer (PR 5) will introduce CapabilityResearchAssessment
+	// and CapabilityResearchSynthesis as separate capabilities so
+	// operators can route each stage independently.
+	CapabilityResearchRouting = "research_routing"
 )
 
 // ResolvedEndpoint holds the resolved connection details for a capability endpoint.

--- a/model/registry_test.go
+++ b/model/registry_test.go
@@ -1030,6 +1030,7 @@ func TestCapabilityConstants_Values(t *testing.T) {
 		{"intent_classification", CapabilityIntentClassification, "intent_classification"},
 		{"layer_normalization", CapabilityLayerNormalization, "layer_normalization"},
 		{"anomaly_review", CapabilityAnomalyReview, "anomaly_review"},
+		{"research_routing", CapabilityResearchRouting, "research_routing"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/processor/research-graph-route/adapters.go
+++ b/processor/research-graph-route/adapters.go
@@ -1,0 +1,141 @@
+package researchroute
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/graph/llm"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/payloadregistry"
+)
+
+// llmRouterAdapter wraps a graph/llm.Client into the Router
+// interface. Production wires the OpenAI-compatible client resolved
+// from the model registry; tests inject a fake Router directly into
+// the Component and skip this adapter entirely.
+type llmRouterAdapter struct {
+	client llm.Client
+}
+
+func newLLMRouterAdapter(client llm.Client) *llmRouterAdapter {
+	return &llmRouterAdapter{client: client}
+}
+
+// Route sends one ChatCompletion with deterministic settings
+// (temperature 0) so the same prompt produces the same JSON across
+// runs — important for trajectory replay + the structured-emit
+// contract. MaxTokens is bounded so a runaway response truncates
+// rather than blowing the budget.
+func (a *llmRouterAdapter) Route(ctx context.Context, systemPrompt, userPrompt string, maxResponseTokens int) (string, string, error) {
+	if a == nil || a.client == nil {
+		return "", "", errors.New("llm client not configured")
+	}
+	zero := 0.0
+	req := llm.ChatRequest{
+		SystemPrompt: systemPrompt,
+		UserPrompt:   userPrompt,
+		MaxTokens:    maxResponseTokens,
+		Temperature:  &zero,
+	}
+	resp, err := a.client.ChatCompletion(ctx, req)
+	if err != nil {
+		return "", "", fmt.Errorf("chat completion: %w", err)
+	}
+	return resp.Content, resp.FinishReason, nil
+}
+
+// natsLoopStore adapts natsclient.KVStore to the LoopStore
+// interface. Mirrors processor/research-graph-classify's adapter —
+// same AGENT_LOOPS bucket, same payload-registry decode pattern.
+//
+// Key conventions:
+//
+//   - research.requested.<loopID>   (read; written by research_graph tool, PR 1)
+//   - classify.complete.<loopID>    (read; written by nl_classify, PR 2)
+//   - route.complete.<loopID>       (write; R2 watches this — trigger)
+//   - route.snapshot.<loopID>       (write; non-trigger queryable copy)
+type natsLoopStore struct {
+	kv      *natsclient.KVStore
+	decoder *message.Decoder
+}
+
+// newNATSLoopStore wires the LoopStore using the supplied KV store
+// and the process-wide payload registry. registry must be non-nil —
+// without it the upstream Intent + ClassifierOutput envelopes cannot
+// be decoded. The factory caller (NewProcessor) is responsible for
+// surfacing a nil-registry config error cleanly.
+func newNATSLoopStore(kv *natsclient.KVStore, registry *payloadregistry.Registry) *natsLoopStore {
+	return &natsLoopStore{
+		kv:      kv,
+		decoder: message.NewDecoder(registry),
+	}
+}
+
+// Key helpers — kept package-private; consumers reference the
+// conceptual operation, not the literal key shape, so a Phase 2
+// reorganisation of trigger naming doesn't ripple across packages.
+
+func loopStoreKeyIntent(loopID string) string           { return "research.requested." + loopID }
+func loopStoreKeyClassifyComplete(loopID string) string { return "classify.complete." + loopID }
+func loopStoreKeyRouteComplete(loopID string) string    { return "route.complete." + loopID }
+func loopStoreKeyRouteSnapshot(loopID string) string    { return "route.snapshot." + loopID }
+
+// GetIntent decodes the research_intent payload from the trigger
+// key. errIntentNotFound surfaces "key not found" so the handler can
+// log + drop without a retry storm.
+func (s *natsLoopStore) GetIntent(ctx context.Context, loopID string) (*research.Intent, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyIntent(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errIntentNotFound
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyIntent(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode intent: %w", err)
+	}
+	intent, ok := decoded.Payload().(*research.Intent)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.Intent", decoded.Payload())
+	}
+	return intent, nil
+}
+
+// GetClassifierOutput decodes the upstream ClassifierOutput from
+// the classify.complete trigger key.
+func (s *natsLoopStore) GetClassifierOutput(ctx context.Context, loopID string) (*research.ClassifierOutput, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyClassifyComplete(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errClassifierOutputNotFound
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyClassifyComplete(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode classifier output: %w", err)
+	}
+	out, ok := decoded.Payload().(*research.ClassifierOutput)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.ClassifierOutput", decoded.Payload())
+	}
+	return out, nil
+}
+
+// PutRouteDecision writes the envelope at R2's trigger key.
+func (s *natsLoopStore) PutRouteDecision(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeyRouteComplete(loopID), envelope)
+	return err
+}
+
+// PutSnapshot writes the envelope at the stable snapshot key.
+// Best-effort: handler logs + continues on failure rather than
+// aborting the chain.
+func (s *natsLoopStore) PutSnapshot(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeyRouteSnapshot(loopID), envelope)
+	return err
+}

--- a/processor/research-graph-route/component.go
+++ b/processor/research-graph-route/component.go
@@ -1,0 +1,463 @@
+package researchroute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph/llm"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/model"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// Component implements the route_search processor. Struct field set
+// is intentionally small; lifecycle methods own the NATS / model-
+// registry plumbing and the per-message handler hands off to the
+// pure routeDecision function in handler.go.
+type Component struct {
+	config Config
+	deps   component.Dependencies
+	logger *slog.Logger
+
+	// Injected dependencies. Tests replace these directly via the
+	// constructor; production wires them via Start() from the
+	// natsclient + model registry on deps.
+	router Router
+	loops  LoopStore
+
+	// llmClient is the underlying graph/llm.Client owned by the
+	// adapter. Held here so Stop can close it cleanly. Nil when
+	// tests inject a Router fake directly.
+	llmClient llm.Client
+
+	// Lifecycle state. One mutex guards started/startTime so a
+	// concurrent Health / DataFlow read can't see a torn read of the
+	// lifecycle flag — same shape as research-graph-classify.
+	mu        sync.RWMutex
+	started   bool
+	startTime time.Time
+	wg        sync.WaitGroup
+
+	// NATS subscriptions kept for cleanup at Stop.
+	subscriptions []*natsclient.Subscription
+
+	// Atomic counters for DataFlow / observability.
+	messagesProcessed int64
+	messagesEmitted   int64
+	errors            int64
+	lastActivity      atomic.Value // time.Time
+
+	// Lifecycle reporter (COMPONENT_STATUS KV).
+	lifecycleReporter component.LifecycleReporter
+}
+
+// Ensure interface compliance.
+var (
+	_ component.Discoverable       = (*Component)(nil)
+	_ component.LifecycleComponent = (*Component)(nil)
+)
+
+// NewProcessor is the component-factory shape registered with the
+// component registry. Parses + validates config, applies defaults,
+// and constructs the Component with the injected production
+// adapters. The LLM router is wired in Start() because the model
+// registry isn't available at construction time.
+func NewProcessor(rawConfig json.RawMessage, deps component.Dependencies) (component.Discoverable, error) {
+	var config Config
+	if err := json.Unmarshal(rawConfig, &config); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config unmarshal")
+	}
+	if config.Ports == nil {
+		config = DefaultConfig()
+	}
+	config.ApplyDefaults()
+	if err := config.Validate(); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config validate")
+	}
+
+	if deps.NATSClient == nil {
+		return nil, errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "NewProcessor", "NATSClient required")
+	}
+
+	logger := deps.GetLoggerWithComponent(ComponentName)
+
+	return &Component{
+		config: config,
+		deps:   deps,
+		logger: logger,
+		// router + loops wired in Start (router needs model registry;
+		// loops needs the open KV bucket).
+	}, nil
+}
+
+// Initialize is part of the LifecycleComponent contract.
+// route_search has nothing to initialise pre-Start — bucket open +
+// LLM client wire happen in Start so they can fail loudly and
+// propagate.
+func (c *Component) Initialize() error { return nil }
+
+// Start opens the AGENT_LOOPS bucket, wires the LLM router from the
+// model registry, subscribes to the configured input ports, and
+// reports idle.
+func (c *Component) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "Start", "context cannot be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return errs.WrapInvalid(err, ComponentName, "Start", "context already cancelled")
+	}
+
+	c.mu.Lock()
+	if c.started {
+		c.mu.Unlock()
+		return errs.WrapFatal(errs.ErrAlreadyStarted, ComponentName, "Start", "already started")
+	}
+	c.mu.Unlock()
+
+	if err := c.openLoopsBucket(ctx); err != nil {
+		return err
+	}
+
+	if err := c.initRouter(); err != nil {
+		return err
+	}
+
+	if err := c.subscribeInputs(ctx); err != nil {
+		return err
+	}
+
+	c.startLifecycleReporter(ctx)
+
+	c.mu.Lock()
+	c.started = true
+	c.startTime = time.Now()
+	c.mu.Unlock()
+
+	if c.lifecycleReporter != nil {
+		if err := c.lifecycleReporter.ReportStage(ctx, "idle"); err != nil {
+			c.logger.Debug("failed to report idle stage", slog.Any("error", err))
+		}
+	}
+
+	c.logger.Info("route_search component started",
+		slog.String("loops_bucket", c.config.LoopsBucket),
+		slog.Duration("route_timeout", c.config.RouteTimeout),
+		slog.Int("max_candidates_in_prompt", c.config.MaxCandidatesInPrompt))
+	return nil
+}
+
+// openLoopsBucket opens (or idempotently creates) the AGENT_LOOPS KV
+// bucket and constructs the LoopStore adapter. Skips construction
+// when c.loops is already non-nil (test-injected).
+func (c *Component) openLoopsBucket(ctx context.Context) error {
+	if c.loops != nil {
+		return nil
+	}
+	bucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      c.config.LoopsBucket,
+		Description: "Agent loops bucket; shared with research-pipeline chain",
+		History:     10,
+		TTL:         24 * time.Hour,
+	})
+	if err != nil {
+		return errs.WrapTransient(err, ComponentName, "Start", "open loops bucket")
+	}
+	if c.deps.PayloadRegistry == nil {
+		return errs.WrapFatal(errs.ErrMissingConfig, ComponentName, "Start", "PayloadRegistry dependency required to decode research payloads")
+	}
+	store := c.deps.NATSClient.NewKVStore(bucket)
+	c.loops = newNATSLoopStore(store, c.deps.PayloadRegistry)
+	return nil
+}
+
+// initRouter resolves the CapabilityResearchRouting endpoint from
+// the model registry and wires an llmRouterAdapter. Unlike
+// research-graph-classify's optional LLM tier, route_search has no
+// keyword fallback — absent capability is a startup error.
+// Skips wiring when c.router is already non-nil (test-injected).
+func (c *Component) initRouter() error {
+	if c.router != nil {
+		return nil
+	}
+	if c.deps.ModelRegistry == nil {
+		return errs.WrapInvalid(errs.ErrMissingConfig, ComponentName, "Start",
+			"model registry required (capability "+model.CapabilityResearchRouting+")")
+	}
+	resolved, ep, err := model.ResolveEndpointWithConfig(c.deps.ModelRegistry, model.CapabilityResearchRouting)
+	if err != nil {
+		return errs.WrapInvalid(err, ComponentName, "Start",
+			"capability "+model.CapabilityResearchRouting+" required")
+	}
+	timeout := model.ResolveCapabilityTimeout(c.deps.ModelRegistry, model.CapabilityResearchRouting, c.config.RouteTimeout, c.logger)
+	if timeout > 0 {
+		c.config.RouteTimeout = timeout
+	}
+	cfg := llm.OpenAIConfigFromEndpoint(resolved, ep, c.logger)
+	cfg.Timeout = c.config.RouteTimeout
+	client, err := llm.NewOpenAIClient(cfg)
+	if err != nil {
+		return errs.WrapTransient(err, ComponentName, "Start", "construct LLM client")
+	}
+	c.llmClient = client
+	c.router = newLLMRouterAdapter(client)
+	c.logger.Info("LLM router wired",
+		slog.String("model", resolved.Model),
+		slog.Duration("timeout", c.config.RouteTimeout))
+	return nil
+}
+
+// subscribeInputs wires NATS subscriptions for each input port.
+func (c *Component) subscribeInputs(ctx context.Context) error {
+	for _, port := range c.config.Ports.Inputs {
+		if port.Subject == "" {
+			continue
+		}
+		if port.Type != "nats" {
+			c.logger.Warn("unsupported port type; skipping",
+				slog.String("port", port.Name),
+				slog.String("type", port.Type))
+			continue
+		}
+		sub, err := c.deps.NATSClient.Subscribe(ctx, port.Subject, func(msgCtx context.Context, msg *nats.Msg) {
+			c.handleMessage(msgCtx, msg.Subject, msg.Data)
+		})
+		if err != nil {
+			return errs.WrapTransient(err, ComponentName, "Start",
+				fmt.Sprintf("subscribe to %s", port.Subject))
+		}
+		c.subscriptions = append(c.subscriptions, sub)
+		c.logger.Debug("subscribed to NATS subject",
+			slog.String("port", port.Name),
+			slog.String("subject", port.Subject))
+	}
+	return nil
+}
+
+// startLifecycleReporter wires the COMPONENT_STATUS KV reporter if
+// available; degrades to a no-op reporter on failure.
+func (c *Component) startLifecycleReporter(ctx context.Context) {
+	statusBucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      "COMPONENT_STATUS",
+		Description: "Component lifecycle status tracking",
+	})
+	if err != nil {
+		c.logger.Warn("COMPONENT_STATUS bucket unavailable; lifecycle reporting disabled",
+			slog.Any("error", err))
+		c.lifecycleReporter = component.NewNoOpLifecycleReporter()
+		return
+	}
+	c.lifecycleReporter = component.NewLifecycleReporterFromConfig(component.LifecycleReporterConfig{
+		KV:               statusBucket,
+		ComponentName:    ComponentName,
+		Logger:           c.logger,
+		EnableThrottling: true,
+	})
+}
+
+// Stop drains subscriptions, closes the LLM client, and flips
+// `started` under c.mu so a concurrent Health / DataFlow read can't
+// see a torn read of the lifecycle flag.
+func (c *Component) Stop(timeout time.Duration) error {
+	c.mu.Lock()
+	if !c.started {
+		c.mu.Unlock()
+		return nil
+	}
+	c.started = false
+	c.mu.Unlock()
+
+	for _, sub := range c.subscriptions {
+		if sub == nil {
+			continue
+		}
+		if err := sub.Unsubscribe(); err != nil {
+			c.logger.Debug("unsubscribe failed during stop", slog.Any("error", err))
+		}
+	}
+	c.subscriptions = nil
+
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		c.logger.Warn("Stop timeout reached with handlers in flight",
+			slog.Duration("timeout", timeout))
+	}
+
+	if c.llmClient != nil {
+		if err := c.llmClient.Close(); err != nil {
+			c.logger.Debug("LLM client close failed during stop", slog.Any("error", err))
+		}
+		c.llmClient = nil
+	}
+	return nil
+}
+
+// handleMessage is the per-message hot path. Recovers loop_id from
+// the subject, loads upstream Intent + ClassifierOutput, runs
+// routeDecision, writes the RouteDecision envelope + the
+// route.complete trigger key. Errors are logged and counted; not
+// propagated to NATS because the publisher is fire-and-forget.
+func (c *Component) handleMessage(ctx context.Context, subject string, _ []byte) {
+	c.wg.Add(1)
+	defer c.wg.Done()
+	atomic.AddInt64(&c.messagesProcessed, 1)
+	c.lastActivity.Store(time.Now())
+
+	loopID := extractLoopIDFromSubject(subject)
+	if loopID == "" {
+		c.logger.Error("could not extract loop_id from subject; ignoring message",
+			slog.String("subject", subject))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	if c.config.RouteTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.config.RouteTimeout)
+		defer cancel()
+	}
+
+	intent, err := c.loops.GetIntent(ctx, loopID)
+	if err != nil {
+		c.logger.Error("could not load research intent; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	classifierOut, err := c.loops.GetClassifierOutput(ctx, loopID)
+	if err != nil {
+		// errClassifierOutputNotFound surfaces as a routing-config
+		// bug (R1 fired without classify.complete written) — same
+		// shape as nl_classify's errIntentNotFound handling.
+		level := slog.LevelError
+		if errors.Is(err, errClassifierOutputNotFound) {
+			level = slog.LevelWarn
+		}
+		c.logger.Log(ctx, level, "could not load classifier output; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	decision, err := routeDecision(ctx, c.router, intent, classifierOut, c.config.MaxResponseTokens, c.config.MaxCandidatesInPrompt)
+	if err != nil {
+		c.logger.Error("route_decision failed; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.String("topic", intent.Topic),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	envelope := message.NewBaseMessage(decision.Schema(), decision, ComponentName)
+	envelopeBytes, err := json.Marshal(envelope)
+	if err != nil {
+		c.logger.Error("marshal route decision envelope failed",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	// Write snapshot first (queryable), then trigger key R2 watches.
+	// Order matches nl_classify's snapshot-then-trigger discipline so
+	// downstream readback can't miss the snapshot when R2 fires.
+	if err := c.loops.PutSnapshot(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Warn("snapshot write failed; chain continues but downstream readback may miss it",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+	}
+
+	if err := c.loops.PutRouteDecision(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Error("route.complete trigger write failed; R2 will not fire",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	atomic.AddInt64(&c.messagesEmitted, 1)
+	c.logger.Info("route_search emitted RouteDecision",
+		slog.String("loop_id", loopID),
+		slog.String("topic", intent.Topic),
+		slog.String("action", decision.Action))
+}
+
+// Meta implements Discoverable.
+func (c *Component) Meta() component.Metadata {
+	return component.Metadata{
+		Name:        ComponentName,
+		Type:        "processor",
+		Description: "ADR-045 route_search: structured-emit routing decision over upstream ClassifierOutput. Emits one of synthesize_directly / retighten / walk_seeds / decompose for R2 dispatch.",
+		Version:     "0.1.0",
+	}
+}
+
+// InputPorts implements Discoverable.
+func (c *Component) InputPorts() []component.Port {
+	ports := make([]component.Port, 0, len(c.config.Ports.Inputs))
+	for _, p := range c.config.Ports.Inputs {
+		ports = append(ports, component.Port{
+			Name:      p.Name,
+			Direction: component.DirectionInput,
+			Required:  p.Required,
+			Config: component.NATSPort{
+				Subject: p.Subject,
+			},
+		})
+	}
+	return ports
+}
+
+// OutputPorts implements Discoverable. route_search has no NATS-
+// publishing output port: emits are KV writes to AGENT_LOOPS.
+func (c *Component) OutputPorts() []component.Port { return []component.Port{} }
+
+// ConfigSchema implements Discoverable.
+func (c *Component) ConfigSchema() component.ConfigSchema { return configSchema }
+
+// Health implements Discoverable.
+func (c *Component) Health() component.HealthStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return component.HealthStatus{
+		Healthy:    c.started,
+		LastCheck:  time.Now(),
+		ErrorCount: int(atomic.LoadInt64(&c.errors)),
+		Uptime:     time.Since(c.startTime),
+	}
+}
+
+// DataFlow implements Discoverable.
+func (c *Component) DataFlow() component.FlowMetrics {
+	processed := atomic.LoadInt64(&c.messagesProcessed)
+	errCount := atomic.LoadInt64(&c.errors)
+	var errRate float64
+	if processed > 0 {
+		errRate = float64(errCount) / float64(processed)
+	}
+	last, _ := c.lastActivity.Load().(time.Time)
+	return component.FlowMetrics{
+		ErrorRate:    errRate,
+		LastActivity: last,
+	}
+}

--- a/processor/research-graph-route/component_test.go
+++ b/processor/research-graph-route/component_test.go
@@ -1,0 +1,288 @@
+package researchroute
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// fakeLoopStore replaces the natsLoopStore for handler integration
+// tests. Records all reads + writes so the test can assert on key
+// ordering, envelope shape, and miss vs hit paths.
+type fakeLoopStore struct {
+	mu sync.Mutex
+
+	intent    *research.Intent
+	intentErr error
+
+	classifierOut    *research.ClassifierOutput
+	classifierOutErr error
+
+	getIntentCalls     int
+	getClassifierCalls int
+
+	snapshotEnvelope []byte
+	snapshotErr      error
+
+	routeEnvelope []byte
+	routeErr      error
+
+	writeOrder []string
+}
+
+func (s *fakeLoopStore) GetIntent(_ context.Context, _ string) (*research.Intent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getIntentCalls++
+	if s.intentErr != nil {
+		return nil, s.intentErr
+	}
+	return s.intent, nil
+}
+
+func (s *fakeLoopStore) GetClassifierOutput(_ context.Context, _ string) (*research.ClassifierOutput, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getClassifierCalls++
+	if s.classifierOutErr != nil {
+		return nil, s.classifierOutErr
+	}
+	return s.classifierOut, nil
+}
+
+func (s *fakeLoopStore) PutSnapshot(_ context.Context, _ string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.snapshotEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "snapshot")
+	return s.snapshotErr
+}
+
+func (s *fakeLoopStore) PutRouteDecision(_ context.Context, _ string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.routeEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "route_complete")
+	return s.routeErr
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// newTestComponent constructs a Component with all injected
+// dependencies stubbed. Skips Start — handleMessage doesn't touch
+// deps once router/loops are set.
+func newTestComponent(loops LoopStore, router Router) *Component {
+	return &Component{
+		config: DefaultConfig(),
+		router: router,
+		loops:  loops,
+		logger: quietLogger(),
+	}
+}
+
+func TestComponent_HandleMessage_HappyPath(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "drone-001 maintenance events"},
+		classifierOut: &research.ClassifierOutput{
+			Topic: "drone-001 maintenance events",
+			Tier:  "0",
+			Candidates: []research.Candidate{
+				{EntityID: "drone-001", Label: "Drone 001", Relevance: 0.9, Tier: "0", Source: "x"},
+			},
+		},
+	}
+	router := &fakeRouter{
+		content: `{"action":"walk_seeds","args":{"seeds":[{"ref":"drone-001","ref_type":"name"}]},"rationale":"seed found"}`,
+	}
+	c := newTestComponent(loops, router)
+	c.handleMessage(context.Background(), "component.route_search.loop-123", nil)
+
+	if atomic.LoadInt64(&c.messagesProcessed) != 1 {
+		t.Errorf("messagesProcessed = %d, want 1", atomic.LoadInt64(&c.messagesProcessed))
+	}
+	if atomic.LoadInt64(&c.errors) != 0 {
+		t.Errorf("errors = %d, want 0", atomic.LoadInt64(&c.errors))
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if loops.getIntentCalls != 1 || loops.getClassifierCalls != 1 {
+		t.Errorf("read calls: intent=%d, classifier=%d", loops.getIntentCalls, loops.getClassifierCalls)
+	}
+	if len(loops.writeOrder) != 2 || loops.writeOrder[0] != "snapshot" || loops.writeOrder[1] != "route_complete" {
+		t.Errorf("write order = %v, want [snapshot route_complete]", loops.writeOrder)
+	}
+	if len(loops.routeEnvelope) == 0 {
+		t.Error("route envelope not written")
+	}
+}
+
+func TestComponent_HandleMessage_IgnoresBadSubject(t *testing.T) {
+	loops := &fakeLoopStore{}
+	router := &fakeRouter{}
+	c := newTestComponent(loops, router)
+	c.handleMessage(context.Background(), "some.other.subject", nil)
+
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1 (bad-subject branch)", atomic.LoadInt64(&c.errors))
+	}
+	if loops.getIntentCalls != 0 {
+		t.Errorf("getIntentCalls = %d, want 0 (bad subject should short-circuit)", loops.getIntentCalls)
+	}
+	if router.called {
+		t.Error("router should not be called on bad subject")
+	}
+}
+
+func TestComponent_HandleMessage_IntentNotFoundIsRecorded(t *testing.T) {
+	loops := &fakeLoopStore{intentErr: errIntentNotFound}
+	router := &fakeRouter{}
+	c := newTestComponent(loops, router)
+	c.handleMessage(context.Background(), "component.route_search.loop-1", nil)
+
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if router.called {
+		t.Error("router called despite missing intent")
+	}
+}
+
+func TestComponent_HandleMessage_ClassifierOutputNotFoundIsRecorded(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:           &research.Intent{Topic: "x"},
+		classifierOutErr: errClassifierOutputNotFound,
+	}
+	router := &fakeRouter{}
+	c := newTestComponent(loops, router)
+	c.handleMessage(context.Background(), "component.route_search.loop-1", nil)
+
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if router.called {
+		t.Error("router called despite missing classifier output")
+	}
+}
+
+func TestComponent_HandleMessage_RouterErrorIsRecorded(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:        &research.Intent{Topic: "x"},
+		classifierOut: &research.ClassifierOutput{Topic: "x", Tier: "0"},
+	}
+	router := &fakeRouter{err: errors.New("503 upstream")}
+	c := newTestComponent(loops, router)
+	c.handleMessage(context.Background(), "component.route_search.loop-1", nil)
+
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 0 {
+		t.Errorf("messagesEmitted = %d, want 0 (router error short-circuits)", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if len(loops.writeOrder) != 0 {
+		t.Errorf("write order = %v, want empty (router error short-circuits)", loops.writeOrder)
+	}
+}
+
+func TestComponent_HandleMessage_SnapshotErrorIsTolerated(t *testing.T) {
+	// Snapshot is best-effort; a failure should NOT block the
+	// trigger write. Otherwise an operational glitch on the
+	// snapshot key would silently drop loops mid-chain.
+	loops := &fakeLoopStore{
+		intent:        &research.Intent{Topic: "x"},
+		classifierOut: &research.ClassifierOutput{Topic: "x", Tier: "0"},
+		snapshotErr:   errors.New("write hiccup"),
+	}
+	router := &fakeRouter{content: `{"action":"synthesize_directly","args":{}}`}
+	c := newTestComponent(loops, router)
+	c.handleMessage(context.Background(), "component.route_search.loop-1", nil)
+
+	if atomic.LoadInt64(&c.errors) != 0 {
+		t.Errorf("errors = %d, want 0 (snapshot failure is best-effort)", atomic.LoadInt64(&c.errors))
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1 (trigger should still fire)", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if len(loops.routeEnvelope) == 0 {
+		t.Error("route envelope not written despite snapshot failure")
+	}
+}
+
+func TestComponent_HandleMessage_TriggerWriteErrorIsRecorded(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:        &research.Intent{Topic: "x"},
+		classifierOut: &research.ClassifierOutput{Topic: "x", Tier: "0"},
+		routeErr:      errors.New("KV down"),
+	}
+	router := &fakeRouter{content: `{"action":"synthesize_directly","args":{}}`}
+	c := newTestComponent(loops, router)
+	c.handleMessage(context.Background(), "component.route_search.loop-1", nil)
+
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1 (trigger write failure is a real error)", atomic.LoadInt64(&c.errors))
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 0 {
+		t.Errorf("messagesEmitted = %d, want 0 (trigger failed)", atomic.LoadInt64(&c.messagesEmitted))
+	}
+}
+
+// --- discoverable surface ---
+
+func TestComponent_DiscoverableSurface(t *testing.T) {
+	c := newTestComponent(&fakeLoopStore{}, &fakeRouter{})
+	meta := c.Meta()
+	if meta.Name != ComponentName {
+		t.Errorf("Meta.Name = %q, want %q", meta.Name, ComponentName)
+	}
+	if meta.Type != "processor" {
+		t.Errorf("Meta.Type = %q, want %q", meta.Type, "processor")
+	}
+	ports := c.InputPorts()
+	if len(ports) != 1 {
+		t.Errorf("InputPorts: got %d, want 1", len(ports))
+	}
+	if len(c.OutputPorts()) != 0 {
+		t.Errorf("OutputPorts: got %d, want 0 (route_search writes via KV, not NATS)", len(c.OutputPorts()))
+	}
+}
+
+// --- config validate / defaults ---
+
+func TestConfig_ValidateRejectsNegativeCaps(t *testing.T) {
+	c := DefaultConfig()
+	c.MaxResponseTokens = -1
+	if err := c.Validate(); err == nil {
+		t.Error("Validate accepted negative max_response_tokens")
+	}
+	c = DefaultConfig()
+	c.MaxCandidatesInPrompt = -1
+	if err := c.Validate(); err == nil {
+		t.Error("Validate accepted negative max_candidates_in_prompt")
+	}
+}
+
+func TestConfig_ApplyDefaultsFillsZeros(t *testing.T) {
+	c := Config{}
+	c.ApplyDefaults()
+	if c.LoopsBucket != "AGENT_LOOPS" {
+		t.Errorf("LoopsBucket = %q, want AGENT_LOOPS", c.LoopsBucket)
+	}
+	if c.RouteTimeout != DefaultRouteTimeout {
+		t.Errorf("RouteTimeout = %v, want %v", c.RouteTimeout, DefaultRouteTimeout)
+	}
+	if c.MaxResponseTokens != DefaultMaxResponseTokens {
+		t.Errorf("MaxResponseTokens = %d, want %d", c.MaxResponseTokens, DefaultMaxResponseTokens)
+	}
+	if c.MaxCandidatesInPrompt != DefaultMaxCandidatesInPrompt {
+		t.Errorf("MaxCandidatesInPrompt = %d, want %d", c.MaxCandidatesInPrompt, DefaultMaxCandidatesInPrompt)
+	}
+}

--- a/processor/research-graph-route/config.go
+++ b/processor/research-graph-route/config.go
@@ -1,0 +1,113 @@
+package researchroute
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+)
+
+// ComponentName is the canonical registry name + log subsystem.
+const ComponentName = "research-graph-route"
+
+// Default knobs surfaced as exported constants so the prompt-builder
+// tests and operator docs can reference them by name rather than
+// duplicating literals.
+const (
+	// DefaultRouteTimeout caps the structured-emit LLM call. Generous
+	// enough for slower self-hosted endpoints; operators can tighten
+	// for faster hosted models.
+	DefaultRouteTimeout = 30 * time.Second
+
+	// DefaultMaxResponseTokens caps the LLM's response budget. The
+	// JSON-shaped output is small (action + args + rationale); 512 is
+	// well above the worst case for the four action shapes.
+	DefaultMaxResponseTokens = 512
+
+	// DefaultMaxCandidatesInPrompt caps how many ClassifierOutput
+	// candidates the prompt embeds. The router doesn't need the full
+	// candidate list to decide — the top-N by relevance is enough —
+	// and a tight cap keeps the prompt fitting frontier-tier and
+	// small-model context windows alike.
+	DefaultMaxCandidatesInPrompt = 10
+)
+
+// Config holds operator-tunable knobs for the route_search component.
+//
+// LLM wiring follows the same model-registry capability seam as
+// processor/research-graph-classify: operator declares
+// CapabilityResearchRouting in the model registry; the component
+// resolves it at Start() time. Absence is a startup error — unlike
+// the optional LLM tier on nl_classify, route_search has no
+// keyword-only fallback (its entire job is the LLM judgment).
+type Config struct {
+	Ports *component.PortConfig `json:"ports,omitempty" schema:"type:ports,description:Port configuration. route_search requires one nats input subscribing to component.route_search.> ,category:basic"`
+
+	LoopsBucket string `json:"loops_bucket,omitempty" schema:"type:string,description:NATS KV bucket holding research-pipeline loops and trigger/completion keys,default:AGENT_LOOPS,category:advanced"`
+
+	RouteTimeout time.Duration `json:"route_timeout,omitempty" schema:"type:duration,description:Timeout for the structured-emit LLM call. Honors capability.research_routing override when set on the model registry,default:30s,category:advanced"`
+
+	MaxResponseTokens int `json:"max_response_tokens,omitempty" schema:"type:int,description:Cap on LLM response tokens. The JSON-shaped output is small; 512 covers the worst case across the four action shapes,default:512,max:2048,category:advanced"`
+
+	MaxCandidatesInPrompt int `json:"max_candidates_in_prompt,omitempty" schema:"type:int,description:Cap on number of ClassifierOutput candidates embedded in the router prompt. Top-N by relevance; tighter caps keep prompts within small-model context windows. 0 means default (10),default:10,max:50,category:advanced"`
+}
+
+// Validate validates the configuration. Negative caps are rejected;
+// zero values fall through to ApplyDefaults (treated as "use
+// default").
+func (c *Config) Validate() error {
+	if c.Ports == nil || len(c.Ports.Inputs) == 0 {
+		return errors.New("ports configuration with at least one input port is required")
+	}
+	if c.MaxResponseTokens < 0 {
+		return errors.New("max_response_tokens must be >= 0")
+	}
+	if c.MaxCandidatesInPrompt < 0 {
+		return errors.New("max_candidates_in_prompt must be >= 0")
+	}
+	return nil
+}
+
+// ApplyDefaults fills in defaults for unset fields.
+func (c *Config) ApplyDefaults() {
+	if c.LoopsBucket == "" {
+		c.LoopsBucket = "AGENT_LOOPS"
+	}
+	if c.RouteTimeout == 0 {
+		c.RouteTimeout = DefaultRouteTimeout
+	}
+	if c.MaxResponseTokens == 0 {
+		c.MaxResponseTokens = DefaultMaxResponseTokens
+	}
+	if c.MaxCandidatesInPrompt == 0 {
+		c.MaxCandidatesInPrompt = DefaultMaxCandidatesInPrompt
+	}
+}
+
+// DefaultConfig returns a default Config skeleton with the standard
+// route_search input port.
+func DefaultConfig() Config {
+	return Config{
+		Ports: &component.PortConfig{
+			Inputs: []component.PortDefinition{
+				{
+					Name:        "trigger",
+					Type:        "nats",
+					Subject:     "component.route_search.>",
+					Required:    true,
+					Description: "R1's publish target. Subject suffix carries the research-pipeline loop_id.",
+				},
+			},
+			Outputs: []component.PortDefinition{},
+		},
+		LoopsBucket:           "AGENT_LOOPS",
+		RouteTimeout:          DefaultRouteTimeout,
+		MaxResponseTokens:     DefaultMaxResponseTokens,
+		MaxCandidatesInPrompt: DefaultMaxCandidatesInPrompt,
+	}
+}
+
+// configSchema is the static configuration schema, generated from
+// Config struct tags at package init.
+var configSchema = component.GenerateConfigSchema(reflect.TypeOf(Config{}))

--- a/processor/research-graph-route/doc.go
+++ b/processor/research-graph-route/doc.go
@@ -1,0 +1,38 @@
+// Package researchroute implements the route_search component from
+// ADR-045 Phase 1 (PR 3 of six per
+// docs/operations/22-adr045-phase1-plan.md).
+//
+// route_search is the first LLM-judgment stage of the graph-search
+// rule chain. It receives a publish trigger on
+// component.route_search.<loop_id>, reads the upstream
+// research.Intent + research.ClassifierOutput payloads from
+// AGENT_LOOPS, builds a structured-emit prompt, calls the configured
+// research_routing LLM endpoint, parses the model's JSON output into
+// a research.RouteDecision, validates per-action arg shape, and
+// writes the RouteDecision envelope plus a route.complete.<loop_id>
+// trigger key that R2 (PR 6) watches to dispatch the next stage.
+//
+// Architectural notes:
+//
+//   - LLM-wrapping component, not agent-wrapping. Direct LLM call via
+//     the configured CapabilityResearchRouting endpoint; the chain
+//     does not delegate decision-making to a free-form ReAct loop.
+//
+//   - Prompt is structured per discipline memory
+//     feedback_persona_prose_needs_decision_criteria: per-action
+//     purpose framing + decision-axis framing (no magic-number
+//     thresholds) + concrete examples for non-obvious choice points
+//     (decompose vs walk_seeds vs retighten) + negative-shape
+//     definition for synthesize_directly.
+//
+//   - Args emitted by the model follow intent-not-structure
+//     (ADR-045 Amendment 2026-05-23): decompose carries axes/focus/
+//     scope; walk_seeds carries seed references (name/partial_id/
+//     candidate_index), not full 6-part entity IDs. Backend
+//     (execute_subqueries, PR 4) resolves to typed sub-queries and
+//     full IDs.
+//
+//   - All public methods are safe for concurrent use across loops;
+//     the component holds no per-call mutable state. Same pattern as
+//     research-graph-classify.
+package researchroute

--- a/processor/research-graph-route/handler.go
+++ b/processor/research-graph-route/handler.go
@@ -1,0 +1,187 @@
+package researchroute
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// Router is the narrow LLM surface this component consumes.
+// Production satisfies it via llmRouterAdapter wrapping a real
+// graph/llm.Client; tests substitute a fake that returns a
+// deterministic raw JSON response per scenario without standing up
+// any LLM infrastructure.
+//
+// Route returns the raw response Content + a short reason string the
+// adapter can use for error diagnostics (model identifier, finish
+// reason, etc.). The handler parses the Content as JSON into a
+// RouteDecision and validates separately so prompt iteration and
+// response-shape drift surface as separate test failures.
+type Router interface {
+	Route(ctx context.Context, systemPrompt, userPrompt string, maxResponseTokens int) (content string, reason string, err error)
+}
+
+// LoopStore is the AGENT_LOOPS read/write surface this component
+// consumes. Production wraps natsclient.KVStore; tests substitute an
+// in-memory map.
+type LoopStore interface {
+	// GetIntent loads the research_intent payload from the
+	// research.requested.<loopID> key. Returned for the prompt's
+	// topic + hints context.
+	GetIntent(ctx context.Context, loopID string) (*research.Intent, error)
+
+	// GetClassifierOutput loads the upstream ClassifierOutput from
+	// the classify.complete.<loopID> trigger key. The router needs
+	// the candidate set, hints, and confidence to make its decision.
+	GetClassifierOutput(ctx context.Context, loopID string) (*research.ClassifierOutput, error)
+
+	// PutRouteDecision writes the RouteDecision envelope at R2's
+	// trigger key route.complete.<loopID>.
+	PutRouteDecision(ctx context.Context, loopID string, envelope []byte) error
+
+	// PutSnapshot writes the envelope at a stable non-trigger key
+	// route.snapshot.<loopID> so operators / downstream queryability
+	// can read the full decision without racing R2's wildcard
+	// watcher. Same pattern as research-graph-classify.
+	PutSnapshot(ctx context.Context, loopID string, envelope []byte) error
+}
+
+// Sentinel errors. Returned for diagnostic clarity in handler logs
+// + so tests can assert specific failure modes via errors.Is.
+var (
+	errIntentNotFound           = fmt.Errorf("research intent not found")
+	errClassifierOutputNotFound = fmt.Errorf("classifier output not found")
+)
+
+// extractLoopIDFromSubject pulls the loop_id off the NATS subject
+// component.route_search.<loop_id>. Returns empty if the subject
+// doesn't match — handler treats empty as a routing-config bug.
+//
+// Format is stable per ADR-045 §Rule chain — R1's publish action
+// uses `subject: "component.route_search.{loop_id}"`. Any deviation
+// is a misconfigured rule, not a parsing problem.
+func extractLoopIDFromSubject(subject string) string {
+	const prefix = "component.route_search."
+	if !strings.HasPrefix(subject, prefix) {
+		return ""
+	}
+	return subject[len(prefix):]
+}
+
+// routeDecision is the pure routing function over injected
+// interfaces — no NATS plumbing leaks in here so the test matrix can
+// drive it through fakes.
+//
+// Returns a validated RouteDecision (action enum + per-action arg
+// shape) on success. Per-action arg validation is done here, not in
+// adapters.go, so a malformed model response surfaces as a specific
+// "router emitted invalid X" error rather than a generic decode
+// failure downstream.
+func routeDecision(ctx context.Context, router Router, intent *research.Intent, classifierOut *research.ClassifierOutput, maxResponseTokens, maxCandidatesInPrompt int) (*research.RouteDecision, error) {
+	if intent == nil {
+		return nil, fmt.Errorf("intent is nil")
+	}
+	if classifierOut == nil {
+		return nil, fmt.Errorf("classifier output is nil")
+	}
+	if router == nil {
+		return nil, fmt.Errorf("router is nil")
+	}
+
+	systemPrompt := buildSystemPrompt()
+	userPrompt := buildUserPrompt(intent, classifierOut, maxCandidatesInPrompt)
+
+	rawContent, reason, err := router.Route(ctx, systemPrompt, userPrompt, maxResponseTokens)
+	if err != nil {
+		return nil, fmt.Errorf("router call: %w", err)
+	}
+	if strings.TrimSpace(rawContent) == "" {
+		return nil, fmt.Errorf("router returned empty content (finish_reason=%q)", reason)
+	}
+
+	jsonBytes, err := extractJSON(rawContent)
+	if err != nil {
+		return nil, fmt.Errorf("extract JSON from router content: %w (raw=%q finish_reason=%q)", err, truncate(rawContent, 200), reason)
+	}
+
+	var decision research.RouteDecision
+	if err := json.Unmarshal(jsonBytes, &decision); err != nil {
+		return nil, fmt.Errorf("decode route decision: %w (raw=%q)", err, truncate(string(jsonBytes), 200))
+	}
+	if err := decision.Validate(); err != nil {
+		return nil, fmt.Errorf("router emitted invalid action: %w", err)
+	}
+
+	// Per-action arg shape validation. Surface a specific error per
+	// branch so prompt iteration can target the failing path.
+	switch decision.Action {
+	case research.ActionDecompose:
+		if _, err := decision.ParseDecomposeArgs(); err != nil {
+			return nil, fmt.Errorf("router emitted invalid decompose args: %w", err)
+		}
+	case research.ActionWalkSeeds:
+		if _, err := decision.ParseWalkSeedsArgs(); err != nil {
+			return nil, fmt.Errorf("router emitted invalid walk_seeds args: %w", err)
+		}
+	case research.ActionRetighten:
+		if _, err := decision.ParseRetightenArgs(); err != nil {
+			return nil, fmt.Errorf("router emitted invalid retighten args: %w", err)
+		}
+	case research.ActionSynthesizeDirectly:
+		// No args expected; if the model emitted some, log-and-keep
+		// (validators downstream don't read them). Don't reject —
+		// frontier models sometimes emit empty maps even when told
+		// not to, and that's not a routing failure.
+	}
+
+	return &decision, nil
+}
+
+// extractJSON pulls a JSON object out of an LLM response. Many
+// models wrap their structured emit in ```json fences or prose
+// preface; this helper extracts the first balanced {...} substring.
+// Falls back to the raw content (trimmed) when no braces are
+// detected. Returns an error if the result still doesn't look like
+// a JSON object.
+func extractJSON(content string) ([]byte, error) {
+	trimmed := strings.TrimSpace(content)
+	// Strip common markdown fences.
+	trimmed = strings.TrimPrefix(trimmed, "```json")
+	trimmed = strings.TrimPrefix(trimmed, "```JSON")
+	trimmed = strings.TrimPrefix(trimmed, "```")
+	trimmed = strings.TrimSuffix(trimmed, "```")
+	trimmed = strings.TrimSpace(trimmed)
+
+	// Locate the outermost {...} object — handles brace counts in
+	// nested values correctly because we walk character-by-character.
+	start := strings.Index(trimmed, "{")
+	if start < 0 {
+		return nil, fmt.Errorf("no JSON object found in content")
+	}
+	depth := 0
+	for i := start; i < len(trimmed); i++ {
+		switch trimmed[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return []byte(trimmed[start : i+1]), nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("unbalanced braces in content (depth=%d)", depth)
+}
+
+// truncate returns s capped at n bytes; longer strings get an
+// ellipsis suffix. Used in error messages so an over-long LLM
+// response doesn't blow up log lines.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/processor/research-graph-route/handler_test.go
+++ b/processor/research-graph-route/handler_test.go
@@ -1,0 +1,466 @@
+package researchroute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// fakeRouter returns canned content / error per scenario. Records
+// the system+user prompts it was called with so prompt-shape tests
+// can verify wiring without running the LLM.
+type fakeRouter struct {
+	mu         sync.Mutex
+	called     bool
+	gotSystem  string
+	gotUser    string
+	gotMaxToks int
+	content    string
+	reason     string
+	err        error
+}
+
+func (f *fakeRouter) Route(_ context.Context, system, user string, maxTokens int) (string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called = true
+	f.gotSystem = system
+	f.gotUser = user
+	f.gotMaxToks = maxTokens
+	return f.content, f.reason, f.err
+}
+
+func TestExtractLoopIDFromSubject(t *testing.T) {
+	cases := []struct {
+		name    string
+		subject string
+		want    string
+	}{
+		{"happy", "component.route_search.loop-123", "loop-123"},
+		{"empty suffix", "component.route_search.", ""},
+		{"wrong prefix", "component.nl_classify.loop-123", ""},
+		{"random", "some.other.subject", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractLoopIDFromSubject(c.subject); got != c.want {
+				t.Errorf("extractLoopIDFromSubject(%q) = %q, want %q", c.subject, got, c.want)
+			}
+		})
+	}
+}
+
+// --- extractJSON ---
+
+func TestExtractJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "bare object",
+			input: `{"action":"synthesize_directly","args":{}}`,
+			want:  `{"action":"synthesize_directly","args":{}}`,
+		},
+		{
+			name:  "markdown fenced",
+			input: "```json\n{\"action\":\"retighten\",\"args\":{\"topic\":\"x\"}}\n```",
+			want:  `{"action":"retighten","args":{"topic":"x"}}`,
+		},
+		{
+			name:  "prose preface",
+			input: `Sure — here is the decision:` + "\n" + `{"action":"walk_seeds","args":{"seeds":[{"ref":"x","ref_type":"name"}]}}` + "\nLet me know if you need more.",
+			want:  `{"action":"walk_seeds","args":{"seeds":[{"ref":"x","ref_type":"name"}]}}`,
+		},
+		{
+			name:  "nested braces preserved",
+			input: `{"action":"decompose","args":{"axes":["a","b"],"focus":"x","scope":"narrow"},"rationale":"y"}`,
+			want:  `{"action":"decompose","args":{"axes":["a","b"],"focus":"x","scope":"narrow"},"rationale":"y"}`,
+		},
+		{
+			name:    "no object",
+			input:   "I cannot answer this.",
+			wantErr: true,
+		},
+		{
+			name:    "unbalanced",
+			input:   `{"action":"x"`,
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := extractJSON(c.input)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("extractJSON: want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("extractJSON: unexpected error %v", err)
+			}
+			if string(got) != c.want {
+				t.Errorf("extractJSON = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// --- routeDecision happy paths ---
+
+func TestRouteDecision_SynthesizeDirectly(t *testing.T) {
+	router := &fakeRouter{
+		content: `{"action":"synthesize_directly","args":{},"rationale":"candidate set is already sufficient"}`,
+	}
+	intent := &research.Intent{Topic: "drone-001 status"}
+	out := &research.ClassifierOutput{
+		Topic:      "drone-001 status",
+		Tier:       "0",
+		Candidates: []research.Candidate{{EntityID: "drone-001", Label: "Drone 001", Tier: "0", Source: "x"}},
+	}
+
+	got, err := routeDecision(context.Background(), router, intent, out, 512, 10)
+	if err != nil {
+		t.Fatalf("routeDecision: %v", err)
+	}
+	if got.Action != research.ActionSynthesizeDirectly {
+		t.Errorf("action = %q, want %q", got.Action, research.ActionSynthesizeDirectly)
+	}
+	if !router.called {
+		t.Error("router not called")
+	}
+	if router.gotMaxToks != 512 {
+		t.Errorf("max_tokens = %d, want 512", router.gotMaxToks)
+	}
+	if !strings.Contains(router.gotUser, "drone-001 status") {
+		t.Errorf("user prompt missing topic: %q", router.gotUser)
+	}
+}
+
+func TestRouteDecision_DecomposeHappyPath(t *testing.T) {
+	router := &fakeRouter{
+		content: `{"action":"decompose","args":{"axes":["entity_type","time"],"focus":"sensor maintenance","scope":"medium"},"rationale":"multi-dim"}`,
+	}
+	got, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x", Tier: "0"},
+		512, 10)
+	if err != nil {
+		t.Fatalf("routeDecision: %v", err)
+	}
+	if got.Action != research.ActionDecompose {
+		t.Fatalf("action: %q", got.Action)
+	}
+	args, err := got.ParseDecomposeArgs()
+	if err != nil {
+		t.Fatalf("ParseDecomposeArgs: %v", err)
+	}
+	if len(args.Axes) != 2 || args.Focus != "sensor maintenance" || args.Scope != research.DecomposeScopeMedium {
+		t.Errorf("decompose args drift: %+v", args)
+	}
+}
+
+func TestRouteDecision_WalkSeedsHappyPath(t *testing.T) {
+	router := &fakeRouter{
+		content: `{"action":"walk_seeds","args":{"seeds":[{"ref":"drone-001","ref_type":"name"},{"ref":"0","ref_type":"candidate_index"}]},"rationale":"have starts"}`,
+	}
+	got, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x", Tier: "0", Candidates: []research.Candidate{{EntityID: "drone-001", Tier: "0", Source: "x"}}},
+		512, 10)
+	if err != nil {
+		t.Fatalf("routeDecision: %v", err)
+	}
+	args, err := got.ParseWalkSeedsArgs()
+	if err != nil {
+		t.Fatalf("ParseWalkSeedsArgs: %v", err)
+	}
+	if len(args.Seeds) != 2 || args.Seeds[0].Ref != "drone-001" {
+		t.Errorf("walk_seeds args drift: %+v", args)
+	}
+}
+
+func TestRouteDecision_RetightenHappyPath(t *testing.T) {
+	router := &fakeRouter{
+		content: `{"action":"retighten","args":{"topic":"refined","hints":{"k":"v"}},"rationale":"vague"}`,
+	}
+	got, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x", Tier: "0"},
+		512, 10)
+	if err != nil {
+		t.Fatalf("routeDecision: %v", err)
+	}
+	args, err := got.ParseRetightenArgs()
+	if err != nil {
+		t.Fatalf("ParseRetightenArgs: %v", err)
+	}
+	if args.Topic != "refined" || args.Hints["k"] != "v" {
+		t.Errorf("retighten args drift: %+v", args)
+	}
+}
+
+// --- routeDecision error paths ---
+
+func TestRouteDecision_RejectsRouterError(t *testing.T) {
+	router := &fakeRouter{err: errors.New("upstream 503")}
+	_, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x"},
+		512, 10)
+	if err == nil || !strings.Contains(err.Error(), "router call") {
+		t.Fatalf("want router-call error, got %v", err)
+	}
+}
+
+func TestRouteDecision_RejectsEmptyContent(t *testing.T) {
+	router := &fakeRouter{content: "   ", reason: "length"}
+	_, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x"},
+		512, 10)
+	if err == nil || !strings.Contains(err.Error(), "empty content") {
+		t.Fatalf("want empty-content error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "length") {
+		t.Errorf("error should include finish_reason: %v", err)
+	}
+}
+
+func TestRouteDecision_RejectsInvalidAction(t *testing.T) {
+	router := &fakeRouter{content: `{"action":"bogus","args":{}}`}
+	_, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x"},
+		512, 10)
+	if err == nil {
+		t.Fatal("want invalid-action error, got nil")
+	}
+	// UnmarshalJSON enforces the enum at decode, so the error
+	// surfaces as a decode failure, not as the post-decode Validate
+	// branch. Either is fine — assert the bogus action shows up.
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("error should mention bogus action: %v", err)
+	}
+}
+
+func TestRouteDecision_RejectsBadDecomposeArgs(t *testing.T) {
+	// Missing focus + missing axes — decode succeeds (Args is loose
+	// at wire level) but per-action validation rejects.
+	router := &fakeRouter{content: `{"action":"decompose","args":{"scope":"narrow"}}`}
+	_, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x"},
+		512, 10)
+	if err == nil || !strings.Contains(err.Error(), "invalid decompose args") {
+		t.Fatalf("want invalid-decompose-args error, got %v", err)
+	}
+}
+
+func TestRouteDecision_RejectsBadWalkSeedsArgs(t *testing.T) {
+	router := &fakeRouter{content: `{"action":"walk_seeds","args":{"seeds":[{"ref":"x","ref_type":"full_id"}]}}`}
+	_, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x"},
+		512, 10)
+	if err == nil || !strings.Contains(err.Error(), "invalid walk_seeds args") {
+		t.Fatalf("want invalid-walk_seeds-args error, got %v", err)
+	}
+}
+
+func TestRouteDecision_RejectsBadRetightenArgs(t *testing.T) {
+	router := &fakeRouter{content: `{"action":"retighten","args":{"hints":{"k":"v"}}}`}
+	_, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x"},
+		512, 10)
+	if err == nil || !strings.Contains(err.Error(), "invalid retighten args") {
+		t.Fatalf("want invalid-retighten-args error, got %v", err)
+	}
+}
+
+func TestRouteDecision_SynthesizeDirectlyToleratesExtraArgs(t *testing.T) {
+	// Frontier models occasionally emit empty args even when told
+	// not to. SynthesizeDirectly tolerates this — downstream
+	// synthesizer ignores Args for this action.
+	router := &fakeRouter{content: `{"action":"synthesize_directly","args":{"extra":"ignored"},"rationale":"x"}`}
+	got, err := routeDecision(context.Background(), router,
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x"},
+		512, 10)
+	if err != nil {
+		t.Fatalf("routeDecision should tolerate extra args on synthesize_directly: %v", err)
+	}
+	if got.Action != research.ActionSynthesizeDirectly {
+		t.Errorf("action drift: %q", got.Action)
+	}
+}
+
+// --- prompt wiring ---
+
+func TestBuildUserPrompt_IncludesTopicAndCandidates(t *testing.T) {
+	intent := &research.Intent{Topic: "sensor maintenance events", Hints: map[string]string{"entity_type": "sensor"}}
+	out := &research.ClassifierOutput{
+		Topic:      "sensor maintenance events",
+		Tier:       "1",
+		Confidence: 0.72,
+		Hints:      map[string]any{"k": "v"},
+		Candidates: []research.Candidate{
+			{EntityID: "sensor-001", Label: "Sensor 001", Type: "sensor", Relevance: 0.9, Tier: "0", Source: "x"},
+			{EntityID: "sensor-002", Label: "Sensor 002", Type: "sensor", Relevance: 0.5, Tier: "0", Source: "x"},
+		},
+	}
+	got := buildUserPrompt(intent, out, 10)
+	// Substring assertions — not a golden snapshot, to avoid
+	// over-pinning the exact wording (prompt iteration is normal).
+	for _, want := range []string{
+		"sensor maintenance events",
+		"entity_type: sensor",
+		"Classifier tier: 1",
+		"Classifier confidence: 0.72",
+		"sensor-001",
+		"sensor-002",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt missing %q\nfull:\n%s", want, got)
+		}
+	}
+}
+
+func TestBuildUserPrompt_CapsCandidateCount(t *testing.T) {
+	// Cap at 2 — verify only 2 candidates render even when 5 are
+	// supplied, and the top-by-relevance ordering is honored.
+	out := &research.ClassifierOutput{
+		Topic: "x",
+		Tier:  "0",
+		Candidates: []research.Candidate{
+			{EntityID: "low", Relevance: 0.1, Tier: "0", Source: "x"},
+			{EntityID: "high", Relevance: 0.9, Tier: "0", Source: "x"},
+			{EntityID: "mid", Relevance: 0.5, Tier: "0", Source: "x"},
+			{EntityID: "low2", Relevance: 0.2, Tier: "0", Source: "x"},
+			{EntityID: "mid2", Relevance: 0.4, Tier: "0", Source: "x"},
+		},
+	}
+	got := buildUserPrompt(&research.Intent{Topic: "x"}, out, 2)
+	if !strings.Contains(got, "high") {
+		t.Errorf("top-relevance 'high' missing from capped prompt:\n%s", got)
+	}
+	if !strings.Contains(got, "mid") {
+		t.Errorf("second-relevance 'mid' missing from capped prompt:\n%s", got)
+	}
+	if strings.Contains(got, "low2") || strings.Contains(got, "mid2") {
+		t.Errorf("low-relevance candidates leaked past cap:\n%s", got)
+	}
+}
+
+func TestBuildUserPrompt_NoCandidatesHasGuidance(t *testing.T) {
+	// Empty candidate set must produce a usable prompt — the model
+	// needs to know "no candidates, consider retighten or
+	// synthesize_directly" rather than an empty list section.
+	got := buildUserPrompt(
+		&research.Intent{Topic: "x"},
+		&research.ClassifierOutput{Topic: "x", Tier: "0"},
+		10)
+	if !strings.Contains(got, "none") {
+		t.Errorf("empty candidate prompt should signal 'none': %s", got)
+	}
+}
+
+// --- buildSystemPrompt sanity ---
+
+func TestBuildSystemPrompt_IncludesAllFourActions(t *testing.T) {
+	got := buildSystemPrompt()
+	for _, action := range []string{
+		research.ActionSynthesizeDirectly,
+		research.ActionRetighten,
+		research.ActionWalkSeeds,
+		research.ActionDecompose,
+	} {
+		if !strings.Contains(got, action) {
+			t.Errorf("system prompt missing action %q", action)
+		}
+	}
+}
+
+func TestBuildSystemPrompt_DescribesIntentShapeArgs(t *testing.T) {
+	// Verify the prompt actually instructs intent-shaped args
+	// (axes/focus/scope for decompose; ref/ref_type for walk_seeds)
+	// rather than the old typed-args shapes. Catches regression
+	// where someone edits the prompt back to the v1 shapes without
+	// updating the ParseArgs helpers.
+	got := buildSystemPrompt()
+	for _, want := range []string{
+		"axes", "focus", "scope",
+		"ref", "ref_type", "name", "partial_id", "candidate_index",
+		"Do not emit full 6-part IDs",
+		"Do not emit typed sub-query objects",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("system prompt missing intent-shape token %q", want)
+		}
+	}
+}
+
+// --- prompt wiring through routeDecision ---
+
+func TestRouteDecision_PassesSystemAndUserPrompts(t *testing.T) {
+	router := &fakeRouter{content: `{"action":"synthesize_directly","args":{}}`}
+	intent := &research.Intent{Topic: "my topic", Hints: map[string]string{"a": "b"}}
+	out := &research.ClassifierOutput{
+		Topic: "my topic", Tier: "0",
+		Candidates: []research.Candidate{{EntityID: "ent-1", Tier: "0", Source: "x"}},
+	}
+	_, err := routeDecision(context.Background(), router, intent, out, 512, 10)
+	if err != nil {
+		t.Fatalf("routeDecision: %v", err)
+	}
+	if !strings.Contains(router.gotSystem, "synthesize_directly") {
+		t.Errorf("system prompt missing action enum: %s", router.gotSystem)
+	}
+	if !strings.Contains(router.gotUser, "my topic") {
+		t.Errorf("user prompt missing topic: %s", router.gotUser)
+	}
+	if !strings.Contains(router.gotUser, "ent-1") {
+		t.Errorf("user prompt missing candidate: %s", router.gotUser)
+	}
+}
+
+// --- envelope round-trip sanity ---
+
+// TestDecisionMarshalUnmarshalsThroughEnvelope verifies the
+// production marshal path (NewBaseMessage → MarshalJSON) keeps the
+// per-action Args shape intact, so the snapshot/trigger writes in
+// handleMessage don't drop fields silently.
+func TestDecisionMarshalUnmarshalsThroughEnvelope(t *testing.T) {
+	d := &research.RouteDecision{
+		Action: research.ActionDecompose,
+		Args: map[string]any{
+			"axes":  []any{"entity_type", "time"},
+			"focus": "x",
+			"scope": research.DecomposeScopeNarrow,
+		},
+	}
+	raw, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back research.RouteDecision
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	args, err := back.ParseDecomposeArgs()
+	if err != nil {
+		t.Fatalf("ParseDecomposeArgs after round-trip: %v", err)
+	}
+	if len(args.Axes) != 2 || args.Focus != "x" {
+		t.Errorf("round-trip lost fields: %+v", args)
+	}
+}

--- a/processor/research-graph-route/prompt.go
+++ b/processor/research-graph-route/prompt.go
@@ -1,0 +1,188 @@
+package researchroute
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// buildSystemPrompt returns the static system message that frames the
+// router's role + decision criteria + output contract. Stable across
+// requests so a per-loop prompt change doesn't ripple into a system-
+// message change (and any per-tenant cache stays warm).
+//
+// Discipline: every action sentence carries a "when to use" criterion
+// per feedback_persona_prose_needs_decision_criteria. No magic-number
+// thresholds (no "confidence < 0.6 → retighten"); decision-axis
+// framing instead so the model picks via reasoning, not lookup.
+// Concrete examples for non-obvious choice points
+// (decompose vs walk_seeds vs retighten can look similar from
+// classifier output alone). Negative-shape for synthesize_directly
+// so the model doesn't default to it when uncertain.
+func buildSystemPrompt() string {
+	return `You are the routing stage of a graph-search pipeline. You receive a research topic and the upstream classifier's initial candidate set. You choose ONE of four next actions and emit a structured JSON object.
+
+Your job is the structural decision — what shape of work comes next. The downstream stages do the work. You do not synthesize, walk, or refine yourself; you only route.
+
+# The four actions
+
+## synthesize_directly
+Use when the candidate set already answers the topic well enough that further graph work would only restate what the classifier surfaced.
+
+Decision axis: would running multi-hop expansion or re-classification produce evidence the synthesizer doesn't already have? If no, route here.
+
+Negative shape — do NOT default to synthesize_directly when uncertain. It is the route that bypasses the rest of the chain. Pick it when the candidate set is already sufficient, not when you cannot tell which other action fits.
+
+## retighten
+Use when the topic and the candidates obviously don't match — the classifier surfaced the wrong slice of the graph and rerunning with refined hints should land closer.
+
+Decision axis: is the gap a TOPIC PHRASING problem (vague topic, ambiguous term, missing entity-type or temporal qualifier) that a better topic + hints would fix? If yes, retighten with a refined topic.
+
+Example: topic "sensor failures" returned entities about sensor calibration sessions because "failure" wasn't disambiguated. Retighten with topic "sensor hardware failures during operation" and hint {entity_type: "fault_event"}.
+
+Do NOT retighten when the candidates look right but you need more graph context — that's walk_seeds. Capped at 2 retighten passes per chain, so a second retighten should only fire if the first retighten genuinely changed the candidate shape.
+
+## walk_seeds
+Use when one or more candidates look like the right starting points but you need their NEIGHBORHOOD — observations, related entities, temporal context — to answer the topic.
+
+Decision axis: is the answer reachable by traversing OUT from concrete seeds in the candidate set? If yes, walk those seeds.
+
+Reference seeds by their display name (e.g. "drone-001"), a partial federated ID (e.g. "robotics.gcs.drone"), or by their position in the candidate list (e.g. "0" for the first candidate). The backend resolves these to full 6-part entity IDs. Do not emit full 6-part IDs yourself — you will not spell them reliably.
+
+## decompose
+Use when the topic spans MULTIPLE structural dimensions that won't be answered by walking a single seed — different entity kinds, multiple time windows, different predicate families, multiple spatial regions.
+
+Decision axis: would the answer require fusing results from STRUCTURALLY DIFFERENT sub-queries? If yes, decompose.
+
+Emit the decomposition INTENT (axes to decompose along, focus concept, scope). The backend constructs the typed sub-queries from templates. Do not emit typed sub-query objects yourself — you will not spell them reliably.
+
+# How to choose between similar-looking actions
+
+- walk_seeds vs decompose: walk_seeds is "go deeper from these starting points"; decompose is "answer this in pieces that fuse together." If the candidate set has a small number of clear starting points, walk_seeds. If the topic itself has multiple structural pieces regardless of which entities the classifier found, decompose.
+
+- retighten vs decompose: retighten when the classifier found the wrong neighborhood; decompose when the classifier found a piece of the right neighborhood but the answer needs more pieces.
+
+- retighten vs synthesize_directly: if the candidate set is sparse or off-topic, retighten is almost always preferable to synthesize_directly. The synthesizer cannot invent evidence the classifier missed.
+
+# Output contract
+
+Emit a single JSON object, no prose, no markdown fences, with this shape:
+
+` + "```" + `
+{
+  "action": "synthesize_directly" | "retighten" | "walk_seeds" | "decompose",
+  "args": { ... per-action shape below ... },
+  "rationale": "one or two sentences explaining the structural reason for this action"
+}
+` + "```" + `
+
+Per-action args:
+
+- synthesize_directly: ` + "`" + `{}` + "`" + ` (empty)
+- retighten: ` + "`" + `{ "topic": "<refined topic string>", "hints": { "<key>": "<value>", ... } }` + "`" + `
+- walk_seeds: ` + "`" + `{ "seeds": [ { "ref": "<name | partial_id | candidate_index>", "ref_type": "name" | "partial_id" | "candidate_index" }, ... ] }` + "`" + `
+- decompose: ` + "`" + `{ "axes": ["<dimension>", ...], "focus": "<central concept>", "scope": "narrow" | "medium" | "broad" }` + "`" + `
+
+Rationale is for operator trajectory review — write the structural reason, not a restatement of the topic. The downstream chain does not pattern-match on rationale; it branches on action only.`
+}
+
+// buildUserPrompt renders the per-request context the router sees:
+// the topic + hints from the Intent, the classifier's tier +
+// confidence + candidates. Bounded by maxCandidatesInPrompt so the
+// prompt stays within small-model context windows.
+//
+// Discipline: candidates render with stable ordering (relevance
+// descending; ties broken by entity ID) so the same loop replayed
+// produces byte-identical prompts. Stable ordering also lets the
+// model's "candidate_index" seed references resolve deterministically
+// at the backend.
+func buildUserPrompt(intent *research.Intent, classifierOut *research.ClassifierOutput, maxCandidatesInPrompt int) string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "Topic: %s\n", intent.Topic)
+
+	if len(intent.Hints) > 0 {
+		sb.WriteString("\nUpstream hints:\n")
+		// Sort hint keys for determinism.
+		keys := make([]string, 0, len(intent.Hints))
+		for k := range intent.Hints {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&sb, "  - %s: %s\n", k, intent.Hints[k])
+		}
+	}
+
+	fmt.Fprintf(&sb, "\nClassifier tier: %s\n", classifierOut.Tier)
+	if classifierOut.Confidence > 0 {
+		fmt.Fprintf(&sb, "Classifier confidence: %.2f\n", classifierOut.Confidence)
+	}
+	if classifierOut.Intent != "" {
+		fmt.Fprintf(&sb, "Classifier intent label: %s\n", classifierOut.Intent)
+	}
+	if classifierOut.Degraded {
+		fmt.Fprintf(&sb, "Classifier degraded: yes (%s)\n", classifierOut.DegradedReason)
+	}
+
+	if len(classifierOut.Hints) > 0 {
+		sb.WriteString("\nClassifier hints:\n")
+		keys := make([]string, 0, len(classifierOut.Hints))
+		for k := range classifierOut.Hints {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&sb, "  - %s: %v\n", k, classifierOut.Hints[k])
+		}
+	}
+
+	sb.WriteString("\nClassifier candidates (top by relevance, indexed for walk_seeds):\n")
+	candidates := orderedCandidates(classifierOut.Candidates, maxCandidatesInPrompt)
+	if len(candidates) == 0 {
+		sb.WriteString("  (none — consider retighten or synthesize_directly per rationale)\n")
+	}
+	for i, c := range candidates {
+		fmt.Fprintf(&sb, "  [%d] %s", i, c.EntityID)
+		if c.Label != "" {
+			fmt.Fprintf(&sb, " — %s", c.Label)
+		}
+		if c.Type != "" {
+			fmt.Fprintf(&sb, " (type=%s)", c.Type)
+		}
+		if c.Relevance > 0 {
+			fmt.Fprintf(&sb, " [relevance=%.2f]", c.Relevance)
+		}
+		if c.Tier != "" {
+			fmt.Fprintf(&sb, " [tier=%s]", c.Tier)
+		}
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("\nChoose ONE action and emit the JSON object per the system prompt's output contract.")
+	return sb.String()
+}
+
+// orderedCandidates returns the top-N candidates by relevance
+// descending. Ties break by EntityID ascending so the same input
+// list produces a byte-identical prompt across runs (important for
+// "candidate_index" reference stability).
+func orderedCandidates(in []research.Candidate, limit int) []research.Candidate {
+	if limit <= 0 || len(in) == 0 {
+		return nil
+	}
+	out := make([]research.Candidate, len(in))
+	copy(out, in)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Relevance != out[j].Relevance {
+			return out[i].Relevance > out[j].Relevance
+		}
+		return out[i].EntityID < out[j].EntityID
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}

--- a/processor/research-graph-route/register.go
+++ b/processor/research-graph-route/register.go
@@ -1,0 +1,20 @@
+package researchroute
+
+import "github.com/c360studio/semstreams/component"
+
+// Register registers the route_search processor with the supplied
+// component registry. Called from componentregistry.Register at
+// process bootstrap so production binaries pick the component up
+// without extra wiring.
+func Register(registry *component.Registry) error {
+	return registry.RegisterWithConfig(component.RegistrationConfig{
+		Name:        ComponentName,
+		Factory:     NewProcessor,
+		Schema:      configSchema,
+		Type:        "processor",
+		Protocol:    "route_search",
+		Domain:      "research",
+		Description: "ADR-045 route_search: structured-emit routing decision over upstream ClassifierOutput. Emits one of synthesize_directly / retighten / walk_seeds / decompose for R2 dispatch.",
+		Version:     "0.1.0",
+	})
+}

--- a/schemas/research-graph-route.v1.json
+++ b/schemas/research-graph-route.v1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "research-graph-route.v1.json",
+  "type": "object",
+  "title": "research-graph-route Configuration",
+  "description": "ADR-045 route_search: structured-emit routing decision over upstream ClassifierOutput. Emits one of synthesize_directly / retighten / walk_seeds / decompose for R2 dispatch.",
+  "properties": {
+    "loops_bucket": {
+      "type": "string",
+      "description": "NATS KV bucket holding research-pipeline loops and trigger/completion keys",
+      "default": "AGENT_LOOPS",
+      "category": "advanced"
+    },
+    "max_candidates_in_prompt": {
+      "type": "integer",
+      "description": "Cap on number of ClassifierOutput candidates embedded in the router prompt. Top-N by relevance; tighter caps keep prompts within small-model context windows. 0 means default (10)",
+      "default": 10,
+      "maximum": 50,
+      "category": "advanced"
+    },
+    "max_response_tokens": {
+      "type": "integer",
+      "description": "Cap on LLM response tokens. The JSON-shaped output is small; 512 covers the worst case across the four action shapes",
+      "default": 512,
+      "maximum": 2048,
+      "category": "advanced"
+    },
+    "ports": {
+      "type": "string",
+      "description": "Port configuration. route_search requires one nats input subscribing to component.route_search.\u003e",
+      "category": "basic"
+    }
+  },
+  "required": [],
+  "x-component-metadata": {
+    "name": "research-graph-route",
+    "type": "processor",
+    "protocol": "route_search",
+    "domain": "research",
+    "version": "0.1.0"
+  }
+}

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1264,6 +1264,7 @@ components:
                         - $ref: ../schemas/objectstore.v1.json
                         - $ref: ../schemas/otel-exporter.v1.json
                         - $ref: ../schemas/research-graph-classify.v1.json
+                        - $ref: ../schemas/research-graph-route.v1.json
                         - $ref: ../schemas/rule-processor.v1.json
                         - $ref: ../schemas/slim-bridge.v1.json
                         - $ref: ../schemas/udp.v1.json


### PR DESCRIPTION
## Summary

Third of six PRs landing the ADR-045 graph-search rule chain. PR 1 (#131) shipped the payloads + research_graph tool; PR 2 (#135) added nl_classify; this PR ships **route_search** — the first LLM judgment stage — plus the **Amendment 2026-05-23 intent-not-structure reshape** of `RouteDecision.Args`.

- New component `processor/research-graph-route`: LLM-wrapping (not agent-wrapping per ADR-045 line 231). One bounded structured-emit call per loop: `(topic, classifier_output) → RouteDecision`.
- Schema reshape: `decompose.args` now emits `{axes, focus, scope}` INTENT; `walk_seeds.args` emits `{seeds: [{ref, ref_type}]}` REFERENCES. Backend (PR 4) resolves to typed sub-queries / full 6-part IDs the model can't reliably spell.
- New `CapabilityResearchRouting` constant in `model/registry.go`. PR 5 will add `CapabilityResearchAssessment` + `CapabilityResearchSynthesis` as separate capabilities so operators can route each LLM-wrapping stage independently.
- Persona prose with decision-axis framing per `[[feedback_persona_prose_needs_decision_criteria]]` — per-action purpose, decision axes (no magic-number thresholds), concrete examples for non-obvious choices, negative-shape for `synthesize_directly`.

## What ships

| Layer | Change |
|---|---|
| `agentic/research/route.go` + `constants.go` | New `DecomposeArgs` / `WalkSeedsArgs` / `SeedRef` / `RetightenArgs` typed views + `Parse*Args` helpers + `IsValidSeedRefType` / `IsValidDecomposeScope` enum guards. `Args` stays loose `map[string]any` at wire level. |
| `agentic/research/roundtrip_test.go` | 12 new tests covering parse helpers + enum guards. Existing roundtrip test updated to new shape. |
| `model/registry.go` + `_test.go` | `CapabilityResearchRouting = "research_routing"` constant + test row. |
| `processor/research-graph-route/` | New package: `doc.go`, `config.go`, `register.go`, `handler.go`, `adapters.go`, `prompt.go`, `component.go`, `handler_test.go`, `component_test.go`. |
| `componentregistry/register.go` | Wires `researchroute.Register` after `researchclassify.Register`. |
| `schemas/research-graph-route.v1.json` + `specs/openapi.v3.yaml` | Generated via `task schema:generate`. |

## Discipline anchors applied

- `[[feedback_tool_signature_intent_not_structure]]` — intent-shaped args; model emits judgment, backend derives structure.
- `[[feedback_persona_prose_needs_decision_criteria]]` — every action sentence carries a "when to use" criterion; negative-shape for the bypass action.
- `[[feedback_production_decoder_round_trip_required]]` — `Parse*Args` exercised through the production wire via `TestDecisionMarshalUnmarshalsThroughEnvelope`.
- `[[feedback_framework_change_needs_branch_integration_sweep]]` — `model/` package touched; integration sweep on `./model/... ./pkg/...` ran clean.

## Test plan

- [x] `go test -race ./...` — clean
- [x] `go test -race -tags=integration ./model/... ./pkg/...` — clean
- [x] `go vet -tags=integration ./...` and `go vet -tags=live_llm ./...` — clean
- [x] `task schema:generate` — produces `schemas/research-graph-route.v1.json` + one `$ref` add in `specs/openapi.v3.yaml`
- [x] `task lint` — 18 pre-existing redefines-builtin-id warnings only; zero new
- [x] `go test ./test/contract/...` — clean
- [x] 33 new tests cover happy paths for all four actions, reject paths for router errors / empty content / invalid action / per-action arg validation failures, snapshot-failure tolerance, lifecycle smoke, config validation

## Phase 1 plan position

PR 1 #131 → PR 2 #135 → **PR 3 (this)** → PR 4 (`execute_subqueries`) → PR 5 (`assess_sufficiency` + `synthesize_answer`) → PR 6 (R0–R6 rule chain + reference flow + smoke test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)