### PR TITLE
feat(test-infra): substrate-flake Step 1 — ephemeral ports + lint guard (gh#220)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,18 @@ jobs:
       - name: Run revive
         run: revive -config revive.toml -formatter friendly ./...
 
+      - name: Substrate-flake guard — fixed-port lint regex matrix test
+        # gh#220 review C1 — the lint guard's regex matrix must be
+        # verified, not implicitly trusted. Runs fixture test that
+        # exercises positive matches + suppression marker.
+        run: bash scripts/lint-test-ports_fixture_test.sh
+
+      - name: Substrate-flake guard — no fixed-port net.Listen in test files
+        # gh#220 Subclass 2 — fixed-port literals in *_test.go collide
+        # under parallel test execution. Single source of truth:
+        # scripts/lint-test-ports.sh, also invoked by task lint.
+        run: bash scripts/lint-test-ports.sh
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/input/websocket/websocket_input_integration_test.go
+++ b/input/websocket/websocket_input_integration_test.go
@@ -5,7 +5,6 @@ package websocket
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -386,19 +385,21 @@ func TestWebSocketInput_MessageEnvelopeTypes(t *testing.T) {
 // HELPER FUNCTIONS
 // =============================================================================
 
+// getAvailablePort asks the kernel for an unused TCP port via :0
+// ephemeral allocation. See gh#220 Subclass 2 — pre-fix the helper
+// scanned port 9082 + offset, which collided under parallel test
+// execution. The :0 pattern inherits the OS ephemeral pool.
+//
+// Race window: between the close here and the websocket server's
+// re-bind, another process could grab the port. Tracked separately
+// — see gh#220 Subclass 2 follow-up for the listener-handoff API fix.
 func getAvailablePort(t *testing.T) int {
 	t.Helper()
-
-	basePort := 9082
-	for i := 0; i < 100; i++ {
-		port := basePort + i
-		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-		if err == nil {
-			_ = ln.Close()
-			return port
-		}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("getAvailablePort: kernel refused :0 ephemeral allocation: %v", err)
 	}
-
-	t.Fatal("Could not find available port for testing")
-	return 9082 // Never reached
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
 }

--- a/output/websocket/metrics_integration_test.go
+++ b/output/websocket/metrics_integration_test.go
@@ -368,20 +368,21 @@ func TestWebSocketOutput_MessageSizeMetrics(t *testing.T) {
 
 // Helper functions for WebSocket metric testing
 
+// getAvailablePort asks the kernel for an unused TCP port via :0
+// ephemeral allocation. See gh#220 Subclass 2 — pre-fix the helper
+// scanned port 8082 + offset, which collided under parallel test
+// execution. The :0 pattern inherits the OS ephemeral pool.
+//
+// Race window: between the close here and the websocket server's
+// re-bind, another process could grab the port. Tracked separately
+// — see gh#220 Subclass 2 follow-up for the listener-handoff API fix.
 func getAvailablePort(t *testing.T) int {
 	t.Helper()
-
-	// Use port 8082 as default for tests, but add offset for parallel tests
-	basePort := 8082
-	for i := 0; i < 100; i++ {
-		port := basePort + i
-		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-		if err == nil {
-			_ = ln.Close()
-			return port
-		}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("getAvailablePort: kernel refused :0 ephemeral allocation: %v", err)
 	}
-
-	t.Fatal("Could not find available port for testing")
-	return 8082 // Never reached
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
 }

--- a/output/websocket/websocket_integration_test.go
+++ b/output/websocket/websocket_integration_test.go
@@ -329,19 +329,26 @@ func TestWebSocketFederation_MessageEnvelopeProtocol(t *testing.T) {
 // HELPER FUNCTIONS
 // =============================================================================
 
+// getIntegrationPort asks the kernel for an unused TCP port via
+// :0 ephemeral allocation. Previously scanned a fixed range starting
+// at 18082, which collided with other tests under parallel execution
+// and produced the gh#220 Subclass 2 flake shape. The :0 pattern
+// inherits whatever ephemeral-port pool the OS makes available,
+// which is broader than a 100-port fixed window and avoids the
+// allocate-from-known-range contention.
+//
+// Race window: between the close here and the websocket server's
+// re-bind in the test, another process could grab the port. That
+// race is structural to the close-then-pass-port pattern and is
+// tracked separately — see gh#220 Subclass 2 follow-up for the
+// listener-handoff API fix.
 func getIntegrationPort(t *testing.T) int {
 	t.Helper()
-
-	basePort := 18082
-	for i := 0; i < 100; i++ {
-		port := basePort + i
-		ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-		if err == nil {
-			ln.Close()
-			return port
-		}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("getIntegrationPort: kernel refused :0 ephemeral allocation: %v", err)
 	}
-
-	t.Fatal("Could not find available port for integration testing")
-	return 18082 // Never reached
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
 }

--- a/scripts/lint-test-ports.sh
+++ b/scripts/lint-test-ports.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# lint-test-ports.sh — substrate-flake guard for gh#220 Subclass 2.
+#
+# Fails (exit 1) if any *_test.go file binds a fixed TCP port via
+# net.Listen. Ephemeral allocation via net.Listen("tcp", ":0") or
+# "127.0.0.1:0" is the required pattern. Fixed-port literals collide
+# under parallel test execution and were the source of gh#209 and the
+# websocket integration flakes.
+#
+# Sourced from BOTH taskfiles/lint.yml and .github/workflows/ci.yml so
+# the regex has a single source of truth (gh#220 review I4).
+#
+# Known false-negative shapes (acceptable for Step 1 — sweep in
+# follow-up if violations surface):
+#   - tcp6 protocol variant: net.Listen("tcp6", ":1234")
+#   - Multi-line: net.Listen("tcp",\n\t":1234")
+#   - String concatenation: net.Listen("tcp", host+":"+portStr)
+#   - Variable indirection: addr := ":1234"; net.Listen("tcp", addr)
+#   - Non-net.Listen APIs: http.Server{Addr: fmt.Sprintf(":%d", N)} etc.
+#     (the github-webhook tests use this — sweep in Subclass 2 follow-up)
+#
+# Run from repo root:
+#   scripts/lint-test-ports.sh
+
+set -euo pipefail
+
+# Pattern 1: literal port like ":18082" or "127.0.0.1:8080" (anything
+# ending in :NNNN where NNNN is non-zero).
+LITERAL_PATTERN='net\.Listen\("tcp[46]?",\s*"[^"]*:[1-9][0-9]*"'
+
+# Pattern 2: Sprintf form, both bare (":%d") and host-prefixed
+# ("127.0.0.1:%d"). The greedy [^"]* between quotes accepts any
+# host segment (or none) before the :%d.
+SPRINTF_PATTERN='net\.Listen\("tcp[46]?",\s*fmt\.Sprintf\("[^"]*:%d'
+
+# Comment-suppression: lines ending with `// gh#220:allow-fixed-port`
+# are exempted (intended for the rare case where the test semantically
+# requires rebinding to a specific port — e.g. verifying the OS
+# released a previously-allocated ephemeral port). The marker is grep-
+# greppable so reviewers can audit all exemptions in one pass.
+SUPPRESS_MARKER='// gh#220:allow-fixed-port'
+
+matches=$(grep -rnE "$LITERAL_PATTERN" --include='*_test.go' . 2>/dev/null | grep -vF "$SUPPRESS_MARKER" || true)
+sprintf_matches=$(grep -rnE "$SPRINTF_PATTERN" --include='*_test.go' . 2>/dev/null | grep -vF "$SUPPRESS_MARKER" || true)
+all=$(printf '%s\n%s\n' "$matches" "$sprintf_matches" | grep -v '^$' || true)
+
+if [ -n "$all" ]; then
+  echo 'FAIL: fixed-port net.Listen in test files (substrate-flake guard, gh#220 Subclass 2)'
+  echo
+  echo "$all"
+  echo
+  echo 'Fix: use net.Listen("tcp", ":0") + read the resolved port from listener.Addr().(*net.TCPAddr).Port.'
+  echo 'See service/service_manager_health_listener_test.go freePort() helper for the canonical pattern.'
+  exit 1
+fi

--- a/scripts/lint-test-ports_fixture_test.sh
+++ b/scripts/lint-test-ports_fixture_test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# lint-test-ports_fixture_test.sh — verifies scripts/lint-test-ports.sh
+# catches the expected matrix of fixed-port shapes and exempts the
+# expected non-violation forms. Run from repo root.
+#
+# Per gh#220 review C1: the lint guard's claim "catches known
+# violations and passes on the post-fix tree" needs explicit
+# verification, not implicit trust.
+
+set -uo pipefail
+
+PASS=0
+FAIL=0
+
+check() {
+  local description=$1
+  local expect=$2   # "match" or "nomatch"
+  local fixture=$3
+
+  local tmp
+  tmp=$(mktemp -d)
+  trap "rm -rf '$tmp'" RETURN
+
+  cat >"$tmp/violation_test.go" <<EOF
+package fixture
+import "net"
+$fixture
+EOF
+
+  # Run the guard in the tmp dir, capture exit code without -e tripping.
+  set +e
+  ( cd "$tmp" && bash "$OLDPWD/scripts/lint-test-ports.sh" >/dev/null 2>&1 )
+  local rc=$?
+  set -e
+
+  if [ "$expect" = "match" ] && [ $rc -ne 1 ]; then
+    echo "FAIL [$description]: expected exit 1 (match), got $rc"
+    FAIL=$((FAIL + 1))
+  elif [ "$expect" = "nomatch" ] && [ $rc -ne 0 ]; then
+    echo "FAIL [$description]: expected exit 0 (nomatch), got $rc"
+    FAIL=$((FAIL + 1))
+  else
+    PASS=$((PASS + 1))
+  fi
+
+  rm -rf "$tmp"
+  trap - RETURN
+}
+
+export OLDPWD="$(pwd)"
+
+# Positive matches — must FAIL the guard (exit 1).
+check 'literal port :18082'            match   'func f() { net.Listen("tcp", ":18082") }'
+check 'literal port with host'         match   'func f() { net.Listen("tcp", "127.0.0.1:8080") }'
+check 'Sprintf bare port'              match   'import "fmt"; func f() { net.Listen("tcp", fmt.Sprintf(":%d", 9000)) }'
+check 'Sprintf host-prefixed port'     match   'import "fmt"; func f() { net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", 9000)) }'
+check 'Sprintf 0.0.0.0 host'           match   'import "fmt"; func f() { net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", 9000)) }'
+
+# Negative matches — must PASS the guard (exit 0).
+check 'ephemeral bare'                 nomatch 'func f() { net.Listen("tcp", ":0") }'
+check 'ephemeral localhost'            nomatch 'func f() { net.Listen("tcp", "127.0.0.1:0") }'
+check 'ephemeral 0.0.0.0'              nomatch 'func f() { net.Listen("tcp", "0.0.0.0:0") }'
+
+# Suppression marker — violation shape with allow-comment must PASS.
+check 'suppressed violation'           nomatch 'import "fmt"; func f() { net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port)) // gh#220:allow-fixed-port
+}'
+
+# Empty file — must PASS.
+check 'empty'                          nomatch ''
+
+echo
+echo "lint-test-ports fixture test: $PASS passed, $FAIL failed"
+[ $FAIL -eq 0 ]

--- a/service/service_manager_health_listener_test.go
+++ b/service/service_manager_health_listener_test.go
@@ -36,8 +36,18 @@ func TestStartHealthListener_BindsHealthAndHealthz(t *testing.T) {
 	// Wait briefly for the listener to come up. ListenAndServe is async
 	// in a goroutine; we poll until the port is reachable to keep the
 	// test deterministic without a wall-clock sleep.
+	//
+	// gh#209 / gh#220 — budget widened from 3s to 10s. The 3s budget
+	// was empirically tight under parallel test load (race-detector
+	// goroutine-scheduling overhead + Docker daemon contention from
+	// sister tests). 10s is conservative per
+	// [[feedback_substrate_flake_discipline]] (wall-clock assertions
+	// need ≥3× tolerance over expected). Happy-path completion is
+	// fast (test binary finishes in ~0.3s total for 3 health-listener
+	// tests) so the wider budget doesn't slow the suite; the budget
+	// is the timeout cap, not the expected wall-clock.
 	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
-	waitForListener(t, addr+"/healthz", 3*time.Second)
+	waitForListener(t, addr+"/healthz", 10*time.Second)
 
 	// /healthz is the liveness probe — should always 200 once the
 	// listener is up. No service state required.
@@ -130,8 +140,9 @@ func TestStopAll_TearsDownHealthListener(t *testing.T) {
 	}
 
 	// Sanity: listener is up before shutdown.
+	// gh#209/gh#220: 3s → 10s for the same reason as the sister test.
 	addr := fmt.Sprintf("http://127.0.0.1:%d", port)
-	waitForListener(t, addr+"/healthz", 3*time.Second)
+	waitForListener(t, addr+"/healthz", 10*time.Second)
 
 	// StopAll is the production shutdown entry point. It must tear
 	// down the dedicated health listener as part of its sequence.
@@ -142,10 +153,16 @@ func TestStopAll_TearsDownHealthListener(t *testing.T) {
 	// Port should be free now — re-binding it succeeds. Poll briefly
 	// since Shutdown returns once the listener stops accepting but the
 	// OS may take a moment to release the port (TIME_WAIT etc.).
-	deadline := time.Now().Add(3 * time.Second)
+	// gh#209/gh#220: 3s → 10s. The TIME_WAIT-release window under
+	// heavy parallel load can stretch — 10s gives enough headroom.
+	deadline := time.Now().Add(10 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		// gh#220:allow-fixed-port — rebind to the previously-allocated
+		// ephemeral port is the test's load-bearing semantic (verifying
+		// the OS released it). The port itself came from freePort(t),
+		// so this is NOT a static-range collision risk.
+		l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port)) // gh#220:allow-fixed-port
 		if err == nil {
 			_ = l.Close()
 			return
@@ -153,7 +170,7 @@ func TestStopAll_TearsDownHealthListener(t *testing.T) {
 		lastErr = err
 		time.Sleep(50 * time.Millisecond)
 	}
-	t.Fatalf("port %d never freed after StopAll within 3s; last bind error: %v", port, lastErr)
+	t.Fatalf("port %d never freed after StopAll within 10s; last bind error: %v", port, lastErr)
 }
 
 // freePort asks the kernel for an unused TCP port. Used by tests that

--- a/taskfiles/lint.yml
+++ b/taskfiles/lint.yml
@@ -2,8 +2,27 @@ version: '3'
 
 tasks:
   default:
-    desc: Run Go linters (vet, fmt, revive)
+    desc: Run Go linters (vet, fmt, revive, substrate-flake-guards)
     cmds:
       - go vet ./...
       - go fmt ./...
       - revive -config revive.toml -formatter friendly ./...
+      - task: test-ports
+
+  test-ports:
+    desc: |
+      Fail if any *_test.go file binds a fixed TCP port via net.Listen.
+      Substrate-flake guard per gh#220 Subclass 2. Regex lives in
+      scripts/lint-test-ports.sh — single source of truth shared with
+      .github/workflows/ci.yml's inline step (review I4).
+    cmds:
+      - echo "running fixed-port lint guard (scripts/lint-test-ports.sh)"
+      - bash scripts/lint-test-ports.sh
+
+  test-ports:test:
+    desc: |
+      Verify the fixed-port lint guard catches the expected matrix of
+      shapes (positive matches) and exempts the allowed forms (negative
+      matches). Runs scripts/lint-test-ports_fixture_test.sh.
+    cmds:
+      - bash scripts/lint-test-ports_fixture_test.sh


### PR DESCRIPTION
## Summary

First concrete deliverable from gh#220's substrate-flake audit. Smallest leverage piece — gets the prevent-regression gate in place before the larger Subclass 1 (testcontainer) migration starts. 8 files, +229/-44.

## Subclass 2 surgical fixes (4 sites)

- **3 websocket port helpers** migrated from fixed-range scan (`basePort + offset` loop) to kernel `:0` ephemeral. Output integration test, output metrics test, input integration test.
- **2 wall-clock budgets in health listener test** widened from 3s to 10s per the discipline memo's ≥3× tolerance rule. gh#209's 3s budget was exhausting under race-detector + parallel load.
- **gh#209 reclassification** — initially catalogued as Subclass 2 (fixed-port) but inspection showed the test already used `:0` via `freePort`. The actual flake was Subclass 3 (wall-clock budget). Audit corrected: Subclass 2 = 3 sites, Subclass 3 = 44.

## Lint guard

- **`scripts/lint-test-ports.sh`** — single source of truth. Catches both literal-port (`":18082"`, `"127.0.0.1:8080"`) and Sprintf forms (`fmt.Sprintf(":%d", ...)`, `fmt.Sprintf("127.0.0.1:%d", ...)`). Supports `// gh#220:allow-fixed-port` suppression for justified rebind-to-known-port cases.
- **`scripts/lint-test-ports_fixture_test.sh`** — 10-case matrix test (positive matches, ephemeral exemptions, suppression marker). Runs as CI step before the main guard so regex regressions are caught deterministically.
- Wired into `taskfiles/lint.yml` and `.github/workflows/ci.yml` — no inline regex duplication.

## Discipline memo

**`feedback_substrate_flake_discipline.md`** (new):
- Three rules for new tests (no fixed-port `net.Listen`; wall-clock assertions need rationale + ≥3× tolerance; testcontainers `Reuse: true` default).
- "Known gaps in Rule 1" section explicitly calls out the close-then-pass-port race + the regex shapes the guard doesn't catch (multi-line, string-concat, variable indirection, non-`net.Listen` APIs).
- "Concrete instances" documents the gh#209 reclassification explicitly so the audit's recursive [[feedback_investigate_before_classifying_as_flake]] discipline is visible to future readers.
- Tooling-pin rule (#4) references gh#221 — see follow-ups below.

## Follow-ups filed

- **gh#221** — pin local revive version to match CI's `revive@latest`. Closes the "documented, not enforced" gap on Rule 4 of the discipline memo (PR #218 case study).

## go-reviewer findings (all blocking applied)

| Finding | Resolution |
|---------|------------|
| C1 — lint regex missed host-prefixed Sprintf | Sharpened regex + added 10-case fixture matrix test |
| C2 — "within 3s" error string stale after 3s→10s bump | Fixed |
| I1 — memo missing "known gaps in Rule 1" section | Added |
| I2 — gh#209 reclassification not explicit in memo | Added to "Concrete instances" |
| I3 — "<50ms" claim was a guess | Softened to "happy-path completion is fast" with measured number (test binary ~0.3s for 3 tests) |
| I4 — regex duplicated between taskfile + CI | Extracted to `scripts/lint-test-ports.sh` as single source of truth |
| I5 — tooling-pin rule "documented, not enforced" is half-measure | Filed gh#221, updated memo reference |
| M1-M4 | Deferred — pre-existing or stylistic, file follow-up if surfaces |

## Pre-merge gates

- `task lint` (vet + fmt + revive + test-ports) — 0 warnings
- `scripts/lint-test-ports_fixture_test.sh` — 10/10 pass
- `go test -race ./service ./input/websocket/... ./output/websocket/...` — clean
- `go vet ./...` + `-tags=integration` + `-tags=live_llm` — clean
- `task schema:generate` — no drift
- go-reviewer pre-merge per [[feedback_review_cadence_pre_commit]]

## Test plan

- [x] Unit + integration tests on touched packages
- [x] Lint guard fixture test catches the matrix
- [x] go-reviewer pre-merge with all blocking findings applied
- [ ] CI gates (Lint, Test, Build, Schema, CI Status Check)
- [ ] Next step in gh#220: Subclass 3 audit (43 wall-clock assertion tests)

Closes #220 Step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)