### PR TITLE
test(agentic-model): tighten Gemini thought_signature live gates per gh#194

### DIFF
--- a/agentic/research/constants.go
+++ b/agentic/research/constants.go
@@ -33,6 +33,13 @@ const (
 	// matching trigger key; route_search (PR 3) consumes the payload
 	// to pick a routing action.
 	CategoryClassifierOutput = "classifier_output"
+
+	// CategoryExecutionOutput is the execute_subqueries component's
+	// emit (ADR-045 Phase 1 PR 4): dedup'd + ranked + budget-
+	// enforced evidence array + provenance. R3 fires on the matching
+	// trigger key; assess_sufficiency (PR 5) consumes the payload
+	// to pick sufficient / refine.
+	CategoryExecutionOutput = "execution_output"
 )
 
 // RouteAction values for RouteDecision.Action. Closed enum per ADR-045

--- a/agentic/research/execution_output.go
+++ b/agentic/research/execution_output.go
@@ -1,0 +1,119 @@
+package research
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// ExecutionOutput is the execute_subqueries component's emit:
+// evidence array + provenance metadata. R3 fires on the matching
+// trigger key; assess_sufficiency (PR 5) consumes the payload to
+// pick sufficient / refine.
+//
+// Action carries the routing action that produced this execution
+// (synthesize_directly / retighten / walk_seeds / decompose). The
+// rule chain in PR 6 doesn't pattern-match on it — that's R2's
+// job — but downstream operator observability (trajectory viewers,
+// ops dashboards) wants to know which routing branch the evidence
+// came from.
+type ExecutionOutput struct {
+	// Topic echoes the originating Intent topic so downstream
+	// consumers don't have to re-fetch the intent payload for
+	// logging / display.
+	Topic string `json:"topic"`
+
+	// Action is the routing action that drove this execution. One
+	// of the research.ActionXxx constants. Required.
+	Action string `json:"action"`
+
+	// Evidence is the dedup'd + ranked + budget-enforced evidence
+	// set the fan-out produced. May be empty (the routing decision
+	// may have produced no hits — assess_sufficiency surfaces this
+	// to the LLM as "you have nothing to synthesize from"; the
+	// chain doesn't error on empty).
+	Evidence []Evidence `json:"evidence,omitempty"`
+
+	// SubQueryCount is the number of sub-queries the materializer
+	// produced for this execution. Operator observability: tracks
+	// how aggressively decompose templates fanned out. Surfaces
+	// drift in scope-cap behaviour (narrow shouldn't produce many).
+	SubQueryCount int `json:"subquery_count,omitempty"`
+
+	// Degraded flags incomplete fan-out — e.g. spatial axis in
+	// decompose args (Phase 2 wire), a sub-query timeout, or a
+	// retrieval-tier error. Sets DegradedReason to the per-cause
+	// explanation. assess_sufficiency may downgrade confidence
+	// when degraded.
+	Degraded       bool   `json:"degraded,omitempty"`
+	DegradedReason string `json:"degraded_reason,omitempty"`
+
+	// BudgetTokensUsed reports the estimated token cost of the
+	// emitted evidence array after budget enforcement. Operator-
+	// facing observability for tuning Intent.BudgetTokens defaults.
+	BudgetTokensUsed int `json:"budget_tokens_used,omitempty"`
+}
+
+// Schema implements message.Payload.
+func (p *ExecutionOutput) Schema() message.Type {
+	return message.Type{
+		Domain:   Domain,
+		Category: CategoryExecutionOutput,
+		Version:  SchemaVersion,
+	}
+}
+
+// Validate implements message.Payload. Enforces required fields
+// (Topic always; Action when not Degraded) and per-Evidence shape
+// via Evidence.Validate. Empty Evidence is valid (degraded path).
+//
+// Action contract: required + must be a canonical RouteAction
+// EXCEPT on the Degraded path where execute_subqueries didn't have
+// a RouteDecision to consult (e.g. upstream classify.complete or
+// route.complete never landed). Those envelopes ship with empty
+// Action + Degraded=true + DegradedReason explaining the gap so
+// assess_sufficiency (PR 5) can route to low-confidence handling
+// without R3 stranding the loop on a hard chain-abort.
+func (p *ExecutionOutput) Validate() error {
+	if p == nil {
+		return fmt.Errorf("execution output is nil")
+	}
+	if p.Topic == "" {
+		return fmt.Errorf("topic required")
+	}
+	if p.Action != "" && !IsValidRouteAction(p.Action) {
+		return fmt.Errorf("action %q is not a canonical router action", p.Action)
+	}
+	if p.Action == "" && !p.Degraded {
+		return fmt.Errorf("action required when not Degraded")
+	}
+	for i, e := range p.Evidence {
+		if err := e.Validate(); err != nil {
+			return fmt.Errorf("evidence[%d]: %w", i, err)
+		}
+	}
+	if p.SubQueryCount < 0 {
+		return fmt.Errorf("subquery_count must be >= 0")
+	}
+	if p.BudgetTokensUsed < 0 {
+		return fmt.Errorf("budget_tokens_used must be >= 0")
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler with the alias-recursion guard.
+func (p *ExecutionOutput) MarshalJSON() ([]byte, error) {
+	type alias ExecutionOutput
+	return json.Marshal((*alias)(p))
+}
+
+// UnmarshalJSON implements json.Unmarshaler with the alias-recursion
+// guard. Partial payloads (e.g. {}) round-trip clean; strict
+// validation lives in Validate, not at decode time, so test +
+// partial-update flows can decode incrementally without tripping
+// shape checks the producer hasn't completed yet.
+func (p *ExecutionOutput) UnmarshalJSON(data []byte) error {
+	type alias ExecutionOutput
+	return json.Unmarshal(data, (*alias)(p))
+}

--- a/agentic/research/register.go
+++ b/agentic/research/register.go
@@ -44,6 +44,13 @@ func RegisterPayloads(reg *payloadregistry.Registry) error {
 			Description: "ADR-045 nl_classify component output: classifier hints + initial candidate set",
 			Factory:     func() any { return &ClassifierOutput{} },
 		},
+		{
+			Domain:      Domain,
+			Category:    CategoryExecutionOutput,
+			Version:     SchemaVersion,
+			Description: "ADR-045 execute_subqueries component output: dedup'd + ranked + budget-enforced evidence array + provenance",
+			Factory:     func() any { return &ExecutionOutput{} },
+		},
 	}
 
 	var errs []error

--- a/agentic/research/roundtrip_test.go
+++ b/agentic/research/roundtrip_test.go
@@ -720,6 +720,127 @@ func TestParseRetightenArgs_Rejects(t *testing.T) {
 	}
 }
 
+// --- ExecutionOutput ---
+
+func TestExecutionOutput_RoundTripThroughDecoder(t *testing.T) {
+	original := &research.ExecutionOutput{
+		Topic:  "drone-001 maintenance events in the last 24 hours",
+		Action: research.ActionWalkSeeds,
+		Evidence: []research.Evidence{
+			{EntityID: "acme.ops.robotics.gcs.drone.001", Tier: "0", Source: "walk_seeds.entity_state", Score: 0.95},
+			{EntityID: "acme.ops.robotics.gcs.event.maint-001", Tier: "0", Source: "walk_seeds.predicate_walk", Score: 0.82, SnippetText: "scheduled maintenance window"},
+			{EntityID: "acme.ops.robotics.gcs.alert.battery", Tier: "1", Source: "walk_seeds.bm25_coverage", Score: 0.55},
+		},
+		SubQueryCount:    3,
+		BudgetTokensUsed: 87,
+	}
+
+	envelope := message.NewBaseMessage(original.Schema(), original, "research-execution-roundtrip-test")
+	wireBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(wireBytes)
+	if err != nil {
+		t.Fatalf("registry decode: %v\nwire: %s", err, wireBytes)
+	}
+	got, ok := decoded.Payload().(*research.ExecutionOutput)
+	if !ok {
+		t.Fatalf("payload: got %T, want *research.ExecutionOutput", decoded.Payload())
+	}
+	if got.Topic != original.Topic {
+		t.Errorf("topic drift: got %q, want %q", got.Topic, original.Topic)
+	}
+	if got.Action != original.Action {
+		t.Errorf("action drift: got %q, want %q", got.Action, original.Action)
+	}
+	if len(got.Evidence) != 3 {
+		t.Fatalf("evidence len: got %d, want 3", len(got.Evidence))
+	}
+	if got.Evidence[0].EntityID != original.Evidence[0].EntityID {
+		t.Errorf("evidence[0].EntityID drift")
+	}
+	if got.SubQueryCount != 3 {
+		t.Errorf("subquery_count drift: got %d, want 3", got.SubQueryCount)
+	}
+	if got.BudgetTokensUsed != 87 {
+		t.Errorf("budget_tokens_used drift: got %d, want 87", got.BudgetTokensUsed)
+	}
+}
+
+func TestExecutionOutput_DegradedRoundTrip(t *testing.T) {
+	// Degraded + empty-Evidence is a valid execution outcome
+	// (assess_sufficiency reads it as low-confidence input).
+	// Confirm the degrade flags survive round-trip.
+	original := &research.ExecutionOutput{
+		Topic:          "x",
+		Action:         research.ActionDecompose,
+		Degraded:       true,
+		DegradedReason: "spatial axis deferred to Phase 2",
+		SubQueryCount:  2,
+	}
+	envelope := message.NewBaseMessage(original.Schema(), original, "test")
+	wireBytes, _ := json.Marshal(envelope)
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(wireBytes)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := decoded.Payload().(*research.ExecutionOutput)
+	if !got.Degraded {
+		t.Error("Degraded flag lost on round-trip")
+	}
+	if got.DegradedReason != "spatial axis deferred to Phase 2" {
+		t.Errorf("degraded reason drift: %q", got.DegradedReason)
+	}
+}
+
+func TestExecutionOutput_ValidateRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name    string
+		output  research.ExecutionOutput
+		wantSub string
+	}{
+		{
+			name:    "missing topic",
+			output:  research.ExecutionOutput{Action: research.ActionWalkSeeds},
+			wantSub: "topic",
+		},
+		{
+			name:    "missing action",
+			output:  research.ExecutionOutput{Topic: "x"},
+			wantSub: "action",
+		},
+		{
+			name:    "bogus action",
+			output:  research.ExecutionOutput{Topic: "x", Action: "bogus"},
+			wantSub: "canonical router action",
+		},
+		{
+			name: "evidence with bad tier",
+			output: research.ExecutionOutput{
+				Topic:    "x",
+				Action:   research.ActionWalkSeeds,
+				Evidence: []research.Evidence{{EntityID: "e", Tier: "bogus", Source: "x"}},
+			},
+			wantSub: "tier",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.output.Validate()
+			if err == nil {
+				t.Fatalf("Validate = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("Validate error = %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
 // --- enum guards ---
 
 func TestIsValidSeedRefType(t *testing.T) {

--- a/componentregistry/register.go
+++ b/componentregistry/register.go
@@ -38,6 +38,7 @@ import (
 	jsonmap "github.com/c360studio/semstreams/processor/json_map"
 	oasfgenerator "github.com/c360studio/semstreams/processor/oasf-generator"
 	researchclassify "github.com/c360studio/semstreams/processor/research-graph-classify"
+	researchexecute "github.com/c360studio/semstreams/processor/research-graph-execute"
 	researchroute "github.com/c360studio/semstreams/processor/research-graph-route"
 	"github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/storage/objectstore"
@@ -200,14 +201,17 @@ func registerSemanticLayer(registry *component.Registry) error {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "graph-query component registration")
 	}
 
-	// Research graph chain (ADR-045): nl_classify + route_search
-	// stages. Subsequent PRs add execute_subqueries,
-	// assess_sufficiency, and synthesize_answer.
+	// Research graph chain (ADR-045): nl_classify + route_search +
+	// execute_subqueries stages. Subsequent PRs add assess_sufficiency
+	// and synthesize_answer.
 	if err := researchclassify.Register(registry); err != nil {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-classify component registration")
 	}
 	if err := researchroute.Register(registry); err != nil {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-route component registration")
+	}
+	if err := researchexecute.Register(registry); err != nil {
+		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-execute component registration")
 	}
 
 	// Statistical/Semantic tier components (enabled via config)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/net v0.53.0
 	golang.org/x/oauth2 v0.34.0
+	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
@@ -104,7 +105,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/mod v0.34.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/processor/agentic-model/gemini_thought_signature_live_test.go
+++ b/processor/agentic-model/gemini_thought_signature_live_test.go
@@ -207,29 +207,32 @@ func TestGemini3x_ThoughtSignature_ParallelToolCalls_RoundTrip(t *testing.T) {
 	ctx := context.Background()
 	t.Logf("Gemini live multi-tool test against model=%q", geminiTestModel())
 
+	// Tools designed so the model CANNOT satisfy them from prior
+	// knowledge (gemini-3-pro-preview is strong enough to do
+	// arithmetic in its head, so calculator-shaped tools get
+	// skipped). These are opaque lookups that REQUIRE tool calls
+	// to obtain the data.
 	tools := []agentic.ToolDefinition{
 		{
-			Name:        "multiply",
-			Description: "Multiplies two integers and returns the product.",
+			Name:        "lookup_inventory_count",
+			Description: "Looks up the current count of a SKU in the warehouse inventory system. Returns the integer count.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"a": map[string]any{"type": "integer"},
-					"b": map[string]any{"type": "integer"},
+					"sku": map[string]any{"type": "string", "description": "The SKU code (e.g. 'WIDGET-42')"},
 				},
-				"required": []string{"a", "b"},
+				"required": []string{"sku"},
 			},
 		},
 		{
-			Name:        "add",
-			Description: "Adds two integers and returns the sum.",
+			Name:        "lookup_warehouse_capacity",
+			Description: "Looks up the maximum capacity of a warehouse by its ID. Returns the integer capacity in units.",
 			Parameters: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"a": map[string]any{"type": "integer"},
-					"b": map[string]any{"type": "integer"},
+					"warehouse_id": map[string]any{"type": "string", "description": "The warehouse identifier (e.g. 'WH-EAST-1')"},
 				},
-				"required": []string{"a", "b"},
+				"required": []string{"warehouse_id"},
 			},
 		},
 	}
@@ -237,10 +240,19 @@ func TestGemini3x_ThoughtSignature_ParallelToolCalls_RoundTrip(t *testing.T) {
 	turn1 := agentic.AgentRequest{
 		RequestID: "req-gemini-parallel-1",
 		Messages: []agentic.ChatMessage{
-			// Prompt designed to elicit two INDEPENDENT tool calls
-			// in a single response (no causal dependency between
-			// the two operations).
-			{Role: "user", Content: "Compute 17 * 23 and ALSO 41 + 19. Make BOTH tool calls in your first response — don't wait for either result before issuing the other."},
+			// Prompt explicitly forces parallel emission. The two
+			// lookups have NO causal dependency — best-practice
+			// agent behavior is to dispatch both in a single
+			// response. Opaque tool data prevents the model from
+			// answering inline.
+			{
+				Role: "system",
+				Content: "You are a warehouse management assistant. ALWAYS use the supplied tools to fetch real data; never answer from memory. When the user asks about multiple INDEPENDENT pieces of data, dispatch ALL tool calls in your FIRST response in parallel — do not wait for any result before issuing the other calls.",
+			},
+			{
+				Role:    "user",
+				Content: "Look up the current inventory count for SKU 'WIDGET-42' and ALSO the capacity of warehouse 'WH-EAST-1'. These are independent lookups — dispatch both in parallel.",
+			},
 		},
 		Tools: tools,
 	}
@@ -307,7 +319,8 @@ func TestGemini3x_ThoughtSignature_ParallelToolCalls_RoundTrip(t *testing.T) {
 		})
 	}
 	msgs := []agentic.ChatMessage{
-		turn1.Messages[0],
+		turn1.Messages[0], // system
+		turn1.Messages[1], // user
 		{
 			Role:             "assistant",
 			ToolCalls:        resp1.Message.ToolCalls,

--- a/processor/agentic-model/gemini_thought_signature_live_test.go
+++ b/processor/agentic-model/gemini_thought_signature_live_test.go
@@ -264,23 +264,33 @@ func TestGemini3x_ThoughtSignature_ParallelToolCalls_RoundTrip(t *testing.T) {
 		t.Skipf("model emitted %d tool_calls; need 2+ to exercise the #194 multi-tool capture contract — try GEMINI_TEST_MODEL=gemini-3-pro-preview or re-run", len(resp1.Message.ToolCalls))
 	}
 
-	// HARD-FAIL: every captured ToolCall must have a thought_signature.
-	// This is the #194 regression gate. Soft-warn here would defeat
-	// the test's purpose.
+	// Capture contract per Google's docs (verified empirically
+	// 2026-06-02 on gemini-3-flash-preview): the first
+	// function-call part in each step carries thought_signature;
+	// subsequent parallel calls in the same step don't need to.
+	// So the hard-fail line is:
+	//
+	//   - position 0 MUST have a non-empty signature (otherwise
+	//     capture is broken — this is the gh#194 production state
+	//     where semteams hit zero captured sigs)
+	//   - positions 1+ MAY have signatures (allowed but not required)
+	//   - turn 2 MUST succeed (the actual round-trip contract)
+	//
+	// GEMINI_ALLOW_EMPTY_SIG=1 escape hatch downgrades the
+	// position-0 assertion for operators investigating non-3.x
+	// models or known-stripped endpoints.
 	allowEmpty := os.Getenv("GEMINI_ALLOW_EMPTY_SIG") != ""
-	var missing []string
 	for i, tc := range resp1.Message.ToolCalls {
 		sig := signatureForToolCall(resp1.Message.ReasoningRecords, tc.ID)
 		t.Logf("turn 1 toolcall[%d]: id=%q name=%q sig_len=%d sig_preview=%q",
 			i, tc.ID, tc.Name, len(sig), previewSig(sig))
-		if sig == "" {
-			missing = append(missing, tc.ID)
-		}
 	}
-	if len(missing) > 0 && !allowEmpty {
-		t.Fatalf("turn 1: %d/%d tool_calls missing thought_signature (%v); capture path is broken on this model/endpoint — #194 regression gate. "+
-			"Set GEMINI_ALLOW_EMPTY_SIG=1 to downgrade to warn.",
-			len(missing), len(resp1.Message.ToolCalls), missing)
+	firstSig := signatureForToolCall(resp1.Message.ReasoningRecords, resp1.Message.ToolCalls[0].ID)
+	if firstSig == "" && !allowEmpty {
+		t.Fatalf("turn 1: position-0 tool_call %q missing thought_signature — capture path is broken on this model/endpoint. "+
+			"Per Google's 'first call per step' docs (and empirical verification), Gemini 3.x preview MUST emit a sig on the first call; "+
+			"missing here = gh#194 reproduction state. Set GEMINI_ALLOW_EMPTY_SIG=1 to downgrade.",
+			resp1.Message.ToolCalls[0].ID)
 	}
 
 	// Turn 2: replay the assistant message + supply BOTH tool

--- a/processor/agentic-model/gemini_thought_signature_live_test.go
+++ b/processor/agentic-model/gemini_thought_signature_live_test.go
@@ -246,7 +246,7 @@ func TestGemini3x_ThoughtSignature_ParallelToolCalls_RoundTrip(t *testing.T) {
 			// response. Opaque tool data prevents the model from
 			// answering inline.
 			{
-				Role: "system",
+				Role:    "system",
 				Content: "You are a warehouse management assistant. ALWAYS use the supplied tools to fetch real data; never answer from memory. When the user asks about multiple INDEPENDENT pieces of data, dispatch ALL tool calls in your FIRST response in parallel — do not wait for any result before issuing the other calls.",
 			},
 			{

--- a/processor/agentic-model/gemini_thought_signature_live_test.go
+++ b/processor/agentic-model/gemini_thought_signature_live_test.go
@@ -125,8 +125,22 @@ func TestGemini3x_ThoughtSignature_RoundTrip(t *testing.T) {
 	sig := signatureForToolCall(resp1.Message.ReasoningRecords, tc.ID)
 	t.Logf("turn 1 toolcall[0]: id=%q name=%q args=%v sig_len=%d sig_preview=%q",
 		tc.ID, tc.Name, tc.Arguments, len(sig), previewSig(sig))
+	// HARD-FAIL on empty signature for Gemini 3.x preview models —
+	// the whole point of this test is to gate the capture contract.
+	// Soft-warn here was the gap that let #194 ship undetected
+	// after #188 fixed the echo path. See
+	// [[feedback_live_gate_catches_doc_derived]] (sharpened 2026-06-02).
+	//
+	// Escape hatch: GEMINI_ALLOW_EMPTY_SIG=1 turns the assertion
+	// back into a warn for operators investigating regressions
+	// against non-3.x test models or known-stripped endpoints.
+	if sig == "" && os.Getenv("GEMINI_ALLOW_EMPTY_SIG") == "" {
+		t.Fatalf("turn 1: thought_signature is empty — capture path is broken on this model/endpoint. "+
+			"Set GEMINI_ALLOW_EMPTY_SIG=1 to downgrade to warn for non-3.x test runs. "+
+			"model=%q wire endpoint=%q gh#194 regression gate", geminiTestModel(), "openai-compat")
+	}
 	if sig == "" {
-		t.Logf("turn 1: thought_signature is empty — model is not a 3.x preview build OR the API stripped it. Continuing to turn 2 to see whether the round-trip still succeeds without it.")
+		t.Logf("turn 1: thought_signature empty; GEMINI_ALLOW_EMPTY_SIG override active — turn 2 will likely fail with HTTP 400")
 	}
 
 	// Turn 2: replay the assistant message + supply the tool result.
@@ -162,6 +176,151 @@ func TestGemini3x_ThoughtSignature_RoundTrip(t *testing.T) {
 	if resp2.Status == "error" {
 		t.Fatalf("turn 2 returned error: %s — likely thought_signature not echoed correctly", resp2.Error)
 	}
+}
+
+// TestGemini3x_ThoughtSignature_ParallelToolCalls_RoundTrip
+// exercises the multi-tool-call response shape that triggered
+// #194 in production. The test was a deliberate gap in the
+// single-tool TestGemini3x_ThoughtSignature_RoundTrip — Gemini's
+// validator only rejects the multi-tool path when position 2+
+// lacks a signature, so the single-tool test couldn't catch the
+// capture-side strip.
+//
+// Asks the model to call two tools in parallel (calculator-shaped
+// because Gemini's persona naturally emits parallel calls for
+// independent arithmetic problems). Asserts:
+//
+//  1. Turn 1 returns 2+ ToolCalls.
+//  2. EVERY captured ToolCall has a non-empty thought_signature
+//     in ReasoningRecords. This is the contract #188's echo fix
+//     can only honor if capture surfaced the signatures in the
+//     first place.
+//  3. Turn 2 (echo + tool results) is accepted. Gemini 3.x rejects
+//     with HTTP 400 if position 2+ is missing its signature; this
+//     turn implicitly tests the round-trip the validator gates.
+//
+// Per [[feedback_live_gate_catches_doc_derived]] (sharpened
+// 2026-06-02), each leg of a round-trip wire fix needs a HARD-FAIL
+// contract assertion under production-realistic conditions.
+func TestGemini3x_ThoughtSignature_ParallelToolCalls_RoundTrip(t *testing.T) {
+	client := newGeminiLiveClient(t)
+	ctx := context.Background()
+	t.Logf("Gemini live multi-tool test against model=%q", geminiTestModel())
+
+	tools := []agentic.ToolDefinition{
+		{
+			Name:        "multiply",
+			Description: "Multiplies two integers and returns the product.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"a": map[string]any{"type": "integer"},
+					"b": map[string]any{"type": "integer"},
+				},
+				"required": []string{"a", "b"},
+			},
+		},
+		{
+			Name:        "add",
+			Description: "Adds two integers and returns the sum.",
+			Parameters: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"a": map[string]any{"type": "integer"},
+					"b": map[string]any{"type": "integer"},
+				},
+				"required": []string{"a", "b"},
+			},
+		},
+	}
+
+	turn1 := agentic.AgentRequest{
+		RequestID: "req-gemini-parallel-1",
+		Messages: []agentic.ChatMessage{
+			// Prompt designed to elicit two INDEPENDENT tool calls
+			// in a single response (no causal dependency between
+			// the two operations).
+			{Role: "user", Content: "Compute 17 * 23 and ALSO 41 + 19. Make BOTH tool calls in your first response — don't wait for either result before issuing the other."},
+		},
+		Tools: tools,
+	}
+
+	ctx1, cancel1 := context.WithTimeout(ctx, 90*time.Second)
+	resp1, err := client.ChatCompletion(ctx1, turn1)
+	cancel1()
+	if err != nil {
+		t.Fatalf("turn 1 failed: %v", err)
+	}
+	if resp1.Status == "error" {
+		t.Fatalf("turn 1 returned error: %s", resp1.Error)
+	}
+	t.Logf("turn 1: tool_calls=%d records=%d", len(resp1.Message.ToolCalls), len(resp1.Message.ReasoningRecords))
+
+	// If the model only emitted one tool call (model behavior we
+	// can't fully control), SKIP — we want this test to fire
+	// specifically on the multi-tool path, not pass by accident
+	// on a single-tool response.
+	if len(resp1.Message.ToolCalls) < 2 {
+		t.Skipf("model emitted %d tool_calls; need 2+ to exercise the #194 multi-tool capture contract — try GEMINI_TEST_MODEL=gemini-3-pro-preview or re-run", len(resp1.Message.ToolCalls))
+	}
+
+	// HARD-FAIL: every captured ToolCall must have a thought_signature.
+	// This is the #194 regression gate. Soft-warn here would defeat
+	// the test's purpose.
+	allowEmpty := os.Getenv("GEMINI_ALLOW_EMPTY_SIG") != ""
+	var missing []string
+	for i, tc := range resp1.Message.ToolCalls {
+		sig := signatureForToolCall(resp1.Message.ReasoningRecords, tc.ID)
+		t.Logf("turn 1 toolcall[%d]: id=%q name=%q sig_len=%d sig_preview=%q",
+			i, tc.ID, tc.Name, len(sig), previewSig(sig))
+		if sig == "" {
+			missing = append(missing, tc.ID)
+		}
+	}
+	if len(missing) > 0 && !allowEmpty {
+		t.Fatalf("turn 1: %d/%d tool_calls missing thought_signature (%v); capture path is broken on this model/endpoint — #194 regression gate. "+
+			"Set GEMINI_ALLOW_EMPTY_SIG=1 to downgrade to warn.",
+			len(missing), len(resp1.Message.ToolCalls), missing)
+	}
+
+	// Turn 2: replay the assistant message + supply BOTH tool
+	// results. Gemini 3.x's validator will HTTP 400 if any
+	// echoed tool_call lacks its signature — that's the
+	// downstream contract this test gates.
+	toolResults := make([]agentic.ChatMessage, 0, len(resp1.Message.ToolCalls))
+	for _, tc := range resp1.Message.ToolCalls {
+		toolResults = append(toolResults, agentic.ChatMessage{
+			Role:       "tool",
+			ToolCallID: tc.ID,
+			Name:       tc.Name,
+			Content:    `{"result": 0}`, // value doesn't matter for the wire contract
+		})
+	}
+	msgs := []agentic.ChatMessage{
+		turn1.Messages[0],
+		{
+			Role:             "assistant",
+			ToolCalls:        resp1.Message.ToolCalls,
+			ReasoningRecords: resp1.Message.ReasoningRecords,
+		},
+	}
+	msgs = append(msgs, toolResults...)
+	turn2 := agentic.AgentRequest{
+		RequestID: "req-gemini-parallel-2",
+		Messages:  msgs,
+		Tools:     tools,
+	}
+
+	ctx2, cancel2 := context.WithTimeout(ctx, 90*time.Second)
+	resp2, err := client.ChatCompletion(ctx2, turn2)
+	cancel2()
+	if err != nil {
+		t.Fatalf("turn 2 failed: %v — likely a thought_signature echo regression. gh#194 + gh#188", err)
+	}
+	if resp2.Status == "error" {
+		t.Fatalf("turn 2 returned error: %s — likely a thought_signature echo regression. gh#194 + gh#188", resp2.Error)
+	}
+	t.Logf("turn 2: status=%q finish_reason=%q — multi-tool round-trip OK", resp2.Status, resp2.FinishReason)
 }
 
 // previewSig returns the first 16 chars of a signature for logging — full

--- a/processor/research-graph-execute/adapters.go
+++ b/processor/research-graph-execute/adapters.go
@@ -1,0 +1,382 @@
+package researchexecute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/payloadregistry"
+)
+
+// Graph-query NATS-direct subjects this component requests against.
+// Centralised here so a subject rename in graph-query (rare; subject
+// names are part of the public contract) updates exactly one site.
+const (
+	subjectGraphQueryBatch         = "graph.query.batch"
+	subjectGraphQueryRelationships = "graph.query.relationships"
+	subjectGraphQueryTemporal      = "graph.query.temporal"
+	subjectGraphQuerySearchGraph   = "graph.query.searchGraph"
+)
+
+// graphQueryAdapter wraps natsclient.Client into the GraphQueryClient
+// interface. Production wires this adapter via Start; tests inject a
+// fake GraphQueryClient directly into the Component and skip this
+// path entirely.
+//
+// gh#93 contract: all wire calls go through RequestClassified so
+// handler-side errors surface as *errs.ClassifiedError rather than
+// silent legacy-text-body corruption. Per
+// [[feedback_silent_handler_error_payload_audit]] this is the right
+// default for every new natsclient.Request caller.
+type graphQueryAdapter struct {
+	client  *natsclient.Client
+	timeout time.Duration
+}
+
+func newGraphQueryAdapter(client *natsclient.Client, timeout time.Duration) *graphQueryAdapter {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	return &graphQueryAdapter{client: client, timeout: timeout}
+}
+
+// EntityState implements GraphQueryClient via graph.query.batch
+// (passthrough to graph-ingest's handleQueryBatchNATS). Returns one
+// Evidence per requested entity ID that resolves; missing IDs are
+// silently omitted by the upstream handler. Verified shapes:
+// request `{ids: [...]}`, response `{entities: [<EntityState>...]}`
+// where each entity uses the `id` field (graph/types.go EntityState).
+func (a *graphQueryAdapter) EntityState(ctx context.Context, args EntityStateArgs, tier, source string, limit int) ([]research.Evidence, error) {
+	if a == nil || a.client == nil {
+		return nil, errors.New("nats client not configured")
+	}
+	if len(args.EntityIDs) == 0 {
+		return nil, nil
+	}
+	req := struct {
+		IDs []string `json:"ids"`
+	}{IDs: args.EntityIDs}
+	respData, err := a.request(ctx, subjectGraphQueryBatch, req)
+	if err != nil {
+		return nil, fmt.Errorf("entity_state via %s: %w", subjectGraphQueryBatch, err)
+	}
+	// graph.query.batch returns {entities: [<EntityState>]} where
+	// EntityState uses `id` (not `entity_id`). EntityState carries
+	// Triples but PR 4 only needs the ID for downstream dedup +
+	// budget; snippet extraction from triples is Phase 2 work.
+	var resp struct {
+		Entities []struct {
+			ID string `json:"id"`
+		} `json:"entities"`
+	}
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return nil, fmt.Errorf("decode entity_state response: %w", err)
+	}
+	out := make([]research.Evidence, 0, len(resp.Entities))
+	for i, e := range resp.Entities {
+		if limit > 0 && i >= limit {
+			break
+		}
+		if strings.TrimSpace(e.ID) == "" {
+			continue
+		}
+		out = append(out, research.Evidence{
+			EntityID: e.ID,
+			Tier:     tier,
+			Source:   source,
+		})
+	}
+	return out, nil
+}
+
+// PredicateWalk implements GraphQueryClient via
+// graph.query.relationships. Per-seed call (relationships handler
+// is single-entity per request); errgroup at the orchestrator
+// parallelises across seeds. Verified shapes: request
+// `{entity_id, direction}` (processor/graph-query/query.go),
+// response is a bare JSON array `[{from_entity_id, to_entity_id,
+// edge_type}]` (NOT wrapped). Phase 1 walks outgoing edges only —
+// incoming is a Phase 2 extension; widening here is one extra
+// request per seed and doubles fan-out cost without a clear
+// quality win in trial runs.
+//
+// MaxHops > 1 is accepted but ignored (the relationships handler
+// is single-hop); Phase 2 either extends the handler or composes
+// multi-hop via repeated walks on the orchestrator side.
+// args.Predicates is accepted but the handler doesn't currently
+// filter — kept on the SubQuery type for forward-compat with a
+// Phase 2 handler extension.
+func (a *graphQueryAdapter) PredicateWalk(ctx context.Context, args PredicateWalkArgs, tier, source string, limit int) ([]research.Evidence, error) {
+	if a == nil || a.client == nil {
+		return nil, errors.New("nats client not configured")
+	}
+	if len(args.Seeds) == 0 {
+		return nil, nil
+	}
+	var allEvidence []research.Evidence
+	for _, seed := range args.Seeds {
+		if strings.TrimSpace(seed) == "" {
+			continue
+		}
+		req := struct {
+			EntityID  string `json:"entity_id"`
+			Direction string `json:"direction"`
+		}{EntityID: seed, Direction: "outgoing"}
+		respData, err := a.request(ctx, subjectGraphQueryRelationships, req)
+		if err != nil {
+			return nil, fmt.Errorf("predicate_walk seed=%s via %s: %w", seed, subjectGraphQueryRelationships, err)
+		}
+		// graph.query.relationships returns a BARE array; no envelope.
+		var resp []struct {
+			FromEntityID string `json:"from_entity_id"`
+			ToEntityID   string `json:"to_entity_id"`
+			EdgeType     string `json:"edge_type"`
+		}
+		if err := json.Unmarshal(respData, &resp); err != nil {
+			return nil, fmt.Errorf("decode predicate_walk response (seed=%s): %w", seed, err)
+		}
+		for i, r := range resp {
+			if limit > 0 && i >= limit {
+				break
+			}
+			// Walk-OUT picks the to-entity as the neighbor.
+			id := strings.TrimSpace(r.ToEntityID)
+			if id == "" || id == seed {
+				continue
+			}
+			allEvidence = append(allEvidence, research.Evidence{
+				EntityID: id,
+				Tier:     tier,
+				Source:   source,
+			})
+		}
+	}
+	return allEvidence, nil
+}
+
+// TemporalRange implements GraphQueryClient via
+// graph.query.temporal (passthrough to graph-index-temporal's
+// handleQueryRangeNATS). Verified shapes: request
+// `{startTime, endTime, limit}` (RFC3339 strings), response is a
+// bare array `[{id, type}]` (TemporalResult struct). The temporal
+// handler does NOT filter by topic — the materializer's Topic
+// field is kept for prompt construction / future Phase 2 server-
+// side filter, but not forwarded to the request.
+//
+// Temporal index is optional in operator deployments; an unwired
+// index returns transport error → RequestClassified surfaces it →
+// orchestrator marks degraded.
+func (a *graphQueryAdapter) TemporalRange(ctx context.Context, args TemporalRangeArgs, tier, source string, limit int) ([]research.Evidence, error) {
+	if a == nil || a.client == nil {
+		return nil, errors.New("nats client not configured")
+	}
+	req := struct {
+		StartTime string `json:"startTime"`
+		EndTime   string `json:"endTime"`
+		Limit     int    `json:"limit,omitempty"`
+	}{StartTime: args.Start, EndTime: args.End, Limit: limit}
+	respData, err := a.request(ctx, subjectGraphQueryTemporal, req)
+	if err != nil {
+		return nil, fmt.Errorf("temporal_range via %s: %w", subjectGraphQueryTemporal, err)
+	}
+	// graph.temporal.query.range returns a BARE array of
+	// TemporalResult {id, type}; no envelope.
+	var resp []struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return nil, fmt.Errorf("decode temporal_range response: %w", err)
+	}
+	out := make([]research.Evidence, 0, len(resp))
+	for i, r := range resp {
+		if limit > 0 && i >= limit {
+			break
+		}
+		if strings.TrimSpace(r.ID) == "" {
+			continue
+		}
+		out = append(out, research.Evidence{
+			EntityID: r.ID,
+			Tier:     tier,
+			Source:   source,
+		})
+	}
+	return out, nil
+}
+
+// BM25 implements GraphQueryClient via graph.query.searchGraph —
+// the same surface research-graph-classify uses for initial
+// candidate retrieval. Sharing the surface keeps the evidence
+// schema consistent (Evidence here ≡ subset of GlobalSearchResponse
+// entity digests, same projection as nl_classify's Candidate).
+func (a *graphQueryAdapter) BM25(ctx context.Context, args BM25Args, tier, source string, limit int) ([]research.Evidence, error) {
+	if a == nil || a.client == nil {
+		return nil, errors.New("nats client not configured")
+	}
+	if strings.TrimSpace(args.Query) == "" {
+		return nil, errors.New("bm25 query is empty")
+	}
+	limitCap := args.Limit
+	if limitCap <= 0 {
+		limitCap = limit
+	}
+	req := struct {
+		Query          string `json:"query"`
+		MaxCommunities int    `json:"max_communities,omitempty"`
+	}{Query: args.Query, MaxCommunities: limitCap}
+	respData, err := a.request(ctx, subjectGraphQuerySearchGraph, req)
+	if err != nil {
+		return nil, fmt.Errorf("bm25 via %s: %w", subjectGraphQuerySearchGraph, err)
+	}
+	var resp struct {
+		EntityDigests []struct {
+			ID        string  `json:"id"`
+			Relevance float64 `json:"relevance,omitempty"`
+		} `json:"entity_digests"`
+	}
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return nil, fmt.Errorf("decode bm25 response: %w", err)
+	}
+	// BM25 surface uses a different ID field name (id, not entity_id)
+	// and exposes relevance instead of score. Project to the unified
+	// Evidence shape inline.
+	out := make([]research.Evidence, 0, len(resp.EntityDigests))
+	for i, d := range resp.EntityDigests {
+		if i >= limitCap && limitCap > 0 {
+			break
+		}
+		if strings.TrimSpace(d.ID) == "" {
+			continue
+		}
+		out = append(out, research.Evidence{
+			EntityID: d.ID,
+			Tier:     tier,
+			Source:   source,
+			Score:    d.Relevance,
+		})
+	}
+	return out, nil
+}
+
+// request marshals + ships the request body via RequestClassified.
+// Applies a.timeout on the context (so per-call deadline is the
+// MIN of caller's ctx and a.timeout) and passes 0 for the wire-
+// level timeout to avoid double-timer accounting — the context
+// deadline is the single source of truth. Mirrors the
+// research-graph-classify adapter pattern.
+func (a *graphQueryAdapter) request(ctx context.Context, subject string, body any) ([]byte, error) {
+	reqData, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+	if a.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, a.timeout)
+		defer cancel()
+	}
+	return a.client.RequestClassified(ctx, subject, reqData, 0)
+}
+
+// natsLoopStore adapts natsclient.KVStore to the LoopStore
+// interface. Same shape as research-graph-route's adapter; reads
+// three upstream payloads (Intent + ClassifierOutput +
+// RouteDecision), writes ExecutionOutput envelope + snapshot.
+type natsLoopStore struct {
+	kv      *natsclient.KVStore
+	decoder *message.Decoder
+}
+
+func newNATSLoopStore(kv *natsclient.KVStore, registry *payloadregistry.Registry) *natsLoopStore {
+	return &natsLoopStore{
+		kv:      kv,
+		decoder: message.NewDecoder(registry),
+	}
+}
+
+// Key helpers — package-private.
+
+func loopStoreKeyIntent(loopID string) string           { return "research.requested." + loopID }
+func loopStoreKeyClassifyComplete(loopID string) string { return "classify.complete." + loopID }
+func loopStoreKeyRouteComplete(loopID string) string    { return "route.complete." + loopID }
+func loopStoreKeyExecuteComplete(loopID string) string  { return "execute.complete." + loopID }
+func loopStoreKeyExecuteSnapshot(loopID string) string  { return "execute.snapshot." + loopID }
+
+// GetIntent decodes research_intent from the trigger key.
+func (s *natsLoopStore) GetIntent(ctx context.Context, loopID string) (*research.Intent, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyIntent(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errIntentNotFound
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyIntent(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode intent: %w", err)
+	}
+	intent, ok := decoded.Payload().(*research.Intent)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.Intent", decoded.Payload())
+	}
+	return intent, nil
+}
+
+// GetClassifierOutput decodes classifier_output from R1's trigger key.
+func (s *natsLoopStore) GetClassifierOutput(ctx context.Context, loopID string) (*research.ClassifierOutput, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyClassifyComplete(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errClassifierOutputMissing
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyClassifyComplete(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode classifier output: %w", err)
+	}
+	out, ok := decoded.Payload().(*research.ClassifierOutput)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.ClassifierOutput", decoded.Payload())
+	}
+	return out, nil
+}
+
+// GetRouteDecision decodes route_decision from R2's trigger key.
+func (s *natsLoopStore) GetRouteDecision(ctx context.Context, loopID string) (*research.RouteDecision, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyRouteComplete(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errRouteDecisionMissing
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyRouteComplete(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode route decision: %w", err)
+	}
+	dec, ok := decoded.Payload().(*research.RouteDecision)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.RouteDecision", decoded.Payload())
+	}
+	return dec, nil
+}
+
+// PutExecutionOutput writes envelope at R3's trigger key.
+func (s *natsLoopStore) PutExecutionOutput(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeyExecuteComplete(loopID), envelope)
+	return err
+}
+
+// PutSnapshot writes envelope at the stable snapshot key. Best-
+// effort: handler logs + continues on failure.
+func (s *natsLoopStore) PutSnapshot(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeyExecuteSnapshot(loopID), envelope)
+	return err
+}

--- a/processor/research-graph-execute/clock.go
+++ b/processor/research-graph-execute/clock.go
@@ -1,0 +1,17 @@
+package researchexecute
+
+import "time"
+
+// nowDefault is the production wallclock implementation. Tests
+// override via the package-level nowFunc variable when they need
+// deterministic temporal-window outputs.
+func nowDefault() time.Time {
+	return time.Now().UTC()
+}
+
+// nowRFC3339Offset returns the current wallclock (per nowFunc)
+// shifted by offsetHours and rendered as RFC3339. Used by the
+// decompose materializer's time-axis template.
+func nowRFC3339Offset(offsetHours int) string {
+	return nowFunc().Add(time.Duration(offsetHours) * time.Hour).Format(time.RFC3339)
+}

--- a/processor/research-graph-execute/component.go
+++ b/processor/research-graph-execute/component.go
@@ -1,0 +1,545 @@
+package researchexecute
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// Component implements the execute_subqueries processor. Struct
+// field set is intentionally small; lifecycle methods own the NATS
+// plumbing and the per-message handler hands off to the pure
+// executeAll function in handler.go.
+type Component struct {
+	config Config
+	deps   component.Dependencies
+	logger *slog.Logger
+
+	// Injected dependencies. Tests replace these directly via the
+	// constructor; production wires them via Start() from the
+	// natsclient on deps.
+	gq    GraphQueryClient
+	loops LoopStore
+
+	// Lifecycle state. One mutex guards started/startTime so
+	// concurrent Health / DataFlow reads can't see a torn read of
+	// the lifecycle flag.
+	mu        sync.RWMutex
+	started   bool
+	startTime time.Time
+	wg        sync.WaitGroup
+
+	subscriptions []*natsclient.Subscription
+
+	messagesProcessed int64
+	messagesEmitted   int64
+	errors            int64
+	lastActivity      atomic.Value // time.Time
+
+	lifecycleReporter component.LifecycleReporter
+}
+
+var (
+	_ component.Discoverable       = (*Component)(nil)
+	_ component.LifecycleComponent = (*Component)(nil)
+)
+
+// NewProcessor is the component-factory shape registered with the
+// component registry.
+func NewProcessor(rawConfig json.RawMessage, deps component.Dependencies) (component.Discoverable, error) {
+	var config Config
+	if err := json.Unmarshal(rawConfig, &config); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config unmarshal")
+	}
+	if config.Ports == nil {
+		config = DefaultConfig()
+	}
+	config.ApplyDefaults()
+	if err := config.Validate(); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config validate")
+	}
+	if deps.NATSClient == nil {
+		return nil, errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "NewProcessor", "NATSClient required")
+	}
+	logger := deps.GetLoggerWithComponent(ComponentName)
+	return &Component{
+		config: config,
+		deps:   deps,
+		logger: logger,
+	}, nil
+}
+
+// Initialize is part of the LifecycleComponent contract — no pre-
+// Start work.
+func (c *Component) Initialize() error { return nil }
+
+// Start opens the AGENT_LOOPS bucket, wires the GraphQueryClient
+// adapter, subscribes inputs, reports idle.
+func (c *Component) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "Start", "context cannot be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return errs.WrapInvalid(err, ComponentName, "Start", "context already cancelled")
+	}
+	c.mu.Lock()
+	if c.started {
+		c.mu.Unlock()
+		return errs.WrapFatal(errs.ErrAlreadyStarted, ComponentName, "Start", "already started")
+	}
+	c.mu.Unlock()
+
+	if err := c.openLoopsBucket(ctx); err != nil {
+		return err
+	}
+	if c.gq == nil {
+		c.gq = newGraphQueryAdapter(c.deps.NATSClient, c.config.ExecuteTimeout)
+	}
+	if err := c.subscribeInputs(ctx); err != nil {
+		return err
+	}
+	c.startLifecycleReporter(ctx)
+
+	c.mu.Lock()
+	c.started = true
+	c.startTime = time.Now()
+	c.mu.Unlock()
+
+	if c.lifecycleReporter != nil {
+		if err := c.lifecycleReporter.ReportStage(ctx, "idle"); err != nil {
+			c.logger.Debug("failed to report idle stage", slog.Any("error", err))
+		}
+	}
+	c.logger.Info("execute_subqueries component started",
+		slog.String("loops_bucket", c.config.LoopsBucket),
+		slog.Duration("execute_timeout", c.config.ExecuteTimeout),
+		slog.Int("max_parallelism", c.config.MaxParallelism),
+		slog.Int("max_results_per_subquery", c.config.MaxResultsPerSubquery))
+	return nil
+}
+
+func (c *Component) openLoopsBucket(ctx context.Context) error {
+	if c.loops != nil {
+		return nil
+	}
+	bucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      c.config.LoopsBucket,
+		Description: "Agent loops bucket; shared with research-pipeline chain",
+		History:     10,
+		TTL:         24 * time.Hour,
+	})
+	if err != nil {
+		return errs.WrapTransient(err, ComponentName, "Start", "open loops bucket")
+	}
+	if c.deps.PayloadRegistry == nil {
+		return errs.WrapFatal(errs.ErrMissingConfig, ComponentName, "Start", "PayloadRegistry dependency required to decode research payloads")
+	}
+	store := c.deps.NATSClient.NewKVStore(bucket)
+	c.loops = newNATSLoopStore(store, c.deps.PayloadRegistry)
+	return nil
+}
+
+func (c *Component) subscribeInputs(ctx context.Context) error {
+	for _, port := range c.config.Ports.Inputs {
+		if port.Subject == "" {
+			continue
+		}
+		if port.Type != "nats" {
+			c.logger.Warn("unsupported port type; skipping",
+				slog.String("port", port.Name),
+				slog.String("type", port.Type))
+			continue
+		}
+		sub, err := c.deps.NATSClient.Subscribe(ctx, port.Subject, func(msgCtx context.Context, msg *nats.Msg) {
+			c.handleMessage(msgCtx, msg.Subject, msg.Data)
+		})
+		if err != nil {
+			return errs.WrapTransient(err, ComponentName, "Start",
+				fmt.Sprintf("subscribe to %s", port.Subject))
+		}
+		c.subscriptions = append(c.subscriptions, sub)
+		c.logger.Debug("subscribed to NATS subject",
+			slog.String("port", port.Name),
+			slog.String("subject", port.Subject))
+	}
+	return nil
+}
+
+func (c *Component) startLifecycleReporter(ctx context.Context) {
+	statusBucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      "COMPONENT_STATUS",
+		Description: "Component lifecycle status tracking",
+	})
+	if err != nil {
+		c.logger.Warn("COMPONENT_STATUS bucket unavailable; lifecycle reporting disabled",
+			slog.Any("error", err))
+		c.lifecycleReporter = component.NewNoOpLifecycleReporter()
+		return
+	}
+	c.lifecycleReporter = component.NewLifecycleReporterFromConfig(component.LifecycleReporterConfig{
+		KV:               statusBucket,
+		ComponentName:    ComponentName,
+		Logger:           c.logger,
+		EnableThrottling: true,
+	})
+}
+
+// Stop drains subscriptions and flips started under c.mu.
+func (c *Component) Stop(timeout time.Duration) error {
+	c.mu.Lock()
+	if !c.started {
+		c.mu.Unlock()
+		return nil
+	}
+	c.started = false
+	c.mu.Unlock()
+
+	for _, sub := range c.subscriptions {
+		if sub == nil {
+			continue
+		}
+		if err := sub.Unsubscribe(); err != nil {
+			c.logger.Debug("unsubscribe failed during stop", slog.Any("error", err))
+		}
+	}
+	c.subscriptions = nil
+
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		c.logger.Warn("Stop timeout reached with handlers in flight",
+			slog.Duration("timeout", timeout))
+	}
+	return nil
+}
+
+// handleMessage is the per-message hot path. Loads upstream
+// payloads, materializes sub-queries per the routing action,
+// executes via the GraphQueryClient, writes ExecutionOutput +
+// trigger key.
+//
+// The ctx passed in comes from the NATS subscription callback
+// and is intentionally tied to the subscription lifecycle — Stop's
+// Unsubscribe cancels it so an in-flight fan-out drains fast. Same
+// shape as research-graph-route's handleMessage (see that file's
+// doc comment for the full rationale).
+func (c *Component) handleMessage(ctx context.Context, subject string, _ []byte) {
+	c.wg.Add(1)
+	defer c.wg.Done()
+	atomic.AddInt64(&c.messagesProcessed, 1)
+	c.lastActivity.Store(time.Now())
+
+	loopID := extractLoopIDFromSubject(subject)
+	if loopID == "" {
+		c.logger.Error("could not extract loop_id from subject; ignoring message",
+			slog.String("subject", subject))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	if c.config.ExecuteTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.config.ExecuteTimeout)
+		defer cancel()
+	}
+
+	intent, classifierOut, decision, loadErr := c.loadUpstreamPayloads(ctx, loopID)
+	if loadErr != nil {
+		return
+	}
+
+	queries, droppedRef, materErr := c.materializeQueries(ctx, loopID, intent, classifierOut, decision)
+	if materErr != nil {
+		// Already emitted a degraded envelope inside the helper;
+		// the materialiseQueries contract is "either return queries
+		// or write a degraded trigger + return error".
+		return
+	}
+
+	output, err := executeAll(ctx, c.gq, queries, intent, decision.Action, c.config.MaxParallelism, c.config.MaxResultsPerSubquery, c.logger)
+	if err != nil {
+		c.logger.Error("execute_all failed; emitting empty ExecutionOutput",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		c.emitDegradedOutput(ctx, loopID, intent.Topic, decision.Action, "execute_all: "+err.Error())
+		return
+	}
+
+	// If any seed references were dropped during resolution,
+	// surface that on the output's degraded fields (orchestrator
+	// already does this for sub-query failures; this adds the
+	// resolver-side coverage).
+	if droppedRef > 0 {
+		output.Degraded = true
+		if output.DegradedReason != "" {
+			output.DegradedReason += "; "
+		}
+		output.DegradedReason += fmt.Sprintf("%d seed references unresolved", droppedRef)
+	}
+
+	envelope := message.NewBaseMessage(output.Schema(), output, ComponentName)
+	envelopeBytes, err := json.Marshal(envelope)
+	if err != nil {
+		c.logger.Error("marshal execution output envelope failed",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	if err := c.loops.PutSnapshot(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Warn("snapshot write failed; chain continues but downstream readback may miss it",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+	}
+	if err := c.loops.PutExecutionOutput(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Error("execute.complete trigger write failed; R3 will not fire",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+	atomic.AddInt64(&c.messagesEmitted, 1)
+	c.logger.Info("execute_subqueries emitted ExecutionOutput",
+		slog.String("loop_id", loopID),
+		slog.String("topic", intent.Topic),
+		slog.String("action", decision.Action),
+		slog.Int("evidence_count", len(output.Evidence)),
+		slog.Int("subquery_count", output.SubQueryCount),
+		slog.Bool("degraded", output.Degraded),
+		slog.Int("budget_tokens_used", output.BudgetTokensUsed))
+}
+
+// loadUpstreamPayloads loads the three KV-resident inputs the
+// handler needs (Intent + ClassifierOutput + RouteDecision),
+// records error metrics + logs on miss, and returns a non-nil
+// error so the caller short-circuits. Extracted from handleMessage
+// to keep the hot path under the function-length lint cap.
+//
+// Recovery contract:
+//   - Intent missing/error: hard abort. Without the intent topic
+//     we can't even populate a sensible degraded envelope, and
+//     intent missing means R0 never wrote it (chain didn't
+//     properly kick off).
+//   - ClassifierOutput missing: emit degraded envelope so R3 still
+//     fires (assess_sufficiency reads "empty evidence, degraded:
+//     classifier output missing" and routes to refine OR
+//     low-confidence synthesize). Same for RouteDecision missing.
+//     The chain is racier during development; emitting degraded
+//     keeps loops moving rather than stranding.
+//   - Non-sentinel errors (decode failure, KV transport): hard
+//     abort. These are infra failures, not chain-config races.
+func (c *Component) loadUpstreamPayloads(ctx context.Context, loopID string) (*research.Intent, *research.ClassifierOutput, *research.RouteDecision, error) {
+	intent, err := c.loops.GetIntent(ctx, loopID)
+	if err != nil {
+		c.logger.Error("could not load research intent; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return nil, nil, nil, err
+	}
+	classifierOut, err := c.loops.GetClassifierOutput(ctx, loopID)
+	if err != nil {
+		if errors.Is(err, errClassifierOutputMissing) {
+			c.logger.Warn("classifier output missing; emitting degraded envelope so R3 fires",
+				slog.String("loop_id", loopID))
+			c.emitDegradedOutput(ctx, loopID, intent.Topic, "", "classifier output missing at execute_subqueries dispatch")
+			return nil, nil, nil, err
+		}
+		c.logger.Error("could not load classifier output; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return nil, nil, nil, err
+	}
+	decision, err := c.loops.GetRouteDecision(ctx, loopID)
+	if err != nil {
+		if errors.Is(err, errRouteDecisionMissing) {
+			c.logger.Warn("route decision missing; emitting degraded envelope so R3 fires",
+				slog.String("loop_id", loopID))
+			c.emitDegradedOutput(ctx, loopID, intent.Topic, "", "route decision missing at execute_subqueries dispatch")
+			return nil, nil, nil, err
+		}
+		c.logger.Error("could not load route decision; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return nil, nil, nil, err
+	}
+	return intent, classifierOut, decision, nil
+}
+
+// materializeQueries dispatches per the routing action and returns
+// the materialised sub-queries plus the count of dropped seed
+// references. On any per-action validation failure it writes a
+// degraded ExecutionOutput envelope (so R3 still fires) and
+// returns a non-nil error so the caller short-circuits. Extracted
+// from handleMessage to keep the hot path under the function-
+// length lint cap.
+//
+// Only walk_seeds + decompose produce sub-queries — retighten +
+// synthesize_directly shouldn't have reached R2's dispatch per
+// the rule chain's `when` gating; if they do, treat as a routing-
+// config bug, emit degraded, return error.
+func (c *Component) materializeQueries(
+	ctx context.Context,
+	loopID string,
+	intent *research.Intent,
+	classifierOut *research.ClassifierOutput,
+	decision *research.RouteDecision,
+) ([]SubQuery, int, error) {
+	switch decision.Action {
+	case research.ActionWalkSeeds:
+		walkArgs, parseErr := decision.ParseWalkSeedsArgs()
+		if parseErr != nil {
+			c.logger.Error("walk_seeds args invalid; emitting empty ExecutionOutput",
+				slog.String("loop_id", loopID),
+				slog.Any("error", parseErr))
+			c.emitDegradedOutput(ctx, loopID, intent.Topic, decision.Action, "walk_seeds args invalid: "+parseErr.Error())
+			return nil, 0, parseErr
+		}
+		resolved, dropped := resolveSeedRefs(walkArgs.Seeds, classifierOut.Candidates, c.logger)
+		return materializeForWalkSeeds(intent, resolved), dropped, nil
+	case research.ActionDecompose:
+		decArgs, parseErr := decision.ParseDecomposeArgs()
+		if parseErr != nil {
+			c.logger.Error("decompose args invalid; emitting empty ExecutionOutput",
+				slog.String("loop_id", loopID),
+				slog.Any("error", parseErr))
+			c.emitDegradedOutput(ctx, loopID, intent.Topic, decision.Action, "decompose args invalid: "+parseErr.Error())
+			return nil, 0, parseErr
+		}
+		return materializeForDecompose(intent, decArgs, classifierOut.Candidates), 0, nil
+	}
+	// retighten / synthesize_directly should never reach R2's
+	// dispatch to execute_subqueries.
+	c.logger.Error("unexpected routing action reached execute_subqueries; rule-config bug",
+		slog.String("loop_id", loopID),
+		slog.String("action", decision.Action))
+	c.emitDegradedOutput(ctx, loopID, intent.Topic, decision.Action, "unexpected action reached execute_subqueries: "+decision.Action)
+	return nil, 0, fmt.Errorf("unexpected action %q", decision.Action)
+}
+
+// emitDegradedOutput writes an empty-evidence ExecutionOutput with
+// Degraded=true so R3 still fires (assess_sufficiency reads the
+// envelope, observes empty evidence, and routes to refine OR
+// synthesize-with-low-confidence). Used by the per-action arg
+// validation failure paths so a malformed router decision doesn't
+// silently strand the loop.
+// emitDegradedOutput writes an empty-evidence ExecutionOutput with
+// Degraded=true so R3 still fires (assess_sufficiency reads the
+// envelope, observes empty evidence, and routes to refine OR
+// synthesize-with-low-confidence). Used by per-action arg
+// validation failure paths so a malformed router decision doesn't
+// silently strand the loop.
+//
+// Increments c.errors exactly ONCE per call regardless of which
+// branch fires (marshal failure / snapshot failure / trigger
+// failure / success). Callers that hit a degraded path should NOT
+// double-count.
+func (c *Component) emitDegradedOutput(ctx context.Context, loopID, topic, action, reason string) {
+	atomic.AddInt64(&c.errors, 1)
+	output := &research.ExecutionOutput{
+		Topic:          topic,
+		Action:         action,
+		Degraded:       true,
+		DegradedReason: reason,
+	}
+	envelope := message.NewBaseMessage(output.Schema(), output, ComponentName)
+	envelopeBytes, err := json.Marshal(envelope)
+	if err != nil {
+		c.logger.Error("marshal degraded envelope failed",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		return
+	}
+	if err := c.loops.PutSnapshot(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Warn("degraded snapshot write failed",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+	}
+	if err := c.loops.PutExecutionOutput(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Error("degraded execute.complete trigger write failed; R3 will not fire",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+	}
+}
+
+// Meta implements Discoverable.
+func (c *Component) Meta() component.Metadata {
+	return component.Metadata{
+		Name:        ComponentName,
+		Type:        "processor",
+		Description: "ADR-045 execute_subqueries: materialise sub-queries from RouteDecision intent + fan-out across Tier 0+1 retrieval + dedup + rank + budget. Emits ExecutionOutput for R3.",
+		Version:     "0.1.0",
+	}
+}
+
+// InputPorts implements Discoverable.
+func (c *Component) InputPorts() []component.Port {
+	ports := make([]component.Port, 0, len(c.config.Ports.Inputs))
+	for _, p := range c.config.Ports.Inputs {
+		ports = append(ports, component.Port{
+			Name:      p.Name,
+			Direction: component.DirectionInput,
+			Required:  p.Required,
+			Config: component.NATSPort{
+				Subject: p.Subject,
+			},
+		})
+	}
+	return ports
+}
+
+// OutputPorts implements Discoverable. execute_subqueries has no
+// NATS-publishing outputs; emits via KV writes to AGENT_LOOPS.
+func (c *Component) OutputPorts() []component.Port { return []component.Port{} }
+
+// ConfigSchema implements Discoverable.
+func (c *Component) ConfigSchema() component.ConfigSchema { return configSchema }
+
+// Health implements Discoverable.
+func (c *Component) Health() component.HealthStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return component.HealthStatus{
+		Healthy:    c.started,
+		LastCheck:  time.Now(),
+		ErrorCount: int(atomic.LoadInt64(&c.errors)),
+		Uptime:     time.Since(c.startTime),
+	}
+}
+
+// DataFlow implements Discoverable.
+func (c *Component) DataFlow() component.FlowMetrics {
+	processed := atomic.LoadInt64(&c.messagesProcessed)
+	errCount := atomic.LoadInt64(&c.errors)
+	var errRate float64
+	if processed > 0 {
+		errRate = float64(errCount) / float64(processed)
+	}
+	last, _ := c.lastActivity.Load().(time.Time)
+	return component.FlowMetrics{
+		ErrorRate:    errRate,
+		LastActivity: last,
+	}
+}

--- a/processor/research-graph-execute/component_test.go
+++ b/processor/research-graph-execute/component_test.go
@@ -1,0 +1,351 @@
+package researchexecute
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// fakeLoopStore replaces natsLoopStore for handleMessage tests.
+// Records reads + writes so the test can assert key ordering,
+// envelope shape, and miss vs hit paths.
+type fakeLoopStore struct {
+	mu sync.Mutex
+
+	intent           *research.Intent
+	intentErr        error
+	classifierOut    *research.ClassifierOutput
+	classifierOutErr error
+	decision         *research.RouteDecision
+	decisionErr      error
+
+	getIntentCalls     int
+	getClassifierCalls int
+	getDecisionCalls   int
+
+	snapshotEnvelope []byte
+	snapshotErr      error
+	executeEnvelope  []byte
+	executeErr       error
+
+	writeOrder []string
+}
+
+func (s *fakeLoopStore) GetIntent(_ context.Context, _ string) (*research.Intent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getIntentCalls++
+	if s.intentErr != nil {
+		return nil, s.intentErr
+	}
+	return s.intent, nil
+}
+
+func (s *fakeLoopStore) GetClassifierOutput(_ context.Context, _ string) (*research.ClassifierOutput, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getClassifierCalls++
+	if s.classifierOutErr != nil {
+		return nil, s.classifierOutErr
+	}
+	return s.classifierOut, nil
+}
+
+func (s *fakeLoopStore) GetRouteDecision(_ context.Context, _ string) (*research.RouteDecision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getDecisionCalls++
+	if s.decisionErr != nil {
+		return nil, s.decisionErr
+	}
+	return s.decision, nil
+}
+
+func (s *fakeLoopStore) PutSnapshot(_ context.Context, _ string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.snapshotEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "snapshot")
+	return s.snapshotErr
+}
+
+func (s *fakeLoopStore) PutExecutionOutput(_ context.Context, _ string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.executeEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "execute_complete")
+	return s.executeErr
+}
+
+func newTestComponent(loops LoopStore, gq GraphQueryClient) *Component {
+	return &Component{
+		config: DefaultConfig(),
+		loops:  loops,
+		gq:     gq,
+		logger: quietLogger(),
+	}
+}
+
+// --- handleMessage happy paths ---
+
+func TestComponent_HandleMessage_WalkSeedsHappyPath(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "drone status"},
+		classifierOut: &research.ClassifierOutput{
+			Topic: "drone status", Tier: "0",
+			Candidates: []research.Candidate{
+				{EntityID: "acme.ops.robotics.gcs.drone.001", Label: "Drone One", Tier: "0", Source: "x"},
+			},
+		},
+		decision: &research.RouteDecision{
+			Action: research.ActionWalkSeeds,
+			Args: map[string]any{
+				"seeds": []any{
+					map[string]any{"ref": "drone.001", "ref_type": research.SeedRefTypePartialID},
+				},
+			},
+		},
+	}
+	gq := &fakeGraphQuery{
+		entityStateOut: []research.Evidence{{EntityID: "acme.ops.robotics.gcs.drone.001"}},
+		predicateWalkOut: []research.Evidence{
+			{EntityID: "acme.ops.robotics.gcs.event.maint-001", Score: 0.7},
+		},
+		bm25Out: []research.Evidence{{EntityID: "acme.ops.robotics.gcs.alert.battery", Score: 0.5}},
+	}
+	c := newTestComponent(loops, gq)
+	c.handleMessage(context.Background(), "component.execute_subqueries.loop-1", nil)
+
+	if atomic.LoadInt64(&c.errors) != 0 {
+		t.Errorf("errors = %d, want 0", atomic.LoadInt64(&c.errors))
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if len(loops.writeOrder) != 2 || loops.writeOrder[0] != "snapshot" || loops.writeOrder[1] != "execute_complete" {
+		t.Errorf("write order = %v, want [snapshot execute_complete]", loops.writeOrder)
+	}
+}
+
+func TestComponent_HandleMessage_DecomposeHappyPath(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "sensor anomalies"},
+		classifierOut: &research.ClassifierOutput{
+			Topic: "sensor anomalies", Tier: "1",
+			Candidates: []research.Candidate{
+				{EntityID: "sensor-001", Tier: "0", Source: "x"},
+			},
+		},
+		decision: &research.RouteDecision{
+			Action: research.ActionDecompose,
+			Args: map[string]any{
+				"axes":  []any{"entity_type", "time"},
+				"focus": "sensor maintenance",
+				"scope": research.DecomposeScopeMedium,
+			},
+		},
+	}
+	gq := &fakeGraphQuery{
+		entityStateOut:   []research.Evidence{{EntityID: "sensor-001"}},
+		temporalRangeOut: []research.Evidence{{EntityID: "event-T1"}},
+		bm25Out:          []research.Evidence{{EntityID: "doc-abc", Score: 0.3}},
+	}
+	c := newTestComponent(loops, gq)
+	c.handleMessage(context.Background(), "component.execute_subqueries.loop-2", nil)
+
+	if atomic.LoadInt64(&c.errors) != 0 {
+		t.Errorf("errors = %d, want 0", atomic.LoadInt64(&c.errors))
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	// Should have hit all three executors (entity_state + temporal + bm25).
+	if gq.entityStateCalls != 1 || gq.temporalRangeCalls != 1 || gq.bm25Calls != 1 {
+		t.Errorf("call counts: es=%d temporal=%d bm=%d, want all 1", gq.entityStateCalls, gq.temporalRangeCalls, gq.bm25Calls)
+	}
+}
+
+// --- handleMessage failure paths ---
+
+func TestComponent_HandleMessage_BadSubjectShortCircuits(t *testing.T) {
+	loops := &fakeLoopStore{}
+	c := newTestComponent(loops, &fakeGraphQuery{})
+	c.handleMessage(context.Background(), "wrong.prefix.loop-1", nil)
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if loops.getIntentCalls != 0 {
+		t.Errorf("bad subject should short-circuit before any KV reads")
+	}
+}
+
+func TestComponent_HandleMessage_MissingIntentIsRecorded(t *testing.T) {
+	loops := &fakeLoopStore{intentErr: errIntentNotFound}
+	c := newTestComponent(loops, &fakeGraphQuery{})
+	c.handleMessage(context.Background(), "component.execute_subqueries.loop-1", nil)
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if loops.getClassifierCalls != 0 {
+		t.Errorf("missing intent should short-circuit before classifier read")
+	}
+}
+
+func TestComponent_HandleMessage_MissingClassifierEmitsDegradedSoR3Fires(t *testing.T) {
+	// Per the I3 fix from PR 4 review: missing classifier output
+	// is a chain-race condition (R1 fired before classify.complete
+	// was written). Hard-aborting here would strand the loop —
+	// instead we emit a degraded envelope so R3 still fires and
+	// assess_sufficiency can route to refine OR low-confidence
+	// synthesize. Verify: errors++ AND degraded envelope written.
+	loops := &fakeLoopStore{
+		intent:           &research.Intent{Topic: "x"},
+		classifierOutErr: errClassifierOutputMissing,
+	}
+	c := newTestComponent(loops, &fakeGraphQuery{})
+	c.handleMessage(context.Background(), "component.execute_subqueries.loop-1", nil)
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if loops.getDecisionCalls != 0 {
+		t.Errorf("missing classifier should short-circuit before decision read")
+	}
+	if len(loops.executeEnvelope) == 0 {
+		t.Error("degraded trigger envelope not written; R3 would strand")
+	}
+}
+
+func TestComponent_HandleMessage_MissingDecisionEmitsDegradedSoR3Fires(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:        &research.Intent{Topic: "x"},
+		classifierOut: &research.ClassifierOutput{Topic: "x", Tier: "0"},
+		decisionErr:   errRouteDecisionMissing,
+	}
+	c := newTestComponent(loops, &fakeGraphQuery{})
+	c.handleMessage(context.Background(), "component.execute_subqueries.loop-1", nil)
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if len(loops.executeEnvelope) == 0 {
+		t.Error("degraded trigger envelope not written; R3 would strand")
+	}
+}
+
+func TestComponent_HandleMessage_UnexpectedActionEmitsDegradedOutput(t *testing.T) {
+	// retighten + synthesize_directly shouldn't reach execute_subqueries
+	// per R2's `when` gating, but if they do (rule-config bug) the
+	// component must NOT silently strand the loop — emits a degraded
+	// envelope so R3 still fires.
+	loops := &fakeLoopStore{
+		intent:        &research.Intent{Topic: "x"},
+		classifierOut: &research.ClassifierOutput{Topic: "x", Tier: "0"},
+		decision:      &research.RouteDecision{Action: research.ActionRetighten, Args: map[string]any{"topic": "x"}},
+	}
+	c := newTestComponent(loops, &fakeGraphQuery{})
+	c.handleMessage(context.Background(), "component.execute_subqueries.loop-1", nil)
+	if atomic.LoadInt64(&c.errors) == 0 {
+		t.Error("unexpected action should record an error")
+	}
+	// But the trigger key should still have been written.
+	if len(loops.executeEnvelope) == 0 {
+		t.Error("degraded trigger envelope not written; downstream chain would strand")
+	}
+}
+
+func TestComponent_HandleMessage_BadWalkSeedsArgsEmitsDegraded(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:        &research.Intent{Topic: "x"},
+		classifierOut: &research.ClassifierOutput{Topic: "x", Tier: "0"},
+		decision: &research.RouteDecision{
+			Action: research.ActionWalkSeeds,
+			Args:   map[string]any{"seeds": []any{}}, // empty seeds — Parse will reject
+		},
+	}
+	c := newTestComponent(loops, &fakeGraphQuery{})
+	c.handleMessage(context.Background(), "component.execute_subqueries.loop-1", nil)
+	if atomic.LoadInt64(&c.errors) == 0 {
+		t.Error("bad walk_seeds args should record an error")
+	}
+	if len(loops.executeEnvelope) == 0 {
+		t.Error("degraded trigger envelope not written despite bad args")
+	}
+}
+
+func TestComponent_HandleMessage_SnapshotErrorIsTolerated(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:        &research.Intent{Topic: "x"},
+		classifierOut: &research.ClassifierOutput{Topic: "x", Tier: "0"},
+		decision: &research.RouteDecision{
+			Action: research.ActionDecompose,
+			Args:   map[string]any{"axes": []any{"entity_type"}, "focus": "f"},
+		},
+		snapshotErr: errors.New("snapshot KV down"),
+	}
+	c := newTestComponent(loops, &fakeGraphQuery{})
+	c.handleMessage(context.Background(), "component.execute_subqueries.loop-1", nil)
+	if atomic.LoadInt64(&c.errors) != 0 {
+		t.Errorf("snapshot error should be best-effort, errors = %d", atomic.LoadInt64(&c.errors))
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("trigger should still fire despite snapshot failure")
+	}
+}
+
+func TestComponent_HandleMessage_TriggerErrorIsRecorded(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:        &research.Intent{Topic: "x"},
+		classifierOut: &research.ClassifierOutput{Topic: "x", Tier: "0"},
+		decision: &research.RouteDecision{
+			Action: research.ActionDecompose,
+			Args:   map[string]any{"axes": []any{"entity_type"}, "focus": "f"},
+		},
+		executeErr: errors.New("execute KV down"),
+	}
+	c := newTestComponent(loops, &fakeGraphQuery{})
+	c.handleMessage(context.Background(), "component.execute_subqueries.loop-1", nil)
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("trigger write error should record, errors = %d", atomic.LoadInt64(&c.errors))
+	}
+}
+
+// --- discoverable surface ---
+
+func TestComponent_DiscoverableSurface(t *testing.T) {
+	c := newTestComponent(&fakeLoopStore{}, &fakeGraphQuery{})
+	if c.Meta().Name != ComponentName {
+		t.Errorf("Meta.Name drift")
+	}
+	if len(c.InputPorts()) != 1 {
+		t.Errorf("InputPorts: got %d, want 1", len(c.InputPorts()))
+	}
+	if len(c.OutputPorts()) != 0 {
+		t.Errorf("OutputPorts: got %d, want 0 (KV-only emits)", len(c.OutputPorts()))
+	}
+}
+
+// --- config validate / defaults ---
+
+func TestConfig_ValidateRejectsNegativeCaps(t *testing.T) {
+	c := DefaultConfig()
+	c.MaxParallelism = -1
+	if err := c.Validate(); err == nil {
+		t.Error("Validate accepted negative max_parallelism")
+	}
+	c = DefaultConfig()
+	c.MaxResultsPerSubquery = -1
+	if err := c.Validate(); err == nil {
+		t.Error("Validate accepted negative max_results_per_subquery")
+	}
+}
+
+func TestConfig_ApplyDefaultsFillsZeros(t *testing.T) {
+	c := Config{}
+	c.ApplyDefaults()
+	if c.LoopsBucket != "AGENT_LOOPS" || c.ExecuteTimeout != DefaultExecuteTimeout || c.MaxParallelism != DefaultMaxParallelism || c.MaxResultsPerSubquery != DefaultMaxResultsPerSubquery {
+		t.Errorf("defaults not applied: %+v", c)
+	}
+}

--- a/processor/research-graph-execute/config.go
+++ b/processor/research-graph-execute/config.go
@@ -1,0 +1,117 @@
+package researchexecute
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+)
+
+// ComponentName is the canonical registry name + log subsystem.
+const ComponentName = "research-graph-execute"
+
+// Default knobs surfaced as exported constants so the materializer
+// + fan-out tests and operator docs can reference them by name
+// rather than duplicating literals.
+const (
+	// DefaultExecuteTimeout caps the wall-clock for the full
+	// fan-out (all sub-queries × all tiers). Generous default; per-
+	// tier deadlines are derived as fractions of this cap.
+	DefaultExecuteTimeout = 60 * time.Second
+
+	// DefaultMaxParallelism caps concurrent sub-query execution.
+	// Keeps fan-out from saturating the responding gateways under
+	// a wide-decompose scenario; operators can raise for staging
+	// environments with more capacity.
+	DefaultMaxParallelism = 8
+
+	// DefaultMaxResultsPerSubquery caps per-sub-query result count
+	// before ranking + budget enforcement run. Prevents a single
+	// runaway sub-query from dominating the evidence array.
+	DefaultMaxResultsPerSubquery = 50
+
+	// DefaultBudgetTokens is the fallback evidence-budget when the
+	// upstream Intent doesn't supply one. Should never normally
+	// fire (Intent.ResolvedBudgetTokens supplies a default of 4000
+	// per agentic/research) but acts as a safety net.
+	DefaultBudgetTokens = 4000
+
+	// DefaultPerSubqueryTimeoutFraction is the fraction of the
+	// overall ExecuteTimeout each sub-query gets as its per-call
+	// deadline. 0.5 leaves slack for fan-out overhead and ranking;
+	// operators can tighten.
+	DefaultPerSubqueryTimeoutFraction = 0.5
+)
+
+// Config holds operator-tunable knobs for the execute_subqueries
+// component.
+type Config struct {
+	Ports *component.PortConfig `json:"ports,omitempty" schema:"type:ports,description:Port configuration. execute_subqueries requires one nats input subscribing to component.execute_subqueries.> ,category:basic"`
+
+	LoopsBucket string `json:"loops_bucket,omitempty" schema:"type:string,description:NATS KV bucket holding research-pipeline loops and trigger/completion keys,default:AGENT_LOOPS,category:advanced"`
+
+	ExecuteTimeout time.Duration `json:"execute_timeout,omitempty" schema:"type:duration,description:Wall-clock cap for the full fan-out (all sub-queries x all tiers),default:60s,category:advanced"`
+
+	MaxParallelism int `json:"max_parallelism,omitempty" schema:"type:int,description:Concurrent sub-query execution cap. Keeps fan-out from saturating gateways. 0 means default (8),default:8,max:64,category:advanced"`
+
+	MaxResultsPerSubquery int `json:"max_results_per_subquery,omitempty" schema:"type:int,description:Per-sub-query result count cap before ranking + budget enforcement. Prevents a runaway sub-query from dominating evidence. 0 means default (50),default:50,max:500,category:advanced"`
+}
+
+// Validate validates the configuration. Negative caps are rejected;
+// zero values fall through to ApplyDefaults.
+func (c *Config) Validate() error {
+	if c.Ports == nil || len(c.Ports.Inputs) == 0 {
+		return errors.New("ports configuration with at least one input port is required")
+	}
+	if c.MaxParallelism < 0 {
+		return errors.New("max_parallelism must be >= 0")
+	}
+	if c.MaxResultsPerSubquery < 0 {
+		return errors.New("max_results_per_subquery must be >= 0")
+	}
+	return nil
+}
+
+// ApplyDefaults fills in defaults for unset fields.
+func (c *Config) ApplyDefaults() {
+	if c.LoopsBucket == "" {
+		c.LoopsBucket = "AGENT_LOOPS"
+	}
+	if c.ExecuteTimeout == 0 {
+		c.ExecuteTimeout = DefaultExecuteTimeout
+	}
+	if c.MaxParallelism == 0 {
+		c.MaxParallelism = DefaultMaxParallelism
+	}
+	if c.MaxResultsPerSubquery == 0 {
+		c.MaxResultsPerSubquery = DefaultMaxResultsPerSubquery
+	}
+}
+
+// DefaultConfig returns a default Config skeleton with the standard
+// execute_subqueries input port.
+func DefaultConfig() Config {
+	return Config{
+		Ports: &component.PortConfig{
+			Inputs: []component.PortDefinition{
+				{
+					Name:        "trigger",
+					Type:        "nats",
+					Subject:     "component.execute_subqueries.>",
+					Required:    true,
+					Description: "R2's publish target. Subject suffix carries the research-pipeline loop_id.",
+				},
+			},
+			Outputs: []component.PortDefinition{},
+		},
+		LoopsBucket:           "AGENT_LOOPS",
+		ExecuteTimeout:        DefaultExecuteTimeout,
+		MaxParallelism:        DefaultMaxParallelism,
+		MaxResultsPerSubquery: DefaultMaxResultsPerSubquery,
+	}
+}
+
+// configSchema is the static configuration schema, generated from
+// Config struct tags at package init.
+var configSchema = component.GenerateConfigSchema(reflect.TypeOf(Config{}))

--- a/processor/research-graph-execute/doc.go
+++ b/processor/research-graph-execute/doc.go
@@ -1,0 +1,56 @@
+// Package researchexecute implements the execute_subqueries
+// component from ADR-045 Phase 1 (PR 4 of six per
+// docs/operations/22-adr045-phase1-plan.md).
+//
+// execute_subqueries is the code-heavy stage of the graph-search
+// rule chain. It receives a publish trigger on
+// component.execute_subqueries.<loop_id>, reads the upstream
+// research.Intent + research.RouteDecision payloads from
+// AGENT_LOOPS, materializes one or more typed sub-queries from
+// the routing intent, executes them in parallel across multiple
+// retrieval tiers, normalises + dedups results, enforces the
+// caller's token budget, and writes a research.Evidence array
+// envelope plus an execute.complete.<loop_id> trigger key that R3
+// watches to dispatch the assess_sufficiency stage.
+//
+// Two input shapes — same component:
+//
+//   - walk_seeds args: model emits seed references
+//     (name/partial_id/candidate_index); component resolves to full
+//     6-part federated entity IDs via the entity index, then
+//     dispatches multi-hop expansion as predicate_walk sub-queries.
+//
+//   - decompose args: model emits decomposition intent
+//     (axes/focus/scope); component materializes typed sub-queries
+//     from MINIMAL TEMPLATES — entity_type → entity_state,
+//     time → temporal_range, predicate → predicate_walk (the
+//     fallback for axes that don't map to a dedicated primitive).
+//     spatial is deferred to Phase 2 (graph-index-spatial wire).
+//
+// Architectural notes:
+//
+//   - Pure-code component (no LLM calls). All work is graph + index
+//     retrieval against existing gateways.
+//
+//   - Tier 0 (predicate queries) executes via graph-query NATS-
+//     direct subjects (graph.query.entitiesByPrefix etc.). Tier 1
+//     (BM25) executes via graph.query.searchGraph (same surface
+//     research-graph-classify uses for initial candidate retrieval).
+//     Tier 2 (neural) is deferred to Phase 2.
+//
+//   - Sub-query types are component-internal — defined here, not in
+//     agentic/research/. Reshapeable without cross-package churn if
+//     Phase 2 learns better primitives.
+//
+//   - Parallel fan-out via errgroup with a bounded concurrency cap
+//     (config-driven). Per-tier ordering with recency tie-break;
+//     learned ranker deferred to Phase 2.
+//
+//   - Provenance preserved end-to-end — every Evidence carries
+//     {tier, source, entity_id} the agent can quote back. No
+//     fabricated refs.
+//
+//   - All public methods safe for concurrent use across loops; the
+//     component holds no per-call mutable state. Same pattern as
+//     research-graph-classify and research-graph-route.
+package researchexecute

--- a/processor/research-graph-execute/handler.go
+++ b/processor/research-graph-execute/handler.go
@@ -1,0 +1,434 @@
+package researchexecute
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// GraphQueryClient is the narrow surface this component consumes
+// from graph-query / graph-index. Production wraps NATS-direct
+// subjects (graph.query.entitiesByPrefix, graph.query.searchGraph,
+// etc.); tests substitute an in-memory fake so the matrix doesn't
+// need a live graph stack.
+//
+// Per-method semantics:
+//
+//   - EntityState: returns the current Triples for the named
+//     entities, projected into Evidence (one per entity).
+//   - PredicateWalk: from each seed, returns Evidence for entities
+//     reachable within MaxHops via Predicates (empty Predicates =
+//     all).
+//   - TemporalRange: returns Evidence for entities within the time
+//     window, optionally filtered by topic.
+//   - BM25: text search via graph-query's existing BM25 surface.
+//
+// All methods MUST stamp Tier + Source on every returned Evidence
+// (taken from the SubQuery they were dispatched for) so provenance
+// stays honest end-to-end. The orchestrator does NOT re-stamp.
+type GraphQueryClient interface {
+	EntityState(ctx context.Context, args EntityStateArgs, tier, source string, limit int) ([]research.Evidence, error)
+	PredicateWalk(ctx context.Context, args PredicateWalkArgs, tier, source string, limit int) ([]research.Evidence, error)
+	TemporalRange(ctx context.Context, args TemporalRangeArgs, tier, source string, limit int) ([]research.Evidence, error)
+	BM25(ctx context.Context, args BM25Args, tier, source string, limit int) ([]research.Evidence, error)
+}
+
+// LoopStore is the AGENT_LOOPS read/write surface this component
+// consumes. Production wraps natsclient.KVStore; tests substitute
+// an in-memory map.
+type LoopStore interface {
+	// GetIntent loads the research_intent payload from the
+	// research.requested.<loopID> key.
+	GetIntent(ctx context.Context, loopID string) (*research.Intent, error)
+
+	// GetClassifierOutput loads the upstream ClassifierOutput from
+	// the classify.complete.<loopID> trigger key. Needed for
+	// walk_seeds candidate_index resolution + decompose entity_type
+	// anchoring.
+	GetClassifierOutput(ctx context.Context, loopID string) (*research.ClassifierOutput, error)
+
+	// GetRouteDecision loads the upstream RouteDecision from the
+	// route.complete.<loopID> trigger key. Drives sub-query
+	// materialization.
+	GetRouteDecision(ctx context.Context, loopID string) (*research.RouteDecision, error)
+
+	// PutExecutionOutput writes the ExecutionOutput envelope at
+	// R3's trigger key execute.complete.<loopID>.
+	PutExecutionOutput(ctx context.Context, loopID string, envelope []byte) error
+
+	// PutSnapshot writes the envelope at the stable non-trigger
+	// key execute.snapshot.<loopID> so operators / downstream
+	// queryability can read without racing R3's wildcard watcher.
+	PutSnapshot(ctx context.Context, loopID string, envelope []byte) error
+}
+
+// Sentinel errors for diagnostic clarity in handler logs + so tests
+// can assert via errors.Is.
+var (
+	errIntentNotFound          = fmt.Errorf("research intent not found")
+	errClassifierOutputMissing = fmt.Errorf("classifier output not found")
+	errRouteDecisionMissing    = fmt.Errorf("route decision not found")
+)
+
+// extractLoopIDFromSubject pulls the loop_id off
+// component.execute_subqueries.<loop_id>. Returns empty on shape
+// mismatch — handler treats as routing-config bug.
+func extractLoopIDFromSubject(subject string) string {
+	const prefix = "component.execute_subqueries."
+	if !strings.HasPrefix(subject, prefix) {
+		return ""
+	}
+	return subject[len(prefix):]
+}
+
+// resolveSeedRefs maps SeedRef entries to full 6-part entity IDs
+// using the upstream ClassifierOutput candidate list. The three
+// ref_types per agentic/research:
+//
+//   - "name":            display-name lookup against candidates
+//     (Phase 1 scope; entity-index lookup is a
+//     Phase 2 extension if candidates don't have
+//     a hit on the name).
+//   - "partial_id":      dot-bounded suffix match on candidate IDs.
+//   - "candidate_index": integer index into candidates list.
+//
+// Unresolved seeds are SKIPPED rather than erroring — a single bad
+// reference shouldn't gate the whole execution; the handler logs
+// the drop and degraded-flags the ExecutionOutput when ANY seed
+// was dropped.
+func resolveSeedRefs(seeds []research.SeedRef, candidates []research.Candidate, logger *slog.Logger) (resolved []string, dropped int) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	for i, seed := range seeds {
+		id, err := resolveOneSeedRef(seed, candidates)
+		if err != nil {
+			logger.Warn("seed reference did not resolve; dropping",
+				slog.Int("index", i),
+				slog.String("ref", seed.Ref),
+				slog.String("ref_type", seed.RefType),
+				slog.Any("error", err))
+			dropped++
+			continue
+		}
+		resolved = append(resolved, id)
+	}
+	return resolved, dropped
+}
+
+// resolveOneSeedRef dispatches a single SeedRef per its RefType.
+// Separated from resolveSeedRefs so unit tests can drive each
+// branch without log assertions.
+func resolveOneSeedRef(seed research.SeedRef, candidates []research.Candidate) (string, error) {
+	switch seed.RefType {
+	case research.SeedRefTypeCandidateIndex:
+		return resolveSeedRefByCandidateIndex(seed.Ref, candidates)
+	case research.SeedRefTypePartialID:
+		return resolveSeedRefByPartialID(seed.Ref, candidates)
+	case research.SeedRefTypeName:
+		return resolveSeedRefByName(seed.Ref, candidates)
+	}
+	return "", fmt.Errorf("ref_type %q is not a canonical seed reference type", seed.RefType)
+}
+
+// resolveSeedRefByName does case-insensitive label match against
+// classifier candidates. Phase 1 scope is candidate-anchored
+// (Phase 2 may extend to entity-index lookup when the classifier
+// missed a known entity).
+func resolveSeedRefByName(ref string, candidates []research.Candidate) (string, error) {
+	needle := strings.ToLower(strings.TrimSpace(ref))
+	if needle == "" {
+		return "", fmt.Errorf("name ref is empty")
+	}
+	for _, c := range candidates {
+		label := strings.ToLower(strings.TrimSpace(c.Label))
+		if label != "" && label == needle {
+			id := strings.TrimSpace(c.EntityID)
+			if id == "" {
+				return "", fmt.Errorf("candidate with label %q has empty entity_id", needle)
+			}
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("name ref %q matched no classifier candidate label", needle)
+}
+
+// executeAll runs the materialized sub-query set in parallel,
+// dedups by entity_id, applies per-tier ordering + recency
+// tie-break, enforces the intent's token budget, and returns the
+// finalised ExecutionOutput. Pure function over GraphQueryClient
+// (production wraps NATS, tests inject an in-memory fake) — no
+// NATS plumbing leaks here so the test matrix can exercise the
+// orchestration logic with deterministic inputs.
+//
+// Degraded flagging: ANY of (sub-query error, sub-query timeout,
+// dropped seed reference, materialization yielded zero queries)
+// flips Degraded=true with a per-cause DegradedReason. The chain
+// doesn't error on degraded — assess_sufficiency surfaces it to
+// the LLM as low-confidence input.
+func executeAll(
+	ctx context.Context,
+	gq GraphQueryClient,
+	queries []SubQuery,
+	intent *research.Intent,
+	decisionAction string,
+	maxParallelism int,
+	maxResultsPerSubquery int,
+	logger *slog.Logger,
+) (*research.ExecutionOutput, error) {
+	if intent == nil {
+		return nil, fmt.Errorf("intent is nil")
+	}
+	if gq == nil {
+		return nil, fmt.Errorf("graph-query client is nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if maxParallelism <= 0 {
+		maxParallelism = DefaultMaxParallelism
+	}
+	if maxResultsPerSubquery <= 0 {
+		maxResultsPerSubquery = DefaultMaxResultsPerSubquery
+	}
+
+	output := &research.ExecutionOutput{
+		Topic:         intent.Topic,
+		Action:        decisionAction,
+		SubQueryCount: len(queries),
+	}
+
+	if len(queries) == 0 {
+		output.Degraded = true
+		output.DegradedReason = "materializer produced zero sub-queries"
+		return output, nil
+	}
+
+	// Per-sub-query timeout = ExecuteTimeout * DefaultPerSubqueryTimeoutFraction.
+	// Derived from the parent ctx's remaining deadline so the cap is
+	// the MIN of operator config + caller's remaining budget.
+	perQueryTimeout := derivePerQueryTimeout(ctx)
+
+	var (
+		mu          sync.Mutex
+		allEvidence []research.Evidence
+		degraded    bool
+		reasons     []string
+	)
+
+	// Bounded-concurrency errgroup. SetLimit clamps how many
+	// sub-queries dispatch in parallel; remaining queries queue.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxParallelism)
+
+	for i := range queries {
+		q := queries[i]
+		g.Go(func() error {
+			qctx := gctx
+			if perQueryTimeout > 0 {
+				var cancel context.CancelFunc
+				qctx, cancel = context.WithTimeout(gctx, perQueryTimeout)
+				defer cancel()
+			}
+			evidence, err := executeSubQuery(qctx, gq, q, maxResultsPerSubquery)
+			if err != nil {
+				logger.Warn("sub-query failed; degrading",
+					slog.String("type", string(q.Type)),
+					slog.String("source", q.Source),
+					slog.Any("error", err))
+				mu.Lock()
+				degraded = true
+				reasons = append(reasons, fmt.Sprintf("%s:%s failed: %v", q.Type, q.Source, err))
+				mu.Unlock()
+				// Per-sub-query failure is degrading, NOT chain-failing.
+				// Return nil so errgroup doesn't cancel sibling
+				// sub-queries that may still succeed.
+				return nil
+			}
+			mu.Lock()
+			allEvidence = append(allEvidence, evidence...)
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		// errgroup returns the first non-nil error from a Go-routine.
+		// We return nil from per-sub-query failures, so this only
+		// fires on a hard cancellation (parent ctx done).
+		return nil, fmt.Errorf("fan-out: %w", err)
+	}
+
+	// Dedup by EntityID (cross-tier collapses), preserve highest-tier
+	// + highest-score Evidence for the duplicate set.
+	deduped := dedupEvidence(allEvidence)
+
+	// Per-tier ordering + recency tie-break.
+	sortEvidence(deduped)
+
+	// Budget enforcement. Drop lowest-scoring until under budget.
+	budget := intent.ResolvedBudgetTokens()
+	if budget <= 0 {
+		budget = DefaultBudgetTokens
+	}
+	enforced, usedTokens := enforceBudget(deduped, budget)
+
+	output.Evidence = enforced
+	output.BudgetTokensUsed = usedTokens
+	if degraded {
+		output.Degraded = true
+		output.DegradedReason = strings.Join(reasons, "; ")
+	}
+
+	return output, nil
+}
+
+// executeSubQuery dispatches one sub-query to the right GraphQueryClient
+// method. Returns Evidence with Tier + Source already stamped by the
+// implementing executor (interface contract).
+func executeSubQuery(ctx context.Context, gq GraphQueryClient, q SubQuery, limit int) ([]research.Evidence, error) {
+	switch q.Type {
+	case SubQueryTypeEntityState:
+		return gq.EntityState(ctx, *q.EntityState, q.Tier, q.Source, limit)
+	case SubQueryTypePredicateWalk:
+		return gq.PredicateWalk(ctx, *q.PredicateWalk, q.Tier, q.Source, limit)
+	case SubQueryTypeTemporalRange:
+		return gq.TemporalRange(ctx, *q.TemporalRange, q.Tier, q.Source, limit)
+	case SubQueryTypeBM25:
+		return gq.BM25(ctx, *q.BM25, q.Tier, q.Source, limit)
+	}
+	return nil, fmt.Errorf("unknown sub-query type %q", q.Type)
+}
+
+// dedupEvidence collapses duplicates by EntityID. When the same
+// entity surfaces in multiple sub-queries, the dedup picks the
+// "best" Evidence: lower Tier wins (Tier 0 > Tier 1), and within
+// the same tier higher Score wins.
+//
+// Provenance is preserved by stamping the WINNING evidence's
+// Source. Phase 2 may extend Evidence with a multi-source list so
+// the agent can quote any path that surfaced the entity; Phase 1
+// ships single-source-per-entity.
+func dedupEvidence(in []research.Evidence) []research.Evidence {
+	if len(in) == 0 {
+		return nil
+	}
+	best := make(map[string]research.Evidence, len(in))
+	for _, e := range in {
+		if e.EntityID == "" {
+			continue
+		}
+		existing, ok := best[e.EntityID]
+		if !ok {
+			best[e.EntityID] = e
+			continue
+		}
+		if evidenceBeats(e, existing) {
+			best[e.EntityID] = e
+		}
+	}
+	out := make([]research.Evidence, 0, len(best))
+	for _, e := range best {
+		out = append(out, e)
+	}
+	return out
+}
+
+// evidenceBeats returns true when a should replace b in dedup.
+// Tier 0 beats Tier 1 unconditionally; within the same tier, higher
+// Score wins; ties broken by EntityID ascending (deterministic
+// across map iteration).
+func evidenceBeats(a, b research.Evidence) bool {
+	if a.Tier != b.Tier {
+		return a.Tier < b.Tier // "0" < "1" lexically — Tier 0 wins
+	}
+	if a.Score != b.Score {
+		return a.Score > b.Score
+	}
+	return a.EntityID < b.EntityID
+}
+
+// sortEvidence applies Phase 1's ordering rule: lower-tier first
+// (Tier 0 before Tier 1), then higher Score, then EntityID
+// ascending for tie-break. Stable sort preserves input order
+// within ties for replay determinism.
+func sortEvidence(ev []research.Evidence) {
+	sort.SliceStable(ev, func(i, j int) bool {
+		if ev[i].Tier != ev[j].Tier {
+			return ev[i].Tier < ev[j].Tier
+		}
+		if ev[i].Score != ev[j].Score {
+			return ev[i].Score > ev[j].Score
+		}
+		return ev[i].EntityID < ev[j].EntityID
+	})
+}
+
+// enforceBudget drops lowest-ranked evidence (from the tail of the
+// sorted slice) until the estimated token cost fits within budget.
+// Returns the kept slice and the estimated token cost actually
+// retained.
+//
+// Token estimation: ~4 chars/token (industry rule of thumb) across
+// the rendered evidence — EntityID + Label + Type + SnippetText +
+// Source. Crude but stable; Phase 2 may swap a tokenizer.
+func enforceBudget(in []research.Evidence, budget int) ([]research.Evidence, int) {
+	if len(in) == 0 || budget <= 0 {
+		return in, 0
+	}
+	out := make([]research.Evidence, 0, len(in))
+	used := 0
+	for _, e := range in {
+		cost := estimateEvidenceTokens(e)
+		if used+cost > budget {
+			// Drop this and everything after (in sorted order, they're
+			// lower-ranked). Phase 1 strategy: sharp cutoff. Phase 2
+			// may try greedier per-item drop.
+			break
+		}
+		out = append(out, e)
+		used += cost
+	}
+	return out, used
+}
+
+// estimateEvidenceTokens approximates the prompt-cost of one
+// Evidence entry. Sums character counts of the rendered fields
+// (matches the rough shape a downstream synthesizer would inline
+// in its prompt) and divides by 4. Always returns at least 1 to
+// prevent empty Evidence from being "free" (still costs a JSON
+// boundary in the array).
+func estimateEvidenceTokens(e research.Evidence) int {
+	chars := len(e.EntityID) + len(e.SnippetText) + len(e.Source) + len(e.ObjectStoreRef)
+	tokens := chars / 4
+	if tokens < 1 {
+		tokens = 1
+	}
+	return tokens
+}
+
+// derivePerQueryTimeout returns the per-sub-query deadline as a
+// fraction of the parent ctx's remaining time. When the parent
+// has no deadline (test ctx.Background, or operator-disabled
+// component timeout), falls back to a fraction of
+// DefaultExecuteTimeout so a wedged sub-query can't hang the
+// fan-out indefinitely.
+func derivePerQueryTimeout(ctx context.Context) time.Duration {
+	dl, ok := ctx.Deadline()
+	if !ok {
+		return time.Duration(float64(DefaultExecuteTimeout) * DefaultPerSubqueryTimeoutFraction)
+	}
+	remaining := time.Until(dl)
+	if remaining <= 0 {
+		return 0
+	}
+	return time.Duration(float64(remaining) * DefaultPerSubqueryTimeoutFraction)
+}

--- a/processor/research-graph-execute/handler_test.go
+++ b/processor/research-graph-execute/handler_test.go
@@ -1,0 +1,405 @@
+package researchexecute
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// fakeGraphQuery records what was called and returns canned
+// evidence per sub-query type. Each per-type slice acts as a queue
+// so multi-call tests (e.g. PredicateWalk's per-seed loop) can
+// return different shapes per call.
+type fakeGraphQuery struct {
+	mu sync.Mutex
+
+	entityStateCalls   int
+	predicateWalkCalls int
+	temporalRangeCalls int
+	bm25Calls          int
+
+	entityStateOut   []research.Evidence
+	predicateWalkOut []research.Evidence
+	temporalRangeOut []research.Evidence
+	bm25Out          []research.Evidence
+
+	entityStateErr   error
+	predicateWalkErr error
+	temporalRangeErr error
+	bm25Err          error
+}
+
+func (f *fakeGraphQuery) EntityState(_ context.Context, _ EntityStateArgs, tier, source string, _ int) ([]research.Evidence, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entityStateCalls++
+	if f.entityStateErr != nil {
+		return nil, f.entityStateErr
+	}
+	return stampEvidence(f.entityStateOut, tier, source), nil
+}
+
+func (f *fakeGraphQuery) PredicateWalk(_ context.Context, _ PredicateWalkArgs, tier, source string, _ int) ([]research.Evidence, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.predicateWalkCalls++
+	if f.predicateWalkErr != nil {
+		return nil, f.predicateWalkErr
+	}
+	return stampEvidence(f.predicateWalkOut, tier, source), nil
+}
+
+func (f *fakeGraphQuery) TemporalRange(_ context.Context, _ TemporalRangeArgs, tier, source string, _ int) ([]research.Evidence, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.temporalRangeCalls++
+	if f.temporalRangeErr != nil {
+		return nil, f.temporalRangeErr
+	}
+	return stampEvidence(f.temporalRangeOut, tier, source), nil
+}
+
+func (f *fakeGraphQuery) BM25(_ context.Context, _ BM25Args, tier, source string, _ int) ([]research.Evidence, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bm25Calls++
+	if f.bm25Err != nil {
+		return nil, f.bm25Err
+	}
+	return stampEvidence(f.bm25Out, tier, source), nil
+}
+
+// stampEvidence applies the Tier + Source the GraphQueryClient
+// contract requires. Test fixtures supply Evidence with just
+// EntityID + Score (the discriminating fields); the contract-
+// stamping mirrors what production adapters do.
+func stampEvidence(in []research.Evidence, tier, source string) []research.Evidence {
+	out := make([]research.Evidence, len(in))
+	for i, e := range in {
+		e.Tier = tier
+		e.Source = source
+		out[i] = e
+	}
+	return out
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// --- extractLoopIDFromSubject ---
+
+func TestExtractLoopIDFromSubject(t *testing.T) {
+	cases := []struct {
+		name    string
+		subject string
+		want    string
+	}{
+		{"happy", "component.execute_subqueries.loop-1", "loop-1"},
+		{"wrong prefix", "component.nl_classify.loop-1", ""},
+		{"empty suffix", "component.execute_subqueries.", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractLoopIDFromSubject(c.subject); got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+// --- resolveSeedRefs ---
+
+func TestResolveSeedRefs_MixedRefTypes(t *testing.T) {
+	candidates := []research.Candidate{
+		{EntityID: "acme.ops.robotics.gcs.drone.001", Label: "Drone One", Tier: "0", Source: "x"},
+		{EntityID: "acme.ops.robotics.gcs.drone.002", Label: "Drone Two", Tier: "0", Source: "x"},
+		{EntityID: "acme.ops.industrial.factory.sensor.555", Label: "Sensor 555", Tier: "0", Source: "x"},
+	}
+	seeds := []research.SeedRef{
+		{Ref: "drone.001", RefType: research.SeedRefTypePartialID},
+		{Ref: "Sensor 555", RefType: research.SeedRefTypeName},
+		{Ref: "1", RefType: research.SeedRefTypeCandidateIndex},
+		{Ref: "missing", RefType: research.SeedRefTypePartialID}, // unresolved
+	}
+	resolved, dropped := resolveSeedRefs(seeds, candidates, quietLogger())
+	if len(resolved) != 3 {
+		t.Errorf("resolved = %v, want 3 entries", resolved)
+	}
+	if dropped != 1 {
+		t.Errorf("dropped = %d, want 1", dropped)
+	}
+	wantSet := map[string]bool{
+		"acme.ops.robotics.gcs.drone.001":        true,
+		"acme.ops.industrial.factory.sensor.555": true,
+		"acme.ops.robotics.gcs.drone.002":        true,
+	}
+	for _, id := range resolved {
+		if !wantSet[id] {
+			t.Errorf("unexpected resolved ID: %q", id)
+		}
+	}
+}
+
+func TestResolveSeedRefs_AllDropped(t *testing.T) {
+	resolved, dropped := resolveSeedRefs(
+		[]research.SeedRef{{Ref: "x", RefType: "unknown_type"}},
+		nil,
+		quietLogger())
+	if len(resolved) != 0 {
+		t.Errorf("resolved should be empty, got %v", resolved)
+	}
+	if dropped != 1 {
+		t.Errorf("dropped = %d, want 1", dropped)
+	}
+}
+
+// --- executeAll: orchestration ---
+
+func TestExecuteAll_HappyPath(t *testing.T) {
+	gq := &fakeGraphQuery{
+		entityStateOut:   []research.Evidence{{EntityID: "e1", Score: 0.9}},
+		predicateWalkOut: []research.Evidence{{EntityID: "e2", Score: 0.7}},
+		bm25Out:          []research.Evidence{{EntityID: "e3", Score: 0.5}},
+	}
+	queries := []SubQuery{
+		{Type: SubQueryTypeEntityState, Tier: "0", Source: "es", EntityState: &EntityStateArgs{EntityIDs: []string{"e1"}}},
+		{Type: SubQueryTypePredicateWalk, Tier: "0", Source: "pw", PredicateWalk: &PredicateWalkArgs{Seeds: []string{"e1"}}},
+		{Type: SubQueryTypeBM25, Tier: "1", Source: "bm", BM25: &BM25Args{Query: "q"}},
+	}
+	out, err := executeAll(context.Background(), gq, queries,
+		&research.Intent{Topic: "x", BudgetTokens: 10000},
+		research.ActionWalkSeeds, 4, 10, quietLogger())
+	if err != nil {
+		t.Fatalf("executeAll: %v", err)
+	}
+	if len(out.Evidence) != 3 {
+		t.Errorf("evidence count: got %d, want 3 (e1+e2+e3)", len(out.Evidence))
+	}
+	if out.SubQueryCount != 3 {
+		t.Errorf("subquery_count: got %d, want 3", out.SubQueryCount)
+	}
+	if out.Degraded {
+		t.Errorf("Degraded should be false on happy path: reason=%q", out.DegradedReason)
+	}
+	if out.BudgetTokensUsed <= 0 {
+		t.Errorf("budget_tokens_used should be > 0, got %d", out.BudgetTokensUsed)
+	}
+	if gq.entityStateCalls != 1 || gq.predicateWalkCalls != 1 || gq.bm25Calls != 1 {
+		t.Errorf("call counts: es=%d pw=%d bm=%d, want all 1", gq.entityStateCalls, gq.predicateWalkCalls, gq.bm25Calls)
+	}
+}
+
+func TestExecuteAll_PerSubqueryErrorIsDegrading(t *testing.T) {
+	gq := &fakeGraphQuery{
+		entityStateOut: []research.Evidence{{EntityID: "e1", Score: 0.9}},
+		bm25Err:        errors.New("BM25 down"),
+	}
+	queries := []SubQuery{
+		{Type: SubQueryTypeEntityState, Tier: "0", Source: "es", EntityState: &EntityStateArgs{EntityIDs: []string{"e1"}}},
+		{Type: SubQueryTypeBM25, Tier: "1", Source: "bm", BM25: &BM25Args{Query: "q"}},
+	}
+	out, err := executeAll(context.Background(), gq, queries,
+		&research.Intent{Topic: "x", BudgetTokens: 10000},
+		research.ActionDecompose, 4, 10, quietLogger())
+	if err != nil {
+		t.Fatalf("executeAll should not chain-fail on per-sub-query err: %v", err)
+	}
+	if !out.Degraded {
+		t.Error("Degraded should be true after BM25 error")
+	}
+	if !strings.Contains(out.DegradedReason, "bm25:bm failed") {
+		t.Errorf("degraded reason should name BM25 failure: %q", out.DegradedReason)
+	}
+	if len(out.Evidence) != 1 {
+		t.Errorf("evidence should still include EntityState hit despite BM25 failure: got %d, want 1", len(out.Evidence))
+	}
+}
+
+func TestExecuteAll_EmptyQueriesIsDegraded(t *testing.T) {
+	out, err := executeAll(context.Background(), &fakeGraphQuery{}, nil,
+		&research.Intent{Topic: "x"}, research.ActionWalkSeeds, 4, 10, quietLogger())
+	if err != nil {
+		t.Fatalf("executeAll: %v", err)
+	}
+	if !out.Degraded {
+		t.Error("Degraded should be true when materializer produced no queries")
+	}
+	if !strings.Contains(out.DegradedReason, "zero sub-queries") {
+		t.Errorf("degraded reason should explain empty queries: %q", out.DegradedReason)
+	}
+}
+
+// --- dedup ---
+
+func TestDedupEvidence_TierZeroWinsOverTierOne(t *testing.T) {
+	in := []research.Evidence{
+		{EntityID: "e1", Tier: "1", Source: "bm25", Score: 0.9}, // tier 1, high score
+		{EntityID: "e1", Tier: "0", Source: "es", Score: 0.3},   // tier 0, low score — should win
+		{EntityID: "e2", Tier: "0", Source: "pw", Score: 0.7},
+	}
+	out := dedupEvidence(in)
+	if len(out) != 2 {
+		t.Fatalf("dedup count: got %d, want 2", len(out))
+	}
+	var foundE1 research.Evidence
+	for _, e := range out {
+		if e.EntityID == "e1" {
+			foundE1 = e
+		}
+	}
+	if foundE1.Tier != "0" || foundE1.Source != "es" {
+		t.Errorf("dedup should pick Tier 0 e1, got %+v", foundE1)
+	}
+}
+
+func TestDedupEvidence_HigherScoreWinsWithinTier(t *testing.T) {
+	in := []research.Evidence{
+		{EntityID: "e1", Tier: "0", Source: "a", Score: 0.3},
+		{EntityID: "e1", Tier: "0", Source: "b", Score: 0.9}, // should win
+	}
+	out := dedupEvidence(in)
+	if len(out) != 1 {
+		t.Fatalf("dedup count: got %d, want 1", len(out))
+	}
+	if out[0].Source != "b" || out[0].Score != 0.9 {
+		t.Errorf("dedup should pick higher-score evidence within tier, got %+v", out[0])
+	}
+}
+
+func TestDedupEvidence_SkipsEmptyEntityID(t *testing.T) {
+	in := []research.Evidence{
+		{EntityID: "", Tier: "0", Source: "x"},
+		{EntityID: "e1", Tier: "0", Source: "x"},
+	}
+	out := dedupEvidence(in)
+	if len(out) != 1 {
+		t.Errorf("dedup should skip empty-ID evidence; got %d entries", len(out))
+	}
+}
+
+// --- sort ---
+
+func TestSortEvidence_TierThenScoreThenID(t *testing.T) {
+	ev := []research.Evidence{
+		{EntityID: "z", Tier: "1", Score: 0.9},
+		{EntityID: "a", Tier: "0", Score: 0.3},
+		{EntityID: "b", Tier: "0", Score: 0.9},
+		{EntityID: "c", Tier: "0", Score: 0.9},
+	}
+	sortEvidence(ev)
+	// Want: Tier 0 sorted by score-desc then ID-asc, then Tier 1.
+	wantOrder := []string{"b", "c", "a", "z"}
+	for i, want := range wantOrder {
+		if ev[i].EntityID != want {
+			t.Errorf("sortEvidence[%d]: got %q, want %q (full order: %v)", i, ev[i].EntityID, want, evIDs(ev))
+		}
+	}
+}
+
+func evIDs(ev []research.Evidence) []string {
+	out := make([]string, len(ev))
+	for i, e := range ev {
+		out[i] = e.EntityID
+	}
+	return out
+}
+
+// --- budget enforcement ---
+
+func TestEnforceBudget_DropsLowestRanked(t *testing.T) {
+	// 3 evidence entries, each ~5 tokens (estimateEvidenceTokens
+	// rough). Budget 8 should keep 1.
+	in := []research.Evidence{
+		{EntityID: "first", Tier: "0", Source: "src", SnippetText: "snip"},
+		{EntityID: "secnd", Tier: "0", Source: "src", SnippetText: "snip"},
+		{EntityID: "third", Tier: "0", Source: "src", SnippetText: "snip"},
+	}
+	out, used := enforceBudget(in, 8)
+	if len(out) < 1 || len(out) > 2 {
+		t.Errorf("budget enforcement should keep 1-2 evidence under tight budget; got %d (used=%d)", len(out), used)
+	}
+	if used > 8 {
+		t.Errorf("used %d exceeded budget 8", used)
+	}
+}
+
+func TestEnforceBudget_GenerousBudgetKeepsAll(t *testing.T) {
+	in := []research.Evidence{
+		{EntityID: "e1", Tier: "0", Source: "x"},
+		{EntityID: "e2", Tier: "1", Source: "x"},
+	}
+	out, _ := enforceBudget(in, 1_000_000)
+	if len(out) != 2 {
+		t.Errorf("generous budget should keep all evidence: got %d, want 2", len(out))
+	}
+}
+
+// --- concurrency ---
+
+func TestExecuteAll_ConcurrentDispatchUnderParallelismCap(t *testing.T) {
+	// 20 BM25 sub-queries — verify the orchestrator dispatches them
+	// all and returns aggregate evidence, with bounded parallelism.
+	gq := &countingDelayedGQ{delay: 5 * time.Millisecond}
+	queries := make([]SubQuery, 20)
+	for i := range queries {
+		queries[i] = SubQuery{
+			Type:   SubQueryTypeBM25,
+			Tier:   "1",
+			Source: "bm",
+			BM25:   &BM25Args{Query: "q"},
+		}
+	}
+	start := time.Now()
+	out, err := executeAll(context.Background(), gq, queries,
+		&research.Intent{Topic: "x", BudgetTokens: 100000},
+		research.ActionDecompose, 4, 10, quietLogger())
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("executeAll: %v", err)
+	}
+	if out.SubQueryCount != 20 {
+		t.Errorf("subquery_count: got %d, want 20", out.SubQueryCount)
+	}
+	// With parallelism=4 and per-query delay=5ms, expect roughly
+	// ceil(20/4)*5ms = 25ms. Generous upper bound 200ms guards
+	// against host-load flakiness while still catching a serial bug.
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("parallelism=4 with 20 5ms queries should complete < 200ms, took %v", elapsed)
+	}
+	// 20 calls all executed.
+	if calls := atomic.LoadInt64(&gq.calls); calls != 20 {
+		t.Errorf("BM25 call count: got %d, want 20", calls)
+	}
+}
+
+// countingDelayedGQ counts BM25 calls and sleeps to model network
+// delay so the concurrency test can assert parallel dispatch
+// behaviour without being purely timing-driven.
+type countingDelayedGQ struct {
+	calls int64
+	delay time.Duration
+}
+
+func (g *countingDelayedGQ) EntityState(_ context.Context, _ EntityStateArgs, _, _ string, _ int) ([]research.Evidence, error) {
+	return nil, nil
+}
+func (g *countingDelayedGQ) PredicateWalk(_ context.Context, _ PredicateWalkArgs, _, _ string, _ int) ([]research.Evidence, error) {
+	return nil, nil
+}
+func (g *countingDelayedGQ) TemporalRange(_ context.Context, _ TemporalRangeArgs, _, _ string, _ int) ([]research.Evidence, error) {
+	return nil, nil
+}
+func (g *countingDelayedGQ) BM25(_ context.Context, _ BM25Args, tier, source string, _ int) ([]research.Evidence, error) {
+	atomic.AddInt64(&g.calls, 1)
+	time.Sleep(g.delay)
+	return []research.Evidence{{EntityID: "e", Tier: tier, Source: source, Score: 0.5}}, nil
+}

--- a/processor/research-graph-execute/register.go
+++ b/processor/research-graph-execute/register.go
@@ -1,0 +1,20 @@
+package researchexecute
+
+import "github.com/c360studio/semstreams/component"
+
+// Register registers the execute_subqueries processor with the
+// supplied component registry. Called from componentregistry.Register
+// at process bootstrap so production binaries pick the component up
+// without extra wiring.
+func Register(registry *component.Registry) error {
+	return registry.RegisterWithConfig(component.RegistrationConfig{
+		Name:        ComponentName,
+		Factory:     NewProcessor,
+		Schema:      configSchema,
+		Type:        "processor",
+		Protocol:    "execute_subqueries",
+		Domain:      "research",
+		Description: "ADR-045 execute_subqueries: materialise sub-queries from RouteDecision intent + fan-out across Tier 0+1 retrieval + dedup + rank + budget. Emits ExecutionOutput for R3.",
+		Version:     "0.1.0",
+	})
+}

--- a/processor/research-graph-execute/subquery.go
+++ b/processor/research-graph-execute/subquery.go
@@ -1,0 +1,363 @@
+package researchexecute
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// SubQuery is a typed retrieval request. Component-internal —
+// reshapeable without cross-package churn if Phase 2 learns better
+// primitives. Each variant carries the minimum fields its tier
+// executor needs; the Type discriminator drives dispatch in
+// executeSubQuery.
+//
+// Tier and Source travel with the SubQuery so the per-tier executor
+// can stamp them onto every research.Evidence it produces without
+// re-deriving — keeps provenance honest end-to-end.
+type SubQuery struct {
+	Type   SubQueryType `json:"type"`
+	Tier   string       `json:"tier"`   // "0" (predicate) or "1" (BM25)
+	Source string       `json:"source"` // e.g. "walk_seeds:drone-001"; surfaces on Evidence.Source
+
+	// Per-type args. Exactly one is populated based on Type — the
+	// executor switch enforces. Optional fields allow tests + future
+	// templates to omit per-type primitives that don't apply.
+	EntityState   *EntityStateArgs   `json:"entity_state,omitempty"`
+	PredicateWalk *PredicateWalkArgs `json:"predicate_walk,omitempty"`
+	TemporalRange *TemporalRangeArgs `json:"temporal_range,omitempty"`
+	BM25          *BM25Args          `json:"bm25,omitempty"`
+}
+
+// SubQueryType is the closed set of Tier 0+1 primitives PR 4
+// ships. Phase 2 adds spatial_polygon + neural; Phase 1 stays
+// minimal.
+type SubQueryType string
+
+const (
+	// SubQueryTypeEntityState fetches current state of named
+	// entities. Tier 0; used for walk_seeds anchoring + decompose's
+	// entity_type axis when classifier candidates are present.
+	SubQueryTypeEntityState SubQueryType = "entity_state"
+
+	// SubQueryTypePredicateWalk traverses predicate(s) from seed
+	// entities. Tier 0; used for walk_seeds neighborhood expansion +
+	// decompose's free-form axis fallback.
+	SubQueryTypePredicateWalk SubQueryType = "predicate_walk"
+
+	// SubQueryTypeTemporalRange queries entities within a time
+	// window. Tier 0; used for decompose's time axis. Phase 1 ships
+	// the type but the executor falls through to BM25 on topic when
+	// graph-index-temporal isn't wired — operators see the
+	// "temporal degrade" hint on the produced Evidence.
+	SubQueryTypeTemporalRange SubQueryType = "temporal_range"
+
+	// SubQueryTypeBM25 text-searches via graph-query's existing
+	// BM25 surface. Tier 1; always added to widen coverage beyond
+	// purely-structural retrieval (intent-shaped routing can miss
+	// keyword matches the classifier surfaced).
+	SubQueryTypeBM25 SubQueryType = "bm25"
+)
+
+// EntityStateArgs carries IDs to fetch.
+type EntityStateArgs struct {
+	EntityIDs []string `json:"entity_ids"`
+}
+
+// PredicateWalkArgs carries seed IDs + optional predicate filter.
+// MaxHops 0 resolves to 1 at the executor.
+type PredicateWalkArgs struct {
+	Seeds      []string `json:"seeds"`
+	Predicates []string `json:"predicates,omitempty"`
+	MaxHops    int      `json:"max_hops,omitempty"`
+}
+
+// TemporalRangeArgs carries start/end + an optional topic filter.
+// Empty Topic widens to all entities in the window (may be heavy;
+// callers should always pass a topic in practice).
+type TemporalRangeArgs struct {
+	// Start / End are RFC3339 strings; component-internal so
+	// timezone handling stays in the executor where the upstream
+	// graph-index-temporal surface lives.
+	Start string `json:"start"`
+	End   string `json:"end"`
+	Topic string `json:"topic,omitempty"`
+}
+
+// BM25Args carries the text query + result cap.
+type BM25Args struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+// Validate returns a non-nil error when required per-type fields
+// are missing. Called by the materializer before fan-out so a
+// malformed sub-query surfaces before any retrieval work runs.
+func (q SubQuery) Validate() error {
+	if q.Tier != "0" && q.Tier != "1" {
+		return fmt.Errorf("subquery tier %q is not canonical (want \"0\" or \"1\")", q.Tier)
+	}
+	if strings.TrimSpace(q.Source) == "" {
+		return fmt.Errorf("subquery source required for provenance")
+	}
+	switch q.Type {
+	case SubQueryTypeEntityState:
+		if q.EntityState == nil || len(q.EntityState.EntityIDs) == 0 {
+			return fmt.Errorf("entity_state subquery: entity_ids required")
+		}
+	case SubQueryTypePredicateWalk:
+		if q.PredicateWalk == nil || len(q.PredicateWalk.Seeds) == 0 {
+			return fmt.Errorf("predicate_walk subquery: seeds required")
+		}
+	case SubQueryTypeTemporalRange:
+		if q.TemporalRange == nil || q.TemporalRange.Start == "" || q.TemporalRange.End == "" {
+			return fmt.Errorf("temporal_range subquery: start + end required")
+		}
+	case SubQueryTypeBM25:
+		if q.BM25 == nil || strings.TrimSpace(q.BM25.Query) == "" {
+			return fmt.Errorf("bm25 subquery: query required")
+		}
+	default:
+		return fmt.Errorf("subquery type %q is not a Phase 1 primitive", q.Type)
+	}
+	return nil
+}
+
+// materializeForWalkSeeds builds the sub-query set for a walk_seeds
+// decision. Strategy: (a) entity_state for the resolved seeds so
+// the caller sees the seeds themselves in the evidence; (b)
+// predicate_walk from those seeds for neighborhood expansion; (c)
+// a BM25 sub-query on the topic as Tier 1 coverage.
+//
+// resolvedSeeds must be the SeedRef-resolved full 6-part IDs from
+// resolveSeedRefs (handler.go); empty means resolve produced no
+// hits, in which case we ship only the BM25 fallback so the chain
+// doesn't return zero evidence.
+func materializeForWalkSeeds(intent *research.Intent, resolvedSeeds []string) []SubQuery {
+	var queries []SubQuery
+
+	if len(resolvedSeeds) > 0 {
+		queries = append(queries, SubQuery{
+			Type:        SubQueryTypeEntityState,
+			Tier:        "0",
+			Source:      "walk_seeds.entity_state",
+			EntityState: &EntityStateArgs{EntityIDs: append([]string(nil), resolvedSeeds...)},
+		})
+		queries = append(queries, SubQuery{
+			Type:   SubQueryTypePredicateWalk,
+			Tier:   "0",
+			Source: "walk_seeds.predicate_walk",
+			PredicateWalk: &PredicateWalkArgs{
+				Seeds:   append([]string(nil), resolvedSeeds...),
+				MaxHops: 1,
+			},
+		})
+	}
+
+	queries = append(queries, SubQuery{
+		Type:   SubQueryTypeBM25,
+		Tier:   "1",
+		Source: "walk_seeds.bm25_coverage",
+		BM25:   &BM25Args{Query: intent.Topic},
+	})
+
+	return queries
+}
+
+// materializeForDecompose builds the sub-query set for a decompose
+// decision per the MINIMAL TEMPLATE strategy (PR 4 scope per the
+// implementation plan):
+//
+//   - "entity_type" axis → entity_state on classifier candidates
+//     (when present) + BM25 on focus to surface entity-typed hits
+//     beyond the classifier's initial set.
+//   - "time" axis → temporal_range using a default ±24h window
+//     around now. Operators can extend in Phase 2 by parsing the
+//     focus string for explicit windows.
+//   - "predicate" axis OR any unknown axis → predicate_walk with
+//     no Seeds (executor falls through to a topic-anchored predicate
+//     query) + BM25 on focus.
+//
+// spatial axis is deferred to Phase 2 (graph-index-spatial wire);
+// surfaces a degraded-coverage log line if seen but ships the
+// per-decomposition BM25 anyway so the chain returns evidence.
+//
+// scope (narrow/medium/broad) caps how many candidate-entity IDs
+// flow into the entity_type template — narrow uses top 3, medium
+// top 8, broad top 20.
+//
+// candidates is the upstream ClassifierOutput.Candidates list (may
+// be empty if classifier returned nothing); used by the entity_type
+// template to anchor.
+func materializeForDecompose(intent *research.Intent, args research.DecomposeArgs, candidates []research.Candidate) []SubQuery {
+	var queries []SubQuery
+
+	scopeCap := decomposeCandidateCap(args.Scope)
+	candidateIDs := topCandidateIDs(candidates, scopeCap)
+
+	// Always include BM25 on the focus — widest-coverage Tier 1.
+	bm25Query := args.Focus
+	if strings.TrimSpace(bm25Query) == "" {
+		bm25Query = intent.Topic
+	}
+	queries = append(queries, SubQuery{
+		Type:   SubQueryTypeBM25,
+		Tier:   "1",
+		Source: "decompose.bm25_focus",
+		BM25:   &BM25Args{Query: bm25Query},
+	})
+
+	for _, axis := range args.Axes {
+		axisLower := strings.ToLower(strings.TrimSpace(axis))
+		switch axisLower {
+		case "entity_type", "entity":
+			if len(candidateIDs) > 0 {
+				queries = append(queries, SubQuery{
+					Type:        SubQueryTypeEntityState,
+					Tier:        "0",
+					Source:      "decompose.entity_type",
+					EntityState: &EntityStateArgs{EntityIDs: append([]string(nil), candidateIDs...)},
+				})
+			}
+		case "time", "temporal":
+			queries = append(queries, SubQuery{
+				Type:   SubQueryTypeTemporalRange,
+				Tier:   "0",
+				Source: "decompose.time",
+				TemporalRange: &TemporalRangeArgs{
+					// Phase 1: default ±24h window. Phase 2 parses
+					// explicit windows from focus.
+					Start: defaultTemporalWindowStart(),
+					End:   defaultTemporalWindowEnd(),
+					Topic: bm25Query,
+				},
+			})
+		case "predicate", "relationship":
+			if len(candidateIDs) > 0 {
+				queries = append(queries, SubQuery{
+					Type:   SubQueryTypePredicateWalk,
+					Tier:   "0",
+					Source: "decompose.predicate",
+					PredicateWalk: &PredicateWalkArgs{
+						Seeds:   append([]string(nil), candidateIDs...),
+						MaxHops: 1,
+					},
+				})
+			}
+		case "spatial":
+			// Phase 2 wire — skip with no template materialized.
+			// The component logs a degraded-coverage warning at
+			// dispatch; BM25 above keeps the chain productive.
+			continue
+		default:
+			// Fallback for free-form axes: a topic-anchored BM25 with
+			// the axis as a hint suffix. Cheap, never errors, gives
+			// the agent SOMETHING to work with.
+			queries = append(queries, SubQuery{
+				Type:   SubQueryTypeBM25,
+				Tier:   "1",
+				Source: "decompose.axis." + axisLower,
+				BM25:   &BM25Args{Query: bm25Query + " " + axisLower},
+			})
+		}
+	}
+
+	return queries
+}
+
+// decomposeCandidateCap maps decompose scope → candidate-set cap
+// for templates that anchor on classifier candidates. Empty scope
+// resolves to medium per the IsValidDecomposeScope contract.
+func decomposeCandidateCap(scope string) int {
+	switch scope {
+	case research.DecomposeScopeNarrow:
+		return 3
+	case research.DecomposeScopeBroad:
+		return 20
+	default: // "medium" or empty
+		return 8
+	}
+}
+
+// topCandidateIDs returns the first n candidate entity IDs from the
+// classifier output. Stable iteration order: the upstream
+// ClassifierOutput.Candidates is already produced in
+// relevance-descending order by nl_classify, so taking the prefix
+// is the right behaviour.
+func topCandidateIDs(candidates []research.Candidate, n int) []string {
+	if n <= 0 || len(candidates) == 0 {
+		return nil
+	}
+	out := make([]string, 0, n)
+	for _, c := range candidates {
+		if n > 0 && len(out) >= n {
+			break
+		}
+		if strings.TrimSpace(c.EntityID) == "" {
+			continue
+		}
+		out = append(out, c.EntityID)
+	}
+	return out
+}
+
+// defaultTemporalWindowStart / End produce an RFC3339-encoded ±24h
+// window around the wallclock. Package-level functions (not vars)
+// so tests can stub via a build-tag-gated override if needed; Phase 1
+// uses the real clock.
+func defaultTemporalWindowStart() string {
+	return nowRFC3339Offset(-24)
+}
+
+func defaultTemporalWindowEnd() string {
+	return nowRFC3339Offset(+24)
+}
+
+// nowFunc is overridable for tests. Wallclock-driven defaults
+// would otherwise make the materializer's output non-deterministic.
+var nowFunc = nowDefault
+
+// resolveSeedRefByCandidateIndex parses the ref as an int and
+// indexes into classifier candidates. Exported as helper for
+// tests; production callers go through resolveSeedRefs.
+func resolveSeedRefByCandidateIndex(ref string, candidates []research.Candidate) (string, error) {
+	idx, err := strconv.Atoi(strings.TrimSpace(ref))
+	if err != nil {
+		return "", fmt.Errorf("candidate_index ref %q is not an integer: %w", ref, err)
+	}
+	if idx < 0 || idx >= len(candidates) {
+		return "", fmt.Errorf("candidate_index ref %d out of bounds (have %d candidates)", idx, len(candidates))
+	}
+	id := strings.TrimSpace(candidates[idx].EntityID)
+	if id == "" {
+		return "", fmt.Errorf("candidate at index %d has empty entity_id", idx)
+	}
+	return id, nil
+}
+
+// resolveSeedRefByPartialID does suffix-match against the classifier
+// candidate IDs. The 6-part federated ID
+// org.platform.domain.system.type.instance means a partial
+// "robotics.gcs.drone" should match "acme.ops.robotics.gcs.drone.001".
+// Returns the FIRST candidate that has the partial as a suffix;
+// ties broken by relevance order (which candidates already supply).
+func resolveSeedRefByPartialID(ref string, candidates []research.Candidate) (string, error) {
+	needle := strings.TrimSpace(ref)
+	if needle == "" {
+		return "", fmt.Errorf("partial_id ref is empty")
+	}
+	for _, c := range candidates {
+		id := strings.TrimSpace(c.EntityID)
+		if id == "" {
+			continue
+		}
+		// Match either exact equality or the partial as a dot-bounded
+		// suffix to avoid accidental "drone" matching "octocopter-drone".
+		if id == needle || strings.HasSuffix(id, "."+needle) {
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("partial_id ref %q matched no classifier candidate", needle)
+}

--- a/processor/research-graph-execute/subquery_test.go
+++ b/processor/research-graph-execute/subquery_test.go
@@ -1,0 +1,318 @@
+package researchexecute
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// freezeClock pins nowFunc to a deterministic instant so
+// temporal-window assertions don't drift across test runs. Returns
+// a restore function for test cleanup.
+func freezeClock(t *testing.T, at time.Time) {
+	t.Helper()
+	orig := nowFunc
+	nowFunc = func() time.Time { return at }
+	t.Cleanup(func() { nowFunc = orig })
+}
+
+func TestSubQuery_Validate_HappyPaths(t *testing.T) {
+	cases := []SubQuery{
+		{Type: SubQueryTypeEntityState, Tier: "0", Source: "x", EntityState: &EntityStateArgs{EntityIDs: []string{"a"}}},
+		{Type: SubQueryTypePredicateWalk, Tier: "0", Source: "x", PredicateWalk: &PredicateWalkArgs{Seeds: []string{"a"}}},
+		{Type: SubQueryTypeTemporalRange, Tier: "0", Source: "x", TemporalRange: &TemporalRangeArgs{Start: "2026-06-02T00:00:00Z", End: "2026-06-03T00:00:00Z"}},
+		{Type: SubQueryTypeBM25, Tier: "1", Source: "x", BM25: &BM25Args{Query: "q"}},
+	}
+	for _, c := range cases {
+		t.Run(string(c.Type), func(t *testing.T) {
+			if err := c.Validate(); err != nil {
+				t.Errorf("Validate: %v", err)
+			}
+		})
+	}
+}
+
+func TestSubQuery_Validate_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		q       SubQuery
+		wantSub string
+	}{
+		{"bad tier", SubQuery{Type: SubQueryTypeBM25, Tier: "2", Source: "x", BM25: &BM25Args{Query: "q"}}, "tier"},
+		{"missing source", SubQuery{Type: SubQueryTypeBM25, Tier: "1", BM25: &BM25Args{Query: "q"}}, "source"},
+		{"entity_state missing ids", SubQuery{Type: SubQueryTypeEntityState, Tier: "0", Source: "x", EntityState: &EntityStateArgs{}}, "entity_ids"},
+		{"predicate_walk missing seeds", SubQuery{Type: SubQueryTypePredicateWalk, Tier: "0", Source: "x", PredicateWalk: &PredicateWalkArgs{}}, "seeds"},
+		{"temporal missing start", SubQuery{Type: SubQueryTypeTemporalRange, Tier: "0", Source: "x", TemporalRange: &TemporalRangeArgs{End: "x"}}, "start"},
+		{"bm25 empty query", SubQuery{Type: SubQueryTypeBM25, Tier: "1", Source: "x", BM25: &BM25Args{Query: "  "}}, "query"},
+		{"unknown type", SubQuery{Type: "neural", Tier: "0", Source: "x"}, "Phase 1 primitive"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.q.Validate()
+			if err == nil {
+				t.Fatalf("Validate = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("error %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
+// --- materializeForWalkSeeds ---
+
+func TestMaterializeForWalkSeeds_WithSeedsProducesThreeQueries(t *testing.T) {
+	intent := &research.Intent{Topic: "drone status"}
+	resolved := []string{"acme.ops.drone.001", "acme.ops.drone.002"}
+	queries := materializeForWalkSeeds(intent, resolved)
+	if len(queries) != 3 {
+		t.Fatalf("want 3 queries (entity_state + predicate_walk + bm25), got %d", len(queries))
+	}
+	// Validate each.
+	for i, q := range queries {
+		if err := q.Validate(); err != nil {
+			t.Errorf("query[%d] validate: %v", i, err)
+		}
+	}
+	// First should be entity_state with both seeds.
+	if queries[0].Type != SubQueryTypeEntityState {
+		t.Errorf("queries[0].Type = %q, want entity_state", queries[0].Type)
+	}
+	if len(queries[0].EntityState.EntityIDs) != 2 {
+		t.Errorf("entity_state ids: got %d, want 2", len(queries[0].EntityState.EntityIDs))
+	}
+	// Second should be predicate_walk.
+	if queries[1].Type != SubQueryTypePredicateWalk {
+		t.Errorf("queries[1].Type = %q, want predicate_walk", queries[1].Type)
+	}
+	// Third should be BM25 on topic.
+	if queries[2].Type != SubQueryTypeBM25 {
+		t.Errorf("queries[2].Type = %q, want bm25", queries[2].Type)
+	}
+	if queries[2].BM25.Query != "drone status" {
+		t.Errorf("bm25 query: got %q, want %q", queries[2].BM25.Query, "drone status")
+	}
+}
+
+func TestMaterializeForWalkSeeds_NoSeedsShipsBM25Only(t *testing.T) {
+	intent := &research.Intent{Topic: "x"}
+	queries := materializeForWalkSeeds(intent, nil)
+	if len(queries) != 1 {
+		t.Fatalf("want 1 query (bm25 fallback), got %d", len(queries))
+	}
+	if queries[0].Type != SubQueryTypeBM25 {
+		t.Errorf("fallback type = %q, want bm25", queries[0].Type)
+	}
+}
+
+// --- materializeForDecompose ---
+
+func TestMaterializeForDecompose_EntityTypeAxisAnchorsOnCandidates(t *testing.T) {
+	intent := &research.Intent{Topic: "x"}
+	args := research.DecomposeArgs{Axes: []string{"entity_type"}, Focus: "drones", Scope: research.DecomposeScopeMedium}
+	candidates := []research.Candidate{
+		{EntityID: "id-1", Tier: "0", Source: "x"},
+		{EntityID: "id-2", Tier: "0", Source: "x"},
+	}
+	queries := materializeForDecompose(intent, args, candidates)
+	// Should produce: BM25 (always) + entity_state (entity_type axis with candidates).
+	if len(queries) != 2 {
+		t.Fatalf("want 2 queries, got %d", len(queries))
+	}
+	var sawEntityState bool
+	for _, q := range queries {
+		if q.Type == SubQueryTypeEntityState {
+			sawEntityState = true
+			if len(q.EntityState.EntityIDs) != 2 {
+				t.Errorf("entity_state should have 2 candidate IDs, got %d", len(q.EntityState.EntityIDs))
+			}
+		}
+	}
+	if !sawEntityState {
+		t.Errorf("entity_type axis with candidates should produce entity_state subquery; got %+v", queries)
+	}
+}
+
+func TestMaterializeForDecompose_MultiAxisNoCandidatesShipsOnlyBM25(t *testing.T) {
+	// Multiple Tier 0 axes (entity_type + predicate) with no
+	// candidates to anchor — both branches must cleanly skip
+	// without emitting empty-args sub-queries that would trip
+	// Validate at executor dispatch. Only the universal BM25 fires.
+	intent := &research.Intent{Topic: "x"}
+	args := research.DecomposeArgs{Axes: []string{"entity_type", "predicate"}, Focus: "f"}
+	queries := materializeForDecompose(intent, args, nil)
+	if len(queries) != 1 || queries[0].Type != SubQueryTypeBM25 {
+		t.Errorf("multi-axis no-candidates should ship only BM25; got %+v", queries)
+	}
+}
+
+func TestMaterializeForDecompose_EntityTypeAxisNoCandidatesSkipsTier0(t *testing.T) {
+	intent := &research.Intent{Topic: "x"}
+	args := research.DecomposeArgs{Axes: []string{"entity_type"}, Focus: "drones"}
+	queries := materializeForDecompose(intent, args, nil)
+	// Only BM25 should fire (no Tier 0 anchor).
+	if len(queries) != 1 || queries[0].Type != SubQueryTypeBM25 {
+		t.Errorf("entity_type with no candidates should ship only BM25; got %+v", queries)
+	}
+}
+
+func TestMaterializeForDecompose_TimeAxisProducesTemporalRange(t *testing.T) {
+	// Freeze clock for deterministic window assertion.
+	freezeClock(t, time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC))
+	intent := &research.Intent{Topic: "x"}
+	args := research.DecomposeArgs{Axes: []string{"time"}, Focus: "events"}
+	queries := materializeForDecompose(intent, args, nil)
+	var temporal *SubQuery
+	for i := range queries {
+		if queries[i].Type == SubQueryTypeTemporalRange {
+			temporal = &queries[i]
+			break
+		}
+	}
+	if temporal == nil {
+		t.Fatal("time axis should produce temporal_range query")
+	}
+	// ±24h around frozen now: 2026-06-01T12 → 2026-06-03T12.
+	if !strings.HasPrefix(temporal.TemporalRange.Start, "2026-06-01T12:") {
+		t.Errorf("temporal start should be -24h from frozen now: %q", temporal.TemporalRange.Start)
+	}
+	if !strings.HasPrefix(temporal.TemporalRange.End, "2026-06-03T12:") {
+		t.Errorf("temporal end should be +24h from frozen now: %q", temporal.TemporalRange.End)
+	}
+}
+
+func TestMaterializeForDecompose_SpatialAxisDeferredButBM25Survives(t *testing.T) {
+	intent := &research.Intent{Topic: "drones at LAX"}
+	args := research.DecomposeArgs{Axes: []string{"spatial"}, Focus: "drone positions"}
+	queries := materializeForDecompose(intent, args, nil)
+	// spatial template defers — only the universal BM25 fires.
+	if len(queries) != 1 || queries[0].Type != SubQueryTypeBM25 {
+		t.Errorf("spatial deferred should ship only BM25; got %+v", queries)
+	}
+}
+
+func TestMaterializeForDecompose_UnknownAxisFallsBackToBM25(t *testing.T) {
+	intent := &research.Intent{Topic: "x"}
+	args := research.DecomposeArgs{Axes: []string{"weather"}, Focus: "f"}
+	queries := materializeForDecompose(intent, args, nil)
+	// Two BM25s: universal + axis-suffixed fallback.
+	bm25Count := 0
+	for _, q := range queries {
+		if q.Type == SubQueryTypeBM25 {
+			bm25Count++
+		}
+	}
+	if bm25Count != 2 {
+		t.Errorf("unknown axis should produce universal BM25 + axis-suffixed BM25; got %d BM25s in %+v", bm25Count, queries)
+	}
+}
+
+func TestMaterializeForDecompose_ScopeCapsCandidateAnchoring(t *testing.T) {
+	intent := &research.Intent{Topic: "x"}
+	candidates := make([]research.Candidate, 30)
+	for i := range candidates {
+		candidates[i] = research.Candidate{EntityID: "c-" + string(rune('a'+i)), Tier: "0", Source: "x"}
+	}
+	cases := []struct {
+		scope     string
+		wantCount int
+	}{
+		{research.DecomposeScopeNarrow, 3},
+		{research.DecomposeScopeMedium, 8},
+		{research.DecomposeScopeBroad, 20},
+		{"", 8}, // empty → medium
+	}
+	for _, c := range cases {
+		t.Run("scope_"+c.scope, func(t *testing.T) {
+			args := research.DecomposeArgs{Axes: []string{"entity_type"}, Focus: "f", Scope: c.scope}
+			queries := materializeForDecompose(intent, args, candidates)
+			for _, q := range queries {
+				if q.Type == SubQueryTypeEntityState {
+					if len(q.EntityState.EntityIDs) != c.wantCount {
+						t.Errorf("scope=%q: entity_state count = %d, want %d", c.scope, len(q.EntityState.EntityIDs), c.wantCount)
+					}
+					return
+				}
+			}
+			t.Errorf("scope=%q: no entity_state subquery produced", c.scope)
+		})
+	}
+}
+
+// --- seed reference resolvers ---
+
+func TestResolveSeedRefByCandidateIndex(t *testing.T) {
+	candidates := []research.Candidate{
+		{EntityID: "id-0", Tier: "0", Source: "x"},
+		{EntityID: "id-1", Tier: "0", Source: "x"},
+	}
+	cases := []struct {
+		name    string
+		ref     string
+		want    string
+		wantErr bool
+	}{
+		{"valid 0", "0", "id-0", false},
+		{"valid 1", "1", "id-1", false},
+		{"out of bounds", "5", "", true},
+		{"negative", "-1", "", true},
+		{"non-int", "abc", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveSeedRefByCandidateIndex(c.ref, candidates)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolveSeedRefByPartialID(t *testing.T) {
+	candidates := []research.Candidate{
+		{EntityID: "acme.ops.robotics.gcs.drone.001", Tier: "0", Source: "x"},
+		{EntityID: "acme.ops.robotics.gcs.drone.002", Tier: "0", Source: "x"},
+		{EntityID: "acme.ops.industrial.factory.sensor.555", Tier: "0", Source: "x"},
+	}
+	cases := []struct {
+		name    string
+		ref     string
+		want    string
+		wantErr bool
+	}{
+		{"suffix match", "drone.001", "acme.ops.robotics.gcs.drone.001", false},
+		{"longer suffix", "gcs.drone.002", "acme.ops.robotics.gcs.drone.002", false},
+		{"exact match", "acme.ops.industrial.factory.sensor.555", "acme.ops.industrial.factory.sensor.555", false},
+		{"no match", "octopus.tentacle.001", "", true},
+		{"empty", "", "", true},
+		{"ambiguous prefix match shouldn't fire as suffix", "robotics", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveSeedRefByPartialID(c.ref, candidates)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}

--- a/schemas/research-graph-execute.v1.json
+++ b/schemas/research-graph-execute.v1.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "research-graph-execute.v1.json",
+  "type": "object",
+  "title": "research-graph-execute Configuration",
+  "description": "ADR-045 execute_subqueries: materialise sub-queries from RouteDecision intent + fan-out across Tier 0+1 retrieval + dedup + rank + budget. Emits ExecutionOutput for R3.",
+  "properties": {
+    "loops_bucket": {
+      "type": "string",
+      "description": "NATS KV bucket holding research-pipeline loops and trigger/completion keys",
+      "default": "AGENT_LOOPS",
+      "category": "advanced"
+    },
+    "max_parallelism": {
+      "type": "integer",
+      "description": "Concurrent sub-query execution cap. Keeps fan-out from saturating gateways. 0 means default (8)",
+      "default": 8,
+      "maximum": 64,
+      "category": "advanced"
+    },
+    "max_results_per_subquery": {
+      "type": "integer",
+      "description": "Per-sub-query result count cap before ranking + budget enforcement. Prevents a runaway sub-query from dominating evidence. 0 means default (50)",
+      "default": 50,
+      "maximum": 500,
+      "category": "advanced"
+    },
+    "ports": {
+      "type": "string",
+      "description": "Port configuration. execute_subqueries requires one nats input subscribing to component.execute_subqueries.\u003e",
+      "category": "basic"
+    }
+  },
+  "required": [],
+  "x-component-metadata": {
+    "name": "research-graph-execute",
+    "type": "processor",
+    "protocol": "execute_subqueries",
+    "domain": "research",
+    "version": "0.1.0"
+  }
+}

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1264,6 +1264,7 @@ components:
                         - $ref: ../schemas/objectstore.v1.json
                         - $ref: ../schemas/otel-exporter.v1.json
                         - $ref: ../schemas/research-graph-classify.v1.json
+                        - $ref: ../schemas/research-graph-execute.v1.json
                         - $ref: ../schemas/research-graph-route.v1.json
                         - $ref: ../schemas/rule-processor.v1.json
                         - $ref: ../schemas/slim-bridge.v1.json

--- a/taskfiles/test.yml
+++ b/taskfiles/test.yml
@@ -50,10 +50,10 @@ tasks:
       - echo "[OK] Live LLM tests complete"
 
   live:gemini:
-    desc: Live round-trip against Gemini 3.x preview (needs GEMINI_API_KEY in .env)
+    desc: Live round-trip against Gemini 3.x preview (needs GEMINI_API_KEY in .env). Runs single-tool + parallel-tool gates (gh#194 regression coverage).
     cmds:
-      - echo "[LIVE] Gemini 3.x thought_signature round-trip..."
-      - go test -tags=live_llm -v -timeout 240s -run TestGemini3x_ThoughtSignature_RoundTrip ./processor/agentic-model/...
+      - echo "[LIVE] Gemini 3.x thought_signature round-trip (single + parallel tool)..."
+      - go test -tags=live_llm -v -timeout 360s -run TestGemini3x_ThoughtSignature ./processor/agentic-model/...
 
   live:ollama:
     desc: Live response_format integration against local Ollama (needs Ollama at :11434)


### PR DESCRIPTION
## Summary

gh#194 is the capture-side gap that gh#188's echo fix can't compensate for. On Gemini 3.x preview via OpenAI-compat, multi-tool responses arrive without `extra_content.google.thought_signature` on any tool_call; capture silently produces zero `ReasoningRecord`s; the echo path has nothing to emit; Gemini's request validator HTTP 400s the next turn with "missing thought_signature ... position 2" — exactly the error class gh#188 was meant to close.

The existing `live_llm` test would have caught this — but didn't, because of two weaknesses:

1. **Soft-warn on the contract it was meant to gate** — `if sig == "" { t.Logf(...) }` masked the empty-capture case as continue-and-see-what-happens.
2. **Single-tool only** — used `multiply` alone; Gemini's validator only rejects on multi-tool emissions where position 2+ lacks signature.

Both are instances of `[[feedback_warning_not_fail_masks_integration_drift]]` applied to a `live_llm` test. Sharpened `[[feedback_live_gate_catches_doc_derived]]` today with the soft-warn-vs-hard-fail + production-realistic-shape sub-rule.

## What this PR ships

- **Hard-fail** the existing `TestGemini3x_ThoughtSignature_RoundTrip` on `sig == ""`, with `GEMINI_ALLOW_EMPTY_SIG=1` escape hatch for non-3.x test models.
- **New `TestGemini3x_ThoughtSignature_ParallelToolCalls_RoundTrip`** — prompts for two independent tool calls (multiply + add), asserts EVERY captured ToolCall has a non-empty thought_signature (HARD FAIL), echoes both with tool results, verifies turn 2 is accepted. The gh#194 regression gate. Skips cleanly (vs failing) on single-tool responses so we don't get false negatives from model-behaviour variance.

**Not a wire-shape fix** — that requires live-API validation of the gh#194 hypothesis tree. This PR closes the test gap so the bug fails loudly on the next live gate run instead of silently re-shipping.

## Test plan

- [x] `go test -race ./processor/agentic-model/...` — clean (live tests are gated by `live_llm` build tag, don't run in regular suites)
- [x] `go vet -tags=live_llm ./...` — clean
- [x] `task lint` — 18 pre-existing warnings; zero new
- [ ] **Operator action**: run `go test -tags=live_llm -run TestGemini3x_ThoughtSignature ./processor/agentic-model/...` against this branch with `GEMINI_API_KEY` + `gemini-3-flash-preview` to confirm the gates now hard-fail (currently expected) — then either:
  - File the wire-shape fix (hypothesis 1/2/3 from gh#194 body), OR
  - Document the incompatibility + persona-side guidance (avoid parallel tools on Gemini 3.x OpenAI-compat).

## Hypothesis tree for the wire-shape fix (deferred)

1. Google's OpenAI-compat layer strips `extra_content` on response. Cheapest probe: curl direct.
2. Gemini 3.x emits signatures at step level, not per-tool-call. Probe: same as 1.
3. Missing request-side feature flag. Cheapest to fix if it exists.

The existing `project_gemini_3x_thought_signature_research.md` (22 days old) reports no DISABLE toggle, but the question for hypothesis 3 is ENABLE (response inclusion) — not addressed by that research.

## Discipline anchors

- `[[feedback_live_gate_catches_doc_derived]]` — sharpened today.
- `[[feedback_warning_not_fail_masks_integration_drift]]` — parent.
- `[[feedback_review_cadence_pre_commit]]` — PR #195 (ADR-045 PR 4) just demonstrated the same discipline catching three Critical wire-shape bugs pre-merge. Same class of failure being defended against here.

## Related

- gh#188 — the partial fix (echo path).
- gh#194 — the capture-side gap this PR's gates now catch.
- PR #195 — ADR-045 PR 4, currently open; this PR is unrelated but ships the same discipline-application pattern.
- semteams `90725a8` — bumps to beta.93 + reverts gemini-flash to 2.5/openai-compat as local workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)