### PR TITLE
fix(lifecycle): Manager.Transition replaces phase triple instead of appending

### DIFF
--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -481,6 +481,18 @@ func (m *Manager) TransitionWith(ctx context.Context, workflow, entityID, newPha
 			delta = append(delta, diffProjectedTriples(reg.meta, entityID, state.Triples, projected)...)
 		}
 
+		// Replace, don't append: every field Transition writes (phase,
+		// audit, mutator-changed scalars) is single-valued, so remove the
+		// prior triple for each predicate before adding the new one. Without
+		// this, transitions ACCUMULATE phase triples (e.g. [dispatched,
+		// executing, completed]); extractTripleScalar reads last-match (so the
+		// Manager stays correct) but the rule engine's GetFieldValue reads
+		// first-match → it sees the stale initial phase and phase guards never
+		// re-fire. Mirrors UpdateFromOperator's add+remove replace model.
+		removePreds := make([]string, 0, len(delta))
+		for _, t := range delta {
+			removePreds = append(removePreds, t.Predicate)
+		}
 		emitReq := &graph.UpdateEntityWithTriplesRequest{
 			Entity: &graph.EntityState{
 				ID:          entityID,
@@ -489,6 +501,7 @@ func (m *Manager) TransitionWith(ctx context.Context, workflow, entityID, newPha
 				MessageType: lifecycleMessageType,
 			},
 			AddTriples:       delta,
+			RemoveTriples:    removePreds,
 			ExpectedRevision: currentRev,
 		}
 		_, err = m.emitter.update(ctx, emitReq)

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -450,12 +450,16 @@ func TestManager_GetRawReturnsAllTriples(t *testing.T) {
 	}
 }
 
-// TestManager_DuplicatePredicateAccumulationGetReturnsLatest exercises
-// the production naive-append merge (per ADR-049 reviewer B1).
-// Repeated transitions accumulate duplicate `mission.phase` triples in
-// the stored EntityState; Manager.Get must project the LAST one
-// (per-predicate latest-wins at read time, not write time).
-func TestManager_DuplicatePredicateAccumulationGetReturnsLatest(t *testing.T) {
+// TestManager_TransitionReplacesPhaseTripleNotAppend guards the
+// replace-not-append invariant: Transition must REMOVE the prior phase
+// triple, leaving exactly one. The earlier naive-append behavior left
+// [planning, flying, completed]; extractTripleScalar (last-match) kept
+// Manager.Get correct, but the rule engine's GetFieldValue reads
+// FIRST-match → it saw the stale "planning" and phase guards never
+// re-fired (semteams autoresearch 4a). With the fix, both read paths
+// see the same single value. Single-valued for every predicate
+// Transition writes (phase + audit), not just phase.
+func TestManager_TransitionReplacesPhaseTripleNotAppend(t *testing.T) {
 	t.Parallel()
 	mgr, _, bucket := newTestManager(t)
 	ctx := context.Background()
@@ -472,21 +476,26 @@ func TestManager_DuplicatePredicateAccumulationGetReturnsLatest(t *testing.T) {
 	}
 
 	stored := bucket.get(id)
-	phaseCount := 0
+	var phaseTriples []message.Triple
 	for _, tr := range stored.Triples {
 		if tr.Predicate == "mission.phase" {
-			phaseCount++
+			phaseTriples = append(phaseTriples, tr)
 		}
 	}
-	if phaseCount < 3 {
-		t.Errorf("expected >= 3 mission.phase triples after Create+2 Transitions (naive append per production), got %d. If this is 1, the fake substrate dedups at write time — the wrong semantic.", phaseCount)
+	if len(phaseTriples) != 1 {
+		t.Fatalf("expected exactly 1 mission.phase triple after Create+2 Transitions (replace, not append), got %d: %+v", len(phaseTriples), phaseTriples)
+	}
+	// The single triple must be the latest phase — so first-match
+	// (rule engine) and last-match (Manager) now agree.
+	if got, _ := phaseTriples[0].Object.(string); got != "completed" {
+		t.Errorf("phase triple object = %q, want completed (both read paths must agree)", got)
 	}
 	got, err := mgr.Get(ctx, "fixture", id)
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	if got.Phase() != "completed" {
-		t.Errorf("after duplicate-predicate accumulation, projected Phase=%q, want completed", got.Phase())
+		t.Errorf("projected Phase=%q, want completed", got.Phase())
 	}
 }
 


### PR DESCRIPTION
## The bug (semteams autoresearch blocker)

`Manager.Transition` built its delta (phase + audit + mutator scalars) and emitted it via `AddTriples` with **no `RemoveTriples`** — so every transition **appended**. The run entity accumulated `[dispatched, executing, completed]` phase triples.

`extractTripleScalar` (lifecycle internals) reads **last-match**, so `Manager.Get` stayed correct. But the rule engine's `GetFieldValue` reads **first-match** → it saw the stale initial `dispatched`, so a rule's `phase==executing` guard never re-fired. autoresearch rule 4a — the first rule to gate on a lifecycle phase — surfaced it (`executing→completed` never fired).

## The fix

Set `RemoveTriples` to every predicate in the transition delta, so each single-valued field (phase + audit + mutator-changed scalars) is **replaced**, not appended — exactly one triple per predicate, correct for both first-match and last-match readers. Mirrors `UpdateFromOperator`'s existing add+remove model; reuses the graph-ingest remove-then-add primitive (atomic within one revision).

**History is unaffected** — `Manager.History` reconstructs from KV revision replay (`bucket.History`), not accumulated audit triples.

## Tests

Rewrote `TestManager_DuplicatePredicateAccumulationGetReturnsLatest` (which encoded the append bug — it asserted ≥3 phase triples) → `TestManager_TransitionReplacesPhaseTripleNotAppend`, asserting exactly one phase triple, object `completed`, and that both read paths agree (`Get().Phase()` + the single-triple object).

## Review + verification

Pre-merge **go-reviewer: APPROVE** (all 7 adversarial checks: RemoveTriples semantics, no-data-loss, removing-all-delta-predicates-safe, History via revision replay, other write paths clean, CAS retry interaction, test genuinely guards the bug). One non-blocking Minor filed as #234 (validate-time predicate-disjointness guard for malformed schemas). Verified: `task lint`, `go test -race ./...`, `go vet` (plain + integration), `go test -tags=integration ./pkg/lifecycle/... ./agentic/agentrun/...`, schema no-drift, contract.

Closes the remaining autoresearch blocker (the `executing→completed` phase guard now fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)