### PR TITLE
docs(clustering): mark semantic_edges as not-yet-wired (gh#238)

### DIFF
--- a/docs/advanced/01-clustering.md
+++ b/docs/advanced/01-clustering.md
@@ -223,7 +223,16 @@ Jaccard = 3/5 = 0.6
 
 ## Semantic Edges
 
-When embeddings are available, virtual edges are created between semantically similar entities:
+> **⚠️ Not yet wired (as of 2026-06-10).** The `SemanticProvider` implementation
+> exists (`graph/clustering/semantic_provider.go`), but the graph-clustering
+> component does not yet instantiate it, so the `semantic_edges` config block below
+> is **not read** — supplying it has no effect (the keys are silently ignored).
+> This section documents the *intended* configuration; wiring is tracked in
+> [gh#238](https://github.com/C360Studio/semstreams/issues/238). Until it lands,
+> community detection clusters on **explicit relationships only**.
+
+When wired, virtual edges will be created between semantically similar entities
+(requires embeddings):
 
 ```json
 {
@@ -235,14 +244,15 @@ When embeddings are available, virtual edges are created between semantically si
 }
 ```
 
-### How Semantic Edges Work
+### How Semantic Edges Will Work
 
 1. Compare embedding vectors using cosine similarity
 2. Create virtual edge if similarity >= threshold
 3. Limit virtual neighbors to prevent explosion
 4. Include virtual edges in LPA neighbor calculation
 
-This allows semantically related entities to cluster together even without explicit relationships.
+This will allow semantically related entities to cluster together even without
+explicit relationships.
 
 ## Storage
 

--- a/docs/concepts/05-embeddings.md
+++ b/docs/concepts/05-embeddings.md
@@ -268,9 +268,17 @@ ObjectStore is a separate component that stores text content for embedding gener
 1. Verify entity implements `ContentStorable` (not just `Graphable`)
 2. Check `StorageRef` is set (content stored to ObjectStore)
 3. Verify embedding service is running (`provider: "http"`)
-4. Lower `similarity_threshold` if entities are borderline similar
+4. Add explicit relationship triples — semantic (virtual) edges that would cluster
+   borderline-similar entities are **not yet wired**
+   ([gh#238](https://github.com/C360Studio/semstreams/issues/238)); until then
+   clustering uses explicit edges only
 
 ### "Too many virtual edges, communities are too large"
+
+> **⚠️ Not yet applicable.** Semantic (virtual) edges are not yet wired
+> ([gh#238](https://github.com/C360Studio/semstreams/issues/238)), so the component
+> does not currently create virtual edges. The `similarity_threshold` guidance
+> below applies once that lands.
 
 1. Raise `similarity_threshold` (try 0.75)
 2. Improve content quality (more specific text)

--- a/docs/concepts/07-community-detection.md
+++ b/docs/concepts/07-community-detection.md
@@ -189,6 +189,11 @@ Community detection is controlled through clustering configuration. Key paramete
 
 ### Virtual Edge Tuning
 
+> **⚠️ Not yet wired.** Semantic (virtual) edges are implemented but not yet
+> instantiated by the component, so these parameters currently have no effect. See
+> [Semantic Edges](../advanced/01-clustering.md#semantic-edges) and
+> [gh#238](https://github.com/C360Studio/semstreams/issues/238).
+
 | Parameter | Default | Effect |
 |-----------|---------|--------|
 | `similarity_threshold` | 0.6 | Minimum cosine similarity for virtual edge |
@@ -265,14 +270,18 @@ Labels keep switching between iterations without converging.
 One community absorbs most entities.
 
 **Cause**: Dense hub nodes connecting everything.
-**Mitigation**: Raise `similarity_threshold`, reduce virtual edges.
+**Mitigation**: Reduce hub over-connection in explicit edges. (Raising
+`similarity_threshold` / reducing virtual edges applies once semantic edges are
+wired — [gh#238](https://github.com/C360Studio/semstreams/issues/238).)
 
 ### Singleton Explosion
 
 Many single-entity communities.
 
 **Cause**: Sparse explicit relationships, no virtual edges.
-**Mitigation**: Lower `similarity_threshold`, add more triples, or accept that entities are genuinely disconnected.
+**Mitigation**: Add more explicit triples, or accept that entities are genuinely
+disconnected. (Lowering `similarity_threshold` to add virtual edges applies once
+semantic edges are wired — [gh#238](https://github.com/C360Studio/semstreams/issues/238).)
 
 ## Related
 


### PR DESCRIPTION
Honest-docs follow-up to gh#238: the community `semantic_edges` virtual-edge feature is documented as live but `SemanticProvider` is never instantiated by the graph-clustering component, so the `semantic_edges` knobs are phantom keys (silently dropped — ADR-054 class).

This is **option 2** from gh#238 ("doc-correct now, regardless of the wire/remove decision"). It does **not** prejudge wiring — the intended config is kept and clearly marked not-yet-wired, so when the feature is wired the banners simply come off.

Changes:
- `docs/advanced/01-clustering.md` — "not yet wired" banner on the canonical **Semantic Edges** section; reframes the config as intended-when-wired.
- `docs/concepts/07-community-detection.md` — banner on **Virtual Edge Tuning**; caveats the Monster-Communities / Singleton-Explosion mitigations that advised the dead `similarity_threshold` knob.
- `docs/concepts/05-embeddings.md` — caveats the two `similarity_threshold` troubleshooting bullets.

Wiring `SemanticProvider` (gh#238 option 1) is the planned next step — notably the clean replacement for the anomaly auto-apply virtual-edge path disabled in #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)