### PR TITLE
fix(graph-gateway): route composites before single-resolver substring checks (gh#206)

### DIFF
--- a/gateway/graph-gateway/component.go
+++ b/gateway/graph-gateway/component.go
@@ -834,9 +834,6 @@ func (c *Component) mapGraphQLQueryToNATSSubject(query string) string {
 	if strings.Contains(query, "entitiesbyprefix") {
 		return "graph.query.prefix"
 	}
-	if strings.Contains(query, "pathsearch") {
-		return "graph.query.pathSearch"
-	}
 	if strings.Contains(query, "spatialsearch") {
 		return "graph.query.spatial"
 	}
@@ -849,32 +846,70 @@ func (c *Component) mapGraphQLQueryToNATSSubject(query string) string {
 	if strings.Contains(query, "findsimilar") || strings.Contains(query, "similarentities") {
 		return "graph.query.similar"
 	}
-	if strings.Contains(query, "relationships") {
-		return "graph.query.relationships"
-	}
-	if strings.Contains(query, "capabilities") {
-		return "graph.query.capabilities"
-	}
 
-	// Composite resolvers — match before their lower-level primitives
-	// so the dedicated subject wins. Convention: most specific first
-	// (mirrors the localsearch-before-globalsearch ordering below).
-	// graphSummary is a composite over predicates + prefix; searchGraph
-	// is a composite over globalSearch + semantic fallback. Both must
-	// match before the generic terms further down.
+	// Composite resolvers — match BEFORE the single-resolver substring
+	// checks below (relationships, capabilities, predicates) so a
+	// composite query whose name, arguments, or result-type fields
+	// happen to include one of those substrings doesn't get hijacked
+	// by a collision lower down.
+	//
+	// gh#206 surfaced this: a globalSearch query with a nested
+	// `relationships { from to predicate }` selection routed to
+	// graph.query.relationships because the relationships substring
+	// check fired first, leaving the composite handler unreached and
+	// returning "empty entity_id". The collision surface is broader
+	// than nested result fields — `mapGraphQLQueryToNATSSubject`
+	// scans the WHOLE lowercased query string, so the substring
+	// match can land on:
+	//
+	//   - Result-type field names (gh#206: GlobalSearchResult carries
+	//     `relationships`, `sources`, `entities`, `community_summaries`)
+	//   - Argument names (`includeRelationships`, `includeSources`,
+	//     and pathSearch's `predicates` are real today)
+	//   - Operation names (`query GetRelationships { ... }`)
+	//   - Fragment names (`fragment Relationships on Query { ... }`)
+	//
+	// Anything sitting BEFORE a composite tier whose token matches one
+	// of those is a collision candidate. Default safe placement for any
+	// resolver that returns a composite result type (PathSearchResult,
+	// GlobalSearchResult, GraphSummary) is in THIS block, even if it
+	// "doesn't currently collide" — the next added substring check or
+	// schema change can flip it accidentally.
+	//
+	// Long-term: route by parsed GraphQL root field rather than
+	// substring scan (see gh#206 "Suggested Fix"). Short-term, the
+	// order below is the structural fix.
 	if strings.Contains(query, "graphsummary") {
 		return "graph.query.summary"
 	}
 	if strings.Contains(query, "searchgraph") {
 		return "graph.query.searchGraph"
 	}
-
-	// GraphRAG search patterns - must come before generic "entity" check
 	if strings.Contains(query, "localsearch") {
 		return "graph.query.localSearch"
 	}
 	if strings.Contains(query, "globalsearch") {
 		return "graph.query.globalSearch"
+	}
+	// pathSearch returns PathSearchResult (composite shape) AND takes
+	// `predicates: [String]` as an arg — a pathSearch query lowercases
+	// to a string containing the `predicates` substring, which would
+	// hijack routing to graph.index.query.predicateList if pathsearch
+	// were positioned below. Moved here from the "most specific" tier
+	// per gh#206 review I1 — its accidental safety in the prior
+	// position would have broken on the next reshuffle.
+	if strings.Contains(query, "pathsearch") {
+		return "graph.query.pathSearch"
+	}
+
+	// Single-resolver substring checks — must come AFTER the composite
+	// resolvers above so a composite query's nested result fields don't
+	// hijack routing. gh#206.
+	if strings.Contains(query, "relationships") {
+		return "graph.query.relationships"
+	}
+	if strings.Contains(query, "capabilities") {
+		return "graph.query.capabilities"
 	}
 
 	// Predicate queries - must come before generic "entity" check

--- a/gateway/graph-gateway/query_test.go
+++ b/gateway/graph-gateway/query_test.go
@@ -2041,3 +2041,147 @@ func TestBuildIntrospectionSchema_GlobalSearchArgs(t *testing.T) {
 		assert.Contains(t, argNames, expected, "globalSearch should have arg %q", expected)
 	}
 }
+
+// TestGateway_MapGraphQLToNATSSubject_NestedSelectionRouting locks in the
+// gh#206 fix: composite resolvers whose result type carries field names
+// that ALSO match generic single-resolver substring checks must route to
+// the composite, not get hijacked by the substring collision in the
+// selection set.
+//
+// Before the gh#206 fix, the routing function ran the generic
+// `relationships` substring check BEFORE the composite search checks.
+// A `globalSearch` query with a nested `relationships { from to }`
+// selection therefore routed to `graph.query.relationships`, which
+// then bailed with `empty entity_id` because there was no
+// `relationships(entityId: ...)` arg in scope. semconnect's demo UI
+// surfaced it; the fix reorders the checks so composites win.
+//
+// Same shape bug also affects `searchGraph` and `localSearch` (both
+// return `GlobalSearchResult` which carries `relationships`), so all
+// three are covered. The inverse — bare `relationships(entityId)` and
+// bare `capabilities` queries must still route to their dedicated
+// subjects after the reorder — is locked by the regression-safe cases.
+func TestGateway_MapGraphQLToNATSSubject_NestedSelectionRouting(t *testing.T) {
+	comp := createTestGateway(t)
+
+	tests := []struct {
+		name            string
+		query           string
+		expectedSubject string
+	}{
+		// gh#206 reproducer — globalSearch with nested relationships
+		// selection. Pre-fix routed to graph.query.relationships; post-fix
+		// must route to graph.query.globalSearch.
+		{
+			name: "gh#206 -- globalSearch with nested relationships",
+			query: `query GlobalSearch($query: String!) {
+				globalSearch(query: $query) {
+					entities { id }
+					relationships { from to predicate }
+					count
+					duration_ms
+				}
+			}`,
+			expectedSubject: "graph.query.globalSearch",
+		},
+		// searchGraph returns GlobalSearchResult (same as globalSearch),
+		// so the same nested-relationships hijack applies. Lock here.
+		{
+			name: "gh#206 -- searchGraph with nested relationships",
+			query: `query SearchGraph($query: String!) {
+				searchGraph(query: $query) {
+					entities { id }
+					relationships { from to predicate }
+					count
+				}
+			}`,
+			expectedSubject: "graph.query.searchGraph",
+		},
+		// localSearch is the third GraphRAG composite. Same shape.
+		{
+			name: "gh#206 -- localSearch with nested relationships",
+			query: `query LocalSearch($query: String!, $entity: String!) {
+				localSearch(query: $query, anchor_entity: $entity) {
+					entities { id }
+					relationships { from to predicate }
+					count
+				}
+			}`,
+			expectedSubject: "graph.query.localSearch",
+		},
+		// Inverse — a bare relationships(entityId) query must still
+		// route to graph.query.relationships after the reorder. The fix
+		// is about composite-precedence, not removing the relationships
+		// route entirely.
+		{
+			name: "regression-safe -- bare relationships(entityId) routes correctly",
+			query: `query Relationships($id: String!) {
+				relationships(entityId: $id, direction: "out") {
+					from to predicate
+				}
+			}`,
+			expectedSubject: "graph.query.relationships",
+		},
+		// Same regression-safe inverse for capabilities.
+		{
+			name:            "regression-safe -- bare capabilities routes correctly",
+			query:           `query { capabilities { name version } }`,
+			expectedSubject: "graph.query.capabilities",
+		},
+		// Defensive: GlobalSearchResult also carries `sources` —
+		// neither has a generic substring check today, but a future
+		// developer who adds one would hit the same class of bug. This
+		// case documents the discipline: any new substring check for a
+		// name that appears in a composite's result type must be
+		// positioned AFTER the composites.
+		{
+			name: "defensive -- globalSearch with nested sources",
+			query: `query GlobalSearch($query: String!) {
+				globalSearch(query: $query) {
+					entities { id }
+					sources { id }
+					count
+				}
+			}`,
+			expectedSubject: "graph.query.globalSearch",
+		},
+		// Argument-name collision class (gh#206 review I2): a
+		// globalSearch call with `includeRelationships: true` arg
+		// lowercases to a string containing the `relationships`
+		// substring. The pre-fix routing would have hijacked this
+		// even without nested result-field selections. Lock against
+		// future regression.
+		{
+			name: "gh#206 class -- globalSearch with includeRelationships arg",
+			query: `query {
+				globalSearch(query: "x", includeRelationships: true) {
+					entities { id }
+				}
+			}`,
+			expectedSubject: "graph.query.globalSearch",
+		},
+		// pathSearch + predicates arg — accidental safety in the
+		// pre-fix code because `pathsearch` was checked in the "most
+		// specific" tier above the `predicates` substring check. Post-
+		// fix (review I1) pathSearch lives in the composite block;
+		// this case locks the structural placement so the next
+		// reshuffle doesn't reintroduce the collision.
+		{
+			name: "gh#206 class -- pathSearch with predicates arg",
+			query: `query {
+				pathSearch(startEntity: "x", predicates: ["a", "b"]) {
+					entities { id }
+					edges { from to }
+				}
+			}`,
+			expectedSubject: "graph.query.pathSearch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subject := comp.mapGraphQLQueryToNATSSubject(tt.query)
+			assert.Equal(t, tt.expectedSubject, subject)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Fixes gh#206 routing collision — composite GraphQL queries with nested `relationships` selections were misrouted to `graph.query.relationships`, breaking semconnect's demo UI with `empty entity_id`.
- Reorder `mapGraphQLQueryToNATSSubject` substring checks: composites (`graphsummary`, `searchgraph`, `localsearch`, `globalsearch`, `pathsearch`) now match BEFORE the generic single-resolver checks (`relationships`, `capabilities`).
- 8-case test suite locks both nested-field and argument-name collision classes plus regression-safe inverses.

## Reproducer (from semconnect)

```graphql
query GlobalSearch($query: String!) {
  globalSearch(query: $query) {
    entities { id }
    relationships { from to predicate }
    count
  }
}
```

Pre-fix: lowercased query contains both `globalsearch` AND `relationships`. The `relationships` check at line 852 fired first → routed to `graph.query.relationships` → handler bailed with `empty entity_id`. Same shape affects `searchGraph` and `localSearch` (both return `GlobalSearchResult` which carries `relationships`).

## Fix

Move four composite-resolver substring checks ahead of the single-resolver checks. `pathsearch` also moved up per go-reviewer I1 — it returns `PathSearchResult` AND takes `predicates: [String]` as an arg, so pathSearch queries lowercase to a string containing `predicates`. Today's safety was accidental ordering; the move locks the structural placement.

## Why substring-match is fragile

`mapGraphQLQueryToNATSSubject` scans the whole lowercased query string. The collision surface is broader than nested result-type field names — the substring can land on:
- Result-type field names (gh#206)
- Argument names (`includeRelationships`, `includeSources`, `predicates`)
- Operation names (`query GetRelationships {...}`)
- Fragment names (`fragment Relationships on Query {...}`)

Anything sitting BEFORE a composite tier whose token matches one of those is a collision candidate. Long-term fix is to route by parsed GraphQL root field; short-term reorder is the structural fix this PR makes.

## Test coverage (8 cases)

| # | Case | Class |
|---|------|-------|
| 1 | `globalSearch` + nested `relationships` | gh#206 reproducer |
| 2 | `searchGraph` + nested `relationships` | gh#206 sister |
| 3 | `localSearch` + nested `relationships` | gh#206 sister |
| 4 | Bare `relationships(entityId)` | regression-safe inverse |
| 5 | Bare `capabilities` | regression-safe inverse |
| 6 | `globalSearch` + nested `sources` | defensive (no current collision) |
| 7 | `globalSearch(includeRelationships: true)` | argument-name collision class |
| 8 | `pathSearch(predicates: [...])` | argument-name collision class |

## Pre-merge gates (all green)

- `task lint`: 20 pre-existing warnings only (none in changed files)
- `go test ./... -race -count=1`: clean, 0 FAILs
- `go test -race -tags=integration ./... -count=1`: 123 packages ok, 0 FAILs
- `go vet ./...` + `-tags=integration` + `-tags=live_llm`: clean
- `task schema:generate`: no drift
- contract tests: ok
- **go-reviewer pre-merge**: APPROVE with 2 Important + 5 Minor. **I1 (pathsearch in composite tier) + I2 (arg-name collision tests) + M3 (ASCII subtest names) + M5 (operation/fragment-name doc note) applied in-PR** per [[feedback_review_cadence_pre_commit]].

## Test plan

- [x] Unit tests with race
- [x] Integration tests with race (123 packages)
- [x] go vet across all build tags
- [x] Schema no drift
- [x] Lint clean on changed files
- [x] go-reviewer pre-merge pass with all blocking findings applied
- [ ] Post-merge: semconnect verifies their demo UI's `globalSearch` calls route correctly

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)