### PR TITLE
feat(processor): assess_sufficiency + synthesize_answer (ADR-045 Phase 1 PR 5)

### DIFF
--- a/agentic/research/assessment_output.go
+++ b/agentic/research/assessment_output.go
@@ -1,0 +1,121 @@
+package research
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// AssessmentOutput is the assess_sufficiency component's emit
+// (ADR-045 Phase 1 PR 5): the sufficient/refine decision over the
+// upstream ExecutionOutput's evidence array. Phase 1's R3 rule
+// dispatches synthesize_answer when Sufficient is true and the
+// refine loop on R4 when Sufficient is false.
+//
+// Per feedback_llm_authored_predicates_rule_opaque, when this payload
+// is stamped onto loop entity triples the Rationale field's
+// triple-predicate is published with WithRuleOpaque(true). Rules
+// branch on the typed Sufficient boolean only.
+type AssessmentOutput struct {
+	// Topic echoes the originating Intent topic so downstream
+	// consumers and trajectory viewers don't have to re-fetch the
+	// intent payload for logging / display. Required.
+	Topic string `json:"topic"`
+
+	// Sufficient is the load-bearing decision. True means the
+	// evidence array is enough to synthesize a useful answer; R3 routes
+	// to synthesize. False means the chain should refine; R4 routes
+	// the RefinedQueries through another execute_subqueries pass.
+	Sufficient bool `json:"sufficient"`
+
+	// RefinedQueries is the refine path's payload — short natural-
+	// language sub-query strings the assessor believes would close the
+	// gap. Empty when Sufficient is true. The Phase 1 refine path
+	// concatenates these into a single hint set and re-runs nl_classify;
+	// Phase 2 may dispatch them as parallel typed sub-queries.
+	//
+	// The shape is deliberately stringy (not typed sub-queries) per
+	// feedback_tool_signature_intent_not_structure: the assessor model
+	// expresses gap intent, the backend constructs typed dispatches.
+	RefinedQueries []string `json:"refined_queries,omitempty"`
+
+	// Rationale is the assessor's natural-language justification for
+	// the decision. Captured for operator trajectory review; rule-
+	// opaque per discipline memory.
+	Rationale string `json:"rationale,omitempty"`
+
+	// Confidence is the assessor's confidence in the sufficiency
+	// decision (0..1). Optional — the assess prompt asks for it as
+	// observability; rules do not branch on it in Phase 1. Operator
+	// trajectory review uses it to spot prompts that flip flags
+	// with low conviction.
+	Confidence float64 `json:"confidence,omitempty"`
+
+	// EvidenceCount echoes len(ExecutionOutput.Evidence) the assessor
+	// saw. Observability — lets the operator confirm the assessor
+	// actually had evidence to read when it claimed Sufficient (a
+	// hallucinated Sufficient=true on EvidenceCount=0 is a prompt
+	// bug worth catching).
+	EvidenceCount int `json:"evidence_count,omitempty"`
+
+	// Degraded flags an assessment that couldn't run cleanly — e.g.
+	// the LLM call failed and the component fell back to a
+	// "Sufficient=false, refine with original intent" safety route,
+	// or upstream ExecutionOutput was missing. assess_sufficiency
+	// surfaces this so R3 / R4 can downgrade their next-stage
+	// confidence without stranding the chain on a hard abort.
+	Degraded       bool   `json:"degraded,omitempty"`
+	DegradedReason string `json:"degraded_reason,omitempty"`
+}
+
+// Schema implements message.Payload.
+func (p *AssessmentOutput) Schema() message.Type {
+	return message.Type{
+		Domain:   Domain,
+		Category: CategoryAssessmentOutput,
+		Version:  SchemaVersion,
+	}
+}
+
+// Validate implements message.Payload. Required: Topic. RefinedQueries
+// items are checked for non-empty strings when present (an empty
+// query string is an assessor-prompt bug). When Sufficient is true
+// RefinedQueries SHOULD be empty — the assessor shouldn't refine
+// what it just declared sufficient — but the check is a Warn at the
+// consuming component, not a Validate-time reject, so the chain
+// stays moving on imperfect assessor emits.
+func (p *AssessmentOutput) Validate() error {
+	if p == nil {
+		return fmt.Errorf("assessment output is nil")
+	}
+	if strings.TrimSpace(p.Topic) == "" {
+		return fmt.Errorf("topic required")
+	}
+	for i, q := range p.RefinedQueries {
+		if strings.TrimSpace(q) == "" {
+			return fmt.Errorf("refined_queries[%d] is empty", i)
+		}
+	}
+	if p.Confidence < 0 || p.Confidence > 1 {
+		return fmt.Errorf("confidence must be in [0,1], got %v", p.Confidence)
+	}
+	if p.EvidenceCount < 0 {
+		return fmt.Errorf("evidence_count must be >= 0, got %d", p.EvidenceCount)
+	}
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler with the alias-recursion guard.
+func (p *AssessmentOutput) MarshalJSON() ([]byte, error) {
+	type alias AssessmentOutput
+	return json.Marshal((*alias)(p))
+}
+
+// UnmarshalJSON implements json.Unmarshaler with the alias-recursion
+// guard.
+func (p *AssessmentOutput) UnmarshalJSON(data []byte) error {
+	type alias AssessmentOutput
+	return json.Unmarshal(data, (*alias)(p))
+}

--- a/agentic/research/constants.go
+++ b/agentic/research/constants.go
@@ -40,6 +40,12 @@ const (
 	// trigger key; assess_sufficiency (PR 5) consumes the payload
 	// to pick sufficient / refine.
 	CategoryExecutionOutput = "execution_output"
+
+	// CategoryAssessmentOutput is the assess_sufficiency component's
+	// emit (ADR-045 Phase 1 PR 5): the sufficient/refine decision
+	// over the upstream ExecutionOutput. R3 dispatches synthesize on
+	// Sufficient, refine on !Sufficient.
+	CategoryAssessmentOutput = "assessment_output"
 )
 
 // RouteAction values for RouteDecision.Action. Closed enum per ADR-045

--- a/agentic/research/register.go
+++ b/agentic/research/register.go
@@ -51,6 +51,13 @@ func RegisterPayloads(reg *payloadregistry.Registry) error {
 			Description: "ADR-045 execute_subqueries component output: dedup'd + ranked + budget-enforced evidence array + provenance",
 			Factory:     func() any { return &ExecutionOutput{} },
 		},
+		{
+			Domain:      Domain,
+			Category:    CategoryAssessmentOutput,
+			Version:     SchemaVersion,
+			Description: "ADR-045 assess_sufficiency component output: sufficient/refine decision + refined queries",
+			Factory:     func() any { return &AssessmentOutput{} },
+		},
 	}
 
 	var errs []error

--- a/agentic/research/roundtrip_test.go
+++ b/agentic/research/roundtrip_test.go
@@ -841,6 +841,155 @@ func TestExecutionOutput_ValidateRejectsInvalid(t *testing.T) {
 	}
 }
 
+// --- AssessmentOutput ---
+
+func TestAssessmentOutput_RoundTripThroughDecoder_Sufficient(t *testing.T) {
+	original := &research.AssessmentOutput{
+		Topic:         "drone-001 maintenance events in the last 24 hours",
+		Sufficient:    true,
+		Rationale:     "candidate set carries the maintenance event triple with a SnippetText line for the 14:32Z fault",
+		Confidence:    0.86,
+		EvidenceCount: 3,
+	}
+
+	envelope := message.NewBaseMessage(original.Schema(), original, "research-assessment-roundtrip-test")
+	wireBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(wireBytes)
+	if err != nil {
+		t.Fatalf("registry decode: %v\nwire: %s", err, wireBytes)
+	}
+	if got := decoded.Type(); got != original.Schema() {
+		t.Errorf("type: got %+v, want %+v", got, original.Schema())
+	}
+	got, ok := decoded.Payload().(*research.AssessmentOutput)
+	if !ok {
+		t.Fatalf("payload: got %T, want *research.AssessmentOutput", decoded.Payload())
+	}
+	if got.Topic != original.Topic {
+		t.Errorf("topic drift: got %q, want %q", got.Topic, original.Topic)
+	}
+	if !got.Sufficient {
+		t.Error("Sufficient lost on round-trip")
+	}
+	if got.Confidence != original.Confidence {
+		t.Errorf("confidence drift: got %v, want %v", got.Confidence, original.Confidence)
+	}
+	if got.EvidenceCount != original.EvidenceCount {
+		t.Errorf("evidence_count drift: got %d, want %d", got.EvidenceCount, original.EvidenceCount)
+	}
+	if got.Rationale != original.Rationale {
+		t.Errorf("rationale drift")
+	}
+	if len(got.RefinedQueries) != 0 {
+		t.Errorf("refined_queries should be empty for Sufficient=true; got %v", got.RefinedQueries)
+	}
+}
+
+func TestAssessmentOutput_RoundTripThroughDecoder_RefinePath(t *testing.T) {
+	original := &research.AssessmentOutput{
+		Topic:      "drone-001 status across the fleet",
+		Sufficient: false,
+		RefinedQueries: []string{
+			"battery alert frequency for drone-001 in the last 7 days",
+			"maintenance events on drone-001 that paged operations",
+		},
+		Rationale:     "evidence covers maintenance window but topic asks about fleet-wide status — need cross-drone slice",
+		Confidence:    0.42,
+		EvidenceCount: 2,
+	}
+	envelope := message.NewBaseMessage(original.Schema(), original, "test")
+	wireBytes, _ := json.Marshal(envelope)
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(wireBytes)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got, ok := decoded.Payload().(*research.AssessmentOutput)
+	if !ok {
+		t.Fatalf("payload: got %T", decoded.Payload())
+	}
+	if got.Sufficient {
+		t.Error("Sufficient drift: got true, want false")
+	}
+	if len(got.RefinedQueries) != 2 {
+		t.Fatalf("refined_queries len: got %d, want 2", len(got.RefinedQueries))
+	}
+	if got.RefinedQueries[0] != original.RefinedQueries[0] {
+		t.Errorf("refined_queries[0] drift")
+	}
+}
+
+func TestAssessmentOutput_DegradedRoundTrip(t *testing.T) {
+	original := &research.AssessmentOutput{
+		Topic:          "x",
+		Sufficient:     false,
+		Degraded:       true,
+		DegradedReason: "upstream execute.complete missing",
+	}
+	envelope := message.NewBaseMessage(original.Schema(), original, "test")
+	wireBytes, _ := json.Marshal(envelope)
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(wireBytes)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := decoded.Payload().(*research.AssessmentOutput)
+	if !got.Degraded {
+		t.Error("Degraded flag lost")
+	}
+	if got.DegradedReason != "upstream execute.complete missing" {
+		t.Errorf("degraded reason drift: %q", got.DegradedReason)
+	}
+}
+
+func TestAssessmentOutput_ValidateRejectsInvalid(t *testing.T) {
+	cases := []struct {
+		name    string
+		output  research.AssessmentOutput
+		wantSub string
+	}{
+		{
+			name:    "missing topic",
+			output:  research.AssessmentOutput{Sufficient: true},
+			wantSub: "topic",
+		},
+		{
+			name: "empty refined query",
+			output: research.AssessmentOutput{
+				Topic:          "x",
+				RefinedQueries: []string{"valid", "   "},
+			},
+			wantSub: "refined_queries[1]",
+		},
+		{
+			name:    "confidence out of range",
+			output:  research.AssessmentOutput{Topic: "x", Confidence: 1.5},
+			wantSub: "confidence",
+		},
+		{
+			name:    "negative evidence count",
+			output:  research.AssessmentOutput{Topic: "x", EvidenceCount: -1},
+			wantSub: "evidence_count",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.output.Validate()
+			if err == nil {
+				t.Fatalf("Validate = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("Validate error = %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
 // --- enum guards ---
 
 func TestIsValidSeedRefType(t *testing.T) {

--- a/componentregistry/register.go
+++ b/componentregistry/register.go
@@ -37,9 +37,11 @@ import (
 	jsongeneric "github.com/c360studio/semstreams/processor/json_generic"
 	jsonmap "github.com/c360studio/semstreams/processor/json_map"
 	oasfgenerator "github.com/c360studio/semstreams/processor/oasf-generator"
+	researchassess "github.com/c360studio/semstreams/processor/research-graph-assess"
 	researchclassify "github.com/c360studio/semstreams/processor/research-graph-classify"
 	researchexecute "github.com/c360studio/semstreams/processor/research-graph-execute"
 	researchroute "github.com/c360studio/semstreams/processor/research-graph-route"
+	researchsynthesize "github.com/c360studio/semstreams/processor/research-graph-synthesize"
 	"github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/storage/objectstore"
 )
@@ -201,9 +203,10 @@ func registerSemanticLayer(registry *component.Registry) error {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "graph-query component registration")
 	}
 
-	// Research graph chain (ADR-045): nl_classify + route_search +
-	// execute_subqueries stages. Subsequent PRs add assess_sufficiency
-	// and synthesize_answer.
+	// Research graph chain (ADR-045 Phase 1): five components wired
+	// in chain order — classify → route → execute → assess →
+	// synthesize. PR 6 wires the seven rules + reference flow that
+	// connect them.
 	if err := researchclassify.Register(registry); err != nil {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-classify component registration")
 	}
@@ -212,6 +215,12 @@ func registerSemanticLayer(registry *component.Registry) error {
 	}
 	if err := researchexecute.Register(registry); err != nil {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-execute component registration")
+	}
+	if err := researchassess.Register(registry); err != nil {
+		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-assess component registration")
+	}
+	if err := researchsynthesize.Register(registry); err != nil {
+		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "research-graph-synthesize component registration")
 	}
 
 	// Statistical/Semantic tier components (enabled via config)

--- a/model/registry.go
+++ b/model/registry.go
@@ -42,11 +42,24 @@ const (
 	// (ADR-045 Phase 1 PR 3) to make a single structured-emit routing
 	// decision per research operation: one of synthesize_directly /
 	// retighten / walk_seeds / decompose. First of the three research
-	// LLM-wrapping capabilities; assess_sufficiency (PR 5) and
-	// synthesize_answer (PR 5) will introduce CapabilityResearchAssessment
-	// and CapabilityResearchSynthesis as separate capabilities so
-	// operators can route each stage independently.
+	// LLM-wrapping capabilities; PR 5 introduces
+	// CapabilityResearchAssessment and CapabilityResearchSynthesis as
+	// separate capabilities so operators can route each stage
+	// independently.
 	CapabilityResearchRouting = "research_routing"
+	// CapabilityResearchAssessment is used by the assess_sufficiency
+	// component (ADR-045 Phase 1 PR 5) to decide whether the
+	// execute_subqueries evidence is sufficient to synthesize from, or
+	// whether the refine loop should retry with sharper sub-queries.
+	// Second of the three research LLM-wrapping capabilities.
+	CapabilityResearchAssessment = "research_assessment"
+	// CapabilityResearchSynthesis is used by the synthesize_answer
+	// component (ADR-045 Phase 1 PR 5) to compose the chain's terminal
+	// natural-language answer from the evidence array. Third of the
+	// three research LLM-wrapping capabilities; operators can route
+	// synthesis to a stronger model than routing/assessment when the
+	// answer quality matters more than the structural-decision speed.
+	CapabilityResearchSynthesis = "research_synthesis"
 )
 
 // ResolvedEndpoint holds the resolved connection details for a capability endpoint.

--- a/model/registry_test.go
+++ b/model/registry_test.go
@@ -1031,6 +1031,8 @@ func TestCapabilityConstants_Values(t *testing.T) {
 		{"layer_normalization", CapabilityLayerNormalization, "layer_normalization"},
 		{"anomaly_review", CapabilityAnomalyReview, "anomaly_review"},
 		{"research_routing", CapabilityResearchRouting, "research_routing"},
+		{"research_assessment", CapabilityResearchAssessment, "research_assessment"},
+		{"research_synthesis", CapabilityResearchSynthesis, "research_synthesis"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -1189,7 +1189,18 @@ func runWithBudget(ctx context.Context, budget time.Duration, fn func(context.Co
 
 	select {
 	case <-done:
-		return false
+		// fn returned. But "returned" is ambiguous when bctx was
+		// cancelled before/while fn ran — the goroutine may have
+		// observed bctx.Done() and returned promptly, which is the
+		// timed-out (or parent-cancelled) case, NOT a within-budget
+		// completion. When parent ctx is pre-cancelled, bctx is born
+		// cancelled and both channels become ready simultaneously;
+		// Go's select picks one at random, so without this check the
+		// function returns the wrong answer ~50% of the time on the
+		// pre-cancel path (caught by
+		// TestRunWithBudget_ParentContextCancellationPropagates
+		// flaking on CI). Inspect bctx to disambiguate.
+		return bctx.Err() != nil
 	case <-bctx.Done():
 		return true
 	}

--- a/processor/research-graph-assess/adapters.go
+++ b/processor/research-graph-assess/adapters.go
@@ -1,0 +1,141 @@
+package researchassess
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/graph/llm"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/payloadregistry"
+)
+
+// llmAssessorAdapter wraps a graph/llm.Client into the Assessor
+// interface. Production wires the OpenAI-compatible client resolved
+// from the model registry; tests inject a fake Assessor directly
+// into the Component and skip this adapter entirely.
+type llmAssessorAdapter struct {
+	client llm.Client
+}
+
+func newLLMAssessorAdapter(client llm.Client) *llmAssessorAdapter {
+	return &llmAssessorAdapter{client: client}
+}
+
+// Assess sends one ChatCompletion with deterministic settings
+// (temperature 0) so the same prompt produces the same JSON across
+// runs — important for trajectory replay + the structured-emit
+// contract. MaxTokens is bounded so a runaway response truncates
+// rather than blowing the budget.
+func (a *llmAssessorAdapter) Assess(ctx context.Context, systemPrompt, userPrompt string, maxResponseTokens int) (string, string, error) {
+	if a == nil || a.client == nil {
+		return "", "", errors.New("llm client not configured")
+	}
+	zero := 0.0
+	req := llm.ChatRequest{
+		SystemPrompt: systemPrompt,
+		UserPrompt:   userPrompt,
+		MaxTokens:    maxResponseTokens,
+		Temperature:  &zero,
+	}
+	resp, err := a.client.ChatCompletion(ctx, req)
+	if err != nil {
+		return "", "", fmt.Errorf("chat completion: %w", err)
+	}
+	return resp.Content, resp.FinishReason, nil
+}
+
+// natsLoopStore adapts natsclient.KVStore to the LoopStore interface.
+// Mirrors processor/research-graph-route's adapter — same
+// AGENT_LOOPS bucket, same payload-registry decode pattern.
+//
+// Key conventions:
+//
+//   - research.requested.<loopID>   (read; written by research_graph tool, PR 1)
+//   - execute.complete.<loopID>     (read; written by execute_subqueries, PR 4)
+//   - assess.complete.<loopID>      (write; R3 watches this — trigger)
+//   - assess.snapshot.<loopID>      (write; non-trigger queryable copy)
+type natsLoopStore struct {
+	kv      *natsclient.KVStore
+	decoder *message.Decoder
+}
+
+// newNATSLoopStore wires the LoopStore using the supplied KV store
+// and the process-wide payload registry. registry must be non-nil —
+// without it the upstream Intent + ExecutionOutput envelopes cannot
+// be decoded. The factory caller (NewProcessor) is responsible for
+// surfacing a nil-registry config error cleanly.
+func newNATSLoopStore(kv *natsclient.KVStore, registry *payloadregistry.Registry) *natsLoopStore {
+	return &natsLoopStore{
+		kv:      kv,
+		decoder: message.NewDecoder(registry),
+	}
+}
+
+// Key helpers — kept package-private; consumers reference the
+// conceptual operation, not the literal key shape, so a Phase 2
+// reorganisation of trigger naming doesn't ripple across packages.
+
+func loopStoreKeyIntent(loopID string) string          { return "research.requested." + loopID }
+func loopStoreKeyExecuteComplete(loopID string) string { return "execute.complete." + loopID }
+func loopStoreKeyAssessComplete(loopID string) string  { return "assess.complete." + loopID }
+func loopStoreKeyAssessSnapshot(loopID string) string  { return "assess.snapshot." + loopID }
+
+// GetIntent decodes the research_intent payload from the trigger
+// key. errIntentNotFound surfaces "key not found" so the handler can
+// log + drop without a retry storm.
+func (s *natsLoopStore) GetIntent(ctx context.Context, loopID string) (*research.Intent, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyIntent(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errIntentNotFound
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyIntent(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode intent: %w", err)
+	}
+	intent, ok := decoded.Payload().(*research.Intent)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.Intent", decoded.Payload())
+	}
+	return intent, nil
+}
+
+// GetExecutionOutput decodes the upstream ExecutionOutput from the
+// execute.complete trigger key.
+func (s *natsLoopStore) GetExecutionOutput(ctx context.Context, loopID string) (*research.ExecutionOutput, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyExecuteComplete(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errExecutionOutputNotFound
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyExecuteComplete(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode execution output: %w", err)
+	}
+	out, ok := decoded.Payload().(*research.ExecutionOutput)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.ExecutionOutput", decoded.Payload())
+	}
+	return out, nil
+}
+
+// PutAssessmentOutput writes the envelope at R3's trigger key.
+func (s *natsLoopStore) PutAssessmentOutput(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeyAssessComplete(loopID), envelope)
+	return err
+}
+
+// PutSnapshot writes the envelope at the stable snapshot key.
+// Best-effort: handler logs + continues on failure rather than
+// aborting the chain.
+func (s *natsLoopStore) PutSnapshot(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeyAssessSnapshot(loopID), envelope)
+	return err
+}

--- a/processor/research-graph-assess/component.go
+++ b/processor/research-graph-assess/component.go
@@ -1,0 +1,499 @@
+package researchassess
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph/llm"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/model"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// Component implements the assess_sufficiency processor. Same shape
+// as research-graph-route — lifecycle methods own the NATS / model-
+// registry plumbing and the per-message handler hands off to the
+// pure assessSufficiency function in handler.go.
+type Component struct {
+	config Config
+	deps   component.Dependencies
+	logger *slog.Logger
+
+	// Injected dependencies. Tests replace these directly via the
+	// constructor; production wires them via Start() from the
+	// natsclient + model registry on deps.
+	assessor Assessor
+	loops    LoopStore
+
+	// llmClient is the underlying graph/llm.Client owned by the
+	// adapter. Held here so Stop can close it cleanly. Nil when
+	// tests inject an Assessor fake directly.
+	llmClient llm.Client
+
+	// Lifecycle state. One mutex guards started/startTime so a
+	// concurrent Health / DataFlow read can't see a torn read of the
+	// lifecycle flag — same shape as research-graph-route.
+	mu        sync.RWMutex
+	started   bool
+	startTime time.Time
+	wg        sync.WaitGroup
+
+	subscriptions []*natsclient.Subscription
+
+	messagesProcessed int64
+	messagesEmitted   int64
+	errors            int64
+	lastActivity      atomic.Value // time.Time
+
+	lifecycleReporter component.LifecycleReporter
+}
+
+var (
+	_ component.Discoverable       = (*Component)(nil)
+	_ component.LifecycleComponent = (*Component)(nil)
+)
+
+// NewProcessor is the component-factory shape registered with the
+// component registry. Parses + validates config, applies defaults,
+// and constructs the Component with the injected production
+// adapters. The LLM assessor is wired in Start() because the model
+// registry isn't available at construction time.
+func NewProcessor(rawConfig json.RawMessage, deps component.Dependencies) (component.Discoverable, error) {
+	var config Config
+	if err := json.Unmarshal(rawConfig, &config); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config unmarshal")
+	}
+	if config.Ports == nil {
+		config = DefaultConfig()
+	}
+	config.ApplyDefaults()
+	if err := config.Validate(); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config validate")
+	}
+
+	if deps.NATSClient == nil {
+		return nil, errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "NewProcessor", "NATSClient required")
+	}
+
+	logger := deps.GetLoggerWithComponent(ComponentName)
+
+	return &Component{
+		config: config,
+		deps:   deps,
+		logger: logger,
+	}, nil
+}
+
+// Initialize is part of the LifecycleComponent contract. Nothing
+// pre-Start.
+func (c *Component) Initialize() error { return nil }
+
+// Start opens the AGENT_LOOPS bucket, wires the LLM assessor from the
+// model registry, subscribes to the configured input ports, and
+// reports idle.
+func (c *Component) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "Start", "context cannot be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return errs.WrapInvalid(err, ComponentName, "Start", "context already cancelled")
+	}
+
+	c.mu.Lock()
+	if c.started {
+		c.mu.Unlock()
+		return errs.WrapFatal(errs.ErrAlreadyStarted, ComponentName, "Start", "already started")
+	}
+	c.mu.Unlock()
+
+	if err := c.openLoopsBucket(ctx); err != nil {
+		return err
+	}
+	if err := c.initAssessor(); err != nil {
+		return err
+	}
+	if err := c.subscribeInputs(ctx); err != nil {
+		return err
+	}
+	c.startLifecycleReporter(ctx)
+
+	c.mu.Lock()
+	c.started = true
+	c.startTime = time.Now()
+	c.mu.Unlock()
+
+	if c.lifecycleReporter != nil {
+		if err := c.lifecycleReporter.ReportStage(ctx, "idle"); err != nil {
+			c.logger.Debug("failed to report idle stage", slog.Any("error", err))
+		}
+	}
+
+	c.logger.Info("assess_sufficiency component started",
+		slog.String("loops_bucket", c.config.LoopsBucket),
+		slog.Duration("assess_timeout", c.config.AssessTimeout),
+		slog.Int("max_evidence_in_prompt", c.config.MaxEvidenceInPrompt))
+	return nil
+}
+
+func (c *Component) openLoopsBucket(ctx context.Context) error {
+	if c.loops != nil {
+		return nil
+	}
+	bucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      c.config.LoopsBucket,
+		Description: "Agent loops bucket; shared with research-pipeline chain",
+		History:     10,
+		TTL:         24 * time.Hour,
+	})
+	if err != nil {
+		return errs.WrapTransient(err, ComponentName, "Start", "open loops bucket")
+	}
+	if c.deps.PayloadRegistry == nil {
+		return errs.WrapFatal(errs.ErrMissingConfig, ComponentName, "Start", "PayloadRegistry dependency required to decode research payloads")
+	}
+	store := c.deps.NATSClient.NewKVStore(bucket)
+	c.loops = newNATSLoopStore(store, c.deps.PayloadRegistry)
+	return nil
+}
+
+// initAssessor resolves the CapabilityResearchAssessment endpoint
+// from the model registry and wires an llmAssessorAdapter. Absent
+// capability is a startup error — assess_sufficiency has no
+// keyword-only fallback. Skips wiring when c.assessor is already
+// non-nil (test-injected).
+func (c *Component) initAssessor() error {
+	if c.assessor != nil {
+		return nil
+	}
+	if c.deps.ModelRegistry == nil {
+		return errs.WrapInvalid(errs.ErrMissingConfig, ComponentName, "Start",
+			"model registry required (capability "+model.CapabilityResearchAssessment+")")
+	}
+	resolved, ep, err := model.ResolveEndpointWithConfig(c.deps.ModelRegistry, model.CapabilityResearchAssessment)
+	if err != nil {
+		return errs.WrapInvalid(err, ComponentName, "Start",
+			"capability "+model.CapabilityResearchAssessment+" required")
+	}
+	timeout := model.ResolveCapabilityTimeout(c.deps.ModelRegistry, model.CapabilityResearchAssessment, c.config.AssessTimeout, c.logger)
+	if timeout > 0 {
+		c.config.AssessTimeout = timeout
+	}
+	cfg := llm.OpenAIConfigFromEndpoint(resolved, ep, c.logger)
+	cfg.Timeout = c.config.AssessTimeout
+	client, err := llm.NewOpenAIClient(cfg)
+	if err != nil {
+		return errs.WrapTransient(err, ComponentName, "Start", "construct LLM client")
+	}
+	c.llmClient = client
+	c.assessor = newLLMAssessorAdapter(client)
+	c.logger.Info("LLM assessor wired",
+		slog.String("model", resolved.Model),
+		slog.Duration("timeout", c.config.AssessTimeout))
+	return nil
+}
+
+func (c *Component) subscribeInputs(ctx context.Context) error {
+	for _, port := range c.config.Ports.Inputs {
+		if port.Subject == "" {
+			continue
+		}
+		if port.Type != "nats" {
+			c.logger.Warn("unsupported port type; skipping",
+				slog.String("port", port.Name),
+				slog.String("type", port.Type))
+			continue
+		}
+		sub, err := c.deps.NATSClient.Subscribe(ctx, port.Subject, func(msgCtx context.Context, msg *nats.Msg) {
+			c.handleMessage(msgCtx, msg.Subject, msg.Data)
+		})
+		if err != nil {
+			return errs.WrapTransient(err, ComponentName, "Start",
+				fmt.Sprintf("subscribe to %s", port.Subject))
+		}
+		c.subscriptions = append(c.subscriptions, sub)
+		c.logger.Debug("subscribed to NATS subject",
+			slog.String("port", port.Name),
+			slog.String("subject", port.Subject))
+	}
+	return nil
+}
+
+func (c *Component) startLifecycleReporter(ctx context.Context) {
+	statusBucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      "COMPONENT_STATUS",
+		Description: "Component lifecycle status tracking",
+	})
+	if err != nil {
+		c.logger.Warn("COMPONENT_STATUS bucket unavailable; lifecycle reporting disabled",
+			slog.Any("error", err))
+		c.lifecycleReporter = component.NewNoOpLifecycleReporter()
+		return
+	}
+	c.lifecycleReporter = component.NewLifecycleReporterFromConfig(component.LifecycleReporterConfig{
+		KV:               statusBucket,
+		ComponentName:    ComponentName,
+		Logger:           c.logger,
+		EnableThrottling: true,
+	})
+}
+
+// Stop drains subscriptions, closes the LLM client, and flips
+// `started` under c.mu.
+func (c *Component) Stop(timeout time.Duration) error {
+	c.mu.Lock()
+	if !c.started {
+		c.mu.Unlock()
+		return nil
+	}
+	c.started = false
+	c.mu.Unlock()
+
+	for _, sub := range c.subscriptions {
+		if sub == nil {
+			continue
+		}
+		if err := sub.Unsubscribe(); err != nil {
+			c.logger.Debug("unsubscribe failed during stop", slog.Any("error", err))
+		}
+	}
+	c.subscriptions = nil
+
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		c.logger.Warn("Stop timeout reached with handlers in flight",
+			slog.Duration("timeout", timeout))
+	}
+
+	if c.llmClient != nil {
+		if err := c.llmClient.Close(); err != nil {
+			c.logger.Debug("LLM client close failed during stop", slog.Any("error", err))
+		}
+		c.llmClient = nil
+	}
+	return nil
+}
+
+// handleMessage is the per-message hot path. Loads upstream Intent +
+// ExecutionOutput, runs assessSufficiency, writes the
+// AssessmentOutput envelope + assess.complete trigger key. Errors
+// are logged and counted; not propagated to NATS because the
+// publisher is fire-and-forget.
+//
+// Recovery contract:
+//   - Intent missing/error: hard abort. Without the intent topic we
+//     can't even populate a sensible degraded envelope.
+//   - ExecutionOutput missing: emit degraded envelope (Sufficient=
+//     false, Degraded=true, refined_queries empty) so R3 still
+//     fires — refine path runs as a safety net. The chain stays
+//     moving rather than stranding.
+//   - assessSufficiency failure (LLM error, parse failure): emit
+//     degraded envelope with the same shape. Trajectory review
+//     surfaces the failure cause via DegradedReason.
+func (c *Component) handleMessage(ctx context.Context, subject string, _ []byte) {
+	c.wg.Add(1)
+	defer c.wg.Done()
+	atomic.AddInt64(&c.messagesProcessed, 1)
+	c.lastActivity.Store(time.Now())
+
+	loopID := extractLoopIDFromSubject(subject)
+	if loopID == "" {
+		c.logger.Error("could not extract loop_id from subject; ignoring message",
+			slog.String("subject", subject))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	if c.config.AssessTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.config.AssessTimeout)
+		defer cancel()
+	}
+
+	intent, err := c.loops.GetIntent(ctx, loopID)
+	if err != nil {
+		c.logger.Error("could not load research intent; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	exec, err := c.loops.GetExecutionOutput(ctx, loopID)
+	if err != nil {
+		level := slog.LevelError
+		if errors.Is(err, errExecutionOutputNotFound) {
+			level = slog.LevelWarn
+		}
+		c.logger.Log(ctx, level, "could not load execution output; emitting degraded assessment",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		c.emitDegraded(ctx, loopID, intent.Topic, "execute.complete missing or undecodeable: "+err.Error())
+		return
+	}
+
+	assessment, err := assessSufficiency(ctx, c.assessor, intent, exec, c.config.MaxResponseTokens, c.config.MaxEvidenceInPrompt, c.config.MaxSnippetCharsInPrompt, c.logger)
+	if err != nil {
+		c.logger.Error("assess_sufficiency failed; emitting degraded assessment",
+			slog.String("loop_id", loopID),
+			slog.String("topic", intent.Topic),
+			slog.Any("error", err))
+		c.emitDegraded(ctx, loopID, intent.Topic, "assessor: "+err.Error())
+		return
+	}
+
+	c.writeAssessment(ctx, loopID, assessment)
+}
+
+// emitDegraded constructs and writes a safety-net AssessmentOutput
+// envelope (Sufficient=false, Degraded=true, RefinedQueries empty)
+// so R3 still fires and the chain doesn't strand. EvidenceCount is
+// zero — the assessor either didn't run or ran on missing input;
+// downstream consumers should treat the field as un-populated.
+func (c *Component) emitDegraded(ctx context.Context, loopID, topic, reason string) {
+	if topic == "" {
+		// Shouldn't happen — handleMessage hard-aborts on missing
+		// Intent — but defend so a future refactor doesn't ship an
+		// envelope that fails AssessmentOutput.Validate.
+		topic = "(unknown)"
+	}
+	out := &research.AssessmentOutput{
+		Topic:          topic,
+		Sufficient:     false,
+		Degraded:       true,
+		DegradedReason: reason,
+	}
+	c.writeAssessment(ctx, loopID, out)
+}
+
+// writeAssessment marshals and writes the assessment envelope. Used
+// by both the happy path and the degraded path so envelope
+// construction stays consistent (snapshot first for queryability,
+// then trigger key for R3).
+//
+// Validate runs before marshal even on the degraded path: emitDegraded
+// constructs Topic + Sufficient=false today, but a future change to
+// either the degraded shape or AssessmentOutput.Validate's rules
+// could ship a wire-invalid envelope silently. Surfacing the
+// validation failure as a logged-and-dropped emit keeps the contract
+// honest at the boundary.
+func (c *Component) writeAssessment(ctx context.Context, loopID string, out *research.AssessmentOutput) {
+	if err := out.Validate(); err != nil {
+		c.logger.Error("assessment output failed validation; refusing to emit",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+	envelope := message.NewBaseMessage(out.Schema(), out, ComponentName)
+	envelopeBytes, err := json.Marshal(envelope)
+	if err != nil {
+		c.logger.Error("marshal assessment output envelope failed",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	// Write snapshot first (queryable), then trigger key R3 watches.
+	// Order matches route_search's snapshot-then-trigger discipline so
+	// downstream readback can't miss the snapshot when R3 fires.
+	if err := c.loops.PutSnapshot(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Warn("snapshot write failed; chain continues but downstream readback may miss it",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+	}
+
+	if err := c.loops.PutAssessmentOutput(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Error("assess.complete trigger write failed; R3 will not fire",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	atomic.AddInt64(&c.messagesEmitted, 1)
+	c.logger.Info("assess_sufficiency emitted AssessmentOutput",
+		slog.String("loop_id", loopID),
+		slog.String("topic", out.Topic),
+		slog.Bool("sufficient", out.Sufficient),
+		slog.Int("refined_query_count", len(out.RefinedQueries)),
+		slog.Bool("degraded", out.Degraded))
+}
+
+// Meta implements Discoverable.
+func (c *Component) Meta() component.Metadata {
+	return component.Metadata{
+		Name:        ComponentName,
+		Type:        "processor",
+		Description: "ADR-045 assess_sufficiency: structured-emit sufficient/refine decision over upstream ExecutionOutput evidence. Drives R3's synthesize-or-refine branch.",
+		Version:     "0.1.0",
+	}
+}
+
+// InputPorts implements Discoverable.
+func (c *Component) InputPorts() []component.Port {
+	ports := make([]component.Port, 0, len(c.config.Ports.Inputs))
+	for _, p := range c.config.Ports.Inputs {
+		ports = append(ports, component.Port{
+			Name:      p.Name,
+			Direction: component.DirectionInput,
+			Required:  p.Required,
+			Config: component.NATSPort{
+				Subject: p.Subject,
+			},
+		})
+	}
+	return ports
+}
+
+// OutputPorts implements Discoverable. assess_sufficiency has no
+// NATS-publishing output port: emits are KV writes to AGENT_LOOPS.
+func (c *Component) OutputPorts() []component.Port { return []component.Port{} }
+
+// ConfigSchema implements Discoverable.
+func (c *Component) ConfigSchema() component.ConfigSchema { return configSchema }
+
+// Health implements Discoverable.
+func (c *Component) Health() component.HealthStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return component.HealthStatus{
+		Healthy:    c.started,
+		LastCheck:  time.Now(),
+		ErrorCount: int(atomic.LoadInt64(&c.errors)),
+		Uptime:     time.Since(c.startTime),
+	}
+}
+
+// DataFlow implements Discoverable.
+func (c *Component) DataFlow() component.FlowMetrics {
+	processed := atomic.LoadInt64(&c.messagesProcessed)
+	errCount := atomic.LoadInt64(&c.errors)
+	var errRate float64
+	if processed > 0 {
+		errRate = float64(errCount) / float64(processed)
+	}
+	last, _ := c.lastActivity.Load().(time.Time)
+	return component.FlowMetrics{
+		ErrorRate:    errRate,
+		LastActivity: last,
+	}
+}

--- a/processor/research-graph-assess/component_test.go
+++ b/processor/research-graph-assess/component_test.go
@@ -1,0 +1,223 @@
+package researchassess
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// fakeLoopStore replaces the natsLoopStore for handler integration
+// tests. Records all reads + writes so the test can assert on key
+// ordering, envelope shape, and miss vs hit paths.
+type fakeLoopStore struct {
+	mu sync.Mutex
+
+	intent    *research.Intent
+	intentErr error
+
+	exec    *research.ExecutionOutput
+	execErr error
+
+	getIntentCalls int
+	getExecCalls   int
+
+	snapshotEnvelope []byte
+	snapshotErr      error
+
+	assessEnvelope []byte
+	assessErr      error
+
+	writeOrder []string
+}
+
+func (s *fakeLoopStore) GetIntent(_ context.Context, _ string) (*research.Intent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getIntentCalls++
+	if s.intentErr != nil {
+		return nil, s.intentErr
+	}
+	return s.intent, nil
+}
+
+func (s *fakeLoopStore) GetExecutionOutput(_ context.Context, _ string) (*research.ExecutionOutput, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getExecCalls++
+	if s.execErr != nil {
+		return nil, s.execErr
+	}
+	return s.exec, nil
+}
+
+func (s *fakeLoopStore) PutSnapshot(_ context.Context, _ string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.snapshotEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "snapshot")
+	return s.snapshotErr
+}
+
+func (s *fakeLoopStore) PutAssessmentOutput(_ context.Context, _ string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.assessEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "assess_complete")
+	return s.assessErr
+}
+
+func newTestComponent(loops LoopStore, assessor Assessor) *Component {
+	return &Component{
+		config:   DefaultConfig(),
+		assessor: assessor,
+		loops:    loops,
+		logger:   quietLogger(),
+	}
+}
+
+func TestComponent_HandleMessage_SufficientHappyPath(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "drone-001 maintenance events"},
+		exec: &research.ExecutionOutput{
+			Topic:    "drone-001 maintenance events",
+			Action:   research.ActionWalkSeeds,
+			Evidence: []research.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x", Score: 0.9}},
+		},
+	}
+	a := &fakeAssessor{
+		content: `{"sufficient":true,"rationale":"covered","confidence":0.8}`,
+	}
+	c := newTestComponent(loops, a)
+	c.handleMessage(context.Background(), "component.assess_sufficiency.loop-xyz", nil)
+
+	if atomic.LoadInt64(&c.messagesProcessed) != 1 {
+		t.Errorf("messagesProcessed = %d, want 1", atomic.LoadInt64(&c.messagesProcessed))
+	}
+	if atomic.LoadInt64(&c.errors) != 0 {
+		t.Errorf("errors = %d, want 0", atomic.LoadInt64(&c.errors))
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if loops.getIntentCalls != 1 || loops.getExecCalls != 1 {
+		t.Errorf("read calls: intent=%d, exec=%d", loops.getIntentCalls, loops.getExecCalls)
+	}
+	if len(loops.writeOrder) != 2 || loops.writeOrder[0] != "snapshot" || loops.writeOrder[1] != "assess_complete" {
+		t.Errorf("write order = %v, want [snapshot assess_complete]", loops.writeOrder)
+	}
+	// Surface-level envelope assertions — payload-level decoding is
+	// covered in the round-trip tests in agentic/research. Here we
+	// just verify the wire bytes carry the expected fields.
+	if !strings.Contains(string(loops.assessEnvelope), `"sufficient":true`) {
+		t.Error("envelope should carry sufficient:true")
+	}
+	if !strings.Contains(string(loops.assessEnvelope), `"evidence_count":1`) {
+		t.Error("envelope should carry evidence_count:1 (echoes upstream Evidence len)")
+	}
+	if !strings.Contains(string(loops.assessEnvelope), `"topic":"drone-001 maintenance events"`) {
+		t.Error("envelope should carry topic echoed from intent")
+	}
+}
+
+func TestComponent_HandleMessage_RefinePath(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "fleet status"},
+		exec: &research.ExecutionOutput{
+			Topic:    "fleet status",
+			Action:   research.ActionDecompose,
+			Evidence: []research.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x"}},
+		},
+	}
+	a := &fakeAssessor{
+		content: `{"sufficient":false,"refined_queries":["all drones","alerts last 24h"],"confidence":0.4}`,
+	}
+	c := newTestComponent(loops, a)
+	c.handleMessage(context.Background(), "component.assess_sufficiency.loop-1", nil)
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("emitted = %d, want 1", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if !strings.Contains(string(loops.assessEnvelope), `"sufficient":false`) {
+		t.Error("envelope should carry sufficient:false")
+	}
+	if !strings.Contains(string(loops.assessEnvelope), "all drones") {
+		t.Error("envelope should carry refined_queries")
+	}
+}
+
+func TestComponent_HandleMessage_IgnoresBadSubject(t *testing.T) {
+	loops := &fakeLoopStore{}
+	a := &fakeAssessor{}
+	c := newTestComponent(loops, a)
+	c.handleMessage(context.Background(), "some.other.subject", nil)
+
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1 (bad-subject branch)", atomic.LoadInt64(&c.errors))
+	}
+	if loops.getIntentCalls != 0 {
+		t.Errorf("getIntentCalls = %d, want 0 (bad subject should short-circuit)", loops.getIntentCalls)
+	}
+	if a.called {
+		t.Error("assessor should not be called on bad subject")
+	}
+}
+
+func TestComponent_HandleMessage_IntentMissingHardAborts(t *testing.T) {
+	loops := &fakeLoopStore{intentErr: errIntentNotFound}
+	a := &fakeAssessor{}
+	c := newTestComponent(loops, a)
+	c.handleMessage(context.Background(), "component.assess_sufficiency.loop-1", nil)
+
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if len(loops.writeOrder) != 0 {
+		t.Errorf("intent missing should NOT emit envelope; writeOrder = %v", loops.writeOrder)
+	}
+	if a.called {
+		t.Error("assessor should not be called when intent missing")
+	}
+}
+
+func TestComponent_HandleMessage_ExecMissingEmitsDegraded(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:  &research.Intent{Topic: "x"},
+		execErr: errExecutionOutputNotFound,
+	}
+	a := &fakeAssessor{}
+	c := newTestComponent(loops, a)
+	c.handleMessage(context.Background(), "component.assess_sufficiency.loop-1", nil)
+
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1 (degraded envelope still emitted)", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if !strings.Contains(string(loops.assessEnvelope), `"degraded":true`) {
+		t.Error("envelope should carry degraded:true")
+	}
+	if !strings.Contains(string(loops.assessEnvelope), `"sufficient":false`) {
+		t.Error("degraded envelope should default sufficient:false (refine safety net)")
+	}
+	if a.called {
+		t.Error("assessor should not be called when exec missing")
+	}
+}
+
+func TestComponent_HandleMessage_AssessorErrorEmitsDegraded(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "x"},
+		exec:   &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose, Evidence: []research.Evidence{{EntityID: "e", Tier: "0", Source: "s"}}},
+	}
+	a := &fakeAssessor{content: `not a JSON object at all`}
+	c := newTestComponent(loops, a)
+	c.handleMessage(context.Background(), "component.assess_sufficiency.loop-1", nil)
+
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1 (degraded envelope on assessor failure)", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if !strings.Contains(string(loops.assessEnvelope), `"degraded":true`) {
+		t.Error("assessor-failure envelope should carry degraded:true")
+	}
+}

--- a/processor/research-graph-assess/config.go
+++ b/processor/research-graph-assess/config.go
@@ -1,0 +1,130 @@
+package researchassess
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+)
+
+// ComponentName is the canonical registry name + log subsystem.
+const ComponentName = "research-graph-assess"
+
+// Default knobs surfaced as exported constants so the prompt-builder
+// tests and operator docs can reference them by name rather than
+// duplicating literals.
+const (
+	// DefaultAssessTimeout caps the structured-emit LLM call.
+	// Generous enough for slower self-hosted endpoints; operators can
+	// tighten for faster hosted models.
+	DefaultAssessTimeout = 30 * time.Second
+
+	// DefaultMaxResponseTokens caps the LLM's response budget. The
+	// JSON-shaped output is small (decision + ~5 refined queries +
+	// rationale); 1024 covers the worst case across both decision
+	// paths.
+	DefaultMaxResponseTokens = 1024
+
+	// DefaultMaxEvidenceInPrompt caps how many ExecutionOutput
+	// evidence items the prompt embeds. The assessor doesn't need
+	// the full evidence array to decide — the top-N by score is
+	// enough — and a tight cap keeps the prompt fitting frontier-tier
+	// and small-model context windows alike.
+	DefaultMaxEvidenceInPrompt = 20
+
+	// DefaultMaxSnippetCharsInPrompt caps how many SnippetText
+	// characters render per evidence item in the prompt. Per-item
+	// rendering past this length truncates with an ellipsis. Keeps
+	// the prompt bounded when individual SnippetText fields are
+	// long.
+	DefaultMaxSnippetCharsInPrompt = 280
+)
+
+// Config holds operator-tunable knobs for the assess_sufficiency
+// component.
+//
+// LLM wiring follows the same model-registry capability seam as
+// route_search: operator declares CapabilityResearchAssessment in the
+// model registry; the component resolves it at Start() time. Absence
+// is a startup error — assess_sufficiency has no keyword-only
+// fallback (its entire job is the LLM judgment).
+type Config struct {
+	Ports *component.PortConfig `json:"ports,omitempty" schema:"type:ports,description:Port configuration. assess_sufficiency requires one nats input subscribing to component.assess_sufficiency.> ,category:basic"`
+
+	LoopsBucket string `json:"loops_bucket,omitempty" schema:"type:string,description:NATS KV bucket holding research-pipeline loops and trigger/completion keys,default:AGENT_LOOPS,category:advanced"`
+
+	AssessTimeout time.Duration `json:"assess_timeout,omitempty" schema:"type:duration,description:Timeout for the structured-emit LLM call. Honors capability.research_assessment override when set on the model registry,default:30s,category:advanced"`
+
+	MaxResponseTokens int `json:"max_response_tokens,omitempty" schema:"type:int,description:Cap on LLM response tokens. The JSON-shaped output is small; 1024 covers the worst case across decision paths,default:1024,max:4096,category:advanced"`
+
+	MaxEvidenceInPrompt int `json:"max_evidence_in_prompt,omitempty" schema:"type:int,description:Cap on number of ExecutionOutput evidence items embedded in the assessor prompt. Top-N by Score; tighter caps keep prompts within small-model context windows. 0 means default (20),default:20,max:100,category:advanced"`
+
+	MaxSnippetCharsInPrompt int `json:"max_snippet_chars_in_prompt,omitempty" schema:"type:int,description:Cap on per-evidence SnippetText characters rendered in the assessor prompt. 0 means default (280),default:280,max:2000,category:advanced"`
+}
+
+// Validate validates the configuration. Negative caps are rejected;
+// zero values fall through to ApplyDefaults (treated as "use
+// default").
+func (c *Config) Validate() error {
+	if c.Ports == nil || len(c.Ports.Inputs) == 0 {
+		return errors.New("ports configuration with at least one input port is required")
+	}
+	if c.MaxResponseTokens < 0 {
+		return errors.New("max_response_tokens must be >= 0")
+	}
+	if c.MaxEvidenceInPrompt < 0 {
+		return errors.New("max_evidence_in_prompt must be >= 0")
+	}
+	if c.MaxSnippetCharsInPrompt < 0 {
+		return errors.New("max_snippet_chars_in_prompt must be >= 0")
+	}
+	return nil
+}
+
+// ApplyDefaults fills in defaults for unset fields.
+func (c *Config) ApplyDefaults() {
+	if c.LoopsBucket == "" {
+		c.LoopsBucket = "AGENT_LOOPS"
+	}
+	if c.AssessTimeout == 0 {
+		c.AssessTimeout = DefaultAssessTimeout
+	}
+	if c.MaxResponseTokens == 0 {
+		c.MaxResponseTokens = DefaultMaxResponseTokens
+	}
+	if c.MaxEvidenceInPrompt == 0 {
+		c.MaxEvidenceInPrompt = DefaultMaxEvidenceInPrompt
+	}
+	if c.MaxSnippetCharsInPrompt == 0 {
+		c.MaxSnippetCharsInPrompt = DefaultMaxSnippetCharsInPrompt
+	}
+}
+
+// DefaultConfig returns a default Config skeleton with the standard
+// assess_sufficiency input port.
+func DefaultConfig() Config {
+	return Config{
+		Ports: &component.PortConfig{
+			Inputs: []component.PortDefinition{
+				{
+					Name:        "trigger",
+					Type:        "nats",
+					Subject:     "component.assess_sufficiency.>",
+					Required:    true,
+					Description: "R3's publish target. Subject suffix carries the research-pipeline loop_id.",
+				},
+			},
+			Outputs: []component.PortDefinition{},
+		},
+		LoopsBucket:             "AGENT_LOOPS",
+		AssessTimeout:           DefaultAssessTimeout,
+		MaxResponseTokens:       DefaultMaxResponseTokens,
+		MaxEvidenceInPrompt:     DefaultMaxEvidenceInPrompt,
+		MaxSnippetCharsInPrompt: DefaultMaxSnippetCharsInPrompt,
+	}
+}
+
+// configSchema is the static configuration schema, generated from
+// Config struct tags at package init.
+var configSchema = component.GenerateConfigSchema(reflect.TypeOf(Config{}))

--- a/processor/research-graph-assess/doc.go
+++ b/processor/research-graph-assess/doc.go
@@ -1,0 +1,47 @@
+// Package researchassess implements the assess_sufficiency component
+// from ADR-045 Phase 1 (PR 5 of six per
+// docs/operations/22-adr045-phase1-plan.md).
+//
+// assess_sufficiency is the second LLM-judgment stage of the graph-
+// search rule chain (after route_search). It receives a publish
+// trigger on component.assess_sufficiency.<loop_id>, reads the
+// upstream research.Intent + research.ExecutionOutput payloads from
+// AGENT_LOOPS, builds a structured-emit prompt, calls the configured
+// research_assessment LLM endpoint, parses the model's JSON output
+// into a research.AssessmentOutput, and writes the AssessmentOutput
+// envelope plus an assess.complete.<loop_id> trigger key that R3
+// (PR 6) watches to dispatch synthesize_answer (Sufficient=true) or
+// the refine loop (Sufficient=false).
+//
+// Architectural notes:
+//
+//   - LLM-wrapping component, not agent-wrapping. Direct LLM call via
+//     the configured CapabilityResearchAssessment endpoint; the chain
+//     does not delegate decision-making to a free-form ReAct loop.
+//
+//   - Prompt is structured per discipline memory
+//     feedback_persona_prose_needs_decision_criteria: per-decision
+//     framing for Sufficient vs Refine, concrete examples for the
+//     "looks adequate but isn't" trap, and negative-shape definition
+//     for Sufficient=true (when NOT to short-circuit).
+//
+//   - RefinedQueries are intent-shaped per
+//     feedback_tool_signature_intent_not_structure: the model emits
+//     short natural-language gap descriptors; the backend constructs
+//     typed dispatches downstream. The model is not asked to spell
+//     sub-query types it can't reliably produce.
+//
+//   - Per-loop ExecutionOutput sample is bounded by config
+//     (MaxEvidenceInPrompt) so the prompt stays within small-model
+//     context windows. Evidence is rendered with stable ordering
+//     (Score descending; ties broken by EntityID) so the same loop
+//     replayed produces byte-identical prompts.
+//
+//   - Authored Rationale predicate is rule-opaque per
+//     feedback_llm_authored_predicates_rule_opaque — rules branch on
+//     the typed Sufficient boolean only.
+//
+//   - All public methods are safe for concurrent use across loops;
+//     the component holds no per-call mutable state. Same pattern as
+//     research-graph-route + research-graph-execute.
+package researchassess

--- a/processor/research-graph-assess/handler.go
+++ b/processor/research-graph-assess/handler.go
@@ -1,0 +1,193 @@
+package researchassess
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/processor/research-graph-llmwrap"
+)
+
+// Assessor is the narrow LLM surface this component consumes.
+// Production satisfies it via llmAssessorAdapter wrapping a real
+// graph/llm.Client; tests substitute a fake that returns a
+// deterministic raw JSON response per scenario without standing up
+// any LLM infrastructure.
+//
+// Assess returns the raw response Content + a short reason string the
+// adapter can use for error diagnostics (model identifier, finish
+// reason, etc.). The handler parses the Content as JSON into an
+// AssessmentOutput and validates separately so prompt iteration and
+// response-shape drift surface as separate test failures.
+type Assessor interface {
+	Assess(ctx context.Context, systemPrompt, userPrompt string, maxResponseTokens int) (content string, reason string, err error)
+}
+
+// LoopStore is the AGENT_LOOPS read/write surface this component
+// consumes. Production wraps natsclient.KVStore; tests substitute an
+// in-memory map.
+type LoopStore interface {
+	// GetIntent loads the research_intent payload from the
+	// research.requested.<loopID> key. Returned for the prompt's
+	// topic + hints context.
+	GetIntent(ctx context.Context, loopID string) (*research.Intent, error)
+
+	// GetExecutionOutput loads the upstream ExecutionOutput from the
+	// execute.complete.<loopID> trigger key. The assessor needs the
+	// evidence array to decide sufficient / refine.
+	GetExecutionOutput(ctx context.Context, loopID string) (*research.ExecutionOutput, error)
+
+	// PutAssessmentOutput writes the AssessmentOutput envelope at R3's
+	// trigger key assess.complete.<loopID>.
+	PutAssessmentOutput(ctx context.Context, loopID string, envelope []byte) error
+
+	// PutSnapshot writes the envelope at a stable non-trigger key
+	// assess.snapshot.<loopID> so operators / downstream queryability
+	// can read the full assessment without racing R3's wildcard
+	// watcher.
+	PutSnapshot(ctx context.Context, loopID string, envelope []byte) error
+}
+
+// Sentinel errors. Returned for diagnostic clarity in handler logs
+// + so tests can assert specific failure modes via errors.Is.
+var (
+	errIntentNotFound          = fmt.Errorf("research intent not found")
+	errExecutionOutputNotFound = fmt.Errorf("execution output not found")
+)
+
+// extractLoopIDFromSubject pulls the loop_id off the NATS subject
+// component.assess_sufficiency.<loop_id>. Returns empty if the
+// subject doesn't match — handler treats empty as a routing-config
+// bug.
+//
+// Format is stable per ADR-045 §Rule chain — R3's publish action uses
+// `subject: "component.assess_sufficiency.{loop_id}"`. Any deviation
+// is a misconfigured rule, not a parsing problem.
+func extractLoopIDFromSubject(subject string) string {
+	const prefix = "component.assess_sufficiency."
+	if !strings.HasPrefix(subject, prefix) {
+		return ""
+	}
+	return subject[len(prefix):]
+}
+
+// assessSufficiency is the pure assessment function over injected
+// interfaces — no NATS plumbing leaks in here so the test matrix can
+// drive it through fakes.
+//
+// Returns a validated AssessmentOutput on success. The handler
+// surfaces Sufficient + RefinedQueries as a tuple, but a true
+// Sufficient with non-empty RefinedQueries surfaces a Warn (the
+// assessor shouldn't refine what it just declared sufficient — a
+// frontier-model action-confusion signal). Keeps Sufficient as the
+// load-bearing decision; rejecting would gate the chain on a
+// known-noisy frontier-model behaviour.
+//
+// logger is used only for defense-in-depth Warn lines. nil is
+// tolerated — falls back to slog.Default — so test callers can skip
+// logger plumbing.
+func assessSufficiency(ctx context.Context, assessor Assessor, intent *research.Intent, exec *research.ExecutionOutput, maxResponseTokens, maxEvidenceInPrompt, maxSnippetCharsInPrompt int, logger *slog.Logger) (*research.AssessmentOutput, error) {
+	if intent == nil {
+		return nil, fmt.Errorf("intent is nil")
+	}
+	if exec == nil {
+		return nil, fmt.Errorf("execution output is nil")
+	}
+	if assessor == nil {
+		return nil, fmt.Errorf("assessor is nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	systemPrompt := buildSystemPrompt()
+	userPrompt := buildUserPrompt(intent, exec, maxEvidenceInPrompt, maxSnippetCharsInPrompt)
+
+	rawContent, reason, err := assessor.Assess(ctx, systemPrompt, userPrompt, maxResponseTokens)
+	if err != nil {
+		return nil, fmt.Errorf("assessor call: %w", err)
+	}
+	if strings.TrimSpace(rawContent) == "" {
+		return nil, fmt.Errorf("assessor returned empty content (finish_reason=%q)", reason)
+	}
+
+	jsonBytes, err := llmwrap.ExtractJSON(rawContent)
+	if err != nil {
+		return nil, fmt.Errorf("extract JSON from assessor content: %w (raw=%q finish_reason=%q)", err, llmwrap.Truncate(rawContent, llmwrap.ErrPayloadTruncateBytes), reason)
+	}
+
+	// The wire shape is intentionally a subset of AssessmentOutput —
+	// the assessor doesn't emit Topic/EvidenceCount/Degraded; those
+	// are populated server-side from the upstream context. Decode
+	// into a narrow struct first to keep the LLM contract honest,
+	// then fold into the full payload.
+	var raw struct {
+		Sufficient     bool     `json:"sufficient"`
+		RefinedQueries []string `json:"refined_queries,omitempty"`
+		Rationale      string   `json:"rationale,omitempty"`
+		Confidence     float64  `json:"confidence,omitempty"`
+	}
+	if err := json.Unmarshal(jsonBytes, &raw); err != nil {
+		return nil, fmt.Errorf("decode assessment output: %w (raw=%q)", err, llmwrap.Truncate(string(jsonBytes), llmwrap.ErrPayloadTruncateBytes))
+	}
+
+	// Drop empty / whitespace-only refined queries the model may emit
+	// before validation reaches Validate. Empty strings here are
+	// frontier-model noise, not assessor intent; preserving them
+	// would block Validate downstream.
+	cleaned := raw.RefinedQueries[:0]
+	for _, q := range raw.RefinedQueries {
+		if strings.TrimSpace(q) != "" {
+			cleaned = append(cleaned, q)
+		}
+	}
+	raw.RefinedQueries = cleaned
+
+	// Clamp confidence to [0,1] silently — a frontier model emitting
+	// 1.05 or -0.1 is a known noise pattern; rejecting would gate the
+	// chain. Clamp keeps the typed field meaningful for trajectory
+	// review.
+	if raw.Confidence < 0 {
+		raw.Confidence = 0
+	}
+	if raw.Confidence > 1 {
+		raw.Confidence = 1
+	}
+
+	// Sufficient=true with non-empty RefinedQueries → Warn, keep
+	// Sufficient as the load-bearing decision. The downstream R3
+	// will route to synthesize on Sufficient; refine path won't see
+	// the queries.
+	if raw.Sufficient && len(raw.RefinedQueries) > 0 {
+		logger.Warn("Sufficient=true emitted with non-empty refined_queries; possible action confusion",
+			slog.Int("refined_query_count", len(raw.RefinedQueries)),
+			slog.String("rationale", llmwrap.Truncate(raw.Rationale, llmwrap.ErrPayloadTruncateBytes)))
+	}
+
+	// Sufficient=false with empty RefinedQueries → also Warn. The
+	// refine loop has nothing to dispatch; R4 will spin a no-op pass.
+	// Don't override Sufficient — let the operator catch the prompt
+	// shape via the Warn.
+	if !raw.Sufficient && len(raw.RefinedQueries) == 0 {
+		logger.Warn("Sufficient=false emitted with empty refined_queries; refine loop will no-op",
+			slog.String("rationale", llmwrap.Truncate(raw.Rationale, llmwrap.ErrPayloadTruncateBytes)))
+	}
+
+	out := &research.AssessmentOutput{
+		Topic:          intent.Topic,
+		Sufficient:     raw.Sufficient,
+		RefinedQueries: raw.RefinedQueries,
+		Rationale:      raw.Rationale,
+		Confidence:     raw.Confidence,
+		EvidenceCount:  len(exec.Evidence),
+		Degraded:       exec.Degraded,
+		DegradedReason: exec.DegradedReason,
+	}
+	if err := out.Validate(); err != nil {
+		return nil, fmt.Errorf("validate assessment output: %w", err)
+	}
+	return out, nil
+}

--- a/processor/research-graph-assess/handler_test.go
+++ b/processor/research-graph-assess/handler_test.go
@@ -1,0 +1,242 @@
+package researchassess
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// fakeAssessor returns canned content / error per scenario. Records
+// the system+user prompts it was called with so prompt-shape tests
+// can verify wiring without running the LLM.
+type fakeAssessor struct {
+	mu         sync.Mutex
+	called     bool
+	gotSystem  string
+	gotUser    string
+	gotMaxToks int
+	content    string
+	reason     string
+	err        error
+}
+
+func (f *fakeAssessor) Assess(_ context.Context, system, user string, maxTokens int) (string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called = true
+	f.gotSystem = system
+	f.gotUser = user
+	f.gotMaxToks = maxTokens
+	return f.content, f.reason, f.err
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestExtractLoopIDFromSubject(t *testing.T) {
+	cases := []struct {
+		name    string
+		subject string
+		want    string
+	}{
+		{"happy", "component.assess_sufficiency.loop-abc", "loop-abc"},
+		{"empty suffix", "component.assess_sufficiency.", ""},
+		{"wrong prefix", "component.route_search.loop-abc", ""},
+		{"random", "some.other.subject", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractLoopIDFromSubject(c.subject); got != c.want {
+				t.Errorf("extractLoopIDFromSubject(%q) = %q, want %q", c.subject, got, c.want)
+			}
+		})
+	}
+}
+
+// --- assessSufficiency happy paths ---
+
+func TestAssessSufficiency_SufficientPath(t *testing.T) {
+	a := &fakeAssessor{
+		content: `{"sufficient":true,"rationale":"evidence covers all named actors","confidence":0.82}`,
+	}
+	intent := &research.Intent{Topic: "drone-001 maintenance events"}
+	exec := &research.ExecutionOutput{
+		Topic:  "drone-001 maintenance events",
+		Action: research.ActionWalkSeeds,
+		Evidence: []research.Evidence{
+			{EntityID: "drone-001", Tier: "0", Source: "walk_seeds.entity_state", Score: 0.9, SnippetText: "Drone 001 maintenance window 14:32Z"},
+		},
+	}
+	got, err := assessSufficiency(context.Background(), a, intent, exec, 1024, 20, 280, quietLogger())
+	if err != nil {
+		t.Fatalf("assessSufficiency: %v", err)
+	}
+	if !got.Sufficient {
+		t.Error("Sufficient = false, want true")
+	}
+	if got.Topic != intent.Topic {
+		t.Errorf("topic = %q, want %q", got.Topic, intent.Topic)
+	}
+	if got.EvidenceCount != 1 {
+		t.Errorf("EvidenceCount = %d, want 1 (echoes len(exec.Evidence))", got.EvidenceCount)
+	}
+	if got.Confidence != 0.82 {
+		t.Errorf("Confidence = %v, want 0.82", got.Confidence)
+	}
+	if !a.called {
+		t.Error("assessor not called")
+	}
+	if a.gotMaxToks != 1024 {
+		t.Errorf("maxTokens = %d, want 1024", a.gotMaxToks)
+	}
+	if !strings.Contains(a.gotUser, "drone-001 maintenance events") {
+		t.Errorf("user prompt missing topic: %q", a.gotUser)
+	}
+}
+
+func TestAssessSufficiency_RefinePath(t *testing.T) {
+	a := &fakeAssessor{
+		content: `{"sufficient":false,"refined_queries":["fleet-wide drone status","battery alerts last 24h"],"rationale":"topic spans fleet but evidence is drone-001 only","confidence":0.4}`,
+	}
+	intent := &research.Intent{Topic: "drone status across the fleet"}
+	exec := &research.ExecutionOutput{
+		Topic:    "drone status across the fleet",
+		Action:   research.ActionWalkSeeds,
+		Evidence: []research.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x"}},
+	}
+	got, err := assessSufficiency(context.Background(), a, intent, exec, 1024, 20, 280, quietLogger())
+	if err != nil {
+		t.Fatalf("assessSufficiency: %v", err)
+	}
+	if got.Sufficient {
+		t.Error("Sufficient = true, want false")
+	}
+	if len(got.RefinedQueries) != 2 {
+		t.Fatalf("RefinedQueries len = %d, want 2", len(got.RefinedQueries))
+	}
+	if got.RefinedQueries[0] != "fleet-wide drone status" {
+		t.Errorf("RefinedQueries[0] drift: %q", got.RefinedQueries[0])
+	}
+}
+
+func TestAssessSufficiency_DropsEmptyRefinedQueries(t *testing.T) {
+	a := &fakeAssessor{
+		content: `{"sufficient":false,"refined_queries":["valid","","   ","also valid"]}`,
+	}
+	got, err := assessSufficiency(context.Background(), a,
+		&research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose},
+		1024, 20, 280, quietLogger())
+	if err != nil {
+		t.Fatalf("assessSufficiency: %v", err)
+	}
+	if len(got.RefinedQueries) != 2 {
+		t.Fatalf("RefinedQueries after clean = %d, want 2 (empty + whitespace dropped)", len(got.RefinedQueries))
+	}
+	if got.RefinedQueries[0] != "valid" || got.RefinedQueries[1] != "also valid" {
+		t.Errorf("RefinedQueries content drift: %v", got.RefinedQueries)
+	}
+}
+
+func TestAssessSufficiency_ClampsConfidence(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want float64
+	}{
+		{"over one", `{"sufficient":true,"confidence":1.5}`, 1.0},
+		{"negative", `{"sufficient":false,"refined_queries":["x"],"confidence":-0.1}`, 0.0},
+		{"valid mid", `{"sufficient":true,"confidence":0.5}`, 0.5},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a := &fakeAssessor{content: c.raw}
+			got, err := assessSufficiency(context.Background(), a,
+				&research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose},
+				1024, 20, 280, quietLogger())
+			if err != nil {
+				t.Fatalf("assessSufficiency: %v", err)
+			}
+			if got.Confidence != c.want {
+				t.Errorf("Confidence = %v, want %v", got.Confidence, c.want)
+			}
+		})
+	}
+}
+
+func TestAssessSufficiency_PropagatesDegradedFromExec(t *testing.T) {
+	a := &fakeAssessor{
+		content: `{"sufficient":false,"refined_queries":["x"],"rationale":"degraded retrieval"}`,
+	}
+	exec := &research.ExecutionOutput{
+		Topic:          "x",
+		Action:         research.ActionDecompose,
+		Degraded:       true,
+		DegradedReason: "spatial axis deferred to Phase 2",
+	}
+	got, err := assessSufficiency(context.Background(), a,
+		&research.Intent{Topic: "x"}, exec, 1024, 20, 280, quietLogger())
+	if err != nil {
+		t.Fatalf("assessSufficiency: %v", err)
+	}
+	if !got.Degraded {
+		t.Error("Degraded should propagate from upstream ExecutionOutput")
+	}
+	if got.DegradedReason != exec.DegradedReason {
+		t.Errorf("DegradedReason drift: got %q, want %q", got.DegradedReason, exec.DegradedReason)
+	}
+}
+
+// --- assessSufficiency error paths ---
+
+func TestAssessSufficiency_RejectsAssessorError(t *testing.T) {
+	a := &fakeAssessor{err: errors.New("upstream 503")}
+	_, err := assessSufficiency(context.Background(), a,
+		&research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose},
+		1024, 20, 280, quietLogger())
+	if err == nil || !strings.Contains(err.Error(), "assessor call") {
+		t.Fatalf("want assessor-call error, got %v", err)
+	}
+}
+
+func TestAssessSufficiency_RejectsEmptyContent(t *testing.T) {
+	a := &fakeAssessor{content: "   ", reason: "length"}
+	_, err := assessSufficiency(context.Background(), a,
+		&research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose},
+		1024, 20, 280, quietLogger())
+	if err == nil || !strings.Contains(err.Error(), "empty content") {
+		t.Fatalf("want empty-content error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "length") {
+		t.Errorf("error should include finish_reason: %v", err)
+	}
+}
+
+func TestAssessSufficiency_RejectsMalformedJSON(t *testing.T) {
+	a := &fakeAssessor{content: `I cannot make a decision today.`}
+	_, err := assessSufficiency(context.Background(), a,
+		&research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose},
+		1024, 20, 280, quietLogger())
+	if err == nil || !strings.Contains(err.Error(), "extract JSON") {
+		t.Fatalf("want extract-JSON error, got %v", err)
+	}
+}
+
+func TestAssessSufficiency_NilGuards(t *testing.T) {
+	a := &fakeAssessor{content: `{"sufficient":true}`}
+	if _, err := assessSufficiency(context.Background(), a, nil, &research.ExecutionOutput{Topic: "x"}, 1024, 20, 280, nil); err == nil {
+		t.Error("want intent-nil error")
+	}
+	if _, err := assessSufficiency(context.Background(), a, &research.Intent{Topic: "x"}, nil, 1024, 20, 280, nil); err == nil {
+		t.Error("want exec-nil error")
+	}
+	if _, err := assessSufficiency(context.Background(), nil, &research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x"}, 1024, 20, 280, nil); err == nil {
+		t.Error("want assessor-nil error")
+	}
+}

--- a/processor/research-graph-assess/prompt.go
+++ b/processor/research-graph-assess/prompt.go
@@ -1,0 +1,176 @@
+package researchassess
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// buildSystemPrompt returns the static system message that frames the
+// assessor's role + decision criteria + output contract. Stable across
+// requests so per-loop prompt changes don't ripple into a system-
+// message change (and any per-tenant cache stays warm).
+//
+// Discipline: every guidance sentence carries a "when to use" criterion
+// per feedback_persona_prose_needs_decision_criteria. No magic-number
+// thresholds (no "if score < 0.6 → refine"); decision-axis framing
+// instead so the model picks via reasoning, not lookup. Concrete
+// examples for the two non-obvious failure shapes (looks-adequate-
+// but-isn't, looks-sparse-but-is). Negative-shape for Sufficient=true
+// so the model doesn't default to it when uncertain.
+func buildSystemPrompt() string {
+	return `You are the sufficiency-assessment stage of a graph-search pipeline. You receive a research topic and the upstream evidence the retrieval stages surfaced. You decide ONE thing: is the evidence enough to write a useful answer, or does the chain need to refine and retrieve more?
+
+You do not synthesize the answer. You only judge whether one CAN be written from what's present.
+
+# The two decisions
+
+## sufficient: true
+Use when the evidence array carries enough material to ground a useful answer to the topic. The downstream synthesizer will quote the evidence directly — your standard is "would a careful writer have enough here to write an answer without inventing facts?"
+
+Decision axis: do the evidence items COVER the topic's named actors, time scope, and asked-about properties? If yes, sufficient.
+
+Negative shape — do NOT default to sufficient=true when uncertain. It short-circuits the refine loop. If the evidence is thin (one entity when the topic asks about many; one tier when the topic spans structures the other tier should have caught), and you can name a SPECIFIC gap a refined query would close, route to sufficient=false.
+
+Example of looks-adequate-but-isn't: topic is "drone-001 status across the fleet"; evidence contains three rich entries about drone-001 alone. The fleet view is missing — refine.
+
+## sufficient: false (refine)
+Use when there is a specific gap a sharper sub-query would close. Emit "refined_queries" — short natural-language descriptions of what to fetch next. The backend constructs typed sub-queries from your descriptions; do not emit typed sub-query objects yourself.
+
+Decision axis: can you name 1-5 specific MISSING pieces? If yes, refine and list them. If you cannot name what is missing, route to sufficient=true even on thin evidence — the refine loop cannot work blind.
+
+Example of looks-sparse-but-is: topic is "what is the warmest temperature the engine reached last hour"; evidence is one entity with one snippet quoting the peak temperature. That is sufficient — even though it is one item, it directly answers the question.
+
+# How to write refined_queries
+
+Each query is a short natural-language phrase (5-20 words) describing what to look for, NOT a typed sub-query, NOT an entity ID, NOT a predicate name. The backend translates your descriptions to typed dispatches.
+
+Good: "battery alert frequency for drone-001 in the last 7 days"
+Good: "maintenance events on the fleet that paged operations"
+Bad: "{entity_state: drone-001}"  (typed sub-query — backend's job)
+Bad: "acme.ops.robotics.gcs.drone.001"  (entity ID — backend's job)
+
+Keep the list focused — 1 to 5 queries is the productive range. More than 5 suggests the refine loop should be split across multiple iterations, not packed into one pass.
+
+# Output contract
+
+Emit a single JSON object, no prose, no markdown fences, with this shape:
+
+` + "```" + `
+{
+  "sufficient": true,
+  "refined_queries": [ "<short description>", ... ],
+  "rationale": "one or two sentences naming the structural reason for the decision",
+  "confidence": 0.0
+}
+` + "```" + `
+
+Field notes:
+- "sufficient": true or false (boolean).
+- "refined_queries": list of short descriptions. Omit the field or pass an empty list when sufficient is true. Keep to 1-5 entries.
+- "rationale": one or two sentences for operator trajectory review. Name the structural reason — "evidence covers maintenance window but topic asks about fleet-wide status" beats "the data looks ok". The downstream chain branches on sufficient only.
+- "confidence": a number between 0.0 and 1.0 describing your own conviction in the decision. Trajectory review uses it to spot prompts that flip flags with low conviction.`
+}
+
+// buildUserPrompt renders the per-request context the assessor sees:
+// the topic + hints from the Intent, the routing action that drove
+// retrieval, the evidence array (bounded by maxEvidenceInPrompt). The
+// degraded flag from upstream is passed through so the model can
+// weigh decision conviction against retrieval health.
+//
+// Discipline: evidence renders with stable ordering (score
+// descending; ties broken by entity ID) so the same loop replayed
+// produces byte-identical prompts. SnippetText is truncated per
+// maxSnippetCharsInPrompt so individual long snippets don't blow the
+// prompt budget.
+func buildUserPrompt(intent *research.Intent, exec *research.ExecutionOutput, maxEvidenceInPrompt, maxSnippetCharsInPrompt int) string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "Topic: %s\n", intent.Topic)
+
+	if len(intent.Hints) > 0 {
+		sb.WriteString("\nUpstream hints:\n")
+		keys := make([]string, 0, len(intent.Hints))
+		for k := range intent.Hints {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&sb, "  - %s: %s\n", k, intent.Hints[k])
+		}
+	}
+
+	if exec.Action != "" {
+		fmt.Fprintf(&sb, "\nRouting action that drove retrieval: %s\n", exec.Action)
+	}
+	fmt.Fprintf(&sb, "Sub-queries dispatched: %d\n", exec.SubQueryCount)
+	fmt.Fprintf(&sb, "Tokens used by retrieval: %d (intent budget %d)\n", exec.BudgetTokensUsed, intent.ResolvedBudgetTokens())
+	if exec.Degraded {
+		fmt.Fprintf(&sb, "Retrieval degraded: yes (%s)\n", exec.DegradedReason)
+		sb.WriteString("Treat the evidence as partial; weigh refine more heavily when in doubt.\n")
+	}
+
+	sb.WriteString("\nEvidence (top by score; tier 0 = predicate/walk, tier 1 = BM25):\n")
+	evidence := orderedEvidence(exec.Evidence, maxEvidenceInPrompt)
+	if len(evidence) == 0 {
+		sb.WriteString("  (none — retrieval surfaced no evidence)\n")
+	}
+	for i, e := range evidence {
+		fmt.Fprintf(&sb, "  [%d] %s", i, e.EntityID)
+		if e.Tier != "" {
+			fmt.Fprintf(&sb, " (tier=%s", e.Tier)
+			if e.Source != "" {
+				fmt.Fprintf(&sb, " src=%s", e.Source)
+			}
+			if e.Score > 0 {
+				fmt.Fprintf(&sb, " score=%.2f", e.Score)
+			}
+			sb.WriteString(")")
+		}
+		if e.SnippetText != "" {
+			snippet := e.SnippetText
+			if maxSnippetCharsInPrompt > 0 && len(snippet) > maxSnippetCharsInPrompt {
+				snippet = snippet[:maxSnippetCharsInPrompt] + "..."
+			}
+			fmt.Fprintf(&sb, "\n      snippet: %s", snippet)
+		}
+		sb.WriteString("\n")
+	}
+
+	if total := len(exec.Evidence); total > len(evidence) {
+		fmt.Fprintf(&sb, "  (... %d more evidence items not shown)\n", total-len(evidence))
+	}
+
+	sb.WriteString("\nDecide sufficient or refine and emit the JSON object per the system prompt's output contract.")
+	return sb.String()
+}
+
+// orderedEvidence returns the top-N evidence items in the canonical
+// chain ordering: tier ascending (tier 0 authoritative first), score
+// descending within a tier, EntityID ascending for tie-break. Matches
+// processor/research-graph-execute/handler.go's sortEvidence so the
+// assessor sees evidence in the same order downstream synthesize
+// will quote it back in. Replay-determinism: same input list always
+// produces a byte-identical prompt.
+func orderedEvidence(in []research.Evidence, limit int) []research.Evidence {
+	if limit <= 0 || len(in) == 0 {
+		return nil
+	}
+	out := make([]research.Evidence, len(in))
+	copy(out, in)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Tier != out[j].Tier {
+			return out[i].Tier < out[j].Tier
+		}
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].EntityID < out[j].EntityID
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}

--- a/processor/research-graph-assess/register.go
+++ b/processor/research-graph-assess/register.go
@@ -1,0 +1,20 @@
+package researchassess
+
+import "github.com/c360studio/semstreams/component"
+
+// Register registers the assess_sufficiency processor with the
+// supplied component registry. Called from
+// componentregistry.Register at process bootstrap so production
+// binaries pick the component up without extra wiring.
+func Register(registry *component.Registry) error {
+	return registry.RegisterWithConfig(component.RegistrationConfig{
+		Name:        ComponentName,
+		Factory:     NewProcessor,
+		Schema:      configSchema,
+		Type:        "processor",
+		Protocol:    "assess_sufficiency",
+		Domain:      "research",
+		Description: "ADR-045 assess_sufficiency: structured-emit sufficient/refine decision over upstream ExecutionOutput evidence. Drives R3's synthesize-or-refine branch.",
+		Version:     "0.1.0",
+	})
+}

--- a/processor/research-graph-llmwrap/doc.go
+++ b/processor/research-graph-llmwrap/doc.go
@@ -1,0 +1,17 @@
+// Package llmwrap holds JSON-extraction and truncation helpers shared
+// across the LLM-wrapping components of the ADR-045 Phase 1 research-
+// graph chain (route_search, assess_sufficiency, synthesize_answer).
+//
+// Scope is deliberately small: extracting a balanced JSON object out
+// of a model's response (markdown fences + prose preface), and
+// capping a string at N bytes with an ellipsis suffix for error-line
+// readability. The chat-completion adapter stays per-component so
+// each component can keep a narrowly-purposed Router/Assessor/
+// Synthesizer interface in its handler; only the response-shape
+// helpers live here.
+//
+// Promoted to a shared package in ADR-045 Phase 1 PR 5 (the second
+// and third LLM-wrapping components). Previously inlined in
+// processor/research-graph-route/handler.go; that copy is removed in
+// the same PR.
+package llmwrap

--- a/processor/research-graph-llmwrap/jsonextract.go
+++ b/processor/research-graph-llmwrap/jsonextract.go
@@ -1,0 +1,76 @@
+package llmwrap
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrPayloadTruncateBytes caps the raw-payload snippet rendered in
+// error messages. 512 keeps the structured-emit JSON's action enum,
+// per-action arg keys, and short rationales visible even when the
+// model wrapped its emit in long prose.
+const ErrPayloadTruncateBytes = 512
+
+// ExtractJSON pulls a balanced JSON object out of an LLM response.
+// Many models wrap structured emits in ```json fences or prose
+// preface; this helper strips fences, then walks the first balanced
+// {...} substring while tracking JSON string-literal context (so a
+// `}` inside a string value, e.g. a rationale field like "axes
+// spanning {time, entity_type}", does not truncate the extraction
+// mid-object). Backslash-escaped quotes inside strings do not toggle
+// the string-context flag.
+//
+// Returns an error if the trimmed content contains no `{`, or if the
+// balanced-brace walker reaches end-of-input with unmatched depth.
+func ExtractJSON(content string) ([]byte, error) {
+	trimmed := strings.TrimSpace(content)
+	trimmed = strings.TrimPrefix(trimmed, "```json")
+	trimmed = strings.TrimPrefix(trimmed, "```JSON")
+	trimmed = strings.TrimPrefix(trimmed, "```")
+	trimmed = strings.TrimSuffix(trimmed, "```")
+	trimmed = strings.TrimSpace(trimmed)
+
+	start := strings.Index(trimmed, "{")
+	if start < 0 {
+		return nil, fmt.Errorf("no JSON object found in content")
+	}
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(trimmed); i++ {
+		ch := trimmed[i]
+		if inString {
+			switch {
+			case escaped:
+				escaped = false
+			case ch == '\\':
+				escaped = true
+			case ch == '"':
+				inString = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return []byte(trimmed[start : i+1]), nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("unbalanced braces in content (depth=%d)", depth)
+}
+
+// Truncate returns s capped at n bytes with an ellipsis suffix on
+// over-long input. Used in error-message construction so an over-long
+// LLM response doesn't blow up log lines or trajectory captures.
+func Truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/processor/research-graph-llmwrap/jsonextract_test.go
+++ b/processor/research-graph-llmwrap/jsonextract_test.go
@@ -1,0 +1,94 @@
+package llmwrap
+
+import "testing"
+
+func TestExtractJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "bare object",
+			input: `{"sufficient":true}`,
+			want:  `{"sufficient":true}`,
+		},
+		{
+			name:  "markdown fenced",
+			input: "```json\n{\"sufficient\":false,\"refined_queries\":[\"x\"]}\n```",
+			want:  `{"sufficient":false,"refined_queries":["x"]}`,
+		},
+		{
+			name:  "prose preface",
+			input: `Sure — here is the assessment:` + "\n" + `{"sufficient":true,"rationale":"clear hits"}` + "\nLet me know if you need more.",
+			want:  `{"sufficient":true,"rationale":"clear hits"}`,
+		},
+		{
+			name:  "nested braces preserved",
+			input: `{"synthesis":"x","evidence_refs":["a","b"],"meta":{"k":"v"}}`,
+			want:  `{"synthesis":"x","evidence_refs":["a","b"],"meta":{"k":"v"}}`,
+		},
+		{
+			name:    "no object",
+			input:   "I cannot answer this.",
+			wantErr: true,
+		},
+		{
+			name:    "unbalanced",
+			input:   `{"action":"x"`,
+			wantErr: true,
+		},
+		{
+			name:  "brace inside string value",
+			input: `{"sufficient":true,"rationale":"axes spanning {time, entity_type}"}`,
+			want:  `{"sufficient":true,"rationale":"axes spanning {time, entity_type}"}`,
+		},
+		{
+			name:  "both braces inside string value",
+			input: `{"sufficient":false,"rationale":"oh no a } in prose and another { for good measure"}`,
+			want:  `{"sufficient":false,"rationale":"oh no a } in prose and another { for good measure"}`,
+		},
+		{
+			name:  "escaped quote does not exit string",
+			input: `{"synthesis":"the \"quoted\" } term"}`,
+			want:  `{"synthesis":"the \"quoted\" } term"}`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := ExtractJSON(c.input)
+			if c.wantErr {
+				if err == nil {
+					t.Errorf("ExtractJSON: want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ExtractJSON: unexpected error %v", err)
+			}
+			if string(got) != c.want {
+				t.Errorf("ExtractJSON = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		n    int
+		want string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello world", 5, "hello..."},
+		{"", 5, ""},
+	}
+	for _, c := range cases {
+		got := Truncate(c.in, c.n)
+		if got != c.want {
+			t.Errorf("Truncate(%q,%d) = %q, want %q", c.in, c.n, got, c.want)
+		}
+	}
+}

--- a/processor/research-graph-route/handler.go
+++ b/processor/research-graph-route/handler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/processor/research-graph-llmwrap"
 )
 
 // Router is the narrow LLM surface this component consumes.
@@ -111,14 +112,14 @@ func routeDecision(ctx context.Context, router Router, intent *research.Intent, 
 		return nil, fmt.Errorf("router returned empty content (finish_reason=%q)", reason)
 	}
 
-	jsonBytes, err := extractJSON(rawContent)
+	jsonBytes, err := llmwrap.ExtractJSON(rawContent)
 	if err != nil {
-		return nil, fmt.Errorf("extract JSON from router content: %w (raw=%q finish_reason=%q)", err, truncate(rawContent, errPayloadTruncateBytes), reason)
+		return nil, fmt.Errorf("extract JSON from router content: %w (raw=%q finish_reason=%q)", err, llmwrap.Truncate(rawContent, llmwrap.ErrPayloadTruncateBytes), reason)
 	}
 
 	var decision research.RouteDecision
 	if err := json.Unmarshal(jsonBytes, &decision); err != nil {
-		return nil, fmt.Errorf("decode route decision: %w (raw=%q)", err, truncate(string(jsonBytes), errPayloadTruncateBytes))
+		return nil, fmt.Errorf("decode route decision: %w (raw=%q)", err, llmwrap.Truncate(string(jsonBytes), llmwrap.ErrPayloadTruncateBytes))
 	}
 	if err := decision.Validate(); err != nil {
 		return nil, fmt.Errorf("router emitted invalid action: %w", err)
@@ -153,83 +154,15 @@ func routeDecision(ctx context.Context, router Router, intent *research.Intent, 
 			logger.Warn("synthesize_directly emitted with non-empty args; possible action confusion",
 				slog.String("action", decision.Action),
 				slog.Int("args_count", len(decision.Args)),
-				slog.String("rationale", truncate(decision.Rationale, errPayloadTruncateBytes)))
+				slog.String("rationale", llmwrap.Truncate(decision.Rationale, llmwrap.ErrPayloadTruncateBytes)))
 		}
 	}
 
 	return &decision, nil
 }
 
-// errPayloadTruncateBytes caps the raw-payload snippet rendered in
-// error messages and the synthesize_directly Warn line. 512 keeps
-// the JSON action enum and per-action arg keys visible even when
-// the model wrapped its emit in long prose. Used at three sites
-// (extract JSON failure, decode failure, synthesize_directly Warn)
-// so a future tweak stays consistent.
-const errPayloadTruncateBytes = 512
-
-// extractJSON pulls a JSON object out of an LLM response. Many
-// models wrap their structured emit in ```json fences or prose
-// preface; this helper extracts the first balanced {...} substring.
-// Falls back to the raw content (trimmed) when no braces are
-// detected. Returns an error if the result still doesn't look like
-// a JSON object.
-func extractJSON(content string) ([]byte, error) {
-	trimmed := strings.TrimSpace(content)
-	// Strip common markdown fences.
-	trimmed = strings.TrimPrefix(trimmed, "```json")
-	trimmed = strings.TrimPrefix(trimmed, "```JSON")
-	trimmed = strings.TrimPrefix(trimmed, "```")
-	trimmed = strings.TrimSuffix(trimmed, "```")
-	trimmed = strings.TrimSpace(trimmed)
-
-	// Locate the outermost {...} object. The walker tracks JSON
-	// string-literal context so a `}` inside a string value (a
-	// model's rationale field is the common case — "axes spanning
-	// {time, entity_type}") doesn't truncate the extraction
-	// mid-object. Backslash-escaped quotes inside strings do not
-	// toggle the string-context flag.
-	start := strings.Index(trimmed, "{")
-	if start < 0 {
-		return nil, fmt.Errorf("no JSON object found in content")
-	}
-	depth := 0
-	inString := false
-	escaped := false
-	for i := start; i < len(trimmed); i++ {
-		ch := trimmed[i]
-		if inString {
-			switch {
-			case escaped:
-				escaped = false
-			case ch == '\\':
-				escaped = true
-			case ch == '"':
-				inString = false
-			}
-			continue
-		}
-		switch ch {
-		case '"':
-			inString = true
-		case '{':
-			depth++
-		case '}':
-			depth--
-			if depth == 0 {
-				return []byte(trimmed[start : i+1]), nil
-			}
-		}
-	}
-	return nil, fmt.Errorf("unbalanced braces in content (depth=%d)", depth)
-}
-
-// truncate returns s capped at n bytes; longer strings get an
-// ellipsis suffix. Used in error messages so an over-long LLM
-// response doesn't blow up log lines.
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "..."
-}
+// extractJSON + truncate were promoted to processor/research-graph-
+// llmwrap in PR 5 so assess_sufficiency + synthesize_answer can share
+// the same balanced-brace + ellipsis-cap helpers. Route_search reaches
+// for them via llmwrap.ExtractJSON / llmwrap.Truncate; same
+// ErrPayloadTruncateBytes constant.

--- a/processor/research-graph-route/handler_test.go
+++ b/processor/research-graph-route/handler_test.go
@@ -58,88 +58,9 @@ func TestExtractLoopIDFromSubject(t *testing.T) {
 	}
 }
 
-// --- extractJSON ---
-
-func TestExtractJSON(t *testing.T) {
-	cases := []struct {
-		name    string
-		input   string
-		want    string
-		wantErr bool
-	}{
-		{
-			name:  "bare object",
-			input: `{"action":"synthesize_directly","args":{}}`,
-			want:  `{"action":"synthesize_directly","args":{}}`,
-		},
-		{
-			name:  "markdown fenced",
-			input: "```json\n{\"action\":\"retighten\",\"args\":{\"topic\":\"x\"}}\n```",
-			want:  `{"action":"retighten","args":{"topic":"x"}}`,
-		},
-		{
-			name:  "prose preface",
-			input: `Sure — here is the decision:` + "\n" + `{"action":"walk_seeds","args":{"seeds":[{"ref":"x","ref_type":"name"}]}}` + "\nLet me know if you need more.",
-			want:  `{"action":"walk_seeds","args":{"seeds":[{"ref":"x","ref_type":"name"}]}}`,
-		},
-		{
-			name:  "nested braces preserved",
-			input: `{"action":"decompose","args":{"axes":["a","b"],"focus":"x","scope":"narrow"},"rationale":"y"}`,
-			want:  `{"action":"decompose","args":{"axes":["a","b"],"focus":"x","scope":"narrow"},"rationale":"y"}`,
-		},
-		{
-			name:    "no object",
-			input:   "I cannot answer this.",
-			wantErr: true,
-		},
-		{
-			name:    "unbalanced",
-			input:   `{"action":"x"`,
-			wantErr: true,
-		},
-		{
-			// Regression: brace inside a string value must NOT truncate
-			// the extraction. Surfaces as soon as the model writes a
-			// rationale like "axes spanning {time, entity_type}".
-			name:  "brace inside string value",
-			input: `{"action":"synthesize_directly","args":{},"rationale":"axes spanning {time, entity_type}"}`,
-			want:  `{"action":"synthesize_directly","args":{},"rationale":"axes spanning {time, entity_type}"}`,
-		},
-		{
-			// Both braces inside a string value — symmetric form of the
-			// above. Catches a walker that toggled string-context only
-			// on `{` (instead of `"`).
-			name:  "both braces inside string value",
-			input: `{"action":"x","args":{},"rationale":"oh no a } in prose and another { for good measure"}`,
-			want:  `{"action":"x","args":{},"rationale":"oh no a } in prose and another { for good measure"}`,
-		},
-		{
-			// Escaped quote inside a string value must NOT exit
-			// string-context. Catches a walker that treats every `"`
-			// as a toggle without tracking the escape.
-			name:  "escaped quote does not exit string",
-			input: `{"action":"retighten","args":{"topic":"the \"quoted\" } term"}}`,
-			want:  `{"action":"retighten","args":{"topic":"the \"quoted\" } term"}}`,
-		},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got, err := extractJSON(c.input)
-			if c.wantErr {
-				if err == nil {
-					t.Errorf("extractJSON: want error, got %q", got)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("extractJSON: unexpected error %v", err)
-			}
-			if string(got) != c.want {
-				t.Errorf("extractJSON = %q, want %q", got, c.want)
-			}
-		})
-	}
-}
+// extractJSON tests moved to processor/research-graph-llmwrap when
+// the helper was promoted to a shared package in PR 5. See
+// processor/research-graph-llmwrap/jsonextract_test.go.
 
 // --- routeDecision happy paths ---
 

--- a/processor/research-graph-synthesize/adapters.go
+++ b/processor/research-graph-synthesize/adapters.go
@@ -1,0 +1,160 @@
+package researchsynthesize
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/graph/llm"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/payloadregistry"
+)
+
+// llmSynthesizerAdapter wraps a graph/llm.Client into the Synthesizer
+// interface. Production wires the OpenAI-compatible client resolved
+// from the model registry; tests inject a fake Synthesizer directly
+// into the Component and skip this adapter entirely.
+type llmSynthesizerAdapter struct {
+	client llm.Client
+}
+
+func newLLMSynthesizerAdapter(client llm.Client) *llmSynthesizerAdapter {
+	return &llmSynthesizerAdapter{client: client}
+}
+
+// Synthesize sends one ChatCompletion with deterministic settings
+// (temperature 0) so the same prompt produces the same JSON across
+// runs.
+func (a *llmSynthesizerAdapter) Synthesize(ctx context.Context, systemPrompt, userPrompt string, maxResponseTokens int) (string, string, error) {
+	if a == nil || a.client == nil {
+		return "", "", errors.New("llm client not configured")
+	}
+	zero := 0.0
+	req := llm.ChatRequest{
+		SystemPrompt: systemPrompt,
+		UserPrompt:   userPrompt,
+		MaxTokens:    maxResponseTokens,
+		Temperature:  &zero,
+	}
+	resp, err := a.client.ChatCompletion(ctx, req)
+	if err != nil {
+		return "", "", fmt.Errorf("chat completion: %w", err)
+	}
+	return resp.Content, resp.FinishReason, nil
+}
+
+// natsLoopStore adapts natsclient.KVStore to the LoopStore interface.
+// Key conventions:
+//
+//   - research.requested.<loopID>     (read; written by research_graph tool, PR 1)
+//   - execute.complete.<loopID>       (read; written by execute_subqueries, PR 4)
+//   - route.complete.<loopID>         (read; written by route_search, PR 3; nil-ok)
+//   - search_result.complete.<loopID> (write; R6 continuation rule watches this
+//     per ADR-045 — the terminal trigger key
+//     names the PAYLOAD shape, not the producing
+//     component)
+//   - synthesize.snapshot.<loopID>    (write; non-trigger queryable copy keyed on
+//     component name for ops observability)
+type natsLoopStore struct {
+	kv      *natsclient.KVStore
+	decoder *message.Decoder
+}
+
+func newNATSLoopStore(kv *natsclient.KVStore, registry *payloadregistry.Registry) *natsLoopStore {
+	return &natsLoopStore{
+		kv:      kv,
+		decoder: message.NewDecoder(registry),
+	}
+}
+
+// Key helpers — package-private.
+
+func loopStoreKeyIntent(loopID string) string          { return "research.requested." + loopID }
+func loopStoreKeyExecuteComplete(loopID string) string { return "execute.complete." + loopID }
+func loopStoreKeyRouteComplete(loopID string) string   { return "route.complete." + loopID }
+func loopStoreKeySearchResultComplete(loopID string) string {
+	return "search_result.complete." + loopID
+}
+func loopStoreKeySynthesizeSnapshot(loopID string) string { return "synthesize.snapshot." + loopID }
+
+// GetIntent decodes the research_intent payload from the trigger
+// key. errIntentNotFound surfaces "key not found".
+func (s *natsLoopStore) GetIntent(ctx context.Context, loopID string) (*research.Intent, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyIntent(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errIntentNotFound
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyIntent(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode intent: %w", err)
+	}
+	intent, ok := decoded.Payload().(*research.Intent)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.Intent", decoded.Payload())
+	}
+	return intent, nil
+}
+
+// GetExecutionOutput decodes ExecutionOutput from execute.complete.
+func (s *natsLoopStore) GetExecutionOutput(ctx context.Context, loopID string) (*research.ExecutionOutput, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyExecuteComplete(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, errExecutionOutputNotFound
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyExecuteComplete(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode execution output: %w", err)
+	}
+	out, ok := decoded.Payload().(*research.ExecutionOutput)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.ExecutionOutput", decoded.Payload())
+	}
+	return out, nil
+}
+
+// GetRouteDecision decodes RouteDecision from route.complete. Returns
+// (nil, nil) on key-not-found so the synthesizer can degrade
+// gracefully — RouteDecision is observability-grade for DecompTrace,
+// not load-bearing for synthesis. Other errors propagate.
+func (s *natsLoopStore) GetRouteDecision(ctx context.Context, loopID string) (*research.RouteDecision, error) {
+	entry, err := s.kv.Get(ctx, loopStoreKeyRouteComplete(loopID))
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("kv get %s: %w", loopStoreKeyRouteComplete(loopID), err)
+	}
+	decoded, err := s.decoder.Decode(entry.Value)
+	if err != nil {
+		return nil, fmt.Errorf("decode route decision: %w", err)
+	}
+	dec, ok := decoded.Payload().(*research.RouteDecision)
+	if !ok {
+		return nil, fmt.Errorf("decoded payload is %T, expected *research.RouteDecision", decoded.Payload())
+	}
+	return dec, nil
+}
+
+// PutSearchResult writes the SearchResult envelope at the
+// search_result.complete.<loopID> trigger key per ADR-045 R6. The
+// terminal trigger names the payload shape, not the producing
+// component, so the continuation rule's key_pattern stays stable
+// across future synthesizer reshuffles.
+func (s *natsLoopStore) PutSearchResult(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeySearchResultComplete(loopID), envelope)
+	return err
+}
+
+// PutSnapshot writes the envelope at the stable snapshot key.
+func (s *natsLoopStore) PutSnapshot(ctx context.Context, loopID string, envelope []byte) error {
+	_, err := s.kv.Put(ctx, loopStoreKeySynthesizeSnapshot(loopID), envelope)
+	return err
+}

--- a/processor/research-graph-synthesize/component.go
+++ b/processor/research-graph-synthesize/component.go
@@ -1,0 +1,471 @@
+package researchsynthesize
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph/llm"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/model"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// Component implements the synthesize_answer processor. Same
+// structural shape as research-graph-route + research-graph-assess.
+type Component struct {
+	config Config
+	deps   component.Dependencies
+	logger *slog.Logger
+
+	synthesizer Synthesizer
+	loops       LoopStore
+
+	llmClient llm.Client
+
+	mu        sync.RWMutex
+	started   bool
+	startTime time.Time
+	wg        sync.WaitGroup
+
+	subscriptions []*natsclient.Subscription
+
+	messagesProcessed int64
+	messagesEmitted   int64
+	errors            int64
+	lastActivity      atomic.Value // time.Time
+
+	lifecycleReporter component.LifecycleReporter
+}
+
+var (
+	_ component.Discoverable       = (*Component)(nil)
+	_ component.LifecycleComponent = (*Component)(nil)
+)
+
+// NewProcessor is the component-factory shape registered with the
+// component registry.
+func NewProcessor(rawConfig json.RawMessage, deps component.Dependencies) (component.Discoverable, error) {
+	var config Config
+	if err := json.Unmarshal(rawConfig, &config); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config unmarshal")
+	}
+	if config.Ports == nil {
+		config = DefaultConfig()
+	}
+	config.ApplyDefaults()
+	if err := config.Validate(); err != nil {
+		return nil, errs.WrapInvalid(err, ComponentName, "NewProcessor", "config validate")
+	}
+
+	if deps.NATSClient == nil {
+		return nil, errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "NewProcessor", "NATSClient required")
+	}
+
+	logger := deps.GetLoggerWithComponent(ComponentName)
+
+	return &Component{
+		config: config,
+		deps:   deps,
+		logger: logger,
+	}, nil
+}
+
+// Initialize is part of the LifecycleComponent contract.
+func (c *Component) Initialize() error { return nil }
+
+// Start opens AGENT_LOOPS, wires the LLM synthesizer, subscribes
+// inputs, reports idle.
+func (c *Component) Start(ctx context.Context) error {
+	if ctx == nil {
+		return errs.WrapInvalid(errs.ErrInvalidConfig, ComponentName, "Start", "context cannot be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return errs.WrapInvalid(err, ComponentName, "Start", "context already cancelled")
+	}
+
+	c.mu.Lock()
+	if c.started {
+		c.mu.Unlock()
+		return errs.WrapFatal(errs.ErrAlreadyStarted, ComponentName, "Start", "already started")
+	}
+	c.mu.Unlock()
+
+	if err := c.openLoopsBucket(ctx); err != nil {
+		return err
+	}
+	if err := c.initSynthesizer(); err != nil {
+		return err
+	}
+	if err := c.subscribeInputs(ctx); err != nil {
+		return err
+	}
+	c.startLifecycleReporter(ctx)
+
+	c.mu.Lock()
+	c.started = true
+	c.startTime = time.Now()
+	c.mu.Unlock()
+
+	if c.lifecycleReporter != nil {
+		if err := c.lifecycleReporter.ReportStage(ctx, "idle"); err != nil {
+			c.logger.Debug("failed to report idle stage", slog.Any("error", err))
+		}
+	}
+
+	c.logger.Info("synthesize_answer component started",
+		slog.String("loops_bucket", c.config.LoopsBucket),
+		slog.Duration("synthesize_timeout", c.config.SynthesizeTimeout),
+		slog.Int("max_evidence_in_prompt", c.config.MaxEvidenceInPrompt))
+	return nil
+}
+
+func (c *Component) openLoopsBucket(ctx context.Context) error {
+	if c.loops != nil {
+		return nil
+	}
+	bucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      c.config.LoopsBucket,
+		Description: "Agent loops bucket; shared with research-pipeline chain",
+		History:     10,
+		TTL:         24 * time.Hour,
+	})
+	if err != nil {
+		return errs.WrapTransient(err, ComponentName, "Start", "open loops bucket")
+	}
+	if c.deps.PayloadRegistry == nil {
+		return errs.WrapFatal(errs.ErrMissingConfig, ComponentName, "Start", "PayloadRegistry dependency required to decode research payloads")
+	}
+	store := c.deps.NATSClient.NewKVStore(bucket)
+	c.loops = newNATSLoopStore(store, c.deps.PayloadRegistry)
+	return nil
+}
+
+func (c *Component) initSynthesizer() error {
+	if c.synthesizer != nil {
+		return nil
+	}
+	if c.deps.ModelRegistry == nil {
+		return errs.WrapInvalid(errs.ErrMissingConfig, ComponentName, "Start",
+			"model registry required (capability "+model.CapabilityResearchSynthesis+")")
+	}
+	resolved, ep, err := model.ResolveEndpointWithConfig(c.deps.ModelRegistry, model.CapabilityResearchSynthesis)
+	if err != nil {
+		return errs.WrapInvalid(err, ComponentName, "Start",
+			"capability "+model.CapabilityResearchSynthesis+" required")
+	}
+	timeout := model.ResolveCapabilityTimeout(c.deps.ModelRegistry, model.CapabilityResearchSynthesis, c.config.SynthesizeTimeout, c.logger)
+	if timeout > 0 {
+		c.config.SynthesizeTimeout = timeout
+	}
+	cfg := llm.OpenAIConfigFromEndpoint(resolved, ep, c.logger)
+	cfg.Timeout = c.config.SynthesizeTimeout
+	client, err := llm.NewOpenAIClient(cfg)
+	if err != nil {
+		return errs.WrapTransient(err, ComponentName, "Start", "construct LLM client")
+	}
+	c.llmClient = client
+	c.synthesizer = newLLMSynthesizerAdapter(client)
+	c.logger.Info("LLM synthesizer wired",
+		slog.String("model", resolved.Model),
+		slog.Duration("timeout", c.config.SynthesizeTimeout))
+	return nil
+}
+
+func (c *Component) subscribeInputs(ctx context.Context) error {
+	for _, port := range c.config.Ports.Inputs {
+		if port.Subject == "" {
+			continue
+		}
+		if port.Type != "nats" {
+			c.logger.Warn("unsupported port type; skipping",
+				slog.String("port", port.Name),
+				slog.String("type", port.Type))
+			continue
+		}
+		sub, err := c.deps.NATSClient.Subscribe(ctx, port.Subject, func(msgCtx context.Context, msg *nats.Msg) {
+			c.handleMessage(msgCtx, msg.Subject, msg.Data)
+		})
+		if err != nil {
+			return errs.WrapTransient(err, ComponentName, "Start",
+				fmt.Sprintf("subscribe to %s", port.Subject))
+		}
+		c.subscriptions = append(c.subscriptions, sub)
+		c.logger.Debug("subscribed to NATS subject",
+			slog.String("port", port.Name),
+			slog.String("subject", port.Subject))
+	}
+	return nil
+}
+
+func (c *Component) startLifecycleReporter(ctx context.Context) {
+	statusBucket, err := c.deps.NATSClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      "COMPONENT_STATUS",
+		Description: "Component lifecycle status tracking",
+	})
+	if err != nil {
+		c.logger.Warn("COMPONENT_STATUS bucket unavailable; lifecycle reporting disabled",
+			slog.Any("error", err))
+		c.lifecycleReporter = component.NewNoOpLifecycleReporter()
+		return
+	}
+	c.lifecycleReporter = component.NewLifecycleReporterFromConfig(component.LifecycleReporterConfig{
+		KV:               statusBucket,
+		ComponentName:    ComponentName,
+		Logger:           c.logger,
+		EnableThrottling: true,
+	})
+}
+
+// Stop drains subscriptions, closes the LLM client.
+func (c *Component) Stop(timeout time.Duration) error {
+	c.mu.Lock()
+	if !c.started {
+		c.mu.Unlock()
+		return nil
+	}
+	c.started = false
+	c.mu.Unlock()
+
+	for _, sub := range c.subscriptions {
+		if sub == nil {
+			continue
+		}
+		if err := sub.Unsubscribe(); err != nil {
+			c.logger.Debug("unsubscribe failed during stop", slog.Any("error", err))
+		}
+	}
+	c.subscriptions = nil
+
+	done := make(chan struct{})
+	go func() {
+		c.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		c.logger.Warn("Stop timeout reached with handlers in flight",
+			slog.Duration("timeout", timeout))
+	}
+
+	if c.llmClient != nil {
+		if err := c.llmClient.Close(); err != nil {
+			c.logger.Debug("LLM client close failed during stop", slog.Any("error", err))
+		}
+		c.llmClient = nil
+	}
+	return nil
+}
+
+// handleMessage is the per-message hot path. Loads upstream Intent +
+// ExecutionOutput (+ optional RouteDecision), runs synthesizeAnswer,
+// writes the SearchResult envelope + synthesize.complete trigger key.
+//
+// Recovery contract:
+//   - Intent missing/error: hard abort. Without the topic we can't
+//     populate a meaningful degraded synthesis.
+//   - ExecutionOutput missing: emit degraded SearchResult so the
+//     continuation rule still fires and the parent gets a clear "no
+//     evidence" signal instead of stranding on a missing key.
+//   - synthesizeAnswer failure: emit degraded SearchResult; trajectory
+//     review surfaces the failure cause.
+//   - RouteDecision missing: NOT an error. Synthesis proceeds with a
+//     DecompTrace built from ExecutionOutput alone.
+func (c *Component) handleMessage(ctx context.Context, subject string, _ []byte) {
+	c.wg.Add(1)
+	defer c.wg.Done()
+	atomic.AddInt64(&c.messagesProcessed, 1)
+	c.lastActivity.Store(time.Now())
+
+	loopID := extractLoopIDFromSubject(subject)
+	if loopID == "" {
+		c.logger.Error("could not extract loop_id from subject; ignoring message",
+			slog.String("subject", subject))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	if c.config.SynthesizeTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.config.SynthesizeTimeout)
+		defer cancel()
+	}
+
+	intent, err := c.loops.GetIntent(ctx, loopID)
+	if err != nil {
+		c.logger.Error("could not load research intent; ignoring message",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	exec, err := c.loops.GetExecutionOutput(ctx, loopID)
+	if err != nil {
+		level := slog.LevelError
+		if errors.Is(err, errExecutionOutputNotFound) {
+			level = slog.LevelWarn
+		}
+		c.logger.Log(ctx, level, "could not load execution output; emitting degraded synthesis",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		c.emitDegraded(ctx, loopID, intent.Topic, "execute.complete missing or undecodeable: "+err.Error())
+		return
+	}
+
+	route, err := c.loops.GetRouteDecision(ctx, loopID)
+	if err != nil {
+		// RouteDecision is observability-grade; a decode error logs
+		// but doesn't fail the synthesis. Treat the same as missing.
+		c.logger.Warn("route decision load failed; proceeding without DecompTrace router action",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		route = nil
+	}
+
+	result, err := synthesizeAnswer(ctx, c.synthesizer, intent, exec, route, c.config.MaxResponseTokens, c.config.MaxEvidenceInPrompt, c.config.MaxSnippetCharsInPrompt, c.logger)
+	if err != nil {
+		c.logger.Error("synthesize_answer failed; emitting degraded synthesis",
+			slog.String("loop_id", loopID),
+			slog.String("topic", intent.Topic),
+			slog.Any("error", err))
+		c.emitDegraded(ctx, loopID, intent.Topic, "synthesizer: "+err.Error())
+		return
+	}
+
+	c.writeResult(ctx, loopID, result)
+}
+
+// emitDegraded constructs and writes a safety-net SearchResult so the
+// continuation rule fires even when synthesis couldn't run cleanly.
+// Synthesis text marks the failure; Evidence is nil; DecompTrace
+// records the upstream RouterAction when available (best effort).
+func (c *Component) emitDegraded(ctx context.Context, loopID, topic, reason string) {
+	if topic == "" {
+		topic = "(unknown)"
+	}
+	result := &research.SearchResult{
+		Synthesis: "Synthesis could not be produced for topic " + topic + ". Reason: " + reason,
+	}
+	c.writeResult(ctx, loopID, result)
+}
+
+// writeResult marshals and writes the SearchResult envelope. Snapshot
+// first (queryable), then trigger key the continuation rule watches.
+//
+// Validate runs before marshal even on the degraded path: emitDegraded
+// constructs a Synthesis string today, but a future change to either
+// the degraded shape or SearchResult.Validate's rules could ship a
+// wire-invalid envelope silently. Surfacing the validation failure
+// as a logged-and-dropped emit keeps the contract honest at the
+// boundary.
+func (c *Component) writeResult(ctx context.Context, loopID string, result *research.SearchResult) {
+	if err := result.Validate(); err != nil {
+		c.logger.Error("search result failed validation; refusing to emit",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+	envelope := message.NewBaseMessage(result.Schema(), result, ComponentName)
+	envelopeBytes, err := json.Marshal(envelope)
+	if err != nil {
+		c.logger.Error("marshal search result envelope failed",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	if err := c.loops.PutSnapshot(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Warn("snapshot write failed; chain continues but downstream readback may miss it",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+	}
+
+	if err := c.loops.PutSearchResult(ctx, loopID, envelopeBytes); err != nil {
+		c.logger.Error("synthesize.complete trigger write failed; continuation rule will not fire",
+			slog.String("loop_id", loopID),
+			slog.Any("error", err))
+		atomic.AddInt64(&c.errors, 1)
+		return
+	}
+
+	atomic.AddInt64(&c.messagesEmitted, 1)
+	c.logger.Info("synthesize_answer emitted SearchResult",
+		slog.String("loop_id", loopID),
+		slog.Int("evidence_count", len(result.Evidence)),
+		slog.Int("synthesis_bytes", len(result.Synthesis)))
+}
+
+// Meta implements Discoverable.
+func (c *Component) Meta() component.Metadata {
+	return component.Metadata{
+		Name:        ComponentName,
+		Type:        "processor",
+		Description: "ADR-045 synthesize_answer: terminal LLM stage. Quote-back-validated synthesis grounded in upstream evidence. Drives the continuation rule.",
+		Version:     "0.1.0",
+	}
+}
+
+// InputPorts implements Discoverable.
+func (c *Component) InputPorts() []component.Port {
+	ports := make([]component.Port, 0, len(c.config.Ports.Inputs))
+	for _, p := range c.config.Ports.Inputs {
+		ports = append(ports, component.Port{
+			Name:      p.Name,
+			Direction: component.DirectionInput,
+			Required:  p.Required,
+			Config: component.NATSPort{
+				Subject: p.Subject,
+			},
+		})
+	}
+	return ports
+}
+
+// OutputPorts implements Discoverable. synthesize_answer has no
+// NATS-publishing output port: emits are KV writes to AGENT_LOOPS.
+func (c *Component) OutputPorts() []component.Port { return []component.Port{} }
+
+// ConfigSchema implements Discoverable.
+func (c *Component) ConfigSchema() component.ConfigSchema { return configSchema }
+
+// Health implements Discoverable.
+func (c *Component) Health() component.HealthStatus {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return component.HealthStatus{
+		Healthy:    c.started,
+		LastCheck:  time.Now(),
+		ErrorCount: int(atomic.LoadInt64(&c.errors)),
+		Uptime:     time.Since(c.startTime),
+	}
+}
+
+// DataFlow implements Discoverable.
+func (c *Component) DataFlow() component.FlowMetrics {
+	processed := atomic.LoadInt64(&c.messagesProcessed)
+	errCount := atomic.LoadInt64(&c.errors)
+	var errRate float64
+	if processed > 0 {
+		errRate = float64(errCount) / float64(processed)
+	}
+	last, _ := c.lastActivity.Load().(time.Time)
+	return component.FlowMetrics{
+		ErrorRate:    errRate,
+		LastActivity: last,
+	}
+}

--- a/processor/research-graph-synthesize/component_test.go
+++ b/processor/research-graph-synthesize/component_test.go
@@ -1,0 +1,231 @@
+package researchsynthesize
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// fakeLoopStore replaces natsLoopStore. Records reads + writes so
+// the test can assert on key ordering, envelope shape, and miss vs
+// hit paths.
+type fakeLoopStore struct {
+	mu sync.Mutex
+
+	intent    *research.Intent
+	intentErr error
+
+	exec    *research.ExecutionOutput
+	execErr error
+
+	route    *research.RouteDecision
+	routeErr error
+
+	getIntentCalls int
+	getExecCalls   int
+	getRouteCalls  int
+
+	snapshotEnvelope []byte
+	snapshotErr      error
+
+	resultEnvelope []byte
+	resultErr      error
+
+	writeOrder []string
+}
+
+func (s *fakeLoopStore) GetIntent(_ context.Context, _ string) (*research.Intent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getIntentCalls++
+	if s.intentErr != nil {
+		return nil, s.intentErr
+	}
+	return s.intent, nil
+}
+
+func (s *fakeLoopStore) GetExecutionOutput(_ context.Context, _ string) (*research.ExecutionOutput, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getExecCalls++
+	if s.execErr != nil {
+		return nil, s.execErr
+	}
+	return s.exec, nil
+}
+
+func (s *fakeLoopStore) GetRouteDecision(_ context.Context, _ string) (*research.RouteDecision, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.getRouteCalls++
+	if s.routeErr != nil {
+		return nil, s.routeErr
+	}
+	return s.route, nil
+}
+
+func (s *fakeLoopStore) PutSnapshot(_ context.Context, _ string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.snapshotEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "snapshot")
+	return s.snapshotErr
+}
+
+func (s *fakeLoopStore) PutSearchResult(_ context.Context, _ string, envelope []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.resultEnvelope = append([]byte(nil), envelope...)
+	s.writeOrder = append(s.writeOrder, "search_result_complete")
+	return s.resultErr
+}
+
+func newTestComponent(loops LoopStore, synth Synthesizer) *Component {
+	return &Component{
+		config:      DefaultConfig(),
+		synthesizer: synth,
+		loops:       loops,
+		logger:      quietLogger(),
+	}
+}
+
+func TestComponent_HandleMessage_HappyPath(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "drone-001 maintenance"},
+		exec: &research.ExecutionOutput{
+			Topic:    "drone-001 maintenance",
+			Action:   research.ActionWalkSeeds,
+			Evidence: []research.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x", Score: 0.9}},
+		},
+		route: &research.RouteDecision{
+			Action: research.ActionWalkSeeds,
+			Args: map[string]any{
+				"seeds": []map[string]string{{"ref": "drone-001", "ref_type": "name"}},
+			},
+		},
+	}
+	s := &fakeSynthesizer{
+		content: `{"synthesis":"Drone 001 has a maintenance window.","evidence_refs":["drone-001"]}`,
+	}
+	c := newTestComponent(loops, s)
+	c.handleMessage(context.Background(), "component.synthesize_answer.loop-9", nil)
+
+	if atomic.LoadInt64(&c.messagesProcessed) != 1 {
+		t.Errorf("messagesProcessed = %d, want 1", atomic.LoadInt64(&c.messagesProcessed))
+	}
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if loops.getIntentCalls != 1 || loops.getExecCalls != 1 || loops.getRouteCalls != 1 {
+		t.Errorf("read calls: intent=%d exec=%d route=%d", loops.getIntentCalls, loops.getExecCalls, loops.getRouteCalls)
+	}
+	if len(loops.writeOrder) != 2 || loops.writeOrder[0] != "snapshot" || loops.writeOrder[1] != "search_result_complete" {
+		t.Errorf("write order = %v, want [snapshot search_result_complete]", loops.writeOrder)
+	}
+	if !strings.Contains(string(loops.resultEnvelope), `Drone 001`) {
+		t.Error("envelope should carry synthesis prose")
+	}
+	if !strings.Contains(string(loops.resultEnvelope), `"router_action":"walk_seeds"`) {
+		t.Error("envelope should carry DecompTrace.RouterAction")
+	}
+}
+
+func TestComponent_HandleMessage_IgnoresBadSubject(t *testing.T) {
+	loops := &fakeLoopStore{}
+	s := &fakeSynthesizer{}
+	c := newTestComponent(loops, s)
+	c.handleMessage(context.Background(), "bad.subject", nil)
+
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if s.called {
+		t.Error("synthesizer should not be called on bad subject")
+	}
+}
+
+func TestComponent_HandleMessage_IntentMissingHardAborts(t *testing.T) {
+	loops := &fakeLoopStore{intentErr: errIntentNotFound}
+	s := &fakeSynthesizer{}
+	c := newTestComponent(loops, s)
+	c.handleMessage(context.Background(), "component.synthesize_answer.loop-x", nil)
+
+	if atomic.LoadInt64(&c.errors) != 1 {
+		t.Errorf("errors = %d, want 1", atomic.LoadInt64(&c.errors))
+	}
+	if len(loops.writeOrder) != 0 {
+		t.Errorf("intent missing should NOT emit envelope; writeOrder = %v", loops.writeOrder)
+	}
+	if s.called {
+		t.Error("synthesizer should not be called when intent missing")
+	}
+}
+
+func TestComponent_HandleMessage_ExecMissingEmitsDegraded(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent:  &research.Intent{Topic: "x"},
+		execErr: errExecutionOutputNotFound,
+	}
+	s := &fakeSynthesizer{}
+	c := newTestComponent(loops, s)
+	c.handleMessage(context.Background(), "component.synthesize_answer.loop-x", nil)
+
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1 (degraded envelope still emitted)", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if !strings.Contains(string(loops.resultEnvelope), "could not be produced") {
+		t.Error("envelope should carry the degraded-synthesis marker")
+	}
+	if s.called {
+		t.Error("synthesizer should not be called when exec missing")
+	}
+}
+
+func TestComponent_HandleMessage_RouteMissingProceeds(t *testing.T) {
+	// Route nil + nil error → graceful pass to synthesizer.
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "x"},
+		exec: &research.ExecutionOutput{
+			Topic:    "x",
+			Action:   research.ActionSynthesizeDirectly,
+			Evidence: []research.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
+		},
+		// route: nil
+	}
+	s := &fakeSynthesizer{
+		content: `{"synthesis":"answer","evidence_refs":["e1"]}`,
+	}
+	c := newTestComponent(loops, s)
+	c.handleMessage(context.Background(), "component.synthesize_answer.loop-x", nil)
+
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if !strings.Contains(string(loops.resultEnvelope), `"router_action":"synthesize_directly"`) {
+		t.Error("DecompTrace should fall back to exec.Action when route missing")
+	}
+}
+
+func TestComponent_HandleMessage_SynthesizerFailEmitsDegraded(t *testing.T) {
+	loops := &fakeLoopStore{
+		intent: &research.Intent{Topic: "x"},
+		exec: &research.ExecutionOutput{
+			Topic: "x", Action: research.ActionDecompose,
+			Evidence: []research.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
+		},
+	}
+	s := &fakeSynthesizer{content: `not JSON at all`}
+	c := newTestComponent(loops, s)
+	c.handleMessage(context.Background(), "component.synthesize_answer.loop-x", nil)
+
+	if atomic.LoadInt64(&c.messagesEmitted) != 1 {
+		t.Errorf("messagesEmitted = %d, want 1 (degraded envelope on synth failure)", atomic.LoadInt64(&c.messagesEmitted))
+	}
+	if !strings.Contains(string(loops.resultEnvelope), "could not be produced") {
+		t.Error("envelope should carry the degraded-synthesis marker")
+	}
+}

--- a/processor/research-graph-synthesize/config.go
+++ b/processor/research-graph-synthesize/config.go
@@ -1,0 +1,138 @@
+package researchsynthesize
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+)
+
+// ComponentName is the canonical registry name + log subsystem.
+const ComponentName = "research-graph-synthesize"
+
+// Default knobs surfaced as exported constants so the prompt-builder
+// tests and operator docs can reference them by name rather than
+// duplicating literals.
+const (
+	// DefaultSynthesizeTimeout caps the structured-emit LLM call.
+	// Set to 30s because natsclient.Client.Subscribe wraps the
+	// per-message handler in a 30-second timeout context
+	// (natsclient/client.go ~line 684) — any synthesize_timeout
+	// above 30s is silently clipped by the subscription wrapper
+	// before reaching the LLM call. Operators tuning past 30s
+	// should raise the natsclient cap; the component-side knob
+	// alone won't reach the wire.
+	DefaultSynthesizeTimeout = 30 * time.Second
+
+	// DefaultMaxResponseTokens caps the LLM's response budget. The
+	// synthesis text can be long; 2048 is the production default,
+	// operators can raise via capability.research_synthesis.
+	DefaultMaxResponseTokens = 2048
+
+	// DefaultMaxEvidenceInPrompt caps how many ExecutionOutput
+	// evidence items the prompt embeds. Higher than assess's cap
+	// because synthesis needs to ground its prose in concrete
+	// references — but still bounded so the prompt fits common
+	// context windows.
+	DefaultMaxEvidenceInPrompt = 30
+
+	// DefaultMaxSnippetCharsInPrompt caps per-evidence SnippetText
+	// chars rendered in the prompt. Higher than assess because
+	// synthesis quotes snippets directly into the answer; truncated
+	// snippets shrink the answer's grounding.
+	DefaultMaxSnippetCharsInPrompt = 480
+)
+
+// Config holds operator-tunable knobs for the synthesize_answer
+// component.
+//
+// LLM wiring follows the same model-registry capability seam as
+// route_search + assess_sufficiency: operator declares
+// CapabilityResearchSynthesis in the model registry; the component
+// resolves it at Start() time. Absence is a startup error.
+type Config struct {
+	Ports *component.PortConfig `json:"ports,omitempty" schema:"type:ports,description:Port configuration. synthesize_answer requires one nats input subscribing to component.synthesize_answer.> ,category:basic"`
+
+	LoopsBucket string `json:"loops_bucket,omitempty" schema:"type:string,description:NATS KV bucket holding research-pipeline loops and trigger/completion keys,default:AGENT_LOOPS,category:advanced"`
+
+	SynthesizeTimeout time.Duration `json:"synthesize_timeout,omitempty" schema:"type:duration,description:Timeout for the structured-emit LLM call. Honors capability.research_synthesis override when set on the model registry. NOTE: natsclient.Subscribe caps per-message context at 30s; values above 30s are silently clipped at the wire,default:30s,category:advanced"`
+
+	MaxResponseTokens int `json:"max_response_tokens,omitempty" schema:"type:int,description:Cap on LLM response tokens for the synthesis output,default:2048,max:8192,category:advanced"`
+
+	MaxEvidenceInPrompt int `json:"max_evidence_in_prompt,omitempty" schema:"type:int,description:Cap on number of ExecutionOutput evidence items embedded in the synthesizer prompt. Top-N by Score; tighter caps keep prompts within small-model context windows. 0 means default (30),default:30,max:200,category:advanced"`
+
+	MaxSnippetCharsInPrompt int `json:"max_snippet_chars_in_prompt,omitempty" schema:"type:int,description:Cap on per-evidence SnippetText characters rendered in the synthesizer prompt. 0 means default (480),default:480,max:4000,category:advanced"`
+}
+
+// Validate validates the configuration. Negative caps are rejected;
+// zero values fall through to ApplyDefaults.
+func (c *Config) Validate() error {
+	if c.Ports == nil || len(c.Ports.Inputs) == 0 {
+		return errors.New("ports configuration with at least one input port is required")
+	}
+	if c.MaxResponseTokens < 0 {
+		return errors.New("max_response_tokens must be >= 0")
+	}
+	if c.MaxEvidenceInPrompt < 0 {
+		return errors.New("max_evidence_in_prompt must be >= 0")
+	}
+	if c.MaxSnippetCharsInPrompt < 0 {
+		return errors.New("max_snippet_chars_in_prompt must be >= 0")
+	}
+	return nil
+}
+
+// ApplyDefaults fills in defaults for unset fields.
+func (c *Config) ApplyDefaults() {
+	if c.LoopsBucket == "" {
+		c.LoopsBucket = "AGENT_LOOPS"
+	}
+	if c.SynthesizeTimeout == 0 {
+		c.SynthesizeTimeout = DefaultSynthesizeTimeout
+	}
+	if c.MaxResponseTokens == 0 {
+		c.MaxResponseTokens = DefaultMaxResponseTokens
+	}
+	if c.MaxEvidenceInPrompt == 0 {
+		c.MaxEvidenceInPrompt = DefaultMaxEvidenceInPrompt
+	}
+	if c.MaxSnippetCharsInPrompt == 0 {
+		c.MaxSnippetCharsInPrompt = DefaultMaxSnippetCharsInPrompt
+	}
+}
+
+// DefaultConfig returns a default Config skeleton with the standard
+// synthesize_answer input port.
+func DefaultConfig() Config {
+	return Config{
+		Ports: &component.PortConfig{
+			Inputs: []component.PortDefinition{
+				{
+					Name:        "trigger",
+					Type:        "nats",
+					Subject:     "component.synthesize_answer.>",
+					Required:    true,
+					Description: "R3's synthesize branch publish target. Subject suffix carries the research-pipeline loop_id.",
+				},
+			},
+			Outputs: []component.PortDefinition{},
+		},
+		LoopsBucket:             "AGENT_LOOPS",
+		SynthesizeTimeout:       DefaultSynthesizeTimeout,
+		MaxResponseTokens:       DefaultMaxResponseTokens,
+		MaxEvidenceInPrompt:     DefaultMaxEvidenceInPrompt,
+		MaxSnippetCharsInPrompt: DefaultMaxSnippetCharsInPrompt,
+	}
+}
+
+// natsclientSubscribeTimeoutCap documents the upstream constraint:
+// natsclient.Client.Subscribe wraps the per-message handler in a
+// 30-second context.WithTimeout. SynthesizeTimeout values above
+// this cap are silently clipped — raising the cap is a natsclient
+// architectural change tracked separately.
+const natsclientSubscribeTimeoutCap = 30 * time.Second
+
+// configSchema is the static configuration schema, generated from
+// Config struct tags at package init.
+var configSchema = component.GenerateConfigSchema(reflect.TypeOf(Config{}))

--- a/processor/research-graph-synthesize/doc.go
+++ b/processor/research-graph-synthesize/doc.go
@@ -1,0 +1,49 @@
+// Package researchsynthesize implements the synthesize_answer
+// component from ADR-045 Phase 1 (PR 5 of six per
+// docs/operations/22-adr045-phase1-plan.md).
+//
+// synthesize_answer is the chain's terminal LLM stage. It receives a
+// publish trigger on component.synthesize_answer.<loop_id>, reads the
+// upstream research.Intent + research.ExecutionOutput payloads (and
+// the research.RouteDecision when present, for the DecompTrace
+// audit), builds a structured-emit prompt, calls the configured
+// research_synthesis LLM endpoint, parses the model's JSON output,
+// runs quote-back validation, and writes the research.SearchResult
+// envelope at search_result.complete.<loop_id> per ADR-045 R6 — the
+// continuation rule (R6 in PR 6) watches this terminal trigger key
+// to deliver the result back to the parent loop. The trigger key
+// names the payload shape, not the producing component, so the
+// continuation rule's key_pattern stays stable across synthesizer
+// reshuffles.
+//
+// Architectural notes:
+//
+//   - LLM-wrapping component, not agent-wrapping. Direct LLM call via
+//     the configured CapabilityResearchSynthesis endpoint.
+//
+//   - Quote-back validation: every ObjectStoreRef and EntityID the
+//     model emits in evidence_refs MUST appear in the input evidence
+//     array. Refs that do not match are stripped and a Warn is
+//     emitted; if the model emits zero valid refs against a non-
+//     empty evidence array, the synthesis is downgraded to degraded
+//     so operators can spot drift quickly. This enforces ADR-045's
+//     "no fabricated refs" contract.
+//
+//   - DecompTrace is constructed server-side from the RouteDecision +
+//     ExecutionOutput; the model is not asked to spell it. The chain
+//     is the authoritative source of structural-decision history.
+//
+//   - Per-loop evidence sample is bounded by config
+//     (MaxEvidenceInPrompt) so the prompt stays within small-model
+//     context windows. Evidence is rendered with stable ordering
+//     (Score descending; ties broken by EntityID) so the same loop
+//     replayed produces byte-identical prompts.
+//
+//   - Authored synthesis prose carries no rule-matchable predicate —
+//     rules pattern-match on the SearchResult schema (Synthesis
+//     present, evidence_refs present), not on prose content.
+//
+//   - All public methods are safe for concurrent use across loops;
+//     the component holds no per-call mutable state. Same pattern as
+//     research-graph-assess + research-graph-route.
+package researchsynthesize

--- a/processor/research-graph-synthesize/handler.go
+++ b/processor/research-graph-synthesize/handler.go
@@ -1,0 +1,291 @@
+package researchsynthesize
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/processor/research-graph-llmwrap"
+)
+
+// Synthesizer is the narrow LLM surface this component consumes.
+// Production satisfies it via llmSynthesizerAdapter wrapping a real
+// graph/llm.Client; tests substitute a fake.
+//
+// Synthesize returns the raw response Content + a short reason string
+// the adapter can use for error diagnostics. The handler parses the
+// Content as JSON, applies quote-back validation, and folds the
+// result into a research.SearchResult.
+type Synthesizer interface {
+	Synthesize(ctx context.Context, systemPrompt, userPrompt string, maxResponseTokens int) (content string, reason string, err error)
+}
+
+// LoopStore is the AGENT_LOOPS read/write surface this component
+// consumes. The RouteDecision read is optional — when present, the
+// DecompTrace captures the router's structural choice; when missing
+// (synthesize_directly fast-path, or a misordered chain), the trace
+// is built from the ExecutionOutput alone.
+type LoopStore interface {
+	GetIntent(ctx context.Context, loopID string) (*research.Intent, error)
+	GetExecutionOutput(ctx context.Context, loopID string) (*research.ExecutionOutput, error)
+	// GetRouteDecision returns (nil, nil) when the key is absent so
+	// the synthesizer can degrade gracefully — RouteDecision is
+	// observability-grade, not load-bearing for synthesis itself.
+	GetRouteDecision(ctx context.Context, loopID string) (*research.RouteDecision, error)
+
+	PutSearchResult(ctx context.Context, loopID string, envelope []byte) error
+	PutSnapshot(ctx context.Context, loopID string, envelope []byte) error
+}
+
+// Sentinel errors. Returned for diagnostic clarity in handler logs.
+var (
+	errIntentNotFound          = fmt.Errorf("research intent not found")
+	errExecutionOutputNotFound = fmt.Errorf("execution output not found")
+)
+
+// fallbackEchoCount caps how many input evidence items the chain
+// echoes back when quote-back validation strips ALL of the
+// synthesizer's emitted refs (a synthesis-prompt failure mode). 8 is
+// enough to give the caller usable citations for trajectory review
+// without flooding the SearchResult; higher would mostly add noise
+// since the synthesizer's prose only referenced refs it couldn't
+// ground in the evidence in the first place.
+const fallbackEchoCount = 8
+
+// extractLoopIDFromSubject pulls the loop_id off the NATS subject
+// component.synthesize_answer.<loop_id>.
+func extractLoopIDFromSubject(subject string) string {
+	const prefix = "component.synthesize_answer."
+	if !strings.HasPrefix(subject, prefix) {
+		return ""
+	}
+	return subject[len(prefix):]
+}
+
+// synthesizeAnswer is the pure synthesis function over injected
+// interfaces — no NATS plumbing leaks in here so the test matrix can
+// drive it through fakes.
+//
+// Returns a validated SearchResult on success. Quote-back validation
+// strips refs the model emitted that don't appear in the input
+// evidence; if the model emits zero valid refs against a non-empty
+// evidence array the result is downgraded but still returned (caller
+// surfaces as warning). The synthesis prose is preserved verbatim —
+// quote-back applies to the evidence_refs field, not free-form prose.
+//
+// route may be nil — synthesis is the chain's terminal output and
+// should still emit useful content when the upstream RouteDecision
+// is unavailable (the DecompTrace falls back to ExecutionOutput-only
+// shape in that case).
+func synthesizeAnswer(ctx context.Context, synthesizer Synthesizer, intent *research.Intent, exec *research.ExecutionOutput, route *research.RouteDecision, maxResponseTokens, maxEvidenceInPrompt, maxSnippetCharsInPrompt int, logger *slog.Logger) (*research.SearchResult, error) {
+	if intent == nil {
+		return nil, fmt.Errorf("intent is nil")
+	}
+	if exec == nil {
+		return nil, fmt.Errorf("execution output is nil")
+	}
+	if synthesizer == nil {
+		return nil, fmt.Errorf("synthesizer is nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	raw, err := callAndDecodeSynthesis(ctx, synthesizer, intent, exec, maxResponseTokens, maxEvidenceInPrompt, maxSnippetCharsInPrompt)
+	if err != nil {
+		return nil, err
+	}
+
+	keptRefs, droppedRefs := quoteBackValidate(raw.EvidenceRefs, exec.Evidence)
+	if len(droppedRefs) > 0 {
+		logger.Warn("synthesizer emitted refs not in input evidence; stripped",
+			slog.Int("dropped_count", len(droppedRefs)),
+			slog.String("first_dropped", llmwrap.Truncate(droppedRefs[0], llmwrap.ErrPayloadTruncateBytes)))
+	}
+
+	echoed := selectEchoedEvidence(exec.Evidence, keptRefs)
+	synthesis := raw.Synthesis
+	if len(exec.Evidence) > 0 && len(keptRefs) == 0 {
+		logger.Warn("synthesizer emitted zero valid evidence refs against non-empty evidence; echoing top items as fallback",
+			slog.Int("evidence_total", len(exec.Evidence)),
+			slog.Int("emitted_refs", len(raw.EvidenceRefs)))
+		// SearchResult has no Degraded field; embed the reason in a
+		// trailing line of the synthesis prose so operator trajectory
+		// review surfaces the drift without a schema migration. The
+		// appended marker is unambiguous in trajectory captures.
+		synthesis = synthesis + "\n\n[note: synthesizer emitted no quote-back refs; chain echoed top evidence]"
+	}
+
+	result := &research.SearchResult{
+		Evidence:    echoed,
+		Synthesis:   synthesis,
+		DecompTrace: buildDecompTrace(route, exec),
+	}
+	if err := result.Validate(); err != nil {
+		return nil, fmt.Errorf("validate search result: %w", err)
+	}
+	return result, nil
+}
+
+// synthesisWire is the narrow wire shape the synthesizer LLM emits.
+// Server-constructed fields (Evidence array, DecompTrace) are folded
+// in after validation, not asked of the model.
+type synthesisWire struct {
+	Synthesis    string   `json:"synthesis"`
+	EvidenceRefs []string `json:"evidence_refs,omitempty"`
+}
+
+// callAndDecodeSynthesis runs the LLM call and decodes its response
+// into the narrow wire shape. Empty content / extract / decode
+// failures surface as typed errors so the handler's degraded path
+// can categorise them.
+func callAndDecodeSynthesis(ctx context.Context, synthesizer Synthesizer, intent *research.Intent, exec *research.ExecutionOutput, maxResponseTokens, maxEvidenceInPrompt, maxSnippetCharsInPrompt int) (synthesisWire, error) {
+	var raw synthesisWire
+	systemPrompt := buildSystemPrompt()
+	userPrompt := buildUserPrompt(intent, exec, maxEvidenceInPrompt, maxSnippetCharsInPrompt)
+
+	rawContent, reason, err := synthesizer.Synthesize(ctx, systemPrompt, userPrompt, maxResponseTokens)
+	if err != nil {
+		return raw, fmt.Errorf("synthesizer call: %w", err)
+	}
+	if strings.TrimSpace(rawContent) == "" {
+		return raw, fmt.Errorf("synthesizer returned empty content (finish_reason=%q)", reason)
+	}
+
+	jsonBytes, err := llmwrap.ExtractJSON(rawContent)
+	if err != nil {
+		return raw, fmt.Errorf("extract JSON from synthesizer content: %w (raw=%q finish_reason=%q)", err, llmwrap.Truncate(rawContent, llmwrap.ErrPayloadTruncateBytes), reason)
+	}
+	if err := json.Unmarshal(jsonBytes, &raw); err != nil {
+		return raw, fmt.Errorf("decode synthesis output: %w (raw=%q)", err, llmwrap.Truncate(string(jsonBytes), llmwrap.ErrPayloadTruncateBytes))
+	}
+	if strings.TrimSpace(raw.Synthesis) == "" {
+		return raw, fmt.Errorf("synthesizer emitted empty synthesis text")
+	}
+	return raw, nil
+}
+
+// quoteBackValidate partitions emitted refs into (kept, dropped) by
+// checking each against the set of valid refs in the input evidence
+// (every EntityID + every non-empty ObjectStoreRef). Duplicates and
+// whitespace-only refs are silently dropped.
+func quoteBackValidate(emittedRefs []string, evidence []research.Evidence) (kept, dropped []string) {
+	validRefs := make(map[string]struct{}, len(evidence)*2)
+	for _, e := range evidence {
+		if e.EntityID != "" {
+			validRefs[e.EntityID] = struct{}{}
+		}
+		if e.ObjectStoreRef != "" {
+			validRefs[e.ObjectStoreRef] = struct{}{}
+		}
+	}
+	kept = make([]string, 0, len(emittedRefs))
+	dropped = make([]string, 0)
+	seen := make(map[string]struct{}, len(emittedRefs))
+	for _, r := range emittedRefs {
+		r = strings.TrimSpace(r)
+		if r == "" {
+			continue
+		}
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		if _, ok := validRefs[r]; ok {
+			kept = append(kept, r)
+		} else {
+			dropped = append(dropped, r)
+		}
+	}
+	return kept, dropped
+}
+
+// selectEchoedEvidence picks the Evidence items the chain echoes
+// back into the SearchResult. If keptRefs is non-empty, return only
+// the matching items (preserving input order); otherwise echo the
+// top-by-score items as a fallback (capped at len(in) since smaller
+// fixtures should round-trip cleanly).
+func selectEchoedEvidence(in []research.Evidence, keptRefs []string) []research.Evidence {
+	if len(in) == 0 {
+		return nil
+	}
+	if len(keptRefs) == 0 {
+		// Fallback: echo the head of the input slice. Input order
+		// matches execute_subqueries' canonical ranking (tier ascending,
+		// score descending within a tier, EntityID ascending for
+		// tie-break — see processor/research-graph-execute/handler.go's
+		// sortEvidence). Capped at fallbackEchoCount so SearchResult
+		// round-trips with a manageable citation list when the
+		// synthesizer emits no valid refs against non-empty evidence.
+		n := len(in)
+		if n > fallbackEchoCount {
+			n = fallbackEchoCount
+		}
+		out := make([]research.Evidence, n)
+		copy(out, in[:n])
+		return out
+	}
+	want := make(map[string]struct{}, len(keptRefs))
+	for _, r := range keptRefs {
+		want[r] = struct{}{}
+	}
+	out := make([]research.Evidence, 0, len(keptRefs))
+	for _, e := range in {
+		if _, ok := want[e.EntityID]; ok {
+			out = append(out, e)
+			continue
+		}
+		if e.ObjectStoreRef != "" {
+			if _, ok := want[e.ObjectStoreRef]; ok {
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
+// buildDecompTrace constructs the DecompTrace from the upstream
+// RouteDecision (when present) plus the ExecutionOutput. The trace
+// is observability-grade — operator trajectory viewers consume it,
+// the chain does not branch on it.
+func buildDecompTrace(route *research.RouteDecision, exec *research.ExecutionOutput) *research.DecompTrace {
+	trace := &research.DecompTrace{}
+	if route != nil {
+		trace.RouterAction = route.Action
+		switch route.Action {
+		case research.ActionWalkSeeds:
+			if args, err := route.ParseWalkSeedsArgs(); err == nil {
+				trace.SeedEntities = make([]string, 0, len(args.Seeds))
+				for _, s := range args.Seeds {
+					trace.SeedEntities = append(trace.SeedEntities, s.Ref)
+				}
+			}
+		case research.ActionDecompose:
+			if args, err := route.ParseDecomposeArgs(); err == nil {
+				// Render the decomposition intent as a single sub-query
+				// map so the DecompTrace contract (loose object array)
+				// captures it.
+				trace.SubQueries = []map[string]any{
+					{
+						"axes":  args.Axes,
+						"focus": args.Focus,
+						"scope": args.Scope,
+					},
+				}
+			}
+		}
+	} else if exec != nil && exec.Action != "" {
+		// No RouteDecision — at least record what action the
+		// upstream ExecutionOutput claimed it ran.
+		trace.RouterAction = exec.Action
+	}
+	// Surface zero-value trace as nil so callers can omit the field
+	// cleanly on synthesize_directly fast-paths.
+	if trace.RouterAction == "" && len(trace.SubQueries) == 0 && len(trace.SeedEntities) == 0 {
+		return nil
+	}
+	return trace
+}

--- a/processor/research-graph-synthesize/handler_test.go
+++ b/processor/research-graph-synthesize/handler_test.go
@@ -1,0 +1,282 @@
+package researchsynthesize
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// fakeSynthesizer returns canned content / error per scenario.
+type fakeSynthesizer struct {
+	mu         sync.Mutex
+	called     bool
+	gotSystem  string
+	gotUser    string
+	gotMaxToks int
+	content    string
+	reason     string
+	err        error
+}
+
+func (f *fakeSynthesizer) Synthesize(_ context.Context, system, user string, maxTokens int) (string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called = true
+	f.gotSystem = system
+	f.gotUser = user
+	f.gotMaxToks = maxTokens
+	return f.content, f.reason, f.err
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestExtractLoopIDFromSubject(t *testing.T) {
+	cases := []struct {
+		name    string
+		subject string
+		want    string
+	}{
+		{"happy", "component.synthesize_answer.loop-77", "loop-77"},
+		{"empty suffix", "component.synthesize_answer.", ""},
+		{"wrong prefix", "component.assess_sufficiency.loop-77", ""},
+		{"random", "some.other.subject", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := extractLoopIDFromSubject(c.subject); got != c.want {
+				t.Errorf("extractLoopIDFromSubject(%q) = %q, want %q", c.subject, got, c.want)
+			}
+		})
+	}
+}
+
+// --- synthesizeAnswer happy paths ---
+
+func TestSynthesizeAnswer_HappyPath_QuoteBackKeepsValidRefs(t *testing.T) {
+	exec := &research.ExecutionOutput{
+		Topic:  "drone fleet maintenance events",
+		Action: research.ActionWalkSeeds,
+		Evidence: []research.Evidence{
+			{EntityID: "acme.ops.robotics.gcs.drone.001", Tier: "0", Source: "walk_seeds", Score: 0.9, SnippetText: "Drone 001 maintenance window 14:32Z"},
+			{EntityID: "acme.ops.robotics.gcs.drone.014", Tier: "1", Source: "bm25", Score: 0.7, ObjectStoreRef: "objstore://research/evidence-014.txt"},
+		},
+	}
+	s := &fakeSynthesizer{
+		content: `{"synthesis":"Two drones reported maintenance: drone.001 and drone.014. See refs.","evidence_refs":["acme.ops.robotics.gcs.drone.001","objstore://research/evidence-014.txt"]}`,
+	}
+	got, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "drone fleet maintenance events"}, exec, nil,
+		2048, 30, 480, quietLogger())
+	if err != nil {
+		t.Fatalf("synthesizeAnswer: %v", err)
+	}
+	if !strings.Contains(got.Synthesis, "drone.001") {
+		t.Errorf("synthesis prose drift: %q", got.Synthesis)
+	}
+	if len(got.Evidence) != 2 {
+		t.Fatalf("Evidence len = %d, want 2 (both refs matched, both echoed)", len(got.Evidence))
+	}
+	// First evidence item should still be acme.ops.robotics.gcs.drone.001
+	if got.Evidence[0].EntityID != "acme.ops.robotics.gcs.drone.001" {
+		t.Errorf("Evidence[0].EntityID drift: %q", got.Evidence[0].EntityID)
+	}
+}
+
+func TestSynthesizeAnswer_QuoteBack_StripsFabricatedRefs(t *testing.T) {
+	exec := &research.ExecutionOutput{
+		Topic:  "x",
+		Action: research.ActionWalkSeeds,
+		Evidence: []research.Evidence{
+			{EntityID: "real-1", Tier: "0", Source: "x"},
+			{EntityID: "real-2", Tier: "0", Source: "x"},
+		},
+	}
+	s := &fakeSynthesizer{
+		content: `{"synthesis":"answer mentions real-1 and fake-99","evidence_refs":["real-1","fake-99","also-fake","real-2"]}`,
+	}
+	got, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "x"}, exec, nil,
+		2048, 30, 480, quietLogger())
+	if err != nil {
+		t.Fatalf("synthesizeAnswer: %v", err)
+	}
+	if len(got.Evidence) != 2 {
+		t.Fatalf("Evidence len = %d, want 2 (real-1 + real-2 kept; fakes stripped)", len(got.Evidence))
+	}
+	ids := []string{got.Evidence[0].EntityID, got.Evidence[1].EntityID}
+	if ids[0] != "real-1" || ids[1] != "real-2" {
+		t.Errorf("kept refs drift: %v", ids)
+	}
+}
+
+func TestSynthesizeAnswer_QuoteBack_NoValidRefsDegrades(t *testing.T) {
+	exec := &research.ExecutionOutput{
+		Topic:    "x",
+		Action:   research.ActionWalkSeeds,
+		Evidence: []research.Evidence{{EntityID: "real-1", Tier: "0", Source: "x"}},
+	}
+	s := &fakeSynthesizer{
+		content: `{"synthesis":"answer makes things up","evidence_refs":["fake-only","another-fake"]}`,
+	}
+	got, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "x"}, exec, nil,
+		2048, 30, 480, quietLogger())
+	if err != nil {
+		t.Fatalf("synthesizeAnswer: %v", err)
+	}
+	if !strings.Contains(got.Synthesis, "[note:") {
+		t.Errorf("expected degraded note appended to synthesis when no refs match: %q", got.Synthesis)
+	}
+	// Fallback echoed top evidence so SearchResult has citations.
+	if len(got.Evidence) == 0 {
+		t.Error("Evidence empty; expected top-N fallback echo")
+	}
+}
+
+func TestSynthesizeAnswer_EmptyEvidenceOK(t *testing.T) {
+	exec := &research.ExecutionOutput{Topic: "x", Action: research.ActionWalkSeeds}
+	s := &fakeSynthesizer{
+		content: `{"synthesis":"No evidence available for this topic.","evidence_refs":[]}`,
+	}
+	got, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "x"}, exec, nil,
+		2048, 30, 480, quietLogger())
+	if err != nil {
+		t.Fatalf("synthesizeAnswer: %v", err)
+	}
+	if len(got.Evidence) != 0 {
+		t.Errorf("Evidence len = %d, want 0 (input was empty)", len(got.Evidence))
+	}
+	if !strings.Contains(got.Synthesis, "No evidence") {
+		t.Errorf("synthesis drift: %q", got.Synthesis)
+	}
+}
+
+func TestSynthesizeAnswer_DecompTrace_FromRouteWalkSeeds(t *testing.T) {
+	exec := &research.ExecutionOutput{
+		Topic:    "x",
+		Action:   research.ActionWalkSeeds,
+		Evidence: []research.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
+	}
+	route := &research.RouteDecision{
+		Action: research.ActionWalkSeeds,
+		Args: map[string]any{
+			"seeds": []map[string]string{
+				{"ref": "drone-001", "ref_type": "name"},
+				{"ref": "0", "ref_type": "candidate_index"},
+			},
+		},
+	}
+	s := &fakeSynthesizer{content: `{"synthesis":"x","evidence_refs":["e1"]}`}
+	got, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "x"}, exec, route,
+		2048, 30, 480, quietLogger())
+	if err != nil {
+		t.Fatalf("synthesizeAnswer: %v", err)
+	}
+	if got.DecompTrace == nil {
+		t.Fatal("DecompTrace missing")
+	}
+	if got.DecompTrace.RouterAction != research.ActionWalkSeeds {
+		t.Errorf("RouterAction = %q, want %q", got.DecompTrace.RouterAction, research.ActionWalkSeeds)
+	}
+	if len(got.DecompTrace.SeedEntities) != 2 {
+		t.Errorf("SeedEntities len = %d, want 2", len(got.DecompTrace.SeedEntities))
+	}
+}
+
+func TestSynthesizeAnswer_DecompTrace_NilRouteFallsBackToExecAction(t *testing.T) {
+	exec := &research.ExecutionOutput{
+		Topic:    "x",
+		Action:   research.ActionSynthesizeDirectly,
+		Evidence: []research.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
+	}
+	s := &fakeSynthesizer{content: `{"synthesis":"x","evidence_refs":["e1"]}`}
+	got, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "x"}, exec, nil,
+		2048, 30, 480, quietLogger())
+	if err != nil {
+		t.Fatalf("synthesizeAnswer: %v", err)
+	}
+	if got.DecompTrace == nil {
+		t.Fatal("DecompTrace should not be nil; exec.Action should populate fallback")
+	}
+	if got.DecompTrace.RouterAction != research.ActionSynthesizeDirectly {
+		t.Errorf("RouterAction = %q, want fallback to exec.Action", got.DecompTrace.RouterAction)
+	}
+}
+
+// --- synthesizeAnswer error paths ---
+
+func TestSynthesizeAnswer_RejectsEmptySynthesis(t *testing.T) {
+	s := &fakeSynthesizer{content: `{"synthesis":"   ","evidence_refs":[]}`}
+	_, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose},
+		nil, 2048, 30, 480, quietLogger())
+	if err == nil || !strings.Contains(err.Error(), "empty synthesis") {
+		t.Fatalf("want empty-synthesis error, got %v", err)
+	}
+}
+
+func TestSynthesizeAnswer_RejectsSynthesizerError(t *testing.T) {
+	s := &fakeSynthesizer{err: errors.New("503")}
+	_, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose},
+		nil, 2048, 30, 480, quietLogger())
+	if err == nil || !strings.Contains(err.Error(), "synthesizer call") {
+		t.Fatalf("want synthesizer-call error, got %v", err)
+	}
+}
+
+func TestSynthesizeAnswer_RejectsMalformedJSON(t *testing.T) {
+	s := &fakeSynthesizer{content: `cannot synthesize`}
+	_, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose},
+		nil, 2048, 30, 480, quietLogger())
+	if err == nil || !strings.Contains(err.Error(), "extract JSON") {
+		t.Fatalf("want extract-JSON error, got %v", err)
+	}
+}
+
+func TestSynthesizeAnswer_DedupRefs(t *testing.T) {
+	exec := &research.ExecutionOutput{
+		Topic:  "x",
+		Action: research.ActionWalkSeeds,
+		Evidence: []research.Evidence{
+			{EntityID: "e1", Tier: "0", Source: "x"},
+		},
+	}
+	s := &fakeSynthesizer{
+		content: `{"synthesis":"x","evidence_refs":["e1","e1","e1"]}`,
+	}
+	got, err := synthesizeAnswer(context.Background(), s,
+		&research.Intent{Topic: "x"}, exec, nil,
+		2048, 30, 480, quietLogger())
+	if err != nil {
+		t.Fatalf("synthesizeAnswer: %v", err)
+	}
+	if len(got.Evidence) != 1 {
+		t.Errorf("Evidence len = %d, want 1 (dups dropped)", len(got.Evidence))
+	}
+}
+
+func TestSynthesizeAnswer_NilGuards(t *testing.T) {
+	s := &fakeSynthesizer{content: `{"synthesis":"x"}`}
+	if _, err := synthesizeAnswer(context.Background(), s, nil, &research.ExecutionOutput{Topic: "x"}, nil, 2048, 30, 480, nil); err == nil {
+		t.Error("want intent-nil error")
+	}
+	if _, err := synthesizeAnswer(context.Background(), s, &research.Intent{Topic: "x"}, nil, nil, 2048, 30, 480, nil); err == nil {
+		t.Error("want exec-nil error")
+	}
+	if _, err := synthesizeAnswer(context.Background(), nil, &research.Intent{Topic: "x"}, &research.ExecutionOutput{Topic: "x"}, nil, 2048, 30, 480, nil); err == nil {
+		t.Error("want synthesizer-nil error")
+	}
+}

--- a/processor/research-graph-synthesize/prompt.go
+++ b/processor/research-graph-synthesize/prompt.go
@@ -1,0 +1,153 @@
+package researchsynthesize
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/c360studio/semstreams/agentic/research"
+)
+
+// buildSystemPrompt returns the static system message that frames the
+// synthesizer's role + the no-fabrication contract + output shape.
+// Stable across requests so per-loop prompt changes don't ripple
+// into a system-message change.
+//
+// Discipline: per-section purpose framing per
+// feedback_persona_prose_needs_decision_criteria. The no-fabrication
+// section uses concrete examples (good ref vs invented ref). The
+// output contract spells out the exact JSON shape so the LLM does
+// not need to guess.
+func buildSystemPrompt() string {
+	return `You are the synthesis stage of a graph-search pipeline. You receive a research topic and the upstream evidence the retrieval and assessment stages surfaced. You write the answer: a natural-language synthesis grounded in the evidence, with a list of the evidence items you used.
+
+You do not invent facts. You do not invent entity IDs, ObjectStore refs, or sources. If the evidence does not support an answer to the topic, say so plainly in the synthesis.
+
+# Quote-back contract (load-bearing)
+
+Every evidence reference you emit in "evidence_refs" MUST be either an EntityID or an ObjectStoreRef that appears EXACTLY in the input evidence array. The backend strips any reference that does not match and surfaces drift to operator review. Repeated drift suggests the prompt is being ignored — operators iterate the prompt, not bypass the validator.
+
+Good: refer to entities by the exact EntityID strings in the evidence (e.g. "acme.ops.robotics.gcs.drone.001").
+Good: refer to ObjectStore-backed content by the exact ObjectStoreRef string (e.g. "objstore://research/evidence-014.txt").
+Bad: invent shorter IDs or rewrite IDs for readability ("drone-001" is wrong if the evidence carries "acme.ops.robotics.gcs.drone.001"; use the long form).
+Bad: cite a source you can name from your training data but did not appear in the evidence.
+
+# Writing the synthesis
+
+Length: as long as the topic needs; do not pad. A 2-sentence answer to a focused topic is preferable to a 5-paragraph answer that restates the evidence in different words.
+
+Structure: lead with the direct answer. Follow with the evidence that supports it. Close with caveats — gaps in the evidence, degraded retrieval flags, conflicting signals.
+
+When evidence is thin: say so. "The evidence shows X but does not cover Y" is a useful answer; making up Y is not.
+
+When evidence is empty: produce a short "no evidence available for this topic" synthesis and emit evidence_refs: []. Do NOT invent.
+
+# Output contract
+
+Emit a single JSON object, no prose, no markdown fences, with this shape:
+
+` + "```" + `
+{
+  "synthesis": "<the natural-language answer; refer to evidence by EntityID or ObjectStoreRef strings exactly as they appear in the input>",
+  "evidence_refs": [
+    "<EntityID or ObjectStoreRef from input>",
+    ...
+  ]
+}
+` + "```" + `
+
+Only emit evidence_refs you actually drew from in writing synthesis. The backend echoes those evidence items back to the caller as citations; padding the list with refs you did not use produces noisy citations for downstream consumers.`
+}
+
+// buildUserPrompt renders the per-request context the synthesizer
+// sees. Evidence is rendered with stable ordering (Score descending;
+// ties broken by EntityID) so the same loop replayed produces
+// byte-identical prompts. SnippetText is truncated per
+// maxSnippetCharsInPrompt.
+func buildUserPrompt(intent *research.Intent, exec *research.ExecutionOutput, maxEvidenceInPrompt, maxSnippetCharsInPrompt int) string {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "Topic: %s\n", intent.Topic)
+
+	if len(intent.Hints) > 0 {
+		sb.WriteString("\nUpstream hints:\n")
+		keys := make([]string, 0, len(intent.Hints))
+		for k := range intent.Hints {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Fprintf(&sb, "  - %s: %s\n", k, intent.Hints[k])
+		}
+	}
+
+	if exec.Degraded {
+		fmt.Fprintf(&sb, "\nRetrieval degraded: yes (%s)\n", exec.DegradedReason)
+		sb.WriteString("Treat the evidence as partial; surface gaps in the synthesis.\n")
+	}
+
+	sb.WriteString("\nEvidence (top by score; refer back to EntityID / ObjectStoreRef strings exactly):\n")
+	evidence := orderedEvidence(exec.Evidence, maxEvidenceInPrompt)
+	if len(evidence) == 0 {
+		sb.WriteString("  (none — produce a no-evidence synthesis per the contract)\n")
+	}
+	for i, e := range evidence {
+		fmt.Fprintf(&sb, "  [%d] %s", i, e.EntityID)
+		if e.Tier != "" {
+			fmt.Fprintf(&sb, " (tier=%s", e.Tier)
+			if e.Source != "" {
+				fmt.Fprintf(&sb, " src=%s", e.Source)
+			}
+			if e.Score > 0 {
+				fmt.Fprintf(&sb, " score=%.2f", e.Score)
+			}
+			sb.WriteString(")")
+		}
+		if e.ObjectStoreRef != "" {
+			fmt.Fprintf(&sb, " obj=%s", e.ObjectStoreRef)
+		}
+		if e.SnippetText != "" {
+			snippet := e.SnippetText
+			if maxSnippetCharsInPrompt > 0 && len(snippet) > maxSnippetCharsInPrompt {
+				snippet = snippet[:maxSnippetCharsInPrompt] + "..."
+			}
+			fmt.Fprintf(&sb, "\n      snippet: %s", snippet)
+		}
+		sb.WriteString("\n")
+	}
+
+	if total := len(exec.Evidence); total > len(evidence) {
+		fmt.Fprintf(&sb, "  (... %d more evidence items not shown)\n", total-len(evidence))
+	}
+
+	sb.WriteString("\nWrite the synthesis and emit the JSON object per the system prompt's output contract.")
+	return sb.String()
+}
+
+// orderedEvidence returns the top-N evidence items in the canonical
+// chain ordering: tier ascending (tier 0 authoritative first), score
+// descending within a tier, EntityID ascending for tie-break. Matches
+// processor/research-graph-execute/handler.go's sortEvidence so the
+// prompt-time ordering and the SearchResult.Evidence echo ordering
+// stay in lockstep (operator trajectory replay reads the same shape
+// at both ends).
+func orderedEvidence(in []research.Evidence, limit int) []research.Evidence {
+	if limit <= 0 || len(in) == 0 {
+		return nil
+	}
+	out := make([]research.Evidence, len(in))
+	copy(out, in)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Tier != out[j].Tier {
+			return out[i].Tier < out[j].Tier
+		}
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].EntityID < out[j].EntityID
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}

--- a/processor/research-graph-synthesize/register.go
+++ b/processor/research-graph-synthesize/register.go
@@ -1,0 +1,19 @@
+package researchsynthesize
+
+import "github.com/c360studio/semstreams/component"
+
+// Register registers the synthesize_answer processor with the
+// supplied component registry. Called from
+// componentregistry.Register at process bootstrap.
+func Register(registry *component.Registry) error {
+	return registry.RegisterWithConfig(component.RegistrationConfig{
+		Name:        ComponentName,
+		Factory:     NewProcessor,
+		Schema:      configSchema,
+		Type:        "processor",
+		Protocol:    "synthesize_answer",
+		Domain:      "research",
+		Description: "ADR-045 synthesize_answer: terminal LLM stage. Quote-back-validated synthesis grounded in upstream evidence. Drives the continuation rule.",
+		Version:     "0.1.0",
+	})
+}

--- a/schemas/research-graph-assess.v1.json
+++ b/schemas/research-graph-assess.v1.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "research-graph-assess.v1.json",
+  "type": "object",
+  "title": "research-graph-assess Configuration",
+  "description": "ADR-045 assess_sufficiency: structured-emit sufficient/refine decision over upstream ExecutionOutput evidence. Drives R3's synthesize-or-refine branch.",
+  "properties": {
+    "loops_bucket": {
+      "type": "string",
+      "description": "NATS KV bucket holding research-pipeline loops and trigger/completion keys",
+      "default": "AGENT_LOOPS",
+      "category": "advanced"
+    },
+    "max_evidence_in_prompt": {
+      "type": "integer",
+      "description": "Cap on number of ExecutionOutput evidence items embedded in the assessor prompt. Top-N by Score; tighter caps keep prompts within small-model context windows. 0 means default (20)",
+      "default": 20,
+      "maximum": 100,
+      "category": "advanced"
+    },
+    "max_response_tokens": {
+      "type": "integer",
+      "description": "Cap on LLM response tokens. The JSON-shaped output is small; 1024 covers the worst case across decision paths",
+      "default": 1024,
+      "maximum": 4096,
+      "category": "advanced"
+    },
+    "max_snippet_chars_in_prompt": {
+      "type": "integer",
+      "description": "Cap on per-evidence SnippetText characters rendered in the assessor prompt. 0 means default (280)",
+      "default": 280,
+      "maximum": 2000,
+      "category": "advanced"
+    },
+    "ports": {
+      "type": "string",
+      "description": "Port configuration. assess_sufficiency requires one nats input subscribing to component.assess_sufficiency.\u003e",
+      "category": "basic"
+    }
+  },
+  "required": [],
+  "x-component-metadata": {
+    "name": "research-graph-assess",
+    "type": "processor",
+    "protocol": "assess_sufficiency",
+    "domain": "research",
+    "version": "0.1.0"
+  }
+}

--- a/schemas/research-graph-synthesize.v1.json
+++ b/schemas/research-graph-synthesize.v1.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "research-graph-synthesize.v1.json",
+  "type": "object",
+  "title": "research-graph-synthesize Configuration",
+  "description": "ADR-045 synthesize_answer: terminal LLM stage. Quote-back-validated synthesis grounded in upstream evidence. Drives the continuation rule.",
+  "properties": {
+    "loops_bucket": {
+      "type": "string",
+      "description": "NATS KV bucket holding research-pipeline loops and trigger/completion keys",
+      "default": "AGENT_LOOPS",
+      "category": "advanced"
+    },
+    "max_evidence_in_prompt": {
+      "type": "integer",
+      "description": "Cap on number of ExecutionOutput evidence items embedded in the synthesizer prompt. Top-N by Score; tighter caps keep prompts within small-model context windows. 0 means default (30)",
+      "default": 30,
+      "maximum": 200,
+      "category": "advanced"
+    },
+    "max_response_tokens": {
+      "type": "integer",
+      "description": "Cap on LLM response tokens for the synthesis output",
+      "default": 2048,
+      "maximum": 8192,
+      "category": "advanced"
+    },
+    "max_snippet_chars_in_prompt": {
+      "type": "integer",
+      "description": "Cap on per-evidence SnippetText characters rendered in the synthesizer prompt. 0 means default (480)",
+      "default": 480,
+      "maximum": 4000,
+      "category": "advanced"
+    },
+    "ports": {
+      "type": "string",
+      "description": "Port configuration. synthesize_answer requires one nats input subscribing to component.synthesize_answer.\u003e",
+      "category": "basic"
+    }
+  },
+  "required": [],
+  "x-component-metadata": {
+    "name": "research-graph-synthesize",
+    "type": "processor",
+    "protocol": "synthesize_answer",
+    "domain": "research",
+    "version": "0.1.0"
+  }
+}

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1263,9 +1263,11 @@ components:
                         - $ref: ../schemas/oasf-generator.v1.json
                         - $ref: ../schemas/objectstore.v1.json
                         - $ref: ../schemas/otel-exporter.v1.json
+                        - $ref: ../schemas/research-graph-assess.v1.json
                         - $ref: ../schemas/research-graph-classify.v1.json
                         - $ref: ../schemas/research-graph-execute.v1.json
                         - $ref: ../schemas/research-graph-route.v1.json
+                        - $ref: ../schemas/research-graph-synthesize.v1.json
                         - $ref: ../schemas/rule-processor.v1.json
                         - $ref: ../schemas/slim-bridge.v1.json
                         - $ref: ../schemas/udp.v1.json


### PR DESCRIPTION
## Summary

ADR-045 Phase 1 PR 5: the final two LLM-judgment stages of the graph-search rule chain. Both new components mirror `processor/research-graph-route`'s structure (doc/config/component/handler/adapters/prompt/register), and ship with a small shared helper extracted from route_search.

- **`processor/research-graph-assess`** — Sufficient/refine decision over upstream `ExecutionOutput`. Emits `research.AssessmentOutput` at `assess.complete.<lid>` (R3 trigger) + `assess.snapshot.<lid>`.
- **`processor/research-graph-synthesize`** — Terminal LLM stage. Quote-back-validated synthesis grounded in the input evidence. Emits `research.SearchResult` at `search_result.complete.<lid>` per ADR-045 R6 + `synthesize.snapshot.<lid>`.
- **`processor/research-graph-llmwrap`** — Shared `ExtractJSON` + `Truncate` helpers lifted out of route_search; route migrated to use them.
- **`agentic/research.AssessmentOutput`** payload registered with round-trip tests.
- **`model.CapabilityResearchAssessment` + `CapabilityResearchSynthesis`** so operators can route each stage independently.

PR 6 will wire R3 (assess output → synthesize vs refine) and R6 (continuation rule on `search_result.complete.*`) per [docs/operations/22-adr045-phase1-plan.md](https://github.com/C360Studio/semstreams/blob/main/docs/operations/22-adr045-phase1-plan.md).

## Pre-merge go-reviewer fixes

A local go-reviewer pass surfaced 2 Critical + 4 substantive findings; all addressed before commit:

- **C1** wire-contract drift — synthesize was writing `synthesize.complete.<lid>`; renamed to `search_result.complete.<lid>` per ADR-045 R6. Terminal triggers name the payload shape, not the producing component, so R6's `key_pattern` stays stable across future synthesizer reshuffles.
- **C2** latent timeout clip — `DefaultSynthesizeTimeout` was 45s but `natsclient.Subscribe` wraps per-message handlers in a 30s context, silently clipping. Lowered to 30s; documented the cap in both the constant and config schema description.
- **I1** degraded-path validation gap — `writeAssessment` + `writeResult` now `Validate()` before marshal even on the degraded path.
- **I3 + I4** evidence-ordering consistency — assess + synthesize prompts now sort evidence tier-asc-then-score-desc-then-EntityID-asc to match `execute_subqueries`' canonical ranking. Trajectory replay reads byte-identical shape at prompt-time vs SearchResult.Evidence echo.
- **N1** assess prompt's JSON example used `//` comments — moved to surrounding prose so a model echoing the shape verbatim emits valid JSON.
- **N3** `fallbackEchoCount` hoisted from magic number.

## Discipline anchors

- `feedback_persona_prose_needs_decision_criteria` — per-decision purpose + decision-axis framing, no magic-number thresholds, negative-shape for `Sufficient=true` and no-fabrication
- `feedback_tool_signature_intent_not_structure` — `RefinedQueries` are stringy descriptions; `evidence_refs` are EntityID/ObjectStoreRef strings; `DecompTrace` + Evidence echo are server-constructed
- `feedback_llm_authored_predicates_rule_opaque` — payload doc-comments call out future triple stamping uses `WithRuleOpaque(true)`
- `feedback_production_decoder_round_trip_required` — `AssessmentOutput` round-trips via `payloadbuiltins.NewTestDecoder`
- `feedback_nats_publishes_use_payload_registry` — all KV writes wrap in `BaseMessage`
- `feedback_framework_change_needs_branch_integration_sweep` — branch-wide `-race -tags=integration` sweep run pre-commit (149 packages green); touches `agentic/research` payload registry + `model/` capability constants + `componentregistry/` wire

## Test plan

- [x] `task lint` — 0 new warnings on PR 5 packages (18 pre-existing on main untouched)
- [x] `go test -race ./...` — PR 5 + adjacent packages green pre- and post-rebase
- [x] `go vet ./...` AND `-tags=integration` AND `-tags=live_llm` clean
- [x] `task schema:generate` — produced `research-graph-assess.v1.json` + `research-graph-synthesize.v1.json` + OpenAPI spec entries (committed; no uncommitted drift)
- [x] `go test ./test/contract/...` green
- [x] Full `-race -tags=integration` branch sweep (149 packages) green
- [ ] CI to confirm above on the GitHub runner
- [ ] PR 6 wiring exercises the chain end-to-end (smoke test for R0–R6 + reference flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)