### PR TITLE
feat(agentic): agent-run substrate — runs as lifecycle Participant (ADR-053)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ cmd/e2e/test/e2e/results/*.txt
 # Claude Code runtime artifacts (local state, not source)
 .claude/scheduled_tasks.lock
 .agents/
+
+# Playwright MCP session artifacts
+.playwright-mcp/

--- a/agentic/agentrun/agentrun.go
+++ b/agentic/agentrun/agentrun.go
@@ -1,0 +1,744 @@
+// Package agentrun implements the AgentRun lifecycle Participant (ADR-053 D1–D6).
+//
+// An AgentRun represents the framework-level entity for a nested agentic loop
+// tree: a coordinator loop that spawns research/architect/builder child loops
+// forms a "run" whose lifecycle (dispatched → executing ⇄ awaiting_approval →
+// terminal) is managed here via the pkg/lifecycle harness.
+//
+// The package provides:
+//   - AgentRun — the lifecycle.Participant struct (D1)
+//   - Register — registers the "agent-run" workflow with a lifecycle.Manager (D2)
+//   - Mint — idempotent run creation at dispatch time (D4)
+//   - ResolveRun — typed-first resolution with ancestry-walk fallback (D6)
+//   - MilestoneSubscriber — subscribes to terminal loop events, pre-resolves the
+//     run, and fans out to product-registered MilestoneHandlers (D6)
+//
+// Import discipline: this package imports agentic + pkg/lifecycle only.
+// pkg/lifecycle MUST NOT import agentic/agentrun — verify with go mod graph.
+package agentrun
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+)
+
+// agentRunTransitions is the declared phase graph for an AgentRun (ADR-053 D2).
+//
+//	dispatched ──> executing ──> awaiting_approval ──> executing (loop back)
+//	dispatched ──> failed | cancelled
+//	executing ──> completed | failed | cancelled
+//	awaiting_approval ──> cancelled
+//	completed, failed, cancelled: terminal
+var agentRunTransitions = lifecycle.Transitions{
+	"dispatched":        {"executing", "failed", "cancelled"},
+	"executing":         {"awaiting_approval", "completed", "failed", "cancelled"},
+	"awaiting_approval": {"executing", "cancelled"},
+	"completed":         {},
+	"failed":            {},
+	"cancelled":         {},
+}
+
+// Predicates stamped by the Manager for agent-run entities.
+const (
+	// PhasePredicate is the triple carrying the run's current phase.
+	PhasePredicate = "agent.run.phase"
+
+	// predicateAuditSource carries the transition source (rule|operator|framework).
+	predicateAuditSource = "agent.run.last_transition_source"
+
+	// predicateAuditAt carries the RFC3339Nano timestamp of the last transition.
+	predicateAuditAt = "agent.run.last_transition_at"
+
+	// predicateAuditFrom carries the phase the entity transitioned out of.
+	predicateAuditFrom = "agent.run.last_transition_from"
+
+	// predicateAuditNote carries an optional free-text note on the transition.
+	predicateAuditNote = "agent.run.last_transition_note"
+
+	// predicateParentRunEntityID carries the parent run's full entity ID, if any.
+	predicateParentRunEntityID = "agent.run.parent_entity_id"
+)
+
+// WorkflowName is the registered workflow type name for agent-run entries.
+// Matches what AgentRun.Workflow() returns.
+const WorkflowName = "agent-run"
+
+// EntityIDPattern matches agent-run chain execution entities in the federated graph.
+// Six-segment shape per the federated EntityID contract; org + platform + instance
+// are wildcarded; domain (agent), system (chain), type (execution) are pinned.
+const EntityIDPattern = "*.*.agent.chain.execution.*"
+
+// AgentRun is the lifecycle.Participant for an agent run (ADR-053 D1).
+//
+// Field tags:
+//   - lifecycle:"id"                                         — entity identity (full 6-part ID, from KV key)
+//   - lifecycle:"phase,predicate=agent.run.phase"            — current phase triple
+//   - lifecycle:"predicate=agent.run.parent_entity_id"       — parent run entity ID triple
+//
+// D1 CRITICAL: EntityIDField MUST hold the FULL 6-part chain.execution entity ID
+// because the projection layer populates it from the entity-state KEY (not a
+// triple). A bare RunID would round-trip to the full dotted key and garble
+// when passed back through TryChainExecutionEntityID (which rejects dots).
+// RunID() derives the bare loop UUID from EntityIDField at read time.
+type AgentRun struct {
+	// EntityIDField is the full 6-part federated ID: org.platform.agent.chain.execution.<runID>
+	// Tagged lifecycle:"id" so the projection layer populates it from the KV key, not a triple.
+	EntityIDField string `json:"-" lifecycle:"id"`
+
+	// PhaseField is the current lifecycle phase.
+	PhaseField string `json:"phase" lifecycle:"phase,predicate=agent.run.phase"`
+
+	// ParentRunEntityID is the parent run's full entity ID, or empty for root runs.
+	ParentRunEntityID string `json:"parent_run_entity_id,omitempty" lifecycle:"predicate=agent.run.parent_entity_id"`
+}
+
+// EntityID returns the full 6-part federated entity ID.
+// Implements lifecycle.Participant.
+func (r *AgentRun) EntityID() string { return r.EntityIDField }
+
+// Workflow returns the registered workflow type name.
+// Implements lifecycle.Participant.
+func (r *AgentRun) Workflow() string { return WorkflowName }
+
+// Phase returns the current lifecycle phase.
+// Implements lifecycle.Participant.
+func (r *AgentRun) Phase() string { return r.PhaseField }
+
+// IsTerminal returns true when the current phase has no declared out-edges.
+// Consults the package-level agentRunTransitions table.
+// Implements lifecycle.Participant.
+func (r *AgentRun) IsTerminal() bool { return agentRunTransitions.IsTerminal(r.PhaseField) }
+
+// ParentEntityID returns the parent run's full entity ID, or "" for root runs.
+// Implements lifecycle.Participant.
+func (r *AgentRun) ParentEntityID() string { return r.ParentRunEntityID }
+
+// RunID derives the bare run loop-id from the full entity ID.
+// Returns ("", false) when EntityIDField is not a valid chain.execution entity ID.
+//
+// The bare RunID == the dispatch-root loop UUID; it is NOT stored as a triple
+// but derived by parsing parts[5] from the 6-part entity ID.
+func (r *AgentRun) RunID() (string, bool) {
+	return runIDFromChainEntityID(r.EntityIDField)
+}
+
+// runIDFromChainEntityID extracts the bare run loop-id (instance segment) from
+// a full chain.execution entity ID. Returns ("", false) for non-matching IDs.
+func runIDFromChainEntityID(entityID string) (string, bool) {
+	if !message.IsValidEntityID(entityID) {
+		return "", false
+	}
+	// IsValidEntityID guarantees exactly 6 dot-separated parts.
+	parts := strings.Split(entityID, ".")
+	if len(parts) != 6 {
+		return "", false
+	}
+	if parts[2] != "agent" || parts[3] != "chain" || parts[4] != "execution" {
+		return "", false
+	}
+	return parts[5], true
+}
+
+// WorkflowDeclaration returns the lifecycle.Workflow ready to pass to
+// Manager.Register (ADR-053 D2). Callers use Register(mgr) rather than
+// calling this directly — it is exported for diagnostic/test use.
+func WorkflowDeclaration() lifecycle.Workflow {
+	return lifecycle.Workflow{
+		Name:            WorkflowName,
+		EntityIDPattern: EntityIDPattern,
+		Phases: []string{
+			"dispatched",
+			"executing",
+			"awaiting_approval",
+			"completed",
+			"failed",
+			"cancelled",
+		},
+		Transitions:    agentRunTransitions,
+		PhasePredicate: PhasePredicate,
+		Schema:         reflect.TypeOf(AgentRun{}),
+		AuditPredicates: lifecycle.AuditSpec{
+			Source: predicateAuditSource,
+			At:     predicateAuditAt,
+			From:   predicateAuditFrom,
+			Note:   predicateAuditNote,
+		},
+		// No OperatorWritablePredicates — run phase is closed to operator writes;
+		// only lifecycle_transition rule actions and the framework itself drive transitions.
+	}
+}
+
+// Register declares the "agent-run" workflow to the given Manager (ADR-053 D2).
+// Must be called at app startup before any create/transition calls land.
+// Returns ErrWorkflowAlreadyRegistered (from lifecycle package) on duplicate registration.
+func Register(mgr *lifecycle.Manager) error {
+	return mgr.Register(WorkflowDeclaration())
+}
+
+// Mint creates (or retrieves if already exists) an AgentRun for the given
+// rootLoopID (ADR-053 D4). The run's entity ID is
+// org.platform.agent.chain.execution.<rootLoopID>, initial phase is "dispatched".
+//
+// Idempotent: if Manager.Create returns lifecycle.ErrAlreadyExists (the run was
+// already minted — common on JetStream redelivery or concurrent rule firings),
+// Mint treats it as success and returns the existing run via Manager.Get.
+//
+// NOTE: there is a narrow concurrent-create race (gh#178) where two goroutines
+// both call Mint for the same ID simultaneously; both may observe ErrAlreadyExists
+// but only one wrote the initial "dispatched" phase. The second caller falls back
+// to Manager.Get which returns the already-minted run — this is correct: the run
+// exists and is in a valid state. The gh#178 concern (which caller's Create "won")
+// does not apply here because all callers want the same initial phase ("dispatched")
+// and the run entity is immutable in terms of identity.
+func Mint(ctx context.Context, mgr MintableManager, org, platform, rootLoopID string) (*AgentRun, error) {
+	entityID, err := agentic.TryChainExecutionEntityID(org, platform, rootLoopID)
+	if err != nil {
+		return nil, fmt.Errorf("agentrun.Mint: build entity ID: %w", err)
+	}
+
+	initial := &AgentRun{
+		EntityIDField: entityID,
+		PhaseField:    "dispatched",
+	}
+	if err := mgr.Create(ctx, initial); err != nil {
+		if errors.Is(err, lifecycle.ErrAlreadyExists) {
+			// Run was already minted (idempotent path). Return existing.
+			existing, getErr := mgr.Get(ctx, WorkflowName, entityID)
+			if getErr != nil {
+				return nil, fmt.Errorf("agentrun.Mint: already-exists Get: %w", getErr)
+			}
+			run, ok := existing.(*AgentRun)
+			if !ok {
+				return nil, fmt.Errorf("agentrun.Mint: Manager.Get returned unexpected type %T", existing)
+			}
+			return run, nil
+		}
+		return nil, fmt.Errorf("agentrun.Mint: Manager.Create: %w", err)
+	}
+	return initial, nil
+}
+
+// MintableManager is the narrowest interface Mint requires — Create + Get only.
+// This lets the rule engine's LifecycleManager satisfy the Mint call without
+// requiring Transition (which the rule path never uses for minting).
+// Production callers use *lifecycle.Manager which satisfies both MintableManager
+// and MockableManager. The rule engine's LifecycleManager satisfies MintableManager.
+type MintableManager interface {
+	// Get reads the entity at entityID for the given workflow.
+	Get(ctx context.Context, workflow, entityID string) (lifecycle.Participant, error)
+	// Create attaches lifecycle to the entity. Returns lifecycle.ErrAlreadyExists
+	// when already lifecycle-managed.
+	Create(ctx context.Context, initial lifecycle.Participant) error
+}
+
+// LoopTripleReader is the narrow interface ResolveRun requires to read
+// entity triples. A concrete *natsclient.Client or any adapter satisfies this.
+// Defined here so callers can mock resolution in tests without a live NATS server.
+type LoopTripleReader interface {
+	// GetLoopRunID reads the agent.run triple from the given loop entity ID.
+	// Returns ("", false, nil) when the triple is absent (not an error — the
+	// loop simply has no run association).
+	// Returns ("", false, err) on read failures (NATS, decode errors).
+	GetLoopRunID(ctx context.Context, loopEntityID string) (runID string, ok bool, err error)
+
+	// GetLoopParentEntityID reads the agent.loop.parent triple from the given
+	// loop entity ID. Returns ("", false, nil) when absent.
+	GetLoopParentEntityID(ctx context.Context, loopEntityID string) (parentEntityID string, ok bool, err error)
+}
+
+// maxAncestryHops is the maximum number of ancestor hops the fallback walk
+// follows before giving up. Bounded to prevent cycles from stalling indefinitely.
+const maxAncestryHops = 32
+
+// ResolveRun resolves the AgentRun for a given loop (ADR-053 D6).
+//
+// Resolution order:
+//  1. Typed-first: read the loop entity's agent.run triple (the RunID stamped at
+//     spawn by buildSpawnIdentityTriples). If present, construct the run entity ID
+//     directly.
+//  2. Ancestry-walk fallback (for pre-migration / un-threaded loops): walk
+//     agent.loop.parent triples up to the root (bounded at maxAncestryHops), then
+//     use the root loop's ID as the run ID. Logs WARN on the fallback path so
+//     un-threaded loops are visible in operator dashboards.
+//
+// Returns lifecycle.ErrEntityNotFound when neither the typed path nor the walk
+// can locate a valid run entity.
+func ResolveRun(ctx context.Context, mgr MockableManager, reader LoopTripleReader, org, platform, loopID string) (*AgentRun, error) {
+	logger := slog.Default()
+
+	loopEntityID, err := agentic.TryLoopExecutionEntityID(org, platform, loopID)
+	if err != nil {
+		return nil, fmt.Errorf("agentrun.ResolveRun: build loop entity ID: %w", err)
+	}
+
+	// -- Path 1: typed agent.run triple --
+	runID, ok, err := reader.GetLoopRunID(ctx, loopEntityID)
+	if err != nil {
+		return nil, fmt.Errorf("agentrun.ResolveRun: read agent.run triple: %w", err)
+	}
+	if ok && runID != "" {
+		runEntityID, err := agentic.TryChainExecutionEntityID(org, platform, runID)
+		if err != nil {
+			return nil, fmt.Errorf("agentrun.ResolveRun: build run entity ID from triple: %w", err)
+		}
+		participant, err := mgr.Get(ctx, WorkflowName, runEntityID)
+		if err != nil {
+			return nil, fmt.Errorf("agentrun.ResolveRun: Manager.Get: %w", err)
+		}
+		run, ok := participant.(*AgentRun)
+		if !ok {
+			return nil, fmt.Errorf("agentrun.ResolveRun: Manager.Get returned unexpected type %T", participant)
+		}
+		return run, nil
+	}
+
+	// -- Path 2: ancestry-walk fallback --
+	// Walk agent.loop.parent triples to the root (the loop with no parent).
+	// The root loop's bare ID is the run ID for pre-migration loops.
+	logger.Warn("agentrun.ResolveRun: agent.run triple absent — falling back to ancestry walk (loop not yet migrated to ADR-053 run threading)",
+		slog.String("loop_id", loopID),
+		slog.String("org", org),
+		slog.String("platform", platform))
+
+	currentEntityID := loopEntityID
+	currentLoopID := loopID
+	for hop := 0; hop < maxAncestryHops; hop++ {
+		parentEntityID, hasParent, err := reader.GetLoopParentEntityID(ctx, currentEntityID)
+		if err != nil {
+			return nil, fmt.Errorf("agentrun.ResolveRun: ancestry walk hop %d: %w", hop, err)
+		}
+		if !hasParent || parentEntityID == "" {
+			// currentLoopID is the root loop — treat as run ID.
+			runEntityID, err := agentic.TryChainExecutionEntityID(org, platform, currentLoopID)
+			if err != nil {
+				return nil, fmt.Errorf("agentrun.ResolveRun: build run entity ID from ancestry root: %w", err)
+			}
+			participant, err := mgr.Get(ctx, WorkflowName, runEntityID)
+			if err != nil {
+				return nil, fmt.Errorf("agentrun.ResolveRun: Manager.Get (ancestry root): %w", err)
+			}
+			run, ok := participant.(*AgentRun)
+			if !ok {
+				return nil, fmt.Errorf("agentrun.ResolveRun: Manager.Get returned unexpected type %T", participant)
+			}
+			return run, nil
+		}
+		// Step up to the parent. Extract the bare loopID from the parent's entity ID
+		// (the parent is a loop-execution entity, not a chain entity).
+		parentLoopID, ok := agentic.LoopIDFromExecutionEntityID(parentEntityID)
+		if !ok {
+			// parentEntityID is not a loop-execution entity — ancestry walk cannot proceed.
+			return nil, fmt.Errorf("agentrun.ResolveRun: ancestry walk hop %d: parent entity %q is not a loop-execution entity ID; cannot continue walk",
+				hop, parentEntityID)
+		}
+		currentEntityID = parentEntityID
+		currentLoopID = parentLoopID
+	}
+
+	return nil, fmt.Errorf("agentrun.ResolveRun: ancestry walk exceeded %d hops without reaching root for loop %q", maxAncestryHops, loopID)
+}
+
+// TriplePublisher is the narrow interface MilestoneHandlers use to write
+// milestone triples onto the run entity (or any entity) via graph-ingest.
+// Reuse the TripleMutator interface shape from the rule action executor; a
+// concrete natsclient-backed implementation satisfies this.
+type TriplePublisher interface {
+	// AddTriple writes a triple via graph-ingest. Returns the KV revision after write.
+	AddTriple(ctx context.Context, ruleID string, triple message.Triple) (uint64, error)
+}
+
+// LoopTerminalEvent carries the terminal event data passed to MilestoneHandlers.
+// Product handlers receive this along with the pre-resolved *AgentRun.
+type LoopTerminalEvent struct {
+	// LoopID is the bare loop UUID that terminated.
+	LoopID string
+	// RunID is the bare run loop-id from the event wire (ADR-053 D8).
+	RunID string
+	// RunEntityID is the full 6-part chain execution entity ID from the wire.
+	RunEntityID string
+	// Category is the agentic message category that identifies the event type:
+	// CategoryLoopCompleted, CategoryLoopFailed, or CategoryLoopCancelled.
+	// Cancellation rides agent.complete (not agent.cancelled), so callers MUST
+	// demux by Category, not by subject.
+	Category string
+	// Outcome is the loop outcome string (success/failed/cancelled/truncated).
+	Outcome string
+	// Role is the loop's role.
+	Role string
+}
+
+// MilestoneHandler is the product-registered handler for terminal loop events.
+// Implementations receive the pre-resolved *AgentRun and a TriplePublisher so
+// they can stamp milestone triples directly onto the run entity via graph-ingest
+// (NOT via Manager — see ADR-053 D5 for the cardinality contract).
+type MilestoneHandler interface {
+	OnLoopTerminal(ctx context.Context, ev LoopTerminalEvent, run *AgentRun, pub TriplePublisher) error
+}
+
+// MockableManager is the subset of *lifecycle.Manager that MilestoneSubscriber
+// uses, expressed as an interface so tests can inject a mock without constructing
+// a real Manager. Production callers use *lifecycle.Manager which satisfies this.
+type MockableManager interface {
+	// Get reads the entity at entityID for the given workflow and projects its
+	// triples into a fresh Participant. Returns lifecycle.ErrEntityNotFound when absent.
+	Get(ctx context.Context, workflow, entityID string) (lifecycle.Participant, error)
+	// Transition moves the entity to newPhase. Used by the terminal-authority
+	// zombie-prevention path (D3). Never called with Manager.Complete — use
+	// an explicit terminal phase.
+	Transition(ctx context.Context, workflow, entityID, newPhase string, source lifecycle.TransitionSource, note string) error
+	// Create attaches lifecycle to the entity at initial.EntityID(). Returns
+	// lifecycle.ErrAlreadyExists when already lifecycle-managed.
+	Create(ctx context.Context, initial lifecycle.Participant) error
+}
+
+// MilestoneSubscriber decodes terminal loop events from NATS (agent.complete.*
+// and agent.failed.*), pre-resolves the run, and fans out to registered handlers
+// (ADR-053 D6, D3).
+//
+// Terminal authority (D3): the subscriber initiates a run → failed/cancelled
+// transition ONLY when the terminating loop IS the run root AND the run is still
+// in "dispatched" with no children (zombie prevention). Product/coordinator closes
+// runs via lifecycle_transition rule actions in all other cases.
+//
+// Never call Manager.Complete — with executing→3 terminals it is non-deterministic
+// (manager.go:671). Always use Manager.Transition with an explicit terminal.
+type MilestoneSubscriber struct {
+	mgr      MockableManager
+	reader   LoopTripleReader
+	pub      TriplePublisher
+	handlers []MilestoneHandler
+	org      string
+	platform string
+	logger   *slog.Logger
+}
+
+// NewMilestoneSubscriber constructs a subscriber wired to the given concrete
+// lifecycle.Manager, reader, publisher, org, and platform. Handlers are
+// registered separately via AddHandler. A nil logger falls back to slog.Default.
+//
+// Production callers use this constructor with a *lifecycle.Manager.
+// Test callers use NewMilestoneSubscriberWithManager with a mock.
+func NewMilestoneSubscriber(
+	mgr *lifecycle.Manager,
+	reader LoopTripleReader,
+	pub TriplePublisher,
+	org, platform string,
+	logger *slog.Logger,
+) *MilestoneSubscriber {
+	return NewMilestoneSubscriberWithManager(mgr, reader, pub, org, platform, logger)
+}
+
+// NewMilestoneSubscriberWithManager constructs a subscriber with any
+// MockableManager (real or test double). Prefer NewMilestoneSubscriber for
+// production callers.
+func NewMilestoneSubscriberWithManager(
+	mgr MockableManager,
+	reader LoopTripleReader,
+	pub TriplePublisher,
+	org, platform string,
+	logger *slog.Logger,
+) *MilestoneSubscriber {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MilestoneSubscriber{
+		mgr:      mgr,
+		reader:   reader,
+		pub:      pub,
+		org:      org,
+		platform: platform,
+		logger:   logger,
+	}
+}
+
+// AddHandler registers a product MilestoneHandler. Must be called before
+// HandleEvent is invoked. Thread-safe with respect to concurrent HandleEvent
+// calls only when called before the subscriber is started.
+func (s *MilestoneSubscriber) AddHandler(h MilestoneHandler) {
+	s.handlers = append(s.handlers, h)
+}
+
+// HandleEvent processes a raw NATS message payload from agent.complete.* or
+// agent.failed.* subjects. It decodes the BaseMessage envelope, demuxes by
+// payload category (not subject — cancellation rides agent.complete), resolves
+// the AgentRun, applies terminal-authority logic (D3), and fans out to handlers.
+//
+// Panic guard: each handler invocation is wrapped in a recover so a panicking
+// product handler does not crash the subscriber goroutine.
+//
+// Returns an error only for infrastructure failures (decode, NATS). Handler
+// errors are logged but do not propagate — the subscriber continues processing
+// subsequent events.
+func (s *MilestoneSubscriber) HandleEvent(ctx context.Context, data []byte) error {
+	// Decode the BaseMessage envelope to extract the category.
+	var envelope struct {
+		Domain   string          `json:"domain"`
+		Category string          `json:"category"`
+		Version  string          `json:"version"`
+		Payload  json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return fmt.Errorf("agentrun: HandleEvent: decode envelope: %w", err)
+	}
+
+	var ev LoopTerminalEvent
+	switch envelope.Category {
+	case agentic.CategoryLoopCompleted:
+		var completed agentic.LoopCompletedEvent
+		if err := json.Unmarshal(envelope.Payload, &completed); err != nil {
+			return fmt.Errorf("agentrun: HandleEvent: decode LoopCompletedEvent: %w", err)
+		}
+		ev = LoopTerminalEvent{
+			LoopID:      completed.LoopID,
+			RunID:       completed.RunID,
+			RunEntityID: completed.RunEntityID,
+			Category:    agentic.CategoryLoopCompleted,
+			Outcome:     completed.Outcome,
+			Role:        completed.Role,
+		}
+
+	case agentic.CategoryLoopCancelled:
+		var cancelled agentic.LoopCancelledEvent
+		if err := json.Unmarshal(envelope.Payload, &cancelled); err != nil {
+			return fmt.Errorf("agentrun: HandleEvent: decode LoopCancelledEvent: %w", err)
+		}
+		ev = LoopTerminalEvent{
+			LoopID:      cancelled.LoopID,
+			RunID:       cancelled.RunID,
+			RunEntityID: cancelled.RunEntityID,
+			Category:    agentic.CategoryLoopCancelled,
+			Outcome:     agentic.OutcomeCancelled,
+			Role:        "",
+		}
+
+	case agentic.CategoryLoopFailed:
+		var failed agentic.LoopFailedEvent
+		if err := json.Unmarshal(envelope.Payload, &failed); err != nil {
+			return fmt.Errorf("agentrun: HandleEvent: decode LoopFailedEvent: %w", err)
+		}
+		ev = LoopTerminalEvent{
+			LoopID:      failed.LoopID,
+			RunID:       failed.RunID,
+			RunEntityID: failed.RunEntityID,
+			Category:    agentic.CategoryLoopFailed,
+			Outcome:     agentic.OutcomeFailed,
+			Role:        failed.Role,
+		}
+
+	default:
+		// Not a terminal loop event — skip silently. Other categories
+		// (loop_created, context_event, etc.) may appear on agent.complete.*
+		// in future; we only act on the terminal set.
+		return nil
+	}
+
+	// Resolve the run. Prefer the wire RunID (D8 typed path); fall back to walk.
+	run, err := s.resolveRunForEvent(ctx, ev)
+	if err != nil {
+		// Resolution failure: log but do not crash the subscriber.
+		s.logger.Warn("agentrun: HandleEvent: run resolution failed — skipping handlers",
+			slog.String("loop_id", ev.LoopID),
+			slog.String("run_id", ev.RunID),
+			slog.String("category", ev.Category),
+			slog.Any("error", err))
+		return nil
+	}
+
+	// Terminal authority (D3): if the terminating loop IS the run root AND the run is
+	// still in "dispatched" (no children handed off yet), transition the run to
+	// failed/cancelled to prevent a zombie. This is the ONLY framework-initiated terminal
+	// transition.
+	//
+	// The root check uses run.RunID() (derived from the resolved run entity), NOT ev.RunID
+	// (the wire field). The wire RunID is populated from LoopEntity.RunID which is set at
+	// spawn via SetRunID — but the root/coordinator loop itself was NOT spawned with a RunID
+	// (it predates the run_scope:new rule firing). Instead, the run_scope=new path stamps
+	// agent.run on the firing entity via tripleMutator; ResolveRun reads that triple and
+	// resolves the run. The wire ev.RunID is therefore "" for root terminations — using it
+	// as the identity check would make D3 unreachable.
+	if run != nil && run.PhaseField == "dispatched" {
+		if runID, ok := run.RunID(); ok && ev.LoopID == runID {
+			terminalPhase := "failed"
+			if ev.Category == agentic.CategoryLoopCancelled {
+				terminalPhase = "cancelled"
+			}
+			reason := fmt.Sprintf("root loop %s terminated in %s before any child handoff", ev.LoopID, ev.Outcome)
+			s.logger.Info("agentrun: HandleEvent: zombie prevention — transitioning dispatched root run to terminal",
+				slog.String("run_entity_id", run.EntityIDField),
+				slog.String("loop_id", ev.LoopID),
+				slog.String("terminal_phase", terminalPhase))
+			if transErr := s.mgr.Transition(ctx, WorkflowName, run.EntityIDField, terminalPhase,
+				lifecycle.TransitionSourceFramework, reason); transErr != nil {
+				s.logger.Warn("agentrun: HandleEvent: zombie-prevention transition failed",
+					slog.String("run_entity_id", run.EntityIDField),
+					slog.Any("error", transErr))
+			}
+		}
+	}
+
+	// Fan out to product handlers with panic guard.
+	for i, h := range s.handlers {
+		func(idx int, handler MilestoneHandler) {
+			defer func() {
+				if r := recover(); r != nil {
+					s.logger.Error("agentrun: MilestoneHandler panicked",
+						slog.Int("handler_index", idx),
+						slog.String("loop_id", ev.LoopID),
+						slog.Any("panic", r))
+				}
+			}()
+			if handlerErr := handler.OnLoopTerminal(ctx, ev, run, s.pub); handlerErr != nil {
+				s.logger.Warn("agentrun: MilestoneHandler error",
+					slog.Int("handler_index", idx),
+					slog.String("loop_id", ev.LoopID),
+					slog.Any("error", handlerErr))
+			}
+		}(i, h)
+	}
+
+	return nil
+}
+
+// resolveRunForEvent resolves the AgentRun for the event. Uses the wire RunEntityID
+// when available (fast path, no walk needed), then falls back to ResolveRun
+// (which does the typed triple lookup + ancestry walk).
+func (s *MilestoneSubscriber) resolveRunForEvent(ctx context.Context, ev LoopTerminalEvent) (*AgentRun, error) {
+	// Fast path: RunEntityID is on the wire (ADR-053 D8 typed propagation).
+	if ev.RunEntityID != "" {
+		participant, err := s.mgr.Get(ctx, WorkflowName, ev.RunEntityID)
+		if err != nil {
+			// Run entity not found — may be a non-run loop. Log and return nil run.
+			s.logger.Debug("agentrun: resolveRunForEvent: Manager.Get from wire RunEntityID failed",
+				slog.String("run_entity_id", ev.RunEntityID),
+				slog.String("loop_id", ev.LoopID),
+				slog.Any("error", err))
+			return nil, nil //nolint:nilerr // deliberate: non-run loops have no run entity
+		}
+		run, ok := participant.(*AgentRun)
+		if !ok {
+			return nil, fmt.Errorf("Manager.Get returned unexpected type %T", participant)
+		}
+		return run, nil
+	}
+
+	if ev.LoopID == "" {
+		return nil, nil
+	}
+
+	// Slow path: use ResolveRun (typed triple + ancestry walk).
+	run, err := ResolveRun(ctx, s.mgr, s.reader, s.org, s.platform, ev.LoopID)
+	if err != nil {
+		if errors.Is(err, lifecycle.ErrEntityNotFound) {
+			// No run entity — this loop is not in a run. Return nil, no error.
+			return nil, nil
+		}
+		return nil, err
+	}
+	return run, nil
+}
+
+// AgentStreamName is the default JetStream stream name for agentic events.
+// Matches agentic-loop config.go default ("AGENT").
+const AgentStreamName = "AGENT"
+
+// StartConfig configures the durable JetStream consumers created by Start.
+// Zero-value is invalid — callers must supply a non-empty StreamName.
+type StartConfig struct {
+	// StreamName is the JetStream stream that holds agent.complete.* and
+	// agent.failed.* messages (default "AGENT"). Must match the agentic-loop's
+	// stream_name config value.
+	StreamName string
+
+	// ConsumerNameSuffix is appended to the stable durable consumer names to
+	// disambiguate instances (e.g. test-specific suffixes). Empty = no suffix.
+	ConsumerNameSuffix string
+}
+
+// Start wires the MilestoneSubscriber to the live NATS connection using DURABLE
+// JetStream consumers. agent.complete.* and agent.failed.* are published into the
+// AGENT JetStream stream by the agentic-loop component; core Subscribe would drop
+// events during subscriber downtime, violating D3/milestone restart-recovery.
+//
+// Two stable durable consumers are created (one per filter subject). They survive
+// subscriber restarts and resume from the last-acked message.
+//
+// cfg.StreamName must be non-empty (use AgentStreamName as the default).
+// The ctx controls the consumers' lifetime; Stop cancels consumption but preserves
+// the durable consumer offsets in NATS for restart recovery.
+//
+// Returns a stop func that cancels consumption — call it on shutdown.
+func (s *MilestoneSubscriber) Start(ctx context.Context, client *natsclient.Client, cfg StartConfig) (stop func(), err error) {
+	if cfg.StreamName == "" {
+		return nil, fmt.Errorf("agentrun: MilestoneSubscriber.Start: StreamName must not be empty")
+	}
+
+	makeDurable := func(suffix string) string {
+		name := "agentrun-milestone-" + suffix
+		if cfg.ConsumerNameSuffix != "" {
+			name += "-" + cfg.ConsumerNameSuffix
+		}
+		return name
+	}
+
+	handleMsg := func(subject string) func(ctx context.Context, msg jetstream.Msg) {
+		return func(msgCtx context.Context, msg jetstream.Msg) {
+			if handleErr := s.HandleEvent(msgCtx, msg.Data()); handleErr != nil {
+				s.logger.Warn("agentrun: MilestoneSubscriber: HandleEvent error",
+					slog.String("subject", subject),
+					slog.Any("error", handleErr))
+				msg.Nak() //nolint:errcheck // best-effort nak; NATS will redeliver
+				return
+			}
+			msg.Ack() //nolint:errcheck // best-effort ack; benign on double-ack
+		}
+	}
+
+	completeConsumer := makeDurable("complete")
+	completeCfg := natsclient.StreamConsumerConfig{
+		StreamName:    cfg.StreamName,
+		ConsumerName:  completeConsumer,
+		FilterSubject: "agent.complete.*",
+		AckPolicy:     "explicit",
+		DeliverPolicy: "new",
+		MaxDeliver:    5,
+		AckWait:       30 * time.Second,
+	}
+	if err := client.ConsumeStreamWithConfig(ctx, completeCfg, handleMsg("agent.complete.*")); err != nil {
+		return nil, fmt.Errorf("agentrun: MilestoneSubscriber: start durable consumer agent.complete.*: %w", err)
+	}
+
+	failedConsumer := makeDurable("failed")
+	failedCfg := natsclient.StreamConsumerConfig{
+		StreamName:    cfg.StreamName,
+		ConsumerName:  failedConsumer,
+		FilterSubject: "agent.failed.*",
+		AckPolicy:     "explicit",
+		DeliverPolicy: "new",
+		MaxDeliver:    5,
+		AckWait:       30 * time.Second,
+	}
+	if err := client.ConsumeStreamWithConfig(ctx, failedCfg, handleMsg("agent.failed.*")); err != nil {
+		// Roll back the first consumer before returning error.
+		client.StopConsumer(cfg.StreamName, completeConsumer)
+		return nil, fmt.Errorf("agentrun: MilestoneSubscriber: start durable consumer agent.failed.*: %w", err)
+	}
+
+	// Stop cancels local consumption; durable state is preserved in NATS for restart recovery.
+	return func() {
+		client.StopConsumer(cfg.StreamName, completeConsumer)
+		client.StopConsumer(cfg.StreamName, failedConsumer)
+	}, nil
+}

--- a/agentic/agentrun/agentrun_integration_test.go
+++ b/agentic/agentrun/agentrun_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+// Integration tests for agentic/agentrun exercising the real lifecycle.Manager
+// projection path against a testcontainer NATS server (ADR-053 C2 review finding).
+//
+// Build tag: go test -tags=integration -race ./agentic/agentrun/...
+package agentrun_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic/agentrun"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_D1_ProjectionRoundTrip verifies that lifecycle.Manager.Get
+// correctly populates AgentRun.EntityIDField with the FULL 6-part chain execution
+// entity ID (ADR-053 D1 critical invariant). The projection layer reads the
+// `lifecycle:"id"` field from the ENTITY_STATES KV key — not from triples.
+//
+// This test drives the production wire path:
+//  1. Write a crafted EntityState (with the agent.run.phase phase triple) directly
+//     into the ENTITY_STATES KV bucket — simulating what graph-ingest would write
+//     after Manager.Create emits to graph.mutation.entity.create_with_triples.
+//  2. Call Manager.Get (production entry point, reads from ENTITY_STATES).
+//  3. Assert EntityIDField == full 6-part chain.execution entity ID (not a bare UUID,
+//     not a garbled form like TryChainExecutionEntityID would reject).
+//
+// Why direct KV write rather than Manager.Create → graph-ingest responder?
+// Manager.Create routes through a NATS request/reply to graph-ingest. Setting up
+// a full stub responder is valid but adds test surface area. The D1 invariant
+// is specifically about the projection layer (KV key → EntityIDField), so
+// writing the KV state directly is more focused and avoids coupling the D1
+// round-trip test to the Manager.Create → graph-ingest wire contract (which
+// has its own integration test in pkg/lifecycle/manager_integration_test.go).
+func TestIntegration_D1_ProjectionRoundTrip(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKVBuckets(graph.BucketEntityStates))
+	ctx := context.Background()
+
+	mgr := lifecycle.NewManager(tc.Client, nil)
+	require.NoError(t, agentrun.Register(mgr), "Register must succeed on a fresh manager")
+
+	// Build the full entity ID that Mint would produce.
+	const (
+		org        = "acme"
+		platform   = "ops"
+		rootLoopID = "d1-integration-test-loop"
+	)
+	fullEntityID := "acme.ops.agent.chain.execution." + rootLoopID
+
+	// Write an EntityState with the agent.run.phase triple directly into
+	// ENTITY_STATES — simulating what graph-ingest writes after Manager.Create.
+	// The KV key is the full entity ID.
+	now := time.Now().UTC()
+	state := graph.EntityState{
+		ID: fullEntityID,
+		Triples: []message.Triple{
+			{
+				Subject:    fullEntityID,
+				Predicate:  agentrun.PhasePredicate, // "agent.run.phase"
+				Object:     "dispatched",
+				Source:     "test",
+				Timestamp:  now,
+				Confidence: 1.0,
+			},
+		},
+		Version:   1,
+		UpdatedAt: now,
+	}
+	stateBytes, err := json.Marshal(state)
+	require.NoError(t, err)
+
+	// Write to ENTITY_STATES KV bucket using the production bucket name as key.
+	bucket, err := tc.Client.GetKeyValueBucket(ctx, graph.BucketEntityStates)
+	require.NoError(t, err, "ENTITY_STATES bucket must be available (WithKVBuckets creates it)")
+
+	_, err = bucket.Put(ctx, fullEntityID, stateBytes)
+	require.NoError(t, err, "KV Put must succeed for the entity state")
+
+	// Manager.Get — the production projection path.
+	participant, err := mgr.Get(ctx, agentrun.WorkflowName, fullEntityID)
+	require.NoError(t, err, "Manager.Get must succeed when entity state is in ENTITY_STATES")
+	require.NotNil(t, participant)
+
+	run, ok := participant.(*agentrun.AgentRun)
+	require.True(t, ok, "Manager.Get must return *agentrun.AgentRun for agent-run workflow")
+
+	// D1 critical: EntityIDField must hold the FULL 6-part chain.execution entity ID.
+	// The projection layer reads this from the KV key (entityID param), NOT from triples.
+	assert.Equal(t, fullEntityID, run.EntityIDField,
+		"D1: EntityIDField must hold the full 6-part entity ID populated from the KV key")
+	assert.Equal(t, "dispatched", run.PhaseField,
+		"PhaseField must be projected from the agent.run.phase triple")
+	assert.False(t, run.IsTerminal(), "dispatched must not be terminal")
+
+	// RunID() must derive the bare loop ID from EntityIDField — not a dot-separated path.
+	runID, ok := run.RunID()
+	require.True(t, ok, "RunID() must succeed for a valid chain.execution entity ID")
+	assert.Equal(t, rootLoopID, runID,
+		"RunID() must return the bare loop UUID, not the full entity ID")
+	assert.NotContains(t, runID, ".",
+		"bare RunID must not contain dots — if it does, D1 EntityIDField holds a bare ID, not the full 6-part ID")
+}

--- a/agentic/agentrun/agentrun_test.go
+++ b/agentic/agentrun/agentrun_test.go
@@ -1,0 +1,769 @@
+// Package agentrun_test contains TDD tests for the agentrun package (ADR-053 Pass B).
+//
+// Tests are organized by ADR decision:
+//   - D1: AgentRun Participant interface compliance + projection round-trip
+//   - D2: WorkflowDeclaration validation
+//   - D4: Mint idempotence
+//   - D6: ResolveRun typed + ancestry-walk fallback (with WARN log verification shape)
+//   - D3: Terminal authority — zombie prevention (root dispatched → failed/cancelled)
+//   - D6: Subscriber category demux (cancellation rides loop_cancelled category)
+//   - D6: Panic guard
+package agentrun_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/agentic/agentrun"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- D1: AgentRun Participant interface compliance ---
+
+func TestAgentRun_ParticipantInterface(t *testing.T) {
+	t.Parallel()
+	run := &agentrun.AgentRun{
+		EntityIDField:     "acme.ops.agent.chain.execution.loop-uuid-abc",
+		PhaseField:        "dispatched",
+		ParentRunEntityID: "acme.ops.agent.chain.execution.parent-uuid",
+	}
+	assert.Equal(t, "acme.ops.agent.chain.execution.loop-uuid-abc", run.EntityID())
+	assert.Equal(t, "agent-run", run.Workflow())
+	assert.Equal(t, "dispatched", run.Phase())
+	assert.False(t, run.IsTerminal(), "dispatched is not terminal")
+	assert.Equal(t, "acme.ops.agent.chain.execution.parent-uuid", run.ParentEntityID())
+}
+
+func TestAgentRun_IsTerminal(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		phase    string
+		terminal bool
+	}{
+		{"dispatched", false},
+		{"executing", false},
+		{"awaiting_approval", false},
+		{"completed", true},
+		{"failed", true},
+		{"cancelled", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.phase, func(t *testing.T) {
+			t.Parallel()
+			run := &agentrun.AgentRun{PhaseField: tc.phase}
+			assert.Equal(t, tc.terminal, run.IsTerminal())
+		})
+	}
+}
+
+func TestAgentRun_RunID_ValidChainEntity(t *testing.T) {
+	t.Parallel()
+	run := &agentrun.AgentRun{
+		EntityIDField: "acme.ops.agent.chain.execution.loop-uuid-abc",
+	}
+	runID, ok := run.RunID()
+	require.True(t, ok)
+	assert.Equal(t, "loop-uuid-abc", runID)
+}
+
+func TestAgentRun_RunID_NonChainEntityReturnsFalse(t *testing.T) {
+	t.Parallel()
+	// agentic-loop entity, not a chain.execution entity.
+	run := &agentrun.AgentRun{
+		EntityIDField: "acme.ops.agent.agentic-loop.execution.loop-uuid",
+	}
+	_, ok := run.RunID()
+	assert.False(t, ok, "RunID should return false for non-chain.execution entity IDs")
+}
+
+// D1 ADR critical: the lifecycle:"id" field must hold the FULL 6-part entity
+// ID, not a bare run UUID. Verify that the struct field tag is correct and
+// that the AgentRun struct compiles as a valid Participant (static type check).
+func TestAgentRun_FullIDInEntityIDField(t *testing.T) {
+	t.Parallel()
+	fullEntityID := "acme.ops.agent.chain.execution.run-uuid-001"
+	run := &agentrun.AgentRun{EntityIDField: fullEntityID}
+	// EntityID() must return the full 6-part ID, not a bare runID.
+	assert.Equal(t, fullEntityID, run.EntityID())
+
+	// RunID() must derive the bare UUID from the full ID — NOT the reverse.
+	runID, ok := run.RunID()
+	require.True(t, ok)
+	assert.Equal(t, "run-uuid-001", runID, "RunID() must parse the instance segment")
+	assert.NotContains(t, runID, ".", "bare RunID must not contain dots")
+}
+
+// D1 projection round-trip guard: verify that the AgentRun struct has the
+// correct lifecycle struct tags for the projection layer. We do this via the
+// WorkflowDeclaration() → Schema field being the correct reflect.Type.
+func TestAgentRun_WorkflowDeclarationSchemaIsAgentRunType(t *testing.T) {
+	t.Parallel()
+	wf := agentrun.WorkflowDeclaration()
+	// Schema must point to AgentRun struct, not a pointer to it.
+	// reflect.TypeOf(AgentRun{}) vs reflect.TypeOf(&AgentRun{}).Elem()
+	// This asserts the Schema was set correctly in WorkflowDeclaration().
+	schemaName := wf.Schema.Name()
+	assert.Equal(t, "AgentRun", schemaName,
+		"Workflow.Schema must be reflect.TypeOf(AgentRun{})")
+}
+
+// --- D2: WorkflowDeclaration validation ---
+
+func TestWorkflowDeclaration_TransitionsValid(t *testing.T) {
+	t.Parallel()
+	wf := agentrun.WorkflowDeclaration()
+	err := wf.Transitions.Validate()
+	require.NoError(t, err, "agent-run transitions table must be internally consistent")
+}
+
+func TestWorkflowDeclaration_EntityIDPattern(t *testing.T) {
+	t.Parallel()
+	wf := agentrun.WorkflowDeclaration()
+	assert.Equal(t, "*.*.agent.chain.execution.*", wf.EntityIDPattern)
+}
+
+func TestWorkflowDeclaration_PhasePredicate(t *testing.T) {
+	t.Parallel()
+	wf := agentrun.WorkflowDeclaration()
+	assert.Equal(t, "agent.run.phase", wf.PhasePredicate)
+}
+
+func TestWorkflowDeclaration_TerminalPhases(t *testing.T) {
+	t.Parallel()
+	wf := agentrun.WorkflowDeclaration()
+	terminals := wf.Transitions.TerminalPhases()
+	assert.ElementsMatch(t, []string{"completed", "failed", "cancelled"}, terminals)
+}
+
+// --- Integration path: use lifecycle.Manager with integration build tag ---
+// The unit tests below use a mock lifecycle manager for phase-logic testing.
+
+// --- Mock lifecycle.Manager for unit tests ---
+
+// mockLifecycleManager is a test double for lifecycle.Manager used by
+// MilestoneSubscriber tests that need phase-transition verification.
+type mockLifecycleManager struct {
+	runs        map[string]*agentrun.AgentRun
+	transitions []transitionCall
+}
+
+type transitionCall struct {
+	entityID string
+	newPhase string
+	source   lifecycle.TransitionSource
+}
+
+func newMockLifecycleManager() *mockLifecycleManager {
+	return &mockLifecycleManager{
+		runs: make(map[string]*agentrun.AgentRun),
+	}
+}
+
+func (m *mockLifecycleManager) seed(run *agentrun.AgentRun) {
+	m.runs[run.EntityIDField] = run
+}
+
+func (m *mockLifecycleManager) Get(_ context.Context, workflow, entityID string) (lifecycle.Participant, error) {
+	if workflow != agentrun.WorkflowName {
+		return nil, lifecycle.ErrWorkflowNotRegistered
+	}
+	run, ok := m.runs[entityID]
+	if !ok {
+		return nil, lifecycle.ErrEntityNotFound
+	}
+	// Return a copy so phase changes on the returned value don't affect stored state.
+	runCopy := *run
+	return &runCopy, nil
+}
+
+func (m *mockLifecycleManager) Transition(_ context.Context, workflow, entityID, newPhase string, source lifecycle.TransitionSource, _ string) error {
+	if workflow != agentrun.WorkflowName {
+		return lifecycle.ErrWorkflowNotRegistered
+	}
+	run, ok := m.runs[entityID]
+	if !ok {
+		return lifecycle.ErrEntityNotFound
+	}
+	m.transitions = append(m.transitions, transitionCall{
+		entityID: entityID,
+		newPhase: newPhase,
+		source:   source,
+	})
+	run.PhaseField = newPhase
+	return nil
+}
+
+func (m *mockLifecycleManager) Create(_ context.Context, initial lifecycle.Participant) error {
+	run, ok := initial.(*agentrun.AgentRun)
+	if !ok {
+		return errors.New("mockLifecycleManager: Create: unexpected type")
+	}
+	if _, exists := m.runs[run.EntityIDField]; exists {
+		return lifecycle.ErrAlreadyExists
+	}
+	runCopy := *run
+	m.runs[run.EntityIDField] = &runCopy
+	return nil
+}
+
+// mockMilestoneSubscriber wraps the real subscriber but injects the mock manager.
+// Since MilestoneSubscriber is a concrete struct, we can't inject a mock mgr
+// through the current constructor. We test subscriber behavior via HandleEvent
+// directly by seeding state into the mock and reading back transitions.
+//
+// To test terminal authority, we use the MilestoneSubscriberForTest which
+// accepts a mock-capable dependency set.
+
+// --- D4: Mint idempotence ---
+
+// TestMint_Idempotent_ErrAlreadyExistsFallsBackToGet verifies that when
+// Manager.Create returns ErrAlreadyExists, Mint falls back to Manager.Get
+// and returns the already-minted run (not an error). This is the production
+// idempotency path for JetStream redeliveries and concurrent rule firings.
+func TestMint_Idempotent_ErrAlreadyExistsFallsBackToGet(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mock := newMockLifecycleManager()
+	// Pre-seed the run to simulate a prior mint.
+	runEntityID := "acme.ops.agent.chain.execution.run-already-exists"
+	existing := &agentrun.AgentRun{
+		EntityIDField: runEntityID,
+		PhaseField:    "dispatched",
+	}
+	mock.seed(existing)
+
+	// Mint with the same ID — Create returns ErrAlreadyExists.
+	// Mint must fall back to Get and return the existing run.
+	result, err := agentrun.Mint(ctx, mock, "acme", "ops", "run-already-exists")
+	require.NoError(t, err, "Mint must not error on ErrAlreadyExists — idempotent path")
+	require.NotNil(t, result)
+	assert.Equal(t, runEntityID, result.EntityID(),
+		"idempotent Mint must return the existing run entity ID")
+	assert.Equal(t, "dispatched", result.Phase(),
+		"idempotent Mint must return the existing run's phase")
+
+	runID, ok := result.RunID()
+	require.True(t, ok)
+	assert.Equal(t, "run-already-exists", runID,
+		"idempotent Mint must return the correct bare RunID")
+}
+
+// TestMint_EntityIDShape verifies the entity ID format produced by Mint.
+func TestMint_EntityIDShape(t *testing.T) {
+	t.Parallel()
+	// Verify the entity ID Mint would construct without needing a Manager.
+	entityID, err := agentic.TryChainExecutionEntityID("acme", "ops", "root-uuid")
+	require.NoError(t, err)
+	assert.Equal(t, "acme.ops.agent.chain.execution.root-uuid", entityID)
+}
+
+func TestMint_EmptyOrgReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := agentic.TryChainExecutionEntityID("", "ops", "root-uuid")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "org must not be empty")
+}
+
+func TestMint_DotInLoopIDReturnsError(t *testing.T) {
+	t.Parallel()
+	_, err := agentic.TryChainExecutionEntityID("acme", "ops", "bad.id.with.dots")
+	require.Error(t, err)
+}
+
+// --- D6: ResolveRun typed + ancestry-walk fallback ---
+
+func TestResolveRun_TypedTriplePath_WhenRunIDPresent(t *testing.T) {
+	t.Parallel()
+	// Set up: reader has agent.run triple on the loop entity.
+	reader := newFakeTripleReader()
+	loopEntityID, _ := agentic.TryLoopExecutionEntityID("acme", "ops", "child-loop-id")
+	reader.set(loopEntityID, "agent.run", "root-run-id")
+
+	// Verify reader returns the runID correctly.
+	runID, ok, err := reader.GetLoopRunID(context.Background(), loopEntityID)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "root-run-id", runID)
+}
+
+func TestResolveRun_AncestryWalkPath_WhenNoRunTriple(t *testing.T) {
+	t.Parallel()
+	reader := newFakeTripleReader()
+	rootEntityID, _ := agentic.TryLoopExecutionEntityID("acme", "ops", "root-loop-id")
+	childEntityID, _ := agentic.TryLoopExecutionEntityID("acme", "ops", "child-loop-id")
+	// Child's agent.loop.parent points to root.
+	reader.set(childEntityID, "agent.loop.parent", rootEntityID)
+	// Root has no parent — reader.GetLoopParentEntityID returns ("", false, nil).
+
+	// Verify the reader gives us the correct parent chain.
+	parentID, hasParent, err := reader.GetLoopParentEntityID(context.Background(), childEntityID)
+	require.NoError(t, err)
+	require.True(t, hasParent)
+	assert.Equal(t, rootEntityID, parentID)
+
+	// Root has no parent.
+	_, rootHasParent, err := reader.GetLoopParentEntityID(context.Background(), rootEntityID)
+	require.NoError(t, err)
+	assert.False(t, rootHasParent)
+}
+
+// --- D3: Terminal authority — zombie prevention ---
+
+// TestTerminalAuthority_RootLoopFailViaResolveWalk exercises D3 via the PRODUCTION
+// resolution path: the root coordinator loop's terminal event carries RunID="" and
+// RunEntityID="" (because the root was not spawned with a RunID — the run_scope:new
+// rule fires AFTER the root starts, stamping agent.run via tripleMutator on the
+// firing entity but NOT updating LoopEntity.RunID). So the subscriber falls through
+// to ResolveRun → reads the agent.run triple from the firing entity (the root loop
+// entity) → builds the chain entity ID → Manager.Get → D3 guard fires.
+//
+// This test drives the exact resolution path production uses when the root loop
+// fails before any child handoff (ev.RunID == "").
+func TestTerminalAuthority_RootLoopFailViaResolveWalk(t *testing.T) {
+	t.Parallel()
+	rootLoopID := "root-loop-id"
+	runEntityID := "acme.ops.agent.chain.execution." + rootLoopID
+
+	run := &agentrun.AgentRun{
+		EntityIDField: runEntityID,
+		PhaseField:    "dispatched",
+	}
+
+	// The reader simulates the effect of run_scope=new stamping agent.run
+	// on the firing (root) entity via tripleMutator (ADR-053 D4).
+	reader := newFakeTripleReader()
+	rootLoopEntityID, _ := agentic.TryLoopExecutionEntityID("acme", "ops", rootLoopID)
+	reader.set(rootLoopEntityID, "agent.run", rootLoopID)
+
+	pub := &fakePublisher{}
+	mock := newMockLifecycleManager()
+	mock.seed(run)
+
+	sub := agentrun.NewMilestoneSubscriberWithManager(mock, reader, pub, "acme", "ops", nil)
+
+	// Build LoopFailedEvent as production emits it for the root coordinator:
+	// RunID="" and RunEntityID="" because LoopEntity.RunID was never set
+	// (root was dispatched before run_scope:new fired).
+	ev := &agentic.LoopFailedEvent{
+		LoopID:   rootLoopID,
+		TaskID:   "task-001",
+		Outcome:  agentic.OutcomeFailed,
+		Reason:   "context exhausted",
+		Error:    "max iterations",
+		Role:     "coordinator",
+		Model:    "model-x",
+		FailedAt: time.Now(),
+		// RunID and RunEntityID deliberately empty — production-realistic shape.
+	}
+	data := mustMarshalBaseMessage(t, ev.Schema(), ev)
+
+	err := sub.HandleEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	// D3: framework must have transitioned the run to "failed".
+	require.Len(t, mock.transitions, 1, "exactly one transition expected")
+	assert.Equal(t, "failed", mock.transitions[0].newPhase,
+		"zombie prevention: root-loop fail before children must transition run to failed")
+	assert.Equal(t, lifecycle.TransitionSourceFramework, mock.transitions[0].source)
+}
+
+// TestTerminalAuthority_ChildLoopFailDoesNotCloseRunViaWireRunID exercises the path
+// where a CHILD loop's terminal event carries RunEntityID on the wire (D8 typed
+// propagation). The child's ev.LoopID != run.RunID(), so D3 must NOT fire.
+func TestTerminalAuthority_ChildLoopFailDoesNotCloseRunViaWireRunID(t *testing.T) {
+	t.Parallel()
+	runEntityID := "acme.ops.agent.chain.execution.root-loop-id"
+	run := &agentrun.AgentRun{
+		EntityIDField: runEntityID,
+		PhaseField:    "dispatched", // still dispatched to test the guard boundary
+	}
+
+	reader := newFakeTripleReader()
+	pub := &fakePublisher{}
+	mock := newMockLifecycleManager()
+	mock.seed(run)
+
+	sub := agentrun.NewMilestoneSubscriberWithManager(mock, reader, pub, "acme", "ops", nil)
+
+	// A CHILD loop fails: ev.LoopID ("child-loop-id") != run.RunID() ("root-loop-id").
+	// Even though the run is in "dispatched", D3 must not fire for a non-root loop.
+	childFailed := &agentic.LoopFailedEvent{
+		LoopID:      "child-loop-id",
+		TaskID:      "task-002",
+		Outcome:     agentic.OutcomeFailed,
+		Reason:      "tool error",
+		Error:       "nats timeout",
+		Role:        "researcher",
+		Model:       "model-y",
+		FailedAt:    time.Now(),
+		RunID:       "root-loop-id",
+		RunEntityID: runEntityID,
+	}
+	data := mustMarshalBaseMessage(t, childFailed.Schema(), childFailed)
+
+	err := sub.HandleEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	// D3: run must NOT be closed by the framework — only the coordinator/product does that.
+	assert.Empty(t, mock.transitions,
+		"child loop failure must NOT close the run (only product/coordinator does that)")
+	assert.Equal(t, "dispatched", mock.runs[runEntityID].PhaseField)
+}
+
+func TestTerminalAuthority_ChildLoop_DoesNotCloseRun(t *testing.T) {
+	t.Parallel()
+	runEntityID := "acme.ops.agent.chain.execution.root-loop-id"
+	run := &agentrun.AgentRun{
+		EntityIDField: runEntityID,
+		PhaseField:    "executing", // already advanced — children are active
+	}
+
+	reader := newFakeTripleReader()
+	pub := &fakePublisher{}
+	mock := newMockLifecycleManager()
+	mock.seed(run)
+
+	sub := agentrun.NewMilestoneSubscriberWithManager(mock, reader, pub, "acme", "ops", nil)
+
+	// A CHILD loop fails: LoopID != RunID.
+	childFailed := &agentic.LoopFailedEvent{
+		LoopID:      "child-loop-id",
+		TaskID:      "task-002",
+		Outcome:     agentic.OutcomeFailed,
+		Reason:      "tool error",
+		Error:       "nats timeout",
+		Role:        "researcher",
+		Model:       "model-y",
+		FailedAt:    time.Now(),
+		RunID:       "root-loop-id",
+		RunEntityID: runEntityID,
+	}
+	data := mustMarshalBaseMessage(t, childFailed.Schema(), childFailed)
+
+	err := sub.HandleEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	// D3: run must NOT be closed by the framework.
+	assert.Empty(t, mock.transitions,
+		"child loop failure must NOT close the run (only product/coordinator does that)")
+	assert.Equal(t, "executing", mock.runs[runEntityID].PhaseField)
+}
+
+func TestTerminalAuthority_RootCancel_Dispatched(t *testing.T) {
+	t.Parallel()
+	runEntityID := "acme.ops.agent.chain.execution.root-cancel-id"
+	run := &agentrun.AgentRun{
+		EntityIDField: runEntityID,
+		PhaseField:    "dispatched",
+	}
+
+	reader := newFakeTripleReader()
+	pub := &fakePublisher{}
+	mock := newMockLifecycleManager()
+	mock.seed(run)
+
+	sub := agentrun.NewMilestoneSubscriberWithManager(mock, reader, pub, "acme", "ops", nil)
+
+	cancelled := &agentic.LoopCancelledEvent{
+		LoopID:      "root-cancel-id",
+		TaskID:      "task-003",
+		Outcome:     agentic.OutcomeCancelled,
+		CancelledBy: "user-xyz",
+		CancelledAt: time.Now(),
+		RunID:       "root-cancel-id",
+		RunEntityID: runEntityID,
+	}
+	data := mustMarshalBaseMessage(t, cancelled.Schema(), cancelled)
+
+	err := sub.HandleEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	require.Len(t, mock.transitions, 1)
+	assert.Equal(t, "cancelled", mock.transitions[0].newPhase,
+		"zombie prevention: root-loop cancel before children must transition run to cancelled")
+}
+
+// --- D6: Subscriber category demux ---
+
+func TestSubscriber_CategoryDemux_CancelledEventDetectedCorrectly(t *testing.T) {
+	t.Parallel()
+	runEntityID := "acme.ops.agent.chain.execution.demux-test"
+	run := &agentrun.AgentRun{
+		EntityIDField: runEntityID,
+		PhaseField:    "executing", // not dispatched — zombie guard won't fire
+	}
+
+	reader := newFakeTripleReader()
+	pub := &fakePublisher{}
+	mock := newMockLifecycleManager()
+	mock.seed(run)
+
+	var receivedCategory string
+	handler := &testMilestoneHandler{
+		fn: func(_ context.Context, ev agentrun.LoopTerminalEvent, _ *agentrun.AgentRun, _ agentrun.TriplePublisher) error {
+			receivedCategory = ev.Category
+			return nil
+		},
+	}
+	sub := agentrun.NewMilestoneSubscriberWithManager(mock, reader, pub, "acme", "ops", nil)
+	sub.AddHandler(handler)
+
+	// LoopCancelledEvent — category=loop_cancelled (not from subject).
+	cancelled := &agentic.LoopCancelledEvent{
+		LoopID:      "child-demux-loop",
+		TaskID:      "task-003",
+		Outcome:     agentic.OutcomeCancelled,
+		CancelledBy: "user-xyz",
+		CancelledAt: time.Now(),
+		RunID:       "demux-test",
+		RunEntityID: runEntityID,
+	}
+	data := mustMarshalBaseMessage(t, cancelled.Schema(), cancelled)
+	err := sub.HandleEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	assert.Equal(t, agentic.CategoryLoopCancelled, receivedCategory,
+		"subscriber must demux by payload category, not by NATS subject")
+}
+
+func TestSubscriber_CategoryDemux_CompletedEventDetectedCorrectly(t *testing.T) {
+	t.Parallel()
+	runEntityID := "acme.ops.agent.chain.execution.completed-run"
+	run := &agentrun.AgentRun{
+		EntityIDField: runEntityID,
+		PhaseField:    "executing",
+	}
+
+	reader := newFakeTripleReader()
+	pub := &fakePublisher{}
+	mock := newMockLifecycleManager()
+	mock.seed(run)
+
+	var receivedCategory string
+	handler := &testMilestoneHandler{
+		fn: func(_ context.Context, ev agentrun.LoopTerminalEvent, _ *agentrun.AgentRun, _ agentrun.TriplePublisher) error {
+			receivedCategory = ev.Category
+			return nil
+		},
+	}
+	sub := agentrun.NewMilestoneSubscriberWithManager(mock, reader, pub, "acme", "ops", nil)
+	sub.AddHandler(handler)
+
+	completed := &agentic.LoopCompletedEvent{
+		LoopID:      "some-loop",
+		TaskID:      "task-004",
+		Outcome:     agentic.OutcomeSuccess,
+		Role:        "researcher",
+		Result:      "done",
+		Model:       "model-z",
+		CompletedAt: time.Now(),
+		RunID:       "completed-run",
+		RunEntityID: runEntityID,
+	}
+	data := mustMarshalBaseMessage(t, completed.Schema(), completed)
+	err := sub.HandleEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	assert.Equal(t, agentic.CategoryLoopCompleted, receivedCategory)
+}
+
+// --- D6: Panic guard in handler ---
+
+func TestSubscriber_PanicGuard_SecondHandlerRunsAfterFirstPanics(t *testing.T) {
+	t.Parallel()
+	runEntityID := "acme.ops.agent.chain.execution.panic-run"
+	run := &agentrun.AgentRun{
+		EntityIDField: runEntityID,
+		PhaseField:    "executing",
+	}
+
+	reader := newFakeTripleReader()
+	pub := &fakePublisher{}
+	mock := newMockLifecycleManager()
+	mock.seed(run)
+
+	var secondHandlerCalled bool
+	sub := agentrun.NewMilestoneSubscriberWithManager(mock, reader, pub, "acme", "ops", nil)
+	sub.AddHandler(&testMilestoneHandler{
+		fn: func(context.Context, agentrun.LoopTerminalEvent, *agentrun.AgentRun, agentrun.TriplePublisher) error {
+			panic("intentional test panic")
+		},
+	})
+	sub.AddHandler(&testMilestoneHandler{
+		fn: func(_ context.Context, _ agentrun.LoopTerminalEvent, _ *agentrun.AgentRun, _ agentrun.TriplePublisher) error {
+			secondHandlerCalled = true
+			return nil
+		},
+	})
+
+	completed := &agentic.LoopCompletedEvent{
+		LoopID:      "non-root-panic-loop",
+		TaskID:      "task-005",
+		Outcome:     agentic.OutcomeSuccess,
+		Role:        "researcher",
+		Result:      "done",
+		Model:       "model-z",
+		CompletedAt: time.Now(),
+		RunID:       "panic-run",
+		RunEntityID: runEntityID,
+	}
+	data := mustMarshalBaseMessage(t, completed.Schema(), completed)
+
+	require.NotPanics(t, func() {
+		err := sub.HandleEvent(context.Background(), data)
+		require.NoError(t, err, "HandleEvent must not propagate panic as error")
+	})
+	assert.True(t, secondHandlerCalled, "second handler must run even when first panics")
+}
+
+// --- D3: Non-run loops (no RunEntityID, no agent.run triple) ---
+
+// TestSubscriber_NonRunLoop_HandlersCalledWithNilRun verifies the exact contract for
+// a standalone loop (not part of any run): resolveRunForEvent returns (nil, nil) →
+// handlers ARE called with run=nil → NO D3 transition fires. This pins the "nil run"
+// handler-call contract so product handlers know to expect nil.
+func TestSubscriber_NonRunLoop_HandlersCalledWithNilRun(t *testing.T) {
+	t.Parallel()
+	// reader has NO agent.run triple for standalone-loop → walk → root has no parent
+	// → Manager.Get for the loop itself returns ErrEntityNotFound → (nil, nil).
+	reader := newFakeTripleReader()
+	pub := &fakePublisher{}
+	mock := newMockLifecycleManager()
+	// mock has NO runs seeded — Manager.Get returns ErrEntityNotFound for any entity.
+
+	var handlerRun *agentrun.AgentRun
+	var handlerCalled bool
+	sub := agentrun.NewMilestoneSubscriberWithManager(mock, reader, pub, "acme", "ops", nil)
+	sub.AddHandler(&testMilestoneHandler{
+		fn: func(_ context.Context, _ agentrun.LoopTerminalEvent, run *agentrun.AgentRun, _ agentrun.TriplePublisher) error {
+			handlerCalled = true
+			handlerRun = run
+			return nil
+		},
+	})
+
+	// Loop with no RunID or RunEntityID and no agent.run triple → non-run loop.
+	completed := &agentic.LoopCompletedEvent{
+		LoopID:      "standalone-loop",
+		TaskID:      "task-006",
+		Outcome:     agentic.OutcomeSuccess,
+		Role:        "researcher",
+		Result:      "done",
+		Model:       "model-z",
+		CompletedAt: time.Now(),
+		// RunID and RunEntityID deliberately empty.
+	}
+	data := mustMarshalBaseMessage(t, completed.Schema(), completed)
+
+	err := sub.HandleEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	// Contract: handlers ARE called with nil run — non-run loops do not produce errors.
+	assert.True(t, handlerCalled, "handlers must be called even for non-run loops (run will be nil)")
+	assert.Nil(t, handlerRun, "run must be nil for a loop with no run association")
+
+	// D3: no transition must have fired — there is no run to transition.
+	assert.Empty(t, mock.transitions, "non-run loop must not trigger any D3 transition")
+}
+
+// --- Helper types ---
+
+// fakeTripleReader implements agentrun.LoopTripleReader for tests.
+type fakeTripleReader struct {
+	triples map[string]map[string]string // entityID → predicate → value
+}
+
+func newFakeTripleReader() *fakeTripleReader {
+	return &fakeTripleReader{triples: make(map[string]map[string]string)}
+}
+
+func (r *fakeTripleReader) set(entityID, predicate, value string) {
+	if r.triples[entityID] == nil {
+		r.triples[entityID] = make(map[string]string)
+	}
+	r.triples[entityID][predicate] = value
+}
+
+func (r *fakeTripleReader) GetLoopRunID(_ context.Context, loopEntityID string) (string, bool, error) {
+	if m, ok := r.triples[loopEntityID]; ok {
+		if v, ok2 := m["agent.run"]; ok2 && v != "" {
+			return v, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+func (r *fakeTripleReader) GetLoopParentEntityID(_ context.Context, loopEntityID string) (string, bool, error) {
+	if m, ok := r.triples[loopEntityID]; ok {
+		if v, ok2 := m["agent.loop.parent"]; ok2 && v != "" {
+			return v, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// fakePublisher implements agentrun.TriplePublisher for tests.
+type fakePublisher struct {
+	calls []message.Triple
+}
+
+func (p *fakePublisher) AddTriple(_ context.Context, _ string, t message.Triple) (uint64, error) {
+	p.calls = append(p.calls, t)
+	return 1, nil
+}
+
+// testMilestoneHandler is a test double for agentrun.MilestoneHandler.
+type testMilestoneHandler struct {
+	fn func(context.Context, agentrun.LoopTerminalEvent, *agentrun.AgentRun, agentrun.TriplePublisher) error
+}
+
+func (h *testMilestoneHandler) OnLoopTerminal(ctx context.Context, ev agentrun.LoopTerminalEvent, run *agentrun.AgentRun, pub agentrun.TriplePublisher) error {
+	return h.fn(ctx, ev, run, pub)
+}
+
+// mustMarshalBaseMessage wraps a payload in the envelope shape HandleEvent.Unmarshal reads.
+func mustMarshalBaseMessage(t *testing.T, schema message.Type, payload any) []byte {
+	t.Helper()
+	payloadBytes, err := json.Marshal(payload)
+	require.NoError(t, err)
+	envelope := map[string]any{
+		"domain":   schema.Domain,
+		"category": schema.Category,
+		"version":  schema.Version,
+		"payload":  json.RawMessage(payloadBytes),
+	}
+	data, err := json.Marshal(envelope)
+	require.NoError(t, err)
+	return data
+}
+
+// --- Static compile-time checks ---
+
+// Ensure mockLifecycleManager satisfies agentrun.MockableManager.
+var _ agentrun.MockableManager = (*mockLifecycleManager)(nil)
+
+// MockableManager defines the subset of lifecycle.Manager that the subscriber
+// uses, so tests can inject a mock without importing the real Manager.
+// (This interface is defined in agentrun package — we verify it here.)
+func init() {
+	// Verify the Participant interface at test compile time.
+	var _ lifecycle.Participant = (*agentrun.AgentRun)(nil)
+	// Verify LoopTripleReader
+	var _ agentrun.LoopTripleReader = (*fakeTripleReader)(nil)
+	// Verify TriplePublisher
+	var _ agentrun.TriplePublisher = (*fakePublisher)(nil)
+	// Verify MilestoneHandler
+	var _ agentrun.MilestoneHandler = (*testMilestoneHandler)(nil)
+}
+
+// Compile-time check: AgentRun satisfies lifecycle.Participant.
+var _ lifecycle.Participant = (*agentrun.AgentRun)(nil)

--- a/agentic/agentrun/nats_reader.go
+++ b/agentic/agentrun/nats_reader.go
@@ -1,0 +1,137 @@
+// Package agentrun — NATS-backed production adapters.
+//
+// NATSLoopTripleReader satisfies LoopTripleReader by reading entity triples
+// directly from the ENTITY_STATES KV bucket via a natsclient.Client.
+//
+// NATSTriplePublisher satisfies TriplePublisher by writing triples through
+// the graph.mutation.triple.add NATS request/response surface (same path as
+// the rule engine's TripleMutator). Neither adapter tracks KV revisions for
+// feedback-loop prevention — they are event-subscriber side effects, not
+// rule-engine transitions.
+//
+// Both adapters are wired in cmd/semstreams and cmd/e2e-semstreams at startup.
+package agentrun
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// natsTripleAddSubject is the NATS request subject for single-triple adds.
+// Must match processor/rule/triple_mutator.go:SubjectTripleAdd.
+const natsTripleAddSubject = "graph.mutation.triple.add"
+
+// natsTripleMutationTimeout is the round-trip budget for triple mutations.
+// Matches the rule engine's MutationTimeout.
+const natsTripleMutationTimeout = 5 * time.Second
+
+// NATSTriplePublisher satisfies agentrun.TriplePublisher via the
+// graph.mutation.triple.add NATS surface. Used by MilestoneSubscriber
+// to stamp milestone triples onto run entities via graph-ingest.
+//
+// The ruleID argument is accepted to satisfy the interface but is NOT
+// forwarded — milestone writes are not rule-engine transitions and need
+// no feedback-loop revision tracking.
+type NATSTriplePublisher struct {
+	client *natsclient.Client
+}
+
+// NewNATSTriplePublisher builds a TriplePublisher backed by the shared
+// graph.mutation.triple.add NATS surface.
+func NewNATSTriplePublisher(client *natsclient.Client) *NATSTriplePublisher {
+	return &NATSTriplePublisher{client: client}
+}
+
+// AddTriple writes a triple through graph-ingest and returns the KV revision.
+func (p *NATSTriplePublisher) AddTriple(ctx context.Context, _ string, triple message.Triple) (uint64, error) {
+	req := graph.AddTripleRequest{Triple: triple}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return 0, fmt.Errorf("agentrun: NATSTriplePublisher: marshal: %w", err)
+	}
+	respData, err := p.client.RequestWithRetry(ctx, natsTripleAddSubject, reqData, natsTripleMutationTimeout, natsclient.DefaultRetryConfig())
+	if err != nil {
+		return 0, fmt.Errorf("agentrun: NATSTriplePublisher: NATS request: %w", err)
+	}
+	var resp graph.AddTripleResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return 0, fmt.Errorf("agentrun: NATSTriplePublisher: unmarshal response: %w", err)
+	}
+	if !resp.Success {
+		return 0, fmt.Errorf("agentrun: NATSTriplePublisher: mutation failed: %s", resp.Error)
+	}
+	return resp.KVRevision, nil
+}
+
+// NATSLoopTripleReader implements LoopTripleReader backed by the ENTITY_STATES
+// KV bucket. Reads are lazy-bucket: the bucket is opened on first use and
+// cached for subsequent calls.
+//
+// Satisfies the LoopTripleReader interface required by ResolveRun and
+// MilestoneSubscriber.
+type NATSLoopTripleReader struct {
+	client *natsclient.Client
+}
+
+// NewNATSLoopTripleReader constructs a LoopTripleReader backed by a natsclient.
+// The client must be connected; the ENTITY_STATES bucket is opened lazily on
+// first read.
+func NewNATSLoopTripleReader(client *natsclient.Client) *NATSLoopTripleReader {
+	return &NATSLoopTripleReader{client: client}
+}
+
+// GetLoopRunID reads the agent.run triple from the given loop entity ID.
+// Returns ("", false, nil) when the triple is absent (not an error).
+// Returns ("", false, err) on NATS or decode failures.
+func (r *NATSLoopTripleReader) GetLoopRunID(ctx context.Context, loopEntityID string) (string, bool, error) {
+	return r.getStringTriple(ctx, loopEntityID, agvocab.LoopRun)
+}
+
+// GetLoopParentEntityID reads the agent.loop.parent triple from the given
+// loop entity ID. Returns ("", false, nil) when absent.
+func (r *NATSLoopTripleReader) GetLoopParentEntityID(ctx context.Context, loopEntityID string) (string, bool, error) {
+	return r.getStringTriple(ctx, loopEntityID, agvocab.LoopParent)
+}
+
+// getStringTriple is the shared read path for both triple-reading methods.
+// It opens the ENTITY_STATES bucket, fetches the entity JSON, and extracts
+// the named predicate's value as a string.
+func (r *NATSLoopTripleReader) getStringTriple(ctx context.Context, entityID, predicate string) (string, bool, error) {
+	bucket, err := r.client.GetKeyValueBucket(ctx, graph.BucketEntityStates)
+	if err != nil {
+		return "", false, fmt.Errorf("agentrun: NATSLoopTripleReader: open bucket: %w", err)
+	}
+
+	entry, err := bucket.Get(ctx, entityID)
+	if err != nil {
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			// Entity not yet in graph — triple is absent.
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("agentrun: NATSLoopTripleReader: KV get %q: %w", entityID, err)
+	}
+
+	var state graph.EntityState
+	if err := json.Unmarshal(entry.Value(), &state); err != nil {
+		return "", false, fmt.Errorf("agentrun: NATSLoopTripleReader: unmarshal entity %q: %w", entityID, err)
+	}
+
+	val, ok := state.GetPropertyValue(predicate)
+	if !ok {
+		return "", false, nil
+	}
+	s, ok := val.(string)
+	if !ok {
+		return "", false, fmt.Errorf("agentrun: NATSLoopTripleReader: predicate %q on entity %q has non-string value %T", predicate, entityID, val)
+	}
+	return s, true, nil
+}

--- a/agentic/entity_ids.go
+++ b/agentic/entity_ids.go
@@ -136,24 +136,44 @@ func TrajectoryStepEntityID(org, platform, loopID string, stepIndex int) string 
 //
 // Panics if any input part is empty or contains a dot, as these represent
 // programming errors — the caller is responsible for supplying well-formed identifiers.
+//
+// Runtime callers where a panic would silently crash a goroutine (event-
+// construction in publish goroutines, tool executors) should use
+// TryChainExecutionEntityID instead and surface the error explicitly.
 func ChainExecutionEntityID(org, platform, chainID string) string {
-	if err := validatePart("org", org); err != nil {
+	id, err := TryChainExecutionEntityID(org, platform, chainID)
+	if err != nil {
 		panic(fmt.Sprintf("ChainExecutionEntityID: %s", err))
+	}
+	return id
+}
+
+// TryChainExecutionEntityID is the error-returning variant of
+// ChainExecutionEntityID. Use this from runtime hot paths (event-
+// construction in publish goroutines, milestone subscribers) where a
+// panic would silently crash the goroutine. Boot-time and post-completion
+// callers that own their inputs can keep using the panicking form.
+//
+// Returns ("", error) when any input part is empty or contains a dot,
+// or when the constructed ID fails IsValidEntityID.
+func TryChainExecutionEntityID(org, platform, chainID string) (string, error) {
+	if err := validatePart("org", org); err != nil {
+		return "", fmt.Errorf("ChainExecutionEntityID: %w", err)
 	}
 	if err := validatePart("platform", platform); err != nil {
-		panic(fmt.Sprintf("ChainExecutionEntityID: %s", err))
+		return "", fmt.Errorf("ChainExecutionEntityID: %w", err)
 	}
 	if err := validatePart("chainID", chainID); err != nil {
-		panic(fmt.Sprintf("ChainExecutionEntityID: %s", err))
+		return "", fmt.Errorf("ChainExecutionEntityID: %w", err)
 	}
 
 	id := fmt.Sprintf("%s.%s.agent.chain.execution.%s", org, platform, chainID)
 
 	if !message.IsValidEntityID(id) {
-		panic(fmt.Sprintf("ChainExecutionEntityID: constructed id %q failed IsValidEntityID — check input values", id))
+		return "", fmt.Errorf("ChainExecutionEntityID: constructed id %q failed IsValidEntityID — check input values", id)
 	}
 
-	return id
+	return id, nil
 }
 
 // LoopIDFromExecutionEntityID extracts the loop_id segment from a 6-part

--- a/agentic/events.go
+++ b/agentic/events.go
@@ -20,6 +20,12 @@ type LoopCreatedEvent struct {
 	MaxIterations    int            `json:"max_iterations"`
 	CreatedAt        time.Time      `json:"created_at"`
 	Metadata         map[string]any `json:"metadata,omitempty"`
+	// RunID is the bare run loop-id this loop belongs to (ADR-053 D8).
+	// Empty when the loop is not part of a run.
+	RunID string `json:"run_id,omitempty"`
+	// RunEntityID is the full 6-part chain execution entity ID for the run
+	// (e.g. "org.platform.agent.chain.execution.<runID>"). Empty when RunID is empty.
+	RunEntityID string `json:"run_entity_id,omitempty"`
 }
 
 // Validate implements message.Payload
@@ -71,6 +77,12 @@ type LoopCompletedEvent struct {
 	ChannelID   string         `json:"channel_id,omitempty"`
 	UserID      string         `json:"user_id,omitempty"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
+	// RunID is the bare run loop-id this loop belongs to (ADR-053 D8).
+	// Empty when the loop is not part of a run.
+	RunID string `json:"run_id,omitempty"`
+	// RunEntityID is the full 6-part chain execution entity ID for the run.
+	// Empty when RunID is empty.
+	RunEntityID string `json:"run_entity_id,omitempty"`
 }
 
 // Validate implements message.Payload
@@ -132,6 +144,12 @@ type LoopFailedEvent struct {
 	ChannelID   string         `json:"channel_id,omitempty"`
 	UserID      string         `json:"user_id,omitempty"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
+	// RunID is the bare run loop-id this loop belongs to (ADR-053 D8).
+	// Empty when the loop is not part of a run.
+	RunID string `json:"run_id,omitempty"`
+	// RunEntityID is the full 6-part chain execution entity ID for the run.
+	// Empty when RunID is empty.
+	RunEntityID string `json:"run_entity_id,omitempty"`
 }
 
 // Validate implements message.Payload
@@ -164,14 +182,24 @@ func (e *LoopFailedEvent) UnmarshalJSON(data []byte) error {
 
 // LoopCancelledEvent is published when a loop is cancelled by user action.
 type LoopCancelledEvent struct {
-	LoopID       string         `json:"loop_id"`
-	TaskID       string         `json:"task_id"`
-	Outcome      string         `json:"outcome"` // OutcomeCancelled
-	CancelledBy  string         `json:"cancelled_by"`
+	LoopID      string `json:"loop_id"`
+	TaskID      string `json:"task_id"`
+	Outcome     string `json:"outcome"` // OutcomeCancelled
+	CancelledBy string `json:"cancelled_by"`
+	// ParentLoopID enables ancestry walks from cancelled loops (parity with
+	// LoopFailedEvent.ParentLoopID). Populated from LoopEntity.ParentLoopID
+	// at cancellation construction time (ADR-053 D8).
+	ParentLoopID string         `json:"parent_loop,omitempty"`
 	WorkflowSlug string         `json:"workflow_slug,omitempty"`
 	WorkflowStep string         `json:"workflow_step,omitempty"`
 	CancelledAt  time.Time      `json:"cancelled_at"`
 	Metadata     map[string]any `json:"metadata,omitempty"`
+	// RunID is the bare run loop-id this loop belongs to (ADR-053 D8).
+	// Empty when the loop is not part of a run.
+	RunID string `json:"run_id,omitempty"`
+	// RunEntityID is the full 6-part chain execution entity ID for the run.
+	// Empty when RunID is empty.
+	RunEntityID string `json:"run_entity_id,omitempty"`
 }
 
 // Validate implements message.Payload

--- a/agentic/run_id_test.go
+++ b/agentic/run_id_test.go
@@ -1,0 +1,327 @@
+package agentic_test
+
+// ADR-053 Pass A — RunID plumbing tests.
+// Covers:
+//  1. TaskMessage RunID JSON round-trip (field present with omitempty).
+//  2. LoopEntity RunID JSON round-trip.
+//  3. All four loop events (Created/Completed/Failed/Cancelled) marshal and
+//     unmarshal RunID + RunEntityID through the production wire (BaseMessage +
+//     registered decoder) per feedback_production_decoder_round_trip_required
+//     and feedback_polymorphic_config_needs_json_roundtrip_test.
+//  4. LoopCancelledEvent ParentLoopID parity with LoopFailedEvent.
+//  5. omitempty discipline — empty RunID must not appear in serialised JSON.
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadbuiltins"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRunIDTestDecoder builds a production decoder from the full builtin registry,
+// satisfying the feedback_production_decoder_round_trip_required discipline.
+func newRunIDTestDecoder(t *testing.T) *message.Decoder {
+	t.Helper()
+	return payloadbuiltins.NewTestDecoder(t)
+}
+
+// --- TaskMessage RunID ---
+
+func TestTaskMessage_RunID_RoundTrip(t *testing.T) {
+	t.Parallel()
+	task := agentic.TaskMessage{
+		TaskID: "task-001",
+		Role:   "coordinator",
+		Model:  "model-a",
+		Prompt: "run the research arc",
+		RunID:  "root-loop-uuid",
+	}
+	data, err := json.Marshal(&task)
+	require.NoError(t, err)
+
+	var got agentic.TaskMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "root-loop-uuid", got.RunID)
+}
+
+func TestTaskMessage_RunID_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	task := agentic.TaskMessage{
+		TaskID: "task-002",
+		Role:   "researcher",
+		Model:  "model-b",
+		Prompt: "investigate X",
+		// RunID deliberately empty
+	}
+	data, err := json.Marshal(&task)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"run_id"`,
+		"empty RunID must be omitted from JSON (omitempty)")
+}
+
+func TestTaskMessage_RunID_PreservesOtherFields(t *testing.T) {
+	t.Parallel()
+	task := agentic.TaskMessage{
+		TaskID:       "task-003",
+		Role:         "architect",
+		Model:        "model-c",
+		Prompt:       "design the system",
+		ParentLoopID: "parent-loop-uuid",
+		RunID:        "run-anchor-uuid",
+	}
+	data, err := json.Marshal(&task)
+	require.NoError(t, err)
+
+	var got agentic.TaskMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "parent-loop-uuid", got.ParentLoopID)
+	assert.Equal(t, "run-anchor-uuid", got.RunID)
+}
+
+// --- LoopEntity RunID ---
+
+func TestLoopEntity_RunID_RoundTrip(t *testing.T) {
+	t.Parallel()
+	entity := agentic.LoopEntity{
+		ID:            "loop-123",
+		TaskID:        "task-001",
+		State:         agentic.LoopStateExploring,
+		Role:          "coordinator",
+		Model:         "model-a",
+		MaxIterations: 10,
+		ParentLoopID:  "parent-loop-uuid",
+		RunID:         "root-loop-uuid",
+	}
+	data, err := json.Marshal(&entity)
+	require.NoError(t, err)
+
+	var got agentic.LoopEntity
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "root-loop-uuid", got.RunID)
+	assert.Equal(t, "parent-loop-uuid", got.ParentLoopID)
+}
+
+func TestLoopEntity_RunID_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	entity := agentic.LoopEntity{
+		ID:            "loop-124",
+		TaskID:        "task-002",
+		State:         agentic.LoopStateExploring,
+		Role:          "researcher",
+		Model:         "model-b",
+		MaxIterations: 5,
+		// RunID deliberately empty
+	}
+	data, err := json.Marshal(&entity)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"run_id"`,
+		"empty RunID must be omitted from JSON (omitempty)")
+}
+
+// --- LoopCreatedEvent RunID+RunEntityID production wire round-trip ---
+
+func TestLoopCreatedEvent_RunID_ProductionWireRoundTrip(t *testing.T) {
+	t.Parallel()
+	ev := &agentic.LoopCreatedEvent{
+		LoopID:        "loop-created-001",
+		TaskID:        "task-001",
+		Role:          "coordinator",
+		Model:         "model-x",
+		MaxIterations: 20,
+		CreatedAt:     time.Now().UTC().Truncate(time.Second),
+		RunID:         "root-loop-uuid",
+		RunEntityID:   "acme.ops.agent.chain.execution.root-loop-uuid",
+	}
+	baseMsg := message.NewBaseMessage(ev.Schema(), ev, "test")
+	data, err := json.Marshal(baseMsg)
+	require.NoError(t, err)
+
+	decoded, err := newRunIDTestDecoder(t).Decode(data)
+	require.NoError(t, err)
+	got, ok := decoded.Payload().(*agentic.LoopCreatedEvent)
+	require.True(t, ok, "expected *agentic.LoopCreatedEvent payload, got %T", decoded.Payload())
+	assert.Equal(t, "root-loop-uuid", got.RunID)
+	assert.Equal(t, "acme.ops.agent.chain.execution.root-loop-uuid", got.RunEntityID)
+	assert.Equal(t, "loop-created-001", got.LoopID)
+}
+
+func TestLoopCreatedEvent_RunID_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	ev := &agentic.LoopCreatedEvent{
+		LoopID:        "loop-created-002",
+		TaskID:        "task-002",
+		Role:          "researcher",
+		Model:         "model-x",
+		MaxIterations: 10,
+		CreatedAt:     time.Now().UTC(),
+		// RunID empty
+	}
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"run_id"`)
+	assert.NotContains(t, string(data), `"run_entity_id"`)
+}
+
+// --- LoopCompletedEvent RunID+RunEntityID production wire round-trip ---
+
+func TestLoopCompletedEvent_RunID_ProductionWireRoundTrip(t *testing.T) {
+	t.Parallel()
+	ev := &agentic.LoopCompletedEvent{
+		LoopID:      "loop-completed-001",
+		TaskID:      "task-001",
+		Outcome:     agentic.OutcomeSuccess,
+		Role:        "coordinator",
+		Result:      "done",
+		Model:       "model-x",
+		CompletedAt: time.Now().UTC().Truncate(time.Second),
+		RunID:       "root-loop-uuid",
+		RunEntityID: "acme.ops.agent.chain.execution.root-loop-uuid",
+	}
+	baseMsg := message.NewBaseMessage(ev.Schema(), ev, "test")
+	data, err := json.Marshal(baseMsg)
+	require.NoError(t, err)
+
+	decoded, err := newRunIDTestDecoder(t).Decode(data)
+	require.NoError(t, err)
+	got, ok := decoded.Payload().(*agentic.LoopCompletedEvent)
+	require.True(t, ok, "expected *agentic.LoopCompletedEvent payload, got %T", decoded.Payload())
+	assert.Equal(t, "root-loop-uuid", got.RunID)
+	assert.Equal(t, "acme.ops.agent.chain.execution.root-loop-uuid", got.RunEntityID)
+}
+
+func TestLoopCompletedEvent_RunID_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	ev := &agentic.LoopCompletedEvent{
+		LoopID:      "loop-completed-002",
+		TaskID:      "task-002",
+		Outcome:     agentic.OutcomeSuccess,
+		Role:        "researcher",
+		Result:      "done",
+		Model:       "model-x",
+		CompletedAt: time.Now().UTC(),
+	}
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"run_id"`)
+	assert.NotContains(t, string(data), `"run_entity_id"`)
+}
+
+// --- LoopFailedEvent RunID+RunEntityID production wire round-trip ---
+
+func TestLoopFailedEvent_RunID_ProductionWireRoundTrip(t *testing.T) {
+	t.Parallel()
+	ev := &agentic.LoopFailedEvent{
+		LoopID:      "loop-failed-001",
+		TaskID:      "task-001",
+		Outcome:     agentic.OutcomeFailed,
+		Reason:      "context exhausted",
+		Error:       "max iterations",
+		Role:        "researcher",
+		Model:       "model-x",
+		FailedAt:    time.Now().UTC().Truncate(time.Second),
+		RunID:       "root-loop-uuid",
+		RunEntityID: "acme.ops.agent.chain.execution.root-loop-uuid",
+	}
+	baseMsg := message.NewBaseMessage(ev.Schema(), ev, "test")
+	data, err := json.Marshal(baseMsg)
+	require.NoError(t, err)
+
+	decoded, err := newRunIDTestDecoder(t).Decode(data)
+	require.NoError(t, err)
+	got, ok := decoded.Payload().(*agentic.LoopFailedEvent)
+	require.True(t, ok, "expected *agentic.LoopFailedEvent payload, got %T", decoded.Payload())
+	assert.Equal(t, "root-loop-uuid", got.RunID)
+	assert.Equal(t, "acme.ops.agent.chain.execution.root-loop-uuid", got.RunEntityID)
+}
+
+func TestLoopFailedEvent_RunID_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	ev := &agentic.LoopFailedEvent{
+		LoopID:   "loop-failed-002",
+		TaskID:   "task-002",
+		Outcome:  agentic.OutcomeFailed,
+		Reason:   "timeout",
+		Error:    "deadline exceeded",
+		Role:     "researcher",
+		Model:    "model-x",
+		FailedAt: time.Now().UTC(),
+	}
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"run_id"`)
+	assert.NotContains(t, string(data), `"run_entity_id"`)
+}
+
+// --- LoopCancelledEvent RunID+RunEntityID+ParentLoopID production wire round-trip ---
+
+func TestLoopCancelledEvent_RunID_ProductionWireRoundTrip(t *testing.T) {
+	t.Parallel()
+	ev := &agentic.LoopCancelledEvent{
+		LoopID:       "loop-cancelled-001",
+		TaskID:       "task-001",
+		Outcome:      agentic.OutcomeCancelled,
+		CancelledBy:  "user-xyz",
+		ParentLoopID: "parent-loop-uuid",
+		CancelledAt:  time.Now().UTC().Truncate(time.Second),
+		RunID:        "root-loop-uuid",
+		RunEntityID:  "acme.ops.agent.chain.execution.root-loop-uuid",
+	}
+	baseMsg := message.NewBaseMessage(ev.Schema(), ev, "test")
+	data, err := json.Marshal(baseMsg)
+	require.NoError(t, err)
+
+	decoded, err := newRunIDTestDecoder(t).Decode(data)
+	require.NoError(t, err)
+	got, ok := decoded.Payload().(*agentic.LoopCancelledEvent)
+	require.True(t, ok, "expected *agentic.LoopCancelledEvent payload, got %T", decoded.Payload())
+	assert.Equal(t, "root-loop-uuid", got.RunID)
+	assert.Equal(t, "acme.ops.agent.chain.execution.root-loop-uuid", got.RunEntityID)
+	assert.Equal(t, "parent-loop-uuid", got.ParentLoopID,
+		"LoopCancelledEvent.ParentLoopID must round-trip (parity with LoopFailedEvent)")
+}
+
+func TestLoopCancelledEvent_ParentLoopID_JSONTagMatchesFailedEvent(t *testing.T) {
+	t.Parallel()
+	// Verify JSON tag is "parent_loop" (matching LoopFailedEvent, not "parent_loop_id").
+	// This pins the wire shape so a future refactor doesn't silently change it.
+	ev := &agentic.LoopCancelledEvent{
+		LoopID:       "loop-cancelled-tag",
+		TaskID:       "task-tag",
+		Outcome:      agentic.OutcomeCancelled,
+		CancelledBy:  "user",
+		ParentLoopID: "parent-loop-abc",
+		CancelledAt:  time.Now().UTC(),
+	}
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(data, &m))
+	_, hasParentLoop := m["parent_loop"]
+	_, hasParentLoopID := m["parent_loop_id"]
+	assert.True(t, hasParentLoop,
+		`LoopCancelledEvent.ParentLoopID must serialise as "parent_loop" (matching LoopFailedEvent wire tag)`)
+	assert.False(t, hasParentLoopID,
+		`LoopCancelledEvent.ParentLoopID must NOT serialise as "parent_loop_id"`)
+}
+
+func TestLoopCancelledEvent_RunID_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	ev := &agentic.LoopCancelledEvent{
+		LoopID:      "loop-cancelled-002",
+		TaskID:      "task-002",
+		Outcome:     agentic.OutcomeCancelled,
+		CancelledBy: "user",
+		CancelledAt: time.Now().UTC(),
+	}
+	data, err := json.Marshal(ev)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"run_id"`)
+	assert.NotContains(t, string(data), `"run_entity_id"`)
+	assert.NotContains(t, string(data), `"parent_loop"`)
+}

--- a/agentic/state.go
+++ b/agentic/state.go
@@ -55,6 +55,9 @@ type LoopEntity struct {
 	StartedAt          time.Time             `json:"started_at,omitempty"`           // When the loop was created
 	TimeoutAt          time.Time             `json:"timeout_at,omitempty"`           // When the loop should timeout
 	ParentLoopID       string                `json:"parent_loop_id,omitempty"`       // Parent loop ID for architect->editor relationship
+	// RunID is the 6-part-derived run anchor; the run loop-id this loop belongs to.
+	// Empty for loops not in a run. Inherited at spawn (ADR-053 D7).
+	RunID string `json:"run_id,omitempty"`
 
 	// Multi-agent depth tracking
 	Depth    int `json:"depth,omitempty"`     // Current depth in agent tree (0 = root)

--- a/agentic/user_types.go
+++ b/agentic/user_types.go
@@ -260,8 +260,11 @@ type TaskMessage struct {
 
 	// Multi-agent hierarchy (optional, for parallel/nested agents)
 	ParentLoopID string `json:"parent_loop_id,omitempty"` // Parent loop ID for nested agents
-	Depth        int    `json:"depth,omitempty"`          // Current depth in agent tree (0 = root)
-	MaxDepth     int    `json:"max_depth,omitempty"`      // Maximum allowed depth
+	// RunID is the 6-part-derived run anchor: the run loop-id this loop belongs to.
+	// Empty for loops not in a run. Inherited at spawn (ADR-053 D7).
+	RunID    string `json:"run_id,omitempty"`
+	Depth    int    `json:"depth,omitempty"`     // Current depth in agent tree (0 = root)
+	MaxDepth int    `json:"max_depth,omitempty"` // Maximum allowed depth
 
 	// Pre-constructed context (optional, skips discovery if present)
 	// When set, the agent loop uses this context directly instead of hydrating

--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/c360studio/semstreams/agentic/agentrun"
 	"github.com/c360studio/semstreams/cmd/e2e-semstreams/mission"
 	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/componentregistry"
@@ -153,6 +154,25 @@ func run() error {
 		return err
 	}
 
+	// Start the agent-run milestone subscriber (ADR-053 D6). Mirrors
+	// cmd/semstreams wiring. No product handlers registered in e2e binary;
+	// D3 zombie-prevention still applies.
+	milestoneSubscriber := agentrun.NewMilestoneSubscriber(
+		svcDeps.LifecycleManager,
+		agentrun.NewNATSLoopTripleReader(natsClient),
+		agentrun.NewNATSTriplePublisher(natsClient),
+		platform.Org,
+		platform.Platform,
+		logger,
+	)
+	stopMilestoneSubscriber, err := milestoneSubscriber.Start(ctx, natsClient, agentrun.StartConfig{
+		StreamName: agentrun.AgentStreamName,
+	})
+	if err != nil {
+		return fmt.Errorf("start agent-run milestone subscriber: %w", err)
+	}
+	defer stopMilestoneSubscriber()
+
 	if err := configureAndCreateServices(cfg, manager, svcDeps); err != nil {
 		return err
 	}
@@ -204,6 +224,10 @@ func wireLifecycleManager(_ context.Context, svcDeps *service.Dependencies, _ *n
 	svcDeps.LifecycleManager = lifecycle.NewManager(svcDeps.NATSClient, svcDeps.Logger)
 	if err := svcDeps.LifecycleManager.Register(mission.WorkflowDeclaration()); err != nil {
 		return fmt.Errorf("register mission workflow: %w", err)
+	}
+	// Register the agent-run workflow (ADR-053 D2). Mirrors cmd/semstreams wiring.
+	if err := agentrun.Register(svcDeps.LifecycleManager); err != nil {
+		return fmt.Errorf("register agent-run workflow: %w", err)
 	}
 	return nil
 }

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/c360studio/semstreams/agentic/agentrun"
 	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/componentregistry"
 	"github.com/c360studio/semstreams/config"
@@ -182,6 +183,37 @@ func run() error {
 	// [[feedback_verify_main_go_wire_for_sister_asks]] —
 	// half-migrated framework binaries silently break workflows.
 	svcDeps.LifecycleManager = lifecycle.NewManager(natsClient, logger)
+
+	// 10c. Register the agent-run workflow (ADR-053 D2). Must come after
+	// the Manager is constructed so lifecycle_* actions that reference
+	// "agent-run" entities resolve at rule-evaluation time, not at boot.
+	// The framework binary registers no product-level handlers — product
+	// code (semteams, etc.) adds MilestoneHandlers via AddHandler.
+	if err := agentrun.Register(svcDeps.LifecycleManager); err != nil {
+		return fmt.Errorf("register agent-run workflow: %w", err)
+	}
+
+	// 10d. Start the agent-run milestone subscriber (ADR-053 D6).
+	// Subscribes to agent.complete.* and agent.failed.*, pre-resolves
+	// the run, applies zombie-prevention terminal authority (D3), and
+	// fans out to registered product handlers. No product handlers
+	// registered in the framework binary; the subscriber still enforces
+	// D3 (zombie prevention) for runs minted by run_scope=new rules.
+	milestoneSubscriber := agentrun.NewMilestoneSubscriber(
+		svcDeps.LifecycleManager,
+		agentrun.NewNATSLoopTripleReader(natsClient),
+		agentrun.NewNATSTriplePublisher(natsClient),
+		platform.Org,
+		platform.Platform,
+		logger,
+	)
+	stopMilestoneSubscriber, err := milestoneSubscriber.Start(ctx, natsClient, agentrun.StartConfig{
+		StreamName: agentrun.AgentStreamName,
+	})
+	if err != nil {
+		return fmt.Errorf("start agent-run milestone subscriber: %w", err)
+	}
+	defer stopMilestoneSubscriber()
 
 	// 11. Configure and create services
 	if err := configureAndCreateServices(cfg, manager, svcDeps); err != nil {

--- a/docs/adr/053-agent-run-substrate.md
+++ b/docs/adr/053-agent-run-substrate.md
@@ -1,0 +1,286 @@
+# ADR-053: Agent-Run Substrate — Nested Agentic Loops as a Lifecycle `Participant`
+
+## Status
+
+**Proposed** — 2026-06-07. Not yet implemented or tagged. Derived from
+[docs/proposals/agent-run-substrate.md](../proposals/agent-run-substrate.md)
+(full design exercise + two adversarial reviews: architect + Codex, both
+RIGHT-WITH-CHANGES, thesis accepted). Builds on
+[ADR-047](047-lifecycle-harness-substrate.md) (Lifecycle harness) and
+[ADR-049](049-lifecycle-harness-prime-schema-over-entity-states.md) (schema over
+ENTITY_STATES). Lifts the reference design from semteams ADR-038 (chain entity).
+Companion memory: `project_agent_run_chain_framework_gap`.
+
+This ADR is **additive** to the rule engine and agentic types; the only breaking
+surface is the **semteams rule-pack migration** (a downstream consumer change,
+lockstep with the framework tag — see Consequences).
+
+## Context
+
+### The gap
+
+A coordinator agentic loop that spawns research/architect/builder child loops
+forms a **run**: a tree of nested loops spanning multiple arcs, accumulating
+cross-arc state (e.g. `autoresearch.best.value`, research/spec/build artifacts).
+The framework models the loop *tree* (`LoopEntity.ParentLoopID`, `agent.loop.parent`
+stamped at spawn by `WriteSpawnIdentity`, `processor/agentic-loop/graph_writer.go:451`)
+but has **no first-class entity for the run itself** — only an unused
+`ChainExecutionEntityID` constructor (`agentic/entity_ids.go:139`). Every
+consumer re-derives run identity.
+
+semteams (our reference-design product) hand-rolls the entire run layer (~600
+LOC of `cmd/semteams/chain/*`): ancestry-walk resolution, a string-keyed lineage
+escape hatch, a completion-event demux, and milestone stampers. The symptom that
+opened this thread was semteams #225 asking for the run's 6-part entity ID on the
+wire — a request the framework couldn't satisfy because it doesn't own the run.
+
+### Two run-identity mechanisms in the reference design (load-bearing)
+
+semteams carries two, side by side:
+
+1. **Ancestry-walk chain (ADR-038):** `chain_id` = dispatch-root loop UUID, found
+   by walking `agent.loop.parent` (`chain/resolver.go:97`).
+2. **`run-loop-entity-id` lineage thread:** pinned in `related_loops` at the root
+   and re-threaded through every spawn rule, read as
+   `$entity.triple.lineage.run-loop-entity-id` (autoresearch `01:48`, `04c:26`;
+   sibling `lineage.plan-loop-entity-id` for the gather-join, research `03a`).
+
+Mechanism #2 exists to dodge the gh#159 completion-time race — **which the
+framework has already closed**: `WriteSpawnIdentity` now stamps `agent.loop.parent`
+atomically *at spawn* (`graph_writer.go:451`, godoc cites the fix). #2 is thus
+partly vestigial. A typed `run_id` set at spawn collapses both mechanisms plus
+the read-side walk.
+
+### What this is not
+
+- Not a new substrate parallel to the Lifecycle harness — the run REUSES it.
+- Not a change to the agentic *loop* model — loops stay in `AGENT_LOOPS` (their
+  per-iteration LLM-judgment lifecycle, high write rate), excluded from
+  `Participant` exactly as ADR-047 decided.
+- Not a milestone-vocabulary owner — milestone predicates stay product-domain.
+- Not a workflow engine, event bus, or markdown renderer.
+
+### Why a `Participant`, and why now
+
+ADR-047 excluded the agentic *loop* from `Participant` ("per-iteration model
+judgment, dynamic trajectory… doesn't fit the declared-transitions-table") but
+explicitly anticipated this case: *"a future agentic role with declared phases
+could implement `Participant` if the fit emerges."* The **run** is a different
+entity from the loop: its lifecycle is a small *declarable* state machine
+(`dispatched → executing ⇄ awaiting_approval → terminal`); the dynamism (which
+arc spawns next, retries) happens *inside* the `executing` phase, not as run-level
+phase churn. The fit has emerged.
+
+The `Manager` surface (`pkg/lifecycle`, post-ADR-049) is a superset of what a run
+needs: `Create`=mint, `Get`/`LookupByEntityID`=resolve, `Transition`/`Complete`/
+`Fail`=lifecycle, `List`/`Watch`/`History`=operator view + KV-revision audit,
+`Children`=tree, `UpdateFromOperator`=operator patches, plus restart recovery,
+the operator gateway (`GET /workflows`), rule integration (`lifecycle_*` actions
++ `$entity.lifecycle.*`), and ENTITY_STATES storage (`manager.go:182`). Building a
+parallel substrate would re-implement all of it.
+
+## Decision
+
+Model the run as a Lifecycle `Participant` (`workflow="agent-run"`), reusing the
+harness wholesale. Add a thin agentic adapter for the parts the harness doesn't
+provide. Eight decisions:
+
+### D1 — `AgentRun` Participant with a full-EntityID identity field
+
+```go
+type AgentRun struct {
+    EntityID_         string `json:"-" lifecycle:"id"` // FULL 6-part: ...agent.chain.execution.<loopID>
+    Phase_            string `json:"phase"`
+    ParentRunEntityID string `json:"parent_run_entity_id,omitempty"`
+}
+func (r *AgentRun) EntityID() string       { return r.EntityID_ }
+func (r *AgentRun) Workflow() string       { return "agent-run" }
+func (r *AgentRun) Phase() string          { return r.Phase_ }
+func (r *AgentRun) ParentEntityID() string { return r.ParentRunEntityID }
+func (r *AgentRun) RunID() (string, bool)  { return runIDFromChainEntityID(r.EntityID_) } // chain entity parser, not LoopIDFromExecutionEntityID
+```
+
+The `lifecycle:"id"` field MUST hold the **full** entity ID. `projection.go`
+populates it from the entity-state KEY, not a triple; a bare `RunID` tagged
+`lifecycle:"id"` would round-trip to the full dotted ID and then panic/garble
+when recomposed through `ChainExecutionEntityID` (which rejects dots). The bare
+run loop-id is **derived**.
+
+### D2 — Registered via the ADR-049 `Register(Workflow)` API
+
+```go
+mgr.Register(lifecycle.Workflow{
+    Name:    "agent-run",
+    Factory: func() lifecycle.Participant { return &AgentRun{} },
+    Transitions: lifecycle.Transitions{
+        "dispatched":        {"executing", "failed", "cancelled"},
+        "executing":         {"awaiting_approval", "completed", "failed", "cancelled"},
+        "awaiting_approval": {"executing", "cancelled"},
+        "completed": {}, "failed": {}, "cancelled": {},
+    },
+    AuditPredicates: lifecycle.AuditSpec{ /* created-at/source/note — free */ },
+})
+```
+
+Milestones are NOT projected `Participant` fields (D5). The run gets the full
+Manager/recovery/gateway/rule-integration surface for the **phase** dimension.
+`Children` is parent→child via a declared link predicate; the loop subtree
+(child→parent `agent.loop.parent`) is **not** free — resolve it via the lifted
+fallback walk (D6) when needed.
+
+### D3 — Terminal authority: framework creates + observes; product decides terminal
+
+- The **framework CREATES** (mint, D4) and **OBSERVES** (subscriber, D7). It does
+  **not** infer run completion from child-loop events.
+- The **product/coordinator EMITS the terminal run decision** (it is the
+  orchestrator that knows when the run is done) by firing a `lifecycle_transition`
+  rule action to `completed`/`failed`/`cancelled`. ADR-028-consistent.
+- **Narrow framework fallback:** if the dispatch-ROOT loop terminates
+  (fail/cancel) *before any child handoff* (run still `dispatched`, no children),
+  the subscriber transitions it to `failed`/`cancelled` to prevent a zombie. This
+  is the ONLY framework-initiated terminal transition.
+- The adapter calls `Transition` with the **explicit** terminal — **never
+  `Manager.Complete`** (with `executing`→3 terminals it picks `reachable[0]`
+  non-deterministically, `manager.go:671`).
+
+### D4 — Mint is a declared rule-action field, not convention
+
+Add to the rule `Action` struct (`processor/rule/actions.go`):
+
+```go
+RunScope string `json:"run_scope,omitempty"` // "new" | "inherit" | "none"
+```
+
+- `new` → mint a run (`Manager.Create(&AgentRun{EntityID_: ChainExecutionEntityID(org,plat,rootLoopID), Phase_: "dispatched"})`), idempotent, at **creation**.
+- `inherit` → propagate the firing loop's `RunID` (normal in-run child spawn).
+- `none`/empty → no run association.
+
+Validated in `Action.Validate()`. Default: `inherit` when the firing entity has a
+run, else `none` — so child spawns are free and only the coordinator's dispatch
+declares `new`. Auto-minting every parentless loop is rejected (would mint a run
+per CLI-chat/HTTP loop, `agentic-dispatch/http.go:301`).
+
+### D5 — Milestones: two write paths + a cardinality contract
+
+Run **phase** → `Manager.Transition` (low-write, CAS, transition-guarded). Run
+**milestones** → product triples on the run entity via the **graph-ingest path**
+(`AddTriple`, last-writer-wins per predicate, no CAS) — NOT `Manager`:
+
+- `UpdateFromOperator` is operator-authority gated, default-deny
+  (`manager_query.go:451`); routing derived milestone data through it makes them
+  operator-patchable and forces product vocab into the framework struct.
+- `Manager` writes are CAS (`updateRetries=5`, `manager.go:399`); a subscriber
+  stamping on every loop completion in a fan-out arc contends on the hot run
+  entity → retry exhaustion. Same rationale ADR-049 used to keep `AGENT_LOOPS`
+  off the CAS path.
+
+**Cardinality contract:** distinguish **scalar run-snapshot** predicates
+(latest-wins correct, e.g. `chain.dispatched.at`, current-best) from
+**cardinality-many per-loop facts** (each child's artifact) — the latter MUST be
+loop-qualified (`chain.artifact.<loopID>.*` or a referenced artifact entity) or
+parallel children silently erase each other. Milestone **vocabulary** stays
+product-domain.
+
+### D6 — Adapter: subscriber + lifted resolution
+
+- **Milestone subscriber** (lifts semteams `subscriber.go`): subscribe to terminal
+  subjects, decode once, **demux by payload CATEGORY** (cancellation is published
+  on `agent.complete`, not a cancel subject — D8), fan to product handlers under a
+  panic guard. The framework pre-resolves the run from the event's `run_id` and
+  passes it in:
+
+  ```go
+  type MilestoneHandler interface {
+      OnLoopTerminal(ctx context.Context, ev agentic.LoopTerminalEvent,
+          run *AgentRun, pub TriplePublisher) error
+  }
+  ```
+- **Fallback resolution** (lifts `Resolver.ChainID` walk + the `RequestClassified`
+  footgun fix, `chain/resolver.go:209`): for pre-migration / un-threaded loops,
+  logged WARN.
+
+### D7 — Typed `run_id` propagation (the redesign), at both spawn sites
+
+- Add `RunID string` to `agentic.TaskMessage` and `agentic.LoopEntity`.
+- Set in `rule.executePublishAgent` (`actions.go:1094`) per `RunScope`, mirroring
+  `ParentLoopID` inheritance (`actions.go:1114`). **Propagate at BOTH spawn
+  sites** — `executePublishAgent` AND the architect→editor sub-spawn — or the
+  second falls back to the walk.
+- Stamp `agent.run` on the loop entity in `buildSpawnIdentityTriples`
+  (`graph_writer.go:506`), atomic at spawn. Upserts read `$entity.triple.agent.run`.
+  (`agent.run` token verified collision-free; full grammar-collision audit at
+  implementation time per `feedback_grammar_collision_audit_on_new_tokens`.)
+
+This collapses both run-identity mechanisms and retires the read-side walk for
+threaded loops.
+
+### D8 — `RunID`/`RunEntityID` on all four loop events
+
+`LoopCreatedEvent` (`handlers.go:468`), `LoopCompletedEvent`, `LoopFailedEvent`,
+and `LoopCancelledEvent` (`events.go:165` — currently lacks even `ParentLoopID`)
+gain `RunID` (bare) + `RunEntityID` (6-part), populated from `LoopEntity.RunID`
+(matching the `ParentLoopID` precedent). Subscribers receive the resolved run on
+the wire — no `resolver.ChainEntityID` round-trip. Because cancellation rides
+`agent.complete`, the subscriber demuxes by payload category, not subject.
+
+## Consequences
+
+### Storage
+
+Run entity in ENTITY_STATES (low-write: phase transitions + audit; passes the
+ADR-049 rubric — graph-reasonable facts, audit free from KV revisions; **no
+private bucket**). Loops stay in high-write `AGENT_LOOPS` (the ADR-049
+exception). Phase via CAS; milestones via graph-ingest. Clean split.
+
+### What we gain
+
+semteams retires its hand-rolled run layer: the resolver/ancestry-walk as
+primary, the three-source fallback, the `run-loop-entity-id` threading, the
+hand-wired completion subscriber, and the `DispatchedStamper` (dissolves into
+`AuditPredicates`). Net product LOC negative. Runs gain an operator API, audit
+history, restart recovery, and rule integration **for free**. The #225 wire-field
+asks are answered as a typed contract, not a `loop_wire.go` patch. The next
+agentic product gets the run primitive instead of re-plumbing it.
+
+### Breaking surface + migration (the dominant cost/risk)
+
+- Framework changes are additive (`RunID` fields, `RunScope`, `AgentRun`, the
+  adapter).
+- **semteams rule-pack migration**: ~**35** rule files; a **family** of
+  run-anchor predicates (`lineage.run-loop-entity-id` AND
+  `lineage.plan-loop-entity-id`); run-anchor vs genuine sibling-lineage is **not
+  syntactically distinguishable** — per-site semantic audit, NOT a sed. Retires
+  `related_loops`-as-run-anchor; keeps `related_loops`-as-sibling-lineage
+  (`lineage.researcher`). Lockstep with the framework tag.
+- Touches ingest→entity→graph→query → **`task e2e:agentic` green required before
+  tag** (CLAUDE.md hard rule).
+
+### Test gate
+
+`task e2e:agentic` plus focused tests: `AgentRun` projection round-trip (full-ID
+identity — guards D1); idempotent mint; `RunScope` schema validation; `RunID`
+inheritance at every spawn path (guards the silent-fallback gap); wire fields on
+created/completed/failed/cancelled + category demux; fallback-walk WARN; semteams
+rule-pack migration coverage via `test/reference_configs_test.go` +
+`chain_entity_coverage` contract test (`feedback_reference_configs_verify_triple_stamping`).
+
+### Deferred (non-goals)
+
+Unified Run/Execution substrate shared with the harness; legacy migration of
+semspec/semdragon/semsage (prior art); milestone vocabulary as framework schema;
+markdown/`write_artifact` (ADR-038 D6); pause/resume semantics (ADR-037);
+cross-run analytics; parallel/multi-arc runs (ADR-038 defers).
+
+### Open at implementation time
+
+Grammar-collision audit over all `$`-token regexes + `agvocab` constants for
+`agent.run*`; confirm cancellation routing/subject and whether a third spawn site
+(dispatcher-direct / MCP) needs `RunID`; finalize the `RunScope` default.
+
+## References
+
+- [docs/proposals/agent-run-substrate.md](../proposals/agent-run-substrate.md) —
+  full design exercise + review history.
+- [ADR-047](047-lifecycle-harness-substrate.md), [ADR-049](049-lifecycle-harness-prime-schema-over-entity-states.md) — the harness this builds on.
+- semteams ADR-038 (chain entity + milestone rendering) — the lifted reference design.
+- [ADR-028](028-orchestration-architecture.md) — rules/coordinator orchestrate; framework observes (D3 grounding).

--- a/docs/proposals/agent-run-substrate.md
+++ b/docs/proposals/agent-run-substrate.md
@@ -1,0 +1,349 @@
+# Agent-Run Substrate — Nested Agentic Loops as a Lifecycle `Participant`
+
+## Status
+
+**PROMOTED to [ADR-053](../adr/053-agent-run-substrate.md) (2026-06-07).** This
+proposal remains the full design-exercise record; the ADR is the authoritative
+decision. Authored 2026-06-07 from the semteams #225 follow-up thread. Two independent adversarial reviews complete
+(architect + Codex), both verdict **RIGHT-WITH-CHANGES, thesis accepted**; this
+document is the single-narrative rewrite around the resolved design (the earlier
+body + appendix split was replaced per Codex P1). All API claims verified
+against HEAD (`pkg/lifecycle` post-ADR-049). Companion memory:
+`project_agent_run_chain_framework_gap`. Review history at the end.
+
+## Summary
+
+A coordinator agentic loop that spawns research/architect/builder child loops
+forms a **run** (semteams calls it a "chain"): a tree of nested loops spanning
+multiple arcs, accumulating cross-arc state. The framework has **no first-class
+primitive** for it — only an unused `ChainExecutionEntityID` constructor
+(`agentic/entity_ids.go:139`). semteams (our reference-design product) hand-rolls
+the whole run layer (~600 LOC of `cmd/semteams/chain/*`).
+
+**Decision:** model the run as a **Lifecycle harness `Participant`**
+(`pkg/lifecycle`). The run has a genuinely *declarable generic* lifecycle, so it
+reuses the harness Manager/recovery/operator-gateway/rule-integration wholesale.
+The agentic *loop* stays excluded from `Participant` (per-iteration LLM
+dynamism, high-write `AGENT_LOOPS` bucket — ADR-047); only the *run* — low-write,
+declarable — participates. This is exactly the case ADR-047 left the door open
+for: *"a future agentic role with declared phases could implement `Participant`
+if the fit emerges."*
+
+The net-new framework code is a **thin agentic adapter**: an `AgentRun`
+Participant, a structurally-declared mint trigger, typed `run_id` propagation,
+and a completion-event milestone subscriber. The one genuine redesign — typed
+`run_id` inherited at spawn — collapses *two* parallel run-identity mechanisms
+into one and retires a race the framework has already closed.
+
+## The gap
+
+| Construct | Status |
+|---|---|
+| `LoopExecutionEntityID`, `ChainExecutionEntityID` (`entity_ids.go`) | ID constructors — HAS (chain one never called by framework) |
+| `LoopEntity.ParentLoopID`, `agent.loop.parent` at spawn (`graph_writer.go:451` `WriteSpawnIdentity`) | walkable loop-tree spine; gh#159 race closed — HAS |
+| **The run as a first-class entity** | minted nowhere, owned by no one, no resolver, no operator view — **MISSING** |
+
+### The reference design has TWO run-identity mechanisms (load-bearing)
+
+1. **Ancestry-walk chain (ADR-038):** `chain_id` = dispatch-root loop UUID, found
+   by `Resolver.ChainID` walking `agent.loop.parent` (`chain/resolver.go:97`,
+   `maxAncestryHops=64`). Milestone-stamping spine.
+2. **`run-loop-entity-id` lineage thread:** `related_loops["run-loop-entity-id"]`
+   pinned at root and re-threaded through every spawn rule (autoresearch
+   `01:48`, `03:39`, `05:56`; dev-via-test `02:44`), read as
+   `$entity.triple.lineage.run-loop-entity-id` to upsert run-scoped state
+   mid-flight (`04c:26`). A sibling predicate `lineage.plan-loop-entity-id`
+   serves the same role for the gather-join (research `03a`).
+
+The thread (#2) exists to dodge the gh#159 completion-time race — **which the
+framework already closed**: `WriteSpawnIdentity` (`graph_writer.go:451`) now
+stamps `agent.loop.parent` atomically *at spawn*, godoc citing the exact fix.
+So #2 is partly vestigial. A typed `run_id` set at spawn collapses both
+mechanisms plus the read-side walk.
+
+## Why framework, why now
+
+- **semteams is the reference-design product**, driving new semstreams patterns;
+  its run layer is proven (smoke #8/#13, ADR-038). Lift the structured contract
+  from the reference product (`feedback_lift_structured_contract_not_friendly_projection`).
+- **Engine gaps file as engine work** (CLAUDE.md orchestration boundaries). The
+  run is a coordination primitive; leaving it product-side means the next
+  agentic product re-plumbs it (and is what produced #225's wire-field asks).
+- Pre-1.0, we own every consumer; take the break (`feedback_greenfield_cross_product_break_now`).
+
+## Design
+
+### 1. `AgentRun` — a `lifecycle.Participant` (agentic-side, imports `pkg/lifecycle`)
+
+```go
+// AgentRun is the coordinating envelope over a nested-loop tree.
+// Lives in an agentic-side package that imports pkg/lifecycle (legal
+// direction; the harness MUST NOT import agentic — ADR-047:133).
+type AgentRun struct {
+    // Identity: the lifecycle:"id" field is populated by projection FROM
+    // THE FULL ENTITY-STATE KEY, not a triple (pkg/lifecycle/projection.go).
+    // So it MUST hold the full 6-part ID; the bare run loop-id is DERIVED.
+    EntityID_ string `json:"-" lifecycle:"id"` // c360.<plat>.agent.chain.execution.<loopID>
+    Phase_    string `json:"phase"`
+    ParentRunEntityID string `json:"parent_run_entity_id,omitempty"`
+    // NOTE: no milestone fields here — milestones are product triples on the
+    // run entity, NOT projected Participant fields (see §5).
+}
+
+func (r *AgentRun) EntityID() string { return r.EntityID_ }
+func (r *AgentRun) Workflow() string { return "agent-run" }
+func (r *AgentRun) Phase() string    { return r.Phase_ }
+func (r *AgentRun) IsTerminal() bool { /* via registered Transitions */ }
+func (r *AgentRun) ParentEntityID() string { return r.ParentRunEntityID }
+// bare run loop-id is derived, never the lifecycle:"id" field:
+func (r *AgentRun) RunID() string { id, _ := agentic.LoopIDFromExecutionEntityID(r.EntityID_); return id }
+```
+
+> **Identity fix (Codex P1, verified):** `projection.go` populates the
+> `lifecycle:"id"` field from the entity-state KEY (full 6-part ID), not a
+> triple. Tagging a *bare* `RunID` as `lifecycle:"id"` would round-trip to the
+> full dotted ID and then panic/garble when recomposed through
+> `ChainExecutionEntityID(org,platform,RunID)` (`entity_ids.go:139` rejects
+> dots). Therefore the `lifecycle:"id"` field holds the **full EntityID**; the
+> bare run loop-id is derived via `LoopIDFromExecutionEntityID`.
+
+Registered once at startup via the **ADR-049 `Register(Workflow)`** signature
+(`manager.go:116` — NOT the old 3-arg ADR-047 form):
+
+```go
+mgr.Register(lifecycle.Workflow{
+    Name:    "agent-run",
+    Factory: func() lifecycle.Participant { return &AgentRun{} },
+    Transitions: lifecycle.Transitions{
+        "dispatched":        {"executing", "failed", "cancelled"},
+        "executing":         {"awaiting_approval", "completed", "failed", "cancelled"},
+        "awaiting_approval": {"executing", "cancelled"},
+        "completed": {}, "failed": {}, "cancelled": {},
+    },
+    AuditPredicates: lifecycle.AuditSpec{ /* At/Source/Note — created-at free */ },
+    // ChildWorkflows / EntityIDPattern as needed for gateway + Children.
+})
+```
+
+### 2. What the harness provides (verified against ADR-049 `Manager`)
+
+`Create` (mint), `Get`/`LookupByEntityID` (resolve), `Transition`/
+`TransitionWith` (phase), `Complete`/`Fail`, `UpdateFromOperator` (operator
+patches, default-deny), `List`/`Watch`/`History` (operator view + KV-revision
+audit), `Children` (parent→child via declared `LinkPredicate`), restart
+recovery, the **existing lifecycle gateway** (`GET /workflows/agent-run`), and
+rule integration (`lifecycle_*` actions + `$entity.lifecycle.*` substitutions).
+Storage is ENTITY_STATES (`manager.go:182`), ADR-049-compliant.
+
+**Corrections vs the first draft (verified):** there is **no `Manager.Update`**
+(use `Transition`/`TransitionWith`/`UpdateFromOperator`); **no `Ancestors`**;
+`Children` runs **parent→child**, while the loop tree is **child→parent**
+(`agent.loop.parent`) — so the run does **NOT** get the loop subtree for free;
+`KVBucket()/KVKey()` are **removed** from `Participant`.
+
+### 3. The agentic adapter (the only net-new framework code)
+
+- **Mint** — at the dispatch/rule layer, structurally declared (§4), calling
+  `Manager.Create(&AgentRun{EntityID_: ChainExecutionEntityID(org,plat,rootLoopID), Phase_: "dispatched"})`.
+  Idempotent (entity ID stable). At **creation**, not completion.
+- **`run_id` propagation** at spawn (§6) — the redesign.
+- **Milestone subscriber** — the one piece the harness doesn't provide:
+  subscribe to terminal subjects, decode once, demux by payload category to
+  product handlers under a panic guard (lifts semteams `subscriber.go`, zero
+  domain). The framework pre-resolves the run from the event's `run_id` and
+  hands it to the product handler, which writes milestone triples via a
+  publisher — **not** via `Manager` (§5):
+
+```go
+type MilestoneHandler interface {
+    OnLoopTerminal(ctx context.Context, ev agentic.LoopTerminalEvent,
+        run *AgentRun, pub TriplePublisher) error
+}
+```
+
+Resolution fallback (`Resolver.ChainID` walk + the `RequestClassified` footgun
+fix, `chain/resolver.go:209`) is lifted into the framework for pre-migration /
+un-threaded loops, logged WARN.
+
+### 4. Terminal authority + structural mint (Codex P1)
+
+**Who closes a run** must be explicit, or the generic subscriber gets it wrong
+(closing on any child failure kills recoverable chains; closing on any child
+success completes early). Resolution:
+
+- **Framework CREATES and OBSERVES.** It mints the run and stamps audit/phase
+  on declared transitions. It does **not** infer run completion from child
+  loop events.
+- **Product/coordinator EMITS the terminal run decision** — the coordinator is
+  the orchestrator that knows when the run is done. It fires a
+  `lifecycle_transition` rule action (or its terminal tool stamps a trigger a
+  rule matches) to move the run to `completed`/`failed`/`cancelled`. This is
+  ADR-028-consistent (rules/coordinator orchestrate; framework observes).
+- **Narrow framework fallback:** if the dispatch-ROOT loop terminates
+  (fail/cancel) **before any child handoff** (run still `dispatched`, no
+  children), the subscriber transitions the run to `failed`/`cancelled` to
+  prevent a zombie. This is the ONLY framework-initiated terminal transition,
+  and it's why mint-at-creation requires the failure subscriber.
+- The adapter calls `Transition` with the **explicit** terminal — **never
+  `Manager.Complete`** (which, with `executing`→3 terminals, picks
+  `reachable[0]` non-deterministically, `manager.go:671`).
+
+**Mint is a declared rule-action field, not prose/convention.** Auto-minting
+every parentless loop would mint a "run" per CLI-chat/HTTP loop
+(`agentic-dispatch/http.go:301`, `component.go:718`). Add a typed field to the
+rule `Action` (`processor/rule/actions.go:180`, today only `RelatedLoops`):
+
+```go
+RunScope string `json:"run_scope,omitempty"` // "new" | "inherit" | "none"
+```
+
+- `new` → mint a run; this spawn is the root.
+- `inherit` → propagate the firing loop's `RunID` (normal in-run child spawn).
+- `none`/empty → no run association (ordinary loops).
+
+Validated in `Action.Validate()`. (Open: default — lean `inherit` when the
+firing entity has a run, else `none`, so child spawns are free and only the
+coordinator's dispatch declares `new`.)
+
+### 5. Milestones — two write paths + a cardinality contract (architect OQ#0 + Codex P2)
+
+Milestones are **product triples on the run entity**, written through the
+**graph-ingest path** (`AddTriple` → `graph.mutation.triple.add`,
+last-writer-wins per predicate, no CAS) — the path semteams uses today — **NOT**
+through `Manager`. Two reasons (both verified):
+
+1. **Authority:** `UpdateFromOperator` is operator-authority gated, default-deny
+   (`AssertRuleWritable`, `manager_query.go:451`). Routing derived milestone
+   data through it would make every milestone operator-patchable and force the
+   product vocabulary into the framework struct — contradicting the non-goal.
+2. **Contention:** `Manager` writes are CAS-on-revision (`updateRetries=5`,
+   `manager.go:399`). A subscriber stamping on every loop completion in a
+   fan-out arc contends on the one hot run entity → retry exhaustion. The
+   graph-ingest path has no CAS (same rationale ADR-049 used to keep AGENT_LOOPS
+   off the CAS path).
+
+So: **run PHASE = `Manager.Transition`** (low-write, transition-guarded);
+**run MILESTONES = `AddTriple`** (higher-frequency, derived, latest-wins).
+
+**Cardinality contract (Codex P2):** "last-writer-wins per predicate" silently
+erases parallel artifacts if N children write the same predicate. The ADR must
+distinguish:
+- **Scalar run-snapshot predicates** (`chain.dispatched.at`, current best
+  value) — single-valued, latest-wins is correct.
+- **Cardinality-many per-loop facts** (each child's artifact) — must be
+  **loop-qualified** (predicate or object carries the loop id, e.g.
+  `chain.artifact.<loopID>.path`, or a separate artifact entity referenced from
+  the run). Fan-out arcs MUST use the cardinality-many shape or they self-erase.
+
+Milestone *vocabulary* stays product-domain; the framework only provides the
+run entity as the home and the resolved run to the handler.
+
+### 6. `run_id` propagation (the redesign) + wire fields
+
+**Typed field, inherited at spawn** — replaces both string-keyed mechanisms:
+
+- Add `RunID string` to `agentic.TaskMessage` and `agentic.LoopEntity`.
+- Set in `rule.executePublishAgent` (`actions.go:1094`) per `RunScope` (§4),
+  mirroring the existing `ParentLoopID` inheritance (`actions.go:1114`).
+  **Propagate at BOTH spawn sites** — `executePublishAgent` AND the
+  architect→editor sub-spawn — or the second silently falls back to the walk
+  (Codex P2).
+- Stamp `agent.run` on the loop entity in `buildSpawnIdentityTriples`
+  (`graph_writer.go:506`), atomic at spawn (no gh#159 race). Upserts read
+  `$entity.triple.agent.run` instead of `lineage.run-loop-entity-id`. (`agent.run`
+  token verified collision-free; full grammar-collision audit still TODO at ADR
+  time per `feedback_grammar_collision_audit_on_new_tokens`.)
+
+**Wire fields on ALL FOUR events (Codex P2), not just the terminals:**
+`LoopCreatedEvent` (`handlers.go:468`, published `agent.created`),
+`LoopCompletedEvent`, `LoopFailedEvent`, and `LoopCancelledEvent`
+(`events.go:165` — currently lacks even `ParentLoopID`) gain `RunID` +
+`RunEntityID` (bare + 6-part, matching the `ParentLoopID` precedent). Populated
+from `LoopEntity.RunID`. Creation is a real event surface the run subscriber may
+need; cancellation is published on **`agent.complete`** (not a cancel subject),
+so the subscriber **must demux by payload category** — it cannot assume subject
+= category.
+
+This kills the read-side walk: handlers receive the resolved run; no
+`resolver.ChainEntityID` round-trip, no walk-failure branch.
+
+## Framework / product boundary
+
+| Piece | Verdict |
+|---|---|
+| `ChainExecutionEntityID`, `LoopIDFromExecutionEntityID`, `agent.loop.parent` at spawn | HAS |
+| Mint / resolve / operator view / recovery / audit / rule-integration | REUSE harness (`Create`/`Get`/gateway/`AuditPredicates`/`lifecycle_*`) |
+| `CompletionSubscriber` demux + panic guard; `RequestClassified` footgun fix; fallback walk | LIFT (adapter) |
+| typed `RunID` propagation; `RunScope` rule field; wire fields on 4 events | NEW |
+| `AgentRun` Participant + Transitions | NEW (thin) |
+| `Manager.Complete` on a run | FORBIDDEN (use explicit `Transition`) |
+| milestone vocab (`chain.*`), role→action gates, stampers | LEAVE (product) |
+| `DispatchedStamper` | DISSOLVES into `AuditPredicates` (created-at free) |
+| markdown rendering; pause/resume decision HTTP | LEAVE (ADR-038 D6 / ADR-037) |
+
+## Storage / write-rate
+
+Run entity in ENTITY_STATES (low-write: a handful of phase transitions + audit;
+passes the ADR-049 rubric — facts the graph reasons over, audit free from KV
+revisions; **no private bucket**). Loops stay in high-write `AGENT_LOOPS` (the
+ADR-049 exception; not Participants). Phase via CAS; milestones via graph-ingest
+(§5). Clean split, both rationales from ADR-049.
+
+## Breaking-change surface + migration (re-scoped — Codex/architect)
+
+- `TaskMessage`/`LoopEntity`/4 events gain fields — additive on structs.
+- New `RunScope` rule-action field — additive, validated.
+- **semteams rule-pack migration is the dominant cost/risk (~2.3× the first
+  estimate):** ~**35** rule files, a **family** of run-anchor predicates
+  (`lineage.run-loop-entity-id` AND `lineage.plan-loop-entity-id`, both used as
+  `update_triple`/`add_triple` subjects), and run-anchor vs genuine
+  sibling-lineage is **not syntactically distinguishable** in the rule JSON —
+  per-site semantic audit, NOT a sed. Retires `related_loops`-as-run-anchor,
+  keeps `related_loops`-as-sibling-lineage (`lineage.researcher`).
+- Touches ingest→entity→graph→query → **`task e2e:agentic` green required before
+  tag** (CLAUDE.md hard rule). Net product LOC negative.
+
+## Test gate (Codex P2 — promote contract tests into the gate)
+
+Beyond `task e2e:agentic`, focused tests required:
+- `AgentRun` lifecycle **projection** round-trip (full-ID identity, no
+  corruption — guards the P1 fix).
+- **Idempotent mint** (duplicate dispatch → one run).
+- **`RunScope` rule-action schema validation** (new/inherit/none + invalid).
+- **`RunID` inheritance at EVERY spawn path** (`executePublishAgent` +
+  architect→editor) — guards the silent-fallback gap.
+- **Wire fields on created/completed/failed/cancelled** + category-demux on
+  `agent.complete`.
+- **Fallback-walk WARN** behavior for un-threaded loops.
+- **semteams rule-pack migration coverage** — `test/reference_configs_test.go`
+  + `chain_entity_coverage` contract test re-run post-migration
+  (`feedback_reference_configs_verify_triple_stamping`).
+
+## Open / deferred / remaining TODO
+
+- **Deferred (non-goals):** unified Run/Execution substrate shared with the
+  harness; legacy migration of semspec/semdragon/semsage (prior art); milestone
+  vocabulary as framework schema; markdown/`write_artifact`; pause/resume
+  semantics; cross-run analytics; parallel/multi-arc runs (ADR-038 defers).
+- **TODO at ADR time:** grammar-collision audit over all `$`-token regexes +
+  `agvocab` constants for `agent.run*`; confirm cancellation routing/subject and
+  whether a third spawn site (dispatcher-direct/MCP) needs `RunID`; finalize the
+  `RunScope` default.
+
+## Review history
+
+- **Architect (2026-06-07):** RIGHT-WITH-CHANGES. Caught the ADR-047→ADR-049 API
+  staleness, the two-write-path resolution, mint-at-rule-layer, the
+  `Manager.Complete` ambiguity, and the migration under-scope.
+- **Codex (2026-06-07):** RIGHT direction, not-yet-ADR-ready. Added the P1
+  identity round-trip corruption, terminal-authority gap, structural-mint-API
+  requirement, the 4-event wire surface + cancellation demux, the milestone
+  cardinality contract, and the test-gate expansion. Directed a body rewrite
+  (this document) over an appendix.
+
+## Next steps
+
+1. Optional third critique on this converged rewrite, else promote to ADR.
+2. ADR with the resolved API + re-scoped semteams migration plan + test gate.
+3. Implement framework adapter + semteams migration as **lockstep PRs**; gate on
+   `task e2e:agentic` + the focused test list.

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -1616,10 +1616,13 @@ func (c *Component) handleCancelSignal(ctx context.Context, signal agentic.UserS
 		TaskID:       entity.TaskID,
 		Outcome:      agentic.OutcomeCancelled,
 		CancelledBy:  signal.UserID,
+		ParentLoopID: entity.ParentLoopID,
 		WorkflowSlug: entity.WorkflowSlug,
 		WorkflowStep: entity.WorkflowStep,
 		CancelledAt:  entity.CancelledAt,
 		Metadata:     entity.Metadata,
+		RunID:        entity.RunID,
+		RunEntityID:  c.handler.resolveRunEntityID(entity.RunID),
 	}
 
 	completionMsg := message.NewBaseMessage(completion.Schema(), &completion, "agentic-loop")

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -516,7 +516,7 @@ func buildSpawnIdentityTriples(loopEntityID string, task *agentic.TaskMessage, o
 		}
 	}
 
-	triples := make([]message.Triple, 0, 7)
+	triples := make([]message.Triple, 0, 8)
 	if task.Role != "" {
 		triples = append(triples, triple(agvocab.LoopRole, task.Role))
 	}
@@ -526,6 +526,13 @@ func buildSpawnIdentityTriples(loopEntityID string, task *agentic.TaskMessage, o
 	if task.ParentLoopID != "" {
 		parentEntityID := agentic.LoopExecutionEntityID(org, platform, task.ParentLoopID)
 		triples = append(triples, triple(agvocab.LoopParent, parentEntityID))
+	}
+	// Stamp agent.run when the loop belongs to a run (ADR-053 D7).
+	// The object is the bare RunID (not a 6-part entity ID) — rules read
+	// it via $entity.triple.agent.run; the full chain entity ID is derived
+	// via ChainExecutionEntityID when needed.
+	if task.RunID != "" {
+		triples = append(triples, triple(agvocab.LoopRun, task.RunID))
 	}
 	if task.WorkflowSlug != "" {
 		triples = append(triples, triple(agvocab.LoopWorkflow, task.WorkflowSlug))

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -390,6 +390,15 @@ func (h *MessageHandler) configureLoopMetadata(loopID string, task TaskMessage) 
 		}
 	}
 
+	// Set run anchor if provided (ADR-053 D7). Inherited from firing entity's RunID.
+	if task.RunID != "" {
+		if err := h.loopManager.SetRunID(loopID, task.RunID); err != nil {
+			h.logger.Warn("failed to set run ID",
+				slog.String("loop_id", loopID),
+				slog.String("error", err.Error()))
+		}
+	}
+
 	// Set workflow context if provided (for loops created by workflow commands)
 	if task.WorkflowSlug != "" || task.WorkflowStep != "" {
 		if err := h.loopManager.SetWorkflowContext(loopID, task.WorkflowSlug, task.WorkflowStep); err != nil {
@@ -465,6 +474,35 @@ func (h *MessageHandler) buildTaskTrajectoryStep(requestID string, task TaskMess
 	return step
 }
 
+// resolveRunEntityID returns the full 6-part ChainExecutionEntityID for a run
+// when runID is non-empty and the handler has a valid platform identity.
+// Returns empty string when runID is empty, or when org/platform are missing
+// (logs Warn in that case so operators notice the gap without breaking the path).
+//
+// Uses TryChainExecutionEntityID (never the panicking form) because this is
+// called from event-construction goroutines — a panic there would silently
+// kill the publish path (feedback_try_loop_entity_id_for_runtime discipline).
+func (h *MessageHandler) resolveRunEntityID(runID string) string {
+	if runID == "" {
+		return ""
+	}
+	if h.platform.Org == "" || h.platform.Platform == "" {
+		h.logger.Warn("resolveRunEntityID: platform identity missing, RunEntityID will be empty",
+			slog.String("run_id", runID))
+		return ""
+	}
+	id, err := agentic.TryChainExecutionEntityID(h.platform.Org, h.platform.Platform, runID)
+	if err != nil {
+		h.logger.Warn("resolveRunEntityID: failed to build chain execution entity ID",
+			slog.String("run_id", runID),
+			slog.String("org", h.platform.Org),
+			slog.String("platform", h.platform.Platform),
+			slog.Any("error", err))
+		return ""
+	}
+	return id
+}
+
 // buildLoopCreatedData marshals a LoopCreatedEvent for publishing.
 func (h *MessageHandler) buildLoopCreatedData(loopID string, task TaskMessage, entity agentic.LoopEntity) ([]byte, error) {
 	created := agentic.LoopCreatedEvent{
@@ -478,6 +516,8 @@ func (h *MessageHandler) buildLoopCreatedData(loopID string, task TaskMessage, e
 		MaxIterations:    entity.MaxIterations,
 		CreatedAt:        time.Now(),
 		Metadata:         task.Metadata,
+		RunID:            task.RunID,
+		RunEntityID:      h.resolveRunEntityID(task.RunID),
 	}
 	createdMsg := message.NewBaseMessage(created.Schema(), &created, "agentic-loop")
 	return json.Marshal(createdMsg)
@@ -1594,6 +1634,8 @@ func (h *MessageHandler) handleCompleteResponse(result *HandlerResult, loopID st
 		ChannelID:   entity.ChannelID,
 		UserID:      entity.UserID,
 		Metadata:    entity.Metadata,
+		RunID:       entity.RunID,
+		RunEntityID: h.resolveRunEntityID(entity.RunID),
 	}
 
 	// Pull token totals from trajectory for cost tracking. Also doubles as
@@ -2120,6 +2162,8 @@ func (h *MessageHandler) buildFailureEvent(loopID, reason, errorMsg string) (*ag
 		ChannelID:    entity.ChannelID,
 		UserID:       entity.UserID,
 		Metadata:     entity.Metadata,
+		RunID:        entity.RunID,
+		RunEntityID:  h.resolveRunEntityID(entity.RunID),
 	}
 
 	// Pull token totals from trajectory for cost tracking

--- a/processor/agentic-loop/spawn_identity_test.go
+++ b/processor/agentic-loop/spawn_identity_test.go
@@ -225,6 +225,7 @@ func TestBuildSpawnIdentityTriples_TripleCountWithFullTask(t *testing.T) {
 		TaskID:       "task-count",
 		Role:         "researcher",
 		ParentLoopID: "parent-id",
+		RunID:        "run-anchor-uuid",
 		WorkflowSlug: "wf",
 		WorkflowStep: "step",
 		UserID:       "user",
@@ -232,7 +233,7 @@ func TestBuildSpawnIdentityTriples_TripleCountWithFullTask(t *testing.T) {
 	}
 
 	triples := buildSpawnIdentityTriples("acme.ops.agent.agentic-loop.execution.spawn-count", task, "acme", "ops")
-	want := 7 // role, task, parent, workflow, workflow_step, user, description
+	want := 8 // role, task, parent, run, workflow, workflow_step, user, description
 	if len(triples) != want {
 		preds := make([]string, 0, len(triples))
 		for _, tr := range triples {
@@ -255,5 +256,110 @@ func TestBuildSpawnIdentityTriples_TimestampPopulated(t *testing.T) {
 	}
 	if time.Since(triples[0].Timestamp) > time.Minute {
 		t.Errorf("timestamp suspiciously old: %v", triples[0].Timestamp)
+	}
+}
+
+// --- ADR-053 Pass A: agent.run triple in spawn identity ---
+
+// TestBuildSpawnIdentityTriples_StampsRunID verifies that agent.run is stamped
+// with the bare RunID string when TaskMessage.RunID is set (ADR-053 D7).
+func TestBuildSpawnIdentityTriples_StampsRunID(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.child-run-001"
+	task := &agentic.TaskMessage{
+		TaskID: "task-run-001",
+		Role:   "researcher",
+		RunID:  "root-loop-uuid",
+	}
+
+	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	predicates := predicateSet(triples)
+
+	if !predicates[agvocab.LoopRun] {
+		t.Fatalf("expected agent.run triple; got predicates: %v", predicates)
+	}
+
+	runID, ok := objectFor(triples, agvocab.LoopRun).(string)
+	if !ok {
+		t.Fatal("LoopRun object is not a string")
+	}
+	if runID != "root-loop-uuid" {
+		t.Errorf("LoopRun = %q, want %q", runID, "root-loop-uuid")
+	}
+}
+
+// TestBuildSpawnIdentityTriples_OmitsRunIDWhenEmpty verifies that agent.run is
+// NOT emitted when TaskMessage.RunID is empty — loops not in a run must not
+// carry a zero-value triple.
+func TestBuildSpawnIdentityTriples_OmitsRunIDWhenEmpty(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.solo-loop"
+	task := &agentic.TaskMessage{
+		TaskID: "task-solo",
+		Role:   "researcher",
+		// RunID empty
+	}
+
+	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	predicates := predicateSet(triples)
+
+	if predicates[agvocab.LoopRun] {
+		t.Errorf("expected agent.run triple to be omitted when RunID is empty")
+	}
+}
+
+// TestBuildSpawnIdentityTriples_RunIDIsNotEntityID guards that the LoopRun
+// object is the BARE run loop-id, not a 6-part entity ID. Rules read
+// $entity.triple.agent.run and pass it to ChainExecutionEntityID on demand;
+// storing the pre-expanded entity ID would double-expand it.
+func TestBuildSpawnIdentityTriples_RunIDIsNotEntityID(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.child-run-002"
+	task := &agentic.TaskMessage{
+		TaskID: "task-run-002",
+		Role:   "coordinator",
+		RunID:  "bare-run-uuid",
+	}
+
+	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	runID, ok := objectFor(triples, agvocab.LoopRun).(string)
+	if !ok {
+		t.Fatal("LoopRun object is not a string")
+	}
+
+	// Must be the bare UUID, not a dotted entity ID.
+	if len(runID) > 0 && runID != "bare-run-uuid" {
+		t.Errorf("LoopRun = %q, want bare UUID %q", runID, "bare-run-uuid")
+	}
+	// Defensive: must not contain dots (which would indicate it was expanded to a 6-part ID).
+	for _, ch := range runID {
+		if ch == '.' {
+			t.Errorf("LoopRun %q contains dots — must be bare loop UUID, not a 6-part entity ID", runID)
+			break
+		}
+	}
+}
+
+// TestBuildSpawnIdentityTriples_SharedTimestamp_WithRunID extends the timestamp
+// test to include RunID — all triples in one batch share the same timestamp.
+func TestBuildSpawnIdentityTriples_SharedTimestamp_WithRunID(t *testing.T) {
+	task := &agentic.TaskMessage{
+		TaskID:       "task-shared-ts-run",
+		Role:         "researcher",
+		ParentLoopID: "parent-id",
+		RunID:        "run-id",
+		WorkflowSlug: "wf",
+		WorkflowStep: "step",
+		UserID:       "user",
+		Prompt:       "prompt",
+	}
+
+	triples := buildSpawnIdentityTriples("acme.ops.agent.agentic-loop.execution.spawn-shared-run", task, "acme", "ops")
+	if len(triples) < 2 {
+		t.Fatalf("expected multiple triples, got %d", len(triples))
+	}
+
+	first := triples[0].Timestamp
+	for i, tr := range triples[1:] {
+		if !tr.Timestamp.Equal(first) {
+			t.Errorf("triple[%d] timestamp %v != triple[0] timestamp %v", i+1, tr.Timestamp, first)
+		}
 	}
 }

--- a/processor/agentic-loop/state.go
+++ b/processor/agentic-loop/state.go
@@ -784,6 +784,23 @@ func (m *LoopManager) SetParentLoopID(loopID, parentLoopID string) error {
 	return m.SetParentLoop(loopID, parentLoopID)
 }
 
+// SetRunID sets the run anchor (bare run loop-id) on the loop entity (ADR-053 D7).
+// The run_id identifies which agent run this loop belongs to. Empty string is
+// accepted to allow explicit clearing, though in practice it is only set
+// when the TaskMessage carries a non-empty RunID.
+func (m *LoopManager) SetRunID(loopID, runID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entity, exists := m.loops[loopID]
+	if !exists {
+		return errs.Wrap(fmt.Errorf("loop %s not found", loopID), "LoopManager", "operation", "find loop")
+	}
+
+	entity.RunID = runID
+	return nil
+}
+
 // SetDepth sets the depth tracking for a loop in the multi-agent hierarchy
 func (m *LoopManager) SetDepth(loopID string, depth, maxDepth int) error {
 	m.mu.Lock()

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -12,11 +12,13 @@ import (
 	"log/slog"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/agentic/agentrun"
 	"github.com/c360studio/semstreams/component"
 	gtypes "github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
 	"github.com/c360studio/semstreams/processor/rule/expression"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
 
 // Action type constants define the supported action types for rule execution.
@@ -199,6 +201,21 @@ type Action struct {
 	// Empty/nil leaves no lineage threaded (back-compat: pre-existing
 	// flows that don't opt in see no Metadata change).
 	RelatedLoops map[string]string `json:"related_loops,omitempty"`
+
+	// RunScope controls agent-run lifecycle management for publish_agent actions (ADR-053 D4).
+	// Three values:
+	//   - "new"     — mint a new AgentRun rooted at the FIRING loop. The spawned task carries
+	//                 the firing loop's ID as its RunID; the framework mints the run entity
+	//                 (idempotent). Use on the coordinator's initial dispatch action.
+	//   - "inherit" — propagate the firing loop's existing agent.run triple to the spawned task.
+	//                 Default when the firing entity already carries a run; preserves the
+	//                 existing run for child loop spawns within the same arc.
+	//   - "none"    — do NOT propagate RunID. Use to suppress run association on standalone
+	//                 loops (CLI-chat, HTTP dispatch) that should not mint runs.
+	//   - ""        — same as "inherit" (backward-compatible default).
+	//
+	// Validated at rule-load time; invalid values return ErrInvalidRunScope.
+	RunScope string `json:"run_scope,omitempty"`
 
 	// WorkflowSlug identifies the workflow for publish_agent actions (e.g., "github-issue-to-pr")
 	WorkflowSlug string `json:"workflow_slug,omitempty"`
@@ -391,7 +408,8 @@ type Publisher interface {
 }
 
 // LifecycleManager is the subset of *lifecycle.Manager used by the
-// rule action executor for the lifecycle_* action family (ADR-047).
+// rule action executor for the lifecycle_* action family (ADR-047) and
+// the agent-run mint path (ADR-053 D4).
 // Defined as an interface so the executor can be tested without a
 // running NATS client.
 type LifecycleManager interface {
@@ -405,6 +423,18 @@ type LifecycleManager interface {
 	// same default-deny as UpdateFromOperator. Identity, phase, and
 	// non-operator-writable fields are protected.
 	AssertRuleWritable(workflow, fieldJSONName string) error
+	// Get reads the entity at entityID for the given workflow. Used by the
+	// RunScope "new" path to read back a run after idempotent mint (ADR-053 D4).
+	Get(ctx context.Context, workflow, entityID string) (lifecycle.Participant, error)
+	// Create attaches lifecycle to the entity at initial.EntityID(). Used by the
+	// RunScope "new" path to mint an AgentRun (ADR-053 D4). Returns
+	// lifecycle.ErrAlreadyExists when already lifecycle-managed.
+	Create(ctx context.Context, initial lifecycle.Participant) error
+	// Note: Transition is NOT part of the rule LifecycleManager interface — the
+	// rule engine never drives terminal transitions directly; that is reserved for
+	// the subscriber's MockableManager (agentrun.MockableManager) which handles
+	// the D3 zombie-prevention path. Keeping the interfaces separate prevents
+	// rule-pack authors from reaching terminal transitions through the rule surface.
 }
 
 // ActionExecutor executes actions for rules.
@@ -1113,6 +1143,123 @@ func (e *ActionExecutor) publishAgentOnce(ctx context.Context, action Action, ec
 	// triggered by non-loop entities (no ParentLoopID set, current behavior).
 	if parentLoopID, ok := agentic.LoopIDFromExecutionEntityID(entityID); ok {
 		task.ParentLoopID = parentLoopID
+	}
+
+	// RunScope controls agent-run lifecycle management (ADR-053 D4, Pass B).
+	//
+	//   "new" (or "") when the trigger entity IS a loop-execution entity:
+	//     Mint a new AgentRun rooted at the firing loop. The firing loop's
+	//     loop-id becomes the run-id. task.RunID is set to that loop-id so
+	//     the spawned child inherits the run. If the trigger entity is NOT a
+	//     loop-execution entity, "new" is treated as "inherit" with a warning.
+	//
+	//   "inherit" or "":
+	//     Default Pass A behavior — propagate the agent.run triple from the
+	//     firing loop entity to the spawned TaskMessage (the child belongs to
+	//     the parent's run). Non-loop trigger entities with no agent.run triple
+	//     produce no inheritance (RunID stays empty).
+	//
+	//   "none":
+	//     Suppress RunID propagation entirely. The spawned loop has no run
+	//     association. Used for standalone fire-and-forget dispatches.
+	switch action.RunScope {
+	case "new":
+		// Mint a new AgentRun rooted at the firing loop entity.
+		// The firing loop's loop-id is the run-id.
+		firingLoopID, isLoop := agentic.LoopIDFromExecutionEntityID(entityID)
+		if !isLoop {
+			// Trigger entity is not a loop-execution entity — cannot mint a run.
+			// Fall through to inherit behavior with a warning.
+			if e.logger != nil {
+				e.logger.Warn("publish_agent: run_scope=new on non-loop trigger entity — falling back to inherit",
+					slog.String("entity_id", entityID),
+					slog.String("rule_id", ec.RuleID()))
+			}
+			// Inherit fallthrough:
+			if ec != nil && ec.Entity != nil {
+				if runIDVal, ok := ec.Entity.GetPropertyValue(agvocab.LoopRun); ok {
+					if runID, ok := runIDVal.(string); ok && runID != "" {
+						task.RunID = runID
+					}
+				}
+			}
+		} else if e.lifecycle != nil {
+			// Parse org and platform from the 6-part entity ID.
+			// IsValidEntityID guarantees exactly 6 dot-separated parts; the firing
+			// entity has already passed through ec which validates entity IDs.
+			idParts := strings.SplitN(entityID, ".", 6)
+			if len(idParts) == 6 {
+				org, platform := idParts[0], idParts[1]
+				if _, mintErr := agentrun.Mint(ctx, e.lifecycle, org, platform, firingLoopID); mintErr != nil {
+					// Mint failure is logged but does not abort the dispatch — the
+					// child loop still publishes; the run entity is just absent.
+					if e.logger != nil {
+						e.logger.Error("publish_agent: agentrun.Mint failed — spawning without run association",
+							slog.String("entity_id", entityID),
+							slog.String("firing_loop_id", firingLoopID),
+							slog.String("rule_id", ec.RuleID()),
+							slog.Any("error", mintErr))
+					}
+				} else {
+					task.RunID = firingLoopID
+					// ADR-053 D4: stamp agent.run on the FIRING (root/coordinator)
+					// entity so its own terminal events carry a resolvable run anchor.
+					// Without this triple the root's entity.RunID is empty (it was not
+					// spawned with a RunID), so ev.RunID=="" in its terminal events and
+					// the D3 zombie-prevention guard can never fire.
+					// The triple is best-effort: a write failure does not abort the
+					// dispatch or the child publish.
+					if e.tripleMutator != nil {
+						runTriple := message.Triple{
+							Subject:    entityID,
+							Predicate:  agvocab.LoopRun,
+							Object:     firingLoopID,
+							Source:     "rule_engine",
+							Timestamp:  time.Now(),
+							Confidence: 1.0,
+						}
+						if _, tripleErr := e.tripleMutator.AddTriple(ctx, ec.RuleID(), runTriple); tripleErr != nil {
+							if e.logger != nil {
+								e.logger.Warn("publish_agent: run_scope=new: failed to stamp agent.run on firing entity — D3 zombie guard may not fire for root-loop failures",
+									slog.String("entity_id", entityID),
+									slog.String("firing_loop_id", firingLoopID),
+									slog.String("rule_id", ec.RuleID()),
+									slog.Any("error", tripleErr))
+							}
+						}
+					}
+				}
+			}
+		} else {
+			// No lifecycle manager wired — log and fall through to inherit.
+			if e.logger != nil {
+				e.logger.Warn("publish_agent: run_scope=new but no lifecycle manager wired — falling back to inherit",
+					slog.String("entity_id", entityID),
+					slog.String("rule_id", ec.RuleID()))
+			}
+			if ec != nil && ec.Entity != nil {
+				if runIDVal, ok := ec.Entity.GetPropertyValue(agvocab.LoopRun); ok {
+					if runID, ok := runIDVal.(string); ok && runID != "" {
+						task.RunID = runID
+					}
+				}
+			}
+		}
+
+	case "none":
+		// Suppress RunID propagation — no run association on the spawned loop.
+
+	default: // "inherit" or ""
+		// Pass A default: propagate the agent.run triple from the firing entity.
+		// Non-loop trigger entities that have no agent.run triple produce no
+		// inheritance (RunID stays empty), which is correct.
+		if ec != nil && ec.Entity != nil {
+			if runIDVal, ok := ec.Entity.GetPropertyValue(agvocab.LoopRun); ok {
+				if runID, ok := runIDVal.(string); ok && runID != "" {
+					task.RunID = runID
+				}
+			}
+		}
 	}
 
 	// Resolve per-agent tool allowlist from the global registry. Nil

--- a/processor/rule/actions_lifecycle_test.go
+++ b/processor/rule/actions_lifecycle_test.go
@@ -185,6 +185,51 @@ func (m *fakeLifecycleManager) AssertRuleWritable(workflow, fieldJSONName string
 	return nil
 }
 
+// Get reads the entity at entityID for the given workflow.
+// Stub: returns ErrEntityNotFound for all queries (tests that need Get
+// behaviour use the agentrun mock, not this lifecycle-action fake).
+func (m *fakeLifecycleManager) Get(_ context.Context, workflow, entityID string) (lifecycle.Participant, error) {
+	entities, ok := m.entities[workflow]
+	if !ok {
+		return nil, lifecycle.ErrEntityNotFound
+	}
+	p, ok := entities[entityID]
+	if !ok {
+		return nil, lifecycle.ErrEntityNotFound
+	}
+	return p, nil
+}
+
+// Create attaches lifecycle to the entity. Stub: always returns nil (success).
+// Tests that need Create behaviour should extend fakeLifecycleManager.
+func (m *fakeLifecycleManager) Create(_ context.Context, initial lifecycle.Participant) error {
+	if _, ok := m.entities[initial.Workflow()]; !ok {
+		m.entities[initial.Workflow()] = make(map[string]*fakeParticipant)
+	}
+	if _, exists := m.entities[initial.Workflow()][initial.EntityID()]; exists {
+		return lifecycle.ErrAlreadyExists
+	}
+	m.entities[initial.Workflow()][initial.EntityID()] = &fakeParticipant{
+		EntityIDF: initial.EntityID(),
+		PhaseF:    initial.Phase(),
+	}
+	return nil
+}
+
+// Transition moves the entity to newPhase. Stub implementation mirrors TransitionWith.
+func (m *fakeLifecycleManager) Transition(_ context.Context, workflow, entityID, newPhase string, _ lifecycle.TransitionSource, _ string) error {
+	entities, ok := m.entities[workflow]
+	if !ok {
+		return fmt.Errorf("workflow %q not found", workflow)
+	}
+	p, ok := entities[entityID]
+	if !ok {
+		return lifecycle.ErrEntityNotFound
+	}
+	p.PhaseF = newPhase
+	return nil
+}
+
 // --- executeLifecycleTransition ---
 
 func TestLifecycleTransition_HappyPath(t *testing.T) {

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -2805,3 +2805,367 @@ func TestExecuteApprove_NoPublisherIsNoOp(t *testing.T) {
 	assert.NoError(t, executor.executeApprove(ctx, action, ec))
 	assert.Len(t, mut.addedTriples, 1, "audit triple still written without publisher")
 }
+
+// --- ADR-053 Pass A: RunID inheritance in executePublishAgent ---
+
+// TestAction_PublishAgent_RunIDInheritedFromLoopEntity verifies that when the
+// trigger entity is a loop execution with an agent.run triple, the spawned
+// TaskMessage.RunID is set to that run ID (ADR-053 D7 inherit default).
+// Drives through the production Execute entry point per
+// feedback_integration_tests_must_drive_production_wire.
+func TestAction_PublishAgent_RunIDInheritedFromLoopEntity(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.researcher",
+		Role:    "researcher",
+		Model:   "mock-model",
+		Prompt:  "investigate the problem",
+	}
+
+	// Build an entity state that carries agent.run = "root-loop-uuid".
+	loopEntityID := "c360.ops.agent.agentic-loop.execution.loop-abc"
+	entity := &gtypes.EntityState{
+		ID: loopEntityID,
+		Triples: []message.Triple{
+			{
+				Subject:   loopEntityID,
+				Predicate: "agent.run",
+				Object:    "root-loop-uuid",
+			},
+		},
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{
+		EntityID: loopEntityID,
+		Entity:   entity,
+	}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+	assert.Equal(t, "root-loop-uuid", task.RunID,
+		"RunID must be inherited from the firing loop entity's agent.run triple (ADR-053 D7)")
+	// ParentLoopID is also inherited independently (existing behaviour preserved).
+	assert.Equal(t, "loop-abc", task.ParentLoopID,
+		"ParentLoopID must still be inherited from the loop entity ID shape")
+}
+
+// TestAction_PublishAgent_RunIDNotInheritedWhenMissing verifies that when the
+// trigger entity has no agent.run triple, the spawned TaskMessage.RunID stays
+// empty — additive-only, back-compat preserved.
+func TestAction_PublishAgent_RunIDNotInheritedWhenMissing(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.researcher",
+		Role:    "researcher",
+		Model:   "mock-model",
+		Prompt:  "investigate",
+	}
+
+	// Loop entity without agent.run triple.
+	loopEntityID := "c360.ops.agent.agentic-loop.execution.loop-xyz"
+	entity := &gtypes.EntityState{
+		ID: loopEntityID,
+		Triples: []message.Triple{
+			{Subject: loopEntityID, Predicate: "agent.loop.role", Object: "researcher"},
+		},
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{
+		EntityID: loopEntityID,
+		Entity:   entity,
+	}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+	assert.Empty(t, task.RunID,
+		"RunID must be empty when the trigger entity has no agent.run triple")
+}
+
+// TestAction_PublishAgent_RunIDInheritedFromNonLoopEntityTriple verifies that
+// RunID inheritance is triple-driven (not loop-shape-gated): any entity with
+// an agent.run triple propagates RunID to the spawned task. This is intentional
+// — a chain entity or coordinator entity acting as trigger can thread RunID
+// forward. ParentLoopID remains loop-execution-shape-gated.
+func TestAction_PublishAgent_RunIDInheritedFromNonLoopEntityTriple(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.researcher",
+		Role:    "researcher",
+		Model:   "mock-model",
+		Prompt:  "investigate",
+	}
+
+	// Chain entity (not a loop execution) carrying an agent.run triple.
+	chainEntityID := "c360.ops.agent.chain.execution.chain-abc"
+	entity := &gtypes.EntityState{
+		ID: chainEntityID,
+		Triples: []message.Triple{
+			{Subject: chainEntityID, Predicate: "agent.run", Object: "root-loop-uuid"},
+		},
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{
+		EntityID: chainEntityID,
+		Entity:   entity,
+	}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+	// RunID IS inherited: triple-driven, not loop-shape-gated.
+	assert.Equal(t, "root-loop-uuid", task.RunID,
+		"RunID must be inherited from agent.run triple on any entity type")
+	// ParentLoopID stays empty: chain entity doesn't match agentic-loop.execution shape.
+	assert.Empty(t, task.ParentLoopID,
+		"ParentLoopID must be empty for non-loop-execution trigger entities")
+}
+
+// --- ADR-053 D4: run_scope tests (I2) ---
+//
+// These tests drive publishAgentOnce through the PRODUCTION executor.Execute entry
+// point (not helpers) to lock the run_scope=new/inherit/none contract.
+
+// TestAction_PublishAgent_RunScopeNew_MintsRunAndStampsAgentRun verifies that
+// run_scope=new: (1) calls Manager.Create (minting the run), (2) sets task.RunID
+// to the firing loop's bare ID on the spawned child, and (3) stamps the
+// agent.run triple on the firing entity via tripleMutator.
+func TestAction_PublishAgent_RunScopeNew_MintsRunAndStampsAgentRun(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pub := &mockPublisher{}
+	mutator := &mockTripleMutator{}
+	// Use the fakeLifecycleManager from actions_lifecycle_test.go (same package).
+	mgr := newFakeManager()
+
+	executor := NewActionExecutorComplete(nil, mutator, pub, nil)
+	executor.SetLifecycleManager(mgr)
+
+	// Trigger entity is a loop-execution entity — the firing coordinator loop.
+	firingLoopID := "coordinator-loop-uuid"
+	loopEntityID := "acme.ops.agent.agentic-loop.execution." + firingLoopID
+
+	action := Action{
+		Type:     ActionTypePublishAgent,
+		Subject:  "agent.task.researcher",
+		Role:     "researcher",
+		Model:    "mock-model",
+		Prompt:   "investigate",
+		RunScope: "new",
+	}
+
+	err := executor.Execute(ctx, action, &ExecutionContext{EntityID: loopEntityID})
+	require.NoError(t, err)
+	require.Len(t, pub.published, 1, "task must be published")
+
+	// Decode the published task.
+	baseMsg, err := newActionsTestDecoder(t).Decode(pub.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	// Child task.RunID must equal the firing loop's bare ID.
+	assert.Equal(t, firingLoopID, task.RunID,
+		"spawned child's RunID must equal the firing loop's bare loop-id")
+
+	// Manager.Create must have been called (run minted in "dispatched").
+	runEntityID := "acme.ops.agent.chain.execution." + firingLoopID
+	_, created := mgr.entities["agent-run"][runEntityID]
+	assert.True(t, created, "Manager.Create must mint the AgentRun entity")
+
+	// agent.run triple must be stamped on the FIRING entity (ADR-053 D4 fix).
+	var agentRunTriple *message.Triple
+	for i := range mutator.addedTriples {
+		if mutator.addedTriples[i].Subject == loopEntityID &&
+			mutator.addedTriples[i].Predicate == "agent.run" {
+			agentRunTriple = &mutator.addedTriples[i]
+			break
+		}
+	}
+	require.NotNil(t, agentRunTriple,
+		"agent.run triple must be stamped on the FIRING entity so the root's terminal events can be resolved")
+	assert.Equal(t, firingLoopID, agentRunTriple.Object,
+		"agent.run triple object must be the bare firing loop ID")
+}
+
+// TestAction_PublishAgent_RunScopeNew_NonLoopEntityFallsBackToInherit verifies that
+// run_scope=new on a non-loop trigger entity (no LoopIDFromExecutionEntityID match)
+// logs a warning and falls back to inherit behavior.
+func TestAction_PublishAgent_RunScopeNew_NonLoopEntityFallsBackToInherit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pub := &mockPublisher{}
+	mgr := newFakeManager()
+
+	executor := NewActionExecutorComplete(nil, nil, pub, nil)
+	executor.SetLifecycleManager(mgr)
+
+	// Non-loop entity (e.g. a sensor entity, not agent.*.execution.*).
+	action := Action{
+		Type:     ActionTypePublishAgent,
+		Subject:  "agent.task.researcher",
+		Role:     "researcher",
+		Model:    "mock-model",
+		Prompt:   "investigate",
+		RunScope: "new",
+	}
+
+	// Non-loop trigger: no LoopIDFromExecutionEntityID match.
+	nonLoopEntity := "acme.ops.iot.sensor.temperature.001"
+	err := executor.Execute(ctx, action, &ExecutionContext{EntityID: nonLoopEntity})
+	require.NoError(t, err)
+	require.Len(t, pub.published, 1, "task must still be published despite non-loop trigger")
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(pub.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	// No run is minted; RunID is empty (inherit from entity, but entity has no agent.run triple).
+	assert.Empty(t, task.RunID,
+		"non-loop trigger with run_scope=new and no agent.run triple must produce empty RunID")
+}
+
+// TestAction_PublishAgent_RunScopeNew_NoLifecycleManagerFallsBackToInherit verifies that
+// run_scope=new with no lifecycle manager wired logs a warning and falls back to inherit.
+func TestAction_PublishAgent_RunScopeNew_NoLifecycleManagerFallsBackToInherit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pub := &mockPublisher{}
+	// No SetLifecycleManager call — lifecycle is nil.
+	executor := NewActionExecutorComplete(nil, nil, pub, nil)
+
+	firingLoopID := "coordinator-loop-uuid"
+	loopEntityID := "acme.ops.agent.agentic-loop.execution." + firingLoopID
+
+	action := Action{
+		Type:     ActionTypePublishAgent,
+		Subject:  "agent.task.researcher",
+		Role:     "researcher",
+		Model:    "mock-model",
+		Prompt:   "investigate",
+		RunScope: "new",
+	}
+
+	err := executor.Execute(ctx, action, &ExecutionContext{EntityID: loopEntityID})
+	require.NoError(t, err)
+	require.Len(t, pub.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(pub.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	// No manager → no mint → RunID stays empty (inherit fallback, entity has no agent.run triple).
+	assert.Empty(t, task.RunID,
+		"run_scope=new with nil lifecycle manager must not panic and produce empty RunID")
+}
+
+// TestAction_PublishAgent_RunScopeNone_SuppressesRunID verifies that run_scope=none
+// prevents RunID propagation even when the trigger entity has an agent.run triple.
+func TestAction_PublishAgent_RunScopeNone_SuppressesRunID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pub := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, pub)
+
+	firingLoopID := "coordinator-loop-uuid"
+	loopEntityID := "acme.ops.agent.agentic-loop.execution." + firingLoopID
+
+	// Entity has an agent.run triple — but run_scope:none suppresses it.
+	entity := &gtypes.EntityState{
+		ID: loopEntityID,
+		Triples: []message.Triple{
+			{Subject: loopEntityID, Predicate: "agent.run", Object: "existing-run-id"},
+		},
+	}
+
+	action := Action{
+		Type:     ActionTypePublishAgent,
+		Subject:  "agent.task.researcher",
+		Role:     "researcher",
+		Model:    "mock-model",
+		Prompt:   "standalone investigate",
+		RunScope: "none",
+	}
+
+	err := executor.Execute(ctx, action, &ExecutionContext{EntityID: loopEntityID, Entity: entity})
+	require.NoError(t, err)
+	require.Len(t, pub.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(pub.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	assert.Empty(t, task.RunID,
+		"run_scope=none must suppress RunID even when the firing entity has an agent.run triple")
+}
+
+// TestAction_PublishAgent_RunScopeNew_MintsRunSuccessfully verifies run_scope=new
+// on a loop entity: Manager.Create is called (minting the run) and task.RunID is set.
+// This complements TestAction_PublishAgent_RunScopeNew_MintsRunAndStampsAgentRun with
+// a table-style case that also confirms the fakeLifecycleManager stores the minted run.
+func TestAction_PublishAgent_RunScopeNew_MintsRunSuccessfully(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	pub := &mockPublisher{}
+	mgr := newFakeManager()
+	executor := NewActionExecutorComplete(nil, nil, pub, nil)
+	executor.SetLifecycleManager(mgr)
+
+	firingLoopID := "coord-fresh-mint"
+	loopEntityID := "acme.ops.agent.agentic-loop.execution." + firingLoopID
+
+	action := Action{
+		Type:     ActionTypePublishAgent,
+		Subject:  "agent.task.researcher",
+		Role:     "researcher",
+		Model:    "mock-model",
+		Prompt:   "investigate",
+		RunScope: "new",
+	}
+
+	err := executor.Execute(ctx, action, &ExecutionContext{EntityID: loopEntityID})
+	require.NoError(t, err)
+	require.Len(t, pub.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(pub.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+	assert.Equal(t, firingLoopID, task.RunID,
+		"run_scope=new: spawned child's RunID must equal the firing loop's bare loop-id")
+
+	// Manager.Create must have created the run entity.
+	runEntityID := "acme.ops.agent.chain.execution." + firingLoopID
+	_, created := mgr.entities["agent-run"][runEntityID]
+	assert.True(t, created, "Manager.Create must mint the AgentRun entity in 'dispatched' phase")
+}

--- a/processor/rule/config_validation.go
+++ b/processor/rule/config_validation.go
@@ -265,6 +265,16 @@ func validateConditionFields(def Definition) error {
 //   - Action.MaxIterations, when set, must be non-negative. Sentinel
 //     0 is valid (operator's explicit unlimited opt-out); negative
 //     values are config errors.
+//
+// validRunScopeValues is the closed set of valid run_scope strings for publish_agent
+// actions (ADR-053 D4). Empty string is also valid (treated as "inherit").
+var validRunScopeValues = map[string]bool{
+	"":        true,
+	"new":     true,
+	"inherit": true,
+	"none":    true,
+}
+
 func validateActionLists(def Definition) error {
 	check := func(label string, actions []Action) error {
 		for i, a := range actions {
@@ -273,6 +283,14 @@ func validateActionLists(def Definition) error {
 					fmt.Errorf("rule %s %s[%d] max_iterations must be >= 0 (0 = unlimited), got %d",
 						def.ID, label, i, *a.MaxIterations),
 					"RuleProcessor", "ValidateDefinition", "validate action max_iterations")
+			}
+			// Validate run_scope for publish_agent actions (ADR-053 D4).
+			// Other action types ignore run_scope (no-op, not an error).
+			if a.Type == ActionTypePublishAgent && !validRunScopeValues[a.RunScope] {
+				return errs.WrapInvalid(
+					fmt.Errorf("rule %s %s[%d] run_scope %q is invalid; valid values: new, inherit, none (or omit for inherit default)",
+						def.ID, label, i, a.RunScope),
+					"RuleProcessor", "ValidateDefinition", "validate action run_scope")
 			}
 		}
 		return nil

--- a/processor/rule/config_validation_test.go
+++ b/processor/rule/config_validation_test.go
@@ -239,3 +239,85 @@ func TestValidateExpressionRule_RejectsRuleOpaqueField(t *testing.T) {
 		}
 	})
 }
+
+// --- ADR-053 D4: run_scope validation tests (I2) ---
+
+// TestValidateActionLists_RunScopeValid verifies that valid run_scope values
+// ("new", "inherit", "none", "") pass ValidateDefinition without error.
+func TestValidateActionLists_RunScopeValid(t *testing.T) {
+	t.Parallel()
+	for _, scope := range []string{"new", "inherit", "none", ""} {
+		scope := scope
+		t.Run("scope_"+scope, func(t *testing.T) {
+			t.Parallel()
+			def := Definition{
+				ID:   "run-scope-valid",
+				Type: "expression",
+				Actions: []Action{
+					{
+						Type:     ActionTypePublishAgent,
+						Subject:  "agent.task.test",
+						RunScope: scope,
+					},
+				},
+			}
+			if err := ValidateDefinition(def); err != nil {
+				t.Errorf("run_scope=%q must be accepted by ValidateDefinition, got: %v", scope, err)
+			}
+		})
+	}
+}
+
+// TestValidateActionLists_RunScopeInvalidRejects verifies that an invalid run_scope
+// value ("always", "auto", "foo") is rejected by ValidateDefinition. This exercises
+// the closed-set validator in validateActionLists (previously unexercised per I2).
+func TestValidateActionLists_RunScopeInvalidRejects(t *testing.T) {
+	t.Parallel()
+	for _, scope := range []string{"always", "auto", "foo", "NEW"} {
+		scope := scope
+		t.Run("scope_"+scope, func(t *testing.T) {
+			t.Parallel()
+			def := Definition{
+				ID:   "run-scope-invalid",
+				Type: "expression",
+				Actions: []Action{
+					{
+						Type:     ActionTypePublishAgent,
+						Subject:  "agent.task.test",
+						RunScope: scope,
+					},
+				},
+			}
+			err := ValidateDefinition(def)
+			if err == nil {
+				t.Fatalf("run_scope=%q must be rejected by ValidateDefinition, got nil", scope)
+			}
+			if !strings.Contains(err.Error(), "run_scope") {
+				t.Errorf("error %q must mention 'run_scope', got: %v", scope, err)
+			}
+		})
+	}
+}
+
+// TestValidateActionLists_RunScopeOnlyCheckedForPublishAgent verifies that
+// run_scope is ignored (not rejected) on non-publish_agent action types.
+// A publish action with an invalid run_scope should pass because the field
+// is only validated for publish_agent.
+func TestValidateActionLists_RunScopeOnlyCheckedForPublishAgent(t *testing.T) {
+	t.Parallel()
+	def := Definition{
+		ID:   "run-scope-non-agent",
+		Type: "expression",
+		Actions: []Action{
+			{
+				Type:      ActionTypeAddTriple,
+				Predicate: "some.predicate",
+				Object:    "val",
+				RunScope:  "invalid-but-not-publish-agent",
+			},
+		},
+	}
+	if err := ValidateDefinition(def); err != nil {
+		t.Errorf("run_scope on non-publish_agent action must not be validated, got: %v", err)
+	}
+}

--- a/processor/rule/cron_substitution_test.go
+++ b/processor/rule/cron_substitution_test.go
@@ -197,3 +197,45 @@ func TestExecutionContext_SubstituteVariables_ScheduleNamespace(t *testing.T) {
 		})
 	}
 }
+
+// TestSubstituteVariables_AgentRunTripleResolves verifies that the
+// $entity.triple.agent.run substitution token resolves correctly through the
+// standard entity-triple substitution layer (M3 grammar-verification per
+// feedback_reference_configs_verify_triple_stamping). The predicate name
+// "agent.run" (LoopRun vocab constant, ADR-053 D7) is verified collision-free
+// against the substitution grammar at implementation time; this test locks the
+// runtime behavior so a future substitution-layer refactor can't silently break
+// the agent.run namespace without surfacing here.
+func TestSubstituteVariables_AgentRunTripleResolves(t *testing.T) {
+	t.Parallel()
+
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.loop-xyz"
+	ec := &ExecutionContext{
+		EntityID: loopEntityID,
+		Entity: &gtypes.EntityState{
+			ID: loopEntityID,
+			Triples: []message.Triple{
+				{Subject: loopEntityID, Predicate: "agent.run", Object: "root-loop-uuid"},
+			},
+		},
+	}
+
+	got := ec.SubstituteVariables("$entity.triple.agent.run")
+	if got != "root-loop-uuid" {
+		t.Errorf("$entity.triple.agent.run resolved to %q, want %q", got, "root-loop-uuid")
+	}
+
+	// Verify an entity WITHOUT agent.run returns an unresolved token (not empty,
+	// not panic): the substitution layer leaves framework-namespace tokens verbatim.
+	ecNoTriple := &ExecutionContext{
+		EntityID: loopEntityID,
+		Entity: &gtypes.EntityState{
+			ID:      loopEntityID,
+			Triples: []message.Triple{},
+		},
+	}
+	absent := ecNoTriple.SubstituteVariables("$entity.triple.agent.run")
+	if absent == "root-loop-uuid" {
+		t.Errorf("absent agent.run triple must not resolve to a value, got %q", absent)
+	}
+}

--- a/schemas/rule-processor.v1.json
+++ b/schemas/rule-processor.v1.json
@@ -151,6 +151,10 @@
                   "type": "string",
                   "description": "role"
                 },
+                "run_scope": {
+                  "type": "string",
+                  "description": "run_scope"
+                },
                 "set": {
                   "type": "object",
                   "description": "set"
@@ -417,6 +421,10 @@
                   "type": "string",
                   "description": "role"
                 },
+                "run_scope": {
+                  "type": "string",
+                  "description": "run_scope"
+                },
                 "set": {
                   "type": "object",
                   "description": "set"
@@ -601,6 +609,10 @@
                   "type": "string",
                   "description": "role"
                 },
+                "run_scope": {
+                  "type": "string",
+                  "description": "run_scope"
+                },
                 "set": {
                   "type": "object",
                   "description": "set"
@@ -784,6 +796,10 @@
                 "role": {
                   "type": "string",
                   "description": "role"
+                },
+                "run_scope": {
+                  "type": "string",
+                  "description": "run_scope"
                 },
                 "set": {
                   "type": "object",
@@ -987,6 +1003,10 @@
                 "role": {
                   "type": "string",
                   "description": "role"
+                },
+                "run_scope": {
+                  "type": "string",
+                  "description": "run_scope"
                 },
                 "set": {
                   "type": "object",

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -456,6 +456,14 @@ const (
 	// DataType: string (entity ID)
 	LoopParent = "agent.loop.parent"
 
+	// LoopRun is the bare run loop-id this loop belongs to (ADR-053 D7).
+	// Stamped at spawn time by buildSpawnIdentityTriples when TaskMessage.RunID is non-empty.
+	// Rules can read this via $entity.triple.agent.run. Grammar-collision-free:
+	// no existing $-regex matches agent.run.* (audited at ADR-053 implementation).
+	// Example: "loop-uuid-of-the-root-coordinator"
+	// DataType: string (bare loop UUID, NOT a 6-part entity ID)
+	LoopRun = "agent.run"
+
 	// LoopWorkflow is the workflow slug this loop belongs to.
 	// Example: "code-review", "feature-implementation"
 	// DataType: string


### PR DESCRIPTION
Promotes ADR-053. Nested agentic loops (a coordinator spawning research/architect/builder children) form a **run**; the framework had no first-class entity for it (only an unused `ChainExecutionEntityID` constructor), so semteams hand-rolled the whole run layer. This lifts that reference design into the framework as a **Lifecycle `Participant`** (`workflow="agent-run"`), reusing the harness (Manager / restart recovery / operator gateway / rule integration / ENTITY_STATES) wholesale.

The ADR + code ship together in this PR (`docs/adr/053-agent-run-substrate.md` + `docs/proposals/agent-run-substrate.md` design record).

## Why a Participant
ADR-047 excluded the agentic **loop** from `Participant` (per-iteration LLM judgment, high-write `AGENT_LOOPS`) but anticipated *"a future agentic role with declared phases could implement `Participant` if the fit emerges."* The **run** is that role: a small declarable lifecycle (`dispatched → executing ⇄ awaiting_approval → terminal`); the dynamism lives *inside* `executing`. The loop stays out; only the run participates.

## Additive / non-breaking
Existing flows are byte-identical (everything `omitempty`; run machinery activates only when a rule declares `run_scope:new`). The **breaking** surface is the semteams rule-pack migration — a separate lockstep PR. `e2e:agentic` passed locally (no regression; 2 loops completed).

## Decisions (D1–D8)
- **D1** `AgentRun` Participant — `lifecycle:"id"` holds the **full** chain.execution entity ID (projection populates it from the entity-state key), bare run-id derived. Guarded by a **real-projection integration round-trip test**.
- **D2** registered via `lifecycle.Workflow` + Transitions table.
- **D3** terminal authority — framework creates+observes; product/coordinator emits the terminal decision via `lifecycle_transition`; narrow framework fallback transitions a dispatched root run to failed/cancelled if the root loop dies before any child handoff (zombie prevention). Never `Manager.Complete`.
- **D4** mint is a declared rule-action field `RunScope` (`new|inherit|none`), validated; `new` mints + stamps `agent.run` on the firing entity.
- **D5** run *phase* via `Manager.Transition` (CAS); *milestones* via graph-ingest `AddTriple` (last-writer-wins) — never Manager writes. Cardinality contract documented.
- **D6** milestone subscriber — **durable** JetStream consumers on `agent.complete.*` + `agent.failed.*`, category-demux, panic-guarded — + `ResolveRun` typed-first/ancestry-walk fallback.
- **D7** typed `RunID` inherited at spawn (collapses the two prior run-identity mechanisms + retires the read-side walk); `agent.run` stamped atomically.
- **D8** `RunID`/`RunEntityID` on all four loop events (+`ParentLoopID` on cancelled).

`TryChainExecutionEntityID` added (panicking constructor delegates) and used at event-construction to avoid killing the publish goroutine.

## Review trail
Two design reviews (architect + Codex, both RIGHT-WITH-CHANGES). Pre-merge **go-reviewer**: 2 Critical + 3 Important + 5 Minor — **all resolved and independently verified** (incl. C1 root-loop zombie-prevention reachability, C2 real-projection round-trip, I1 durable consumption). Verified: `task lint`, `go test -race ./...`, `go vet` (plain + integration), integration tests (real NATS), `task schema:generate` (only the `run_scope` field), and `task e2e:agentic`.

## Follow-up (separate, lockstep)
semteams rule-pack migration (~35 files, the run-anchor predicate family) retiring the hand-rolled chain layer — gated on `e2e:agentic` at tag time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)