### PR TITLE
fix(e2e): --build on remaining tiers that reused stale images (gh#246 follow-up)

### DIFF
--- a/taskfiles/e2e/core.yml
+++ b/taskfiles/e2e/core.yml
@@ -7,7 +7,8 @@ tasks:
     deps: [":e2e:clean", ":e2e:check-ports", ":build:e2e"]
     cmds:
       - echo "[E2E] Starting SemStreams E2E environment..."
-      - docker compose -f docker/compose/e2e.yml up -d --wait
+      # --build so the tier exercises CURRENT source, not a stale cached image (gh#246 follow-up).
+      - docker compose -f docker/compose/e2e.yml up -d --wait --build
       - echo "[OK] All services are healthy"
       - echo "[E2E] Running core tests (health + dataflow)..."
       - cmd: cd cmd/e2e && ./e2e --scenario all
@@ -20,7 +21,7 @@ tasks:
     deps: [":e2e:clean", ":e2e:check-ports"]
     cmds:
       - echo "[E2E DEBUG] Starting SemStreams E2E environment..."
-      - docker compose -f docker/compose/e2e.yml up -d
+      - docker compose -f docker/compose/e2e.yml up -d --build
       - echo "[E2E DEBUG] Waiting for NATS to be ready..."
       - |
         for i in {1..30}; do

--- a/taskfiles/e2e/semantic.yml
+++ b/taskfiles/e2e/semantic.yml
@@ -60,7 +60,8 @@ tasks:
     deps: [":e2e:clean", ":e2e:check-ports", ":build:e2e"]
     cmds:
       - echo "[COMPARE] Running statistical variant first..."
-      - docker compose -f docker/compose/tiered.yml --profile statistical up -d --wait
+      # --build for parity with the semantic-variant step below (gh#246 follow-up).
+      - docker compose -f docker/compose/tiered.yml --profile statistical up -d --wait --build
       - cmd: cd cmd/e2e && ./e2e --scenario tiered --variant statistical --output-dir ./test/e2e/results
         ignore_error: true
       - docker compose -f docker/compose/tiered.yml --profile statistical down -v --timeout 15


### PR DESCRIPTION
Follow-up audit after #247 (gh#246). Every e2e tier's `docker compose up` was checked for `--build`; three tasks still reused a stale cached image and silently tested old code (the exact trap that hid the gh#246 boot failure):

- `e2e:core` default + debug
- `e2e:semantic` `compare` (statistical-variant step — its semantic sibling already built)

The `statistical`/`semantic`/`structural` **default** tasks already had `--build`. No behavior change beyond rebuilding each run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)