### PR TITLE
fix(graph-ingest): update_with_triples add-leg replaces by predicate, not append (gh#244)

### DIFF
--- a/graph/mutation_requests.go
+++ b/graph/mutation_requests.go
@@ -59,9 +59,18 @@ type CreateEntityWithTriplesRequest struct {
 // CAS succeeds or the retry budget is exhausted. This is correct for
 // the "facts accumulate" model the graph layer was built around.
 type UpdateEntityWithTriplesRequest struct {
-	Entity        *EntityState     `json:"entity"`
+	Entity *EntityState `json:"entity"`
+	// AddTriples are applied with REPLACE-by-(subject,predicate) semantics
+	// (MergeTriples — gh#244): every predicate present in AddTriples has its
+	// prior values on the entity fully replaced. This is upsert, NOT
+	// incremental append. For a SINGLE-valued predicate, send the one new
+	// value (the old one is dropped). For a MULTI-valued predicate, send the
+	// FULL desired set — a partial set drops the omitted siblings. To ADD to
+	// a predicate while preserving existing values, use triple.add /
+	// triple.add_batch instead. Predicates absent from AddTriples are
+	// untouched.
 	AddTriples    []message.Triple `json:"add_triples,omitempty"`
-	RemoveTriples []string         `json:"remove_triples,omitempty"` // Triple predicates to remove
+	RemoveTriples []string         `json:"remove_triples,omitempty"` // Predicates to delete (pure delete; runs before the AddTriples merge)
 	// ExpectedRevision opts into single-pass CAS-on-condition writes.
 	// Non-zero = require entity's current KV revision to match exactly;
 	// zero = existing UpdateWithRetry behavior (no CAS check on caller

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -70,9 +70,11 @@ func (f *fakeEmitter) update(_ context.Context, req *graph.UpdateEntityWithTripl
 		}
 		merged = kept
 	}
-	// Naive append — matches mutations.go:559 and :656 exactly. Per-predicate
-	// latest-wins is a READ-time concern, not a write-time merge.
-	merged = append(merged, req.AddTriples...)
+	// Replace-by-(subject,predicate) via MergeTriples — mirrors the
+	// production graph-ingest update_with_triples add-leg (gh#244). Must
+	// match the handler or this mock silently tests a different contract
+	// than the wire it stands in for.
+	merged = graph.MergeTriples(merged, req.AddTriples)
 	state := *req.Entity
 	state.Triples = merged
 	f.bucket.put(req.Entity.ID, &state)

--- a/processor/graph-ingest/entity_mutation_integration_test.go
+++ b/processor/graph-ingest/entity_mutation_integration_test.go
@@ -3,6 +3,7 @@
 package graphingest
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -257,6 +258,132 @@ func TestIntegration_HandleEntityUpdateWithTriples_AddAndRemove(t *testing.T) {
 	assert.True(t, predicates["test.keep"], "test.keep should survive")
 	assert.False(t, predicates["test.drop"], "test.drop should be removed")
 	assert.True(t, predicates["test.added"], "test.added should be appended")
+}
+
+// applyUpdateWT runs one update_with_triples against entityID via the
+// requested handler path — the default UpdateWithRetry path (useCAS=false,
+// ExpectedRevision=0) or the CAS-on-condition path (useCAS=true,
+// ExpectedRevision=current rev, the path pkg/lifecycle.Manager uses) —
+// and returns the entity's stored triples. Fails the test on any error.
+func applyUpdateWT(t *testing.T, ctx context.Context, c *Component, entityID string, add []message.Triple, remove []string, useCAS bool) []message.Triple {
+	t.Helper()
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:        &graph.EntityState{ID: entityID, MessageType: testMutationType, Version: 1, UpdatedAt: time.Now()},
+		AddTriples:    add,
+		RemoveTriples: remove,
+	}
+	if useCAS {
+		_, rev, err := c.fetchEntityState(ctx, entityID)
+		require.NoError(t, err, "fetch current revision for CAS path")
+		req.ExpectedRevision = rev
+	}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+	respBytes, err := c.handleEntityUpdateWithTriples(ctx, reqBytes)
+	require.NoError(t, err)
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	require.True(t, resp.Success, "update_with_triples should succeed; err=%q", resp.Error)
+	stored, _, err := c.fetchEntityState(ctx, entityID)
+	require.NoError(t, err, "read back stored entity")
+	return stored.Triples
+}
+
+// objectsForPredicate returns the Objects of every triple matching predicate.
+func objectsForPredicate(triples []message.Triple, predicate string) []any {
+	out := []any{}
+	for _, tr := range triples {
+		if tr.Predicate == predicate {
+			out = append(out, tr.Object)
+		}
+	}
+	return out
+}
+
+// TestIntegration_HandleEntityUpdateWithTriples_ReplaceByPredicate locks the
+// gh#244 fix: the AddTriples leg replaces by (subject,predicate) via
+// MergeTriples — matching the DataManager UpdateEntityWithTriples contract —
+// rather than appending. Run against BOTH handler paths.
+//
+// Before the fix, the single-valued sub-case accumulated duplicate predicates
+// (status [active, completed]) whenever the caller didn't defensively name
+// the predicate in RemoveTriples — the silent re-bloat semspec measured in
+// gh#242. update_with_triples is upsert/replace; incremental append is
+// triple.add_batch's job.
+func TestIntegration_HandleEntityUpdateWithTriples_ReplaceByPredicate(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		idtok  string
+		useCAS bool
+	}{
+		{"UpdateWithRetry", "uwr", false},
+		{"CAS", "cas", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, c := startBatchTestComponent(t)
+			entityID := "c360.test.entity.replacepred." + tc.idtok + ".001"
+
+			now := time.Now()
+			seed := &graph.EntityState{
+				ID: entityID, MessageType: testMutationType, Version: 1, UpdatedAt: now,
+				Triples: []message.Triple{
+					{Subject: entityID, Predicate: "test.status", Object: "active", Timestamp: now, Confidence: 1.0},
+					{Subject: entityID, Predicate: "test.keep", Object: "keep-me", Timestamp: now, Confidence: 1.0},
+					{Subject: entityID, Predicate: "test.member", Object: "a", Timestamp: now, Confidence: 1.0},
+					{Subject: entityID, Predicate: "test.member", Object: "b", Timestamp: now, Confidence: 1.0},
+				},
+			}
+			require.NoError(t, c.CreateEntity(ctx, seed), "seed entity")
+
+			// (1) Single-valued replace WITHOUT RemoveTriples: status active→completed.
+			//     Pre-fix this appended, leaving BOTH active and completed.
+			triples := applyUpdateWT(t, ctx, c, entityID, []message.Triple{
+				{Subject: entityID, Predicate: "test.status", Object: "completed", Timestamp: time.Now(), Confidence: 1.0},
+			}, nil, tc.useCAS)
+			assert.Equal(t, []any{"completed"}, objectsForPredicate(triples, "test.status"),
+				"single-valued predicate must be REPLACED (exactly one value), not accumulated")
+
+			// (3) Untouched predicate survives.
+			assert.Equal(t, []any{"keep-me"}, objectsForPredicate(triples, "test.keep"),
+				"a predicate absent from AddTriples must survive untouched")
+
+			// (2) Multi-valued replace: send the FULL new set {c,d} → replaces {a,b}.
+			triples = applyUpdateWT(t, ctx, c, entityID, []message.Triple{
+				{Subject: entityID, Predicate: "test.member", Object: "c", Timestamp: time.Now(), Confidence: 1.0},
+				{Subject: entityID, Predicate: "test.member", Object: "d", Timestamp: time.Now(), Confidence: 1.0},
+			}, nil, tc.useCAS)
+			assert.ElementsMatch(t, []any{"c", "d"}, objectsForPredicate(triples, "test.member"),
+				"multi-valued predicate replaced by the full new set — prior members dropped, not accumulated")
+
+			// (4) Idempotent re-persist: applying the same value again must not duplicate.
+			triples = applyUpdateWT(t, ctx, c, entityID, []message.Triple{
+				{Subject: entityID, Predicate: "test.status", Object: "completed", Timestamp: time.Now(), Confidence: 1.0},
+			}, nil, tc.useCAS)
+			assert.Equal(t, []any{"completed"}, objectsForPredicate(triples, "test.status"),
+				"re-persisting the same value must stay idempotent (no duplicate)")
+		})
+	}
+}
+
+// TestIntegration_HandleEntityUpdateWithTriples_RemoveOnlyPureDelete confirms
+// RemoveTriples still deletes a predicate's values when AddTriples does not
+// re-add it (pure delete — unchanged by the gh#244 replace-by-predicate fix,
+// which only governs the add leg).
+func TestIntegration_HandleEntityUpdateWithTriples_RemoveOnlyPureDelete(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+	const entityID = "c360.test.entity.puredelete.del.001"
+	now := time.Now()
+	require.NoError(t, c.CreateEntity(ctx, &graph.EntityState{
+		ID: entityID, MessageType: testMutationType, Version: 1, UpdatedAt: now,
+		Triples: []message.Triple{
+			{Subject: entityID, Predicate: "test.status", Object: "active", Timestamp: now, Confidence: 1.0},
+			{Subject: entityID, Predicate: "test.keep", Object: "keep-me", Timestamp: now, Confidence: 1.0},
+		},
+	}), "seed entity")
+
+	triples := applyUpdateWT(t, ctx, c, entityID, nil, []string{"test.status"}, false)
+	assert.Empty(t, objectsForPredicate(triples, "test.status"), "remove-only must delete the predicate's values")
+	assert.Equal(t, []any{"keep-me"}, objectsForPredicate(triples, "test.keep"), "unrelated predicate untouched")
 }
 
 func TestIntegration_HandleEntityDelete_Existing(t *testing.T) {

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -538,7 +538,7 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		}
 
 		// Re-apply the delta on each attempt: drop triples whose
-		// Predicate appears in RemoveTriples, then append AddTriples.
+		// Predicate appears in RemoveTriples, then merge AddTriples in.
 		// triplesRemoved is reset each attempt so it reflects the
 		// final successful apply.
 		triplesRemoved = 0
@@ -559,7 +559,16 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 			merged = kept
 		}
 		if len(req.AddTriples) > 0 {
-			merged = append(merged, req.AddTriples...)
+			// MergeTriples = replace-by-(subject,predicate): a predicate
+			// present in AddTriples fully replaces its prior values
+			// (upsert), matching the DataManager UpdateEntityWithTriples
+			// contract (graph/datamanager/manager.go) — gh#244. This is
+			// NOT incremental append; a caller that wants to preserve
+			// existing values of a predicate and add more uses
+			// triple.add / triple.add_batch. Replace-by-predicate also
+			// keeps single-valued predicates unique, which is what the
+			// lifecycle replace-not-append fix relies on.
+			merged = graph.MergeTriples(merged, req.AddTriples)
 		}
 
 		// Build the new entity: caller's metadata (req.Entity) +
@@ -656,7 +665,9 @@ func (c *Component) handleEntityUpdateWithTriplesCAS(ctx context.Context, req *g
 		merged = kept
 	}
 	if len(req.AddTriples) > 0 {
-		merged = append(merged, req.AddTriples...)
+		// Replace-by-(subject,predicate), matching the UpdateWithRetry
+		// path and the DataManager contract (gh#244) — not append.
+		merged = graph.MergeTriples(merged, req.AddTriples)
 	}
 
 	// Build the new entity: caller's metadata + merged triples.


### PR DESCRIPTION
Closes #244.

## What

The `graph.mutation.entity.update_with_triples` NATS handler applied its `AddTriples` leg via plain `append`, diverging from the in-process DataManager method `UpdateEntityWithTriples` (`graph/datamanager/manager.go:1238`) which uses `MergeTriples`. Two add-leg semantics for one logical operation. This switches both handler paths to `graph.MergeTriples` → **replace-by-`(subject,predicate)` / upsert**.

## Why

Under `append`, a caller re-persisting an entity's field set duplicated every re-added predicate, and a single-valued scalar whose value changed (`status` `active`→`completed`) accumulated **both** values unless the caller defensively named the predicate in `RemoveTriples`. That silent re-bloat is the residual #242 (semspec) fingerprinted.

## Contract after the fix

- **Single-valued predicate**: the new value replaces the old (and ends up *unique* — the property the beta.103 lifecycle replace-not-append fix depends on).
- **Multi-valued predicate**: send the **full desired set**; it replaces the prior set. A partial set drops omitted siblings.
- Predicates absent from `AddTriples` are untouched.
- `RemoveTriples` still does pure deletes (runs before the merge).
- **Incremental append** is `triple.add` / `triple.add_batch`'s job — clean separation.

Documented on the `UpdateEntityWithTriplesRequest` wire type (read by external repos).

## Compatibility — corrective behavior change, no caller regressed

Not a silent break: it **corrects** a latent bloat bug on lifecycle `UpdateFromOperator`, whose `projectPatchToTriples` omits a remove for non-nil patch values — under `append`, re-patching a scalar doubled it. Every `RemoveTriples`-defended caller is **invariant** under the switch:
- `Manager.Transition` removes every added predicate first (beta.103);
- `Manager` attach adds predicates absent from the entity;
- semconnect `replaceEntityTriples` and semspec `upsertEntityVia` both populate `RemoveTriples` with all re-added predicates (verified cross-repo).

No in-repo caller other than `pkg/lifecycle` uses the subject. → `e2e:structural` + `e2e:lifecycle` run as gates before merge.

## Tests

New integration tests lock the contract, parametrized over **both** handler paths (default UpdateWithRetry + CAS/ExpectedRevision): single-valued replace (no RemoveTriples), multi-valued full-set replace, untouched-predicate preserved, idempotent re-persist, and pure-delete. They **fail under the old append**. Also fixed the lifecycle `fakeEmitter` test mock, which still emulated `append` (now drives the production merge wire).

Reviewed by go-reviewer (APPROVE; its two Minor findings — the stale mock and the undocumented wire contract — applied here).

## Note (cross-repo, not this PR)

semspec `workflow/graphutil/triple.go` has a now-stale comment describing the handler as "raw-appends"; its operational guidance ("send the complete current set") stays correct. Worth a heads-up to semspec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)