### PR TITLE
fix(rule): preserve source type on substituted action.Object (gh#207)

### DIFF
--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -578,9 +578,22 @@ func (e *ActionExecutor) ExecuteAddTriple(ctx context.Context, action Action, ec
 		return message.Triple{}, errors.New("predicate is required for add_triple action")
 	}
 
-	// Substitute variables in predicate and object
+	// Substitute variables in predicate (always string — Action.Predicate
+	// is a name, not a value). For Object, attempt typed single-token
+	// resolution first (gh#207): when action.Object is exactly one
+	// supported substitution token, propagate the source type
+	// unchanged (float64 / bool / int / string) so numeric upserts
+	// stay type-faithful. Fall back to string substitution for mixed
+	// templates, literal strings, and unrecognized tokens — those
+	// require string-concat semantics, and the destination Triple.Object
+	// being `any` accepts string Objects without loss.
 	predicate := ec.SubstituteVariables(action.Predicate)
-	object := ec.SubstituteVariables(action.Object)
+	var object any
+	if typed, ok := ec.SubstituteVariablesTyped(action.Object); ok {
+		object = typed
+	} else {
+		object = ec.SubstituteVariables(action.Object)
+	}
 
 	// Parse TTL
 	ttl, err := action.ParseTTL()
@@ -786,8 +799,19 @@ func (e *ActionExecutor) executeUpdateTriple(ctx context.Context, action Action,
 		return errors.New("predicate is required for update_triple action")
 	}
 
+	// Predicate substitution is always string (it's a name). For Object,
+	// attempt typed single-token resolution first so numeric upserts
+	// round-trip the source type (gh#207). String fallback covers
+	// literal Objects, mixed templates, and unrecognized tokens. Same
+	// dispatch shape as ExecuteAddTriple — both actions land their
+	// Object in a `message.Triple{Object: any}`, so symmetry is correct.
 	predicate := ec.SubstituteVariables(action.Predicate)
-	object := ec.SubstituteVariables(action.Object)
+	var object any
+	if typed, ok := ec.SubstituteVariablesTyped(action.Object); ok {
+		object = typed
+	} else {
+		object = ec.SubstituteVariables(action.Object)
+	}
 
 	if e.logger != nil {
 		e.logger.Debug("Updating triple (remove + add)",

--- a/processor/rule/expression/evaluator.go
+++ b/processor/rule/expression/evaluator.go
@@ -2,6 +2,7 @@
 package expression
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -713,6 +714,31 @@ func compareValuesWithError(a, b interface{}) (int, error) {
 	return 0, nil
 }
 
+// toFloat64 attempts to coerce v to a float64. Returns (value, true)
+// for any numeric Go type AND for strings that parse cleanly via
+// strconv.ParseFloat. (0, false) otherwise.
+//
+// gh#207 string-widening: before this widening, toFloat64 had no
+// `string` case, so a stringified-numeric Object (e.g. "0.83" produced
+// by the pre-fix substitution path before gh#207 also fixed the
+// stamping side) fell through to the lexicographic string compare in
+// compareValuesWithError. That silently misordered values whose
+// magnitudes crossed a power-of-10 boundary: lex "9.9" > "10.0", but
+// numeric 9.9 < 10.0. Same defect for any external producer that ever
+// stamped a numeric value as a string (e.g. a tool that emits its
+// payload through json.Marshal of a *string field).
+//
+// The widening means two strings that BOTH parse numerically will now
+// numeric-compare instead of lex-compare. Cross-repo survey (semstreams
+// + semteams rule packs) found zero current conditions that depend on
+// lex-of-numeric-shaped-strings, so this is observably additive. Worth
+// flagging in a feedback memo: authors writing string literals that
+// "happen to look numeric" (e.g. version strings "1.2", phone-number
+// fragments) will see them compared as floats — usually fine, but a
+// version literal "1.10" vs "1.9" now compares 1.10 < 1.9 (numerically
+// true; semantically "version 1.10 > 1.9" backward). Rule authors who
+// truly need string semantics should write `regex` / `contains`
+// against the field, not `lt`/`gt`.
 func toFloat64(v interface{}) (float64, bool) {
 	switch val := v.(type) {
 	case float64:
@@ -739,6 +765,46 @@ func toFloat64(v interface{}) (float64, bool) {
 		return float64(val), true
 	case uint64:
 		return float64(val), true
+	case json.Number:
+		// json.Number arrives when a decoder was configured with
+		// UseNumber() to preserve precision (avoiding float64's
+		// 15-digit limit on large integers). Used elsewhere in the
+		// codebase (processor/agentic-loop, message/oms). Forward-
+		// looking: no current rule pack stamps json.Number on a
+		// Triple Object, but the type is in circulation and a future
+		// producer could surface it. Treating it like a numeric Go
+		// type avoids a silent regression where compareValues falls
+		// to lex-compare on the underlying string representation.
+		f, err := val.Float64()
+		if err != nil {
+			return 0, false
+		}
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, false
+		}
+		return f, true
+	case string:
+		// Empty string is never numeric — ParseFloat would error and
+		// we'd return (0, false), but the empty check makes the intent
+		// explicit and avoids a tight-loop allocation in
+		// compareValuesWithError when both sides are empty strings.
+		if val == "" {
+			return 0, false
+		}
+		f, err := strconv.ParseFloat(val, 64)
+		if err != nil {
+			return 0, false
+		}
+		// NaN/Inf rejection: ParseFloat accepts "NaN", "Inf",
+		// "infinity" (case-insensitive). NaN is especially dangerous
+		// because every comparison (==, <, >) returns false, which
+		// compareValuesWithError converts to `return 0, nil` — silently
+		// equivalent to "equal". Treat both as "not numeric" so the
+		// fallback string-compare path handles them deterministically.
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return 0, false
+		}
+		return f, true
 	default:
 		return 0, false
 	}

--- a/processor/rule/typed_substitution.go
+++ b/processor/rule/typed_substitution.go
@@ -1,0 +1,195 @@
+// Package rule — Typed single-token substitution for action.Object.
+//
+// gh#207 fix: `Action.Object` is typed `string`, but the destination
+// `message.Triple.Object` is typed `any` and documented to carry
+// `float64 / bool / string / int` literals (see message/triple.go:43).
+// `ExecutionContext.SubstituteVariables` is `string → string` — it
+// always returns a string, so a substituted Object loses its source
+// type. The canonical reproducer is `update_triple` upserting
+// `autoresearch.best.value` from a float-typed source triple: the
+// destination lands as the stringified float, breaking both downstream
+// consumers (typed Go reads) AND rule conditions (`toFloat64` in
+// expression/evaluator.go has no string case, so numeric `lt`/`gt`
+// against the stringified value falls to lexicographic compare and
+// silently misorders across power-of-10 boundaries).
+//
+// `SubstituteVariablesTyped` is the typed counterpart, applied at the
+// `add_triple` / `update_triple` call sites BEFORE the string
+// substitution path. It resolves the template only when it consists
+// of exactly one supported substitution token (no surrounding text,
+// no concatenation) — for mixed templates and literal-only strings,
+// the caller falls back to `SubstituteVariables` because string-concat
+// semantics require string output.
+//
+// First-match semantic preserved for `$entity.triple.X` /
+// `$related.triple.X`: if multiple triples on the entity carry the
+// same predicate with DIFFERENT Object types (degenerate but legal),
+// the FIRST stamped triple wins by both type AND value. Prior to this
+// helper, all values were string-coerced; the new behavior is
+// observable only in the degenerate mixed-type case. Cross-repo survey
+// (semstreams + semteams rule packs, 19 sites) found zero production
+// rules that stamp the same predicate with mixed Object types.
+//
+// Two known semantic divergences vs. the pre-fix string path. Both are
+// degenerate (no production rule exercises either) but documented so
+// the next reader doesn't have to re-derive them:
+//
+//  1. Predicates literally named `<X>.length` or `<X>.triples` —
+//     pre-fix, the string path's pre-pass (applyTripleLengthSubstitutions
+//     / applyTripleTriplesSubstitutions) interpreted the trailing token
+//     as a count/enumeration suffix and resolved against an entity with
+//     predicate `<X>`. Post-fix, the typed regex `[\w.-]+` captures the
+//     full predicate INCLUDING the trailing `.length` / `.triples`, so
+//     a triple genuinely named that wins. If a future rule pack needs
+//     the pre-fix suffix-interpretation semantic, change the regex to
+//     reject these suffixes (e.g. negative lookahead) and let the call
+//     fall back to the string path that handles them.
+//
+//  2. `$message.<path>` resolving to a JSON `null` — ExtractMessageValue
+//     in expression/message_path.go returns (nil, true) for a present-
+//     but-null terminal. The typed path propagates that nil to the
+//     destination Triple's Object as a typed nil, where the pre-fix
+//     string path rendered it as the literal string "<nil>". The
+//     post-fix behavior is more honest about the absence; consumers
+//     that distinguished `Object == "<nil>"` as a sentinel will break
+//     (no current consumer surveyed does this).
+//
+// NO reflection in the resolution path. Type passes through as `any`
+// without inspection — the existing `triple.Object` is already `any`,
+// so we propagate it directly. `reflect.TypeOf` is used only in tests
+// to assert source/destination type equality.
+package rule
+
+import (
+	"regexp"
+
+	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/processor/rule/expression"
+)
+
+// typedEntityTripleRe matches `$entity.triple.<predicate>` when the
+// ENTIRE template is exactly that token. Anchored on both ends so a
+// mixed template (`"prefix-$entity.triple.X"`) or trailing suffix
+// (`"$entity.triple.X.length"`, `"$entity.triple.X "`) fails the
+// match and the caller falls back to string substitution.
+//
+// Predicate character class allows letters, digits, dot, hyphen,
+// underscore — matching the predicate shapes used in production
+// (e.g. `lineage.run-loop-entity-id` carries a hyphen).
+var typedEntityTripleRe = regexp.MustCompile(`^\$entity\.triple\.([\w.-]+)$`)
+
+// typedRelatedTripleRe — mirror of typedEntityTripleRe for the related
+// entity. Same anchoring + character-class discipline.
+var typedRelatedTripleRe = regexp.MustCompile(`^\$related\.triple\.([\w.-]+)$`)
+
+// typedMessageRe matches `$message.<dotted.path>` when the entire
+// template is exactly that token. Path segments are word-only (no
+// hyphens) — mirrors messageTokenRe in message_substitution.go for
+// the existing string path. Anchored.
+var typedMessageRe = regexp.MustCompile(`^\$message\.(\w+(?:\.\w+)*)$`)
+
+// SubstituteVariablesTyped attempts to resolve template to a typed
+// value when it is EXACTLY one supported substitution token (no
+// surrounding text, no concatenation, no recognized suffix like
+// `.length` or `.triples`).
+//
+// Return contract:
+//
+//   - (value, true) — template matched a single supported token AND
+//     resolution found a value. value is typed `any`, carrying the
+//     source's Go type unchanged.
+//   - (nil, false) — every other case: mixed template, literal-only
+//     string (no `$`), unsupported namespace, single token whose
+//     target doesn't exist (e.g. `$entity.triple.X` where X isn't on
+//     the entity at fire time), or a recognized suffix like
+//     `.length` / `.triples` (those carry typed semantics — int and
+//     `[]string` — but are deferred to the string path which already
+//     handles them via applyTripleLengthSubstitutions /
+//     applyTripleTriplesSubstitutions).
+//
+// Callers that need a string result for concatenation or templating
+// MUST fall back to SubstituteVariables when this returns false.
+// Designed specifically for `action.Object` on `add_triple` /
+// `update_triple` where preserving the source's numeric/bool type is
+// required (gh#207).
+//
+// Supported single-token patterns:
+//
+//   - "$entity.triple.<predicate>" — first matching triple's Object
+//     on the trigger entity (type `any`, source-preserving).
+//   - "$related.triple.<predicate>" — same on the related entity.
+//   - "$message.<dotted.path>" — typed value from MessageData via
+//     expression.ExtractMessageValue. JSON-decoded numbers arrive as
+//     `float64` by default unless the producer used `json.Number`.
+//   - "$state.iteration" — `int` (MatchState.Iteration).
+//   - "$state.max_iterations" — `int` (MatchState.MaxIterations).
+//
+// Inherently-string namespaces ($entity.id, $now, $caller.*,
+// $schedule.*, entity-part segments) are NOT supported here — callers
+// don't lose anything by falling through to the string path for
+// those since the destination value is already a string. Returning
+// (nil, false) for them keeps the caller dispatch logic simple
+// (one boolean check).
+//
+// The empty template, the bare "$" string, and templates that don't
+// start with "$" all short-circuit to (nil, false) without scanning.
+func (ec *ExecutionContext) SubstituteVariablesTyped(template string) (any, bool) {
+	if len(template) < 2 || template[0] != '$' {
+		return nil, false
+	}
+
+	if m := typedEntityTripleRe.FindStringSubmatch(template); m != nil {
+		return lookupTripleObjectTyped(ec.Entity, m[1])
+	}
+	if m := typedRelatedTripleRe.FindStringSubmatch(template); m != nil {
+		return lookupTripleObjectTyped(ec.Related, m[1])
+	}
+	if m := typedMessageRe.FindStringSubmatch(template); m != nil {
+		if ec.MessageData == nil {
+			return nil, false
+		}
+		return expression.ExtractMessageValue(expression.MessageFields(ec.MessageData), m[1])
+	}
+
+	switch template {
+	case "$state.iteration":
+		if ec.State == nil {
+			return nil, false
+		}
+		return ec.State.Iteration, true
+	case "$state.max_iterations":
+		if ec.State == nil {
+			return nil, false
+		}
+		return ec.State.MaxIterations, true
+	}
+
+	return nil, false
+}
+
+// lookupTripleObjectTyped scans entity.Triples for the first triple
+// matching predicate and returns its Object as-is (typed `any`).
+// Returns (nil, false) when entity is nil OR no triple matches —
+// caller treats as "single-token-but-unresolved" and falls back to
+// the string path (which logs the unresolved-template warning).
+//
+// First-match: in the degenerate case where multiple triples carry
+// the same predicate with different types, the FIRST stamped wins by
+// both type AND value. Pre-fix behaviour string-coerced every
+// candidate so the type-mismatch was invisible; cross-repo survey
+// found zero production rules that exercise this corner.
+//
+// Linear scan matches the existing inline pattern in
+// substituteVariablesWith — no reflection, no allocation beyond the
+// returned `any` interface header.
+func lookupTripleObjectTyped(entity *gtypes.EntityState, predicate string) (any, bool) {
+	if entity == nil {
+		return nil, false
+	}
+	for _, triple := range entity.Triples {
+		if triple.Predicate == predicate {
+			return triple.Object, true
+		}
+	}
+	return nil, false
+}

--- a/processor/rule/typed_substitution_test.go
+++ b/processor/rule/typed_substitution_test.go
@@ -1,0 +1,428 @@
+// Package rule — gh#207 typed Object substitution tests.
+//
+// The pre-fix test suite (TestAction_AddTriple, TestAction_UpdateTriple)
+// used string-only Object values, which made the type-erasure bug
+// invisible by construction: comparing two strings via assert.Equal is
+// type-vacuous. These tests enumerate every primitive Object type the
+// `message.Triple` doc lists as supported (float64, int, bool, string)
+// and assert both VALUE and reflect.TypeOf equality at the destination.
+//
+// Test discipline lifted from gh#207's forensic finding: when a field's
+// destination type is wider than its declared input type
+// (Action.Object string → Triple.Object any here), tests must
+// enumerate the destination's documented types and assert
+// type-preservation, not just value-preservation. See
+// feedback_polymorphic_config_needs_json_roundtrip_test for the
+// sister discipline this extends.
+//
+// reflect.TypeOf usage here is test-only — the runtime substitution
+// path uses no reflection, per the hot-path constraint.
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/processor/rule/expression"
+)
+
+// typedObjectCase parameterizes the round-trip test across every
+// primitive Object type message.Triple's doc lists.
+type typedObjectCase struct {
+	name      string
+	sourceObj any // value stored on the source triple's Object
+}
+
+func typedObjectCases() []typedObjectCase {
+	return []typedObjectCase{
+		{"float64 — the bug reproducer", float64(0.8327193260192871)},
+		{"float64 — power-of-10 boundary value", float64(9.9)},
+		{"int — iteration-counter shape", int(42)},
+		{"bool — true", true},
+		{"bool — false", false},
+		{"string — entity-ID shape", "c360.platform.robotics.mav1.drone.001"},
+		{"string — short literal", "active"},
+	}
+}
+
+// TestExecuteAddTriple_SubstitutedObject_PreservesType is the gh#207
+// regression test on the add_triple side. Source triple stamped with
+// a typed Object; rule action references it via single-token
+// substitution; destination triple must carry the same Go type.
+func TestExecuteAddTriple_SubstitutedObject_PreservesType(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	entityID := "c360.platform.robotics.mav1.drone.001"
+
+	for _, tc := range typedObjectCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &mockTripleMutator{}
+			executor := NewActionExecutorWithMutator(nil, mock)
+
+			// Entity carries a single source triple with the typed Object.
+			entity := &gtypes.EntityState{
+				ID: entityID,
+				Triples: []message.Triple{
+					{Subject: entityID, Predicate: "source.value", Object: tc.sourceObj},
+				},
+			}
+
+			action := Action{
+				Type:      ActionTypeAddTriple,
+				Predicate: "dest.value",
+				Object:    "$entity.triple.source.value",
+			}
+
+			_, err := executor.ExecuteAddTriple(ctx, action, &ExecutionContext{
+				EntityID: entityID,
+				Entity:   entity,
+			})
+			require.NoError(t, err)
+
+			require.Len(t, mock.addedTriples, 1)
+			got := mock.addedTriples[0].Object
+
+			// Value equality alone passes the bug class — both sides as
+			// strings ("0.8327..." vs "0.8327...") would assert.Equal
+			// just fine. The type assertion is the load-bearing check.
+			assert.Equal(t, tc.sourceObj, got, "Object value should round-trip")
+			assert.Equal(t, reflect.TypeOf(tc.sourceObj), reflect.TypeOf(got),
+				"Object Go type should round-trip — gh#207 regression")
+		})
+	}
+}
+
+// TestExecuteUpdateTriple_SubstitutedObject_PreservesType — the
+// gh#207 regression test on the update_triple side. Symmetric with
+// the add_triple variant because both actions share the typed-then-
+// string substitution dispatch pattern. The autoresearch
+// `best.value` upsert from semteams was the original reproducer.
+func TestExecuteUpdateTriple_SubstitutedObject_PreservesType(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	entityID := "c360.platform.robotics.mav1.drone.001"
+
+	for _, tc := range typedObjectCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &mockTripleMutator{}
+			executor := NewActionExecutorWithMutator(nil, mock)
+
+			entity := &gtypes.EntityState{
+				ID: entityID,
+				Triples: []message.Triple{
+					{Subject: entityID, Predicate: "source.value", Object: tc.sourceObj},
+				},
+			}
+
+			action := Action{
+				Type:      ActionTypeUpdateTriple,
+				Predicate: "dest.value",
+				Object:    "$entity.triple.source.value",
+			}
+
+			err := executor.Execute(ctx, action, &ExecutionContext{
+				EntityID: entityID,
+				Entity:   entity,
+			})
+			require.NoError(t, err)
+
+			require.Len(t, mock.addedTriples, 1)
+			got := mock.addedTriples[0].Object
+			assert.Equal(t, tc.sourceObj, got, "Object value should round-trip")
+			assert.Equal(t, reflect.TypeOf(tc.sourceObj), reflect.TypeOf(got),
+				"Object Go type should round-trip — gh#207 regression")
+		})
+	}
+}
+
+// TestExecuteAddTriple_MixedTemplate_FallsBackToString locks in the
+// string-fallback contract: when action.Object is a mixed template
+// (concat, prefix, suffix), the destination Object must be a string
+// — that's the existing behaviour and the only sensible one for
+// string-concat semantics. Without this test the typed path could
+// silently swallow mixed templates and break string-concat patterns.
+func TestExecuteAddTriple_MixedTemplate_FallsBackToString(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	entityID := "c360.platform.robotics.mav1.drone.001"
+
+	mock := &mockTripleMutator{}
+	executor := NewActionExecutorWithMutator(nil, mock)
+	entity := &gtypes.EntityState{
+		ID: entityID,
+		Triples: []message.Triple{
+			{Subject: entityID, Predicate: "source.value", Object: float64(0.5)},
+		},
+	}
+
+	action := Action{
+		Type:      ActionTypeAddTriple,
+		Predicate: "dest.value",
+		Object:    "value-is-$entity.triple.source.value-end",
+	}
+
+	_, err := executor.ExecuteAddTriple(ctx, action, &ExecutionContext{
+		EntityID: entityID,
+		Entity:   entity,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, mock.addedTriples, 1)
+	got := mock.addedTriples[0].Object
+	assert.IsType(t, "", got, "mixed-template Object should be string")
+	assert.Equal(t, "value-is-0.5-end", got, "string concatenation should preserve template shape")
+}
+
+// TestExecuteAddTriple_LiteralObject_PreservesString locks in the
+// behaviour for literal-only Object values: a string Object like
+// `"escalated"` must remain a string. This is the dominant case in
+// every production rule pack (18/19 sites in the cross-repo survey)
+// and the typed path must NOT corrupt it.
+func TestExecuteAddTriple_LiteralObject_PreservesString(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockTripleMutator{}
+	executor := NewActionExecutorWithMutator(nil, mock)
+
+	action := Action{
+		Type:      ActionTypeAddTriple,
+		Predicate: "workflow.phase",
+		Object:    "escalated",
+	}
+
+	_, err := executor.ExecuteAddTriple(ctx, action, &ExecutionContext{
+		EntityID: "c360.platform.robotics.mav1.drone.001",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, mock.addedTriples, 1)
+	got := mock.addedTriples[0].Object
+	assert.IsType(t, "", got, "literal Object should be string")
+	assert.Equal(t, "escalated", got)
+}
+
+// TestExecuteAddTriple_FirstMatchSemantic_MixedTypes documents the
+// degenerate behaviour: when an entity carries multiple triples with
+// the same predicate but different Object types, the FIRST stamped
+// wins by both type AND value. Pre-fix, all values were
+// string-coerced so the type mismatch was invisible — this is the
+// only observable behaviour change, and the cross-repo survey
+// found zero production rules that exercise it.
+func TestExecuteAddTriple_FirstMatchSemantic_MixedTypes(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	entityID := "c360.platform.robotics.mav1.drone.001"
+	mock := &mockTripleMutator{}
+	executor := NewActionExecutorWithMutator(nil, mock)
+
+	// Degenerate: two triples, same predicate, different types. First
+	// stamped is float64; second is string. The typed path returns the
+	// first match.
+	entity := &gtypes.EntityState{
+		ID: entityID,
+		Triples: []message.Triple{
+			{Subject: entityID, Predicate: "ambiguous", Object: float64(1.5)},
+			{Subject: entityID, Predicate: "ambiguous", Object: "second-stamp"},
+		},
+	}
+
+	action := Action{
+		Type:      ActionTypeAddTriple,
+		Predicate: "dest",
+		Object:    "$entity.triple.ambiguous",
+	}
+
+	_, err := executor.ExecuteAddTriple(ctx, action, &ExecutionContext{
+		EntityID: entityID,
+		Entity:   entity,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, mock.addedTriples, 1)
+	got := mock.addedTriples[0].Object
+	assert.Equal(t, float64(1.5), got, "first-match by both value AND type")
+	assert.Equal(t, reflect.TypeOf(float64(0)), reflect.TypeOf(got))
+}
+
+// TestNumericCompare_AfterStringifiedObject_UsesNumericSemantics is
+// the gh#207 read-side integration test. Even AFTER the typed-Object
+// fix on the write side, any pre-existing stringified-numeric Object
+// (left over from before the fix, or stamped through an external
+// producer that uses fmt.Sprintf rather than typed Object) must still
+// participate in numeric `lt`/`gt`/`between` comparisons correctly.
+//
+// Pre-toFloat64-widening: `"9.9" lt 10.0` lex-compared as
+// "9.9" > "10" (because '9' > '1'), so the condition silently
+// returned false — wrong by numeric semantics. Power-of-10 boundary
+// is the surface where lex and numeric disagree.
+//
+// Drives the production wire — NewExpressionRule(def).EvaluateEntityState —
+// per [[feedback_integration_tests_must_drive_production_wire]]. A
+// helper-direct compareValues test would pass without exercising the
+// rule-evaluation path that production uses.
+func TestNumericCompare_AfterStringifiedObject_UsesNumericSemantics(t *testing.T) {
+	tests := []struct {
+		name      string
+		objectVal any
+		operator  string
+		compareTo float64
+		want      bool
+	}{
+		// Power-of-10 boundary — the bug surface where lex and numeric
+		// disagree. Pre-fix: "9.9" > "10" lex → lt returns false.
+		// Post-fix: 9.9 < 10 numeric → lt returns true.
+		{"string 9.9 lt 10.0 — boundary case", "9.9", "lt", 10.0, true},
+		{"string 9.9 gt 10.0 — boundary case", "9.9", "gt", 10.0, false},
+
+		// Magnitudes within the same order — lex and numeric agree
+		// (would have passed pre-fix too).
+		{"string 0.4 lt 0.5", "0.4", "lt", 0.5, true},
+		{"string 0.8 gt 0.5", "0.8", "gt", 0.5, true},
+
+		// Float64 source (no stringification) — unchanged behavior.
+		{"float64 9.9 lt 10.0", float64(9.9), "lt", 10.0, true},
+		{"float64 9.9 gt 10.0", float64(9.9), "gt", 10.0, false},
+
+		// Non-numeric strings still fail numeric compare and fall to
+		// string compare — regression-safe path for legitimate string
+		// values that happen to be compared with a numeric operator.
+		// "alpha" > "10" lex because 'a' (0x61) > '1' (0x31), so lt
+		// returns false. Asserting the fallback path stays intact.
+		{"non-numeric string vs numeric — falls to string compare", "alpha", "lt", 10.0, false},
+
+		// json.Number support — UseNumber() decoder produces these to
+		// preserve precision. compareValuesWithError must numeric-
+		// compare against them, not fall to lex on the underlying
+		// string. Per the type-switch case in toFloat64.
+		{"json.Number lt 10.0 — boundary case", json.Number("9.9"), "lt", 10.0, true},
+		{"json.Number gt 10.0 — boundary case", json.Number("9.9"), "gt", 10.0, false},
+
+		// NaN rejection — strconv.ParseFloat accepts "NaN" but the
+		// resulting compare would silently produce "equal" (NaN op
+		// anything = false → compareValuesWithError returns 0 = equal).
+		// We explicitly reject NaN at toFloat64 so the fallback string
+		// path handles it deterministically. "NaN" > "10" lex
+		// ('N' = 0x4E > '1' = 0x31), so lt returns false.
+		{"NaN string rejected from numeric — falls to string", "NaN", "lt", 10.0, false},
+
+		// Inf rejection — same shape. "Inf" > "10" lex ('I' > '1'),
+		// so lt returns false. Without rejection, +Inf < 10 numeric
+		// would be false; rejecting routes through lex which agrees
+		// by coincidence here, but the discipline is "don't admit
+		// non-finite floats into compare."
+		{"Inf string rejected from numeric — falls to string", "Inf", "lt", 10.0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			def := Definition{
+				ID:      "gh207-numeric-compare-after-stringified",
+				Type:    "expression",
+				Name:    "gh#207 numeric compare locks",
+				Enabled: true,
+				Logic:   expression.LogicAnd,
+				Conditions: []expression.ConditionExpression{
+					{Field: "metric.value", Operator: tt.operator, Value: tt.compareTo, Required: true},
+				},
+			}
+			rule, err := NewExpressionRule(def)
+			require.NoError(t, err)
+
+			entity := createTestEntityState("test.entity.id", []message.Triple{
+				{Subject: "test.entity.id", Predicate: "metric.value", Object: tt.objectVal},
+			})
+
+			got := rule.EvaluateEntityState(entity)
+			assert.Equal(t, tt.want, got,
+				"compareValues with toFloat64 string-widening must produce numeric semantics for parsable strings")
+		})
+	}
+}
+
+// TestSubstituteVariablesTyped_ReturnContract directly exercises the
+// helper's (any, bool) contract for each supported namespace, plus
+// the fall-through cases. Driven through the public API on
+// ExecutionContext so the regex-based dispatch + type-routing logic
+// is locked.
+func TestSubstituteVariablesTyped_ReturnContract(t *testing.T) {
+	t.Parallel()
+	entityID := "c360.platform.robotics.mav1.drone.001"
+	relatedID := "c360.platform.fleet.alpha.fleet.001"
+
+	entity := &gtypes.EntityState{
+		ID: entityID,
+		Triples: []message.Triple{
+			{Subject: entityID, Predicate: "metric.value", Object: float64(0.83)},
+			{Subject: entityID, Predicate: "metric.active", Object: true},
+		},
+	}
+	related := &gtypes.EntityState{
+		ID: relatedID,
+		Triples: []message.Triple{
+			{Subject: relatedID, Predicate: "fleet.size", Object: int(7)},
+		},
+	}
+	ec := &ExecutionContext{
+		EntityID:    entityID,
+		RelatedID:   relatedID,
+		Entity:      entity,
+		Related:     related,
+		MessageData: map[string]any{"score": 0.42, "flag": true, "nested": map[string]any{"deep": "value"}, "nullable": nil},
+		State:       &MatchState{Iteration: 3, MaxIterations: 5},
+	}
+
+	tests := []struct {
+		name       string
+		template   string
+		wantOK     bool
+		wantValue  any
+		wantTypeOf any // sample of expected Go type; nil when wantOK=false
+	}{
+		{"entity.triple float64", "$entity.triple.metric.value", true, float64(0.83), float64(0)},
+		{"entity.triple bool", "$entity.triple.metric.active", true, true, false},
+		{"related.triple int", "$related.triple.fleet.size", true, int(7), int(0)},
+		{"message scalar float", "$message.score", true, 0.42, float64(0)},
+		{"message scalar bool", "$message.flag", true, true, false},
+		{"message nested path", "$message.nested.deep", true, "value", ""},
+		// JSON null at terminal — ExtractMessageValue returns (nil, true);
+		// the typed path propagates as (nil, true) with no type sample.
+		// Locking this so the package-doc divergence note (#2) stays true.
+		{"message null value — typed nil propagates", "$message.nullable", true, nil, nil},
+		{"state.iteration int", "$state.iteration", true, int(3), int(0)},
+		{"state.max_iterations int", "$state.max_iterations", true, int(5), int(0)},
+		{"unresolved entity triple", "$entity.triple.missing", false, nil, nil},
+		{"mixed template", "prefix-$entity.triple.metric.value", false, nil, nil},
+		{"literal only", "escalated", false, nil, nil},
+		{"bare $", "$", false, nil, nil},
+		{"empty", "", false, nil, nil},
+		{"trailing space", "$entity.triple.metric.value ", false, nil, nil},
+		{"with .length suffix", "$entity.triple.metric.value.length", false, nil, nil},
+		{"with .triples suffix", "$entity.triple.metric.value.triples", false, nil, nil},
+		{"unsupported namespace $entity.id", "$entity.id", false, nil, nil},
+		{"unsupported namespace $now", "$now", false, nil, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			val, ok := ec.SubstituteVariablesTyped(tt.template)
+			assert.Equal(t, tt.wantOK, ok)
+			if !tt.wantOK {
+				assert.Nil(t, val, "value should be nil on false return")
+				return
+			}
+			assert.Equal(t, tt.wantValue, val)
+			assert.Equal(t, reflect.TypeOf(tt.wantTypeOf), reflect.TypeOf(val),
+				"Go type must match expected")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes gh#207: `update_triple` / `add_triple` silently stringified destination Triple.Object when action.Object was a substitution token (`Action.Object string` → `Triple.Object any` bridge via string→string substitution).
- Adds `SubstituteVariablesTyped` typed-passthrough helper; widens `toFloat64` to handle string + json.Number (rejects NaN/Inf) so pre-existing stringified-numerics also numeric-compare correctly.
- Re-establishes the pre-merge go-reviewer discipline that #148 skipped per [[feedback_review_cadence_pre_commit]].

## What broke (two symptoms)

1. **Type-erased Triple.Object** — float64 source triple substituted into `update_triple` Object landed as string at the destination. Downstream Go consumers' type-switch failed; semteams autoresearch chain bailed with `needs_clarification`.

2. **Silent lex-vs-numeric corruption in rule conditions** — `toFloat64` had no `string` case, so a stringified-numeric Object fell to `fmt.Sprintf("%v")` lex compare. `"9.9" > "10.0"` lex but `9.9 < 10.0` numeric, so any `lt`/`gt`/`between` against a stringified value silently misordered across power-of-10 boundaries.

Cross-repo blast-radius survey (semstreams + semteams rule packs, 19 sites total): exactly 1 site broken today — semteams `configs/rules/autoresearch/04c-execute-promote-best-on-kept.json` `best.value` upsert. 18:1 string-dominated; fix is observably additive.

Design pin (with semteams sign-off): https://github.com/C360Studio/semstreams/issues/207#issuecomment-4612544038

## What's in this PR

- **`processor/rule/typed_substitution.go`** (new) — `SubstituteVariablesTyped(template) (any, bool)`. Anchored regex matching for single-token templates ($entity.triple.X, $related.triple.X, $message.X, $state.iteration, $state.max_iterations). Returns (nil, false) for mixed templates, literals, and unresolved tokens — caller falls back to existing string path. No reflection in resolution; package-level regex compilation.
- **`processor/rule/actions.go`** — `ExecuteAddTriple` and `executeUpdateTriple` use typed-then-string fall-through dispatch for `action.Object`. Symmetric across both actions.
- **`processor/rule/expression/evaluator.go`** — `toFloat64` accepts `string` (strconv.ParseFloat) and `json.Number`. Rejects NaN/Inf (NaN's all-false comparisons would silently make `compareValues == 0`).
- **`processor/rule/typed_substitution_test.go`** (new) — type-parameterized round-trip tests for both actions (float64/int/bool/string), 17-case return-contract matrix, first-match degenerate case, rule-condition integration test driving `NewExpressionRule.EvaluateEntityState` per [[feedback_integration_tests_must_drive_production_wire]].

## Discipline this PR re-establishes

The bug shipped through #148 with **zero reviews**. This PR's pre-merge gate is the explicit fix to that gap.

go-reviewer returned APPROVE — 0 Critical, 0 Important, 5 Minor, all applied in-PR rather than deferred:

| Finding | Resolution |
|---------|------------|
| M1 — missing `.triples` suffix test | Added (symmetric to `.length`) |
| M2 — `<X>.length` / `<X>.triples` predicate-naming divergence | Package-doc note |
| M3 — JSON null → typed nil semantic shift | Package-doc note + test case |
| M4 — toFloat64 admits NaN, Inf, sci notation | NaN/Inf rejected; tests added |
| M5 — json.Number not handled | `case json.Number:` added; tests added |

Post-merge follow-up: new feedback memo *"Wider-destination-type fields need type-parameterized round-trip tests"* — extends [[feedback_polymorphic_config_needs_json_roundtrip_test]]. The pre-fix `TestAction_AddTriple` / `TestAction_UpdateTriple` suites both used string-only Object inputs; `assert.Equal` between two strings was type-vacuous for the bug class.

## Pre-merge gates (all green)

- `go test ./... -race -count=1` — all packages pass
- `go test -race -tags=integration ./... -count=1` — 123 packages ok, 0 FAILs
- `go vet ./...` + `-tags=integration` + `-tags=live_llm` — clean
- `task schema:generate` — no drift
- `task lint` — no new warnings (20 pre-existing only, none in changed files)
- contract tests — ok

## Test plan

- [x] Unit tests with race
- [x] Integration tests with race
- [x] go vet across all build tags
- [x] Schema regeneration with no drift
- [x] Lint clean on changed files
- [x] go-reviewer pre-merge pass
- [ ] After merge: semteams pulls the new tag and verifies the autoresearch convergence past iter 2 in their smoke #14

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)