### PR TITLE
feat(agentic): rule-addressable run entity ID via agent.run.entity_id (ADR-053 follow-up)

### DIFF
--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -527,12 +527,16 @@ func buildSpawnIdentityTriples(loopEntityID string, task *agentic.TaskMessage, o
 		parentEntityID := agentic.LoopExecutionEntityID(org, platform, task.ParentLoopID)
 		triples = append(triples, triple(agvocab.LoopParent, parentEntityID))
 	}
-	// Stamp agent.run when the loop belongs to a run (ADR-053 D7).
-	// The object is the bare RunID (not a 6-part entity ID) — rules read
-	// it via $entity.triple.agent.run; the full chain entity ID is derived
-	// via ChainExecutionEntityID when needed.
+	// Stamp the run anchor when the loop belongs to a run (ADR-053 D7).
+	// Two triples: agent.run = bare RunID (used by ResolveRun/RunID());
+	// agent.run.entity_id = the full 6-part chain.execution ID, the
+	// rule-addressable upsert SUBJECT (rules cannot derive the 6-part from
+	// the bare id — substitution is string interpolation, not function calls).
 	if task.RunID != "" {
 		triples = append(triples, triple(agvocab.LoopRun, task.RunID))
+		if runEntityID, err := agentic.TryChainExecutionEntityID(org, platform, task.RunID); err == nil {
+			triples = append(triples, triple(agvocab.LoopRunEntityID, runEntityID))
+		}
 	}
 	if task.WorkflowSlug != "" {
 		triples = append(triples, triple(agvocab.LoopWorkflow, task.WorkflowSlug))

--- a/processor/agentic-loop/spawn_identity_test.go
+++ b/processor/agentic-loop/spawn_identity_test.go
@@ -233,7 +233,7 @@ func TestBuildSpawnIdentityTriples_TripleCountWithFullTask(t *testing.T) {
 	}
 
 	triples := buildSpawnIdentityTriples("acme.ops.agent.agentic-loop.execution.spawn-count", task, "acme", "ops")
-	want := 8 // role, task, parent, run, workflow, workflow_step, user, description
+	want := 9 // role, task, parent, run, run.entity_id, workflow, workflow_step, user, description
 	if len(triples) != want {
 		preds := make([]string, 0, len(triples))
 		for _, tr := range triples {
@@ -285,6 +285,19 @@ func TestBuildSpawnIdentityTriples_StampsRunID(t *testing.T) {
 	if runID != "root-loop-uuid" {
 		t.Errorf("LoopRun = %q, want %q", runID, "root-loop-uuid")
 	}
+
+	// ADR-053 follow-up: agent.run.entity_id is the FULL 6-part chain entity ID,
+	// the rule-addressable upsert subject.
+	if !predicates[agvocab.LoopRunEntityID] {
+		t.Fatalf("expected agent.run.entity_id triple; got predicates: %v", predicates)
+	}
+	runEntityID, ok := objectFor(triples, agvocab.LoopRunEntityID).(string)
+	if !ok {
+		t.Fatal("LoopRunEntityID object is not a string")
+	}
+	if want := "acme.ops.agent.chain.execution.root-loop-uuid"; runEntityID != want {
+		t.Errorf("LoopRunEntityID = %q, want %q", runEntityID, want)
+	}
 }
 
 // TestBuildSpawnIdentityTriples_OmitsRunIDWhenEmpty verifies that agent.run is
@@ -304,12 +317,15 @@ func TestBuildSpawnIdentityTriples_OmitsRunIDWhenEmpty(t *testing.T) {
 	if predicates[agvocab.LoopRun] {
 		t.Errorf("expected agent.run triple to be omitted when RunID is empty")
 	}
+	if predicates[agvocab.LoopRunEntityID] {
+		t.Errorf("expected agent.run.entity_id triple to be omitted when RunID is empty")
+	}
 }
 
 // TestBuildSpawnIdentityTriples_RunIDIsNotEntityID guards that the LoopRun
-// object is the BARE run loop-id, not a 6-part entity ID. Rules read
-// $entity.triple.agent.run and pass it to ChainExecutionEntityID on demand;
-// storing the pre-expanded entity ID would double-expand it.
+// object is the BARE run loop-id (the 6-part form lives on the separate
+// agent.run.entity_id triple). Conflating the two would break ResolveRun,
+// which reads agent.run as a bare id and rebuilds the chain entity ID.
 func TestBuildSpawnIdentityTriples_RunIDIsNotEntityID(t *testing.T) {
 	loopEntityID := "acme.ops.agent.agentic-loop.execution.child-run-002"
 	task := &agentic.TaskMessage{

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -1210,22 +1210,28 @@ func (e *ActionExecutor) publishAgentOnce(ctx context.Context, action Action, ec
 					// The triple is best-effort: a write failure does not abort the
 					// dispatch or the child publish.
 					if e.tripleMutator != nil {
-						runTriple := message.Triple{
-							Subject:    entityID,
-							Predicate:  agvocab.LoopRun,
-							Object:     firingLoopID,
-							Source:     "rule_engine",
-							Timestamp:  time.Now(),
-							Confidence: 1.0,
-						}
-						if _, tripleErr := e.tripleMutator.AddTriple(ctx, ec.RuleID(), runTriple); tripleErr != nil {
-							if e.logger != nil {
-								e.logger.Warn("publish_agent: run_scope=new: failed to stamp agent.run on firing entity — D3 zombie guard may not fire for root-loop failures",
+						stampRun := func(predicate, object string) {
+							if _, tripleErr := e.tripleMutator.AddTriple(ctx, ec.RuleID(), message.Triple{
+								Subject:    entityID,
+								Predicate:  predicate,
+								Object:     object,
+								Source:     "rule_engine",
+								Timestamp:  time.Now(),
+								Confidence: 1.0,
+							}); tripleErr != nil && e.logger != nil {
+								e.logger.Warn("publish_agent: run_scope=new: failed to stamp run anchor on firing entity",
 									slog.String("entity_id", entityID),
+									slog.String("predicate", predicate),
 									slog.String("firing_loop_id", firingLoopID),
 									slog.String("rule_id", ec.RuleID()),
 									slog.Any("error", tripleErr))
 							}
+						}
+						// agent.run (bare) → D3 root resolution; agent.run.entity_id
+						// (6-part) → rule-addressable upsert subject (ADR-053 follow-up).
+						stampRun(agvocab.LoopRun, firingLoopID)
+						if runEntityID, idErr := agentic.TryChainExecutionEntityID(org, platform, firingLoopID); idErr == nil {
+							stampRun(agvocab.LoopRunEntityID, runEntityID)
 						}
 					}
 				}

--- a/processor/rule/cron_substitution_test.go
+++ b/processor/rule/cron_substitution_test.go
@@ -216,6 +216,7 @@ func TestSubstituteVariables_AgentRunTripleResolves(t *testing.T) {
 			ID: loopEntityID,
 			Triples: []message.Triple{
 				{Subject: loopEntityID, Predicate: "agent.run", Object: "root-loop-uuid"},
+				{Subject: loopEntityID, Predicate: "agent.run.entity_id", Object: "acme.ops.agent.chain.execution.root-loop-uuid"},
 			},
 		},
 	}
@@ -223,6 +224,14 @@ func TestSubstituteVariables_AgentRunTripleResolves(t *testing.T) {
 	got := ec.SubstituteVariables("$entity.triple.agent.run")
 	if got != "root-loop-uuid" {
 		t.Errorf("$entity.triple.agent.run resolved to %q, want %q", got, "root-loop-uuid")
+	}
+
+	// ADR-053 follow-up: the 6-part run entity ID is the rule-addressable upsert
+	// subject. $entity.triple.agent.run.entity_id must resolve to the full ID so a
+	// rule can use it as an add_triple/update_triple Subject.
+	gotEntity := ec.SubstituteVariables("$entity.triple.agent.run.entity_id")
+	if want := "acme.ops.agent.chain.execution.root-loop-uuid"; gotEntity != want {
+		t.Errorf("$entity.triple.agent.run.entity_id resolved to %q, want %q", gotEntity, want)
 	}
 
 	// Verify an entity WITHOUT agent.run returns an unresolved token (not empty,

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -464,6 +464,19 @@ const (
 	// DataType: string (bare loop UUID, NOT a 6-part entity ID)
 	LoopRun = "agent.run"
 
+	// LoopRunEntityID is the FULL 6-part chain.execution entity ID of the run
+	// this loop belongs to (ADR-053). Stamped at spawn alongside LoopRun.
+	// This is the rule-addressable upsert SUBJECT for run-scoped state: a rule
+	// firing on a loop reads $entity.triple.agent.run.entity_id and uses it as
+	// the Subject of add_triple/update_triple (the typed replacement for the
+	// old $entity.triple.lineage.run-loop-entity-id pattern). Rules cannot
+	// derive the 6-part from the bare LoopRun (substitution is string interp,
+	// not function calls), so the framework stamps the full form directly.
+	// For computed run-state, prefer a Go agentrun.MilestoneHandler instead.
+	// Example: "org.platform.agent.chain.execution.<runID>"
+	// DataType: string (6-part federated entity ID)
+	LoopRunEntityID = "agent.run.entity_id"
+
 	// LoopWorkflow is the workflow slug this loop belongs to.
 	// Example: "code-review", "feature-implementation"
 	// DataType: string


### PR DESCRIPTION
## Why

semteams asked how rules address the run entity as an **upsert subject**. Previously they used `$entity.triple.lineage.run-loop-entity-id` (a loop entity). ADR-053's run entity is a distinct `agent.chain.execution.*`, and the framework stamped only the **bare** `agent.run`. A rule can read `$entity.triple.agent.run` but **cannot** derive the 6-part `agent.chain.execution.<runID>` from it — rule substitution is string interpolation, not function calls. So there was no rule-addressable run-entity ID. (The code comment claiming "derive via `ChainExecutionEntityID` when needed" doesn't hold for the rule layer.)

## What

Stamp the full 6-part run entity ID as **`agent.run.entity_id`** at both spawn sites:
- `buildSpawnIdentityTriples` — for every spawned loop in a run (covers semteams' child-loop upserts).
- the `run_scope=new` firing-entity stamp — for the root/coordinator.

Rules now use **`$entity.triple.agent.run.entity_id`** as the upsert subject — a near drop-in replacement for the old `lineage.run-loop-entity-id`, via the existing `$entity.triple.*` mechanism (no new substitution-engine machinery; token verified collision-free against the substitution regexes). The bare `agent.run` stays (`ResolveRun`/`RunID()` use it).

## a + b, not either/or

This is path **(a)** — the declarative rule route. Path **(b)** — Go `agentrun.MilestoneHandler` (resolved `*AgentRun` + `TriplePublisher`) — shipped in beta.100 and is the right tool for **computed** run-state. semteams picks per upsert: declarative → rules via `agent.run.entity_id`; computed → Go handler.

This completes ADR-053's rule-addressing surface for the run entity (the substrate finishing its own contract).

## Safety

Additive; existing flows unaffected (triple stamped only when the loop is in a run). No schema change (triples aren't component schema). Tests: spawn-identity asserts both triples, omit-when-empty, and the exact count; a substitution test asserts `$entity.triple.agent.run.entity_id` resolves to the 6-part. Verified: build, `go test -race ./...`, lint, vet ×2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)