### PR TITLE
fix(openapi): converge loop wire contract (gh#225) + resolve StatePatchRequest $ref (gh#227)

### DIFF
--- a/gateway/lifecycle-gateway/openapi.go
+++ b/gateway/lifecycle-gateway/openapi.go
@@ -178,6 +178,7 @@ func lifecycleGatewayOpenAPISpec() *service.OpenAPISpec {
 			},
 		},
 		RequestBodyTypes: []reflect.Type{
+			reflect.TypeOf(StatePatchRequest{}),
 			reflect.TypeOf(TransitionRequest{}),
 		},
 	}

--- a/processor/agentic-dispatch/http.go
+++ b/processor/agentic-dispatch/http.go
@@ -511,11 +511,15 @@ type ApprovalAcceptResponse struct {
 }
 
 // ActivityEvent represents a real-time activity event sent via SSE.
+// Data is a *Loop projected from the AGENT_LOOPS KV entry. See the Loop schema
+// for the full field set; fields absent from a given source stay empty.
+// (OpenAPI 3.0 cannot express per-event SSE JSON schema — see the Loop and
+// ActivityEvent component schemas for the documented shapes.)
 type ActivityEvent struct {
-	Type      string          `json:"type"` // loop_created, loop_updated, loop_deleted
-	LoopID    string          `json:"loop_id"`
-	Timestamp time.Time       `json:"timestamp"`
-	Data      json.RawMessage `json:"data,omitempty"`
+	Type      string    `json:"type"` // loop_created, loop_updated, loop_deleted
+	LoopID    string    `json:"loop_id"`
+	Timestamp time.Time `json:"timestamp"`
+	Data      *Loop     `json:"data,omitempty"`
 }
 
 // handleListLoops returns all tracked loops with optional filtering.
@@ -553,8 +557,14 @@ func (c *Component) handleListLoops(w http.ResponseWriter, r *http.Request) {
 	c.metrics.recordHTTPRequest("/loops", "GET", "200")
 	c.metrics.recordHTTPDuration("/loops", "GET", time.Since(startTime).Seconds())
 
+	// Project to the canonical wire type before encoding.
+	wireLoops := make([]Loop, len(loops))
+	for i, l := range loops {
+		wireLoops[i] = loopFromInfo(l)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(loops); err != nil {
+	if err := json.NewEncoder(w).Encode(wireLoops); err != nil {
 		c.logger.ErrorContext(ctx, "failed to encode loops list",
 			slog.String("request_id", requestID),
 			slog.String("error", err.Error()))
@@ -589,8 +599,11 @@ func (c *Component) handleGetLoop(w http.ResponseWriter, r *http.Request) {
 	c.metrics.recordHTTPRequest("/loops/{id}", "GET", "200")
 	c.metrics.recordHTTPDuration("/loops/{id}", "GET", time.Since(startTime).Seconds())
 
+	// Project to the canonical wire type before encoding.
+	wireLoop := loopFromInfo(loop)
+
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(loop); err != nil {
+	if err := json.NewEncoder(w).Encode(wireLoop); err != nil {
 		c.logger.ErrorContext(ctx, "failed to encode loop",
 			slog.String("request_id", requestID),
 			slog.String("loop_id", loopID),
@@ -970,12 +983,29 @@ func (c *Component) handleActivityStream(w http.ResponseWriter, r *http.Request)
 				Timestamp: entry.Created(),
 			}
 
-			// Include value for non-delete operations
+			// Project non-delete entries onto the canonical Loop wire type.
+			// COMPLETE_<loopID> keys carry terminal event payloads; all other
+			// keys carry agentic.LoopEntity live state.
 			if entry.Operation() != jetstream.KeyValueDelete {
-				if json.Valid(entry.Value()) {
-					event.Data = entry.Value()
+				var loop Loop
+				var ok bool
+				if strings.HasPrefix(entry.Key(), "COMPLETE_") {
+					if loop, ok = loopFromCompletion(entry.Value()); !ok {
+						c.logger.DebugContext(ctx, "activity stream: dropping undecodable completion payload",
+							slog.String("key", entry.Key()))
+					}
 				} else {
-					event.Data, _ = json.Marshal(string(entry.Value()))
+					var e agentic.LoopEntity
+					if err := json.Unmarshal(entry.Value(), &e); err != nil {
+						c.logger.DebugContext(ctx, "activity stream: dropping undecodable loop entity",
+							slog.String("key", entry.Key()),
+							slog.String("error", err.Error()))
+					} else {
+						loop, ok = loopFromEntity(&e), true
+					}
+				}
+				if ok {
+					event.Data = &loop
 				}
 			}
 
@@ -1180,6 +1210,8 @@ func agenticDispatchOpenAPISpec() *service.OpenAPISpec {
 						"200": {
 							Description: "List of loops",
 							ContentType: "application/json",
+							SchemaRef:   "#/components/schemas/Loop",
+							IsArray:     true,
 						},
 					},
 				},
@@ -1196,6 +1228,7 @@ func agenticDispatchOpenAPISpec() *service.OpenAPISpec {
 						"200": {
 							Description: "Loop details",
 							ContentType: "application/json",
+							SchemaRef:   "#/components/schemas/Loop",
 						},
 						"404": {
 							Description: "Loop not found",
@@ -1266,11 +1299,11 @@ func agenticDispatchOpenAPISpec() *service.OpenAPISpec {
 			"/activity": {
 				GET: &service.OperationSpec{
 					Summary:     "Real-time activity events (SSE)",
-					Description: "Server-Sent Events stream of loop activity. Events include loop_created, loop_updated, loop_deleted. Connect with EventSource or curl -N.",
+					Description: "Server-Sent Events stream of loop activity. Events include loop_created, loop_updated, loop_deleted. Each event's data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.",
 					Tags:        []string{"AgenticDispatch"},
 					Responses: map[string]service.ResponseSpec{
 						"200": {
-							Description: "SSE event stream",
+							Description: "SSE event stream of ActivityEvent objects. Each event's data field is a Loop (see #/components/schemas/ActivityEvent and #/components/schemas/Loop).",
 							ContentType: "text/event-stream",
 						},
 					},
@@ -1291,6 +1324,7 @@ func agenticDispatchOpenAPISpec() *service.OpenAPISpec {
 			},
 		},
 		ResponseTypes: []reflect.Type{
+			reflect.TypeOf(Loop{}),
 			reflect.TypeOf(LoopInfo{}),
 			reflect.TypeOf(HTTPMessageResponse{}),
 			reflect.TypeOf(SignalResponse{}),

--- a/processor/agentic-dispatch/http_loops_test.go
+++ b/processor/agentic-dispatch/http_loops_test.go
@@ -327,11 +327,15 @@ func TestMapKVOperation(t *testing.T) {
 }
 
 func TestActivityEventSerialization(t *testing.T) {
+	loop := &Loop{
+		LoopID: "loop-123",
+		State:  "pending",
+	}
 	event := ActivityEvent{
 		Type:      "loop_created",
 		LoopID:    "loop-123",
 		Timestamp: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
-		Data:      json.RawMessage(`{"state":"pending"}`),
+		Data:      loop,
 	}
 
 	data, err := json.Marshal(event)
@@ -343,7 +347,9 @@ func TestActivityEventSerialization(t *testing.T) {
 
 	assert.Equal(t, "loop_created", decoded.Type)
 	assert.Equal(t, "loop-123", decoded.LoopID)
-	assert.JSONEq(t, `{"state":"pending"}`, string(decoded.Data))
+	require.NotNil(t, decoded.Data)
+	assert.Equal(t, "loop-123", decoded.Data.LoopID)
+	assert.Equal(t, "pending", decoded.Data.State)
 }
 
 func TestSignalResponseSerialization(t *testing.T) {

--- a/processor/agentic-dispatch/loop_wire.go
+++ b/processor/agentic-dispatch/loop_wire.go
@@ -1,0 +1,123 @@
+package agenticdispatch
+
+import (
+	"encoding/json"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// Loop is the canonical wire contract for both the /loops and /activity endpoints.
+// It is a flat superset: fields absent from a given source remain zero/empty.
+// LoopInfo (in-memory tracker) and agentic.LoopEntity (KV entity) each project
+// onto this type, so consumers see a single consistent shape regardless of
+// whether the data originated from a live tracker record or a KV watch event.
+type Loop struct {
+	LoopID        string `json:"loop_id"`
+	TaskID        string `json:"task_id,omitempty"`
+	State         string `json:"state,omitempty"`
+	Role          string `json:"role,omitempty"`
+	Iterations    int    `json:"iterations,omitempty"`
+	MaxIterations int    `json:"max_iterations,omitempty"`
+	UserID        string `json:"user_id,omitempty"`
+	ChannelType   string `json:"channel_type,omitempty"`
+	ParentLoopID  string `json:"parent_loop_id,omitempty"`
+	Outcome       string `json:"outcome,omitempty"`
+	Result        string `json:"result,omitempty"`
+	Error         string `json:"error,omitempty"`
+	Prompt        string `json:"prompt,omitempty"`
+	TokensIn      int    `json:"tokens_in,omitempty"`
+	TokensOut     int    `json:"tokens_out,omitempty"`
+	// PendingApproval is populated when the loop is in awaiting_approval state.
+	PendingApproval *PendingApprovalInfo `json:"pending_approval,omitempty"`
+}
+
+// loopFromInfo projects the dispatch-owned in-memory tracker record onto Loop.
+// ParentLoopID stays empty — the tracker does not record spawn relationships today.
+func loopFromInfo(in *LoopInfo) Loop {
+	return Loop{
+		LoopID:          in.LoopID,
+		TaskID:          in.TaskID,
+		State:           in.State,
+		Role:            in.Role,
+		Iterations:      in.Iterations,
+		MaxIterations:   in.MaxIterations,
+		UserID:          in.UserID,
+		ChannelType:     in.ChannelType,
+		ParentLoopID:    "", // not tracked in LoopInfo today — scoped-out follow-up
+		Outcome:         in.Outcome,
+		Result:          in.Result,
+		Error:           in.Error,
+		Prompt:          "", // not on LoopInfo; populated only from completion events
+		TokensIn:        0,  // not on LoopInfo
+		TokensOut:       0,  // not on LoopInfo
+		PendingApproval: in.PendingApproval,
+	}
+}
+
+// loopFromEntity projects a framework-owned KV LoopEntity (key=<loopID>) onto Loop.
+// Token and prompt fields are not stored on live entities — they appear only in
+// completion events.
+func loopFromEntity(e *agentic.LoopEntity) Loop {
+	return Loop{
+		LoopID:        e.ID,
+		TaskID:        e.TaskID,
+		State:         e.State.String(),
+		Role:          e.Role,
+		Iterations:    e.Iterations,
+		MaxIterations: e.MaxIterations,
+		UserID:        e.UserID,
+		ChannelType:   e.ChannelType,
+		ParentLoopID:  e.ParentLoopID,
+		Outcome:       e.Outcome,
+		Result:        e.Result,
+		Error:         e.Error,
+		Prompt:        "", // not present on live LoopEntity
+		TokensIn:      0,  // not present on live LoopEntity
+		TokensOut:     0,  // not present on live LoopEntity
+	}
+}
+
+// completionWire is a minimal union struct that covers the common fields of
+// LoopCompletedEvent, LoopFailedEvent, and LoopCancelledEvent.
+// It normalises the "parent_loop" json tag (used by completion events) onto
+// ParentLoopID so callers don't need to know about the divergence.
+type completionWire struct {
+	LoopID       string `json:"loop_id"`
+	TaskID       string `json:"task_id"`
+	Role         string `json:"role"`
+	State        string `json:"state"` // may be absent from some completion events
+	Outcome      string `json:"outcome"`
+	Result       string `json:"result"`
+	Error        string `json:"error"`
+	Prompt       string `json:"prompt"`
+	Iterations   int    `json:"iterations"`
+	TokensIn     int    `json:"tokens_in"`
+	TokensOut    int    `json:"tokens_out"`
+	ParentLoopID string `json:"parent_loop"` // events.go uses "parent_loop"; normalised onto Loop.ParentLoopID
+}
+
+// loopFromCompletion projects a COMPLETE_<loopID> terminal event payload onto Loop.
+// Returns ok=false only when the bytes cannot be unmarshalled or yield no loop_id.
+func loopFromCompletion(raw []byte) (Loop, bool) {
+	var w completionWire
+	if err := json.Unmarshal(raw, &w); err != nil {
+		return Loop{}, false
+	}
+	if w.LoopID == "" {
+		return Loop{}, false
+	}
+	return Loop{
+		LoopID:       w.LoopID,
+		TaskID:       w.TaskID,
+		State:        w.State,
+		Role:         w.Role,
+		Iterations:   w.Iterations,
+		Outcome:      w.Outcome,
+		Result:       w.Result,
+		Error:        w.Error,
+		Prompt:       w.Prompt,
+		TokensIn:     w.TokensIn,
+		TokensOut:    w.TokensOut,
+		ParentLoopID: w.ParentLoopID,
+	}, true
+}

--- a/processor/agentic-dispatch/loop_wire_test.go
+++ b/processor/agentic-dispatch/loop_wire_test.go
@@ -1,0 +1,306 @@
+package agenticdispatch
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// TestLoopFromEntity_RoundTrip verifies that a LoopEntity survives a
+// marshal→unmarshal cycle and projects correctly onto the Loop wire type.
+// In particular it guards the id→loop_id normalisation and the
+// LoopState.String() conversion.
+func TestLoopFromEntity_RoundTrip(t *testing.T) {
+	entity := agentic.LoopEntity{
+		ID:            "loop-abc",
+		TaskID:        "task-xyz",
+		State:         agentic.LoopStateExecuting,
+		Role:          "coordinator",
+		Model:         "gpt-4o",
+		Iterations:    3,
+		MaxIterations: 20,
+		UserID:        "user-1",
+		ChannelType:   "cli",
+		ParentLoopID:  "loop-parent",
+		Outcome:       "",
+		Result:        "",
+		Error:         "",
+	}
+
+	// Production round-trip: marshal to JSON then unmarshal back.
+	raw, err := json.Marshal(entity)
+	if err != nil {
+		t.Fatalf("marshal LoopEntity: %v", err)
+	}
+
+	var decoded agentic.LoopEntity
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal LoopEntity: %v", err)
+	}
+
+	got := loopFromEntity(&decoded)
+
+	if got.LoopID != entity.ID {
+		t.Errorf("LoopID: got %q, want %q (id→loop_id normalisation)", got.LoopID, entity.ID)
+	}
+	if got.TaskID != entity.TaskID {
+		t.Errorf("TaskID: got %q, want %q", got.TaskID, entity.TaskID)
+	}
+	if got.State != entity.State.String() {
+		t.Errorf("State: got %q, want %q", got.State, entity.State.String())
+	}
+	if got.Role != entity.Role {
+		t.Errorf("Role: got %q, want %q", got.Role, entity.Role)
+	}
+	if got.Iterations != entity.Iterations {
+		t.Errorf("Iterations: got %d, want %d", got.Iterations, entity.Iterations)
+	}
+	if got.MaxIterations != entity.MaxIterations {
+		t.Errorf("MaxIterations: got %d, want %d", got.MaxIterations, entity.MaxIterations)
+	}
+	if got.UserID != entity.UserID {
+		t.Errorf("UserID: got %q, want %q", got.UserID, entity.UserID)
+	}
+	if got.ChannelType != entity.ChannelType {
+		t.Errorf("ChannelType: got %q, want %q", got.ChannelType, entity.ChannelType)
+	}
+	if got.ParentLoopID != entity.ParentLoopID {
+		t.Errorf("ParentLoopID: got %q, want %q", got.ParentLoopID, entity.ParentLoopID)
+	}
+	// Token and prompt fields are absent from live entities.
+	if got.TokensIn != 0 || got.TokensOut != 0 {
+		t.Errorf("expected zero token counts from entity, got in=%d out=%d", got.TokensIn, got.TokensOut)
+	}
+	if got.Prompt != "" {
+		t.Errorf("expected empty Prompt from entity, got %q", got.Prompt)
+	}
+}
+
+// TestLoopFromCompletion_CompletedEvent verifies that a LoopCompletedEvent
+// survives a marshal→loopFromCompletion round-trip with all consumer-critical
+// fields intact, including the parent_loop→parent_loop_id tag normalisation.
+func TestLoopFromCompletion_CompletedEvent(t *testing.T) {
+	event := agentic.LoopCompletedEvent{
+		LoopID:       "loop-done",
+		TaskID:       "task-1",
+		Outcome:      agentic.OutcomeSuccess,
+		Role:         "coordinator",
+		Result:       "answer text",
+		Prompt:       "what is 2+2?",
+		Model:        "gpt-4o",
+		Iterations:   5,
+		TokensIn:     100,
+		TokensOut:    200,
+		ParentLoopID: "loop-root",
+		CompletedAt:  time.Now(),
+	}
+
+	raw, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal LoopCompletedEvent: %v", err)
+	}
+
+	got, ok := loopFromCompletion(raw)
+	if !ok {
+		t.Fatalf("loopFromCompletion returned ok=false for valid LoopCompletedEvent")
+	}
+
+	if got.LoopID != event.LoopID {
+		t.Errorf("LoopID: got %q, want %q", got.LoopID, event.LoopID)
+	}
+	if got.TaskID != event.TaskID {
+		t.Errorf("TaskID: got %q, want %q", got.TaskID, event.TaskID)
+	}
+	if got.Outcome != event.Outcome {
+		t.Errorf("Outcome: got %q, want %q", got.Outcome, event.Outcome)
+	}
+	if got.Result != event.Result {
+		t.Errorf("Result: got %q, want %q", got.Result, event.Result)
+	}
+	if got.Prompt != event.Prompt {
+		t.Errorf("Prompt: got %q, want %q", got.Prompt, event.Prompt)
+	}
+	if got.TokensIn != event.TokensIn {
+		t.Errorf("TokensIn: got %d, want %d", got.TokensIn, event.TokensIn)
+	}
+	if got.TokensOut != event.TokensOut {
+		t.Errorf("TokensOut: got %d, want %d", got.TokensOut, event.TokensOut)
+	}
+	// The critical tag-drift normalisation: events.go uses "parent_loop";
+	// Loop must expose it as parent_loop_id.
+	if got.ParentLoopID != event.ParentLoopID {
+		t.Errorf("ParentLoopID (parent_loop tag normalisation): got %q, want %q", got.ParentLoopID, event.ParentLoopID)
+	}
+}
+
+// TestLoopFromCompletion_FailedEvent verifies the LoopFailedEvent path,
+// specifically that Error and Prompt survive and that parent_loop is normalised.
+func TestLoopFromCompletion_FailedEvent(t *testing.T) {
+	event := agentic.LoopFailedEvent{
+		LoopID:       "loop-fail",
+		TaskID:       "task-2",
+		Outcome:      agentic.OutcomeFailed,
+		Role:         "researcher",
+		Error:        "context limit exceeded",
+		Prompt:       "summarise everything",
+		Model:        "gpt-4o-mini",
+		Iterations:   20,
+		TokensIn:     500,
+		TokensOut:    10,
+		ParentLoopID: "loop-chain-root",
+	}
+
+	raw, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal LoopFailedEvent: %v", err)
+	}
+
+	got, ok := loopFromCompletion(raw)
+	if !ok {
+		t.Fatalf("loopFromCompletion returned ok=false for valid LoopFailedEvent")
+	}
+
+	if got.LoopID != event.LoopID {
+		t.Errorf("LoopID: got %q, want %q", got.LoopID, event.LoopID)
+	}
+	if got.Error != event.Error {
+		t.Errorf("Error: got %q, want %q", got.Error, event.Error)
+	}
+	if got.Prompt != event.Prompt {
+		t.Errorf("Prompt: got %q, want %q", got.Prompt, event.Prompt)
+	}
+	if got.TokensIn != event.TokensIn {
+		t.Errorf("TokensIn: got %d, want %d", got.TokensIn, event.TokensIn)
+	}
+	if got.TokensOut != event.TokensOut {
+		t.Errorf("TokensOut: got %d, want %d", got.TokensOut, event.TokensOut)
+	}
+	if got.ParentLoopID != event.ParentLoopID {
+		t.Errorf("ParentLoopID: got %q, want %q", got.ParentLoopID, event.ParentLoopID)
+	}
+}
+
+// TestLoopFromCompletion_CancelledEvent verifies the LoopCancelledEvent path —
+// the terminal variant with the most absent fields. It carries no Role/Result/
+// Error/Prompt/State/tokens/parent_loop, so the projection must populate
+// LoopID/TaskID/Outcome and zero-fill the rest cleanly rather than erroring.
+func TestLoopFromCompletion_CancelledEvent(t *testing.T) {
+	event := agentic.LoopCancelledEvent{
+		LoopID:      "loop-cancel",
+		TaskID:      "task-3",
+		Outcome:     agentic.OutcomeCancelled,
+		CancelledBy: "operator",
+	}
+
+	raw, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("marshal LoopCancelledEvent: %v", err)
+	}
+
+	got, ok := loopFromCompletion(raw)
+	if !ok {
+		t.Fatalf("loopFromCompletion returned ok=false for valid LoopCancelledEvent")
+	}
+
+	if got.LoopID != event.LoopID {
+		t.Errorf("LoopID: got %q, want %q", got.LoopID, event.LoopID)
+	}
+	if got.TaskID != event.TaskID {
+		t.Errorf("TaskID: got %q, want %q", got.TaskID, event.TaskID)
+	}
+	if got.Outcome != event.Outcome {
+		t.Errorf("Outcome: got %q, want %q", got.Outcome, event.Outcome)
+	}
+	// Fields absent from LoopCancelledEvent must zero-fill cleanly.
+	if got.Role != "" || got.Result != "" || got.Error != "" || got.Prompt != "" || got.State != "" {
+		t.Errorf("expected absent fields to be empty, got Role=%q Result=%q Error=%q Prompt=%q State=%q",
+			got.Role, got.Result, got.Error, got.Prompt, got.State)
+	}
+	if got.TokensIn != 0 || got.TokensOut != 0 {
+		t.Errorf("expected zero tokens, got in=%d out=%d", got.TokensIn, got.TokensOut)
+	}
+	if got.ParentLoopID != "" {
+		t.Errorf("ParentLoopID: got %q, want empty", got.ParentLoopID)
+	}
+}
+
+// TestLoopFromCompletion_InvalidPayload verifies that ok=false is returned for
+// byte sequences that cannot be decoded or yield no loop_id.
+func TestLoopFromCompletion_InvalidPayload(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  []byte
+	}{
+		{"not JSON", []byte("not-json")},
+		{"empty object", []byte("{}")},
+		{"null", []byte("null")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := loopFromCompletion(tc.raw)
+			if ok {
+				t.Errorf("expected ok=false for %q", tc.raw)
+			}
+		})
+	}
+}
+
+// TestLoopFromInfo_Projection verifies that LoopInfo fields project correctly
+// onto the Loop wire type, including PendingApproval survival and the
+// intentional omission of ParentLoopID (not tracked in LoopInfo today).
+func TestLoopFromInfo_Projection(t *testing.T) {
+	approval := &PendingApprovalInfo{
+		CallID:      "call-1",
+		ToolName:    "bash",
+		Reason:      "destructive",
+		RequestedAt: time.Now(),
+	}
+	info := &LoopInfo{
+		LoopID:          "loop-tracked",
+		TaskID:          "task-t",
+		State:           "executing",
+		Role:            "ops",
+		Iterations:      2,
+		MaxIterations:   10,
+		UserID:          "user-ops",
+		ChannelType:     "slack",
+		Outcome:         "success",
+		Result:          "done",
+		Error:           "",
+		PendingApproval: approval,
+	}
+
+	got := loopFromInfo(info)
+
+	if got.LoopID != info.LoopID {
+		t.Errorf("LoopID: got %q, want %q", got.LoopID, info.LoopID)
+	}
+	if got.State != info.State {
+		t.Errorf("State: got %q, want %q", got.State, info.State)
+	}
+	if got.Outcome != info.Outcome {
+		t.Errorf("Outcome: got %q, want %q", got.Outcome, info.Outcome)
+	}
+	if got.Result != info.Result {
+		t.Errorf("Result: got %q, want %q", got.Result, info.Result)
+	}
+	if got.PendingApproval == nil {
+		t.Fatal("PendingApproval should not be nil")
+	}
+	if got.PendingApproval.CallID != approval.CallID {
+		t.Errorf("PendingApproval.CallID: got %q, want %q", got.PendingApproval.CallID, approval.CallID)
+	}
+	// ParentLoopID must be empty — LoopInfo does not track spawn relationships.
+	if got.ParentLoopID != "" {
+		t.Errorf("ParentLoopID: expected empty, got %q", got.ParentLoopID)
+	}
+	// Token and prompt fields not on LoopInfo — must be zero.
+	if got.TokensIn != 0 || got.TokensOut != 0 {
+		t.Errorf("expected zero token counts from LoopInfo, got in=%d out=%d", got.TokensIn, got.TokensOut)
+	}
+	if got.Prompt != "" {
+		t.Errorf("expected empty Prompt from LoopInfo, got %q", got.Prompt)
+	}
+}

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1941,6 +1941,9 @@ components:
                 - accepted
                 - timestamp
             type: object
+        StatePatchRequest:
+            additionalProperties: {}
+            type: object
         StatsResponse:
             properties:
                 applied:

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -16,12 +16,12 @@ paths:
     /activity:
         get:
             summary: Real-time activity events (SSE)
-            description: Server-Sent Events stream of loop activity. Events include loop_created, loop_updated, loop_deleted. Connect with EventSource or curl -N.
+            description: 'Server-Sent Events stream of loop activity. Events include loop_created, loop_updated, loop_deleted. Each event''s data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.'
             tags:
                 - AgenticDispatch
             responses:
                 "200":
-                    description: SSE event stream
+                    description: 'SSE event stream of ActivityEvent objects. Each event''s data field is a Loop (see #/components/schemas/ActivityEvent and #/components/schemas/Loop).'
     /commands:
         get:
             summary: List available commands
@@ -536,7 +536,9 @@ paths:
                     content:
                         application/json:
                             schema:
-                                type: object
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/Loop'
     /loops/{id}:
         get:
             summary: Get single loop by ID
@@ -555,7 +557,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                type: object
+                                $ref: '#/components/schemas/Loop'
                 "404":
                     description: Loop not found
     /loops/{id}/approval:
@@ -1167,8 +1169,65 @@ components:
         ActivityEvent:
             properties:
                 data:
-                    format: byte
-                    type: string
+                    anyOf:
+                        - properties:
+                            channel_type:
+                                type: string
+                            error:
+                                type: string
+                            iterations:
+                                type: integer
+                            loop_id:
+                                type: string
+                            max_iterations:
+                                type: integer
+                            outcome:
+                                type: string
+                            parent_loop_id:
+                                type: string
+                            pending_approval:
+                                anyOf:
+                                    - properties:
+                                        arguments:
+                                            additionalProperties: {}
+                                            type: object
+                                        call_id:
+                                            type: string
+                                        reason:
+                                            type: string
+                                        requested_at:
+                                            format: date-time
+                                            type: string
+                                        tool_name:
+                                            type: string
+                                        trace_id:
+                                            type: string
+                                      required:
+                                        - call_id
+                                        - tool_name
+                                        - requested_at
+                                      type: object
+                                    - type: "null"
+                            prompt:
+                                type: string
+                            result:
+                                type: string
+                            role:
+                                type: string
+                            state:
+                                type: string
+                            task_id:
+                                type: string
+                            tokens_in:
+                                type: integer
+                            tokens_out:
+                                type: integer
+                            user_id:
+                                type: string
+                          required:
+                            - loop_id
+                          type: object
+                        - type: "null"
                 loop_id:
                     type: string
                 timestamp:
@@ -1467,6 +1526,64 @@ components:
                 - source
                 - message
                 - fields
+            type: object
+        Loop:
+            properties:
+                channel_type:
+                    type: string
+                error:
+                    type: string
+                iterations:
+                    type: integer
+                loop_id:
+                    type: string
+                max_iterations:
+                    type: integer
+                outcome:
+                    type: string
+                parent_loop_id:
+                    type: string
+                pending_approval:
+                    anyOf:
+                        - properties:
+                            arguments:
+                                additionalProperties: {}
+                                type: object
+                            call_id:
+                                type: string
+                            reason:
+                                type: string
+                            requested_at:
+                                format: date-time
+                                type: string
+                            tool_name:
+                                type: string
+                            trace_id:
+                                type: string
+                          required:
+                            - call_id
+                            - tool_name
+                            - requested_at
+                          type: object
+                        - type: "null"
+                prompt:
+                    type: string
+                result:
+                    type: string
+                role:
+                    type: string
+                state:
+                    type: string
+                task_id:
+                    type: string
+                tokens_in:
+                    type: integer
+                tokens_out:
+                    type: integer
+                user_id:
+                    type: string
+            required:
+                - loop_id
             type: object
         LoopInfo:
             properties:


### PR DESCRIPTION
Two paired OpenAPI/spec fixes in the agentic-dispatch + lifecycle-gateway registration family. Each unblocks a different sister repo.

## gh#225 — canonical `Loop` wire type for `/loops` + `/activity`

The SSE `/activity` payload rendered as opaque `{format:byte}` in the spec, forcing the semteams UI to hand-model `WireLoop` + a `normalizeWireLoop` shim (which already shipped a `time.Duration`-as-string field-drift bug). `/loops` (`LoopInfo`) and `/activity` (`LoopEntity` + `COMPLETE_` terminal events) exposed two divergent shapes.

**Fix:** one canonical `Loop` wire type both endpoints project to —
- `loopFromInfo` (dispatch-owned in-memory tracker)
- `loopFromEntity` (framework-owned `AGENT_LOOPS` `LoopEntity`, `id`→`loop_id`)
- `loopFromCompletion` (`COMPLETE_` terminal events, `parent_loop`→`parent_loop_id`)

`ActivityEvent.Data` changes `json.RawMessage`→`*Loop` so the reflector emits a typed schema (`anyOf:[Loop,null]`) with **no reflector hook**. The activity stream now does key-discriminated projection instead of zero-copy passthrough; undecodable payloads are debug-logged and dropped (data omitted).

Wire contract only — **exclusive state ownership preserved** (no re-serving KV state as dispatch-owned). Field set locked to exactly what the semteams consumer reads, so the shim fully retires. Dispatch lineage backfill on `/loops` is scoped out (follow-up); `loopFromInfo` leaves `parent_loop_id` empty (no regression).

### Design + review trail
- Architect-designed; design review caught the issue's own miss: `/activity` watches `AGENT_LOOPS` which carries **both** `LoopEntity` and `COMPLETE_` terminal events — a naive single-unmarshal would silently drop completion data (`result`/`tokens`/`prompt`).
- Pre-merge **go-reviewer: APPROVE**, all findings Minor. Applied: added `LoopCancelledEvent` projection test (closes the gh#207-class monomorphic-coverage gap) + debug-log on decode-miss.
- Filed #226 (pre-existing: envelope `loop_id` carries `COMPLETE_` prefix while `data.loop_id` is bare — out of scope here).

## gh#227 — `StatePatchRequest` `$ref` was dangling

`POST /workflows/{type}/{id}/state` referenced `#/components/schemas/StatePatchRequest`, but the type was missing from the lifecycle-gateway's `RequestBodyTypes` (only `TransitionRequest` was registered), so the generator never emitted it — the only dangling `$ref` in the spec. `openapi-typescript` and strict bundlers fail to resolve it, blocking semspec's `generate:types:semstreams` step and the `generate:check` CI gate.

**Fix:** add `reflect.TypeOf(StatePatchRequest{})` to `RequestBodyTypes`. The named `map[string]any` names correctly and emits `{type:object, additionalProperties:{}}`. **All 18 schema-component refs now resolve, zero dangling.**

Filed #228 for the engine gap that let this ship clean: CI's schema gate checks *drift*, not *ref-resolution* — proposes a generation-time ref-resolution check that fails the build.

## Verification

- `go vet ./...` + `go vet -tags=integration ./...` clean
- `go test -race ./processor/agentic-dispatch/...` pass (incl. new projection tests)
- `task lint` clean
- `task schema:generate` idempotent; `specs/openapi.v3.yaml` diff is exactly the `Loop` schema + endpoint `$ref`s + `StatePatchRequest`

Closes #225
Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)