### PR TITLE
feat(agentic-loop): stamp loop RunID run anchor on ToolCall.Metadata (gh#250)

### DIFF
--- a/agentic/tools.go
+++ b/agentic/tools.go
@@ -157,6 +157,40 @@ const MetadataKeyDecideActionAllowlist = "agent.decide.action_allowlist"
 // a Go string) — readers coerce on access.
 const MetadataKeyRelatedLoops = "agent.related_loops"
 
+// MetadataKeyRunID is the ToolCall.Metadata key under which agentic-loop
+// dispatch stamps the loop's run anchor — the bare run loop-id (ADR-053
+// D7/D8) — when the loop belongs to a run. A tool executor reads it to
+// obtain the run/chain identity directly, instead of re-deriving it by
+// walking agent.loop.parent ancestry triples from its LoopID back to the
+// chain root over graph.query.entity (the hand-rolled ancestry resolver
+// the semteams product shell carried for ADR-053 Phase 5, issue #250).
+//
+// Empty/absent when the loop is not part of a run — a standalone loop
+// stamps neither this nor MetadataKeyRunEntityID (back-compat). Paired
+// with MetadataKeyRunEntityID, which carries the resolved 6-part chain
+// execution entity ID for the same run.
+//
+// Stamped authoritatively (overwrite), unlike the loop_id soft-fallback:
+// the run anchor is a framework fact derived from the loop's typed RunID
+// (set via LoopManager.SetRunID at loop creation), and there is no
+// legitimate caller-override use case, so dispatch always supplies it.
+const MetadataKeyRunID = "agent.run_id"
+
+// MetadataKeyRunEntityID is the ToolCall.Metadata key carrying the
+// resolved 6-part chain execution entity ID
+// (org.platform.agent.chain.execution.<runID>) for the loop's run
+// anchor. Mirrors LoopCreatedEvent.RunEntityID / LoopCompletedEvent.
+// RunEntityID so a tool executor and an event subscriber resolve the
+// same run/chain entity.
+//
+// Stamped alongside MetadataKeyRunID by agentic-loop dispatch when the
+// loop belongs to a run AND the handler has a valid platform identity
+// (org+platform). Absent when RunID is empty or the platform identity
+// is missing; a consumer that needs the entity ID under a missing
+// platform can reconstruct it from MetadataKeyRunID plus its own
+// org/platform via agentic.ChainExecutionEntityID.
+const MetadataKeyRunEntityID = "agent.run_entity_id"
+
 // LineageTriplePrefix is the predicate prefix for cross-arc loop-ID
 // lineage triples stamped on a spawned loop's entity at loop-creation
 // time. Each entry in TaskMessage.Metadata[MetadataKeyRelatedLoops]

--- a/processor/agentic-loop/dispatch_test.go
+++ b/processor/agentic-loop/dispatch_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/types"
 )
 
 // TestDispatchToolCall_StampsLoopID is the regression for the wedge
@@ -186,6 +187,263 @@ func TestDispatchToolCall_DequeuedCallStampsLoopID(t *testing.T) {
 	}
 	if got := metadata["loop_id"]; got != loopID {
 		t.Errorf("payload.metadata.loop_id = %v, want %q (the bash-sandbox routing key)", got, loopID)
+	}
+}
+
+// TestDispatchToolCall_StampsRunAnchor is the issue #250 regression:
+// when a loop belongs to a run (ADR-053 D7), dispatch must stamp the run
+// anchor onto the outgoing ToolCall.Metadata so a tool executor reads the
+// run/chain identity directly instead of walking agent.loop.parent
+// ancestry back to the chain root. Both the bare run loop-id
+// (MetadataKeyRunID) and the resolved 6-part chain execution entity ID
+// (MetadataKeyRunEntityID) land on the wire when a platform identity is
+// configured. Drives the production marshal path end-to-end.
+func TestDispatchToolCall_StampsRunAnchor(t *testing.T) {
+	handler := NewMessageHandler(DefaultConfig())
+	handler.SetPlatform(types.PlatformMeta{Org: "acme", Platform: "ops"})
+
+	loopID, err := handler.loopManager.CreateLoop("task-run", "general", "m", 20)
+	if err != nil {
+		t.Fatalf("CreateLoop: %v", err)
+	}
+	const runID = "run-anchor-1"
+	if err := handler.loopManager.SetRunID(loopID, runID); err != nil {
+		t.Fatalf("SetRunID: %v", err)
+	}
+
+	good := agentic.ToolCall{
+		ID:        "call-run",
+		Name:      "test_tool",
+		Arguments: map[string]any{"q": "hello"},
+	}
+
+	result := &HandlerResult{}
+	dispatched, storeErr := handler.tryDispatchOrSynthesize(result, loopID, good)
+	if storeErr != nil {
+		t.Fatalf("storeErr = %v, want nil", storeErr)
+	}
+	if !dispatched {
+		t.Fatal("dispatched = false, want true")
+	}
+
+	payload := findPublishedToolCallPayload(t, result, "test_tool")
+	metadata, ok := payload["metadata"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload.metadata not a map: %T", payload["metadata"])
+	}
+	if got := metadata[agentic.MetadataKeyRunID]; got != runID {
+		t.Errorf("payload.metadata[%q] = %v, want %q", agentic.MetadataKeyRunID, got, runID)
+	}
+	// org.platform.agent.chain.execution.<runID>
+	wantEntityID := agentic.ChainExecutionEntityID("acme", "ops", runID)
+	if got := metadata[agentic.MetadataKeyRunEntityID]; got != wantEntityID {
+		t.Errorf("payload.metadata[%q] = %v, want %q", agentic.MetadataKeyRunEntityID, got, wantEntityID)
+	}
+	// The loop_id soft-fallback must still be stamped alongside.
+	if got := metadata["loop_id"]; got != loopID {
+		t.Errorf("payload.metadata.loop_id = %v, want %q (run-anchor stamp must not displace it)", got, loopID)
+	}
+}
+
+// TestDispatchToolCall_StandaloneLoopNoRunAnchor pins the back-compat
+// contract: a loop that is NOT part of a run (no SetRunID call) must
+// leave both run-anchor keys absent. Stamping an empty/zero run anchor
+// would hand executors a phantom run identity and route attestation /
+// run-scoped triples to a nonexistent chain entity.
+func TestDispatchToolCall_StandaloneLoopNoRunAnchor(t *testing.T) {
+	handler := NewMessageHandler(DefaultConfig())
+	handler.SetPlatform(types.PlatformMeta{Org: "acme", Platform: "ops"})
+
+	loopID, err := handler.loopManager.CreateLoop("task-standalone", "general", "m", 20)
+	if err != nil {
+		t.Fatalf("CreateLoop: %v", err)
+	}
+	// Intentionally NO SetRunID — this loop is standalone.
+
+	good := agentic.ToolCall{ID: "call-standalone", Name: "test_tool"}
+	result := &HandlerResult{}
+	if _, storeErr := handler.tryDispatchOrSynthesize(result, loopID, good); storeErr != nil {
+		t.Fatalf("storeErr = %v, want nil", storeErr)
+	}
+
+	payload := findPublishedToolCallPayload(t, result, "test_tool")
+	metadata, _ := payload["metadata"].(map[string]any)
+	if got, present := metadata[agentic.MetadataKeyRunID]; present {
+		t.Errorf("payload.metadata[%q] = %v, want absent (standalone loop)", agentic.MetadataKeyRunID, got)
+	}
+	if got, present := metadata[agentic.MetadataKeyRunEntityID]; present {
+		t.Errorf("payload.metadata[%q] = %v, want absent (standalone loop)", agentic.MetadataKeyRunEntityID, got)
+	}
+	// loop_id is unconditional and must still be present.
+	if got := metadata["loop_id"]; got != loopID {
+		t.Errorf("payload.metadata.loop_id = %v, want %q", got, loopID)
+	}
+}
+
+// TestDispatchToolCall_RunIDWithoutPlatformOmitsEntityID locks the
+// graceful-degradation contract for a misconfigured deploy: a loop with a
+// run anchor but no platform identity stamps the bare run loop-id (which
+// needs no platform) while omitting the 6-part entity ID (which can't be
+// constructed). resolveRunEntityID returns "" in that case rather than a
+// malformed ID, so the executor can still reconstruct the entity from
+// run_id plus its own platform identity.
+func TestDispatchToolCall_RunIDWithoutPlatformOmitsEntityID(t *testing.T) {
+	handler := NewMessageHandler(DefaultConfig())
+	// Intentionally NO SetPlatform — org/platform are empty.
+
+	loopID, err := handler.loopManager.CreateLoop("task-noplatform", "general", "m", 20)
+	if err != nil {
+		t.Fatalf("CreateLoop: %v", err)
+	}
+	const runID = "run-anchor-2"
+	if err := handler.loopManager.SetRunID(loopID, runID); err != nil {
+		t.Fatalf("SetRunID: %v", err)
+	}
+
+	good := agentic.ToolCall{ID: "call-noplatform", Name: "test_tool"}
+	result := &HandlerResult{}
+	if _, storeErr := handler.tryDispatchOrSynthesize(result, loopID, good); storeErr != nil {
+		t.Fatalf("storeErr = %v, want nil", storeErr)
+	}
+
+	payload := findPublishedToolCallPayload(t, result, "test_tool")
+	metadata, _ := payload["metadata"].(map[string]any)
+	if got := metadata[agentic.MetadataKeyRunID]; got != runID {
+		t.Errorf("payload.metadata[%q] = %v, want %q (run_id needs no platform)", agentic.MetadataKeyRunID, got, runID)
+	}
+	if got, present := metadata[agentic.MetadataKeyRunEntityID]; present {
+		t.Errorf("payload.metadata[%q] = %v, want absent (no platform identity)", agentic.MetadataKeyRunEntityID, got)
+	}
+}
+
+// TestDispatchToolCall_RunAnchorOverwritesCallerValue is the symmetric
+// counterpart to TestDispatchToolCall_PreservesExplicitMetadata: where
+// loop_id is don't-clobber (caller value wins), the run anchor is
+// authoritative (framework value wins). A caller that pre-populated a
+// stale/bogus run anchor on the ToolCall must NOT see it survive —
+// otherwise attestation / run-scoped triples route to the wrong chain
+// entity. Pins the deliberate, thrice-documented overwrite contract so a
+// future refactor that copy-pastes the adjacent don't-clobber guard onto
+// the run anchor fails loudly instead of regressing silently.
+func TestDispatchToolCall_RunAnchorOverwritesCallerValue(t *testing.T) {
+	handler := NewMessageHandler(DefaultConfig())
+	handler.SetPlatform(types.PlatformMeta{Org: "acme", Platform: "ops"})
+
+	loopID, err := handler.loopManager.CreateLoop("task-overwrite", "general", "m", 20)
+	if err != nil {
+		t.Fatalf("CreateLoop: %v", err)
+	}
+	const runID = "run-real-1"
+	if err := handler.loopManager.SetRunID(loopID, runID); err != nil {
+		t.Fatalf("SetRunID: %v", err)
+	}
+
+	good := agentic.ToolCall{
+		ID:   "call-overwrite",
+		Name: "test_tool",
+		Metadata: map[string]any{
+			agentic.MetadataKeyRunID:       "stale-bogus-run",
+			agentic.MetadataKeyRunEntityID: "stale.bogus.entity",
+			"extra":                        "preserved",
+		},
+	}
+
+	result := &HandlerResult{}
+	if _, storeErr := handler.tryDispatchOrSynthesize(result, loopID, good); storeErr != nil {
+		t.Fatalf("storeErr = %v, want nil", storeErr)
+	}
+
+	payload := findPublishedToolCallPayload(t, result, "test_tool")
+	metadata, _ := payload["metadata"].(map[string]any)
+	if got := metadata[agentic.MetadataKeyRunID]; got != runID {
+		t.Errorf("payload.metadata[%q] = %v, want framework value %q (authoritative overwrite violated)", agentic.MetadataKeyRunID, got, runID)
+	}
+	wantEntityID := agentic.ChainExecutionEntityID("acme", "ops", runID)
+	if got := metadata[agentic.MetadataKeyRunEntityID]; got != wantEntityID {
+		t.Errorf("payload.metadata[%q] = %v, want framework value %q (authoritative overwrite violated)", agentic.MetadataKeyRunEntityID, got, wantEntityID)
+	}
+	// Unrelated caller keys must still survive the overwrite of the run anchor.
+	if got := metadata["extra"]; got != "preserved" {
+		t.Errorf("payload.metadata.extra = %v, want \"preserved\" (unrelated keys must survive)", got)
+	}
+}
+
+// TestDispatchToolCall_ApprovalRedispatchStampsRunAnchor mirrors the
+// loop_id approval-path regression (TestDispatchToolCall_ApprovalRedispatchStampsLoopID)
+// for the run anchor. dispatchApprovedCall constructs a fresh ToolCall
+// with neither LoopID nor Metadata and lands directly on the
+// dispatchToolCall stamp — the only production caller that bypasses the
+// upstream stamp. This pins the run anchor to that path so a refactor
+// moving the stamp out of dispatchToolCall regresses with a failing test.
+func TestDispatchToolCall_ApprovalRedispatchStampsRunAnchor(t *testing.T) {
+	handler := NewMessageHandler(DefaultConfig())
+	handler.SetPlatform(types.PlatformMeta{Org: "acme", Platform: "ops"})
+
+	loopID, err := handler.loopManager.CreateLoop("task-approve-run", "general", "m", 20)
+	if err != nil {
+		t.Fatalf("CreateLoop: %v", err)
+	}
+	const runID = "run-approve-1"
+	if err := handler.loopManager.SetRunID(loopID, runID); err != nil {
+		t.Fatalf("SetRunID: %v", err)
+	}
+
+	pending := agentic.PendingApprovalState{CallID: "call-approved-run", ToolName: "test_tool"}
+	result := &HandlerResult{}
+	if err := handler.dispatchApprovedCall(loopID, pending, map[string]any{"q": "x"}, "alice@example.com", result); err != nil {
+		t.Fatalf("dispatchApprovedCall: %v", err)
+	}
+
+	payload := findPublishedToolCallPayload(t, result, "test_tool")
+	metadata, _ := payload["metadata"].(map[string]any)
+	if got := metadata[agentic.MetadataKeyRunID]; got != runID {
+		t.Errorf("approval path: payload.metadata[%q] = %v, want %q", agentic.MetadataKeyRunID, got, runID)
+	}
+	wantEntityID := agentic.ChainExecutionEntityID("acme", "ops", runID)
+	if got := metadata[agentic.MetadataKeyRunEntityID]; got != wantEntityID {
+		t.Errorf("approval path: payload.metadata[%q] = %v, want %q", agentic.MetadataKeyRunEntityID, got, wantEntityID)
+	}
+}
+
+// TestDispatchToolCall_DequeuedCallStampsRunAnchor mirrors the loop_id
+// dequeue-path regression (TestDispatchToolCall_DequeuedCallStampsLoopID)
+// for the run anchor. Queued tail calls (the most likely path semteams's
+// concurrent-chain repro hit) reach dispatch via dispatchedFromQueue; the
+// run anchor must land there too.
+func TestDispatchToolCall_DequeuedCallStampsRunAnchor(t *testing.T) {
+	handler := NewMessageHandler(DefaultConfig())
+	handler.SetPlatform(types.PlatformMeta{Org: "acme", Platform: "ops"})
+
+	loopID, err := handler.loopManager.CreateLoop("task-queue-run", "general", "m", 20)
+	if err != nil {
+		t.Fatalf("CreateLoop: %v", err)
+	}
+	const runID = "run-queue-1"
+	if err := handler.loopManager.SetRunID(loopID, runID); err != nil {
+		t.Fatalf("SetRunID: %v", err)
+	}
+
+	handler.loopManager.QueueToolCalls(loopID, []agentic.ToolCall{
+		{ID: "call-queued-run", Name: "test_tool", LoopID: loopID},
+	})
+
+	result := &HandlerResult{}
+	dispatched, sErr := handler.dispatchedFromQueue(result, loopID)
+	if sErr != nil {
+		t.Fatalf("dispatchedFromQueue: %v", sErr)
+	}
+	if !dispatched {
+		t.Fatal("dispatched = false, want true (queue had one call)")
+	}
+
+	payload := findPublishedToolCallPayload(t, result, "test_tool")
+	metadata, _ := payload["metadata"].(map[string]any)
+	if got := metadata[agentic.MetadataKeyRunID]; got != runID {
+		t.Errorf("dequeue path: payload.metadata[%q] = %v, want %q", agentic.MetadataKeyRunID, got, runID)
+	}
+	wantEntityID := agentic.ChainExecutionEntityID("acme", "ops", runID)
+	if got := metadata[agentic.MetadataKeyRunEntityID]; got != wantEntityID {
+		t.Errorf("dequeue path: payload.metadata[%q] = %v, want %q", agentic.MetadataKeyRunEntityID, got, wantEntityID)
 	}
 }
 

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -1302,10 +1302,22 @@ func (h *MessageHandler) dispatchedFromQueue(result *HandlerResult, loopID strin
 //     against beta.37; cmd/semteams/sandbox/integration_test.go had
 //     to manually populate Metadata["task_id"] to get past 404s.
 //
-// Both writes are conditional ("don't clobber") so an LLM or upstream
-// caller that explicitly set either field keeps its value. New
+// Both loop_id writes are conditional ("don't clobber") so an LLM or
+// upstream caller that explicitly set either field keeps its value. New
 // callers should not need to set either — dispatch propagates loopID
 // naturally.
+//
+// When the loop belongs to a run (ADR-053), dispatch additionally stamps
+// the run anchor onto tc.Metadata so tool executors read the run/chain
+// identity directly rather than walking ancestry (issue #250):
+//
+//   - tc.Metadata[MetadataKeyRunID] — the bare run loop-id.
+//   - tc.Metadata[MetadataKeyRunEntityID] — the resolved 6-part chain
+//     execution entity ID (present only when a platform identity is set).
+//
+// Unlike the loop_id writes these are authoritative (overwrite): the run
+// anchor is a framework fact derived from the loop's typed RunID, not a
+// caller-routable hint. Both keys stay absent for a standalone loop.
 func (h *MessageHandler) dispatchToolCall(result *HandlerResult, loopID string, tc agentic.ToolCall) error {
 	if err := h.loopManager.AddPendingTool(loopID, tc.ID); err != nil {
 		return err
@@ -1323,6 +1335,22 @@ func (h *MessageHandler) dispatchToolCall(result *HandlerResult, loopID string, 
 	}
 	if _, ok := tc.Metadata["loop_id"]; !ok {
 		tc.Metadata["loop_id"] = loopID
+	}
+
+	// Stamp the loop's run anchor (ADR-053 D7/D8) so tool executors read
+	// the run/chain identity directly instead of walking agent.loop.parent
+	// ancestry from LoopID back to the chain root (issue #250, semteams
+	// ADR-053 Phase 5). Only stamped when the loop belongs to a run; a
+	// standalone loop leaves both keys absent (back-compat).
+	//
+	// Authoritative, unlike the loop_id soft-fallback above: the run anchor
+	// is a framework fact derived from the loop's typed RunID, so dispatch
+	// overwrites rather than yielding to any caller-supplied value.
+	if runID := h.loopManager.GetRunID(loopID); runID != "" {
+		tc.Metadata[agentic.MetadataKeyRunID] = runID
+		if runEntityID := h.resolveRunEntityID(runID); runEntityID != "" {
+			tc.Metadata[agentic.MetadataKeyRunEntityID] = runEntityID
+		}
 	}
 
 	toolMsg := message.NewBaseMessage(tc.Schema(), &tc, "agentic-loop")

--- a/processor/agentic-loop/state.go
+++ b/processor/agentic-loop/state.go
@@ -801,6 +801,24 @@ func (m *LoopManager) SetRunID(loopID, runID string) error {
 	return nil
 }
 
+// GetRunID returns the run anchor (bare run loop-id) for a loop, or the
+// empty string when the loop is unknown or not part of a run (ADR-053 D7).
+// Read-only counterpart to SetRunID; dispatch reads it to stamp the run
+// anchor onto outgoing ToolCall.Metadata (issue #250). Returns "" rather
+// than an error so the best-effort dispatch stamp stays branchless — an
+// unknown loop and a runless loop are indistinguishable to the consumer
+// (both mean "no run anchor"), and dispatch must never fail over it.
+func (m *LoopManager) GetRunID(loopID string) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	entity, exists := m.loops[loopID]
+	if !exists {
+		return ""
+	}
+	return entity.RunID
+}
+
 // SetDepth sets the depth tracking for a loop in the multi-agent hierarchy
 func (m *LoopManager) SetDepth(loopID string, depth, maxDepth int) error {
 	m.mu.Lock()

--- a/processor/agentic-loop/state_test.go
+++ b/processor/agentic-loop/state_test.go
@@ -1000,3 +1000,32 @@ func TestLoopManager_HasActiveLoopForTask(t *testing.T) {
 		t.Fatal("HasActiveLoopForTask should return false for terminal loop")
 	}
 }
+
+// TestLoopManager_GetRunID is the read-side counterpart to SetRunID
+// (ADR-053 D7, issue #250). A freshly created loop carries no run anchor;
+// after SetRunID it reads back; an unknown loop reads "" rather than
+// erroring so the best-effort dispatch stamp stays branchless.
+func TestLoopManager_GetRunID(t *testing.T) {
+	manager := agenticloop.NewLoopManager()
+
+	loopID, err := manager.CreateLoop("task-run", "general", "qwen-32b")
+	if err != nil {
+		t.Fatalf("CreateLoop() error = %v", err)
+	}
+
+	if got := manager.GetRunID(loopID); got != "" {
+		t.Errorf("GetRunID() before SetRunID = %q, want \"\" (loop not part of a run)", got)
+	}
+
+	const runID = "run-anchor-xyz"
+	if err := manager.SetRunID(loopID, runID); err != nil {
+		t.Fatalf("SetRunID() error = %v", err)
+	}
+	if got := manager.GetRunID(loopID); got != runID {
+		t.Errorf("GetRunID() after SetRunID = %q, want %q", got, runID)
+	}
+
+	if got := manager.GetRunID("no-such-loop"); got != "" {
+		t.Errorf("GetRunID(unknown) = %q, want \"\" (no error, no panic)", got)
+	}
+}


### PR DESCRIPTION
Closes #250.

## Problem

Post-ADR-053 every loop carries a typed `RunID` (the run anchor), but a **tool executor had no way to read it** — `ToolCall` has no `RunID` field and `dispatchToolCall` only injected `loop_id` into `Metadata`. So semteams' product-shell tools (`chainbash` / `requestsandbox` / `querysandboxattestation`) re-derived the run/chain entity by walking `agent.loop.parent` ancestry triples back to the chain root over `graph.query.entity` RPC — the hand-rolled `cmd/semteams/chain/Resolver`. The framework already knew the answer at spawn time.

## Change

`dispatchToolCall` (the shared dispatch stamp that already injects `loop_id`) now also stamps the run anchor onto `tc.Metadata` whenever the loop belongs to a run:

| Key (exported const in `agentic/tools.go`) | Value |
|---|---|
| `agent.run_id` (`MetadataKeyRunID`) | bare run loop-id |
| `agent.run_entity_id` (`MetadataKeyRunEntityID`) | resolved 6-part `org.platform.agent.chain.execution.<runID>` (present when a platform identity is configured) |

- New `LoopManager.GetRunID(loopID) string` getter reads the anchor the loop already stores via `SetRunID` (returns `""` for unknown/runless loop — best-effort, never errors dispatch).
- **Authoritative overwrite** (unlike `loop_id`'s don't-clobber): the run anchor is a framework fact derived from the loop's typed `RunID`, not a caller-routable hint.
- A **standalone loop leaves both keys absent** (back-compat). Purely additive — no `ToolCall` struct field, no schema regen.

## Already-shipped secondary ask

The issue's secondary ask (`LoopFailedEvent`/`LoopCompletedEvent` carrying `RunID`) was **already shipped in a prior tag** — both events already populate `RunID`/`RunEntityID` (`handlers.go`). This PR is the remaining gap (the ToolCall path).

## Unblocks

semteams ADR-053 Phase 5: the tools read `tc.Metadata[agentic.MetadataKeyRunID]` / `MetadataKeyRunEntityID` directly (public field + exported const — no private-field blockage) and retire the ancestry `Resolver` walk.

## Tests

Drive the **production marshal wire** end-to-end across all three dispatch paths and both contract dimensions:
- Paths: normal (`tryDispatchOrSynthesize`), approval re-dispatch (`dispatchApprovedCall`), queue dequeue (`dispatchedFromQueue`) — matching the existing `loop_id` one-test-per-path discipline.
- Branches: run+platform (both keys), standalone (no keys), run+no-platform (`run_id` only).
- Authoritative-overwrite contract (symmetric counterpart to `TestDispatchToolCall_PreservesExplicitMetadata`).
- `TestLoopManager_GetRunID` unit test.

## Local CI gates (all green)

- `go build ./...`, `go test -race ./...` (123 pkgs), integration-tag vet
- `task lint` (revive + port guard), `gofmt`, `go vet`
- `task schema:generate` → no drift; `go test ./test/contract/...`

## Review

Pre-merge adversarial multi-lens review (correctness/concurrency, consumer-contract, dispatch-path coverage, clobber semantics, back-compat/audit) — no blocking/high/medium findings. Two confirmed coverage-hardening findings (per-path tests + overwrite-contract test) folded in before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)