### PR TITLE
fix: semteams-flagged bundle — Gemini thought_signature echo (#188) + RequestWithRetryClassified (#192)

### DIFF
--- a/natsclient/errors.go
+++ b/natsclient/errors.go
@@ -233,8 +233,53 @@ func ClassifyReply(msg *nats.Msg) ([]byte, error) {
 // Handler failures arrive as a *errs.ClassifiedError reconstructed
 // from the X-Error-Class header (or the legacy body prefix as
 // fallback). Caller branches on errs.IsInvalid / IsTransient / IsFatal.
+//
+// Use this for QUERIES. For MUTATIONS where the responder is
+// idempotent AND emits classified errors, use
+// RequestWithRetryClassified — retrying on a hung query masks
+// responder problems as latency. See
+// docs/operations/07-nats-request-retry.md for the full rule.
 func (c *Client) RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error) {
 	msg, err := c.RequestWithHeaders(ctx, subject, data, nil, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return ClassifyReply(msg)
+}
+
+// RequestWithRetryClassified is the retry-aware sibling of
+// RequestClassified. It runs RequestWithRetry's retry-on-transport-
+// failure loop and then runs the final reply through ClassifyReply
+// so the returned error covers both transport (retried away) AND
+// handler failure modes uniformly. Closes gh#192: pre-beta.93 the
+// consumer-side method matrix exposed Request / RequestClassified /
+// RequestWithRetry but had no retry+classify combination, forcing
+// mutation-path callers to either skip the classified contract or
+// wrap RequestWithRetry in a `json.Valid` pre-decode guard (the
+// shape semteams shipped in cmd/semteams/tools/addsource/executor.go
+// before this method existed).
+//
+// Use this for MUTATIONS where the responder is idempotent AND
+// emits classified errors. The classified contract round-trips per
+// the same rules as RequestClassified: transport failures arrive as
+// the underlying error after the retry budget exhausts (classifies
+// as ErrorTransient via pkg/errs.IsTransient); handler failures
+// arrive as *errs.ClassifiedError reconstructed from the
+// X-Error-Class header (or the legacy body prefix as fallback).
+// Caller branches on errs.IsInvalid / IsTransient / IsFatal.
+//
+// For QUERIES use RequestClassified; retrying on a hung query
+// masks responder problems as latency. See
+// docs/operations/07-nats-request-retry.md for the full
+// mutation-vs-query rule.
+func (c *Client) RequestWithRetryClassified(
+	ctx context.Context,
+	subject string,
+	data []byte,
+	timeout time.Duration,
+	retry RetryConfig,
+) ([]byte, error) {
+	msg, err := c.requestMsgWithRetry(ctx, subject, data, timeout, retry)
 	if err != nil {
 		return nil, err
 	}

--- a/natsclient/errors_integration_test.go
+++ b/natsclient/errors_integration_test.go
@@ -200,3 +200,157 @@ func TestIntegration_RequestClassified_SuccessPath(t *testing.T) {
 		t.Fatalf("data = %q, want %q", data, want)
 	}
 }
+
+// TestIntegration_RequestWithRetryClassified_RoundTripPreservesClass
+// is the gh#192 matrix-gap-closure regression net. Mirrors the
+// RequestClassified case table but drives through the retry-aware
+// entry point — proves the retry loop preserves the classified
+// contract instead of returning the legacy text-body shape (which
+// is the Footgun semteams shipped a `json.Valid` workaround for in
+// cmd/semteams/tools/addsource/executor.go).
+func TestIntegration_RequestWithRetryClassified_RoundTripPreservesClass(t *testing.T) {
+	ctx := context.Background()
+
+	natsContainer, natsURL := startNATSContainer(ctx, t)
+	defer natsContainer.Terminate(ctx)
+
+	client, err := NewClient(natsURL)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(ctx)
+
+	cases := []struct {
+		name        string
+		handlerErr  error
+		isInvalid   bool
+		isTransient bool
+		isFatal     bool
+		wantInMsg   string
+	}{
+		{
+			name:       "invalid_class_round_trips",
+			handlerErr: errs.WrapInvalid(errors.New("bad mutation shape"), "Test", "Handle", "validate"),
+			isInvalid:  true,
+			wantInMsg:  "bad mutation shape",
+		},
+		{
+			name:        "transient_class_round_trips",
+			handlerErr:  errs.WrapTransient(errors.New("kv temporarily unavailable"), "Test", "Handle", "write"),
+			isTransient: true,
+			wantInMsg:   "kv temporarily unavailable",
+		},
+		{
+			name:       "fatal_class_round_trips",
+			handlerErr: errs.WrapFatal(errors.New("kv permanently unreachable"), "Test", "Handle", "write"),
+			isFatal:    true,
+			wantInMsg:  "kv permanently unreachable",
+		},
+	}
+
+	retry := DefaultRetryConfig()
+	retry.InitialBackoff = 20 * time.Millisecond
+	retry.MaxRetries = 2
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			subject := "test.retry_classified." + tc.name
+			_, err = client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+				return nil, tc.handlerErr
+			})
+			require.NoError(t, err)
+			time.Sleep(50 * time.Millisecond)
+
+			data, err := client.RequestWithRetryClassified(ctx, subject, []byte("write"), 2*time.Second, retry)
+			if data != nil {
+				t.Errorf("data should be nil on classified error; got %q", data)
+			}
+			if err == nil {
+				t.Fatal("expected classified error")
+			}
+			if errs.IsInvalid(err) != tc.isInvalid {
+				t.Errorf("IsInvalid=%v, want %v (err=%v)", errs.IsInvalid(err), tc.isInvalid, err)
+			}
+			if errs.IsTransient(err) != tc.isTransient {
+				t.Errorf("IsTransient=%v, want %v (err=%v)", errs.IsTransient(err), tc.isTransient, err)
+			}
+			if errs.IsFatal(err) != tc.isFatal {
+				t.Errorf("IsFatal=%v, want %v (err=%v)", errs.IsFatal(err), tc.isFatal, err)
+			}
+			if !strings.Contains(err.Error(), tc.wantInMsg) {
+				t.Errorf("err=%q, want substring %q", err.Error(), tc.wantInMsg)
+			}
+		})
+	}
+}
+
+// TestIntegration_RequestWithRetryClassified_SuccessPath confirms
+// the non-error path through the retry-aware entry point: handler
+// returns (data, nil), caller gets the same data, nil error.
+func TestIntegration_RequestWithRetryClassified_SuccessPath(t *testing.T) {
+	ctx := context.Background()
+
+	natsContainer, natsURL := startNATSContainer(ctx, t)
+	defer natsContainer.Terminate(ctx)
+
+	client, err := NewClient(natsURL)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(ctx)
+
+	subject := "test.retry_classified.success"
+	want := []byte(`{"ok":true,"id":"abc123"}`)
+	_, err = client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+		return want, nil
+	})
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
+
+	data, err := client.RequestWithRetryClassified(ctx, subject, []byte("write"), 2*time.Second, DefaultRetryConfig())
+	require.NoError(t, err)
+	if !bytes.Equal(data, want) {
+		t.Fatalf("data = %q, want %q", data, want)
+	}
+}
+
+// TestIntegration_RequestWithRetryClassified_RetriesThenSucceeds
+// pins that the retry loop actually retries — responder starts late,
+// the request retries through the responder-not-ready window, then
+// succeeds with the classified contract intact. Catches a refactor
+// that accidentally bypasses retry (e.g. delegating to
+// RequestClassified directly).
+func TestIntegration_RequestWithRetryClassified_RetriesThenSucceeds(t *testing.T) {
+	ctx := context.Background()
+
+	natsContainer, natsURL := startNATSContainer(ctx, t)
+	defer natsContainer.Terminate(ctx)
+
+	client, err := NewClient(natsURL)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(ctx)
+
+	subject := "test.retry_classified.late_responder"
+	want := []byte(`{"ack":"after-delay"}`)
+
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		_, err := client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+			return want, nil
+		})
+		if err != nil {
+			t.Logf("late subscribe failed: %v", err)
+		}
+	}()
+
+	retry := DefaultRetryConfig()
+	retry.InitialBackoff = 50 * time.Millisecond
+	retry.MaxRetries = 5
+	retry.BackoffMultiplier = 1.5
+
+	data, err := client.RequestWithRetryClassified(ctx, subject, []byte("write"), 2*time.Second, retry)
+	require.NoError(t, err, "retry+classified should succeed once late responder comes up")
+	if !bytes.Equal(data, want) {
+		t.Fatalf("data = %q, want %q", data, want)
+	}
+}

--- a/natsclient/request.go
+++ b/natsclient/request.go
@@ -272,6 +272,14 @@ func DefaultRetryConfig() RetryConfig {
 // to the same state on duplicate receives. For QUERIES use Request
 // instead; retrying on timeout masks hung responders as latency. See
 // docs/operations/07-nats-request-retry.md for the full rule.
+//
+// Footgun: when the responder returns a Go error, SubscribeForRequests
+// wire-encodes the failure as a legacy "error: <msg>" text body with
+// nil err. This method returns reply.Data on transport success without
+// running it through ClassifyReply, so callers that json.Unmarshal the
+// body silently corrupt on handler errors. For mutation paths that
+// want both retry AND classified error handling, use
+// RequestWithRetryClassified (closes the matrix gap filed as gh#192).
 func (c *Client) RequestWithRetry(
 	ctx context.Context,
 	subject string,
@@ -279,6 +287,25 @@ func (c *Client) RequestWithRetry(
 	timeout time.Duration,
 	retry RetryConfig,
 ) ([]byte, error) {
+	msg, err := c.requestMsgWithRetry(ctx, subject, data, timeout, retry)
+	if err != nil {
+		return nil, err
+	}
+	return msg.Data, nil
+}
+
+// requestMsgWithRetry is the shared retry-loop helper. Returns the
+// raw *nats.Msg so callers can either extract .Data (RequestWithRetry)
+// or run the message through ClassifyReply (RequestWithRetryClassified
+// in errors.go). Keeps the two retry-aware request methods in lockstep
+// so a future retry-logic tweak doesn't silently drift between them.
+func (c *Client) requestMsgWithRetry(
+	ctx context.Context,
+	subject string,
+	data []byte,
+	timeout time.Duration,
+	retry RetryConfig,
+) (*nats.Msg, error) {
 	c.mu.RLock()
 	conn := c.conn
 	c.mu.RUnlock()
@@ -314,7 +341,7 @@ func (c *Client) RequestWithRetry(
 
 		if err == nil {
 			c.resetCircuit()
-			return reply.Data, nil
+			return reply, nil
 		}
 
 		lastErr = err

--- a/processor/agentic-model/adapter_gemini.go
+++ b/processor/agentic-model/adapter_gemini.go
@@ -67,25 +67,31 @@ func (a *GeminiAdapter) NormalizeMessages(messages []wire.Message) []wire.Messag
 }
 
 // rebuildGeminiThoughtSignature walks an assistant message's tool_calls
-// and converts the framework-internal carrier on the FIRST tool_call
-// (only) into Gemini's extra_content.google.thought_signature shape.
-// Subsequent tool_calls in the same message have their carrier
-// stripped — per Gemini's "first call per step" rule, sending the
-// signature on every tool_call duplicates information and risks
-// rejection on a strict-mode preview build.
+// and converts the framework-internal carrier on EVERY tool_call that
+// has one into Gemini's extra_content.google.thought_signature shape.
+//
+// History (gh#188, 2026-06-02): the prior implementation gated emit
+// on the FIRST tool_call only, citing Google's "the model only sets
+// the signature on the first call in a parallel response" docs
+// (ADR-037 chunk 8). That was a misreading — the docs describe what
+// Gemini PUTS INTO responses, not what the client must ECHO BACK.
+// semteams smoke #13 hit HTTP 400 from Gemini 3.x preview ("Function
+// call is missing a thought_signature in functionCall parts. ...
+// position 2.") because position-2's captured signature was being
+// stripped on echo. The capture path correctly stores N signatures
+// into N ReasoningRecords; the echo path now correctly re-attaches
+// all N. Multi-tool-call cases (parallel-in-one-step on Gemini's
+// side, AND sequential-step-2-bundled-into-tool_calls on our wire
+// model) both want every signature preserved per
+// [[feedback_live_gate_catches_doc_derived]].
 func rebuildGeminiThoughtSignature(msg *wire.Message) {
 	if msg == nil {
 		return
 	}
-	firstHandled := false
 	for j := range msg.ToolCalls {
 		tc := &msg.ToolCalls[j]
 		rawSig, ok := tc.Extras[wireKeyC360ThoughtSignature]
 		if !ok {
-			continue
-		}
-		if firstHandled {
-			delete(tc.Extras, wireKeyC360ThoughtSignature)
 			continue
 		}
 		var sig string
@@ -108,7 +114,6 @@ func rebuildGeminiThoughtSignature(msg *wire.Message) {
 			tc.Extras[wireKeyExtraContent] = b
 		}
 		delete(tc.Extras, wireKeyC360ThoughtSignature)
-		firstHandled = true
 	}
 }
 

--- a/processor/agentic-model/adapter_gemini_thought_signature_test.go
+++ b/processor/agentic-model/adapter_gemini_thought_signature_test.go
@@ -118,15 +118,24 @@ func TestGeminiAdapter_NormalizeMessages_ReconstructsExtraContent(t *testing.T) 
 	}
 }
 
-// TestGeminiAdapter_NormalizeMessages_OnlyFirstToolCallKeepsSignature
+// TestGeminiAdapter_NormalizeMessages_AllToolCallsKeepSignature
 // asserts that when an assistant message carries multiple tool_calls
-// each with the framework-internal carrier, only the FIRST emits
-// extra_content. Gemini's "first call per step" contract: sending the
-// signature on every tool_call duplicates information.
-func TestGeminiAdapter_NormalizeMessages_OnlyFirstToolCallKeepsSignature(t *testing.T) {
+// each with the framework-internal carrier, EVERY position emits
+// extra_content with its corresponding thought_signature.
+//
+// Inverts the prior pinning (gh#188, 2026-06-02): the previous test
+// pinned a docs-derived "first-call-per-step" interpretation that
+// surfaces as HTTP 400 on Gemini 3.x preview when position 2+
+// signatures get stripped on echo. The docs describe what Gemini
+// PUTS INTO responses; the client must ECHO BACK every captured
+// signature. Per [[feedback_live_gate_catches_doc_derived]] the
+// docs-derived behavior should have been live-gated before pinning —
+// this test now enforces the correct contract.
+func TestGeminiAdapter_NormalizeMessages_AllToolCallsKeepSignature(t *testing.T) {
 	adapter := &GeminiAdapter{}
 	sigA, _ := json.Marshal("sig-A")
 	sigB, _ := json.Marshal("sig-B")
+	sigC, _ := json.Marshal("sig-C")
 	msg := wire.Message{
 		Role: "assistant",
 		ToolCalls: []wire.ToolCall{
@@ -140,26 +149,77 @@ func TestGeminiAdapter_NormalizeMessages_OnlyFirstToolCallKeepsSignature(t *test
 				Function: wire.Function{Name: "f2"},
 				Extras:   map[string]json.RawMessage{wireKeyC360ThoughtSignature: sigB},
 			},
+			{
+				ID:       "call-3",
+				Function: wire.Function{Name: "f3"},
+				Extras:   map[string]json.RawMessage{wireKeyC360ThoughtSignature: sigC},
+			},
 		},
 	}
 	_ = msg.SetContentString("hi")
 
 	out := adapter.NormalizeMessages([]wire.Message{msg})
 
-	first := out[0].ToolCalls[0]
-	if _, ok := first.Extras[wireKeyExtraContent]; !ok {
-		t.Error("first tool_call should carry extra_content")
+	wantSigs := []string{"sig-A", "sig-B", "sig-C"}
+	for i, want := range wantSigs {
+		tc := out[0].ToolCalls[i]
+		rawExtra, ok := tc.Extras[wireKeyExtraContent]
+		if !ok {
+			t.Errorf("tool_call[%d] (call-%d): missing extra_content; gh#188 regression — every captured signature must echo", i, i+1)
+			continue
+		}
+		if _, stillCarrier := tc.Extras[wireKeyC360ThoughtSignature]; stillCarrier {
+			t.Errorf("tool_call[%d] (call-%d): framework carrier should be deleted after rebuild", i, i+1)
+		}
+		var shape struct {
+			Google struct {
+				ThoughtSignature string `json:"thought_signature"`
+			} `json:"google"`
+		}
+		if err := json.Unmarshal(rawExtra, &shape); err != nil {
+			t.Errorf("tool_call[%d] decode extra_content: %v", i, err)
+			continue
+		}
+		if shape.Google.ThoughtSignature != want {
+			t.Errorf("tool_call[%d] thought_signature = %q, want %q", i, shape.Google.ThoughtSignature, want)
+		}
 	}
-	if _, ok := first.Extras[wireKeyC360ThoughtSignature]; ok {
-		t.Error("first tool_call: carrier should be deleted after rebuild")
-	}
+}
 
-	second := out[0].ToolCalls[1]
-	if _, ok := second.Extras[wireKeyExtraContent]; ok {
-		t.Error("second tool_call: extra_content should NOT be set (Gemini first-call-per-step)")
+// TestGeminiAdapter_NormalizeMessages_MissingCarrierIsToleratedAtAnyPosition
+// pins that a tool_call without a carrier at ANY position (not just
+// non-first) cleanly skips without affecting siblings. Catches the
+// "I deleted the gate but introduced an early-return" regression
+// shape.
+func TestGeminiAdapter_NormalizeMessages_MissingCarrierIsToleratedAtAnyPosition(t *testing.T) {
+	adapter := &GeminiAdapter{}
+	sigA, _ := json.Marshal("sig-A")
+	sigC, _ := json.Marshal("sig-C")
+	msg := wire.Message{
+		Role: "assistant",
+		ToolCalls: []wire.ToolCall{
+			{ID: "call-1", Function: wire.Function{Name: "f1"}, Extras: map[string]json.RawMessage{wireKeyC360ThoughtSignature: sigA}},
+			{ID: "call-2", Function: wire.Function{Name: "f2"}}, // no carrier
+			{ID: "call-3", Function: wire.Function{Name: "f3"}, Extras: map[string]json.RawMessage{wireKeyC360ThoughtSignature: sigC}},
+		},
 	}
-	if _, ok := second.Extras[wireKeyC360ThoughtSignature]; ok {
-		t.Error("second tool_call: carrier should be stripped")
+	_ = msg.SetContentString("hi")
+
+	out := adapter.NormalizeMessages([]wire.Message{msg})
+
+	if _, ok := out[0].ToolCalls[0].Extras[wireKeyExtraContent]; !ok {
+		t.Error("tool_call[0]: extra_content missing (sig-A should have been emitted)")
+	}
+	// tool_call[1] supplied no carrier → no extra_content expected.
+	// Verify only if Extras was somehow populated (nil is the clean
+	// case for "no signature was present").
+	if extras := out[0].ToolCalls[1].Extras; extras != nil {
+		if _, ok := extras[wireKeyExtraContent]; ok {
+			t.Error("tool_call[1]: should NOT have extra_content (no carrier was supplied)")
+		}
+	}
+	if _, ok := out[0].ToolCalls[2].Extras[wireKeyExtraContent]; !ok {
+		t.Error("tool_call[2]: extra_content missing (sig-C should have been emitted, gap at position 1 must not block position 2)")
 	}
 }
 


### PR DESCRIPTION
## Summary

Bundle of two semteams-flagged fixes shipped together to unblock 3.x adoption and close a long-standing matrix gap.

| Commit | Issue | Severity | Effect |
|---|---|---|---|
| 81024bb | #188 | **Bug** (active prod impact) | Gemini 3.x preview no longer rejects multi-tool-call echoes; semteams can drop the OpenAI-compat downgrade and re-enable reasoning + customtools + 1M context |
| 1245280 | #192 | Enhancement (deletable workaround) | mutation-path callers get `retry + classify` combination; semteams' `json.Valid` guard in `tools/addsource/executor.go` becomes deletable |

## #188 — Gemini thought_signature echo

`rebuildGeminiThoughtSignature` gated `extra_content` emit on a `firstHandled` bool — only position 0 of the tool_calls array got its signature echoed; positions 1+ had the framework-internal carrier stripped silently. semteams smoke #13 hit HTTP 400 from Gemini 3.x preview ("Function call is missing a thought_signature in functionCall parts. ... position 2.").

The interpretive root cause: ADR-037 chunk 8 (2026-05-10) read Google's "first call per step" docs as a **client-echo** rule. Refetching the docs confirms it's a **response-generation** statement — what Gemini puts INTO responses, not what the client must echo BACK. Also: our wire model bundles parallel AND sequential multi-step into one OpenAI-compat tool_calls array, so "position 2" on our side may be "sequential-step-2" on Gemini's side, which absolutely requires its own signature.

**Three-line production change** (delete the gate) + two new tests:
- `TestGeminiAdapter_NormalizeMessages_AllToolCallsKeepSignature` (inverts the prior pinning): three tool_calls, three captured signatures, every position emits its corresponding `extra_content.google.thought_signature`.
- `TestGeminiAdapter_NormalizeMessages_MissingCarrierIsToleratedAtAnyPosition`: sparse case — positions 0 and 2 have carriers but position 1 doesn't. Catches the "deleted the gate but introduced an early-return" regression class.

Per [[feedback_live_gate_catches_doc_derived]], the original ADR-037 cycle should have backfilled a multi-tool-call live gate. The existing `gemini_thought_signature_live_test.go` exercises a single tool definition only; extending to multi-tool-call is a follow-up if semteams smoke evidence isn't sufficient.

## #192 — RequestWithRetryClassified

Pre-beta.93, the natsclient consumer-side method matrix covered 3 of 4 combinations of {retry, classify-error}. Mutation-path callers (`graph.ingest.add.*` per `docs/operations/07-nats-request-retry.md`) needed retry + classify but had no upstream method. semteams shipped a `json.Valid` pre-decode guard in `cmd/semteams/tools/addsource/executor.go` as the workaround — load-bearing implicit context until upstream filled the gap.

**~30 LOC implementation** mirroring `RequestClassified`'s shape:
- New `(c *Client) RequestWithRetryClassified` in `natsclient/errors.go`.
- New private `(c *Client) requestMsgWithRetry` helper in `natsclient/request.go`. Extracted from `RequestWithRetry`'s loop so both retry-aware methods share the same retry logic — keeps them in lockstep so future tweaks don't drift. `RequestWithRetry` is now a thin wrapper that calls the helper and extracts `.Data`; observable behavior is byte-identical.
- Doc comment on `RequestWithRetry` now names the legacy text-body Footgun explicitly so future archaeology lands at the right decision: callers needing both retry AND classified errors pick the new method.

**3 new integration tests** mirror the gh#93 round-trip contract on the retry-aware entry point: `RoundTripPreservesClass` (table of invalid/transient/fatal), `SuccessPath`, `RetriesThenSucceeds` (late responder).

## Discipline anchors

- [[feedback_live_gate_catches_doc_derived]] — root cause of #188 was docs-derived behavior pinned without a live gate. The new sparse-position test plus the inverted multi-tool-call test close the unit-level gap; multi-tool-call live gate is the next discipline backfill.
- [[feedback_framework_change_needs_branch_integration_sweep]] — `natsclient/` touched; ran `go test -race -tags=integration ./natsclient/... ./pkg/...` clean.
- [[feedback_pr_complete_system_unit]] — bundled as one PR because both are semteams-flagged bugs/gaps reaching cleanly-shipped state at the same time. Two distinct logical commits inside.

## Test plan

- [x] `go test -race ./...` — clean
- [x] `go test -race -tags=integration ./natsclient/... ./pkg/...` — clean
- [x] `go vet -tags=integration ./...` and `-tags=live_llm ./...` — clean
- [x] `task lint` — 18 pre-existing redefines-builtin-id warnings only; zero new
- [x] `go test ./test/contract/...` — clean
- [x] All 7 RequestClassified + RequestWithRetryClassified integration tests pass
- [x] All Gemini thought_signature tests (existing + 2 new) pass

## What semteams gets

- **Immediate**: drop the OpenAI-compat downgrade workaround, re-enable Gemini 3.x with reasoning + customtools + 1M context once beta.93 ships.
- **Soon-after**: delete the `json.Valid` guard at `cmd/semteams/tools/addsource/executor.go`; switch to `RequestWithRetryClassified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)