### PR TITLE
test(e2e): research-graph tier — ADR-045 Phase 1 R0-R6 chain end-to-end

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,6 +40,8 @@ includes:
     taskfile: ./taskfiles/e2e/semantic.yml
   e2e:agentic:
     taskfile: ./taskfiles/e2e/agentic.yml
+  e2e:research-graph:
+    taskfile: ./taskfiles/e2e/research-graph.yml
   e2e:deep-research:
     taskfile: ./taskfiles/e2e/deep-research.yml
   e2e:crud-tools:

--- a/cmd/e2e/main.go
+++ b/cmd/e2e/main.go
@@ -24,6 +24,7 @@ import (
 	deepresearch "github.com/c360studio/semstreams/test/e2e/scenarios/deep-research"
 	lifecyclescenario "github.com/c360studio/semstreams/test/e2e/scenarios/lifecycle"
 	opsscenario "github.com/c360studio/semstreams/test/e2e/scenarios/ops"
+	researchgraph "github.com/c360studio/semstreams/test/e2e/scenarios/research-graph"
 	"github.com/c360studio/semstreams/test/e2e/scenarios/throughput"
 )
 
@@ -219,6 +220,7 @@ func handleListCommand(listScenarios bool) bool {
 	fmt.Println("  e2e:statistical - BM25 + community detection (~60s)")
 	fmt.Println("  e2e:semantic    - Neural embeddings + LLM (~90s)")
 	fmt.Println("  e2e:agentic     - Agent loop + tools with mock LLM (~30s)")
+	fmt.Println("  e2e:research-graph - ADR-045 R0-R6 chain with mock LLM (~30s)")
 	fmt.Println("")
 	fmt.Println("Individual Scenarios:")
 	fmt.Println("")
@@ -238,6 +240,8 @@ func handleListCommand(listScenarios bool) bool {
 	fmt.Println("                      Override with AGENTIC_LLM_URL for real LLM")
 	fmt.Println("    deep-research   - Rules-driven multi-agent research flow")
 	fmt.Println("                      Requires rule-processor with deep-research rules")
+	fmt.Println("    research-graph  - ADR-045 Phase 1 R0-R6 chain end-to-end")
+	fmt.Println("                      Mock LLM scripted with synthesize_directly happy path")
 	fmt.Println("")
 	fmt.Println("  Lifecycle (ADR-047):")
 	fmt.Println("    lifecycle       - Lifecycle-gateway + rule-engine + Manager round-trip")
@@ -402,6 +406,14 @@ func createScenario(
 		cfg := deepresearch.DefaultConfig()
 		cfg.MetricsURL = flags.metricsURL
 		return deepresearch.NewScenario(edgeClient, cfg)
+
+	// Research-graph scenario (ADR-045 Phase 1 R0-R6 chain)
+	case "research-graph":
+		cfg := researchgraph.DefaultConfig()
+		if flags.metricsURL != "" {
+			cfg.MetricsURL = flags.metricsURL
+		}
+		return researchgraph.NewScenario(edgeClient, cfg)
 
 	// CRUD-tools scenario (ADR-029 Pattern-B CRUD round-trip)
 	case "crud-tools":

--- a/configs/research-graph-e2e.json
+++ b/configs/research-graph-e2e.json
@@ -1,0 +1,301 @@
+{
+  "_doc": [
+    "ADR-045 Phase 1 research-graph e2e configuration.",
+    "Wires the five research-graph components + agentic-loop/dispatch/tools/model + graph-ingest/query + rule-processor (loading R0-R6 pack) against a mock LLM endpoint for deterministic e2e validation.",
+    "Used by docker/compose/research-graph.yml + task e2e:research-graph.",
+    "Reference flow at configs/examples/research-graph-pipeline.json is the operator-facing template; this file is the e2e-tuned variant."
+  ],
+  "version": "1.0.0",
+  "platform": {
+    "org": "c360",
+    "id": "research-graph-e2e",
+    "type": "agentic-e2e",
+    "region": "local",
+    "instance_id": "rg-e2e-001",
+    "environment": "test"
+  },
+  "tier": "agentic",
+  "nats": {
+    "urls": ["nats://localhost:4222"]
+  },
+  "model_registry": {
+    "endpoints": {
+      "mock": {
+        "provider": "openai",
+        "url": "http://mock-llm:8080/v1",
+        "model": "mock-model",
+        "max_tokens": 4096,
+        "supports_tools": true,
+        "tool_format": "openai",
+        "stream": false
+      }
+    },
+    "defaults": {
+      "model": "mock"
+    },
+    "capabilities": {
+      "general":             { "preferred": ["mock"] },
+      "research_routing":    { "preferred": ["mock"] },
+      "research_assessment": { "preferred": ["mock"] },
+      "research_synthesis":  { "preferred": ["mock"] }
+    }
+  },
+  "services": {
+    "service-manager": {
+      "name": "service-manager",
+      "enabled": true,
+      "config": {
+        "http_port": 8080,
+        "swagger_ui": true,
+        "server_info": {
+          "title": "SemStreams ADR-045 Research-Graph E2E",
+          "description": "Phase 1 chain end-to-end against mock LLM.",
+          "version": "0.1.0"
+        }
+      }
+    },
+    "component-manager": {
+      "name": "component-manager",
+      "enabled": true,
+      "config": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "enabled": true,
+      "config": {
+        "port": 9090,
+        "path": "/metrics",
+        "include_go_metrics": true
+      }
+    },
+    "message-logger": {
+      "name": "message-logger",
+      "enabled": true,
+      "config": {
+        "buffer_size": 10000,
+        "monitor_subjects": ["agent.*", "tool.*", "component.*", "graph.mutation.*"],
+        "enable_kv_query": true,
+        "log_level": "INFO"
+      }
+    },
+    "log-forwarder": {
+      "name": "log-forwarder",
+      "enabled": true,
+      "config": {
+        "min_level": "DEBUG",
+        "exclude_sources": []
+      }
+    }
+  },
+  "components": {
+    "agentic-dispatch": {
+      "type": "processor",
+      "name": "agentic-dispatch",
+      "enabled": true,
+      "config": {
+        "default_role": "general",
+        "default_tools": ["research_graph", "read_loop_result"],
+        "auto_continue": false,
+        "stream_name": "USER",
+        "ports": {
+          "inputs": [
+            {"name": "user.message", "type": "jetstream", "subject": "user.message.>", "stream_name": "USER", "required": true},
+            {"name": "agent.complete", "type": "jetstream", "subject": "agent.complete.*", "stream_name": "AGENT", "required": true}
+          ],
+          "outputs": [
+            {"name": "agent.task", "type": "jetstream", "subject": "agent.task.*", "stream_name": "AGENT"},
+            {"name": "user.response", "type": "nats", "subject": "user.response.*"}
+          ]
+        }
+      }
+    },
+    "agentic-loop": {
+      "type": "processor",
+      "name": "agentic-loop",
+      "enabled": true,
+      "config": {
+        "max_iterations": 5,
+        "timeout": "120s",
+        "stream_name": "AGENT",
+        "loops_bucket": "AGENT_LOOPS",
+        "ports": {
+          "inputs": [
+            {"name": "agent.task", "type": "jetstream", "subject": "agent.task.*", "stream_name": "AGENT", "required": true},
+            {"name": "agent.response", "type": "jetstream", "subject": "agent.response.>", "stream_name": "AGENT", "required": true},
+            {"name": "tool.result", "type": "jetstream", "subject": "tool.result.>", "stream_name": "TOOL", "required": true}
+          ],
+          "outputs": [
+            {"name": "agent.request", "type": "jetstream", "subject": "agent.request.*", "stream_name": "AGENT"},
+            {"name": "tool.execute", "type": "jetstream", "subject": "tool.execute.*", "stream_name": "TOOL"},
+            {"name": "agent.complete", "type": "jetstream", "subject": "agent.complete.*", "stream_name": "AGENT"}
+          ],
+          "kv_write": [
+            {"name": "loops", "type": "kv-write", "bucket": "AGENT_LOOPS"}
+          ]
+        }
+      }
+    },
+    "agentic-model": {
+      "type": "processor",
+      "name": "agentic-model",
+      "enabled": true,
+      "config": {
+        "stream_name": "AGENT",
+        "timeout": "120s",
+        "ports": {
+          "inputs": [
+            {"name": "agent.request", "type": "jetstream", "subject": "agent.request.>", "stream_name": "AGENT", "required": true}
+          ],
+          "outputs": [
+            {"name": "agent.response", "type": "jetstream", "subject": "agent.response.*", "stream_name": "AGENT", "required": true}
+          ]
+        }
+      }
+    },
+    "agentic-tools": {
+      "type": "processor",
+      "name": "agentic-tools",
+      "enabled": true,
+      "config": {
+        "stream_name": "TOOL",
+        "timeout": "60s",
+        "allowed_tools": ["research_graph", "read_loop_result", "decide"],
+        "loops_bucket": "AGENT_LOOPS",
+        "ports": {
+          "inputs": [
+            {"name": "tool.execute", "type": "jetstream", "subject": "tool.execute.>", "stream_name": "TOOL", "required": true}
+          ],
+          "outputs": [
+            {"name": "tool.result", "type": "jetstream", "subject": "tool.result.*", "stream_name": "TOOL", "required": true}
+          ],
+          "kv_read": [
+            {"name": "entity_states", "type": "kv-read", "bucket": "ENTITY_STATES"}
+          ]
+        }
+      }
+    },
+    "graph-ingest": {
+      "type": "processor",
+      "name": "graph-ingest",
+      "enabled": true,
+      "config": {
+        "enable_hierarchy": true,
+        "ports": {
+          "inputs": [
+            {"name": "graph_mutations", "subject": "graph.mutation.>", "type": "nats"}
+          ],
+          "outputs": [
+            {"name": "entity_states", "subject": "ENTITY_STATES", "type": "kv-write"}
+          ]
+        }
+      }
+    },
+    "graph-query": {
+      "type": "processor",
+      "name": "graph-query",
+      "enabled": true,
+      "config": {
+        "ports": {
+          "inputs": [
+            {"name": "graph.query", "subject": "graph.query.>", "type": "nats", "required": true}
+          ],
+          "kv_read": [
+            {"name": "entity_states", "type": "kv-read", "bucket": "ENTITY_STATES"}
+          ]
+        }
+      }
+    },
+    "research-graph-classify": {
+      "type": "processor",
+      "name": "research-graph-classify",
+      "enabled": true,
+      "config": {
+        "ports": {
+          "inputs": [
+            {"name": "classify_trigger", "type": "nats", "subject": "component.nl_classify.>", "required": true}
+          ]
+        }
+      }
+    },
+    "research-graph-route": {
+      "type": "processor",
+      "name": "research-graph-route",
+      "enabled": true,
+      "config": {
+        "model_capability": "research_routing",
+        "ports": {
+          "inputs": [
+            {"name": "route_trigger", "type": "nats", "subject": "component.route_search.>", "required": true}
+          ]
+        }
+      }
+    },
+    "research-graph-execute": {
+      "type": "processor",
+      "name": "research-graph-execute",
+      "enabled": true,
+      "config": {
+        "ports": {
+          "inputs": [
+            {"name": "execute_trigger", "type": "nats", "subject": "component.execute_subqueries.>", "required": true}
+          ]
+        }
+      }
+    },
+    "research-graph-assess": {
+      "type": "processor",
+      "name": "research-graph-assess",
+      "enabled": true,
+      "config": {
+        "model_capability": "research_assessment",
+        "ports": {
+          "inputs": [
+            {"name": "assess_trigger", "type": "nats", "subject": "component.assess_sufficiency.>", "required": true}
+          ]
+        }
+      }
+    },
+    "research-graph-synthesize": {
+      "type": "processor",
+      "name": "research-graph-synthesize",
+      "enabled": true,
+      "config": {
+        "model_capability": "research_synthesis",
+        "ports": {
+          "inputs": [
+            {"name": "synthesize_trigger", "type": "nats", "subject": "component.synthesize_answer.>", "required": true}
+          ]
+        }
+      }
+    },
+    "rule-processor": {
+      "type": "processor",
+      "name": "rule-processor",
+      "enabled": true,
+      "config": {
+        "rules_files": [
+          "/app/configs/rules/research-graph/00-kickoff-classify.json",
+          "/app/configs/rules/research-graph/01-classify-routes.json",
+          "/app/configs/rules/research-graph/02-route-decision-dispatch.json",
+          "/app/configs/rules/research-graph/03-execute-assesses.json",
+          "/app/configs/rules/research-graph/04-assess-dispatch.json",
+          "/app/configs/rules/research-graph/05-continuation.json"
+        ],
+        "enable_graph_integration": true,
+        "entity_watch_buckets": {
+          "ENTITY_STATES": [">"]
+        },
+        "ports": {
+          "inputs": [
+            {"name": "entity_states", "subject": "ENTITY_STATES.>", "type": "kv-watch", "bucket": "ENTITY_STATES"}
+          ],
+          "outputs": [
+            {"name": "component.dispatch", "subject": "component.*", "type": "nats", "description": "Per-stage dispatch published by R0-R4"},
+            {"name": "agent.task", "subject": "agent.task.*", "type": "jetstream", "stream_name": "AGENT", "description": "R6 continuation publishes back to parent role"},
+            {"name": "graph.mutation", "subject": "graph.mutation.*", "type": "nats", "description": "remove_triple actions in R2/R4 reset stage markers"}
+          ]
+        }
+      }
+    }
+  }
+}

--- a/docker/compose/research-graph.yml
+++ b/docker/compose/research-graph.yml
@@ -1,0 +1,100 @@
+# Research-Graph E2E Test Environment for SemStreams (ADR-045 Phase 1)
+#
+# Tests the full R0-R6 chain end-to-end:
+#   parent agent → research_graph tool → kickoff triples →
+#   nl_classify → route_search (mock LLM: synthesize_directly) →
+#   synthesize_answer (mock LLM) → R6 continuation → parent receives
+#
+# Usage:
+#   task e2e:research-graph                                # mock LLM (default)
+#   AGENTIC_LLM_URL=http://localhost:11434/v1 task e2e:research-graph  # Ollama
+#
+# Port range: 4xxxx (distinct from agentic's 3xxxx + lifecycle's 5xxxx)
+# to avoid host port collisions when running tiers concurrently.
+
+services:
+  # NATS Server with JetStream
+  nats:
+    image: nats:2.10-alpine
+    container_name: semstreams-research-graph-nats
+    ports:
+      - "44222:4222"  # Client connections (4xxxx range)
+      - "48222:8222"  # HTTP monitoring
+    command:
+      ["-js", "-sd", "/data", "-m", "8222", "--name", "semstreams-research-graph-nats"]
+    volumes:
+      - nats-research-graph-data:/data
+    networks:
+      - semstreams-research-graph-net
+    healthcheck:
+      test:
+        ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8222/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # Mock OpenAI Server with the research-graph preset (route + assess +
+  # synthesize marker-matched responses + parent's research_graph tool
+  # call). Per applyResearchGraphPreset in test/e2e/mock/cmd/main.go.
+  mock-llm:
+    build:
+      context: ../..
+      dockerfile: test/e2e/mock/Dockerfile
+    container_name: semstreams-research-graph-mock-llm
+    command: ["--scenario", "research-graph"]
+    ports:
+      - "48180:8080"  # Mock LLM (4xxxx range)
+      - "48181:8081"  # Mock AGNTCY (directory + OTEL — unused but exposed for consistency)
+    networks:
+      - semstreams-research-graph-net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+
+  # SemStreams Application with research-graph chain
+  semstreams:
+    # Per-target image tag — see docker/compose/e2e.yml for rationale.
+    image: c360studio/semstreams:e2e-production
+    build:
+      context: ../..
+      dockerfile: docker/Dockerfile
+      target: production
+    container_name: semstreams-research-graph-app
+    command: ["--config", "/app/configs/research-graph-e2e.json"]
+    depends_on:
+      nats:
+        condition: service_healthy
+      mock-llm:
+        condition: service_healthy
+    environment:
+      - SEMSTREAMS_NATS_URLS=nats://nats:4222
+      - SEMSTREAMS_LOG_LEVEL=debug
+      - SEMSTREAMS_DEBUG=${SEMSTREAMS_DEBUG:-false}
+      - SEMSTREAMS_DEBUG_PORT=6060
+      - AGENTIC_LLM_URL=${AGENTIC_LLM_URL:-http://mock-llm:8080/v1}
+    volumes:
+      - ../../configs:/app/configs:ro
+      - ../../testdata:/data/testdata:ro
+    ports:
+      - "48080:8080"  # HTTP API (health, components)
+      - "49090:9090"  # Prometheus metrics
+      - "46060:6060"  # pprof (when SEMSTREAMS_DEBUG=true)
+    networks:
+      - semstreams-research-graph-net
+    healthcheck:
+      test:
+        ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/readyz"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+networks:
+  semstreams-research-graph-net:
+    driver: bridge
+
+volumes:
+  nats-research-graph-data:
+    driver: local

--- a/processor/agentic-tools/executors/research_graph.go
+++ b/processor/agentic-tools/executors/research_graph.go
@@ -334,11 +334,28 @@ func (e *ResearchGraphExecutor) researchGraph(ctx context.Context, call agentic.
 	// chain stalls observably (no rule fires; operator sees the gap
 	// in trajectory data) rather than the parent loop crashing.
 	//
-	// parentRole comes from call.Metadata["role"] when the framework's
-	// agentic-loop dispatcher propagates the spawning loop's role onto
-	// each tool call's Metadata (it does; see TaskMessage → ToolCall
-	// metadata threading). Empty when the tool runs outside an agent
-	// loop; R6 then falls back to its configured default_parent_role.
+	// parentRole comes from call.Metadata["role"], which the framework's
+	// agentic-loop dispatcher populates from the spawning TaskMessage's
+	// Metadata at dispatch time (see agentic-loop/handlers.go
+	// CacheMetadata + the ToolCall.Metadata merge in handlers.go:1053+).
+	//
+	// CONTRACT: any production path that creates a TaskMessage for an
+	// agent capable of calling research_graph MUST populate
+	// TaskMessage.Metadata["role"] with the spawning role's name.
+	// Without it, parentRole is empty, the kickoff triple
+	// research.parent_role is omitted, and R6's continuation
+	// publish_agent substitutes `$entity.triple.research.parent_role`
+	// to a literal — the spawned task's Role field carries the
+	// unresolved template string and downstream role-registry lookups
+	// fail loudly.
+	//
+	// This contract is exercised by
+	// test/e2e/scenarios/research-graph/scenario.go's injectParentTask
+	// stage (the only e2e that drives a parent task directly to
+	// agent.task.*). agentic-dispatch's user-message → task path
+	// already populates Metadata["role"] from the default_role config.
+	// New parent-spawning paths (rule action publish_agent, custom
+	// dispatchers, sister-product chain roots) need to do the same.
 	parentRole := ""
 	if call.Metadata != nil {
 		if r, ok := call.Metadata["role"].(string); ok {

--- a/processor/research-graph-assess/prompt.go
+++ b/processor/research-graph-assess/prompt.go
@@ -20,8 +20,14 @@ import (
 // examples for the two non-obvious failure shapes (looks-adequate-
 // but-isn't, looks-sparse-but-is). Negative-shape for Sufficient=true
 // so the model doesn't default to it when uncertain.
+// SystemPromptMarker is the first sentence of buildSystemPrompt's
+// output, exported for the e2e mock LLM marker-matching. See
+// processor/research-graph-route/prompt.go SystemPromptMarker for
+// the full rationale.
+const SystemPromptMarker = "You are the sufficiency-assessment stage of a graph-search pipeline"
+
 func buildSystemPrompt() string {
-	return `You are the sufficiency-assessment stage of a graph-search pipeline. You receive a research topic and the upstream evidence the retrieval stages surfaced. You decide ONE thing: is the evidence enough to write a useful answer, or does the chain need to refine and retrieve more?
+	return SystemPromptMarker + `. You receive a research topic and the upstream evidence the retrieval stages surfaced. You decide ONE thing: is the evidence enough to write a useful answer, or does the chain need to refine and retrieve more?
 
 You do not synthesize the answer. You only judge whether one CAN be written from what's present.
 

--- a/processor/research-graph-route/prompt.go
+++ b/processor/research-graph-route/prompt.go
@@ -8,6 +8,17 @@ import (
 	"github.com/c360studio/semstreams/agentic/research"
 )
 
+// SystemPromptMarker is the first sentence of buildSystemPrompt's
+// output, exported so the e2e mock LLM scenario preset can match
+// against it without copying the substring. A persona-prose edit that
+// changes this sentence forces the importing test code to update too
+// rather than silently failing the mock match (which would surface as
+// "chain hung at route_search" with no link back to the marker drift).
+//
+// Same pattern in processor/research-graph-assess/prompt.go and
+// processor/research-graph-synthesize/prompt.go.
+const SystemPromptMarker = "You are the routing stage of a graph-search pipeline"
+
 // buildSystemPrompt returns the static system message that frames the
 // router's role + decision criteria + output contract. Stable across
 // requests so a per-loop prompt change doesn't ripple into a system-
@@ -22,7 +33,7 @@ import (
 // classifier output alone). Negative-shape for synthesize_directly
 // so the model doesn't default to it when uncertain.
 func buildSystemPrompt() string {
-	return `You are the routing stage of a graph-search pipeline. You receive a research topic and the upstream classifier's initial candidate set. You choose ONE of four next actions and emit a structured JSON object.
+	return SystemPromptMarker + `. You receive a research topic and the upstream classifier's initial candidate set. You choose ONE of four next actions and emit a structured JSON object.
 
 Your job is the structural decision — what shape of work comes next. The downstream stages do the work. You do not synthesize, walk, or refine yourself; you only route.
 

--- a/processor/research-graph-synthesize/prompt.go
+++ b/processor/research-graph-synthesize/prompt.go
@@ -18,8 +18,14 @@ import (
 // section uses concrete examples (good ref vs invented ref). The
 // output contract spells out the exact JSON shape so the LLM does
 // not need to guess.
+// SystemPromptMarker is the first sentence of buildSystemPrompt's
+// output, exported for the e2e mock LLM marker-matching. See
+// processor/research-graph-route/prompt.go SystemPromptMarker for
+// the full rationale.
+const SystemPromptMarker = "You are the synthesis stage of a graph-search pipeline"
+
 func buildSystemPrompt() string {
-	return `You are the synthesis stage of a graph-search pipeline. You receive a research topic and the upstream evidence the retrieval and assessment stages surfaced. You write the answer: a natural-language synthesis grounded in the evidence, with a list of the evidence items you used.
+	return SystemPromptMarker + `. You receive a research topic and the upstream evidence the retrieval and assessment stages surfaced. You write the answer: a natural-language synthesis grounded in the evidence, with a list of the evidence items you used.
 
 You do not invent facts. You do not invent entity IDs, ObjectStore refs, or sources. If the evidence does not support an answer to the topic, say so plainly in the synthesis.
 

--- a/taskfiles/e2e/research-graph.yml
+++ b/taskfiles/e2e/research-graph.yml
@@ -1,0 +1,71 @@
+version: "3"
+
+# Research-Graph Tier: ADR-045 Phase 1 R0-R6 chain end-to-end
+# Uses the same mock OpenAI server shape as e2e:agentic, scripted via
+# --scenario=research-graph (test/e2e/mock/cmd/main.go).
+#
+# Override with AGENTIC_LLM_URL=http://localhost:11434/v1 for real LLM
+# testing (response quality + JSON-shape adherence at scale).
+
+tasks:
+  default:
+    desc: "Research-graph tier: ADR-045 R0-R6 chain end-to-end (~30s)"
+    silent: false
+    deps: [":e2e:clean", ":e2e:check-ports", ":build:e2e"]
+    cmds:
+      - echo "[RESEARCH-GRAPH] Starting research-graph tier E2E test..."
+      - docker compose -f docker/compose/research-graph.yml up -d --wait --build
+      - echo "[OK] Services are healthy (NATS + mock-llm + semstreams)"
+      - echo "[RESEARCH-GRAPH] Running research-graph scenario..."
+      - cmd: cd cmd/e2e && ./e2e --scenario research-graph --base-url http://localhost:48080 --output-dir ./test/e2e/results --metrics-url http://localhost:49090
+        ignore_error: true
+      - docker compose -f docker/compose/research-graph.yml down -v --timeout 15
+
+  up:
+    desc: Start research-graph tier services without running tests
+    silent: false
+    cmds:
+      - echo "[RESEARCH-GRAPH] Starting research-graph tier services..."
+      - docker compose -f docker/compose/research-graph.yml up -d --wait --build
+      - echo "[OK] Services are healthy"
+      - 'echo ""'
+      - 'echo "Services:"'
+      - 'echo "  NATS:       nats://localhost:44222"'
+      - 'echo "  Mock LLM:   http://localhost:48180"'
+      - 'echo "  SemStreams: http://localhost:48080"'
+      - 'echo "  Metrics:    http://localhost:49090/metrics"'
+      - 'echo "  PProf:      http://localhost:46060/debug/pprof/ (if SEMSTREAMS_DEBUG=true)"'
+      - 'echo ""'
+      - 'echo "To run tests: task e2e:research-graph:test"'
+      - 'echo "To stop:      task e2e:research-graph:down"'
+
+  test:
+    desc: Run research-graph tests against already-running services
+    silent: false
+    deps: [":build:e2e"]
+    cmds:
+      - echo "[RESEARCH-GRAPH] Running research-graph scenario..."
+      - cd cmd/e2e && ./e2e --scenario research-graph --base-url http://localhost:48080 --output-dir ./test/e2e/results --metrics-url http://localhost:49090
+
+  down:
+    desc: Stop research-graph tier services
+    silent: false
+    cmds:
+      - echo "[RESEARCH-GRAPH] Stopping research-graph tier services..."
+      - docker compose -f docker/compose/research-graph.yml down -v --timeout 15
+      - echo "[OK] Services stopped"
+
+  logs:
+    desc: Tail logs from research-graph services
+    silent: false
+    cmds:
+      - docker compose -f docker/compose/research-graph.yml logs -f
+
+  clean:
+    desc: Clean research-graph tier environment
+    silent: false
+    cmds:
+      - echo "[RESEARCH-GRAPH] Cleaning research-graph tier environment..."
+      - docker compose -f docker/compose/research-graph.yml down -v --timeout 15 2>/dev/null || true
+      - docker volume ls -q --filter name=research-graph | xargs -r docker volume rm 2>/dev/null || true
+      - echo "[OK] Research-graph environment cleaned"

--- a/test/e2e/mock/cmd/main.go
+++ b/test/e2e/mock/cmd/main.go
@@ -20,7 +20,7 @@ import (
 func main() {
 	port := flag.Int("port", 8080, "Port for OpenAI mock server")
 	agntcyPort := flag.Int("agntcy-port", 8081, "Port for AGNTCY mock server")
-	scenario := flag.String("scenario", "default", "Which preset of role responses / tool-call scripts to apply (default, deep-research, crud-tools, ops)")
+	scenario := flag.String("scenario", "default", "Which preset of role responses / tool-call scripts to apply (default, deep-research, crud-tools, ops, research-graph)")
 	flag.Parse()
 
 	openaiAddr := fmt.Sprintf(":%d", *port)
@@ -79,6 +79,8 @@ func applyScenarioPreset(server *mock.OpenAIServer, scenario string) {
 		applyCRUDToolsPreset(server)
 	case "ops":
 		applyOpsPreset(server)
+	case "research-graph":
+		applyResearchGraphPreset(server)
 	default:
 		// "default" leaves the server's base configuration in place —
 		// agentic tier uses this path, plus any future scenario that just
@@ -233,4 +235,92 @@ func applyOpsPreset(server *mock.OpenAIServer) {
 			},
 		},
 	})
+}
+
+// applyResearchGraphPreset scripts the ADR-045 Phase 1 chain end-to-end
+// via marker-matched responses for the three LLM-wrapping components
+// plus a parent-agent research_graph tool call.
+//
+// Happy-path coverage: parent fires `research_graph(topic=...)`, the
+// chain runs nl_classify (deterministic Go code; no LLM in keyword-tier
+// classifier mode), route_search emits `synthesize_directly`, the
+// chain skips execute + assess, synthesize_answer emits a SearchResult
+// envelope, R6 fires the continuation back to the parent, and the
+// parent's continuation iteration completes via the default text path.
+//
+// The synthesize_directly route is the cheapest path that still
+// exercises R0 → R1 → R2 → R6 + every triple-stamp seam — the
+// orchestration claim PR #203 made. Refine-loop coverage
+// (walk_seeds / decompose + assess + iteration cap) is a follow-up;
+// shipping the happy path first locks the wire.
+//
+// Markers are the stable opening sentences of each LLM-wrapping
+// component's system prompt (see processor/research-graph-*/prompt.go).
+// JSON shapes match research.RouteDecision / research.SearchResult /
+// research.AssessmentOutput exactly so the components' JSON extractor
+// + Validate succeed without retries — deterministic e2e timing.
+func applyResearchGraphPreset(server *mock.OpenAIServer) {
+	server.
+		WithRoleResponses([]mock.RoleResponse{
+			{
+				Marker: "You are the routing stage of a graph-search pipeline",
+				Content: `{
+  "action": "synthesize_directly",
+  "args": {},
+  "rationale": "Classifier candidate set covers the topic; no graph expansion needed."
+}`,
+			},
+			{
+				// Assess is unreachable on the synthesize_directly happy
+				// path but the marker is wired here so a route-misroute
+				// regression (e.g. route returns decompose by accident)
+				// surfaces as "chain hung at assess" rather than "mock
+				// returned wrong JSON shape and synthesize never fired."
+				Marker: "You are the sufficiency-assessment stage of a graph-search pipeline",
+				Content: `{
+  "sufficient": true,
+  "refined_queries": []
+}`,
+			},
+			{
+				Marker: "You are the synthesis stage of a graph-search pipeline",
+				Content: `{
+  "synthesis": "Drone hover anomalies cluster around the GCS-001 platform during low-altitude maneuvers. Two of the three surfaced candidates show elevated yaw drift telemetry preceding the anomaly. Recommend correlating with wind speed logs.",
+  "evidence": [
+    {"entity_id": "acme.ops.robotics.gcs.drone.001", "tier": "0", "source": "classifier", "snippet": "Drone 001 telemetry indicates yaw drift during hover at <50m AGL."},
+    {"entity_id": "acme.ops.robotics.gcs.drone.002", "tier": "0", "source": "classifier", "snippet": "Drone 002 sibling unit; identical firmware and GCS link."}
+  ],
+  "decomp_trace": {
+    "router_action": "synthesize_directly",
+    "subquery_count": 0,
+    "evidence_count_pre_dedup": 2,
+    "evidence_count_post_dedup": 2,
+    "tier_breakdown": {"0": 2},
+    "budget_tokens_used": 0
+  },
+  "tokens_used": 120,
+  "iterations": 0
+}`,
+			},
+		}).
+		// Parent agent's task says "use research_graph to investigate
+		// the topic". The mock matches on a unique substring from that
+		// prompt and emits a research_graph tool call. The chain then
+		// runs; when R6's continuation comes back to the parent, the
+		// continuation prompt does NOT contain this marker (it carries
+		// the SearchResult ref + topic from the rule pack), so the
+		// mock falls through to the default completion content + the
+		// parent loop terminates naturally.
+		WithRoleToolCallSequence([]mock.RoleToolCall{
+			{
+				Marker:   "Investigate the research topic via research_graph",
+				ToolName: "research_graph",
+				Args: map[string]any{
+					"topic": "drone hover anomalies",
+					"hints": map[string]any{
+						"domain": "robotics",
+					},
+				},
+			},
+		})
 }

--- a/test/e2e/mock/cmd/main.go
+++ b/test/e2e/mock/cmd/main.go
@@ -12,6 +12,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	researchassess "github.com/c360studio/semstreams/processor/research-graph-assess"
+	researchroute "github.com/c360studio/semstreams/processor/research-graph-route"
+	researchsynthesize "github.com/c360studio/semstreams/processor/research-graph-synthesize"
 	"github.com/c360studio/semstreams/test/e2e/mock"
 	crudtools "github.com/c360studio/semstreams/test/e2e/scenarios/crud-tools"
 	opsscenario "github.com/c360studio/semstreams/test/e2e/scenarios/ops"
@@ -254,16 +257,19 @@ func applyOpsPreset(server *mock.OpenAIServer) {
 // (walk_seeds / decompose + assess + iteration cap) is a follow-up;
 // shipping the happy path first locks the wire.
 //
-// Markers are the stable opening sentences of each LLM-wrapping
-// component's system prompt (see processor/research-graph-*/prompt.go).
-// JSON shapes match research.RouteDecision / research.SearchResult /
-// research.AssessmentOutput exactly so the components' JSON extractor
-// + Validate succeed without retries — deterministic e2e timing.
+// Markers are the SystemPromptMarker constants exported from each
+// LLM-wrapping component's prompt.go. Importing rather than inlining
+// the substring means a persona-prose edit that severs the marker
+// breaks the compile, not the e2e silently (per go-reviewer I3 on
+// PR #205). JSON shapes match research.RouteDecision /
+// research.SearchResult / research.AssessmentOutput exactly so the
+// components' JSON extractor + Validate succeed without retries —
+// deterministic e2e timing.
 func applyResearchGraphPreset(server *mock.OpenAIServer) {
 	server.
 		WithRoleResponses([]mock.RoleResponse{
 			{
-				Marker: "You are the routing stage of a graph-search pipeline",
+				Marker: researchroute.SystemPromptMarker,
 				Content: `{
   "action": "synthesize_directly",
   "args": {},
@@ -276,14 +282,14 @@ func applyResearchGraphPreset(server *mock.OpenAIServer) {
 				// regression (e.g. route returns decompose by accident)
 				// surfaces as "chain hung at assess" rather than "mock
 				// returned wrong JSON shape and synthesize never fired."
-				Marker: "You are the sufficiency-assessment stage of a graph-search pipeline",
+				Marker: researchassess.SystemPromptMarker,
 				Content: `{
   "sufficient": true,
   "refined_queries": []
 }`,
 			},
 			{
-				Marker: "You are the synthesis stage of a graph-search pipeline",
+				Marker: researchsynthesize.SystemPromptMarker,
 				Content: `{
   "synthesis": "Drone hover anomalies cluster around the GCS-001 platform during low-altitude maneuvers. Two of the three surfaced candidates show elevated yaw drift telemetry preceding the anomaly. Recommend correlating with wind speed logs.",
   "evidence": [

--- a/test/e2e/scenarios/research-graph/scenario.go
+++ b/test/e2e/scenarios/research-graph/scenario.go
@@ -1,0 +1,536 @@
+// Package researchgraph provides the ADR-045 research-graph chain
+// E2E scenario.
+//
+// The scenario boots the reference flow (configs/research-graph-e2e.json)
+// via docker compose with a mock LLM scripted (test/e2e/mock/cmd/main.go
+// `research-graph` preset) to return:
+//   - `research_graph` tool call when the parent agent receives the
+//     investigate-via-research_graph prompt
+//   - `synthesize_directly` action when route_search's persona prompt
+//     fires (chosen as the happy path that exercises R0 → R1 → R2 → R6
+//   - every triple-stamp seam without touching execute + assess)
+//   - SearchResult JSON when synthesize_answer's persona prompt fires
+//
+// Coverage scope: the synthesize_directly happy path. Refine-loop
+// coverage (walk_seeds / decompose + assess + iteration cap fallback)
+// is a follow-up — shipping the happy path first locks the orchestration
+// wire claim PR #203 made.
+//
+// Stages, in firing order:
+//
+//  1. verify-components — all 5 research-graph-* + agentic-* + rule processor healthy
+//  2. capture-baseline — Prometheus snapshot for diff diagnostics
+//  3. inject-parent-task — publish a TaskMessage with the research_graph trigger marker
+//  4. wait-for-research-pipeline-loop — poll AGENT_LOOPS for an rg_* entity (chain kickoff)
+//  5. wait-for-search-result-stamp — poll the loop entity for research.search_result.complete
+//  6. verify-orchestration-triples — assert kickoff + per-stage completion triples land
+//  7. verify-search-result-envelope — assert the SearchResult landed at COMPLETE_<rg_loopID>
+//  8. verify-r6-continuation — confirm a continuation agent.task fired back to the parent role
+//
+// Any stage failure short-circuits with a clear diagnostic. Per-stage
+// duration is recorded in result.Metrics for trajectory dashboards.
+package researchgraph
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/test/e2e/client"
+	"github.com/c360studio/semstreams/test/e2e/scenarios"
+)
+
+// Scenario validates the ADR-045 Phase 1 chain works end-to-end.
+type Scenario struct {
+	name        string
+	description string
+
+	natsURL    string
+	metricsURL string
+
+	nats    *client.NATSValidationClient
+	metrics *client.MetricsClient
+	obs     *client.ObservabilityClient
+
+	config *Config
+}
+
+// Config holds tunable timeouts + expected results.
+type Config struct {
+	NATSURL    string `json:"nats_url"`
+	MetricsURL string `json:"metrics_url"`
+
+	// ChainKickoffTimeout caps how long we wait for the rg_<loopID>
+	// entity to appear in AGENT_LOOPS after the parent task fires.
+	// Covers parent-loop dispatch + research_graph tool execution +
+	// LoopEntity write. Default 30s.
+	ChainKickoffTimeout time.Duration `json:"chain_kickoff_timeout"`
+
+	// CompleteTimeout caps how long we wait for the
+	// research.search_result.complete triple to appear on the loop
+	// entity. Covers the full R0 → R1 → R2 → synthesize chain plus
+	// graph-ingest write latency. Default 60s.
+	CompleteTimeout time.Duration `json:"complete_timeout"`
+
+	// Platform identity must match configs/research-graph-e2e.json
+	// platform block — used to construct LoopExecutionEntityID for
+	// triple lookup. Hardcoded here rather than read from the config
+	// to keep the scenario self-contained.
+	PlatformOrg      string `json:"platform_org"`
+	PlatformInstance string `json:"platform_instance"`
+}
+
+// DefaultConfig returns defaults aligned with docker/compose/research-graph.yml.
+func DefaultConfig() *Config {
+	return &Config{
+		NATSURL:             "nats://localhost:44222",
+		MetricsURL:          "http://localhost:49090",
+		ChainKickoffTimeout: 30 * time.Second,
+		CompleteTimeout:     60 * time.Second,
+		PlatformOrg:         "c360",
+		PlatformInstance:    "rg-e2e-001",
+	}
+}
+
+// NewScenario constructs the scenario with the given observability
+// client + (optional) config override.
+func NewScenario(obs *client.ObservabilityClient, config *Config) *Scenario {
+	if config == nil {
+		config = DefaultConfig()
+	}
+	return &Scenario{
+		name:        "research-graph",
+		description: "Validates ADR-045 Phase 1 R0-R6 chain end-to-end through the synthesize_directly route",
+		natsURL:     config.NATSURL,
+		metricsURL:  config.MetricsURL,
+		obs:         obs,
+		config:      config,
+	}
+}
+
+// Name returns the scenario name.
+func (s *Scenario) Name() string { return s.name }
+
+// Description returns the scenario description.
+func (s *Scenario) Description() string { return s.description }
+
+// Setup creates NATS + metrics clients.
+func (s *Scenario) Setup(ctx context.Context) error {
+	natsClient, err := client.NewNATSValidationClient(ctx, s.natsURL)
+	if err != nil {
+		return fmt.Errorf("create NATS client: %w", err)
+	}
+	s.nats = natsClient
+	s.metrics = client.NewMetricsClient(s.metricsURL)
+	return nil
+}
+
+// Teardown closes connections.
+func (s *Scenario) Teardown(ctx context.Context) error {
+	if s.nats != nil {
+		return s.nats.Close(ctx)
+	}
+	return nil
+}
+
+// Execute runs the chain end-to-end.
+func (s *Scenario) Execute(ctx context.Context) (*scenarios.Result, error) {
+	result := &scenarios.Result{
+		ScenarioName: s.name,
+		StartTime:    time.Now(),
+		Success:      false,
+		Metrics:      make(map[string]any),
+		Details:      make(map[string]any),
+		Errors:       []string{},
+		Warnings:     []string{},
+	}
+
+	stages := []struct {
+		name string
+		fn   func(context.Context, *scenarios.Result) error
+	}{
+		{"verify-components", s.verifyComponents},
+		{"capture-baseline", s.captureBaseline},
+		{"inject-parent-task", s.injectParentTask},
+		{"wait-for-research-pipeline-loop", s.waitForResearchPipelineLoop},
+		{"wait-for-search-result-stamp", s.waitForSearchResultStamp},
+		{"verify-orchestration-triples", s.verifyOrchestrationTriples},
+		{"verify-search-result-envelope", s.verifySearchResultEnvelope},
+		{"verify-r6-continuation", s.verifyR6Continuation},
+	}
+
+	for _, stage := range stages {
+		stageStart := time.Now()
+		if err := stage.fn(ctx, result); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", stage.name, err))
+			result.Error = fmt.Sprintf("%s failed: %v", stage.name, err)
+			result.EndTime = time.Now()
+			result.Duration = result.EndTime.Sub(result.StartTime)
+			return result, nil
+		}
+		result.Metrics[fmt.Sprintf("%s_duration_ms", stage.name)] = time.Since(stageStart).Milliseconds()
+	}
+
+	result.Success = true
+	result.EndTime = time.Now()
+	result.Duration = result.EndTime.Sub(result.StartTime)
+	return result, nil
+}
+
+// verifyComponents confirms the five research-graph components + rule
+// processor + supporting agentic infra are all healthy. A missing
+// component here means the docker compose / config is broken before
+// we even fire a task, so this gate runs first.
+func (s *Scenario) verifyComponents(ctx context.Context, result *scenarios.Result) error {
+	components, err := s.obs.GetComponents(ctx)
+	if err != nil {
+		return fmt.Errorf("get components: %w", err)
+	}
+	required := []string{
+		"agentic-dispatch",
+		"agentic-loop",
+		"agentic-model",
+		"agentic-tools",
+		"graph-ingest",
+		"rule-processor",
+		"research-graph-classify",
+		"research-graph-route",
+		"research-graph-execute",
+		"research-graph-assess",
+		"research-graph-synthesize",
+	}
+	found := make(map[string]bool, len(components))
+	for _, comp := range components {
+		found[comp.Name] = comp.Enabled && comp.Healthy
+	}
+	missing := []string{}
+	unhealthy := []string{}
+	for _, req := range required {
+		healthy, exists := found[req]
+		if !exists {
+			missing = append(missing, req)
+		} else if !healthy {
+			unhealthy = append(unhealthy, req)
+		}
+	}
+	result.Details["components_required"] = required
+	result.Details["components_healthy"] = found
+	if len(missing) > 0 {
+		return fmt.Errorf("missing components: %v", missing)
+	}
+	if len(unhealthy) > 0 {
+		return fmt.Errorf("unhealthy components: %v", unhealthy)
+	}
+	return nil
+}
+
+// captureBaseline snapshots Prometheus for diff diagnostics on failure.
+func (s *Scenario) captureBaseline(ctx context.Context, result *scenarios.Result) error {
+	snapshot, err := s.metrics.FetchSnapshot(ctx)
+	if err != nil {
+		result.Warnings = append(result.Warnings, fmt.Sprintf("baseline snapshot: %v", err))
+		return nil
+	}
+	result.Details["baseline_snapshot"] = snapshot
+	return nil
+}
+
+// injectParentTask publishes a TaskMessage with the research_graph
+// trigger marker. The mock LLM's "research-graph" preset matches the
+// marker via WithRoleToolCallSequence and emits a research_graph tool
+// call; the parent loop then dispatches to research_graph and the
+// chain kicks off.
+func (s *Scenario) injectParentTask(ctx context.Context, result *scenarios.Result) error {
+	parentLoopID := fmt.Sprintf("e2e-parent-%d", time.Now().UnixNano())
+	task := agentic.TaskMessage{
+		LoopID: parentLoopID,
+		TaskID: fmt.Sprintf("e2e-rg-task-%d", time.Now().UnixNano()),
+		Role:   "general",
+		Model:  "mock",
+		// "Investigate the research topic via research_graph" is the
+		// exact marker the mock preset matches on
+		// (applyResearchGraphPreset in test/e2e/mock/cmd/main.go).
+		// Any drift between this prompt and the marker breaks the
+		// scenario at wait-for-research-pipeline-loop with a clean
+		// "no rg_* loop appeared" diagnostic — the marker is the
+		// load-bearing seam between this scenario and the mock.
+		Prompt: "Investigate the research topic via research_graph — emit a single research_graph tool call with topic=\"drone hover anomalies\" and hints={domain:robotics}.",
+		// Metadata["role"] propagates through CacheMetadata →
+		// ToolCall.Metadata so the research_graph tool stamps
+		// research.parent_role for R6's continuation publish_agent.
+		// A real agentic-dispatch flow populates this from the
+		// parent's role; e2e mirrors that explicitly so R6's
+		// `role: $entity.triple.research.parent_role` substitution
+		// resolves to "general" and the continuation task can dispatch.
+		Metadata: map[string]any{"role": "general"},
+		Tools: []agentic.ToolDefinition{
+			{
+				Name:        "research_graph",
+				Description: "Spawn an asynchronous graph-research operation.",
+				Parameters: map[string]any{
+					"type":     "object",
+					"required": []string{"topic"},
+					"properties": map[string]any{
+						"topic": map[string]any{"type": "string"},
+						"hints": map[string]any{"type": "object"},
+					},
+				},
+			},
+		},
+	}
+	taskMsg := message.NewBaseMessage(task.Schema(), &task, "e2e-research-graph")
+	taskData, err := json.Marshal(taskMsg)
+	if err != nil {
+		return fmt.Errorf("marshal task: %w", err)
+	}
+	if err := s.nats.Publish(ctx, "agent.task.e2e-research-graph", taskData); err != nil {
+		return fmt.Errorf("publish task: %w", err)
+	}
+	result.Details["parent_loop_id"] = parentLoopID
+	result.Details["parent_task_id"] = task.TaskID
+	return nil
+}
+
+// waitForResearchPipelineLoop polls AGENT_LOOPS for an entry keyed
+// `rg_<8-hex-chars>` to appear — that's the research-pipeline LoopEntity
+// the research_graph tool writes at chain kickoff. Once we have the
+// loop ID, downstream stages can construct the 6-part loop-execution
+// entity ID to look up orchestration triples.
+func (s *Scenario) waitForResearchPipelineLoop(ctx context.Context, result *scenarios.Result) error {
+	deadline := time.Now().Add(s.config.ChainKickoffTimeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+		keys, err := s.nats.GetBucketKeysSample(ctx, "AGENT_LOOPS", 200)
+		if err != nil {
+			continue
+		}
+		for _, k := range keys {
+			if strings.HasPrefix(k, "rg_") && !strings.Contains(k, ".") {
+				// Bare `rg_<id>` key (not `research.requested.rg_<id>`
+				// or `classify.complete.rg_<id>`) is the LoopEntity.
+				result.Details["research_loop_id"] = k
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("no rg_* loop entity appeared in AGENT_LOOPS within %v — parent agent's research_graph tool may not have fired (check mock LLM marker match)", s.config.ChainKickoffTimeout)
+}
+
+// waitForSearchResultStamp polls the research-pipeline loop entity in
+// ENTITY_STATES for the research.search_result.complete triple — the
+// terminal stamp synthesize_answer emits before R6 fires. Stronger
+// gate than waiting for a generic completion metric because it
+// asserts the specific orchestration triple that R6 keys on.
+func (s *Scenario) waitForSearchResultStamp(ctx context.Context, result *scenarios.Result) error {
+	loopID, ok := result.Details["research_loop_id"].(string)
+	if !ok || loopID == "" {
+		return fmt.Errorf("research_loop_id not set (waitForResearchPipelineLoop didn't populate it)")
+	}
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(s.config.PlatformOrg, s.config.PlatformInstance, loopID)
+	if err != nil {
+		return fmt.Errorf("construct loop entity ID for %s: %w", loopID, err)
+	}
+	result.Details["research_loop_entity_id"] = loopEntityID
+
+	deadline := time.Now().Add(s.config.CompleteTimeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+		entity, err := s.nats.GetEntity(ctx, loopEntityID)
+		if err != nil {
+			continue
+		}
+		for _, t := range entity.Triples {
+			if t.Predicate == research.PredicateResearchSearchResultComplete {
+				result.Details["search_result_complete_stamped"] = true
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("research.search_result.complete triple did not land on %s within %v — chain stalled before terminal synthesis", loopEntityID, s.config.CompleteTimeout)
+}
+
+// verifyOrchestrationTriples fetches the research-pipeline loop entity
+// and asserts every expected orchestration triple is present. The full
+// set covers: kickoff (loop.role, research.requested, .topic, .loop_id,
+// .parent_loop, .parent_role, .budget_tokens, .max_iterations) +
+// per-stage completion (classify, route, search_result) +
+// route-decision branch (research.route.action == "synthesize_directly").
+// execute/assess triples are NOT expected on this path — that's the
+// whole point of routing via synthesize_directly.
+func (s *Scenario) verifyOrchestrationTriples(ctx context.Context, result *scenarios.Result) error {
+	loopEntityID, ok := result.Details["research_loop_entity_id"].(string)
+	if !ok || loopEntityID == "" {
+		return fmt.Errorf("research_loop_entity_id not set")
+	}
+	entity, err := s.nats.GetEntity(ctx, loopEntityID)
+	if err != nil {
+		return fmt.Errorf("fetch loop entity %s: %w", loopEntityID, err)
+	}
+
+	got := make(map[string]string, len(entity.Triples))
+	for _, t := range entity.Triples {
+		obj, _ := t.Object.(string)
+		got[t.Predicate] = obj
+	}
+
+	// Kickoff predicates (stamped by research_graph tool).
+	requiredKickoff := map[string]string{
+		research.PredicateLoopRole:           research.PipelineRole,
+		research.PredicateResearchRequested:  "true",
+		research.PredicateResearchTopic:      "drone hover anomalies",
+		research.PredicateResearchLoopID:     result.Details["research_loop_id"].(string),
+		research.PredicateResearchParentRole: "general",
+	}
+	missing := []string{}
+	mismatched := []string{}
+	for pred, want := range requiredKickoff {
+		actual, present := got[pred]
+		if !present {
+			missing = append(missing, pred)
+			continue
+		}
+		if actual != want {
+			mismatched = append(mismatched, fmt.Sprintf("%s: got %q want %q", pred, actual, want))
+		}
+	}
+
+	// Per-stage completion predicates (timestamps; existence-only check).
+	for _, pred := range []string{
+		research.PredicateResearchClassifyComplete,
+		research.PredicateResearchRouteComplete,
+		research.PredicateResearchSearchResultComplete,
+	} {
+		if _, present := got[pred]; !present {
+			missing = append(missing, pred)
+		}
+	}
+
+	// Route action — load-bearing for R2's dispatch.
+	if got[research.PredicateResearchRouteAction] != research.ActionSynthesizeDirectly {
+		mismatched = append(mismatched, fmt.Sprintf("%s: got %q want %q",
+			research.PredicateResearchRouteAction,
+			got[research.PredicateResearchRouteAction],
+			research.ActionSynthesizeDirectly))
+	}
+
+	// Execute + Assess triples must be ABSENT on the synthesize_directly
+	// path — their presence would mean the route mis-fired and the chain
+	// took an unintended branch. Assert absence loudly so a router
+	// regression surfaces here, not in a downstream operator's trajectory
+	// review.
+	unexpected := []string{}
+	for _, pred := range []string{
+		research.PredicateResearchExecuteComplete,
+		research.PredicateResearchAssessComplete,
+	} {
+		if _, present := got[pred]; present {
+			unexpected = append(unexpected, pred)
+		}
+	}
+
+	result.Metrics["orchestration_triples_total"] = len(entity.Triples)
+	result.Details["orchestration_predicates"] = predicateList(got)
+
+	if len(missing) > 0 || len(mismatched) > 0 || len(unexpected) > 0 {
+		return fmt.Errorf("orchestration triples failed: missing=%v mismatched=%v unexpected=%v",
+			missing, mismatched, unexpected)
+	}
+	return nil
+}
+
+// verifySearchResultEnvelope confirms synthesize_answer wrote the
+// SearchResult envelope at the read_loop_result-readable key
+// (COMPLETE_<rg_loopID>). Without this write, R6's continuation
+// publish_agent fires but the parent's read_loop_result returns
+// key-not-found — a known degraded path documented in
+// processor/research-graph-synthesize/handler.go's PutLoopCompletion
+// godoc. E2E pins the happy path: the envelope MUST land.
+func (s *Scenario) verifySearchResultEnvelope(ctx context.Context, result *scenarios.Result) error {
+	loopID, ok := result.Details["research_loop_id"].(string)
+	if !ok || loopID == "" {
+		return fmt.Errorf("research_loop_id not set")
+	}
+	envelope, err := s.nats.GetKV(ctx, "AGENT_LOOPS", "COMPLETE_"+loopID)
+	if err != nil {
+		return fmt.Errorf("fetch COMPLETE_%s: %w (read_loop_result will return key-not-found for R6's spawned parent)", loopID, err)
+	}
+	if len(envelope) == 0 {
+		return fmt.Errorf("COMPLETE_%s envelope is empty", loopID)
+	}
+	// Quick shape check — decode the BaseMessage and confirm the
+	// payload category. Full payload validation is the component's
+	// roundtrip test; here we just ensure operators can read it back.
+	if !bytesContainsCategory(envelope, research.CategoryResult) {
+		return fmt.Errorf("COMPLETE_%s envelope does not carry research/result payload — got %s", loopID, truncate(string(envelope), 200))
+	}
+	result.Metrics["search_result_envelope_bytes"] = len(envelope)
+	return nil
+}
+
+// verifyR6Continuation confirms R6 published a continuation task back
+// to the parent role. The mock LLM's parent role gets the continuation
+// prompt (which contains $entity.triple.research.loop_id substituted +
+// the topic) and falls through to the default completion content. We
+// verify that at least one agentic_dispatch_tasks_submitted_total or
+// loops_completed metric increment happened ABOVE baseline — the
+// continuation task spawning is the rule chain's deliverable.
+func (s *Scenario) verifyR6Continuation(ctx context.Context, result *scenarios.Result) error {
+	// agentic_loop_loops_completed_total counts every completed loop.
+	// On the happy path we expect:
+	//   1. Parent loop (general role, fires research_graph then waits)
+	//   2. Continuation parent loop (R6-spawned, general role, completes via default text)
+	// So >= 2 loops completed. The exact number depends on whether the
+	// parent loop with the research_graph tool call also counts; we
+	// tolerate >= 2 here and tighten if needed.
+	loops, err := s.metrics.SumMetricsByName(ctx, "semstreams_agentic_loop_loops_completed_total")
+	if err != nil {
+		return fmt.Errorf("read loops_completed metric: %w", err)
+	}
+	result.Metrics["loops_completed_total"] = loops
+	if loops < 2 {
+		return fmt.Errorf("expected >= 2 agent loops completed (parent + R6 continuation) but saw %v — R6 may not have dispatched a continuation task", loops)
+	}
+	result.Details["r6_continuation_fired"] = true
+	return nil
+}
+
+// predicateList renders the predicates of a triple map as a sorted
+// slice so failure details are reproducible. The Object isn't returned
+// because timestamps are nondeterministic.
+func predicateList(triples map[string]string) []string {
+	out := make([]string, 0, len(triples))
+	for k := range triples {
+		out = append(out, k)
+	}
+	return out
+}
+
+// bytesContainsCategory is a cheap shape check that avoids pulling in
+// the full payload registry just to assert the envelope is a result.
+// The BaseMessage JSON places the category in the type discriminator
+// — a substring search for "\"category\":\"result\"" is sufficient to
+// distinguish from intent / classifier_output / etc.
+func bytesContainsCategory(data []byte, category string) bool {
+	needle := fmt.Sprintf("%q:%q", "category", category)
+	return strings.Contains(string(data), needle)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/test/e2e/scenarios/research-graph/scenario.go
+++ b/test/e2e/scenarios/research-graph/scenario.go
@@ -19,13 +19,12 @@
 // Stages, in firing order:
 //
 //  1. verify-components — all 5 research-graph-* + agentic-* + rule processor healthy
-//  2. capture-baseline — Prometheus snapshot for diff diagnostics
-//  3. inject-parent-task — publish a TaskMessage with the research_graph trigger marker
-//  4. wait-for-research-pipeline-loop — poll AGENT_LOOPS for an rg_* entity (chain kickoff)
-//  5. wait-for-search-result-stamp — poll the loop entity for research.search_result.complete
-//  6. verify-orchestration-triples — assert kickoff + per-stage completion triples land
-//  7. verify-search-result-envelope — assert the SearchResult landed at COMPLETE_<rg_loopID>
-//  8. verify-r6-continuation — confirm a continuation agent.task fired back to the parent role
+//  2. inject-parent-task — publish a TaskMessage with the research_graph trigger marker
+//  3. wait-for-research-pipeline-loop — poll AGENT_LOOPS for an rg_* entity (chain kickoff)
+//  4. wait-for-search-result-stamp — poll the loop entity for research.search_result.complete
+//  5. verify-orchestration-triples — assert kickoff + per-stage completion triples land
+//  6. verify-search-result-envelope — assert the SearchResult landed at COMPLETE_<rg_loopID>
+//  7. verify-r6-continuation — confirm a continuation agent.task fired back to the parent role
 //
 // Any stage failure short-circuits with a clear diagnostic. Per-stage
 // duration is recorded in result.Metrics for trajectory dashboards.
@@ -155,7 +154,6 @@ func (s *Scenario) Execute(ctx context.Context) (*scenarios.Result, error) {
 		fn   func(context.Context, *scenarios.Result) error
 	}{
 		{"verify-components", s.verifyComponents},
-		{"capture-baseline", s.captureBaseline},
 		{"inject-parent-task", s.injectParentTask},
 		{"wait-for-research-pipeline-loop", s.waitForResearchPipelineLoop},
 		{"wait-for-search-result-stamp", s.waitForSearchResultStamp},
@@ -226,17 +224,6 @@ func (s *Scenario) verifyComponents(ctx context.Context, result *scenarios.Resul
 	if len(unhealthy) > 0 {
 		return fmt.Errorf("unhealthy components: %v", unhealthy)
 	}
-	return nil
-}
-
-// captureBaseline snapshots Prometheus for diff diagnostics on failure.
-func (s *Scenario) captureBaseline(ctx context.Context, result *scenarios.Result) error {
-	snapshot, err := s.metrics.FetchSnapshot(ctx)
-	if err != nil {
-		result.Warnings = append(result.Warnings, fmt.Sprintf("baseline snapshot: %v", err))
-		return nil
-	}
-	result.Details["baseline_snapshot"] = snapshot
 	return nil
 }
 
@@ -386,13 +373,23 @@ func (s *Scenario) verifyOrchestrationTriples(ctx context.Context, result *scena
 		got[t.Predicate] = obj
 	}
 
-	// Kickoff predicates (stamped by research_graph tool).
+	// Kickoff predicates (stamped by research_graph tool). The
+	// research_graph tool's parser uses DefaultBudgetTokens=4000 +
+	// DefaultMaxIterations=5 when the parent task omits them (which
+	// this scenario does). The parent_loop value is the scenario's
+	// generated parent loop id. Full 8-predicate set per
+	// BuildKickoffTriples; a drop on refactor surfaces here loudly
+	// rather than letting the chain still run on the minimum trigger
+	// state per go-reviewer I1 on PR #205.
 	requiredKickoff := map[string]string{
-		research.PredicateLoopRole:           research.PipelineRole,
-		research.PredicateResearchRequested:  "true",
-		research.PredicateResearchTopic:      "drone hover anomalies",
-		research.PredicateResearchLoopID:     result.Details["research_loop_id"].(string),
-		research.PredicateResearchParentRole: "general",
+		research.PredicateLoopRole:              research.PipelineRole,
+		research.PredicateResearchRequested:     "true",
+		research.PredicateResearchTopic:         "drone hover anomalies",
+		research.PredicateResearchLoopID:        result.Details["research_loop_id"].(string),
+		research.PredicateResearchParentRole:    "general",
+		research.PredicateResearchParentLoop:    result.Details["parent_loop_id"].(string),
+		research.PredicateResearchBudgetTokens:  "4000",
+		research.PredicateResearchMaxIterations: "5",
 	}
 	missing := []string{}
 	mismatched := []string{}
@@ -430,11 +427,15 @@ func (s *Scenario) verifyOrchestrationTriples(ctx context.Context, result *scena
 	// path — their presence would mean the route mis-fired and the chain
 	// took an unintended branch. Assert absence loudly so a router
 	// regression surfaces here, not in a downstream operator's trajectory
-	// review.
+	// review. Full paired set per Build{Execute,Assess}CompleteTriples
+	// so a batch-split refactor that stamps half a stage's triples
+	// surfaces too (per go-reviewer I2 on PR #205).
 	unexpected := []string{}
 	for _, pred := range []string{
 		research.PredicateResearchExecuteComplete,
+		research.PredicateResearchExecuteEvidenceCount,
 		research.PredicateResearchAssessComplete,
+		research.PredicateResearchAssessSufficient,
 	} {
 		if _, present := got[pred]; present {
 			unexpected = append(unexpected, pred)


### PR DESCRIPTION
Closes the e2e-coverage gap user flagged after beta.95 — \"do we have any e2e coverage of what we just claimed?\" Answer was no (only the rule-engine smoke test under processor/rule, no docker integration). This PR adds the docker e2e tier.

## What ships

- **`docker/compose/research-graph.yml`** — NATS + mock-llm + semstreams containers, 4xxxx port range (distinct from agentic 3xxxx + lifecycle 5xxxx, no host port collisions when running tiers concurrently).
- **`configs/research-graph-e2e.json`** — operator-runnable config wiring all 5 research-graph components + agentic-loop/dispatch/tools/model + graph-ingest/query + rule-processor (loading R0-R6 pack) against the mock LLM endpoint.
- **`test/e2e/mock/cmd/main.go`** — new `research-graph` scenario preset:
  - `WithRoleResponses` marker-matched on each LLM-wrapping component's persona prose ("You are the routing stage / sufficiency-assessment stage / synthesis stage of a graph-search pipeline") returning the canonical JSON shapes (RouteDecision, AssessmentOutput, SearchResult).
  - `WithRoleToolCallSequence` returning a `research_graph` tool call when the parent agent's prompt fires.
- **`test/e2e/scenarios/research-graph/scenario.go`** — 8-stage scenario:
  1. `verify-components` — all 11 required components healthy
  2. `capture-baseline` — Prometheus snapshot
  3. `inject-parent-task` — publish a TaskMessage with the research_graph trigger marker + Metadata.role propagation for R6's continuation
  4. `wait-for-research-pipeline-loop` — poll AGENT_LOOPS for `rg_*` entity (chain kickoff)
  5. `wait-for-search-result-stamp` — poll the loop entity for `research.search_result.complete` triple
  6. `verify-orchestration-triples` — kickoff + per-stage completion triples land; execute+assess triples are ABSENT (router-misroute gate)
  7. `verify-search-result-envelope` — SearchResult landed at `COMPLETE_<rg_loopID>` (read_loop_result-readable)
  8. `verify-r6-continuation` — `loops_completed_total >= 2` (parent + R6 continuation)
- **`taskfiles/e2e/research-graph.yml`** — default/up/test/down/logs/clean tasks mirroring `e2e:agentic.yml`.
- **`cmd/e2e/main.go`** — scenario dispatch + list-scenarios entry.

## Local run

\`\`\`
task e2e:research-graph
...
Scenario completed successfully duration=1.026083208s
  orchestration_triples_total: 16
  loops_completed_total:        2
  search_result_envelope_bytes: 378
\`\`\`

Stage timings (ms): verify-components 1, capture-baseline 5, inject-parent-task 0, wait-for-research-pipeline-loop 504, wait-for-search-result-stamp 505, verify-orchestration-triples 1, verify-search-result-envelope 1, verify-r6-continuation 5.

## Coverage scope

The synthesize_directly happy path: R0 → R1 → R2 (route to synthesize) → synthesize_answer → R6 → parent continuation. Exercises every triple-stamp seam, the rule processor's entity-state watch, R6's role-substitution publish_agent.

NOT covered (Phase 2 follow-up):
- `walk_seeds` / `decompose` routes through `execute_subqueries`
- Refine loop through `assess_sufficiency` with cap-exhaust fallback
- Retighten loop through R2's stage-marker clear

Happy path was the load-bearing claim PR #203 (beta.95) made; locking it first closes the operator-deploy honesty gap.

## Test plan

- [x] `task e2e:research-graph` green locally (1.03s)
- [x] `go build ./...` clean
- [x] `go test -race ./test/e2e/mock/...` clean
- [x] `gofmt` clean
- [ ] CI green
- [ ] go-reviewer pre-merge pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)