### PR TITLE
fix(agentrun): MilestoneSubscriber skips gracefully when AGENT stream absent (gh#246)

### DIFF
--- a/agentic/agentrun/agentrun.go
+++ b/agentic/agentrun/agentrun.go
@@ -697,7 +697,7 @@ func (s *MilestoneSubscriber) Start(ctx context.Context, client *natsclient.Clie
 		if errors.Is(streamErr, jetstream.ErrStreamNotFound) {
 			s.logger.Info("agentrun: MilestoneSubscriber disabled — stream not present",
 				slog.String("stream", cfg.StreamName),
-				slog.String("hint", "no agentic components in this deployment; agent.complete/failed milestones will not be processed"))
+				slog.String("hint", "likely no agentic components in this deployment (or the stream isn't created yet at boot); agent.complete/failed milestones will not be processed"))
 			return func() {}, nil
 		}
 		return nil, fmt.Errorf("agentrun: MilestoneSubscriber.Start: check stream %q: %w", cfg.StreamName, streamErr)

--- a/agentic/agentrun/agentrun.go
+++ b/agentic/agentrun/agentrun.go
@@ -685,6 +685,24 @@ func (s *MilestoneSubscriber) Start(ctx context.Context, client *natsclient.Clie
 		return nil, fmt.Errorf("agentrun: MilestoneSubscriber.Start: StreamName must not be empty")
 	}
 
+	// Graceful no-op when the target stream is absent (gh#246). The
+	// agent-run milestone subscriber only matters when agentic components
+	// run — they create the AGENT stream and publish agent.complete.* /
+	// agent.failed.*. A deployment without them (graph- or lifecycle-only)
+	// has nothing to subscribe to and must still BOOT; before this, the
+	// consumer start surfaced "stream not found" and both binaries
+	// returned it from run() → os.Exit(1). The returned no-op stop is safe
+	// to defer at the call site.
+	if _, streamErr := client.GetStream(ctx, cfg.StreamName); streamErr != nil {
+		if errors.Is(streamErr, jetstream.ErrStreamNotFound) {
+			s.logger.Info("agentrun: MilestoneSubscriber disabled — stream not present",
+				slog.String("stream", cfg.StreamName),
+				slog.String("hint", "no agentic components in this deployment; agent.complete/failed milestones will not be processed"))
+			return func() {}, nil
+		}
+		return nil, fmt.Errorf("agentrun: MilestoneSubscriber.Start: check stream %q: %w", cfg.StreamName, streamErr)
+	}
+
 	makeDurable := func(suffix string) string {
 		name := "agentrun-milestone-" + suffix
 		if cfg.ConsumerNameSuffix != "" {

--- a/agentic/agentrun/agentrun_integration_test.go
+++ b/agentic/agentrun/agentrun_integration_test.go
@@ -109,3 +109,48 @@ func TestIntegration_D1_ProjectionRoundTrip(t *testing.T) {
 	assert.NotContains(t, runID, ".",
 		"bare RunID must not contain dots — if it does, D1 EntityIDField holds a bare ID, not the full 6-part ID")
 }
+
+// TestIntegration_MilestoneSubscriber_GracefulSkipWhenStreamAbsent pins gh#246:
+// Start MUST NOT abort boot when the AGENT stream is absent (a deployment with no
+// agentic components — e.g. graph/lifecycle-only). It logs and returns a no-op stop
+// + nil error instead of the "stream not found" error that previously propagated out
+// of run() in both binaries → os.Exit(1) (the silent-red e2e:lifecycle/structural
+// tiers and the latent production boot failure).
+func TestIntegration_MilestoneSubscriber_GracefulSkipWhenStreamAbsent(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKVBuckets(graph.BucketEntityStates))
+	ctx := context.Background()
+
+	mgr := lifecycle.NewManager(tc.Client, nil)
+	require.NoError(t, agentrun.Register(mgr))
+	// reader/pub are unused on the stream-absent early-return path; nil logger
+	// is defaulted by the constructor.
+	sub := agentrun.NewMilestoneSubscriber(mgr, nil, nil, "acme", "ops", nil)
+
+	stop, err := sub.Start(ctx, tc.Client, agentrun.StartConfig{StreamName: agentrun.AgentStreamName})
+	require.NoError(t, err, "Start must not error when the AGENT stream is absent (gh#246)")
+	require.NotNil(t, stop, "Start must return a non-nil (no-op) stop func when skipping")
+	stop() // no-op stop must not panic
+}
+
+// TestIntegration_MilestoneSubscriber_StartsWhenStreamPresent confirms the normal
+// path is unchanged by the gh#246 graceful-skip: with the AGENT stream present,
+// Start wires the durable consumers and returns a real stop.
+func TestIntegration_MilestoneSubscriber_StartsWhenStreamPresent(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKVBuckets(graph.BucketEntityStates))
+	ctx := context.Background()
+
+	_, err := tc.CreateStream(ctx, agentrun.AgentStreamName, []string{"agent.>"})
+	require.NoError(t, err, "create AGENT stream")
+
+	mgr := lifecycle.NewManager(tc.Client, nil)
+	require.NoError(t, agentrun.Register(mgr))
+	sub := agentrun.NewMilestoneSubscriber(mgr, nil, nil, "acme", "ops", nil)
+
+	stop, err := sub.Start(ctx, tc.Client, agentrun.StartConfig{
+		StreamName:         agentrun.AgentStreamName,
+		ConsumerNameSuffix: "gh246-present",
+	})
+	require.NoError(t, err, "Start must succeed when the AGENT stream is present")
+	require.NotNil(t, stop)
+	stop()
+}

--- a/taskfiles/e2e/lifecycle.yml
+++ b/taskfiles/e2e/lifecycle.yml
@@ -7,7 +7,10 @@ tasks:
     deps: [":e2e:clean", ":e2e:check-ports", ":build:e2e"]
     cmds:
       - echo "[E2E LIFECYCLE] Starting SemStreams lifecycle environment..."
-      - docker compose -f docker/compose/lifecycle.yml up -d --wait
+      # --build so the tier exercises CURRENT source, not a stale cached image
+      # (the agentic tier already does this; lifecycle silently reused a stale
+      # build, masking the gh#246 boot fix).
+      - docker compose -f docker/compose/lifecycle.yml up -d --wait --build
       - echo "[OK] All services are healthy"
       - echo "[E2E LIFECYCLE] Running lifecycle scenario..."
       - cmd: cd cmd/e2e && ./e2e --scenario lifecycle
@@ -20,7 +23,7 @@ tasks:
     deps: [":e2e:clean", ":e2e:check-ports"]
     cmds:
       - echo "[E2E LIFECYCLE DEBUG] Starting SemStreams lifecycle environment..."
-      - docker compose -f docker/compose/lifecycle.yml up -d
+      - docker compose -f docker/compose/lifecycle.yml up -d --build
       - echo "[E2E LIFECYCLE DEBUG] Waiting for NATS..."
       - |
         for i in {1..30}; do


### PR DESCRIPTION
Closes #246.

## Problem

`agentrun.MilestoneSubscriber.Start` (ADR-053 D6) is wired **unconditionally** in both binaries' `run()` and **hard-failed boot** when the `AGENT` JetStream stream was absent:

```
Error: start agent-run milestone subscriber: ... ConsumeStreamWithConfig: failed to get stream AGENT: stream not found
```

Any deployment whose config declares no agentic components (no `AGENT` stream) couldn't start. This **silently red-lined `e2e:lifecycle` and `e2e:structural` since beta.100** (their configs have no agentic components) and is a **latent production boot failure** for graph/lifecycle-only deployments.

## Fix

`Start` now probes the target stream with `GetStream` first. If it's absent (`jetstream.ErrStreamNotFound`), it logs one INFO and returns a **no-op stop + nil error** instead of aborting — the subscriber is only meaningful when agentic components run (they create `AGENT` and publish `agent.complete.*`/`agent.failed.*`). Any *other* `GetStream` error still surfaces. The normal path (stream present) is unchanged.

## Also: e2e:lifecycle was reusing a stale image

While validating, found the `e2e:lifecycle` task ran `up -d --wait` **without `--build`** (unlike the agentic tier) — so it reused a cached app image and never exercised current source. That masked the boot fix on the first re-run and means the tier could ship green against stale code. Added `--build` to the default + debug tasks.

## Tests

Integration tests (testcontainer NATS): graceful-skip returns no-op + nil when `AGENT` is absent; normal start still wires the durable consumers when `AGENT` is present. Validated end-to-end with `task e2e:lifecycle` (now boots + runs the lifecycle scenario).

This unblocks the `e2e:lifecycle` gate for #244 (the `update_with_triples` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)