### PR TITLE
feat(agentic-tools): config-level decide-action restriction policy (gh#239)

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -129,14 +129,15 @@ func run() error {
 	// deps.ToolRegistry. Mirrors cmd/semstreams/main.go — see ADR-029.
 	toolRegistry := agentictools.NewExecutorRegistry()
 	if err := executors.RegisterBuiltins(ctx, toolRegistry, executors.ToolDependencies{
-		NATSClient:          natsClient,
-		Platform:            platform,
-		Logger:              logger,
-		RuleManager:         buildRuleManager(ctx, natsClient, configManager, logger),
-		FlowManager:         buildFlowManager(natsClient, logger),
-		PersonaManager:      buildPersonaManager(natsClient, logger),
-		FlowTemplateManager: buildFlowTemplateManager(natsClient, logger),
-		ComponentRegistry:   componentRegistry,
+		NATSClient:              natsClient,
+		Platform:                platform,
+		Logger:                  logger,
+		RuleManager:             buildRuleManager(ctx, natsClient, configManager, logger),
+		FlowManager:             buildFlowManager(natsClient, logger),
+		PersonaManager:          buildPersonaManager(natsClient, logger),
+		FlowTemplateManager:     buildFlowTemplateManager(natsClient, logger),
+		ComponentRegistry:       componentRegistry,
+		RestrictedDecideActions: extractRestrictedDecideActions(cfg, logger),
 	}); err != nil {
 		return fmt.Errorf("register builtin tools: %w", err)
 	}
@@ -537,6 +538,30 @@ func extractPlatformMeta(cfg *config.Config) types.PlatformMeta {
 		Org:      cfg.Platform.Org,
 		Platform: platformID,
 	}
+}
+
+// extractRestrictedDecideActions reads the deployment-level decide-action
+// restriction policy (gh#239) from the agentic-tools component config so an
+// e2e flow config can exercise the gate. Mirrors the cmd/semstreams helper;
+// empty means the permissive default.
+func extractRestrictedDecideActions(cfg *config.Config, logger *slog.Logger) []string {
+	for _, cc := range cfg.Components {
+		if cc.Name != "agentic-tools" || !cc.Enabled {
+			continue
+		}
+		var tcfg struct {
+			RestrictedDecideActions []string `json:"restricted_decide_actions"`
+		}
+		if err := json.Unmarshal(cc.Config, &tcfg); err != nil {
+			logger.Warn("could not parse agentic-tools restricted_decide_actions; decide-action restriction disabled (permissive default)",
+				slog.Any("error", err))
+			continue
+		}
+		if len(tcfg.RestrictedDecideActions) > 0 {
+			return tcfg.RestrictedDecideActions
+		}
+	}
+	return nil
 }
 
 func setupRegistriesAndManager(cfg *config.Config) (*component.Registry, *service.Manager, error) {

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -155,15 +155,16 @@ func run() error {
 	}
 	toolRegistry := agentictools.NewExecutorRegistry()
 	if err := executors.RegisterBuiltins(ctx, toolRegistry, executors.ToolDependencies{
-		NATSClient:          natsClient,
-		Platform:            platform,
-		Logger:              logger,
-		RuleManager:         buildRuleManager(ctx, natsClient, configManager, logger),
-		FlowManager:         buildFlowManager(natsClient, logger),
-		PersonaManager:      personaMgr,
-		FlowTemplateManager: buildFlowTemplateManager(natsClient, logger),
-		ComponentRegistry:   componentRegistry,
-		LoopsBucket:         extractLoopsBucket(cfg),
+		NATSClient:              natsClient,
+		Platform:                platform,
+		Logger:                  logger,
+		RuleManager:             buildRuleManager(ctx, natsClient, configManager, logger),
+		FlowManager:             buildFlowManager(natsClient, logger),
+		PersonaManager:          personaMgr,
+		FlowTemplateManager:     buildFlowTemplateManager(natsClient, logger),
+		ComponentRegistry:       componentRegistry,
+		LoopsBucket:             extractLoopsBucket(cfg),
+		RestrictedDecideActions: extractRestrictedDecideActions(cfg, logger),
 	}); err != nil {
 		return fmt.Errorf("register builtin tools: %w", err)
 	}
@@ -362,6 +363,37 @@ func extractLoopsBucket(cfg *config.Config) string {
 		}
 	}
 	return ""
+}
+
+// extractRestrictedDecideActions reads the deployment-level decide-action
+// restriction policy (gh#239) from the agentic-tools component config. The
+// decide tool bars these action names for every coordinator task (front-
+// door and rule-spawned); empty means the permissive default. Mirrors
+// extractLoopsBucket — the agentic-tools Config field is the operator/schema
+// surface; this bridges it into the boot-time ToolDependencies.
+func extractRestrictedDecideActions(cfg *config.Config, logger *slog.Logger) []string {
+	for _, cc := range cfg.Components {
+		if cc.Name != "agentic-tools" || !cc.Enabled {
+			continue
+		}
+		var tcfg struct {
+			RestrictedDecideActions []string `json:"restricted_decide_actions"`
+		}
+		if err := json.Unmarshal(cc.Config, &tcfg); err != nil {
+			// Don't silently fall back to permissive: a malformed policy
+			// disables a guard the operator explicitly asked for. The
+			// typed component Config unmarshal backstops genuine type
+			// errors, but warn here so the security-adjacent gate's
+			// non-enforcement is never silent.
+			logger.Warn("could not parse agentic-tools restricted_decide_actions; decide-action restriction disabled (permissive default)",
+				slog.Any("error", err))
+			continue
+		}
+		if len(tcfg.RestrictedDecideActions) > 0 {
+			return tcfg.RestrictedDecideActions
+		}
+	}
+	return nil
 }
 
 // extractPlatformMeta extracts platform identity from config.

--- a/processor/agentic-tools/config.go
+++ b/processor/agentic-tools/config.go
@@ -17,8 +17,17 @@ type Config struct {
 	Timeout              string                `json:"timeout"              schema:"type:string,description:Tool execution timeout,category:advanced,default:60s"`
 	AllowedTools         []string              `json:"allowed_tools"        schema:"type:array,description:List of allowed tools (nil/empty allows all),category:advanced"`
 	ApprovalRequired     []string              `json:"approval_required,omitempty" schema:"type:array,description:Tool names requiring human approval before execution,category:advanced"`
-	EnableCategories     bool                  `json:"enable_categories,omitempty" schema:"type:bool,description:Enable tool category filtering for role-based access,category:advanced,default:false"`
-	LoopsBucket          string                `json:"loops_bucket,omitempty" schema:"type:string,description:NATS KV bucket name holding agent loop state (for read_loop_result),default:AGENT_LOOPS,category:advanced"`
+	// RestrictedDecideActions is the deployment-level decide-action
+	// restriction policy (gh#239): decide action names barred for every
+	// coordinator task — front-door and rule-spawned — composing with and
+	// taking precedence over the per-task action_allowlist. Vocabulary-
+	// agnostic: a product shell maps its run mode onto this list (e.g.
+	// SemTeams "autonomous" → ["ask_user"]). Empty = permissive default
+	// (no behaviour change). Sourced at boot into ToolDependencies, mirror
+	// of LoopsBucket.
+	RestrictedDecideActions []string `json:"restricted_decide_actions,omitempty" schema:"type:array,description:Decide-action names barred for every coordinator task (front-door and rule-spawned) — composes with and takes precedence over per-task action_allowlist; vocabulary-agnostic run/deployment clarification policy; empty means permissive default,category:advanced"`
+	EnableCategories        bool     `json:"enable_categories,omitempty" schema:"type:bool,description:Enable tool category filtering for role-based access,category:advanced,default:false"`
+	LoopsBucket             string   `json:"loops_bucket,omitempty" schema:"type:string,description:NATS KV bucket name holding agent loop state (for read_loop_result),default:AGENT_LOOPS,category:advanced"`
 
 	// ToolRetries is an opt-in per-tool retry policy. Tools not listed run
 	// without retries. Use this for tools where transient failures (timeout,

--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -41,6 +41,29 @@ var decideSAPCoercedTotal = promauto.NewCounterVec(
 	[]string{"from_action", "to_action"},
 )
 
+// decideActionRestrictedTotal counts every decide call rejected by the
+// deployment-level decide-action restriction policy (gh#239). The policy
+// is vocabulary-agnostic: the framework restricts whatever action strings
+// the deployment names; a consuming product (e.g. SemTeams "autonomous"
+// mode) maps its product mode onto the restricted set. Operators alert on
+// a sustained non-zero rate — it means the persona prose and the
+// restriction policy disagree (coordinators keep reaching for an action
+// the deployment bars), so the fix is the persona prompt, not loosening
+// the policy.
+//
+// Cardinality bound: action is the SAP-normalised restricted member that
+// was hit, drawn from the configured restriction list, so cardinality
+// stays at the size of that list.
+var decideActionRestrictedTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "semstreams",
+		Subsystem: "decide_tool",
+		Name:      "action_restricted_total",
+		Help:      "Number of decide calls rejected by the deployment-level decide-action restriction policy (gh#239). High rate signals the persona prose and the restriction policy disagree; fix the persona prompt rather than loosening the policy.",
+	},
+	[]string{"action"},
+)
+
 // DecideToolName is the name agents use to invoke the coordinator's
 // terminal decision tool.
 const DecideToolName = "decide"
@@ -99,15 +122,59 @@ type DecideExecutor struct {
 	publisher TriplePublisher
 	platform  types.PlatformMeta
 	logger    *slog.Logger
+	// restrictedActions is the deployment-level decide-action restriction
+	// set (gh#239), keyed by SAP-normalised action so cased/hyphenated
+	// drift cannot slip the gate. nil/empty ⇒ permissive (interactive)
+	// default: no action is restricted, identical to pre-gh#239 behaviour.
+	restrictedActions map[string]struct{}
 }
 
-// NewDecideExecutor constructs the executor given a triple publisher and
-// the platform identity used to build the coordinator's loop entity ID.
-// Logger defaults to slog.Default(); set explicitly via SetLogger when
-// the caller has a structured logger handy (the registration path does
-// — see executors/register_decide.go).
-func NewDecideExecutor(publisher TriplePublisher, platform types.PlatformMeta) *DecideExecutor {
-	return &DecideExecutor{publisher: publisher, platform: platform, logger: slog.Default()}
+// NewDecideExecutor constructs the executor given a triple publisher, the
+// platform identity used to build the coordinator's loop entity ID, and the
+// deployment-level decide-action restriction list (gh#239).
+//
+// restrictedActions is the run/deployment clarification-policy seam: any
+// action string named here is rejected at decide-resolution time for EVERY
+// coordinator task — front-door and rule-spawned alike — taking precedence
+// over (and composing with) the per-task action_allowlist. The list is
+// vocabulary-agnostic; the framework knows nothing of "interactive" vs
+// "autonomous" — a consuming product maps its mode onto the list (e.g.
+// SemTeams autonomous → ["ask_user"]). nil/empty preserves the historical
+// permissive default (no restriction).
+//
+// Entries are SAP-normalised (lowercase, hyphen→underscore, trimmed) into a
+// set at construction so the runtime check is O(1) and immune to cased /
+// hyphenated drift. Logger defaults to slog.Default(); set explicitly via
+// SetLogger when the caller has a structured logger handy.
+func NewDecideExecutor(publisher TriplePublisher, platform types.PlatformMeta, restrictedActions []string) *DecideExecutor {
+	return &DecideExecutor{
+		publisher:         publisher,
+		platform:          platform,
+		logger:            slog.Default(),
+		restrictedActions: newRestrictedActionSet(restrictedActions),
+	}
+}
+
+// newRestrictedActionSet builds the SAP-normalised restriction lookup from
+// the configured list. Empty/whitespace entries are dropped. Returns nil
+// for an effectively-empty input so isDecideActionRestricted's len check
+// short-circuits the permissive default with zero allocation.
+func newRestrictedActionSet(actions []string) map[string]struct{} {
+	if len(actions) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(actions))
+	for _, a := range actions {
+		n := normaliseActionForSAP(a)
+		if n == "" {
+			continue
+		}
+		set[n] = struct{}{}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return set
 }
 
 // SetLogger replaces the default logger. nil-safe — a nil argument
@@ -224,6 +291,36 @@ func (e *DecideExecutor) decide(ctx context.Context, call agentic.ToolCall) (age
 			ErrorKind: agentic.ToolErrorInvalidArgs,
 		}, nil
 	}
+
+	// Deployment-level decide-action restriction (run clarification
+	// policy, gh#239). Applied AFTER allowlist resolution so it sees the
+	// canonical (post-SAP-coercion) action, and BEFORE the SAP success
+	// signals fire — a restricted action is rejected outright, so emitting
+	// "coercion succeeded" telemetry for it would be misleading. The gate
+	// takes PRECEDENCE over any per-task action_allowlist (a restricted
+	// action is rejected even when the allowlist would admit it) AND
+	// covers coordinators that carry no allowlist at all — the front door,
+	// the structural hole gh#239 closes. Same ToolErrorInvalidArgs →
+	// re-pick treatment as an off-allowlist action: the loop iterates and
+	// the model resolves without the restricted action (no dead-end, no
+	// extra round-trip).
+	if e.isDecideActionRestricted(allowlist.canonicalAction) {
+		decideActionRestrictedTotal.WithLabelValues(normaliseActionForSAP(allowlist.canonicalAction)).Inc()
+		e.logger.Info("decide tool rejected a deployment-restricted action",
+			"loop_id", call.LoopID,
+			"action", allowlist.canonicalAction,
+			"hint", "barred by the deployment's restricted_decide_actions policy; a sustained rate here means the persona prose and the policy disagree — fix the persona prompt rather than loosening the policy")
+		return agentic.ToolResult{
+			CallID: call.ID,
+			Error: fmt.Sprintf(
+				"action %q is restricted by deployment policy and cannot be used in this run; "+
+					"resolve without it and re-emit a different action your role's system prompt enumerates.",
+				allowlist.canonicalAction,
+			),
+			ErrorKind: agentic.ToolErrorInvalidArgs,
+		}, nil
+	}
+
 	sapCoerced := allowlist.coerced
 	if sapCoerced {
 		// Signal 1: slog.Warn — fires per coercion. Warn level so it
@@ -457,6 +554,20 @@ func resolveActionAllowlist(metadata map[string]any, action string) allowlistRes
 			strings.Join(allowlist, ", "),
 		),
 	}
+}
+
+// isDecideActionRestricted reports whether action is barred by the
+// deployment-level decide-action restriction policy (gh#239). The
+// comparison is SAP-normalised (the set was normalised at construction)
+// so cased/hyphenated drift — "Ask-User", "ask_user", " ask-user " —
+// cannot slip a restricted action past the gate. An empty restriction set
+// always returns false (the permissive default), short-circuited cheaply.
+func (e *DecideExecutor) isDecideActionRestricted(action string) bool {
+	if len(e.restrictedActions) == 0 {
+		return false
+	}
+	_, restricted := e.restrictedActions[normaliseActionForSAP(action)]
+	return restricted
 }
 
 // normaliseActionForSAP applies the V1 normalisation rules: lowercase,

--- a/processor/agentic-tools/decide_test.go
+++ b/processor/agentic-tools/decide_test.go
@@ -52,7 +52,13 @@ func (p *recordingPublisher) AddTriplesBatch(_ context.Context, triples []messag
 }
 
 func newDecideExecutor(publisher TriplePublisher) *DecideExecutor {
-	return NewDecideExecutor(publisher, types.PlatformMeta{Org: "acme", Platform: "test"})
+	return NewDecideExecutor(publisher, types.PlatformMeta{Org: "acme", Platform: "test"}, nil)
+}
+
+// newDecideExecutorRestricted builds an executor with a deployment-level
+// decide-action restriction policy (gh#239) for the restriction tests.
+func newDecideExecutorRestricted(publisher TriplePublisher, restricted ...string) *DecideExecutor {
+	return NewDecideExecutor(publisher, types.PlatformMeta{Org: "acme", Platform: "test"}, restricted)
 }
 
 func TestDecideExecutor_ListTools(t *testing.T) {
@@ -307,6 +313,226 @@ func TestDecideExecutor_ActionAllowlist_EmptyAllowlistMeansFreeform(t *testing.T
 	})
 	if res.Error != "" {
 		t.Errorf("empty-allowlist mode rejected: %q", res.Error)
+	}
+}
+
+// --- gh#239: deployment-level decide-action restriction policy ---
+
+// TestDecideExecutor_RestrictedAction_FrontDoorRejects is the core gh#239
+// case: a coordinator that carries NO per-task allowlist (the front door)
+// still has a restricted action structurally barred. Returns
+// ToolErrorInvalidArgs (so the loop iterates and the model re-picks), names
+// the action, and publishes no triples.
+func TestDecideExecutor_RestrictedAction_FrontDoorRejects(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutorRestricted(pub, "ask_user")
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		// No Metadata: the front-door shape gh#239 closes.
+		Arguments: map[string]any{
+			"action": "ask_user",
+			"reason": "need the user to clarify",
+		},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("ErrorKind = %v, want ToolErrorInvalidArgs (restriction gate)", res.ErrorKind)
+	}
+	if !strings.Contains(res.Error, "ask_user") {
+		t.Errorf("expected Error to name the restricted action; got %q", res.Error)
+	}
+	if res.StopLoop {
+		t.Errorf("StopLoop should be false on restriction rejection — let the loop iterate")
+	}
+	if len(pub.triples) != 0 {
+		t.Errorf("no triples should be published on restriction rejection, got %d", len(pub.triples))
+	}
+}
+
+// TestDecideExecutor_RestrictedAction_TakesPrecedenceOverAllowlist proves
+// the restriction beats a per-task allowlist that WOULD admit the action.
+// This is the precedence semantics: forbidden ∪ off-allowlist both reject.
+func TestDecideExecutor_RestrictedAction_TakesPrecedenceOverAllowlist(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutorRestricted(pub, "ask_user")
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Metadata: map[string]any{
+			// ask_user IS on the allowlist, yet the deployment policy bars it.
+			agentic.MetadataKeyDecideActionAllowlist: []any{"ask_user", "respond_direct"},
+		},
+		Arguments: map[string]any{
+			"action": "ask_user",
+			"reason": "allowlist admits it but policy forbids it",
+		},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("ErrorKind = %v, want ToolErrorInvalidArgs (restriction precedence over allowlist)", res.ErrorKind)
+	}
+	if len(pub.triples) != 0 {
+		t.Errorf("no triples on restricted action even when allowlisted, got %d", len(pub.triples))
+	}
+}
+
+// TestDecideExecutor_RestrictedAction_NormalisedDriftStillRejected proves
+// the gate is SAP-normalised on both sides: cased/hyphenated drift in the
+// emitted action ("Ask-User") cannot slip a restricted action, and a
+// config-side drift in the restriction list ("Ask-User") still bars the
+// canonical action ("ask_user"). Either way the gate holds.
+func TestDecideExecutor_RestrictedAction_NormalisedDriftStillRejected(t *testing.T) {
+	t.Run("drift in emitted action", func(t *testing.T) {
+		pub := &recordingPublisher{}
+		e := newDecideExecutorRestricted(pub, "ask_user")
+		res, _ := e.Execute(context.Background(), agentic.ToolCall{
+			ID: "c1", Name: DecideToolName, LoopID: "loop-abc",
+			Arguments: map[string]any{"action": "Ask-User", "reason": "drift"},
+		})
+		if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+			t.Errorf("ErrorKind = %v, want ToolErrorInvalidArgs ('Ask-User' must not slip the gate)", res.ErrorKind)
+		}
+	})
+	t.Run("drift in restriction config", func(t *testing.T) {
+		pub := &recordingPublisher{}
+		e := newDecideExecutorRestricted(pub, "Ask-User", "  ", "")
+		res, _ := e.Execute(context.Background(), agentic.ToolCall{
+			ID: "c1", Name: DecideToolName, LoopID: "loop-abc",
+			Arguments: map[string]any{"action": "ask_user", "reason": "canonical"},
+		})
+		if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+			t.Errorf("ErrorKind = %v, want ToolErrorInvalidArgs (normalised config entry must bar canonical action)", res.ErrorKind)
+		}
+	})
+}
+
+// TestDecideExecutor_RestrictedAction_UnrelatedActionPasses confirms the
+// policy is surgical: an action NOT on the restriction list flows through
+// normally, publishing its triples and stopping the loop.
+func TestDecideExecutor_RestrictedAction_UnrelatedActionPasses(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutorRestricted(pub, "ask_user")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Arguments: map[string]any{
+			"action": "respond_direct",
+			"reason": "resolved autonomously",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if res.Error != "" {
+		t.Errorf("unrelated action rejected by restriction policy: %q", res.Error)
+	}
+	if !res.StopLoop {
+		t.Errorf("expected StopLoop=true on a non-restricted action")
+	}
+	if len(pub.triples) != 2 {
+		t.Errorf("expected 2 triples on a non-restricted action, got %d", len(pub.triples))
+	}
+}
+
+// TestDecideExecutor_RestrictedAction_EmptyPolicyIsPermissive locks the
+// gh#239 default: no restriction list ⇒ no behaviour change. An action that
+// would be barred under a policy flows through when the policy is empty.
+func TestDecideExecutor_RestrictedAction_EmptyPolicyIsPermissive(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutorRestricted(pub) // empty restriction list
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Arguments: map[string]any{
+			"action": "ask_user",
+			"reason": "permissive default",
+		},
+	})
+	if res.Error != "" {
+		t.Errorf("permissive default rejected an action: %q", res.Error)
+	}
+	if !res.StopLoop {
+		t.Errorf("expected StopLoop=true under permissive default")
+	}
+}
+
+// TestDecideExecutor_RestrictedAction_BeatsSAPCoercion proves the
+// restriction is evaluated on the canonical (post-SAP) action and takes
+// precedence over SAP success: an emitted "ask-user" that SAP would coerce
+// to the allowlisted "ask_user" is still rejected, and the SAP-coercion
+// audit triple is NOT published (the action never reached the success path).
+func TestDecideExecutor_RestrictedAction_BeatsSAPCoercion(t *testing.T) {
+	pub := &recordingPublisher{}
+	e := newDecideExecutorRestricted(pub, "ask_user")
+
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Metadata: map[string]any{
+			agentic.MetadataKeyDecideActionAllowlist: []any{"ask_user", "respond_direct"},
+		},
+		Arguments: map[string]any{
+			"action": "ask-user", // SAP would coerce → "ask_user"
+			"reason": "drift that resolves to a restricted action",
+		},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("ErrorKind = %v, want ToolErrorInvalidArgs (restriction beats SAP coercion)", res.ErrorKind)
+	}
+	if len(pub.triples) != 0 {
+		t.Errorf("no triples (incl. SAP audit) should publish when restriction rejects, got %d", len(pub.triples))
+	}
+}
+
+// TestDecideExecutor_RestrictedDecideActions_ConfigRoundTrip drives the
+// full operator → runtime wire: the restricted_decide_actions JSON an
+// operator writes, decoded into the agentic-tools Config, then handed to
+// NewDecideExecutor, must enforce the gate. Guards the operator-configurable
+// surface per the JSON-round-trip discipline.
+func TestDecideExecutor_RestrictedDecideActions_ConfigRoundTrip(t *testing.T) {
+	const raw = `{"timeout":"60s","restricted_decide_actions":["ask_user"]}`
+
+	var cfg Config
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if len(cfg.RestrictedDecideActions) != 1 || cfg.RestrictedDecideActions[0] != "ask_user" {
+		t.Fatalf("config round-trip dropped the field: got %#v", cfg.RestrictedDecideActions)
+	}
+
+	pub := &recordingPublisher{}
+	e := NewDecideExecutor(pub, types.PlatformMeta{Org: "acme", Platform: "test"}, cfg.RestrictedDecideActions)
+	res, _ := e.Execute(context.Background(), agentic.ToolCall{
+		ID:     "c1",
+		Name:   DecideToolName,
+		LoopID: "loop-abc",
+		Arguments: map[string]any{
+			"action": "ask_user",
+			"reason": "config-driven restriction must fire",
+		},
+	})
+	if res.ErrorKind != agentic.ToolErrorInvalidArgs {
+		t.Errorf("ErrorKind = %v, want ToolErrorInvalidArgs (config-sourced restriction must enforce)", res.ErrorKind)
+	}
+	if len(pub.triples) != 0 {
+		t.Errorf("no triples on config-sourced restriction rejection, got %d", len(pub.triples))
+	}
+
+	// And re-marshal preserves the field (full round-trip).
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal config: %v", err)
+	}
+	if !strings.Contains(string(out), `"restricted_decide_actions":["ask_user"]`) {
+		t.Errorf("re-marshal dropped restricted_decide_actions: %s", out)
 	}
 }
 
@@ -733,7 +959,7 @@ func TestDecideExecutor_OptionalFieldsOmitted(t *testing.T) {
 // clear the whole rule chain needs to be updated.
 func TestDecideExecutor_LoopEntityIDFormat(t *testing.T) {
 	pub := &recordingPublisher{}
-	e := NewDecideExecutor(pub, types.PlatformMeta{Org: "c360", Platform: "deep-research-001"})
+	e := NewDecideExecutor(pub, types.PlatformMeta{Org: "c360", Platform: "deep-research-001"}, nil)
 
 	_, _ = e.Execute(context.Background(), agentic.ToolCall{
 		ID:     "c1",

--- a/processor/agentic-tools/executors/register.go
+++ b/processor/agentic-tools/executors/register.go
@@ -35,6 +35,8 @@ import (
 //     query_entity) are skipped
 //   - RuleManager nil → rule CRUD tools are skipped
 //   - ComponentRegistry nil → list_components skipped (Pattern-B step 5)
+//   - RestrictedDecideActions nil/empty → permissive default (no decide
+//     action restricted)
 //   - SkipBuiltins nil/empty → all builtins register (today's behaviour)
 //
 // Platform is a value type (not pointer) because PlatformMeta is a small
@@ -55,6 +57,15 @@ type ToolDependencies struct {
 	// the name is frozen at RegisterBuiltins for the lifetime of the
 	// process.
 	LoopsBucket string
+	// RestrictedDecideActions is the deployment-level decide-action
+	// restriction policy (gh#239): decide action names barred for EVERY
+	// coordinator task (front-door and rule-spawned), composing with and
+	// taking precedence over the per-task action_allowlist. Sourced from
+	// the agentic-tools component config's restricted_decide_actions at
+	// boot (main.go) and frozen for the process lifetime, like LoopsBucket.
+	// nil/empty = permissive default. Vocabulary-agnostic: a product shell
+	// maps its run mode (e.g. autonomous) onto this list.
+	RestrictedDecideActions []string
 	// SkipBuiltins is the list of builtin group keys to NOT register.
 	// Product shells set this when they want to register their own
 	// implementation under a canonical tool name (e.g., a chain-scoped
@@ -173,7 +184,9 @@ func RegisterBuiltins(ctx context.Context, reg *agentictools.ExecutorRegistry, d
 		logger.Warn("nats client not available; skipping stateful tool registration (read_loop_result, decide, emit_diagnosis, query_entity); web_search and http_request fall back to text-only return without graph emission")
 	} else {
 		gate("read_loop_result", func() error { return registerReadLoopResult(ctx, reg, deps.NATSClient, logger, loopsBucket) })
-		gate("decide", func() error { return registerDecide(reg, deps.NATSClient, deps.Platform, logger) })
+		gate("decide", func() error {
+			return registerDecide(reg, deps.NATSClient, deps.Platform, deps.RestrictedDecideActions, logger)
+		})
 		gate("emit_diagnosis", func() error { return registerEmitDiagnosis(reg, deps.NATSClient, deps.Platform, logger) })
 		gate("graph_query", func() error { return registerGraphQuery(ctx, reg, deps.NATSClient, logger) })
 		gate("write_todos", func() error { return registerWriteTodos(reg, deps.NATSClient, deps.Platform, logger) })

--- a/processor/agentic-tools/executors/register_decide.go
+++ b/processor/agentic-tools/executors/register_decide.go
@@ -13,14 +13,15 @@ import (
 // publishes triples via the graph.mutation.triple.add NATS surface (same
 // path rule actions use). A registry-level failure (duplicate name)
 // returns the error so RegisterBuiltins can surface it at boot.
-func registerDecide(tools *agentictools.ExecutorRegistry, natsClient *natsclient.Client, platform component.PlatformMeta, logger *slog.Logger) error {
+func registerDecide(tools *agentictools.ExecutorRegistry, natsClient *natsclient.Client, platform component.PlatformMeta, restrictedDecideActions []string, logger *slog.Logger) error {
 	publisher := agentictools.NewNATSTriplePublisher(natsClient)
-	executor := agentictools.NewDecideExecutor(publisher, platform)
+	executor := agentictools.NewDecideExecutor(publisher, platform, restrictedDecideActions)
 	if err := tools.RegisterTool(agentictools.DecideToolName, executor); err != nil {
 		return fmt.Errorf("register decide: %w", err)
 	}
 	logger.Info("Registered decide tool",
 		slog.String("org", platform.Org),
-		slog.String("platform", platform.Platform))
+		slog.String("platform", platform.Platform),
+		slog.Int("restricted_decide_actions", len(restrictedDecideActions)))
 	return nil
 }

--- a/schemas/agentic-tools.v1.json
+++ b/schemas/agentic-tools.v1.json
@@ -49,6 +49,14 @@
       "description": "Port configuration",
       "category": "basic"
     },
+    "restricted_decide_actions": {
+      "type": "array",
+      "description": "Decide-action names barred for every coordinator task (front-door and rule-spawned) — composes with and takes precedence over per-task action_allowlist; vocabulary-agnostic run/deployment clarification policy; empty means permissive default",
+      "items": {
+        "type": "string"
+      },
+      "category": "advanced"
+    },
     "stream_name": {
       "type": "string",
       "description": "JetStream stream name for agentic messages",


### PR DESCRIPTION
Closes #239.

## What

Adds a deployment-level, **vocabulary-agnostic** decide-action restriction seam — the *run clarification policy* gh#239 asks for. New config field:

```jsonc
// agentic-tools component config
"restricted_decide_actions": ["ask_user"]   // empty/omitted = permissive default
```

It bars named decide actions for **every** coordinator task — front-door **and** rule-spawned — composing with and taking **precedence over** the per-task `action_allowlist`.

## Design decision: framework seam, not product feature

Per discussion on #239, the split is: **the policy is product, the enforcement seam is framework.** The framework owns only the generic restrict-list and knows nothing of `interactive|autonomous` — a product shell (SemTeams) maps its mode onto the list (`autonomous → ["ask_user"]`). The `clarification_policy` enum stays product-side (lift the contract, not the projection).

The seam is irreducibly framework because (a) the front-door coordinator `TaskMessage` is framework-built with no decide-action injection hook, and (b) `decide` actions aren't tool-scopable (they're argument values of one tool, gated only inside `resolveActionAllowlist`). This **completes an existing primitive** (`action_allowlist` was already a framework decide-action gate; this extends its coverage to deployment-wide + front-door), mirroring the `approval_required → ApprovalFilter` precedent.

## Enforcement

In `decide()`, right after `resolveActionAllowlist` resolves the canonical (post-SAP) action and **before** any SAP success signal:
- covers front-door coordinators with no allowlist (the structural hole #239 names);
- precedence over a per-task allowlist (rejected even if allowlisted);
- SAP-normalised on both sides (`Ask-User`/`ask_user` drift can't slip — in emitted action or config);
- beats SAP coercion (no misleading "coerced" telemetry on a rejection);
- returns `ToolErrorInvalidArgs` → loop iterates, model re-picks (no dead-end).

Wiring mirrors `LoopsBucket`: Config field is the operator/schema surface; `extractRestrictedDecideActions(cfg, logger)` bridges it into `ToolDependencies` at boot in **both** binaries (malformed policy warns rather than silently disabling the gate). Construction param on `NewDecideExecutor` keeps the gate non-forgettable.

## Compatibility

**Additive** — empty default = no behaviour change. No wire/contract change. No e2e-for-breaking obligation; `e2e:agentic` run as a regression gate. Observability via `semstreams_decide_tool_action_restricted_total{action}`.

**Known boundary:** a product shell that sets `SkipBuiltins: ["decide"]` and registers its own decide executor bypasses this restriction — the gate lives on the *framework* decide, which is the intended override path.

## Tests

8 new tests: front-door reject, precedence-over-allowlist, SAP-drift (emitted + config sides), beats-SAP-coercion, permissive default, and a full operator-wire config JSON round-trip. All 22 pre-existing decide tests still green under `-race`. Lint clean, schema regenerated (only the new field).

Reviewed by go-reviewer (all 6 load-bearing invariants PASS; its two findings applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)