### PR TITLE
feat(executors): Runner interface + WithRunner option for per-call dispatch routing

### DIFF
--- a/processor/agentic-tools/executors/bash.go
+++ b/processor/agentic-tools/executors/bash.go
@@ -5,6 +5,15 @@
 // Otherwise, they run locally via os/exec with sensitive environment variables
 // stripped.
 //
+// The remote dispatch path is fronted by the Runner interface so downstream
+// products can supply custom routing logic (per-tenant devcontainers,
+// load-balancing across sandbox replicas, attestation-aware routing, A/B
+// testing) without wrapping BashExecutor. *runner.Client is the default
+// implementation; product shells inject alternates via WithRunner. This
+// is the per-call extension point the forthcoming capability-aware
+// execution-environment substrate (ADR-052, see
+// docs/proposals/sandbox-substrate.md) plugs into.
+//
 // Ported from semspec/tools/bash.
 package executors
 
@@ -27,11 +36,32 @@ const (
 	bashDefaultTimeout = 120 * time.Second
 )
 
-// BashExecutor runs shell commands locally or via the remote runner client
-// (which routes to a remote sandbox container — see SANDBOX_URL).
+// Runner is the per-call interface BashExecutor uses to dispatch commands
+// to a remote sandbox server. *runner.Client satisfies it (default,
+// constructed from sandboxURL). Product shells supply custom
+// implementations via WithRunner for per-call routing — e.g.,
+// attestation-aware routing to per-tenant devcontainers, load-balancing
+// across replicas, or A/B testing alternate sandbox backends. This is
+// the framework extension point the forthcoming capability-aware
+// execution-environment substrate (ADR-052) builds on; the interface
+// itself is product-agnostic and carries no devcontainer, attestation,
+// or tenancy concepts.
+type Runner interface {
+	Exec(ctx context.Context, taskID, command string, timeoutMs int) (*runner.ExecResult, error)
+}
+
+// Compile-time assertion that *runner.Client satisfies Runner. Any future
+// signature drift on *runner.Client.Exec surfaces here as a compile error
+// in the package that owns the contract, not as a runtime panic during
+// remote dispatch.
+var _ Runner = (*runner.Client)(nil)
+
+// BashExecutor runs shell commands locally or via a Runner (which routes
+// to a remote sandbox container — see SANDBOX_URL for the URL-based
+// default, WithRunner for custom routing).
 type BashExecutor struct {
 	workDir string
-	runner  *runner.Client
+	runner  Runner
 	timeout time.Duration
 }
 
@@ -43,17 +73,37 @@ func WithBashTimeout(d time.Duration) BashOption {
 	return func(e *BashExecutor) { e.timeout = d }
 }
 
+// WithRunner overrides the runner constructed from sandboxURL. When
+// provided, sandboxURL is ignored; the supplied Runner handles all
+// remote dispatch. Mutually exclusive with the URL-based constructor;
+// either call NewBashExecutor("", "", WithRunner(custom)) or pass a
+// URL and omit the option. Passing the untyped nil is treated as
+// "no override" (URL-based default applies if a URL was given). A
+// typed-nil wrapped in a Runner interface value — e.g., `var r Runner
+// = (*runner.Client)(nil); WithRunner(r)` — is NOT detected and will
+// panic on first Exec; construct your Runner before passing it in.
+func WithRunner(r Runner) BashOption {
+	return func(e *BashExecutor) {
+		if r != nil {
+			e.runner = r
+		}
+	}
+}
+
 // NewBashExecutor creates a bash executor. If sandboxURL is non-empty, commands
-// are routed to the sandbox container.
+// are routed to the sandbox container via the default *runner.Client. Pass
+// WithRunner to inject a custom Runner instead; when supplied, it overrides
+// the URL-based default.
 func NewBashExecutor(workDir, sandboxURL string, opts ...BashOption) *BashExecutor {
 	e := &BashExecutor{
 		workDir: workDir,
 	}
-	for _, opt := range opts {
-		opt(e)
-	}
 	if sandboxURL != "" {
 		e.runner = runner.NewClient(sandboxURL)
+	}
+	// Options apply after URL-based init so WithRunner can override.
+	for _, opt := range opts {
+		opt(e)
 	}
 	return e
 }

--- a/processor/agentic-tools/executors/bash_test.go
+++ b/processor/agentic-tools/executors/bash_test.go
@@ -3,6 +3,7 @@ package executors
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,9 +11,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/processor/agentic-tools/runner"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -439,6 +442,118 @@ func TestBashExecutor_VerifyClean_SandboxBlocksOnDirty(t *testing.T) {
 	// command must NOT have been issued.
 	require.Len(t, *calls, 1, "real command should not have been issued; calls: %+v", *calls)
 	assert.Contains(t, (*calls)[0].command, "git status")
+}
+
+// recordingRunner is a Runner that captures every Exec call and returns
+// a canned ExecResult. Lets tests prove (1) WithRunner replaces the
+// URL-based default and (2) BashExecutor routes through the supplied
+// Runner without touching the network. Mirrors the role of
+// newFakeSandboxServer for the URL-based path, but without HTTP — the
+// whole point of the Runner interface is per-call routing without an
+// HTTP middlebox.
+type recordingRunner struct {
+	mu     sync.Mutex
+	calls  []recordedExec
+	result *runner.ExecResult
+	err    error
+}
+
+type recordedExec struct {
+	taskID    string
+	command   string
+	timeoutMs int
+}
+
+func (r *recordingRunner) Exec(_ context.Context, taskID, command string, timeoutMs int) (*runner.ExecResult, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, recordedExec{taskID: taskID, command: command, timeoutMs: timeoutMs})
+	r.mu.Unlock()
+	return r.result, r.err
+}
+
+// TestBashExecutor_WithRunner_RoutesThroughCustomRunner is the primary
+// boundary test for the Runner interface extension point. Product shells
+// (e.g., semteams's per-tenant devcontainer router) supply a custom
+// Runner via WithRunner and expect every remote dispatch to go through
+// it — no fallback to local exec, no HTTP, no URL-based runner.
+func TestBashExecutor_WithRunner_RoutesThroughCustomRunner(t *testing.T) {
+	rec := &recordingRunner{
+		result: &runner.ExecResult{Stdout: "from-custom-runner", ExitCode: 0},
+	}
+	e := NewBashExecutor("", "", WithRunner(rec))
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "cr-1",
+		Name:      "bash",
+		Arguments: map[string]any{"command": "echo hi"},
+		Metadata:  map[string]any{"task_id": "task-abc"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, res.Error)
+	assert.Equal(t, "from-custom-runner", res.Content)
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	require.Len(t, rec.calls, 1)
+	assert.Equal(t, "task-abc", rec.calls[0].taskID)
+	assert.Equal(t, "echo hi", rec.calls[0].command)
+	assert.Greater(t, rec.calls[0].timeoutMs, 0, "timeout must be propagated as ms")
+}
+
+// TestBashExecutor_WithRunner_OverridesURL pins the mutual-exclusion
+// contract: when both a sandboxURL and WithRunner are supplied, WithRunner
+// wins. Documented behavior — callers are expected to use one or the
+// other, but the constructor must not silently revert to the URL-based
+// runner if both arrive. The HTTP handler fails the test the instant
+// the contract breaks (matches the newFakeSandboxServer pattern above)
+// so the diagnosis is "URL runner was invoked", not "custom runner
+// returned the wrong content."
+func TestBashExecutor_WithRunner_OverridesURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("WithRunner did not override; URL runner was invoked at %s", r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	rec := &recordingRunner{result: &runner.ExecResult{Stdout: "custom-wins", ExitCode: 0}}
+	e := NewBashExecutor("/unused", server.URL, WithRunner(rec))
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "cr-2",
+		Name:      "bash",
+		Arguments: map[string]any{"command": "echo override"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "custom-wins", res.Content)
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	require.Len(t, rec.calls, 1)
+}
+
+// TestBashExecutor_WithRunner_NilIsNoop confirms that passing a nil
+// Runner via WithRunner does NOT clobber the URL-based default. Keeps
+// callers safe from accidentally disabling the URL-based runner with
+// an uninitialized custom impl.
+func TestBashExecutor_WithRunner_NilIsNoop(t *testing.T) {
+	e := NewBashExecutor("/tmp", "http://sandbox:8080", WithRunner(nil))
+	assert.NotNil(t, e.runner, "nil Runner must not clear the URL-constructed default")
+}
+
+// TestBashExecutor_WithRunner_PropagatesError surfaces transport-layer
+// errors through the same path as the URL-based runner — exec failure
+// becomes a ToolResult.Error, not a returned err.
+func TestBashExecutor_WithRunner_PropagatesError(t *testing.T) {
+	rec := &recordingRunner{err: errors.New("router unavailable")}
+	e := NewBashExecutor("", "", WithRunner(rec))
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:        "cr-3",
+		Name:      "bash",
+		Arguments: map[string]any{"command": "echo hi"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, res.Error, "remote exec failed")
+	assert.Contains(t, res.Error, "router unavailable")
 }
 
 // TestBashExecutor_VerifyClean_SandboxAllowsClean covers the success


### PR DESCRIPTION
## Summary

- Adds `Runner` interface + `WithRunner(Runner) BashOption` to `processor/agentic-tools/executors/BashExecutor`, giving downstream products a per-call extension point for remote-dispatch routing (per-tenant devcontainers, attestation-aware routing, load-balancing, A/B testing).
- Unblocks **semteams**'s multi-tenant sandbox (their proposed shape, implemented verbatim).
- Backward-compat: `NewBashExecutor(workDir, sandboxURL)` signature unchanged; `runner` field stays unexported; `register_bash.go` env-driven path unmodified.

## Design notes

- `Runner` interface declared in `executors` (consumer-owned interface per Go idiom), not in `runner` — keeps the producer pkg unaware of being plugged into.
- Single-method interface — exactly what `BashExecutor` uses (`Exec(ctx, taskID, command, timeoutMs)`). The full `*runner.Client` has 10+ methods; none belong here.
- Constructor reordered: opts now apply AFTER URL-based init so `WithRunner` can override the URL-constructed default.
- Compile-time assertion `var _ Runner = (*runner.Client)(nil)` locks the contract — future signature drift on `*runner.Client.Exec` surfaces as a compile error in this package, not a runtime panic.
- `WithRunner(nil)` is no-op (URL default applies). Typed-nil-via-interface is documented as caller error (not detected by guard).
- Framework substrate plug-point for the forthcoming `pkg/sandbox` capability-aware execution-environment substrate ([ADR-052 / docs/proposals/sandbox-substrate.md](../blob/main/docs/proposals/sandbox-substrate.md)). Interface is product-agnostic — no devcontainer/attestation/tenancy concepts.

## Pre-merge gates (all green locally)

- `go test -race ./...` — pass
- `go test -race -tags=integration ./...` — pass on retry (one transient testcontainers Docker-API timeout in `TestHotReload_SeedIdempotency`, unrelated to this PR's path; re-run in isolation passes in 2.4s; pre-existing flake class — tracking issue filed separately)
- `go vet -tags=integration ./...` + `go vet -tags=live_llm ./...` — clean
- `task lint` — no new warnings (18 pre-existing `redefines-builtin-id` in unrelated files)
- `task schema:generate` — no drift in `schemas/` `specs/`
- `go test ./test/contract/...` — pass
- `task build` — pass

## go-reviewer pre-merge pass

Returned no Critical findings. Applied the two Important suggestions in this PR:
- **I1**: Sharpened `WithRunner` doc to document the typed-nil-via-interface trap (caller must construct Runner before passing).
- **I2**: Added `var _ Runner = (*runner.Client)(nil)` compile-time assertion.
- **N3**: Switched `WithRunner_OverridesURL` test to `t.Errorf`-in-handler (matches existing `newFakeSandboxServer` pattern; converts contract break from end-of-test assertion to immediate failure).

## Test plan

- [x] `go test -race ./processor/agentic-tools/executors/...` green (5 new test cases)
- [x] Backward-compat: `grep -rn "\.runner\b" processor/agentic-tools/executors/` confirms no external readers of the renamed field
- [x] `register_bash.go` env path unmodified (verified by inspection)
- [x] go-reviewer pre-merge approval (Important findings I1+I2 applied; nits N1, N2, N4, N5 left as flagged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)