### PR TITLE
feat: ADR-055 + Wave 0 T1 — idempotent stream publish + dedup window

### DIFF
--- a/config/streams.go
+++ b/config/streams.go
@@ -23,6 +23,19 @@ type StreamConfig struct {
 	MaxBytes  int64    `json:"max_bytes,omitempty"` // Max storage size in bytes (0 = unlimited)
 	Retention string   `json:"retention,omitempty"` // "limits", "interest", "workqueue" (default: limits)
 	Replicas  int      `json:"replicas,omitempty"`  // Replication factor (default: 1)
+
+	// Duplicates is the server-side duplicate-detection window for the
+	// Nats-Msg-Id header (e.g. "2m", "30m", "1h"). Producers using
+	// Client.PublishToStreamWithMsgID rely on this window to collapse
+	// redeliveries of the same logical event (ADR-055 §5, "T1"). Empty
+	// leaves the window unset, so the NATS server applies its default of
+	// 2 minutes — adequate for steady-state redelivery but shorter than a
+	// restart/recovery replay horizon. Streams whose producers need
+	// dedup across that horizon set this explicitly. Must be <= MaxAge:
+	// the NATS server REJECTS (does not clamp) an explicit window larger
+	// than MaxAge, so createStream clamps it down to MaxAge with a warning
+	// rather than letting EnsureStreams abort boot.
+	Duplicates string `json:"duplicates,omitempty"`
 }
 
 // StreamConfigs is a map of stream name to configuration.
@@ -355,6 +368,30 @@ func (sm *StreamsManager) createStream(ctx context.Context, name string, cfg Str
 		maxAge = 7 * 24 * time.Hour // Default: 7 days
 	}
 
+	// Parse duplicate-detection window. Empty leaves Duplicates at zero so
+	// the NATS server applies its default (2 minutes); a parse failure falls
+	// back to that default rather than failing stream creation. See ADR-055
+	// §5 "T1".
+	var duplicates time.Duration
+	if cfg.Duplicates != "" {
+		var dupErr error
+		duplicates, dupErr = parseDurationWithDays(cfg.Duplicates)
+		if dupErr != nil {
+			sm.logger.Warn("Invalid duplicates window, using server default",
+				"stream", name, "duplicates", cfg.Duplicates, "error", dupErr)
+			duplicates = 0
+		}
+	}
+	// The NATS server rejects an explicit duplicate window larger than MaxAge
+	// (it does not clamp it). Clamp down to MaxAge with a warning so a
+	// misconfigured window degrades gracefully instead of aborting boot in
+	// EnsureStreams. maxAge is always > 0 here (defaulted to 7d above).
+	if duplicates > maxAge {
+		sm.logger.Warn("duplicates window exceeds max_age; clamping to max_age",
+			"stream", name, "duplicates", duplicates, "max_age", maxAge)
+		duplicates = maxAge
+	}
+
 	// Replicas default
 	replicas := cfg.Replicas
 	if replicas <= 0 {
@@ -362,26 +399,43 @@ func (sm *StreamsManager) createStream(ctx context.Context, name string, cfg Str
 	}
 
 	streamCfg := jetstream.StreamConfig{
-		Name:      name,
-		Subjects:  cfg.Subjects,
-		Storage:   storage,
-		Retention: retention,
-		MaxAge:    maxAge,
-		MaxBytes:  cfg.MaxBytes, // 0 means unlimited
-		Discard:   jetstream.DiscardOld,
-		Replicas:  replicas,
+		Name:       name,
+		Subjects:   cfg.Subjects,
+		Storage:    storage,
+		Retention:  retention,
+		MaxAge:     maxAge,
+		MaxBytes:   cfg.MaxBytes, // 0 means unlimited
+		Discard:    jetstream.DiscardOld,
+		Replicas:   replicas,
+		Duplicates: duplicates,
 	}
 
 	// Try to get existing stream
 	existingStream, err := js.Stream(ctx, name)
 	if err == nil {
-		// Stream exists - check if subjects match
+		// Stream exists - update on drift in subjects or the duplicate window.
 		existingCfg := existingStream.CachedInfo().Config
-		if !subjectsEqual(existingCfg.Subjects, cfg.Subjects) {
-			sm.logger.Info("Updating stream subjects",
+
+		// When the framework config doesn't specify a window, preserve the
+		// server-assigned/operator-set one so a subjects-only update doesn't
+		// silently reset it to the server default — and so we never trigger an
+		// update purely because the server reports its default (2m) for our
+		// unset zero.
+		if cfg.Duplicates == "" {
+			streamCfg.Duplicates = existingCfg.Duplicates
+		}
+
+		subjectsDrift := !subjectsEqual(existingCfg.Subjects, cfg.Subjects)
+		duplicatesDrift := cfg.Duplicates != "" && existingCfg.Duplicates != streamCfg.Duplicates
+		if subjectsDrift || duplicatesDrift {
+			sm.logger.Info("Updating stream config",
 				"stream", name,
+				"subjects_drift", subjectsDrift,
+				"duplicates_drift", duplicatesDrift,
 				"old_subjects", existingCfg.Subjects,
-				"new_subjects", cfg.Subjects)
+				"new_subjects", cfg.Subjects,
+				"old_duplicates", existingCfg.Duplicates,
+				"new_duplicates", streamCfg.Duplicates)
 			_, err = js.UpdateStream(ctx, streamCfg)
 			if err != nil {
 				return fmt.Errorf("update stream: %w", err)
@@ -402,7 +456,8 @@ func (sm *StreamsManager) createStream(ctx context.Context, name string, cfg Str
 		"stream", name,
 		"subjects", cfg.Subjects,
 		"storage", cfg.Storage,
-		"max_age", maxAge)
+		"max_age", maxAge,
+		"duplicates", duplicates)
 
 	return nil
 }

--- a/config/streams_duplicates_integration_test.go
+++ b/config/streams_duplicates_integration_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+package config
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// TestCreateStream_DuplicatesWindow verifies the duplicate-detection window
+// plumbs from StreamConfig.Duplicates into the JetStream stream, that an
+// explicit window change is applied to an existing stream, and that an unset
+// window preserves the existing one rather than resetting it to the server
+// default (ADR-055 §5 "T1"; the review's existing-stream-update concern).
+func TestCreateStream_DuplicatesWindow(t *testing.T) {
+	client := natsclient.NewTestClient(t, natsclient.WithJetStream())
+	sm := NewStreamsManager(client.Client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	js, err := client.Client.JetStream()
+	require.NoError(t, err)
+
+	const name = "DUPWINDOW"
+	windowOf := func() time.Duration {
+		stream, serr := js.Stream(ctx, name)
+		require.NoError(t, serr)
+		info, ierr := stream.Info(ctx)
+		require.NoError(t, ierr)
+		return info.Config.Duplicates
+	}
+
+	// 1. Create with an explicit 30m window.
+	require.NoError(t, sm.createStream(ctx, name, StreamConfig{
+		Subjects:   []string{"dupwindow.>"},
+		Storage:    "memory",
+		Duplicates: "30m",
+	}))
+	assert.Equal(t, 30*time.Minute, windowOf(), "explicit window must plumb through to the stream")
+
+	// 2. Re-create with a different explicit window → applied via UpdateStream.
+	require.NoError(t, sm.createStream(ctx, name, StreamConfig{
+		Subjects:   []string{"dupwindow.>"},
+		Storage:    "memory",
+		Duplicates: "1h",
+	}))
+	assert.Equal(t, time.Hour, windowOf(), "explicit window drift must be applied")
+
+	// 3. Re-create with NO window set → existing window preserved, not reset.
+	require.NoError(t, sm.createStream(ctx, name, StreamConfig{
+		Subjects: []string{"dupwindow.>"},
+		Storage:  "memory",
+	}))
+	assert.Equal(t, time.Hour, windowOf(),
+		"unset window must preserve the existing window, not reset to the server default")
+}
+
+// TestCreateStream_DuplicatesWindow_ClampedToMaxAge verifies that a window
+// larger than MaxAge is clamped down rather than aborting boot — the NATS
+// server rejects (does not clamp) an explicit window > MaxAge, so createStream
+// must clamp client-side (go-reviewer S1).
+func TestCreateStream_DuplicatesWindow_ClampedToMaxAge(t *testing.T) {
+	client := natsclient.NewTestClient(t, natsclient.WithJetStream())
+	sm := NewStreamsManager(client.Client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, sm.createStream(ctx, "DUPCLAMP", StreamConfig{
+		Subjects:   []string{"dupclamp.>"},
+		Storage:    "memory",
+		MaxAge:     "5m",
+		Duplicates: "30m", // larger than MaxAge → must clamp, not reject
+	}), "a window larger than max_age must clamp, not fail stream creation")
+
+	js, err := client.Client.JetStream()
+	require.NoError(t, err)
+	stream, err := js.Stream(ctx, "DUPCLAMP")
+	require.NoError(t, err)
+	info, err := stream.Info(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 5*time.Minute, info.Config.Duplicates, "window must be clamped to max_age")
+	assert.Equal(t, 5*time.Minute, info.Config.MaxAge)
+}
+
+// TestCreateStream_DuplicatesWindow_InvalidFallsBackToDefault verifies a
+// malformed duration does not fail stream creation — it falls back to the
+// server default (zero window) with a warning.
+func TestCreateStream_DuplicatesWindow_InvalidFallsBackToDefault(t *testing.T) {
+	client := natsclient.NewTestClient(t, natsclient.WithJetStream())
+	sm := NewStreamsManager(client.Client, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	require.NoError(t, sm.createStream(ctx, "DUPBAD", StreamConfig{
+		Subjects:   []string{"dupbad.>"},
+		Storage:    "memory",
+		Duplicates: "not-a-duration",
+	}), "an invalid duplicates window must not fail stream creation")
+}

--- a/docs/adr/039-tool-call-governance-rule-driven.md
+++ b/docs/adr/039-tool-call-governance-rule-driven.md
@@ -2,6 +2,15 @@
 
 ## Status
 
+**Audit mechanism amended by [ADR-055](055-graph-write-intent-taxonomy.md) §3a**
+— 2026-06-11. The `approve`/`deny` "auditability via the graph" choice (audit
+triples written to the rule-ID subject) relied on `triple.add` auto-vivify creating
+a phantom non-6-part rule-ID entity. ADR-055 retires auto-vivify entity creation, so
+the verdict audit moves to a registered append-only verdict event on the
+`GOVERNANCE_VERDICT_AUDIT` stream. The explicit-verdict-audit goal and the
+"verdict is structural; audit-write failure must not flip it" discipline are
+preserved; only the storage mechanism changes. The rest of this ADR stands.
+
 **Proposed — 2026-05-12.** Migrates tool-call governance from the
 in-process filter pattern shipped in beta.67+68 onto the rules engine.
 The forcing function: semspec hit unmarshal noise from the

--- a/docs/adr/049-lifecycle-harness-prime-schema-over-entity-states.md
+++ b/docs/adr/049-lifecycle-harness-prime-schema-over-entity-states.md
@@ -12,6 +12,16 @@ Working name throughout the design exercise: "ADR-047-prime." This
 is the canonical numbered ADR; the working name remains useful in
 the proposal documents as a continuity marker.
 
+**Extended by [ADR-055](055-graph-write-intent-taxonomy.md)** —
+2026-06-11. ADR-049's bucket-ownership rubric and CAS-on-condition
+state-write choice stand and are validated. ADR-055 generalizes the
+"schema owner over ENTITY_STATES" principle beyond the lifecycle
+harness into a write-intent taxonomy (every entity is born with a
+semantic envelope; `triple.add` loses its auto-vivify-create power),
+and resolves the one gap this ADR left open — Participant *identity*
+gains a Graphable origin via a generic `ParticipantEntity` adapter
+while transitions stay on the CAS wire defined here.
+
 ## Context
 
 ### What ADR-047 shipped

--- a/docs/adr/055-graph-write-intent-taxonomy.md
+++ b/docs/adr/055-graph-write-intent-taxonomy.md
@@ -1,0 +1,618 @@
+# ADR-055: Write-Intent Taxonomy — Entity Birth Requires an Envelope (The Mutation API Is Not a Producer API)
+
+## Status
+
+**Proposed** — 2026-06-11. Not yet implemented or tagged. Derived from a
+two-pass multi-agent audit + design exercise, then a five-lens adversarial
+review (architect / breaker / feasibility / code-accuracy / completeness) whose
+findings are folded in below; every load-bearing fact is verified against code.
+Review verdict: **READY WITH CHANGES** — the four-lane decision is sound; the
+amendments correct miscounts and over-claims an implementer would otherwise build
+wrong. Evidence base:
+
+- [`docs/proposals/graphable-bypass-audit.md`](../proposals/graphable-bypass-audit.md)
+  — the blast-radius audit (9 producer clusters, 55 call sites, 21 confirmed
+  anti-pattern writes / 7 entity types, 0 of 21 overturned under adversarial review).
+- [`docs/proposals/graphable-fix-plan.md`](../proposals/graphable-fix-plan.md)
+  — the per-entity fix plan + the CAS-flavor decision matrix + the transport-guard
+  break-test findings (T1/T2/StorageRef).
+
+**Extends and partially amends** [ADR-049](049-lifecycle-harness-prime-schema-over-entity-states.md):
+ADR-049's bucket-ownership rubric and its CAS-on-condition state-write choice both
+stand and are **validated**. ADR-055 generalizes ADR-049's insight beyond the
+lifecycle harness and amends one blind spot — *non-lifecycle* producers still
+birth envelope-less entities via `triple.add`. Builds on
+[ADR-047](047-lifecycle-harness-substrate.md) (Participant concept),
+[ADR-053](053-agent-run-substrate.md) (agent-run as Participant), and
+[ADR-054](054-semantic-indexing-eligibility.md) (the create envelope carries the
+`IndexingProfile`). Honors [ADR-028](028-orchestration-architecture.md) and the
+KV-twofer.
+
+## Context
+
+### The anti-pattern
+
+SemStreams' founding architecture is `Events → Graphable interface → Knowledge
+Graph`: a domain payload implements `graph.Graphable` (`EntityID()` +
+`Triples()`), is published as a `BaseMessage`, flows through a JetStream stream,
+and graph-ingest's consumer (`extractEntityFromMessage` `component.go:857` →
+`MergeEntity` `:946`) writes it to `ENTITY_STATES`, **stamping `MessageType`
+provenance** (`:885`). A domain Go type with domain expertise owns each entity's
+existence and shape.
+
+In parallel, graph-ingest hosts a **mutation API** for second-writers. The audit
+found this API has crept into use as a **producer API**: 21 confirmed call sites
+across 7 entity types synthesize a 6-part entity ID and stamp hand-assembled
+triples — **creating first-class domain entities with no backing Graphable type
+and, often, no `MessageType`**. The mechanism is auto-vivify: `AddTriple`
+(`component.go:1411-1423`) and `AddTriples` (`component.go:1511-1521`) both create
+a missing entity from a bare `triple.Subject` as `EntityState{Version:0}` with a
+**zero-value `MessageType`** — an envelope-less record. The result is invisible,
+unclassified graph state: entities born with no producer contract, no domain,
+category, version, or indexing profile.
+
+ADR-054's own note named the canonical case: *"The motivating
+`agent.agentic-loop.step` entities enter via the mutation API, not the Graphable
+path."* It is not isolated.
+
+### What ADR-049 established, and its blind spot
+
+ADR-049 was right about two things this ADR depends on: (1) state lives in
+`ENTITY_STATES`, not a private bucket; (2) state transitions need CAS-on-condition
+(reject-if-moved), which the append/merge path cannot give, so lifecycle uses
+`UpdateEntityWithTriplesRequest.ExpectedRevision`. The lifecycle `Participant`
+struct owns the schema via reflection projection and stamps
+`MessageType=lifecycle/harness/v1`.
+
+ADR-049 solved entity *classification* for the lifecycle harness — and as a
+consequence **lifecycle entities are already envelope-compliant**: `Manager.Create`
+births them via `create_with_triples` (atomic create-or-fail) carrying
+`lifecycleMessageType`. **The blind spot:** ADR-049 did not generalize the
+requirement. A *non-lifecycle* producer that needs an entity has no Participant
+struct and reaches for `triple.add` auto-vivify — birthing an envelope-less
+entity. ADR-049's rubric answers *where state lives*; it does not answer *what
+guarantees an entity's birth carries*. This ADR adds that layer, and the lifecycle
+harness becomes the **exemplar** of the pattern, not an exception to it.
+
+### The verified CAS-flavor facts (the foundation)
+
+- **Graphable stream → `MergeEntity`** (`component.go:946`): `UpdateWithRetry` =
+  CAS-with-retry, **async, never rejects, APPENDS** on merge (`:1006`, no (s,p,o)
+  dedup). Fact-accumulation.
+- **`update_with_triples` default** (`ExpectedRevision=0`): CAS-with-retry +
+  `MergeTriples` = **REPLACE-by-(subject,predicate)** (gh#244). Already must-exist
+  (`mutations.go:530`).
+- **`update_with_triples` + `ExpectedRevision>0`** (`updateEntityAtRevision`
+  `:1311`): **CAS-on-condition, REJECTS, synchronous**. The state-machine primitive
+  `Manager.Transition` uses.
+- **`entity.create_with_triples`** (`CreateEntityStrict`): **atomic create-or-fail**
+  (`ErrKVKeyExists` on duplicate). One-shot birth.
+
+## Decision
+
+### 1. graph-ingest's entity-birth-and-mutation write surface is a four-lane taxonomy
+
+This taxonomy governs entity **birth and triple mutation**. Fact retraction
+(`triple.remove`) and entity death (`entity.delete`) are real, distinct write
+intents that fit none of these lanes and are **out of scope** for this ADR (see
+Open Question #6). The external operator gateway (semconnect CS-API: bare
+`entity.create`/`entity.update`/`entity.delete`) is a projection over these lanes,
+reconciled in §2.
+
+| Lane | Ingress | Conflict semantics | Creates? | Envelope |
+|---|---|---|---|---|
+| **Fact arrival** | Graphable stream consumer | CAS-with-retry, async, never rejects, **appends** | yes (merge/create) | **carried** (registered payload → `MessageType`) |
+| **Entity create** | `entity.create_with_triples` | atomic **create-or-fail** | yes | **required** |
+| **State transition** | `state.transition` (= `update_with_triples` + `ExpectedRevision`) | **CAS-on-condition, rejects, sync**, replace-by-predicate | no (must-exist) | inherited |
+| **Evidence append** | `evidence.append` (= `triple.add` / `add_batch`, made must-exist) | append multi-valued, **must-exist** | **no** | inherited |
+
+Four *intents* over **three subjects + a discriminator**: the State-transition and
+mutation-replace cases are the same `update_with_triples` subject discriminated by
+`ExpectedRevision` (0 vs >0, `mutations.go:511`). **Only the Evidence-append lane
+changes behavior** under this ADR (`triple.add`/`add_batch` gain must-exist);
+`update_with_triples` is already must-exist, and the State-transition lane's only
+change is the create-envelope requirement (§2). Entities are born **only** through
+*Fact arrival* or *Entity create* — both envelope-bearing.
+
+### 2. Entity creation requires a semantic envelope (the core normative rule)
+
+> **No write may create an entity without a semantic envelope** — a registered
+> payload type (Graphable, `MessageType` stamped at ingest) for the Fact-arrival
+> lane, or an explicit `MessageType` (domain/category/version) on the
+> Entity-create lane. The producer contract includes, at minimum: domain,
+> category, version, and (per ADR-054) an `IndexingProfile`.
+
+**External operator gateway.** The bare CS-API subjects (`graph.mutation.entity.create`
+`mutations.go:40`, `entity.update` `:53`, `entity.delete` `:66`) are a gateway
+projection, NOT additional lanes. To preserve this invariant, **bare
+`entity.create` is subject to the envelope rule**: either the gateway default-stamps
+a `MessageType`/`IndexingProfile` on the `EntityState` before write, or bare
+`entity.create` is deprecated for external creates in favor of
+`entity.create_with_triples`. Bare `entity.update` (must-exist replace,
+`mutations.go:411`) is a gateway projection over the State-transition lane.
+Without this, an external POST through bare `entity.create` can still birth an
+envelope-less entity — the one ingress that would otherwise defeat §1.
+
+### 2.1 Why the transition lane is request/reply, not a stream
+
+A state transition's defining need is **synchronous conditional reject** ("apply
+iff still at rev R; tell me *now* if I lost so I re-read and retry") — what
+`Manager.Transition`'s loop runs on. A JetStream stream is async fire-and-forget;
+you don't synchronously learn whether the CAS won. You *can* stream it via
+`Nats-Expected-Last-Subject-Sequence`, but that requires one subject per entity,
+making ENTITY_STATES a projection of a transition stream — event-sourcing state,
+KV stops being the source of truth, restart means replay-rebuild. The KV-twofer
+already gives durable transition audit via revision replay (ADR-049 G4), so
+streaming buys nothing here at large cost. The transition lane belongs in the RPC
+family — and already exists as `update_with_triples`+`ExpectedRevision`.
+
+### 3. `triple.add` and `add_batch` lose auto-vivify-create power (must-exist)
+
+`triple.add` / `add_batch` become **must-exist**: they reject "entity not found"
+when the Subject is absent. **Both** auto-vivify-create branches are removed —
+`AddTriple` (`component.go:1411-1423`) AND `AddTriples` (`component.go:1511-1521`).
+This matters: the 7 conjurors reach the footgun via
+`graph.mutation.triple.add_batch` → `AddTriples` (`decide.go:723`,
+`write_todos.go:440`, `triplepub.go:99`, `scratchpad.go:217`, `emit_diagnosis.go:199`),
+NOT the singular `AddTriple` — deleting only `:1417` would ship the footgun live
+on the batch path. (`graph/datamanager.Manager.AddTriple`, `edge_ops.go:16`, is a
+distinct GetEntity-first implementation already must-exist-shaped; do not conflate.)
+
+**This converts envelope-less producers into fail-fast errors** while
+append-to-existing survives (renamed `evidence.append` for intent). But the
+"derived-fact stampers are uniformly unaffected" claim is **not** uniformly true;
+three carve-outs:
+
+- **Governance deny/approve audit (a must-exist casualty — see §3a).** Not all
+  ~26 cleared stampers target an existing Graphable-origin entity.
+- **In-process inference/applier bypass.** `tripleAdderAdapter.AddTriple`
+  (`component.go:159-161`) calls `Component.AddTriple` in-process (wired at `:660`),
+  invoked at `hierarchy.go:239/:313/:368` and `applier.go:193` — writing inverse
+  edges onto *different* subjects (siblingID/containerID) than the one being
+  ingested. These normally target pre-existing entities (siblings via
+  `ListWithPrefix`; containers pre-created via `ensureContainerExists`→`CreateEntity`),
+  but under must-exist any ordering race flips from silent no-op to fail-fast. A
+  Wave-0 audit must grep every in-process `Component.AddTriple` caller and confirm
+  none relies on auto-vivify ordering — assert it, don't assume it.
+- **Subject-override cross-entity stamps.** The `add_triple` rule action supports
+  `action.Subject` override (`resolveTripleSubject`, `actions.go:576`) targeting an
+  entity OTHER than the trigger. The shipped `configs/rules/example-fan-out/02-stamp-completion-on-parent.json`
+  stamps a counter onto a B1-conjured parent loop-execution entity; under must-exist
+  the parent's origin must land first. Naturally satisfied by causal ordering
+  (parent spawns before child completes) AND by the closing-move sequencing (B1
+  lands before the flip), but the example-fan-out pack is explicitly **gated on B1**,
+  and the parent origin (`WriteSpawnIdentity`) is best-effort fire-and-forget
+  (`graph_writer.go:485`) — a dropped origin converts silent auto-vivify to a hard
+  child-counter fail.
+
+**Precise claim:** must-exist is safe for stampers targeting an
+independently-existing Graphable-origin entity (rule-engine trigger-entity stamps,
+inference-applier edges between pre-existing 6-part entities). The ~8 loop-derived
+stampers become safe only after B1 + origin-first ordering. The governance-audit
+writes (§3a) and the in-process inference bypass need explicit handling.
+
+**Ordering consequence:** an entity's origin must land before any derived stamp or
+transition on it — a fail-fast precondition, not a silent self-heal. Each
+conjuror's origin write must be promoted from best-effort to error-propagating
+when it becomes the must-exist precondition. Per-producer ordering is in the fix
+plan §6–7. An Open Question (#7) records whether benign origin races warrant a
+bounded must-exist retry-with-backoff vs hard fail-fast.
+
+**Observability.** "Loud fail-fast" is operationalized: a Wave-0 rejection metric
+labelled by subject + reason, plus a structured log, per the ADR-054 cost-ledger
+discipline. Every conjuror migrating to a mutation lane becomes a new
+`natsclient.Request` caller and MUST check the `error: <msg>` response-payload
+prefix (the body-prefix convention) or silently treat rejection as success — the
+silent-handler-error class that has shipped 3×. State this as a Wave-0 invariant.
+
+### 3a. Governance deny/approve audit: a must-exist casualty, migrated before the flip
+
+`executeDeny` (`actions.go:1390-1418`) and `executeApprove` (`:1435-1467`) write an
+audit triple with `Subject = ec.RuleID()` via `tripleMutator.AddTriple` →
+`graph.mutation.triple.add` → `Component.AddTriple`'s auto-vivify branch — the only
+write path that skips `validateEntityID`. Rule IDs are bare slugs (zero dots:
+`role-gate-rule`, `architect_complete_spawn_editor`), so they fail the 6-part
+`entityIDRegex` and **can take no birth lane**. The write is best-effort: on
+failure both callers "intentionally fall through — verdict is structural"
+(`:1414`, `:1465`) and only log. `configs/agentic.json` uses `approve` in
+production. **Under must-exist, the first deny/approve on a never-seen rule-ID
+rejects "entity not found" and the ADR-039 audit triple silently vanishes.**
+
+**Decision: a dedicated append-only verdict-EVENT store, not a mutable bucket.**
+A verdict is an *event* (N per rule over time, per [[feedback_separate_contract_from_run]]:
+the rule is the contract, each verdict is a run/event) — not state keyed by rule.
+Two wrong shapes to reject explicitly: (a) it does **not** belong in `ENTITY_STATES`
+(rule-IDs are not domain entities; they fail the 6-part contract and would pollute
+inference/search), and (b) it must **not** be a KV bucket keyed by `ruleID` with
+`History:1` — that is "last-verdict-wins," which silently *recreates* the audit
+loss this section exists to prevent. The current audit triples are written to a
+phantom non-6-part rule-ID "entity" and have **no code readers** (verified: only
+`PredicateRuleDeny`/`PredicateRuleApprove` consts exist; ADR-039's "operators query
+the graph" reads these phantom entities). The verdict is *already* an event —
+`executeApprove` already publishes one to a routing subject — so the audit triple
+is a redundant parallel record.
+
+**The concrete contract (§3a must ship this, not a bare "bucket"):**
+
+- **Store.** A dedicated JetStream stream `GOVERNANCE_VERDICT_AUDIT`, subject
+  `governance.verdict.{decision}.{rule_token}` (`decision` ∈ `deny`|`approve`).
+  **`rule_token` is a subject-safe stable encoding of the rule ID — NOT the raw
+  `rule_id`.** Rule IDs are free-form config strings (`Definition.ID`,
+  `rule_factory.go:16`; validated non-empty only, `expression_factory.go:285`), so a
+  raw ID can contain `.` (the NATS token separator), spaces, `*`/`>` (wildcards), or
+  future product-namespaced IDs — any of which break subject publishing AND
+  filtering. `rule_token` is a deterministic hash or token-encoding (e.g. a short
+  hash); the **canonical `rule_id` is carried in the payload** for display/query.
+  **Append-only by construction** — each verdict is a new stream sequence; no key to
+  overwrite, so last-verdict-wins is structurally impossible. Retention = `MaxAge`
+  sized to the audit/compliance horizon — its own knob, the reason for a dedicated
+  stream rather than riding AGENT. (Considered alternative: KV keyed by a unique
+  event ID, written once so `History` is moot — also append-safe, but the key would
+  need the same `rule_token` encoding; the stream is preferred because the verdict is
+  already an event and ADR-039 values JetStream history for auditability.)
+- **Payload (envelope-compliant per §2).** A *registered* verdict-event payload
+  type — `domain=governance, category=verdict, version=v1` — published through the
+  payload registry, so the audit record carries its own producer contract. Schema:
+  `{decision, rule_id, reason, timestamp, entity_id, loop_id?, call_id?}`. The
+  always-present fields are at the call site: `ruleID`, `reason`, `EntityID`.
+  **`loop_id`/`call_id` are OPTIONAL and sourced from `ExecutionContext.MessageData`
+  (`execution_context.go:135`), NOT the routing subject** — `executeDeny` has no
+  subject (`actions.go:1390`), and `MessageData` is nil for entity-state-driven and
+  cron-fired rules. Emit them when present (omit otherwise); do not assume a
+  tool-call message is always in scope.
+- **Emit ownership — a dedicated `VerdictAuditor` dependency, not the operator
+  `Publisher`.** The framework emits the audit event on **both** deny and approve
+  via an explicit, framework-owned `VerdictAuditor` (emitter) interface injected
+  into the `ActionExecutor` — distinct from the operator-configured routing
+  `Publisher`. This is deliberate: piggybacking the operator `Publisher` would let
+  config drift (a missing/misrouted publish target) accidentally disable the audit
+  trail. The `VerdictAuditor` is always wired by the rule processor; audit is a
+  framework guarantee, not an operator opt-in. This **replaces** the
+  `AddTriple(ruleID, rule.deny/approve)` write entirely — so `triple.add` leaves the
+  governance path and must-exist never touches it. The operator's routing publish to
+  the dispatcher (via `Publisher`) is unchanged.
+- **Failure semantics (preserve ADR-039 + make loss observable).** The audit emit
+  stays **best-effort — a failed emit MUST NOT flip the verdict** (deny stays
+  terminal, approve stays permissive; `actions.go:1414`/`:1465`). But add a
+  `governance_verdict_audit_failures_total{decision,mode}` counter + Error log + a
+  health signal, so lost audit records are observable — critical in `enforce` mode,
+  where a silent audit gap on an enforced denial is a compliance hole.
+- **Eligibility (resist scope-creep into "governance state").** This store is for
+  rule/tool-call **verdict events only** — non-domain events over rule/call IDs;
+  **not** semantic entities, **not** inputs to graph inference/search/rules. The
+  name is `GOVERNANCE_VERDICT_AUDIT` (not a generic "governance bucket") precisely
+  so it cannot become a side channel for facts that are inconvenient to model. A
+  governance fact that needs graph-query semantics is born as a real entity via a
+  birth lane, or mirrored intentionally (explicit, ADR-054-indexing-profiled) —
+  never defaulted here.
+- **Read path.** Operators read verdict history by replaying/filtering the stream
+  (`governance.verdict.deny.{rule}` etc.) via a governance gateway query, replacing
+  the phantom-rule-ID-entity path. (No code reads the triples today, so no in-repo
+  reader migrates; the operator-facing graph query in ops-doc 17 is redirected.)
+- **Migration (before the closing-move flip).** (1) register the verdict-event
+  payload type + provision the stream; (2) swap `executeDeny`/`executeApprove`'s
+  `AddTriple` for the framework verdict-event emit; (3) update the tests asserting
+  triple writes (`processor/rule/deny_integration_test.go:329` and the approve
+  counterpart) to assert the stream event; (4) update
+  `docs/operations/17-tool-call-governance.md:155-179` (promises `rule.deny`/
+  `rule.approve` triples + "operators query the graph"); (5) regression test
+  asserting a verdict event lands for every deny/approve.
+
+**This amends [ADR-039](039-tool-call-governance-rule-driven.md)'s audit mechanism**
+(triple-on-rule-ID → verdict-event-on-stream) while preserving its goal: an
+explicit, queryable verdict audit ("show me every tool call we explicitly denied").
+ADR-039's "auditability via the graph" rested on phantom rule-ID entities; the
+stream is the honest home for an append-only event log.
+
+### 4. The per-predicate decision matrix (classify predicates, not entities)
+
+Most entities are **hybrids** whose predicates split across lanes:
+
+```
+For each predicate of an entity:
+  1. Phase-transition race or read-modify-write counter race?
+        YES → State transition (CAS-on-condition). A Participant predicate.
+  2. Single-valued AND re-emitted onto the same Subject over the entity's life?
+        YES → update_with_triples default (MergeTriples replace-by-(s,p)).
+  3. Else (born-once-and-never-re-emitted identity, accumulating links, immutable bodies)
+        → a birth lane: Fact arrival (non-Participant, with guards §5) OR
+          Entity create (Participant identity, §6).
+```
+
+A **mutable single-valued predicate may NOT ride the Fact-arrival stream** — the
+stream appends, so `GetFieldValue` first-match would read the stale value
+(beta.103 class). `mission.Command`'s re-emitted `mission.command` (launch→abort)
+is the canonical example: such predicates belong on the replace lane, not the
+stream.
+
+**No fourth "replace mode" is added to the stream consumer.** The replace need is
+served by `update_with_triples` default. The primitive set {append-stream + guards,
+mutation-replace, CAS-on-condition} is complete *on the create/append/replace/
+transition axis* — a deliberate-completion decision
+(`feedback_reactive_patches_vs_engine_completion`), not a claim that the four lanes
+exhaust every NATS verb (retraction/death are out of scope, §1).
+
+### 5. Transport guards the Fact-arrival lane requires (preconditions, not options)
+
+The break-tests proved the Fact lane unsafe without these. They apply to
+**non-Participant** Fact-arrival entities (trajectory-step, web-observation,
+operating-model bodies, loop-execution); Participant identity rides the
+create-or-fail lane (§6) and is exempt.
+
+- **T1 — idempotent publish + dedup window (THREE parts).** `PublishToStream`
+  sets no `Nats-Msg-Id` (`client.go:793-799`); the consumer is at-least-once and
+  `MergeEntity` appends. Wave 0 must deliver: **(a)** `PublishToStreamWithMsgID`
+  with a deterministic ID (`loopID:spawn`, `entityID:vN`); **(b)** a `Duplicates`
+  field on `config.StreamConfig` (`config/streams.go:19-26` has none today) plumbed
+  into BOTH stream builders (`config/streams.go` createStream, `natsclient/stream.go`
+  ensureStreamForConsumer), defaulted to the recovery horizon; **(c)** an explicit
+  UpdateStream-or-recreate decision for already-existing prod streams (AGENT,
+  entity-ingest) — `createStream` only calls `UpdateStream` on subject changes
+  (`config/streams.go:380-388`), so a window-only change needs a new path. **Without
+  (b)+(c) the window is the NATS server default of 2 minutes** — adequate for
+  steady-state redelivery, shorter than the `DeliverPolicy:all` restart-replay
+  horizon. The window size is now a Wave-0 config default, so Open Question #1 is a
+  **must-decide-in-Wave-0** item, not deferred. Because the consumer is durable with
+  a stable name, ordinary restarts resume from last-ack; the exposure is
+  consumer-recreation / fresh-deploy catch-up replay, which can re-append born-once
+  predicates outside the window — see §7-G3 and Open Question #1 ((s,p,o)-idempotent
+  merge is the belt-and-suspenders fix).
+- **T2 — single-Subject Graphable (target invariant + exception list, not a
+  universal fact).** `extractEntityFromMessage` files all `Triples()` under one key
+  = `EntityID()` with no Subject regrouping (`component.go:882-887`); a triple whose
+  `Subject != EntityID()` is silently misfiled. **Known violators today:**
+  `sensorml.Asset` (deliberate inverse `isHostedBy` edge on the child subject,
+  `graphable.go:124`), `federation.EventPayload` (`event_payload.go:41`),
+  `objectstore.StoredMessage` (`stored_message.go:143`, verbatim pass-throughs).
+  Therefore: **WARN-and-regroup-by-Subject** in `extractEntityFromMessage` (mirror
+  the `AddTriples` `bySubject` split at `component.go:1478-1484`) so cross-entity
+  edges land on the right key — NOT a hard reject. New single-Subject Graphables are
+  the target; the regroup keeps existing multi-Subject producers correct.
+  (`sensorml.Asset` is currently unwired — no `MarshalJSON`, no payload registration
+  — so the regression is latent-on-wiring, not live-on-main; that is why the guard
+  must regroup rather than reject before the ADR-044 Phase 5 bridge lands.)
+- **StorageRef extraction (two halves).** Consumer side: `extractEntityFromMessage`
+  must type-assert `ContentStorable` and set `StorageRef` (MergeEntity merges it on
+  the existing branch, `:1008-1009`). Producer side: the canonical pilot
+  `TrajectoryStepEntity` stores its ref in an **unexported** `storageRef` field
+  (`trajectory_entity.go:22`) that won't JSON-round-trip — it needs an exported,
+  round-tripping field + offload-before-publish ordering, with a production-decoder
+  round-trip test.
+
+### 6. Lifecycle: already envelope-compliant; identity born via the create-or-fail lane
+
+ADR-049's CAS-for-transitions is **correct and stays** — the State-transition lane
+used as designed; lifecycle is the **exemplar**. And lifecycle entities are
+**already envelope-compliant**: `Manager.Create` births them via
+`create_with_triples` (Entity-create lane, create-or-fail) carrying
+`lifecycleMessageType`. So lifecycle is not a violator of §2's invariant.
+
+The one enrichment this ADR proposes: give a Participant a **richer typed envelope**
+(per-Participant domain/category/version + `IndexingProfile`) instead of the generic
+`lifecycleMessageType`, by having `Manager.Create` build its `create_with_triples`
+payload from a registered `lifecycle.ParticipantEntity` adapter rather than the
+generic reflection projection. **Critically, this origin is born on the Entity-create
+lane (create-or-fail), NOT the Fact-arrival append stream.** That binding (the
+review's load-bearing correction) has three consequences:
+
+- **No field-classifier is needed.** A one-shot create-or-fail cannot duplicate
+  single-valued predicates, so the adapter may include the full initial triple set
+  exactly as `buildInitialTriples` does today (identity + initial phase + audit).
+  The "exclude every single-valued predicate" rule that an *append-stream* origin
+  would have required does not apply here.
+- **T1 is moot for Participants.** Create-or-fail is not the append path, so there
+  is no redelivery-duplication exposure; the §5 guards govern only non-Participant
+  Fact-arrival entities.
+- **agent-run reaches parity with mission.** `AgentRun` (`agentrun.go`, ADR-053)
+  is created via `Manager.Create` like mission, so it is *already* enveloped; the
+  adapter upgrades its envelope from generic `lifecycleMessageType` to a typed
+  `agent.run.*` payload. This is an enhancement, not a fix.
+
+**Mission, honestly framed.** Mission demonstrates the State-transition lane (CAS)
+and a single-Subject stream Graphable (`mission.Command`) in an **e2e harness** —
+but `mission.Command.Triples()` stamps a *command* predicate (`mission.command`,
+`command.go:71-76`), not the Participant identity (born via `Manager.Create` on the
+create-or-fail lane), and it publishes on the un-guarded `PublishToStream` path
+(`command.go:318`) — a **T1 target to fix, not a T1 exemplar**. No production
+Participant yet has a typed identity envelope via the adapter. **The hybrid is
+therefore DESIGNED and validated against the guarantee table (§7), not PROVEN in
+production.**
+
+### 7. Guarantee-preservation walkthrough (validated against ADR-049's seven guarantees)
+
+With Participant identity on the create-or-fail lane and transitions on CAS:
+
+| Guarantee | Verdict |
+|---|---|
+| **G1** reject-on-mismatch transitions | PRESERVED by construction — transitions ride `ExpectedRevision`, never the stream. |
+| **G2** atomic phase+audit landing | PRESERVED — one Transition delta under one `ExpectedRevision`. |
+| **G3** create-or-fail race | PRESERVED **natively** — `Manager.Create` has two race-safe paths: absent → `CreateEntityStrict` (atomic create-or-fail, `ErrKVKeyExists`); present-without-phase → `update_with_triples`+`ExpectedRevision` attach (rejects concurrent attach). Identity on the create-or-fail lane means **G3 no longer depends on T1** (the prior append-stream framing did). |
+| **G4** History fidelity (revision replay) | PRESERVED — transitions stay off the append stream; bounded per-transition revisions. |
+| **G5** replace-not-append single-valued phase (beta.103) | PRESERVED — phase/audit/counter scalars ride CAS-replace, never the append stream. The beta.103 break is `extractTripleScalar` last-match vs rule-engine `GetFieldValue` first-match under blind-append; keeping single-valued predicates off the append path is the fix. |
+| **G6** provenance (`MessageType`) | PRESERVED and **enriched** — the typed adapter payload carries a per-Participant envelope, stamped at create. |
+| **G7** transition-table + terminal/drift validation | PRESERVED — runs synchronously in the req/reply loop. |
+
+For **non-Participant** Fact-arrival entities (B1 loop-execution, B2
+trajectory-step, etc.), born-once identity safety holds **iff** the origin publish
+is T1-idempotent AND redelivery stays within the JetStream Duplicates window;
+`DeliverPolicy:all` replay outside the window (consumer recreation / fresh-deploy
+catch-up) re-appends born-once predicates unless `MergeEntity` gains
+(s,p,o)-set-idempotent merge — see Open Question #1. Either promote (s,p,o)-idempotent
+merge to a Wave-0 primitive alongside T1, or scope the guarantee to "within the
+Duplicates window" with the accepted bounded-re-merge tradeoff. Do not present T1
+as unconditionally sufficient.
+
+## Migration
+
+Sequenced waves (per-entity detail in the fix plan §7–8). **Closing-move ordering:**
+migrate every producer to a birth lane first, then flip `triple.add`/`add_batch` to
+must-exist last, so `main` is never broken in between.
+
+- **Wave 0 — framework primitives:**
+  - **B-1 governance-audit migration** (§3a) — move `rule.deny`/`rule.approve` from
+    the rule-ID triple write to the `GOVERNANCE_VERDICT_AUDIT` verdict-event stream
+    (registered payload, append-only) + failure metric + regression test + ops-doc
+    update. Gates the closing move.
+  - **T1 (three parts)** — `PublishToStreamWithMsgID` + `config.StreamConfig.Duplicates`
+    plumbed into both builders + the existing-stream update path; decide the window
+    size (Open Question #1). Optionally (s,p,o)-idempotent merge in `MergeEntity`.
+  - **T2** WARN-and-regroup-by-Subject + **StorageRef extraction** (both halves) in
+    `extractEntityFromMessage`.
+  - Lane naming + the §3 rejection metric + the body-prefix-error Wave-0 invariant.
+  - In-process `Component.AddTriple` caller audit (§3).
+  - **ADR-054 Phase 1** (IndexingProfiler, lenient) so birth envelopes carry it.
+- **Wave 1 — pilots:** model-endpoint (mutation-replace pilot), trajectory-step
+  (Fact-arrival + ContentStorable pilot).
+- **Wave 2:** loop-execution. **Precondition:** the agentic graph-ingest input is
+  `sensor.processed.entity` only (`configs/agentic.json`) — agentic entities reach
+  graph-ingest via `graph.mutation.*` today, so B1/B2 must ADD a graph-ingest
+  entity-stream input + an agentic-loop publish leg to every agentic config. Surface
+  this in B1/B2 effort.
+- **Wave 3 — replace siblings:** web-observation, operating-model family.
+- **Wave 4 — lifecycle enrichment:** the `ParticipantEntity` adapter (+ the
+  `lifecycle:"origin"` tag contract if the adapter is taken generic — Open Question
+  #2), then agent-run's typed envelope, then the github-pr-workflow example. **Gated
+  on ADR-053 landing** for the agent-run leg; the adapter + example can ship
+  independently if ADR-053 slips.
+- **Closing move:** delete BOTH auto-vivify-create branches
+  (`component.go:1411-1423` and `:1511-1521`); flip `triple.add`/`add_batch` to
+  must-exist. Gated on a relevant e2e tier green (breaking-change hard rule) and on
+  the **LLM-authored free-facts** path (audit §4.7, on-by-default) being routed
+  through a constrained-ID birth lane or quarantined — it must not silently fail the
+  flip.
+
+### Backward compatibility — existing envelope-less entities
+
+The must-exist flip governs only **future** births; the ~21 already-conjured records
+in `ENTITY_STATES` (LLMAssisted defaults on) persist with `MessageType`=zero. The
+**indexing** dimension is already covered by ADR-054's lenient-default + stamp-on-touch
+sweep (ADR-054 lines 282-288, 354-356) — cross-reference, don't re-solve. The
+**provenance** dimension (MessageType/domain/category/version) is not covered by
+ADR-054's profile backfill: either (a) fold a provenance stamp into ADR-054's
+stamp-on-touch sweep (one pass, both predicates), (b) a one-time sentinel
+(`legacy/unclassified/v0`) backfill, or (c) accept legacy records stay
+`MessageType`-less with documented reader behavior (any `message_type`-branching
+reader — including ADR-054's dry-run report — must tolerate empty), noting
+self-retiring types (loop/trajectory die with `COMPLETE_*`) shrink the durable
+residual. Decide before the flip.
+
+## Consequences
+
+### Positive
+
+- **Unclassified entity birth becomes unrepresentable** (for future births; see
+  Backward compatibility for the existing population, and §1 for the
+  retraction/death scope boundary — this guarantee is about birth, not death).
+- **State keeps its correct primitive.** CAS-on-condition transitions stay
+  first-class (validates ADR-049). No state is forced onto an event-shaped wire.
+- **The catalog unifies.** agent-run gains a typed envelope like mission; the 7
+  conjured types gain typed schema owners.
+- **The footgun is removed at the source** — `triple.add`/`add_batch` can no longer
+  birth an entity; the failure mode is a metered fail-fast, not silent invisible state.
+- **ADR-054 coupling is natural** — the birth envelope is where `IndexingProfile` lives.
+
+### Negative (accepted tradeoffs)
+
+- **Producer-side migration cost** across 7 entity types + one example; operating-model
+  is an L-effort four-type conversion.
+- **Origin-first ordering becomes a hard precondition** per conjuror (was a silent
+  self-heal). The integrity gain restated as a cost.
+- **Fact-lane hardening is mandatory before anything rides it** (T1 three-part / T2
+  regroup / StorageRef).
+- **Governance-audit relocation** is required before the flip (§3a).
+- **`state.transition` / `evidence.append` renaming is breaking** if done as a subject
+  rename (post-1.0 discipline); the load-bearing change (must-exist) is separable from
+  the cosmetic rename.
+
+### Neutral / changed
+
+- `update_with_triples` + `ExpectedRevision` is unchanged in mechanism — only promoted
+  in name and given a mandatory create envelope.
+- The Graphable stream consumer is unchanged except the additive T1/T2/StorageRef guards.
+- Lifecycle Participants are unchanged in birth mechanism (already create-or-fail +
+  envelope); the adapter only enriches the envelope.
+
+## Open questions deferred
+
+1. **JetStream dedup window vs restart replay (T1) — must decide in Wave 0.** Size the
+   `Duplicates` window to the recovery horizon, accept bounded re-merge, or add an
+   (s,p,o)-idempotent merge guard in `MergeEntity`? The window size is now a Wave-0
+   config default.
+2. **`ParticipantEntity` adapter scope (Wave-4 prerequisite).** Generic adapter
+   framework-wide (needs a `lifecycle:"origin"` field-classifier tag with parse-time
+   `origin ⇒ readonly+born-once` validation + a lint that no phase/audit predicate is
+   origin-tagged) vs hand-rolled per-Participant origins (mission-style). The classifier
+   is a prerequisite for the generic adapter, not deferrable past Wave 4.
+3. **A no-phase-change CAS mutator (`Manager.MutateWith`)** for RMW counters — build now
+   or ship the example with a documented interim?
+4. **LLM-authored free facts (audit §4.7) — hard gate on the closing move.** The purest
+   conjure (uncontrolled ID space, on by default) must be routed through a constrained-ID
+   birth lane or quarantined before must-exist lands.
+5. **Rename vs compat** for the two must-exist lanes — promote/rename now or change only
+   semantics under existing subject names?
+6. **Retraction/death lane.** `triple.remove` of a single-valued phase/audit predicate
+   can corrupt a transition guard the same way append did (beta.103 G5); `entity.delete`
+   has no lane. Does delete/remove need must-exist + CAS-eligibility + envelope-inheritance,
+   or a separate governed lane? Deferred.
+7. **Benign origin races** — when an origin lands late, is a bounded must-exist
+   retry-with-backoff warranted vs hard fail-fast? Affects every conjuror's derived
+   stampers.
+
+## Relationship to other ADRs
+
+- **Extends and partially amends** [ADR-049](049-lifecycle-harness-prime-schema-over-entity-states.md).
+  Its bucket-ownership rubric and CAS-on-condition state-write choice stand and are
+  validated; rubric item 5 ("don't need fine-grained CAS") remains the per-predicate
+  lane test. ADR-055 generalizes the schema-owner principle beyond lifecycle, adds the
+  write-intent taxonomy + envelope-on-create requirement, and frames lifecycle as the
+  exemplar (already create-or-fail + enveloped).
+- **Completes** [ADR-053](053-agent-run-substrate.md). agent-run is born via
+  `Manager.Create` (enveloped); the typed adapter upgrades its envelope. The Wave-4
+  agent-run leg is **gated on ADR-053 landing**.
+- **Couples to** [ADR-054](054-semantic-indexing-eligibility.md). The birth envelope
+  carries `IndexingProfile`; Wave 0 sequences ADR-054 Phase 1 first. The existing-entity
+  provenance backfill should ride ADR-054's stamp-on-touch sweep.
+- **Amends** [ADR-039](039-tool-call-governance-rule-driven.md)'s audit mechanism
+  (§3a): the `rule.deny`/`rule.approve` triple-on-rule-ID becomes a registered
+  verdict event on the `GOVERNANCE_VERDICT_AUDIT` stream. ADR-039's explicit-verdict-
+  audit goal is preserved; its phantom-rule-ID-entity read path is retired.
+- **Honors** [ADR-028](028-orchestration-architecture.md) and **reinforces** the
+  single-writer-to-ENTITY_STATES invariant and the KV-twofer.
+
+## What this ADR is NOT
+
+- **Not "everything must be Graphable."** State legitimately needs CAS-with-reject the
+  event-shaped Graphable stream cannot give. The invariant is envelope-on-birth.
+- **Not a reversal of ADR-049.** It validates ADR-049's CAS-for-state and extends its
+  schema-owner principle; the lifecycle harness is the exemplar.
+- **Not a claim the mutation API is wrong.** Derived-fact stamps, state transitions, and
+  the external operator gateway are first-class — but the gateway's bare `entity.create`
+  is brought under the envelope rule (§2), and *envelope-less entity creation* (`triple.add`/
+  `add_batch` auto-vivify) is retired. Retiring auto-vivify also affects the rule-ID
+  governance audit (§3a), which is migrated, not left in the "untouched" set.
+- **Not the per-entity implementation.** B1–B7 designs live in
+  [`graphable-fix-plan.md`](../proposals/graphable-fix-plan.md).
+
+## References
+
+- Evidence base: the two proposals above (audit + fix plan).
+- Code anchors:
+  - `processor/graph-ingest/component.go:857` (`extractEntityFromMessage`), `:946`
+    (`MergeEntity`), `:1006` (append), `:1311` (`updateEntityAtRevision`), `:885`
+    (`MessageType` stamp), `:1411-1423` (`AddTriple` auto-vivify — deleted) and
+    `:1511-1521` (`AddTriples`/add_batch auto-vivify — deleted), `:1478-1484`
+    (`AddTriples` bySubject regroup — the T2 model)
+  - `processor/graph-ingest/mutations.go` (subjects + handlers; `:40/:53/:66` bare CS-API)
+  - `processor/rule/actions.go:1390-1467` (deny/approve), `:576` (subject override)
+  - `natsclient/client.go:793-799` (`PublishToStream`, the T1 gap)
+  - `config/streams.go:19-26` (`StreamConfig`, no `Duplicates`)
+  - `pkg/lifecycle/manager.go` (`Create`, `Transition`), `pkg/lifecycle/projection.go:202`
+    (`projectStructToTriples`), `pkg/lifecycle/tags.go:14-67` (`fieldMeta` — no origin classifier)
+  - `parser/sensorml/graphable.go:124`, `federation/event_payload.go:41`,
+    `storage/objectstore/stored_message.go:143` (T2 exceptions)
+- Discipline memories applied: `feedback_write_api_taxonomy_envelope_on_create`,
+  `feedback_bucket_ownership_rubric`, `feedback_reactive_patches_vs_engine_completion`,
+  `feedback_lifecycle_transition_replace_not_append`, `feedback_silent_handler_error_payload_audit`,
+  `feedback_e2e_required_for_breaking_changes`.
+- Principles: `docs/concepts/02-kv-twofer.md`, `docs/concepts/15-payload-registry.md`,
+  CLAUDE.md "Architectural Identity (Not an Event Bus)".

--- a/docs/proposals/graphable-bypass-audit.md
+++ b/docs/proposals/graphable-bypass-audit.md
@@ -1,0 +1,334 @@
+# Blast-Radius Audit: The graph-ingest Mutation API as a Producer API
+
+> Status: audit only (blast-radius sizing). Fix design is a separate planning
+> step. Generated 2026-06-11 via a 40-agent fan-out audit (9 producer clusters,
+> 55 call sites classified, every anti-pattern finding adversarially refuted —
+> 0 of 21 overturned). Motivated by ADR-054's note: *"The motivating
+> `agent.agentic-loop.step` entities enter via the mutation API, not the
+> Graphable path."*
+
+## 1. Executive Summary
+
+The anti-pattern is **real, concentrated, and high-confidence**. Of 55 classified
+mutation-API call sites, **21 are confirmed anti-pattern** writes that originate
+first-class domain entities through the graph-ingest mutation API instead of the
+canonical `Events → Graphable → graph-ingest` path. Every one survived
+adversarial refutation. The blast radius is **not** spread thinly — it collapses
+to **seven distinct entity types** across **five producer clusters**:
+
+- **agentic-loop graph_writer** — loop-execution, trajectory-step, model-endpoint
+- **agentic-tools terminal executors** — ops-diagnosis, web-observation
+- **agentic-memory output port** — operating-model (profile/layer/entry/lesson) + LLM-authored free facts
+- **github-pr-workflow example** — workflow-execution
+
+Only **one** of the seven (trajectory-step) already has a Graphable Go type — it
+is a pure plumbing fix (register + change emit path). The other six have **no
+Graphable producer at all** and need a type defined. A separate **grey zone of 9
+lifecycle-harness sites** (`pkg/lifecycle` + `agentrun` milestone publisher) is
+Flavor-A-shaped on ownership but is the explicitly-debated ADR-047/049 substrate
+decision — it must be resolved by an ADR call, not folded into the fix. The
+remaining 26 sites are cleanly legitimate (derived-fact, external-gateway,
+operational) and are **out of fix scope**.
+
+**The defect is squarely producer-side** — not query-side, not storage-side.
+
+## 2. The Two Paths and What "Mutation API as Producer" Means
+
+**Path 1 — Canonical Graphable.** A registered payload TYPE implements
+`graph.Graphable` (`EntityID() string` + `Triples() []message.Triple`). It is
+published as a `BaseMessage` through the payload registry, flows through a
+JetStream stream, and graph-ingest's consumer
+(`processor/graph-ingest/component.go:857` `extractEntityFromMessage` → `:844`
+`MergeEntity`) writes it to `ENTITY_STATES`, **stamping `MessageType` provenance**
+(`:885`). A domain Go type with domain expertise OWNS the entity's existence.
+
+**Path 2 — Mutation API.** graph-ingest hosts NATS request/reply subjects
+(`graph.mutation.triple.add` / `.add_batch` / `.triple.remove` /
+`.entity.create*` / `.entity.update*` / `.entity.delete`) plus in-process write
+methods. These write hand-assembled triples directly. `AddTriple`/`AddTriples`
+**auto-vivifies** the Subject on first stamp (`mutations.go:28-30`: *"AddTriple's
+CAS path creates the entity if it doesn't exist"*) — **no payload type, no
+registry envelope, often no MessageType.**
+
+**"Mutation API as producer"** = a component synthesizes a 6-part entity ID (the
+primary key of a thing-in-the-world) and stamps hand-assembled triples on it via
+Path 2, **creating** an entity that has no backing Graphable type and never
+flowed through Path 1. Two flavors:
+
+- **Flavor A (conjured):** no Graphable type exists; the entity exists *only*
+  because triples were stamped.
+- **Flavor B (bypassed):** a Graphable type EXISTS, but the producer harvests
+  its `.Triples()` and ships them through the mutation API instead of publishing
+  the payload.
+
+**Critical re-classification trap:** a derived-fact stamp is only legitimate if
+the Subject has a **Graphable origin**. A writer that is the first-and-only
+toucher of a Subject that never had a Graphable origin is *conjuring*, not
+deriving — even if the line looks like a derived edge.
+
+## 3. Blast Radius Table — Confirmed Anti-Pattern Call Sites
+
+| # | Entity Type | Location | Flavor | Severity | Missing Graphable Type |
+|---|---|---|---|---|---|
+| 1 | loop-execution | `processor/agentic-loop/graph_writer.go:269-293` WriteLoopCompletion | conjured | **high** | `agentic.LoopExecutionEntity` (none) |
+| 2 | loop-execution | `graph_writer.go:299-323` WriteLoopFailure | conjured | **high** | same (co-conjuror) |
+| 3 | loop-execution | `graph_writer.go:474-496` WriteSpawnIdentity | conjured | **high** | same (spawn-time first toucher) |
+| 4 | loop-execution | `graph_writer.go:561-577` WriteLoopCancellation | conjured | **high** | same (terminal co-conjuror) |
+| 5 | loop-execution | `graph_writer.go:173-227` WriteSyntheticDecide | conjured | low | same (derived-onto-conjured) |
+| 6 | loop-execution | `graph_writer.go:394-417` WriteLineageTriples | conjured | low | same (derived-onto-conjured) |
+| 7 | loop↔step edge | `graph_writer.go:759-767` LoopHasStep | bypassed | medium | `agentic.TrajectoryStepEntity` (exists) |
+| 8 | model-endpoint | `graph_writer.go:229-258` WriteModelEndpoints | conjured | **high** | `agentic.ModelEndpointEntity` (none) |
+| 9 | trajectory-step | `graph_writer.go:328-366` WriteTrajectorySteps | **bypassed** | **high** | `agentic.TrajectoryStepEntity` (EXISTS, unregistered) |
+| 10 | ops-diagnosis | `processor/agentic-tools/emit_diagnosis.go:199` | conjured | **high** | `agentic.OpsDiagnosisFinding` (none) |
+| 11 | web-observation | `processor/agentic-tools/executors/websearch.go:259` | conjured | **high** | `agentic.WebObservation` (none) |
+| 12 | web-observation | `processor/agentic-tools/executors/httprequest.go:270` | conjured | **high** | same (shares ID constructor + predicates) |
+| 13 | om-lesson | `processor/agentic-memory/handlers.go:139-157→170` persistCompactionAsLesson | conjured | **high** | `operatingmodel.Lesson` Graphable (none) |
+| 14 | om-profile/layer/entry | `processor/agentic-memory/layer_approved_handler.go:54→61` | conjured | **high** | `operatingmodel.{Profile,Layer,Entry}` Graphable (none) |
+| 15 | LLM-authored facts | `processor/agentic-memory/handlers.go:208` handleCompactionStarting | conjured | **high** | none (no controlled ID space — purest conjure) |
+| 16 | om-transport seam | `processor/agentic-memory/publisher.go:102-149` publishGraphMutations | conjured | low | (shared seam; classified by its 3 callers above) |
+| 17 | workflow-execution | `examples/github-pr-workflow/component.go:288-304` handleIssueEvent | conjured | **high** | `WorkflowExecutionEntity` (none) — conjuring ROOT |
+| 18 | workflow-execution | `component.go:372-380` handleQualifierComplete | conjured | medium | same (derived-onto-conjured) |
+| 19 | workflow-execution | `component.go:397-411` handleDeveloperComplete | conjured | medium | same (derived-onto-conjured) |
+| 20 | workflow-execution | `component.go:423-446` handleReviewerComplete | conjured | medium | same (derived-onto-conjured) |
+| 21 | workflow-execution | `component.go:561-583` accumulateTokens / incrementRejections | conjured | medium | same (derived-onto-conjured counters) |
+
+Rows 17–21 are one entity family (the workflow-execution Subject) with the
+conjuring root at row 17. **21 confirmed call sites → 7 entity types → 8 fixable
+units** (row 16 is a transport seam, not an independent entity).
+
+## 4. Entity-Type Catalog — The "What Needs to Become Graphable" List
+
+### 4.1 loop-execution `{org}.{platform}.agent.agentic-loop.execution.{loopID}` — CONJURED (no type)
+
+- **Writers:** `graph_writer.go` — `WriteSpawnIdentity` (:474, usually FIRST
+  toucher at spawn), `WriteLoopCompletion` (:269), `WriteLoopFailure` (:299),
+  `WriteLoopCancellation` (:561); derived-onto-conjured stampers
+  `WriteSyntheticDecide` (:173), `WriteLineageTriples` (:394). Downstream
+  second-writers inheriting the conjured Subject: `decide.go:432`,
+  `write_todos.go:236/249`, `scratchpad.go:217`, `research-graph-llmwrap/triplepub.go`,
+  `actions.go:1212` run-anchor (all currently *legit-derived modulo the missing origin*).
+- **Graphable type:** NONE. `agentic.LoopExecutionEntityID` (`entity_ids.go:54`)
+  is a bare string formatter. `LoopCompletedEvent`/`LoopFailedEvent`/
+  `LoopCancelledEvent` are registered payloads but are fire-and-ack **events**,
+  not Graphable.
+- **Canonical home:** Define `agentic.LoopExecutionEntity`, register in
+  `agentic/payload_registry.go`, publish through the agent loop stream →
+  graph-ingest. **Single largest lever:** ADR-054:90 names this exact entity as
+  the motivating case; fixing the origin retroactively legitimizes ~8 downstream
+  derived-fact stampers.
+
+### 4.2 trajectory-step `{org}.{platform}.agent.agentic-loop.step.{loopID}-{stepIndex}` — BYPASSED (type exists)
+
+- **Writer:** `graph_writer.go:328-366` `WriteTrajectorySteps` harvests
+  `entity.Triples()` (:757) and ships via `triple.add`.
+- **Graphable type:** **EXISTS** — `agentic.TrajectoryStepEntity`
+  (`trajectory_entity.go:15/26/33`; also `ContentStorable`). NOT registered
+  (`payload_registry.go:19-44` omits it), no `MarshalJSON`.
+- **Canonical home:** Register it (add `MarshalJSON` wrapping `BaseMessage`),
+  publish through the existing loop stream. **Pure plumbing fix.** ObjectStore
+  content offload at `:348` already works and stays. The `LoopHasStep` edge
+  (row 7) rides the same payload's `Triples()`.
+
+### 4.3 model-endpoint `{org}.{platform}.agent.model-registry.endpoint.{endpointName}` — CONJURED (no type)
+
+- **Writer:** `graph_writer.go:229-258` `WriteModelEndpoints` at startup.
+- **Graphable type:** NONE. `model.EndpointConfig` (`model/registry.go:195`) has
+  no `EntityID()`/`Triples()`.
+- **Canonical home:** `agentic.ModelEndpointEntity` wrapping `model.EndpointConfig`;
+  `Triples()` reuses `buildModelEndpointTriples`. One `BaseMessage` per endpoint
+  at boot. **Low complexity.**
+
+### 4.4 ops-diagnosis `{org}.{platform}.ops.diagnosis.finding.{uuid}` — CONJURED (no type)
+
+- **Writer:** `agentic-tools/emit_diagnosis.go:199` — mints uuid (:178),
+  `OpsDiagnosisEntityID` (:179), `AddTriplesBatch`. Entity is **born** at the
+  graph-ingest seam.
+- **Graphable type:** NONE. `agentic.OpsDiagnosisEntityID`
+  (`ops_diagnosis_entity.go:21`) is a pure constructor.
+- **Canonical home:** `agentic.OpsDiagnosisFinding`, publish through registry.
+  **Self-contained, single call site.**
+
+### 4.5 web-observation `{org}.{platform}.agent.web.observation.{sha256-16(canonicalURL)}` — CONJURED (no type)
+
+- **Writers:** `websearch.go:259` (6 predicates/result), `httprequest.go:270`
+  (7 predicates/fetch). Content-addressed for cross-loop dedup; each stamps a
+  `LoopObservedWeb`/`LoopFetchedWeb` back-link onto the conjured loop entity.
+- **Graphable type:** NONE. `agentic.TryWebObservationEntityID`
+  (`web_observation_entity.go:50`) is a pure ID/canonicalizer/hasher.
+- **Canonical home:** `agentic.WebObservation` (one type serves both writers,
+  shared constructor + vocabulary). Preserve the opportunistic
+  log+counter+continue emission pattern.
+
+### 4.6 operating-model family — CONJURED (no types)
+
+Four conjured ID spaces, all written through the `agentic-memory`
+`graph_mutations` output port (`publisher.go:138` → `graph.mutation.{loopID}`):
+
+- `user.teams.profile.{userID}`, `user.teams.om-layer.{userID}-{layer}`,
+  `user.teams.om-entry.{entryID}` — `layer_approved_handler.go:54→61`, harvesting
+  `LayerApproved.Triples(org,platform)` (the payload exists but its method is
+  `Triples(org,platform)`, deliberately **not** the no-arg `graph.Graphable.Triples()`).
+- `user.teams.lesson.{lessonID}` — `handlers.go:139-157→170`, mints
+  `lesson-{uuid}`, calls free function `LessonTriples`.
+- **Graphable type:** NONE in `agentic/operating-model/` (zero no-arg
+  `Triples() []message.Triple`; all builders are free functions).
+- **Canonical home:** Define `operatingmodel.{Profile,Layer,Entry,Lesson}`
+  Graphable types, register an operating-model `payload_registry.go`, publish
+  through the AGENT stream. The `has_layer`/`has_lesson` edges become
+  legit-derived once the profile has a Graphable origin. **Largest single-package
+  conversion** (4 types + retire the custom transport seam).
+
+### 4.7 LLM-authored free facts — CONJURED (no type, no controlled ID space)
+
+- **Writer:** `handlers.go:208` `handleCompactionStarting` — ships
+  `LLMExtractor.ExtractFacts` (`llm_extractor.go:54`) output verbatim; Subjects
+  are **model-chosen**, no constructor, no 6-part validation, no MessageType.
+  `LLMAssisted.Enabled` defaults `true` (`config.go:27,244`) — **live by default.**
+- **Graphable type:** NONE — and no deterministic ID space at all. The **purest
+  conjure** in the catalog. The package's own godoc (`lesson.go:13-17`) flags
+  this as the legacy "triples no reader could find."
+- **Canonical home:** Less "define a type", more "constrain the ID space" —
+  route extraction through a Lesson/Fact Graphable shape with constructor-governed
+  6-part Subjects. **Needs a design decision (see §8).**
+
+### 4.8 workflow-execution `{org}.github.repo.{repo}.workflow.{issueNumber}` — CONJURED (no type)
+
+- **Writers (one family):** conjuring root `component.go:288-304`
+  `handleIssueEvent`; derived-onto-conjured updaters at :372, :397, :423,
+  :561/:573. Package godoc (`entities.go:8-12`) **self-documents the anti-pattern
+  by design**: *"does not instantiate these entities directly — it writes
+  workflow-phase triples via the graph mutation API instead."*
+- **Graphable type:** NONE for `.workflow.{n}`. Three real Graphables
+  (`GitHubIssueEntity`, `GitHubPREntity`, `GitHubReviewEntity`) own disjoint spaces.
+- **Canonical home:** Either a `WorkflowExecutionEntity` Graphable, **or** —
+  because it is workflow-instance-shaped — a `pkg/lifecycle.Participant`
+  (ADR-047). Example/demo, low production stakes, but the cleanest teaching case.
+
+## 5. Grey Zone — Lifecycle / Participant Substrate (9 sites, needs explicit decision)
+
+**Sites:** `pkg/lifecycle/graph_emit.go:124` (update) & `:162` (create);
+`manager.go:330` (create-fresh), `:357` (attach-to-existing), `:507`
+(Transition/Complete/Fail), `:633` (UpdateFromOperator); `agentrun/nats_reader.go:55-72`
+(milestone publisher). Entities: `*.*.agent.chain.execution.*` (`agentrun.AgentRun`)
+and `*.*.lifecycle.gcs.mission.*` (`mission.State`).
+
+**The tension.** On pure Subject-ownership these are **Flavor-A-shaped**: they
+originate first-class domain entities in `ENTITY_STATES` via
+`entity.create_with_triples`/`update_with_triples`, with no `graph.Graphable`
+producer — `AgentRun`/`mission.State` implement `lifecycle.Participant`
+(`EntityID`/`Workflow`/`Phase`) but have **no `Triples()`**; the harness
+reflection-projects struct-tagged fields (`projectStructToTriples`).
+
+**Why it stays grey, not A.** (1) A typed domain owner DOES exist (the
+Participant struct owns the shape via tagged fields); (2) every emit stamps
+`lifecycleMessageType` (`manager.go:22-26`) — provenance IS present, unlike bare
+`triple.add` conjurers; (3) **this exact write surface was the subject of a
+dedicated ADR.** ADR-049 ran the bucket-ownership rubric per-field and explicitly
+chose mutation-API/ENTITY_STATES emission over both a private bucket *and* the
+Graphable path, **rejecting the Graphable path for a CAS-revision reason**. The
+`manager.go:357` attach branch is even legit-derived for **mission** (real
+Graphable `MissionCommand` origin) but conjuring-substrate for **agent-run** — a
+branch legit for one Participant and conjuring for another is the definition of grey.
+
+**Decision needed:** does Participant state ride the Graphable path (define a
+generic `lifecycle.ParticipantEntity` adapter exposing projected triples via
+`Triples()`) or stay on the deliberately-chosen CAS-on-condition mutation wire?
+**This is an ADR-049 re-open, not a call-site patch.** Do not fold into §7.
+
+## 6. Cleared (Legitimate) — Out of Fix Scope (26 sites)
+
+**Legit-derived-fact (computed predicates on a Graphable-origin Subject):**
+
+- Rule engine: `actions.go:600/684/821/1353` — stamp onto the rule's **trigger
+  entity** (already exists via ENTITY_STATES watch, ADR-028). (`actions.go:1212`
+  run-anchor is derived-onto-the-conjured-loop-entity; its root is §4.1.)
+- Inference appliers: `applier.go:270/193/95` (`:95` rides the **entity stream**,
+  not the mutation API), `hierarchy.go:239/313/368/423` — derived edges between
+  pre-existing Graphable-origin entities. `anomaly.go:190`, `component.go:1256`
+  are wiring-only.
+
+**Legit-operational (does NOT target domain ENTITY_STATES):**
+
+- `triple_mutator.go:48/93` (generic legs — verdict inherited from callers),
+  `graph_writer.go:92/129` (shared transport).
+- `actions.go:1398` executeDeny, `:1448` executeApprove — Subject is the **rule
+  ID**, governance audit (ADR-039), never a domain entity.
+- `lpa.go:567` `InferRelationshipsFromCommunities` (**no production consumer**),
+  `storage.go:104` `SaveCommunity` (own `COMMUNITY_INDEX` bucket).
+
+**Legit-external-gateway / canonical-path citizens (catalog inputs):**
+
+- `federation.EventPayload`, `oms.Observation`, `sensorml.Asset`,
+  `objectstore.StoredMessage` — all canonical-path-intended.
+
+**Refuted/reclassified notes:**
+
+- `graph_writer.go:759-767` (LoopHasStep) reclassified conjured→bypassed: its
+  Object is the bypassed `TrajectoryStepEntity`; fix rides §4.2, not §4.1.
+- The agentic-loop and agentic-tools/research derived stampers
+  (`WriteSyntheticDecide`, `WriteLineageTriples`, `decide.go`, `write_todos.go`,
+  `scratchpad.go`, `triplepub.go`) are **genuinely derived in shape** — they
+  become clean legit-derived-facts **automatically** once §4.1 gives the loop
+  entity a Graphable origin. Not independent fix targets; they are *why* §4.1 is
+  the highest-leverage fix.
+
+## 7. Fix-Shape Grouping (implementation deliberately omitted)
+
+### Group A — "Type EXISTS, just register + change emit path" (lowest effort)
+
+**Seam:** `agentic/payload_registry.go` + emit at `graph_writer.go:357-365`.
+
+- **trajectory-step** (§4.2). Add `MarshalJSON`, register, publish through the
+  existing loop stream. **Effort: S.**
+
+### Group B — "Define + register Graphable payload, route through graph-ingest"
+
+**Seam:** new Graphable type in the owning package + its `payload_registry.go`
+`init()` + replace `graph.mutation.*` emit with a `BaseMessage` publish through
+the stream graph-ingest consumes.
+
+- **B1 loop-execution** (§4.1) — **highest leverage, M-L.** One type retires 4
+  conjuring writers + ~8 downstream stampers in one landing. *Couples to ADR-054.*
+- **B2 model-endpoint** (§4.3) — **S.** Static config, `Triples()` already factored.
+- **B3 ops-diagnosis** (§4.4) — **S.** Single call site.
+- **B4 web-observation** (§4.5) — **S-M.** One type, two writers, shared constructor.
+- **B5 operating-model family** (§4.6) — **L.** Four types + retire the
+  `agentic-memory` `graph_mutations` custom-envelope port.
+- **B6 workflow-execution example** (§4.8) — **S-M**, **decision-gated**:
+  Graphable vs `lifecycle.Participant`. Demo code.
+
+### Group C — "Needs a design decision before any fix"
+
+- **LLM-authored free facts** (§4.7) — the conjure is the *uncontrolled ID space*.
+  On-by-default, so live blast radius. **Effort: design + M.**
+- **Lifecycle grey zone** (§5) — **ADR-049 re-open.** ADR-049 already rejected the
+  Graphable path once (CAS-revision concern); reversing has real design cost.
+
+## 8. Open Questions / Risks for Fix-Planning
+
+1. **ADR-054 coupling.** B1 (loop-execution) is ADR-054:90's motivating case.
+   Sequence the conversion against ADR-054's indexing-eligibility phases so the
+   new payload type carries the right `IndexingProfiler` envelope from day one.
+2. **CAS / atomicity on the canonical path.** Several conjured writers rely on
+   the mutation API's per-Subject CAS atomicity (`triple.add_batch` atomic
+   batches; lifecycle `ExpectedRevision`). The Graphable→stream→graph-ingest path
+   uses `MergeEntity` per-predicate merge. Confirm no loss of atomicity/ordering
+   (esp. the lifecycle replace-not-append discipline, beta.103).
+3. **Downstream derived-fact stampers must not regress.** ~8 sites write to the
+   conjured loop Subject. After B1 they become legit-derived **only if** the
+   Graphable loop entity exists in ENTITY_STATES **before** the first derived
+   stamp fires — else the auto-vivify they implicitly depend on disappears and
+   they start failing CAS.
+4. **Operating-model dual-source (§4.6 + §4.7).** Lessons have two producers
+   (deterministic `persistCompactionAsLesson` and the LLM free-fact path).
+   Decide whether C collapses into the B5 Lesson shape or stays distinct.
+5. **Web-observation re-population.** Content-addressed dedup means a fetch may
+   re-populate an existing vertex. Confirm `MergeEntity` per-predicate merge
+   preserves the one-vertex-per-canonical-URL intent.
+6. **Lifecycle decision sequencing.** The grey zone blocks nothing, but if the
+   ADR-049 re-open lands toward the Graphable path it defines a reusable
+   `ParticipantEntity` adapter that B6 could ride — decide the lifecycle call
+   before/after B6 to avoid building the projection adapter twice.
+7. **Example vs framework priority.** B6 (github-pr-workflow) self-documents the
+   anti-pattern (`entities.go:8-12`). Decide fix-first (reference others copy) vs
+   fix-last (after the framework types it models exist).

--- a/docs/proposals/graphable-fix-plan.md
+++ b/docs/proposals/graphable-fix-plan.md
@@ -1,0 +1,301 @@
+# Fix Plan: A Write-API Taxonomy for graph-ingest (retiring "mutation API as producer")
+
+> Status: DESIGN + PLAN. No production code here. Companion to
+> `docs/proposals/graphable-bypass-audit.md` (the blast-radius audit). Reframed
+> from the audit's first-cut "everything must be Graphable" framing onto the
+> correct axis: **the defect is metadata-less entity *birth*, not "not
+> Graphable."** Grounded in two multi-agent passes (audit + design) with every
+> load-bearing fact verified against code; adversarial break-tests folded in.
+>
+> **AUTHORITATIVE DECISION RECORD: [ADR-055](../adr/055-graph-write-intent-taxonomy.md).**
+> ADR-055 was multi-lens reviewed; two of its corrections override this doc where
+> they differ: (1) **Participant identity is born on the Entity-create lane
+> (`create_with_triples`, create-or-fail), NOT the Fact-arrival append stream** —
+> this dissolves the "field-classifier filter" problem (a one-shot create can't
+> duplicate single-valued predicates) and makes T1 moot for Participants. (2) The
+> **rule-ID governance audit (`rule.deny`/`rule.approve`) is a must-exist casualty**
+> that must move to a dedicated governance bucket before the flip — it is NOT in
+> the "untouched ~26 stampers" set. Treat ADR-055 §3/§3a/§5/§6 as the corrected
+> versions of this doc's §2.2/§5/§6.
+
+## 1. The invariant (corrected)
+
+We are **not** establishing "every first-class entity must be Graphable." That
+over-corrects — Graphable is append/event-shaped and a *bad fit for state*
+("transition this entity only if it is still at revision R"). The invariant is:
+
+> **Every entity is *born* through a lane that carries a semantic envelope
+> (MessageType / domain / category / version). No write may *create* an entity
+> without one. State transitions keep their CAS-with-reject semantics as a
+> first-class lane.**
+
+The leak is unclassified entity *birth* via `triple.add`'s auto-vivify
+(`AddTriple`, `component.go:1417` — creates a record from a bare `triple.Subject`
+with no MessageType, no producer contract). Kill *that*, and "invisible
+unclassified graph state" becomes structurally impossible — without forcing state
+onto an event-shaped wire it doesn't fit.
+
+## 2. The graph-ingest write surface — four intent-typed lanes
+
+This answers the design question directly ("a port/stream for state transitions +
+remove `triple.add`"). The surface is four lanes by *write intent*. Critically,
+the transition lane stays **request/reply, not a JetStream stream** — see §2.1.
+
+| Lane | Ingress | Shape | Conflict semantics | Creates? | Envelope |
+|---|---|---|---|---|---|
+| **Fact arrival** | Graphable stream consumer *(exists)* | JetStream consume | CAS-with-retry, async, **never rejects, APPENDS** | yes — merge/create | **carried** (registered payload → `MessageType` stamped `component.go:885`) |
+| **Entity create** | `entity.create_with_triples` *(exists)* | request/reply | atomic **create-or-fail** (`ErrKVKeyExists`) | yes | **required** |
+| **State transition** | `state.transition` *(promote `update_with_triples`+`ExpectedRevision`)* | request/reply | **CAS-on-condition, REJECTS, sync**, replace-by-predicate | no (must-exist) | inherited |
+| **Evidence append** | `evidence.append` *(neuter `triple.add`/`add_batch`)* | request/reply (batched) | append multi-valued, **must-exist** | **no** | inherited |
+| ~~Auto-vivify create~~ | ~~`triple.add` bare-Subject~~ | — | — | **DELETED** | — |
+
+Every entity is born only through **Fact arrival** or **Entity create**, both
+envelope-bearing. The bottom two lanes are must-exist. An unclassified,
+`MessageType`-less entity is unrepresentable.
+
+### 2.1 Why the transition lane is request/reply, not a stream
+
+A state transition's defining need is **synchronous conditional reject** ("apply
+iff still at rev R; tell me *now* if I lost so I re-read and retry"). That reject
+channel is what `Manager.Transition`'s loop runs on (`manager.go:431-524`). A
+JetStream stream is async fire-and-forget — you don't synchronously learn whether
+the CAS won. You *can* stream it via `Nats-Expected-Last-Subject-Sequence`
+(publish-time optimistic concurrency with a sync `PubAck` error), but that
+requires **one subject per entity**, making ENTITY_STATES a *projection* of a
+transition stream — i.e. event-sourcing state, KV stops being the source of
+truth, restart means replay-rebuild. The **KV-twofer already gives durable
+transition audit for free via revision replay** (ADR-049 G4), so streaming buys
+nothing here at large cost. The transition lane belongs in the RPC family — and
+it already does: `update_with_triples`+`ExpectedRevision` is *already* must-exist
++ CAS-on-condition (`mutations.go:493`, `updateEntityAtRevision:1311`). The work
+is promotion/naming + a mandatory envelope on create, not stream-ification.
+
+### 2.2 "Remove `triple.add`" = remove its *create* power (must-exist), keep append
+
+`triple.add` welds two behaviors: (a) append-to-existing (legit evidence — the
+~26 cleared rule/inference derived-fact stampers), and (b) auto-vivify a missing
+entity (the footgun). Sever (b): make `triple.add`/`add_batch` **must-exist**
+(reject "entity not found" when the Subject is absent), optionally renamed
+`evidence.append`. This converts **every one of the 7 conjurors into a hard
+error**, forcing each onto an enveloped birth lane, while the 26 legit stampers
+(which write onto entities that already exist via ENTITY_STATES watch / prior
+Graphable origin) keep working untouched. **The ordering risk stops being a
+silent auto-vivify and becomes a fail-fast** — which is the point.
+
+> **KEY DECISION (see §6):** this *replaces* the grounding plan's "keep
+> auto-vivify as the self-healing ordering safety net" with "must-exist +
+> origin-first ordering." It is the higher-integrity choice (structural
+> invariant) but costs per-conjuror ordering guarantees. Your "remove
+> `triple.add`" steer chooses must-exist; this plan adopts it.
+
+## 3. The per-predicate decision matrix (the durable contribution)
+
+Classify **each predicate**, not each entity — most entities are *hybrids* whose
+predicates split across lanes. Keyed on: single-valued vs accumulating, and
+second-writer/transition race vs not.
+
+```
+For each predicate of an entity:
+  1. Phase-transition race or read-modify-write counter race?
+        YES → lane (iii) state.transition (CAS-on-condition). It's a Participant.
+  2. Single-valued AND re-emitted onto the same Subject over the entity's life
+     (restart re-assert, re-populate, per-boot)?
+        YES → lane (ii) update_with_triples default (MergeTriples REPLACE-by-(s,p), gh#244).
+  3. Else (born-once identity, accumulating links, immutable bodies)
+        → lane (i) Graphable stream (with the two transport guards below).
+```
+
+- **(i) stream / append** — born-once, never re-emitted. Identity, accumulating
+  links, immutable bodies.
+- **(ii) mutation-replace** — single-valued, re-emitted, no transition race.
+  Config leaves, profile-root version, re-populated content-addressed vertices.
+- **(iii) state.transition CAS** — phase advances, RMW counters.
+
+**Do NOT build a fourth "replace mode" on the stream consumer.** The replace need
+is already served by lane (ii) (`MergeTriples`, gh#244). A parallel replace-mode
+on `MergeEntity` would fork stream-consumer semantics and duplicate gh#244. The
+primitive set {append-stream + (T1/T2), mutation-replace, CAS-on-condition} is
+complete — this is the deliberate-completion answer, not a gap-of-the-week patch.
+
+## 4. Transport guards the fact lane requires (break-test findings — mandatory)
+
+The fact-arrival lane is **not free**. The design phase's adversarial pass found
+two defects that make it unsafe even for born-once predicates without hardening:
+
+- **T1 — IDEMPOTENT PUBLISH (redelivery safety).** `natsclient.PublishToStream`
+  sets **no `Nats-Msg-Id`** (`client.go:793-799`) → JetStream publish-dedup is OFF
+  and the consumer is at-least-once. On any redelivery, `MergeEntity`'s blind
+  append (`component.go:1006`) re-appends — duplicating even "born-once"
+  single-valued predicates. **Every stream-riding entity MUST publish with a
+  deterministic `Nats-Msg-Id`** (`loopID:spawn`, `entityID:vN`). New framework
+  affordance: `PublishToStreamWithMsgID`. Without T1, "written once" is an
+  app-layer fiction the transport violates.
+- **T2 — SINGLE-SUBJECT GRAPHABLE (mis-file safety).** `extractEntityFromMessage`
+  (`component.go:882-887`) writes *all* of `graphable.Triples()` to one KV key =
+  `EntityID()`, **no Subject regrouping** (the `bySubject` split lives only in the
+  `AddTriples` handler). **Any triple whose `Subject != EntityID()` is silently
+  misfiled** and unreachable by a per-ID `Get`. **Every Graphable MUST be
+  single-Subject**; cross-entity links (`has_step`, `has_layer`, `has_lesson`)
+  live on the Graphable whose EntityID is the link's Subject — never the child.
+  Add a framework guard asserting `t.Subject == EntityID()` in
+  `extractEntityFromMessage` (reject + log loudly).
+- **StorageRef extraction.** `extractEntityFromMessage` never populates
+  `entity.StorageRef` from a `ContentStorable` payload (the embedding worker
+  branches on `StorageRef != nil`), so offloaded content silently stops being
+  embedded. Patch: type-assert `ContentStorable` and set `StorageRef` (MergeEntity
+  already merges it on the existing branch, `component.go:1008-1009`). Generic,
+  additive.
+
+## 5. ADR-049 reopen — it *validates* ADR-049, it doesn't reverse it
+
+ADR-049 already put lifecycle state **in ENTITY_STATES** (graph-visible; it
+reversed the private-bucket predecessor) and chose the CAS-on-condition mutation
+wire *because transitions need reject-on-mismatch the merge/stream path can't
+give*. Under the corrected taxonomy, that is **lane (iii) used correctly** —
+ADR-049 is the *exemplar of the state pattern*, not a violator.
+
+What it didn't do: give Participants a Graphable **origin** for their *identity*.
+Mission already does (verified: `mission.Command` is a clean single-Subject
+Graphable, registered `mission.command.v1`, phase stamped as a CAS second writer);
+`AgentRun` does not (no `Triples()`), so its `chain.execution` entity is conjured
+by `Manager.Create`'s wire alone. The reopen's job is to make agent-run look like
+mission.
+
+**Recommendation C (hybrid):** Participant **identity + accumulating attributes**
+ride lane (i) via a generic `lifecycle.ParticipantEntity` adapter
+(`Triples() = projectStructToTriples(...)` filtered to non-single-valued / origin
+fields); **phase + audit scalars + projected counters stay on lane (iii)**
+(`Manager.Transition`/`TransitionWith`). Walked against the seven guarantees:
+
+| Guarantee | Hybrid verdict |
+|---|---|
+| **G1** reject-on-mismatch transitions | PRESERVED by construction (transitions never touch the stream). Guard: lint that no phase/audit predicate appears in any adapter `Triples()`. |
+| **G2** atomic phase+audit landing | PRESERVED (one Transition delta under one `ExpectedRevision`). |
+| **G3** create-or-fail race | PRESERVED (`Manager.Create`→`CreateEntityStrict`), *but the origin publish must be T1-idempotent* or a redelivered origin re-appends identity. |
+| **G4** History fidelity (revision replay) | PRESERVED (transitions stay off the append stream; origin appends don't scatter audit). |
+| **G5** replace-not-append single-valued phase (beta.103) | **THE FRAGILE ONE.** Stream appends, no replace. PRESERVED **only if** the adapter excludes *every* single-valued predicate. Mandatory guard. |
+| **G6** provenance (`MessageType`) | PRESERVED (origin payload is a registered type → stamped at `component.go:885`). |
+| **G7** transition-table + terminal/drift validation | PRESERVED (runs synchronously in the req/reply loop; identity-only origin has nothing to validate). |
+
+**Verdict: the hybrid holds iff** the adapter `Triples()` excludes every
+single-valued predicate (G1/G4/G5), the origin publish is T1-idempotent (G3), and
+single-Subject (T2). Mission satisfies all three in production — the existence
+proof. **Decide the reopen independently; it gates B7.**
+
+## 6. The ordering decision (must-exist vs auto-vivify)
+
+This is the one place the corrected plan diverges from the grounding plan, and it
+follows from "remove `triple.add`":
+
+- **Grounding plan (auto-vivify safety net):** keep `triple.add` auto-vivify;
+  derived stamps that race ahead of the origin self-heal because a late origin
+  merge converges on the same key (relies on T1 so convergence doesn't duplicate).
+  Less invasive; leaves the footgun loaded.
+- **This plan (must-exist + origin-first):** neuter `triple.add` to must-exist;
+  each conjuror's **origin must land before any derived stamp / transition on that
+  entity**. Ordering becomes a hard precondition enforced by fail-fast errors.
+  Higher integrity; costs per-conjuror ordering guarantees.
+
+The 26 legit stampers are unaffected either way (their Subjects already exist).
+Only the conjurors must establish origin-first ordering — which is tractable: for
+loop-execution, spawn-create lands synchronously before the loop executes, so the
+mid-loop stamps (decide/write_todos/scratchpad) always find the entity present.
+**This plan adopts must-exist.** The per-entity ordering guarantees are in §7.
+
+## 7. Per-entity application (B1–B7)
+
+Each entity maps its predicates onto the matrix. Condensed from the verified
+design pass; effort S < M < L.
+
+- **B1 loop-execution (L)** — `agentic.LoopExecutionEntity`, Phase-discriminated
+  (`spawn`/`completed`/`failed`/`cancelled`), single-Subject (`has_step` lives on
+  B2). Born-once spawn + terminal predicate sets, disjoint → lane (i) **with T1
+  msg-IDs** (`loopID:spawn`, `loopID:terminal`) — without T1, redelivery
+  re-appends outcome/tokens/cost (beta.103). Not a Participant (no phase race).
+  Folds synthetic-decide into the completion payload; one BaseMessage = one
+  revision = one UPDATED event (improves gh#159). **Origin-first:** spawn-create
+  before the loop executes. *Highest leverage — legitimizes ~8 downstream
+  stampers.* Couples to ADR-054 (`content`). Drop the hierarchy-on-loop promise
+  (or make it idempotent-(s,p,o)).
+- **B2 trajectory-step (M)** — reuse the EXISTING `agentic.TrajectoryStepEntity`
+  (already Graphable+ContentStorable); add `MarshalJSON` + an **exported**
+  `StorageReference` field + Schema. Lane (i), single-Subject (`has_step` on the
+  loop). Consumes the **StorageRef extraction** framework patch (§4) — that's the
+  real work; without it offloaded step text stops embedding (e2e:semantic gate).
+  Needs a graph-ingest input wire in every agent-loop config.
+- **B3 model-endpoint (S)** — `agentic.ModelEndpointEntity` wrapping
+  `model.EndpointConfig`; `Triples()` = `buildModelEndpointTriples`. Re-emitted
+  every boot → **lane (ii)** (`update_with_triples` replace), restart-idempotent,
+  zero flow wiring (the production agentic flow's graph-ingest input is
+  `graph.mutation.>` only — no entity-stream consumer). **The Path-(ii) pilot.**
+  Must check the `error:` response prefix on the new mutation caller.
+- **B4 web-observation (S–M)** — content-addressed vertex (one per canonical URL),
+  single-Subject (loop back-links stay on the loop). Re-fetch re-populates the
+  same single-valued predicates → **lane (ii)** replace. Mirrors B3.
+- **B6 operating-model (L)** — **FOUR single-Subject Graphables**
+  (`Profile`/`Layer`/`Entry`/`Lesson`), one per KV record (T2: a multi-Subject
+  payload would misfile every entry into the layer record → entries vanish).
+  `handleLayerApproved` publishes 1 profile + 1 layer + N entry BaseMessages.
+  Bodies = lane (i) + T1; the **profile root** (single-valued `version`/`last_updated`
+  + multi-valued `has_layer`/`has_lesson`) = lane (ii) replace. The custom
+  `graph.mutation.{loopID}` envelope is **orphaned in-repo** (no consumer) → the
+  migration is a net fix. Leave the `publishGraphMutations` seam for Group-C.
+- **B7 workflow-execution example (M)** — **the textbook Participant** and the
+  matrix in microcosm: identity → lane (i) (T1); `workflow.phase`+audit → lane
+  (iii) `Manager.Transition`; `tokens.total`/`review.rejections` RMW counters →
+  lane (iii) `TransitionWith` mutator (plain replace loses concurrent increments).
+  **HARD-GATED on the ADR-049 reopen** (rides its origin mechanism). Ships alone
+  as the canonical teaching artifact (README is part of the deliverable). Possible
+  framework gap: a no-phase-change CAS mutator (`Manager.MutateWith`) for counters;
+  interim `update_triple` is safe under the example's `MaxAckPending:1`.
+
+## 8. Sequenced landing plan
+
+**Wave 0 — framework primitives (land first; small; unblock everything):**
+1. **Must-exist `triple.add`/`add_batch`** + the four-lane naming
+   (`evidence.append`, `state.transition`). The footgun removal; converts every
+   conjuror to a fail-fast. *(Breaking-ish for the conjurors — that's the point;
+   stage behind the per-entity migrations or land with a deprecation window.)*
+2. **T1** `PublishToStreamWithMsgID` + dedup-window config. Unblocks all
+   stream-side units.
+3. **T2** single-Subject guard + **StorageRef extraction** in
+   `extractEntityFromMessage`. Closes the misfile + embedding-drop classes
+   generically.
+4. **ADR-054 Phase 1** (IndexingProfiler, LENIENT) — soft; lands before B1/B2 so
+   they carry the right envelope.
+
+**Wave 1 — pilots (parallel, prove the patterns):** B3 (lane-ii replace pilot),
+B2 (lane-i ContentStorable pilot, consumes T1/T2/StorageRef).
+
+**Wave 2 — core entity:** B1 loop-execution (after pilots prove T1 + entity-port
+wiring; coordinate after B2 so the loop origin precedes `has_step`).
+
+**Wave 3 — replace siblings (parallel after B3):** B4, B6.
+
+**Wave 4 — lifecycle gate:** ADR-049 reopen (Recommendation C + adapter +
+agent-run origin), then B7 (hard-gated on it).
+
+## 9. Open questions needing a human call
+
+1. **JetStream dedup window vs restart replay (T1).** A deterministic `Nats-Msg-Id`
+   only dedups within the `Duplicates` window; restart replay (`DeliverPolicy all`)
+   can re-merge outside it. Size the window to the recovery horizon, accept
+   bounded re-merge, or add an (s,p,o) idempotent-merge guard? The one place T1
+   alone may be insufficient.
+2. **Must-exist rollout shape.** Land the `triple.add` must-exist flip *before*
+   the per-entity migrations (forces them, but breaks them loudly in the interim)
+   or *after* (each conjuror migrates first, then the flip is a no-op)? Recommend
+   after — migrate every conjuror to an enveloped birth lane, then flip must-exist
+   as the closing move so nothing is ever broken on `main`.
+3. **ParticipantEntity adapter scope (ADR-049).** Generic adapter framework-wide,
+   or hand-rolled per-Participant origins (mission-style)? Adapter is cheap but
+   adds a field-classifier tag contract.
+4. **B7 counter primitive.** Build `Manager.MutateWith` (no-phase-change CAS
+   mutator) now, or ship B7 with documented-interim `update_triple`?
+5. **Group-C (LLM-authored free facts).** B6 leaves the `publishGraphMutations`
+   seam for it. Constrained-ID-space Graphable, or stays on the custom envelope?
+   Gates full port deletion. On-by-default today, so it is live blast radius.
+6. **`state.transition` / `evidence.append` renaming vs compat.** Promote/rename
+   now (breaking, post-1.0 discipline) or keep `update_with_triples`/`triple.add`
+   subject names and change only semantics (must-exist)? The semantic change
+   (must-exist) is the load-bearing part; the rename is cosmetic clarity.

--- a/natsclient/client.go
+++ b/natsclient/client.go
@@ -769,6 +769,34 @@ func (m *Client) CreateStream(ctx context.Context, cfg jetstream.StreamConfig) (
 // PublishToStream publishes to a JetStream stream with automatic trace context propagation.
 // If no trace context exists in ctx, one is auto-generated for distributed tracing.
 func (m *Client) PublishToStream(ctx context.Context, subject string, data []byte) error {
+	return m.publishToStream(ctx, subject, data, "")
+}
+
+// PublishToStreamWithMsgID publishes to a JetStream stream stamping the
+// Nats-Msg-Id header so the server's duplicate-detection window collapses
+// re-publishes/redeliveries of the same logical event to a single store.
+//
+// This is the producer half of the at-least-once idempotency contract
+// (ADR-055 §5, "T1"): graph-ingest's stream consumer is at-least-once and
+// MergeEntity APPENDS triples on merge, so a redelivered born-once entity
+// payload would double-apply its triples without dedup. Callers pass a
+// DETERMINISTIC msgID for the logical event (e.g. "<loopID>:spawn",
+// "<entityID>:v<n>") so a retry/redelivery carries the same ID.
+//
+// Scope of the guarantee: dedup only holds WITHIN the stream's configured
+// duplicate window (config.StreamConfig.Duplicates; the NATS server default
+// is 2m when unset). Redelivery outside that window — e.g. DeliverPolicy:all
+// replay on consumer recreation — can still re-append; see ADR-055 Open
+// Question #1. An empty msgID is equivalent to PublishToStream (no dedup),
+// so this is a safe drop-in.
+func (m *Client) PublishToStreamWithMsgID(ctx context.Context, subject string, data []byte, msgID string) error {
+	return m.publishToStream(ctx, subject, data, msgID)
+}
+
+// publishToStream is the shared publish path for PublishToStream and
+// PublishToStreamWithMsgID. A non-empty msgID is stamped as the Nats-Msg-Id
+// header for server-side duplicate detection.
+func (m *Client) publishToStream(ctx context.Context, subject string, data []byte, msgID string) error {
 	// Check circuit breaker first
 	if m.Status() == StatusCircuitOpen {
 		return ErrCircuitOpen
@@ -793,6 +821,13 @@ func (m *Client) PublishToStream(ctx context.Context, subject string, data []byt
 	msg := &nats.Msg{
 		Subject: subject,
 		Data:    data,
+	}
+	if msgID != "" {
+		// Initialize the header here (rather than relying on InjectTrace,
+		// which early-returns when no trace context is present) so the
+		// dedup ID is always carried.
+		msg.Header = make(nats.Header)
+		msg.Header.Set(nats.MsgIdHdr, msgID)
 	}
 	InjectTrace(ctx, msg)
 

--- a/natsclient/publish_msgid_integration_test.go
+++ b/natsclient/publish_msgid_integration_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+
+package natsclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_PublishToStreamWithMsgID_Dedup verifies the ADR-055 §5 "T1"
+// contract: a deterministic Nats-Msg-Id collapses re-publishes of the same
+// logical event to a single stored message within the stream's duplicate
+// window, distinct IDs each store, and an empty ID opts out of dedup entirely
+// (drop-in PublishToStream behavior).
+func TestIntegration_PublishToStreamWithMsgID_Dedup(t *testing.T) {
+	ctx := context.Background()
+
+	natsContainer, natsURL := startNATSContainerWithJS(ctx, t)
+	defer natsContainer.Terminate(ctx)
+
+	client, err := NewClient(natsURL)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(ctx)
+
+	// Stream with an explicit duplicate-detection window.
+	stream, err := client.EnsureStream(ctx, jetstream.StreamConfig{
+		Name:       "MSGID_STREAM",
+		Subjects:   []string{"msgid.>"},
+		Storage:    jetstream.MemoryStorage,
+		Duplicates: 2 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	msgCount := func() uint64 {
+		info, ierr := stream.Info(ctx)
+		require.NoError(t, ierr)
+		return info.State.Msgs
+	}
+
+	// Same msgID twice → deduped to one stored message. PublishMsg returns a
+	// PubAck with Duplicate=true (no error) on the second call.
+	require.NoError(t, client.PublishToStreamWithMsgID(ctx, "msgid.test", []byte("first"), "evt-1"))
+	require.NoError(t, client.PublishToStreamWithMsgID(ctx, "msgid.test", []byte("first-again"), "evt-1"))
+	assert.Equal(t, uint64(1), msgCount(),
+		"same Nats-Msg-Id within the window must dedup to one stored message")
+
+	// Distinct msgID → a new message.
+	require.NoError(t, client.PublishToStreamWithMsgID(ctx, "msgid.test", []byte("second"), "evt-2"))
+	assert.Equal(t, uint64(2), msgCount(), "distinct Nats-Msg-Id must store a new message")
+
+	// Empty msgID → no dedup; two identical publishes both store.
+	require.NoError(t, client.PublishToStreamWithMsgID(ctx, "msgid.test", []byte("x"), ""))
+	require.NoError(t, client.PublishToStreamWithMsgID(ctx, "msgid.test", []byte("x"), ""))
+	assert.Equal(t, uint64(4), msgCount(), "empty msgID must not dedup")
+}
+
+// TestIntegration_PublishToStreamWithMsgID_NotConnected verifies the circuit
+// guard mirrors PublishToStream / PublishToStreamWithAck.
+func TestIntegration_PublishToStreamWithMsgID_NotConnected(t *testing.T) {
+	client, err := NewClient("nats://localhost:4222")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = client.PublishToStreamWithMsgID(ctx, "test.subject", []byte("data"), "id-1")
+	assert.Equal(t, ErrNotConnected, err)
+}

--- a/natsclient/stream.go
+++ b/natsclient/stream.go
@@ -79,6 +79,12 @@ type StreamAutoCreateConfig struct {
 	// MaxAge is the maximum age of messages (default 7 days).
 	MaxAge time.Duration
 
+	// Duplicates is the server-side duplicate-detection window for the
+	// Nats-Msg-Id header (ADR-055 §5 "T1"). Zero leaves the NATS server
+	// default (2m). Must be <= MaxAge or the server rejects creation;
+	// ensureStreamForConsumer clamps it down to MaxAge when it exceeds it.
+	Duplicates time.Duration
+
 	// MaxBytes is the maximum total size (0 = unlimited).
 	MaxBytes int64
 
@@ -388,6 +394,17 @@ func (c *Client) ensureStreamForConsumer(ctx context.Context, js jetstream.JetSt
 	}
 	if autoConfig.Replicas > 0 {
 		streamCfg.Replicas = autoConfig.Replicas
+	}
+	if autoConfig.Duplicates > 0 {
+		dup := autoConfig.Duplicates
+		// Server rejects an explicit window > MaxAge; clamp to keep auto-create
+		// from failing on a misconfigured window (mirrors config.createStream).
+		if streamCfg.MaxAge > 0 && dup > streamCfg.MaxAge {
+			c.logger.Warn("duplicates window exceeds max_age; clamping to max_age",
+				"stream", cfg.StreamName, "duplicates", dup, "max_age", streamCfg.MaxAge)
+			dup = streamCfg.MaxAge
+		}
+		streamCfg.Duplicates = dup
 	}
 
 	// Create the stream


### PR DESCRIPTION
## What

Lands **ADR-055** (write-intent taxonomy — *the mutation API is not a producer API*) and its **Wave 0 / T1** framework primitive.

The audit found graph-ingest's mutation API has become a *producer* API — 21 confirmed sites across 7 entity types conjure entities via `triple.add` auto-vivify, with no backing `Graphable` type and no `MessageType` envelope. ADR-055 reframes the fix as a **four-lane write surface** (fact-arrival / entity-create / state-transition / evidence-append) where *no write may create an entity without a semantic envelope*, and `triple.add`/`add_batch` lose auto-vivify-create. T1 is the first, additive, non-breaking primitive everything stream-side depends on.

## T1 (the code)

- **`Client.PublishToStreamWithMsgID`** — stamps `Nats-Msg-Id` for JetStream server-side dedup, so an at-least-once redelivery doesn't double-apply a born-once payload through graph-ingest's *appending* `MergeEntity`. Empty `msgID` is a drop-in equivalent to `PublishToStream`; both share a `publishToStream` helper preserving circuit-breaker/trace semantics.
- **`config.StreamConfig.Duplicates`** — plumbs the dedup window into `createStream`, with a drift-aware existing-stream update path that applies a window change *and* preserves an unset window (no spurious `UpdateStream` on the server-default 2m). Also plumbed into the natsclient auto-create builder.
- **MaxAge clamp** — the NATS server *rejects* (does not clamp) an explicit window `> MaxAge`, so both builders clamp client-side with a warning rather than aborting boot.

## Scope / guarantee boundary

Dedup holds *within* the configured window. Replay outside it (`DeliverPolicy:all` on consumer recreation) can still re-append — this is ADR-055 **Open Question #1** (an `(s,p,o)`-idempotent merge in `MergeEntity` is the belt-and-suspenders follow-up). No production callers yet; T1 is the primitive later waves wire in.

## Verification

- `task lint` (revive clean) · `go vet -tags=integration` · `gofmt` · `task schema:generate` (no drift) · contract tests — all green
- New + existing stream integration tests pass with `-race`: dedup-within-window, distinct-IDs-store, empty-ID-opt-out, window-drift-applied, unset-window-preserved, MaxAge-clamp, not-connected
- **go-reviewer: APPROVE-WITH-NITS** — both should-fix items (the MaxAge clamp + the second auto-create builder named in the ADR) addressed in this PR

## Notes for reviewers

The first commit is the design (ADR-055 + blast-radius audit + fix-plan + ADR-039/049 cross-links); the second is the T1 code. ADR-055 was multi-lens reviewed before this PR (verdict READY-WITH-CHANGES, amendments folded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)