### PR TITLE
fix(agentic-dispatch): project run_id + run_entity_id onto the Loop wire (ADR-053 follow-up)

### DIFF
--- a/processor/agentic-dispatch/http.go
+++ b/processor/agentic-dispatch/http.go
@@ -1001,7 +1001,7 @@ func (c *Component) handleActivityStream(w http.ResponseWriter, r *http.Request)
 							slog.String("key", entry.Key()),
 							slog.String("error", err.Error()))
 					} else {
-						loop, ok = loopFromEntity(&e), true
+						loop, ok = loopFromEntity(&e, c.deps.Platform.Org, c.deps.Platform.Platform), true
 					}
 				}
 				if ok {

--- a/processor/agentic-dispatch/loop_wire.go
+++ b/processor/agentic-dispatch/loop_wire.go
@@ -21,12 +21,18 @@ type Loop struct {
 	UserID        string `json:"user_id,omitempty"`
 	ChannelType   string `json:"channel_type,omitempty"`
 	ParentLoopID  string `json:"parent_loop_id,omitempty"`
-	Outcome       string `json:"outcome,omitempty"`
-	Result        string `json:"result,omitempty"`
-	Error         string `json:"error,omitempty"`
-	Prompt        string `json:"prompt,omitempty"`
-	TokensIn      int    `json:"tokens_in,omitempty"`
-	TokensOut     int    `json:"tokens_out,omitempty"`
+	// RunID is the bare run loop-id this loop belongs to (ADR-053). RunEntityID
+	// is the full 6-part chain.execution entity ID — the form a consumer feeds to
+	// graph getEntity() to read chain-level triples, WITHOUT re-deriving it
+	// client-side. Both empty for loops not in a run.
+	RunID       string `json:"run_id,omitempty"`
+	RunEntityID string `json:"run_entity_id,omitempty"`
+	Outcome     string `json:"outcome,omitempty"`
+	Result      string `json:"result,omitempty"`
+	Error       string `json:"error,omitempty"`
+	Prompt      string `json:"prompt,omitempty"`
+	TokensIn    int    `json:"tokens_in,omitempty"`
+	TokensOut   int    `json:"tokens_out,omitempty"`
 	// PendingApproval is populated when the loop is in awaiting_approval state.
 	PendingApproval *PendingApprovalInfo `json:"pending_approval,omitempty"`
 }
@@ -44,6 +50,8 @@ func loopFromInfo(in *LoopInfo) Loop {
 		UserID:          in.UserID,
 		ChannelType:     in.ChannelType,
 		ParentLoopID:    "", // not tracked in LoopInfo today — scoped-out follow-up
+		RunID:           "", // not tracked in LoopInfo today — /activity (loopFromEntity) carries it
+		RunEntityID:     "", // ditto
 		Outcome:         in.Outcome,
 		Result:          in.Result,
 		Error:           in.Error,
@@ -56,8 +64,18 @@ func loopFromInfo(in *LoopInfo) Loop {
 
 // loopFromEntity projects a framework-owned KV LoopEntity (key=<loopID>) onto Loop.
 // Token and prompt fields are not stored on live entities — they appear only in
-// completion events.
-func loopFromEntity(e *agentic.LoopEntity) Loop {
+// completion events. org/platform are the dispatch component's platform identity,
+// needed to derive RunEntityID (the 6-part chain.execution ID) since LoopEntity
+// stores only the bare RunID.
+func loopFromEntity(e *agentic.LoopEntity, org, platform string) Loop {
+	var runEntityID string
+	if e.RunID != "" {
+		// Best-effort: a malformed RunID/platform leaves RunEntityID empty rather
+		// than failing the projection (the bare RunID still ships).
+		if id, err := agentic.TryChainExecutionEntityID(org, platform, e.RunID); err == nil {
+			runEntityID = id
+		}
+	}
 	return Loop{
 		LoopID:        e.ID,
 		TaskID:        e.TaskID,
@@ -68,6 +86,8 @@ func loopFromEntity(e *agentic.LoopEntity) Loop {
 		UserID:        e.UserID,
 		ChannelType:   e.ChannelType,
 		ParentLoopID:  e.ParentLoopID,
+		RunID:         e.RunID,
+		RunEntityID:   runEntityID,
 		Outcome:       e.Outcome,
 		Result:        e.Result,
 		Error:         e.Error,
@@ -93,7 +113,9 @@ type completionWire struct {
 	Iterations   int    `json:"iterations"`
 	TokensIn     int    `json:"tokens_in"`
 	TokensOut    int    `json:"tokens_out"`
-	ParentLoopID string `json:"parent_loop"` // events.go uses "parent_loop"; normalised onto Loop.ParentLoopID
+	ParentLoopID string `json:"parent_loop"`   // events.go uses "parent_loop"; normalised onto Loop.ParentLoopID
+	RunID        string `json:"run_id"`        // ADR-053: present on terminal events
+	RunEntityID  string `json:"run_entity_id"` // ADR-053: 6-part, present on terminal events
 }
 
 // loopFromCompletion projects a COMPLETE_<loopID> terminal event payload onto Loop.
@@ -119,5 +141,7 @@ func loopFromCompletion(raw []byte) (Loop, bool) {
 		TokensIn:     w.TokensIn,
 		TokensOut:    w.TokensOut,
 		ParentLoopID: w.ParentLoopID,
+		RunID:        w.RunID,
+		RunEntityID:  w.RunEntityID,
 	}, true
 }

--- a/processor/agentic-dispatch/loop_wire_test.go
+++ b/processor/agentic-dispatch/loop_wire_test.go
@@ -1,6 +1,7 @@
 package agenticdispatch
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ func TestLoopFromEntity_RoundTrip(t *testing.T) {
 		UserID:        "user-1",
 		ChannelType:   "cli",
 		ParentLoopID:  "loop-parent",
+		RunID:         "run-root",
 		Outcome:       "",
 		Result:        "",
 		Error:         "",
@@ -40,7 +42,7 @@ func TestLoopFromEntity_RoundTrip(t *testing.T) {
 		t.Fatalf("unmarshal LoopEntity: %v", err)
 	}
 
-	got := loopFromEntity(&decoded)
+	got := loopFromEntity(&decoded, "c360", "ops")
 
 	if got.LoopID != entity.ID {
 		t.Errorf("LoopID: got %q, want %q (id→loop_id normalisation)", got.LoopID, entity.ID)
@@ -69,12 +71,62 @@ func TestLoopFromEntity_RoundTrip(t *testing.T) {
 	if got.ParentLoopID != entity.ParentLoopID {
 		t.Errorf("ParentLoopID: got %q, want %q", got.ParentLoopID, entity.ParentLoopID)
 	}
+	// ADR-053: run_id is the bare id; run_entity_id is the derived 6-part the UI
+	// feeds to getEntity() without client-side reconstruction.
+	if got.RunID != entity.RunID {
+		t.Errorf("RunID: got %q, want %q", got.RunID, entity.RunID)
+	}
+	if want := "c360.ops.agent.chain.execution.run-root"; got.RunEntityID != want {
+		t.Errorf("RunEntityID: got %q, want %q (derived from org/platform + RunID)", got.RunEntityID, want)
+	}
 	// Token and prompt fields are absent from live entities.
 	if got.TokensIn != 0 || got.TokensOut != 0 {
 		t.Errorf("expected zero token counts from entity, got in=%d out=%d", got.TokensIn, got.TokensOut)
 	}
 	if got.Prompt != "" {
 		t.Errorf("expected empty Prompt from entity, got %q", got.Prompt)
+	}
+}
+
+// TestLoopRunFields_EmptyRunIDOmitted verifies the run fields stay empty (and so
+// omitempty-drop from the wire) when the loop is not part of a run.
+func TestLoopRunFields_EmptyRunIDOmitted(t *testing.T) {
+	got := loopFromEntity(&agentic.LoopEntity{ID: "loop-x", State: agentic.LoopStateExecuting, MaxIterations: 5}, "c360", "ops")
+	if got.RunID != "" || got.RunEntityID != "" {
+		t.Errorf("expected empty run fields for non-run loop, got run_id=%q run_entity_id=%q", got.RunID, got.RunEntityID)
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal Loop: %v", err)
+	}
+	if bytes.Contains(raw, []byte("run_id")) || bytes.Contains(raw, []byte("run_entity_id")) {
+		t.Errorf("expected run fields omitted from JSON, got %s", raw)
+	}
+}
+
+// TestLoopFromCompletion_RunFields verifies run_id + run_entity_id project from a
+// real terminal event (the event carries both; no derivation needed here).
+func TestLoopFromCompletion_RunFields(t *testing.T) {
+	event := agentic.LoopCompletedEvent{
+		LoopID:      "loop-child",
+		TaskID:      "task-1",
+		Outcome:     agentic.OutcomeSuccess,
+		RunID:       "run-root",
+		RunEntityID: "c360.ops.agent.chain.execution.run-root",
+	}
+	raw, err := json.Marshal(&event)
+	if err != nil {
+		t.Fatalf("marshal LoopCompletedEvent: %v", err)
+	}
+	got, ok := loopFromCompletion(raw)
+	if !ok {
+		t.Fatalf("loopFromCompletion returned ok=false")
+	}
+	if got.RunID != event.RunID {
+		t.Errorf("RunID: got %q, want %q", got.RunID, event.RunID)
+	}
+	if got.RunEntityID != event.RunEntityID {
+		t.Errorf("RunEntityID: got %q, want %q", got.RunEntityID, event.RunEntityID)
 	}
 }
 

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1214,6 +1214,10 @@ components:
                                 type: string
                             role:
                                 type: string
+                            run_entity_id:
+                                type: string
+                            run_id:
+                                type: string
                             state:
                                 type: string
                             task_id:
@@ -1571,6 +1575,10 @@ components:
                 result:
                     type: string
                 role:
+                    type: string
+                run_entity_id:
+                    type: string
+                run_id:
                     type: string
                 state:
                     type: string


### PR DESCRIPTION
## Summary

beta.100 (ADR-053) put `RunID` on `LoopEntity` and the loop events, but never projected it onto the `/activity` + `/loops` `Loop` wire struct (`loop_wire.go`) — so the semteams UI still can't read the run from `/activity`. This closes that gap.

Adds two fields to `Loop`:
- **`run_id`** — the bare run loop-id (semteams' literal ask).
- **`run_entity_id`** — the full 6-part `agent.chain.execution.<runID>` ID. This is the form a consumer feeds to graph `getEntity()` to read chain-level triples **without re-deriving the 6-part ID client-side** — the exact requirement that motivated the run primitive in the first place. Shipping only the bare `run_id` would reintroduce the client-side PlatformMeta-derivation problem.

## Projection

- `loopFromEntity` derives `run_entity_id` from the dispatch component's platform (`c.deps.Platform`) since `LoopEntity` stores only the bare `RunID`; projects both.
- `loopFromCompletion` projects both directly (terminal events already carry both, ADR-053 D8).
- `loopFromInfo` leaves them empty — the in-memory `/loops` tracker has no `RunID`, same posture as `parent_loop_id` (documented follow-up).

## Safety

Additive (`omitempty`); existing consumers unaffected. Schema regenerated — `run_id`/`run_entity_id` now appear on the `Loop` schema for both endpoints.

Tests: round-trip from a real `LoopEntity` (asserts the derived 6-part), from a real `LoopCompletedEvent`, and the empty-RunID omitempty-drop case.

Verified: `go build ./...`, `go test -race ./processor/agentic-dispatch/...`, `task lint`, `go vet` (plain + integration), contract tests, `task schema:generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)