### PR TITLE
feat(graph-ingest): ADR-054 Phase 1 — indexing eligibility (indexing_profile stamp)

### DIFF
--- a/docs/adr/054-semantic-indexing-eligibility.md
+++ b/docs/adr/054-semantic-indexing-eligibility.md
@@ -173,9 +173,14 @@ returns.)
   }
   ```
 
-- **(b) Mutation-envelope field** — the mutation API request gains an optional
+- **(b) Mutation-envelope field** — the **create** and **update** mutation
+  requests (`create_with_triples`, `update_with_triples`) gain an optional
   `indexing_profile` field so rule/lifecycle/loop/memory/research-graph writers
-  declare intent. *This is the channel the registry-only design lacked.*
+  declare intent. *This is the channel the registry-only design lacked.* The
+  field is deliberately NOT added to `triple.add` / `triple.add_batch`: a
+  profile is set at entity birth, and per ADR-055 those requests must not create
+  entities (they append evidence to an existing one, whose profile is already
+  set). See §5 forward-compatibility note.
 
 - **(c) graph-ingest fallback** — when neither (a) nor (b) supplies a profile,
   graph-ingest derives a *floor* from `message.Type` (registry) and the parsed
@@ -184,9 +189,24 @@ returns.)
 
 ### 5. graph-ingest enforcement mechanics
 
-- **Stamp at create.** Profile is materialized on entity creation
-  (`create_with_triples`, first `triple.add` that creates an entity, and the
-  referential-integrity stub path `processor/graph-ingest/component.go:1200`).
+- **Stamp at the envelope-establishing creation seam.** Profile is materialized
+  exactly where an entity is *born with a semantic envelope*: the Graphable
+  JetStream arrival (`extractEntityFromMessage` → `MergeEntity` first write) and
+  the `create_with_triples` mutation (`createEntity`). A real producer merging
+  into a profile-less referential-integrity stub is also a birth, so the
+  stub→real upgrade in `MergeEntity`'s merge branch stamps too. The
+  `reconcileIndexingProfile` helper at each seam keeps an explicit declaration
+  (envelope/Graphable, stamped upstream) and otherwise applies the floor.
+- **Forward-compatibility with ADR-055 (no debt).** ADR-054's "stamp the
+  profile at entity birth" and ADR-055's "entity birth requires a semantic
+  envelope" are the **same seam** — the profile rides the envelope. The
+  `triple.add` / `triple.add_batch` *auto-vivify* paths (which create an entity
+  with no envelope) are therefore **NOT** a stamp point: they are the exact
+  ADR-055 defect being removed, so threading a profile through them would build
+  on soon-deleted code. An entity auto-vivified via `triple.add` before ADR-055
+  lands simply carries no profile triple, which lenient Phase-1 consumers handle
+  correctly (absent = index). When ADR-055 makes those paths must-exist, nothing
+  here changes.
 - **Single-valued, replace-on-write.** `entity.indexing.profile` MUST be
   written `RemoveTriples + AddTriples`, never appended. The merge path currently
   appends (`MergeEntity`), and an appended single-valued predicate accumulates

--- a/graph/mutation_requests.go
+++ b/graph/mutation_requests.go
@@ -37,10 +37,21 @@ type DeleteEntityRequest struct {
 
 // CreateEntityWithTriplesRequest creates entity with triples atomically
 type CreateEntityWithTriplesRequest struct {
-	Entity    *EntityState     `json:"entity"`
-	Triples   []message.Triple `json:"triples"`
-	TraceID   string           `json:"trace_id,omitempty"`
-	RequestID string           `json:"request_id,omitempty"`
+	Entity  *EntityState     `json:"entity"`
+	Triples []message.Triple `json:"triples"`
+	// IndexingProfile optionally declares the entity's indexing profile at
+	// creation (ADR-054 channel b): one of "content"|"control"|"signal"|
+	// "trace". When set, graph-ingest stamps entity.indexing.profile from it
+	// (highest precedence). When empty, graph-ingest falls through to the
+	// Graphable IndexingProfiler, then the fallback floor. Invalid values are
+	// treated as absent (lenient). This is the channel the registry-only
+	// design lacked — rule/lifecycle/loop/memory/research-graph writers use it
+	// to declare intent. Only meaningful on CREATE; entity-birth is the only
+	// place a profile is set (see also UpdateEntityWithTriplesRequest for the
+	// explicit-override exception).
+	IndexingProfile string `json:"indexing_profile,omitempty"`
+	TraceID         string `json:"trace_id,omitempty"`
+	RequestID       string `json:"request_id,omitempty"`
 }
 
 // UpdateEntityWithTriplesRequest updates entity and modifies triples atomically.
@@ -78,8 +89,15 @@ type UpdateEntityWithTriplesRequest struct {
 	// uses the non-zero path per ADR-049 to preserve state-machine
 	// correctness under concurrent writes.
 	ExpectedRevision uint64 `json:"expected_revision,omitempty"`
-	TraceID          string `json:"trace_id,omitempty"`
-	RequestID        string `json:"request_id,omitempty"`
+	// IndexingProfile, when non-empty, is the EXPLICIT-OVERRIDE channel for an
+	// entity's indexing profile (ADR-054 §5). A profile is otherwise immutable
+	// after creation; setting it here replaces entity.indexing.profile
+	// (RemoveTriples + AddTriples, single-valued). Empty leaves the existing
+	// profile untouched. This is the only post-creation way to re-profile an
+	// entity — a later triple.add by a different writer must NOT change it.
+	IndexingProfile string `json:"indexing_profile,omitempty"`
+	TraceID         string `json:"trace_id,omitempty"`
+	RequestID       string `json:"request_id,omitempty"`
 }
 
 // AddTripleRequest adds a triple to an existing entity

--- a/message/behaviors.go
+++ b/message/behaviors.go
@@ -133,3 +133,23 @@ type Expirable interface {
 	// Returns 0 if payload never expires.
 	TTL() time.Duration
 }
+
+// IndexingProfiler lets a Graphable payload declare its indexing profile —
+// the producer's hint for which semantic substrates (embedding, community
+// clustering, search) should index the entity (ADR-054). It does NOT affect
+// the structural graph, which is always queryable/traversable regardless of
+// profile ("graph visibility is storage; indexing is policy").
+//
+// Optional and additive: a payload that does not implement it falls through
+// to graph-ingest's resolution order (mutation-envelope field, then the
+// fallback floor derived from MessageType + EntityID type-segment). Absence
+// means "let the framework decide", never "no profile".
+//
+// Valid return values are the four indexing profiles in the vocabulary
+// package: IndexingProfileContent, IndexingProfileControl,
+// IndexingProfileSignal, IndexingProfileTrace. An empty or unrecognized
+// return is treated as absent (graph-ingest falls through to the floor).
+type IndexingProfiler interface {
+	// IndexingProfile returns one of "content" | "control" | "signal" | "trace".
+	IndexingProfile() string
+}

--- a/processor/graph-clustering/component.go
+++ b/processor/graph-clustering/component.go
@@ -24,6 +24,7 @@ import (
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/pkg/resource"
+	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -1359,6 +1360,22 @@ func newKVEntityQuerier(entityBucket jetstream.KeyValue, logger *slog.Logger) *k
 }
 
 // GetEntities retrieves entities by their IDs from ENTITY_STATES bucket
+// observeIndexingProfileForClustering emits a Debug observation when an entity
+// carries an indexing profile that ADR-054 Phase 3 would exclude from the
+// community/structural substrates (trace). Phase 1 is LENIENT — it never
+// excludes — so this is purely the dry-run signal that informs the Phase 3
+// policy, never an action. Strict enforcement is gated on gh#238 plus the
+// cost-ledger preconditions (gate-silent-exclusion-flips-with-cost-ledger).
+func observeIndexingProfileForClustering(logger *slog.Logger, es *graph.EntityState) {
+	if v, ok := es.GetPropertyValue(vocabulary.EntityIndexingProfile); ok {
+		if profile, _ := v.(string); profile == vocabulary.IndexingProfileTrace {
+			logger.Debug("entity has trace indexing profile; clustering it anyway (ADR-054 Phase 1 lenient)",
+				slog.String("entity", es.ID),
+				slog.String("indexing_profile", profile))
+		}
+	}
+}
+
 func (q *kvEntityQuerier) GetEntities(ctx context.Context, ids []string) ([]*graph.EntityState, error) {
 	entities := make([]*graph.EntityState, 0, len(ids))
 
@@ -1383,6 +1400,12 @@ func (q *kvEntityQuerier) GetEntities(ctx context.Context, ids []string) ([]*gra
 			q.logger.Warn("failed to unmarshal entity", slog.String("id", id), slog.Any("error", err))
 			continue
 		}
+
+		// ADR-054 Phase 1 (lenient): observe the entity's indexing profile but
+		// never exclude it from clustering. Community/structural eligibility
+		// enforcement is Phase 3, coupled to gh#238 (semantic edges) and gated
+		// on the cost-ledger preconditions — so this is a provable no-op here.
+		observeIndexingProfileForClustering(q.logger, &entity)
 
 		entities = append(entities, &entity)
 	}

--- a/processor/graph-clustering/indexing_profile_test.go
+++ b/processor/graph-clustering/indexing_profile_test.go
@@ -1,0 +1,43 @@
+package graphclustering
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/vocabulary"
+)
+
+// ADR-054 Phase 1 is LENIENT: graph-clustering observes the indexing profile
+// (Debug dry-run signal) but never excludes an entity from community/structural
+// detection. observeIndexingProfileForClustering only logs — it must handle
+// every profile (and an absent profile) without panicking, and it has no return
+// value, so by construction nothing is filtered. Strict enforcement is Phase 3,
+// coupled to gh#238 and gated on the cost-ledger preconditions.
+func TestObserveIndexingProfileForClustering_LenientNoPanic(t *testing.T) {
+	logger := slog.Default()
+	for _, profile := range []string{
+		vocabulary.IndexingProfileTrace,
+		vocabulary.IndexingProfileSignal,
+		vocabulary.IndexingProfileContent,
+		vocabulary.IndexingProfileControl,
+		"",
+		"garbage",
+	} {
+		es := &graph.EntityState{ID: "c360.platform.test.sys.widget.001"}
+		if profile != "" {
+			es.Triples = []message.Triple{{
+				Subject:   es.ID,
+				Predicate: vocabulary.EntityIndexingProfile,
+				Object:    profile,
+			}}
+		}
+		// Must not panic and must not mutate the entity (observation only).
+		before := len(es.Triples)
+		observeIndexingProfileForClustering(logger, es)
+		if len(es.Triples) != before {
+			t.Errorf("observeIndexingProfileForClustering mutated the entity (profile %q)", profile)
+		}
+	}
+}

--- a/processor/graph-embedding/component.go
+++ b/processor/graph-embedding/component.go
@@ -22,6 +22,7 @@ import (
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/pkg/resource"
 	"github.com/c360studio/semstreams/storage/objectstore"
+	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -909,6 +910,30 @@ func (c *Component) processEntityBatch(ctx context.Context, entityIDs []string) 
 }
 
 // queueEntityForEmbedding queues an entity for async embedding generation
+// indexingEligible reports whether an entity should be indexed for embeddings
+// based on its ADR-054 indexing profile (entity.indexing.profile).
+//
+// Phase 1 is LENIENT: every entity is eligible regardless of profile, so this
+// always returns true (provable no-op, zero behavior change). It reads the
+// profile and emits a Debug observation for the profiles Phase 3 will exclude
+// (trace, raw signal) — that is the dry-run signal, not an action.
+//
+// Strict enforcement (actually skipping ineligible entities + emitting
+// embedding_skipped_total) is ADR-054 Phase 3, and MUST NOT ship as a bare
+// toggle: it is gated on the cost-ledger preconditions (dry-run report,
+// skipped metric, golden-corpus regression test, backfill) per
+// gate-silent-exclusion-flips-with-cost-ledger. So Phase 1 never excludes.
+func (c *Component) indexingEligible(es *graph.EntityState) bool {
+	if v, ok := es.GetPropertyValue(vocabulary.EntityIndexingProfile); ok {
+		if profile, _ := v.(string); profile == vocabulary.IndexingProfileTrace || profile == vocabulary.IndexingProfileSignal {
+			c.logger.Debug("entity has a non-embedding indexing profile; indexing anyway (ADR-054 Phase 1 lenient)",
+				slog.String("entity", es.ID),
+				slog.String("indexing_profile", profile))
+		}
+	}
+	return true
+}
+
 func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string, data []byte) {
 	// Report embedding stage (throttled to avoid KV spam)
 	if err := c.lifecycleReporter.ReportStage(ctx, "embedding"); err != nil {
@@ -921,6 +946,14 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 		c.logger.Warn("failed to unmarshal entity state",
 			slog.String("entity", entityID),
 			slog.Any("error", err))
+		return
+	}
+
+	// ADR-054 Phase 1 (lenient): consult the entity's indexing profile but
+	// never exclude — strict enforcement is Phase 3, gated on the cost-ledger
+	// preconditions. indexingEligible always returns true here, so this is a
+	// provable no-op (zero behavior change); it is the seam Phase 3 turns live.
+	if !c.indexingEligible(&entityState) {
 		return
 	}
 

--- a/processor/graph-embedding/indexing_profile_test.go
+++ b/processor/graph-embedding/indexing_profile_test.go
@@ -1,0 +1,46 @@
+package graphembedding
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/vocabulary"
+)
+
+// ADR-054 Phase 1 is LENIENT: graph-embedding consults the indexing profile but
+// never excludes an entity. indexingEligible must return true for EVERY profile
+// (and for an absent profile), so the gate is a provable no-op — strict
+// enforcement is Phase 3, gated on the cost-ledger preconditions.
+func TestIndexingEligible_Phase1IsAlwaysEligible(t *testing.T) {
+	comp := &Component{logger: slog.Default()}
+
+	cases := []struct {
+		name    string
+		profile string // "" => no profile triple at all
+	}{
+		{"content", vocabulary.IndexingProfileContent},
+		{"control", vocabulary.IndexingProfileControl},
+		{"signal", vocabulary.IndexingProfileSignal},
+		{"trace", vocabulary.IndexingProfileTrace},
+		{"absent", ""},
+		{"unrecognized", "garbage"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			es := &graph.EntityState{ID: "c360.platform.test.sys.widget.001"}
+			if tc.profile != "" {
+				es.Triples = []message.Triple{{
+					Subject:   es.ID,
+					Predicate: vocabulary.EntityIndexingProfile,
+					Object:    tc.profile,
+				}}
+			}
+			assert.True(t, comp.indexingEligible(es),
+				"Phase 1 lenient: profile %q must remain eligible for embedding", tc.profile)
+		})
+	}
+}

--- a/processor/graph-ingest/cas_integration_test.go
+++ b/processor/graph-ingest/cas_integration_test.go
@@ -116,8 +116,8 @@ func TestIntegration_ConcurrentAddTriple(t *testing.T) {
 		require.NoError(t, json.Unmarshal(entry.Value, &finalEntity))
 
 		expectedTripleCount := 1 + concurrency
-		assert.Equal(t, expectedTripleCount, len(finalEntity.Triples),
-			"entity should have all triples (no lost updates)")
+		assert.Equal(t, expectedTripleCount, nonProfileTripleCount(&finalEntity),
+			"entity should have all triples (no lost updates); ADR-054 profile stamp excluded")
 
 		// Verify version was incremented correctly
 		assert.GreaterOrEqual(t, finalEntity.Version, uint64(concurrency+1),
@@ -339,7 +339,7 @@ func TestIntegration_CASRetryBehavior(t *testing.T) {
 		var finalEntity graph.EntityState
 		require.NoError(t, json.Unmarshal(entry.Value, &finalEntity))
 
-		assert.Equal(t, concurrency, len(finalEntity.Triples),
-			"all triples should be present")
+		assert.Equal(t, concurrency, nonProfileTripleCount(&finalEntity),
+			"all triples should be present; ADR-054 profile stamp excluded")
 	})
 }

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -23,6 +23,8 @@ import (
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/cache"
 	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/pkg/types"
+	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -37,6 +39,9 @@ var (
 var (
 	metricsOnce         sync.Once
 	entitiesUpdatedOnce prometheus.Counter
+
+	indexingProfileOnce       sync.Once
+	indexingProfileDefaultVec *prometheus.CounterVec
 )
 
 // entityIDRegex validates entity ID format: org.platform.domain.system.type.instance
@@ -62,6 +67,31 @@ func getEntitiesUpdatedMetric(registry *metric.MetricsRegistry) prometheus.Count
 		}
 	})
 	return entitiesUpdatedOnce
+}
+
+// getIndexingProfileDefaultMetric returns the process-wide counter that fires
+// whenever graph-ingest falls back to the indexing-profile floor at entity
+// creation — i.e. neither a Graphable IndexingProfiler nor a mutation-envelope
+// indexing_profile field declared a profile (ADR-054 §5). Labeled by
+// message_type so operators can see WHICH producers omit a declaration: a new
+// "content" type nobody declared would otherwise silently default to "control"
+// and never be embedded. message_type is the low-cardinality registry key; the
+// full entity subject is intentionally NOT a label (cardinality bomb).
+func getIndexingProfileDefaultMetric(registry *metric.MetricsRegistry) *prometheus.CounterVec {
+	indexingProfileOnce.Do(func() {
+		indexingProfileDefaultVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "graph_ingest",
+			Name:      "indexing_profile_default_total",
+			Help:      "Entities whose indexing profile fell back to the default floor (no producer declaration)",
+		}, []string{"message_type"})
+		if registry != nil {
+			_ = registry.RegisterCounterVec("graph-ingest", "indexing_profile_default_total", indexingProfileDefaultVec)
+		} else {
+			_ = prometheus.DefaultRegisterer.Register(indexingProfileDefaultVec)
+		}
+	})
+	return indexingProfileDefaultVec
 }
 
 // Config holds configuration for graph-ingest component
@@ -195,8 +225,9 @@ type Component struct {
 	lastActivity      atomic.Value // stores time.Time
 
 	// Prometheus metrics (for e2e test compatibility with datamanager metrics)
-	entitiesUpdated prometheus.Counter
-	metricsRegistry *metric.MetricsRegistry
+	entitiesUpdated        prometheus.Counter
+	indexingProfileDefault *prometheus.CounterVec
+	metricsRegistry        *metric.MetricsRegistry
 
 	// Lifecycle reporting
 	lifecycleReporter component.LifecycleReporter
@@ -234,13 +265,14 @@ func CreateGraphIngest(rawConfig json.RawMessage, deps component.Dependencies) (
 
 	// Create component
 	comp := &Component{
-		name:            "graph-ingest",
-		config:          config,
-		decoder:         message.NewDecoder(deps.PayloadRegistry),
-		natsClient:      natsClient,
-		logger:          logger,
-		entitiesUpdated: getEntitiesUpdatedMetric(deps.MetricsRegistry),
-		metricsRegistry: deps.MetricsRegistry,
+		name:                   "graph-ingest",
+		config:                 config,
+		decoder:                message.NewDecoder(deps.PayloadRegistry),
+		natsClient:             natsClient,
+		logger:                 logger,
+		entitiesUpdated:        getEntitiesUpdatedMetric(deps.MetricsRegistry),
+		indexingProfileDefault: getIndexingProfileDefaultMetric(deps.MetricsRegistry),
+		metricsRegistry:        deps.MetricsRegistry,
 	}
 
 	// Initialize last activity
@@ -886,7 +918,120 @@ func (c *Component) extractEntityFromMessage(msg *message.BaseMessage) (*graph.E
 		Version:     1,
 	}
 
+	// ADR-054 channel (a): a Graphable payload MAY also declare its indexing
+	// profile via the optional IndexingProfiler interface. Stamp it explicitly
+	// here so it's present on entity.Triples by the time MergeEntity reaches
+	// its create seam; absence (or an invalid value) falls through to the
+	// fallback floor there.
+	if profiler, ok := payload.(message.IndexingProfiler); ok {
+		stampExplicitIndexingProfile(entity, profiler.IndexingProfile())
+	}
+
 	return entity, nil
+}
+
+// removeIndexingProfileTriples drops every entity.indexing.profile triple from
+// the entity (the single-valued predicate is replace-on-write, never appended).
+func removeIndexingProfileTriples(entity *graph.EntityState) {
+	filtered := entity.Triples[:0]
+	for _, t := range entity.Triples {
+		if t.Predicate != vocabulary.EntityIndexingProfile {
+			filtered = append(filtered, t)
+		}
+	}
+	entity.Triples = filtered
+}
+
+// appendIndexingProfileTriple appends one entity.indexing.profile triple.
+// Callers are responsible for having removed any prior value first.
+func appendIndexingProfileTriple(entity *graph.EntityState, profile string) {
+	entity.Triples = append(entity.Triples, message.Triple{
+		Subject:    entity.ID,
+		Predicate:  vocabulary.EntityIndexingProfile,
+		Object:     profile,
+		Source:     "graph-ingest-indexing-profile",
+		Timestamp:  time.Now(),
+		Confidence: 1.0,
+	})
+}
+
+// stampExplicitIndexingProfile sets entity.indexing.profile to an explicitly
+// declared profile (replace-on-write, single-valued). Empty or unrecognized
+// values are ignored — the entity then falls through to the fallback floor at
+// its create seam rather than failing (lenient Phase 1 semantics). Used by the
+// Graphable IndexingProfiler channel (extractEntityFromMessage) and the
+// mutation-envelope channel (handleEntityCreateWithTriples).
+func stampExplicitIndexingProfile(entity *graph.EntityState, profile string) {
+	if entity == nil || !vocabulary.IsValidIndexingProfile(profile) {
+		return
+	}
+	removeIndexingProfileTriples(entity)
+	appendIndexingProfileTriple(entity, profile)
+}
+
+// reconcileIndexingProfile is the entity-CREATION-seam stamp (ADR-054 §5). It
+// runs at every place an entity is born — createEntity, MergeEntity's
+// first-write branch, and the stub→real upgrade in MergeEntity's merge branch —
+// and never on a plain update of an already-profiled entity, so a profile is
+// immutable once set. It enforces the single-valued invariant and applies the
+// fallback floor when nothing was declared:
+//
+//   - ≥1 profile triple present (an explicit declaration was stamped upstream,
+//     or a real producer is upgrading a profile-less stub): keep the FIRST and
+//     drop any duplicates. No floor, no metric.
+//   - 0 profile triples present: derive the floor (deriveIndexingProfileFloor),
+//     append it, and increment indexing_profile_default_total{message_type}.
+func (c *Component) reconcileIndexingProfile(entity *graph.EntityState) {
+	if entity == nil {
+		return
+	}
+	kept := false
+	filtered := entity.Triples[:0]
+	for _, t := range entity.Triples {
+		if t.Predicate == vocabulary.EntityIndexingProfile {
+			if kept {
+				continue // single-valued: drop duplicates, keep the first
+			}
+			kept = true
+		}
+		filtered = append(filtered, t)
+	}
+	entity.Triples = filtered
+	if kept {
+		return
+	}
+	appendIndexingProfileTriple(entity, deriveIndexingProfileFloor(entity))
+	if c.indexingProfileDefault != nil {
+		c.indexingProfileDefault.WithLabelValues(indexingProfileMetricLabel(entity.MessageType)).Inc()
+	}
+}
+
+// deriveIndexingProfileFloor returns the floor profile for an entity that
+// declared none (ADR-054 channel c). Phase 1 is deliberately minimal: it
+// defaults to "control" — the policy "fail toward keeping the substrate
+// reachable" — for every undeclared entity. The EntityID type-segment
+// (parsed below) and the MessageType registry are the seam where Phase 2 adds
+// type-aware floors (telemetry → signal, audit → trace); until then the
+// default-fallback metric surfaces which producers still need a declaration.
+func deriveIndexingProfileFloor(entity *graph.EntityState) string {
+	// Phase 2 hook: branch on parsed.Type / entity.MessageType here. Parsing is
+	// kept now so the floor is computed from the same inputs Phase 2 will use.
+	if _, err := types.ParseEntityID(entity.ID); err != nil {
+		return vocabulary.IndexingProfileControl
+	}
+	return vocabulary.IndexingProfileControl
+}
+
+// indexingProfileMetricLabel renders a message.Type as a stable, low-cardinality
+// metric label, or "unknown" for any incomplete Type. The IsValid guard (all
+// three of Domain/Category/Version present) prevents a partial Type from
+// producing a non-semantic label like ".widget.v1" or "test.widget." — a
+// malformed producer surfaces as "unknown" rather than a junk label key.
+func indexingProfileMetricLabel(mt message.Type) string {
+	if !mt.IsValid() {
+		return "unknown"
+	}
+	return mt.Key()
 }
 
 // ============================================================================
@@ -990,6 +1135,9 @@ func (c *Component) MergeEntity(ctx context.Context, entity *graph.EntityState) 
 			if len(hierarchyTriples) > 0 {
 				entity.Triples = append(entity.Triples, hierarchyTriples...)
 			}
+			// ADR-054: first write is entity birth — stamp the profile
+			// (explicit-if-declared via IndexingProfiler, else floor).
+			c.reconcileIndexingProfile(entity)
 			data, err := json.Marshal(entity)
 			if err == nil {
 				bytesWritten = len(data)
@@ -1008,6 +1156,12 @@ func (c *Component) MergeEntity(ctx context.Context, entity *graph.EntityState) 
 		if entity.StorageRef != nil {
 			existing.StorageRef = entity.StorageRef
 		}
+		// ADR-054: a real producer merging into a profile-less referential-
+		// integrity stub is that entity's true birth — reconcile stamps the
+		// profile (kept from the incoming declaration, else floor). For an
+		// already-profiled entity this is a no-op (keep-first preserves the
+		// create-time value), so a re-arrival never re-profiles.
+		c.reconcileIndexingProfile(&existing)
 		existing.Version++
 		existing.UpdatedAt = time.Now()
 		data, err := json.Marshal(&existing)
@@ -1087,6 +1241,11 @@ func (c *Component) createEntity(ctx context.Context, entity *graph.EntityState,
 			entity.Triples = append(entity.Triples, hierarchyTriples...)
 		}
 	}
+
+	// ADR-054: stamp the indexing profile at the creation seam — keeps an
+	// explicit declaration (envelope/Graphable, already on entity.Triples) and
+	// otherwise applies the fallback floor + default metric.
+	c.reconcileIndexingProfile(entity)
 
 	// Serialize entity (now includes hierarchy triples if enabled)
 	data, err := json.Marshal(entity)

--- a/processor/graph-ingest/entity_mutation_integration_test.go
+++ b/processor/graph-ingest/entity_mutation_integration_test.go
@@ -143,7 +143,9 @@ func TestIntegration_HandleEntityCreateWithTriples_PreservesProvenance(t *testin
 	var resp graph.CreateEntityWithTriplesResponse
 	require.NoError(t, json.Unmarshal(respBytes, &resp))
 	require.True(t, resp.Success, "create_with_triples on fresh ID should succeed; err=%q", resp.Error)
-	assert.Equal(t, 2, resp.TriplesAdded)
+	// 2 request triples + the ADR-054 entity.indexing.profile stamp applied at
+	// the create seam. TriplesAdded reflects the total stored on the entity.
+	assert.Equal(t, 3, resp.TriplesAdded)
 
 	// Verify provenance survived to storage — the load-bearing reason
 	// for the *_with_triples variant over a plain add_batch upsert.
@@ -155,7 +157,7 @@ func TestIntegration_HandleEntityCreateWithTriples_PreservesProvenance(t *testin
 	assert.NotNil(t, stored.StorageRef, "StorageRef preserved")
 	assert.Equal(t, "test-bucket", stored.StorageRef.StorageInstance)
 	assert.Equal(t, "test/key", stored.StorageRef.Key)
-	assert.Len(t, stored.Triples, 2, "req.Triples should REPLACE Entity.Triples, not append")
+	assert.Equal(t, 2, nonProfileTripleCount(&stored), "req.Triples should REPLACE Entity.Triples, not append (ADR-054 profile stamp excluded)")
 	for _, tr := range stored.Triples {
 		assert.NotEqual(t, "should.be.replaced", tr.Predicate,
 			"distractor predicate from req.Entity.Triples must not survive when req.Triples is non-empty")

--- a/processor/graph-ingest/hierarchy_sync_integration_test.go
+++ b/processor/graph-ingest/hierarchy_sync_integration_test.go
@@ -461,8 +461,9 @@ func TestComponent_SynchronousHierarchy_DisabledConfig(t *testing.T) {
 		err = json.Unmarshal(entry.Value, &storedEntity)
 		require.NoError(t, err)
 
-		// Should only have the base triple (no hierarchy)
-		assert.Equal(t, 1, len(storedEntity.Triples),
+		// Should only have the base triple (no hierarchy); the ADR-054
+		// indexing-profile stamp is framework metadata, not a hierarchy triple.
+		assert.Equal(t, 1, nonProfileTripleCount(&storedEntity),
 			"disabled hierarchy should not add any triples")
 
 		for _, triple := range storedEntity.Triples {

--- a/processor/graph-ingest/indexing_profile_test.go
+++ b/processor/graph-ingest/indexing_profile_test.go
@@ -1,0 +1,397 @@
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/vocabulary"
+)
+
+// ADR-054 Phase 1: graph-ingest stamps a single-valued entity.indexing.profile
+// triple at every entity-CREATION seam (create_with_triples, Graphable arrival,
+// stub→real upgrade), resolving via precedence envelope > Graphable
+// IndexingProfiler > fallback floor (default control). It is NEVER stamped on a
+// plain update (immutable after create) except via the explicit envelope
+// override on update_with_triples. These tests drive the production mutation
+// handlers and create seams against the mock KV bucket.
+
+const testProfileEntityID = "c360.platform.test.sys.widget.001"
+
+func testWidgetMessageType() message.Type {
+	return message.Type{Domain: "test", Category: "widget", Version: "v1"}
+}
+
+func storedEntity(t *testing.T, comp *Component, id string) *graph.EntityState {
+	t.Helper()
+	entry, err := comp.entityBucket.Get(context.Background(), id)
+	require.NoError(t, err, "entity %s should be stored", id)
+	var es graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &es))
+	return &es
+}
+
+// profileValues returns every entity.indexing.profile object on the entity, so
+// tests can assert the single-valued invariant (len must be exactly 1).
+func profileValues(es *graph.EntityState) []string {
+	var out []string
+	for _, tr := range es.Triples {
+		if tr.Predicate == vocabulary.EntityIndexingProfile {
+			if s, ok := tr.Object.(string); ok {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}
+
+func userTriple(predicate string, object any) message.Triple {
+	return message.Triple{Subject: testProfileEntityID, Predicate: predicate, Object: object, Timestamp: time.Now()}
+}
+
+// --- create_with_triples (production handler) ---
+
+func TestIndexingProfile_CreateWithTriples_DefaultsToControlFloor(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity:  &graph.EntityState{ID: testProfileEntityID, MessageType: testWidgetMessageType()},
+		Triples: []message.Triple{userTriple("robotics.status.armed", true)},
+	}
+	data, _ := json.Marshal(req)
+
+	respData, err := comp.handleEntityCreateWithTriples(context.Background(), data)
+	require.NoError(t, err)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "create should succeed: %s", resp.Error)
+
+	es := storedEntity(t, comp, testProfileEntityID)
+	assert.Equal(t, []string{vocabulary.IndexingProfileControl}, profileValues(es),
+		"undeclared entity must default to exactly one control-floor profile")
+}
+
+func TestIndexingProfile_CreateWithTriples_EnvelopeProfileWins(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity:          &graph.EntityState{ID: testProfileEntityID, MessageType: testWidgetMessageType()},
+		Triples:         []message.Triple{userTriple("doc.body.text", "hello")},
+		IndexingProfile: vocabulary.IndexingProfileContent,
+	}
+	data, _ := json.Marshal(req)
+
+	respData, err := comp.handleEntityCreateWithTriples(context.Background(), data)
+	require.NoError(t, err)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "create should succeed: %s", resp.Error)
+
+	es := storedEntity(t, comp, testProfileEntityID)
+	assert.Equal(t, []string{vocabulary.IndexingProfileContent}, profileValues(es),
+		"explicit envelope profile must win over the floor")
+}
+
+func TestIndexingProfile_CreateWithTriples_InvalidEnvelopeFallsToFloor(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity:          &graph.EntityState{ID: testProfileEntityID, MessageType: testWidgetMessageType()},
+		IndexingProfile: "not-a-real-profile",
+	}
+	data, _ := json.Marshal(req)
+
+	respData, err := comp.handleEntityCreateWithTriples(context.Background(), data)
+	require.NoError(t, err)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "create should succeed (invalid profile is lenient, not fatal): %s", resp.Error)
+
+	es := storedEntity(t, comp, testProfileEntityID)
+	assert.Equal(t, []string{vocabulary.IndexingProfileControl}, profileValues(es),
+		"an invalid envelope profile is treated as absent and falls to the floor")
+}
+
+// --- update_with_triples explicit override ---
+
+func TestIndexingProfile_UpdateOverride_ReplacesProfile(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	// Create with the control floor.
+	createReq := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: testProfileEntityID, MessageType: testWidgetMessageType()},
+	}
+	createData, _ := json.Marshal(createReq)
+	_, err := comp.handleEntityCreateWithTriples(ctx, createData)
+	require.NoError(t, err)
+	require.Equal(t, []string{vocabulary.IndexingProfileControl}, profileValues(storedEntity(t, comp, testProfileEntityID)))
+
+	// Override to content via the explicit envelope channel.
+	updateReq := graph.UpdateEntityWithTriplesRequest{
+		Entity:          &graph.EntityState{ID: testProfileEntityID},
+		IndexingProfile: vocabulary.IndexingProfileContent,
+	}
+	updateData, _ := json.Marshal(updateReq)
+	respData, err := comp.handleEntityUpdateWithTriples(ctx, updateData)
+	require.NoError(t, err)
+	var resp graph.MutationResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "update override should succeed: %s", resp.Error)
+
+	es := storedEntity(t, comp, testProfileEntityID)
+	assert.Equal(t, []string{vocabulary.IndexingProfileContent}, profileValues(es),
+		"explicit override must REPLACE the profile (single-valued, no accumulation)")
+}
+
+func TestIndexingProfile_UpdateOverride_InvalidRejected(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	createReq := graph.CreateEntityWithTriplesRequest{Entity: &graph.EntityState{ID: testProfileEntityID, MessageType: testWidgetMessageType()}}
+	createData, _ := json.Marshal(createReq)
+	_, err := comp.handleEntityCreateWithTriples(ctx, createData)
+	require.NoError(t, err)
+
+	updateReq := graph.UpdateEntityWithTriplesRequest{
+		Entity:          &graph.EntityState{ID: testProfileEntityID},
+		IndexingProfile: "bogus",
+	}
+	updateData, _ := json.Marshal(updateReq)
+	respData, err := comp.handleEntityUpdateWithTriples(ctx, updateData)
+	require.NoError(t, err)
+	var resp graph.MutationResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	assert.False(t, resp.Success, "an invalid explicit override must be rejected (not silently dropped)")
+}
+
+// --- Graphable arrival (channel a) via MergeEntity ---
+
+type testGraphablePayload struct {
+	id      string
+	triples []message.Triple
+	profile string // empty => does not implement a meaningful profile
+}
+
+func (p *testGraphablePayload) EntityID() string             { return p.id }
+func (p *testGraphablePayload) Triples() []message.Triple    { return p.triples }
+func (p *testGraphablePayload) IndexingProfile() string      { return p.profile }
+func (p *testGraphablePayload) Validate() error              { return nil }
+func (p *testGraphablePayload) MarshalJSON() ([]byte, error) { return []byte("{}"), nil }
+func (p *testGraphablePayload) UnmarshalJSON([]byte) error   { return nil }
+func (p *testGraphablePayload) Schema() message.Type {
+	return message.Type{Domain: "test", Category: "graphable", Version: "v1"}
+}
+
+func TestIndexingProfile_Graphable_IndexingProfilerWins(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	payload := &testGraphablePayload{
+		id:      testProfileEntityID,
+		triples: []message.Triple{userTriple("doc.body.text", "content here")},
+		profile: vocabulary.IndexingProfileContent,
+	}
+	msg := message.NewBaseMessage(payload.Schema(), payload, "test")
+
+	entity, err := comp.extractEntityFromMessage(msg)
+	require.NoError(t, err)
+	require.NoError(t, comp.MergeEntity(context.Background(), entity))
+
+	es := storedEntity(t, comp, testProfileEntityID)
+	assert.Equal(t, []string{vocabulary.IndexingProfileContent}, profileValues(es),
+		"a Graphable IndexingProfiler declaration must be stamped at the merge create seam")
+}
+
+func TestIndexingProfile_Graphable_NoProfilerFallsToFloor(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	// Payload returns "" from IndexingProfile() => treated as absent.
+	payload := &testGraphablePayload{id: testProfileEntityID, triples: []message.Triple{userTriple("k", "v")}}
+	msg := message.NewBaseMessage(payload.Schema(), payload, "test")
+
+	entity, err := comp.extractEntityFromMessage(msg)
+	require.NoError(t, err)
+	require.NoError(t, comp.MergeEntity(context.Background(), entity))
+
+	es := storedEntity(t, comp, testProfileEntityID)
+	assert.Equal(t, []string{vocabulary.IndexingProfileControl}, profileValues(es),
+		"a Graphable that declares no profile falls to the control floor")
+}
+
+// --- single-valued invariant: re-arrival must not accumulate or re-profile ---
+
+func TestIndexingProfile_ReArrival_DoesNotAccumulateOrReProfile(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	// First arrival: declares content.
+	first := &testGraphablePayload{id: testProfileEntityID, triples: []message.Triple{userTriple("doc.body.text", "v1")}, profile: vocabulary.IndexingProfileContent}
+	e1, err := comp.extractEntityFromMessage(message.NewBaseMessage(first.Schema(), first, "test"))
+	require.NoError(t, err)
+	require.NoError(t, comp.MergeEntity(ctx, e1))
+
+	// Second arrival of the SAME entity declaring a DIFFERENT profile (trace):
+	// the profile is immutable after create, so this must NOT re-profile and
+	// must NOT add a second profile triple.
+	second := &testGraphablePayload{id: testProfileEntityID, triples: []message.Triple{userTriple("doc.body.text", "v2")}, profile: vocabulary.IndexingProfileTrace}
+	e2, err := comp.extractEntityFromMessage(message.NewBaseMessage(second.Schema(), second, "test"))
+	require.NoError(t, err)
+	require.NoError(t, comp.MergeEntity(ctx, e2))
+
+	es := storedEntity(t, comp, testProfileEntityID)
+	assert.Equal(t, []string{vocabulary.IndexingProfileContent}, profileValues(es),
+		"re-arrival must keep the create-time profile and stay single-valued")
+}
+
+// --- stub → real upgrade ---
+
+func TestIndexingProfile_StubUpgrade_StampsOnRealArrival(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	// Simulate a referential-integrity stub already present (no profile).
+	stub := &graph.EntityState{
+		ID:      testProfileEntityID,
+		Version: 1,
+		Triples: []message.Triple{{Subject: testProfileEntityID, Predicate: "core.identity.stub", Object: true, Timestamp: time.Now()}},
+	}
+	stubData, _ := json.Marshal(stub)
+	_, err := comp.entityBucket.Put(ctx, testProfileEntityID, stubData)
+	require.NoError(t, err)
+	require.Empty(t, profileValues(storedEntity(t, comp, testProfileEntityID)), "stub starts with no profile")
+
+	// Real producer arrives and merges into the stub: this is the entity's true
+	// birth, so the profile must be stamped now (floor, since none declared).
+	realArrival := &testGraphablePayload{id: testProfileEntityID, triples: []message.Triple{userTriple("doc.body.text", "real")}}
+	entity, err := comp.extractEntityFromMessage(message.NewBaseMessage(realArrival.Schema(), realArrival, "test"))
+	require.NoError(t, err)
+	require.NoError(t, comp.MergeEntity(ctx, entity))
+
+	es := storedEntity(t, comp, testProfileEntityID)
+	assert.Equal(t, []string{vocabulary.IndexingProfileControl}, profileValues(es),
+		"a real producer merging into a profile-less stub must stamp the profile")
+}
+
+// --- ADR-054 §1 invariant: the structural graph is NEVER gated by profile ---
+
+func TestIndexingProfile_StructuralGraphNeverGated_TraceEntityStaysQueryable(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity:          &graph.EntityState{ID: testProfileEntityID, MessageType: testWidgetMessageType()},
+		Triples:         []message.Triple{userTriple("audit.event.kind", "trace-line")},
+		IndexingProfile: vocabulary.IndexingProfileTrace,
+	}
+	createData, _ := json.Marshal(req)
+	_, err := comp.handleEntityCreateWithTriples(ctx, createData)
+	require.NoError(t, err)
+
+	// A 'trace' entity is excluded from EMBEDDING (Phase 3) but must remain
+	// fully queryable/traversable: the query path must not filter on profile.
+	queryReq, _ := json.Marshal(map[string]any{"prefix": "c360", "limit": 10})
+	respData, err := comp.handleQueryPrefixNATS(ctx, queryReq)
+	require.NoError(t, err)
+	var resp struct {
+		Entities []graph.EntityState `json:"entities"`
+	}
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.Len(t, resp.Entities, 1, "trace entity must still be returned by structural query")
+	assert.Equal(t, []string{vocabulary.IndexingProfileTrace}, profileValues(&resp.Entities[0]))
+}
+
+// --- helper-level unit tests ---
+
+func TestReconcileIndexingProfile_DedupesToFirst(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	es := &graph.EntityState{ID: testProfileEntityID, MessageType: testWidgetMessageType()}
+	es.Triples = []message.Triple{
+		{Subject: es.ID, Predicate: vocabulary.EntityIndexingProfile, Object: vocabulary.IndexingProfileContent},
+		userTriple("k", "v"),
+		{Subject: es.ID, Predicate: vocabulary.EntityIndexingProfile, Object: vocabulary.IndexingProfileTrace},
+	}
+	comp.reconcileIndexingProfile(es)
+	assert.Equal(t, []string{vocabulary.IndexingProfileContent}, profileValues(es),
+		"reconcile keeps the FIRST profile and drops duplicates (single-valued)")
+}
+
+// TestIndexingProfile_FloorMetric_FiresExactlyOnFloor proves the operator-
+// load-bearing indexing_profile_default_total counter increments EXACTLY when
+// the floor is applied (no producer declaration) and NOT when a profile is
+// declared or on a re-arrival of an already-profiled entity. The Phase-3
+// strict-exclusion flip is gated on a cost-ledger built from this counter, so
+// an unconditional or mislabeled increment must fail a test, not ship silently.
+func TestIndexingProfile_FloorMetric_FiresExactlyOnFloor(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	// A unique message_type isolates this counter label from any other test
+	// touching the process-global vec.
+	mt := message.Type{Domain: "metrictest", Category: "widget", Version: "v1"}
+	counter := getIndexingProfileDefaultMetric(nil).WithLabelValues(mt.Key())
+
+	create := func(id, profile string) {
+		req := graph.CreateEntityWithTriplesRequest{
+			Entity:          &graph.EntityState{ID: id, MessageType: mt},
+			IndexingProfile: profile,
+		}
+		data, _ := json.Marshal(req)
+		_, err := comp.handleEntityCreateWithTriples(ctx, data)
+		require.NoError(t, err)
+	}
+
+	// (a) No declaration → floor applied → metric increments by exactly 1.
+	before := testutil.ToFloat64(counter)
+	create("c360.platform.metrictest.sys.widget.001", "")
+	assert.InDelta(t, before+1, testutil.ToFloat64(counter), 0.0001,
+		"floor fallback must increment indexing_profile_default_total exactly once")
+
+	// (b) Explicit declaration → floor NOT applied → metric unchanged.
+	before = testutil.ToFloat64(counter)
+	create("c360.platform.metrictest.sys.widget.002", vocabulary.IndexingProfileContent)
+	assert.InDelta(t, before, testutil.ToFloat64(counter), 0.0001,
+		"a declared profile must NOT increment the default-floor metric")
+
+	// (c) Re-arrival of the floor-stamped entity (001) → profile already present
+	//     → keep-first, no floor → metric unchanged (immutability is not a default).
+	before = testutil.ToFloat64(counter)
+	payload := &testGraphablePayload{id: "c360.platform.metrictest.sys.widget.001", triples: []message.Triple{userTriple("k", "v2")}}
+	entity, err := comp.extractEntityFromMessage(message.NewBaseMessage(mt, payload, "test"))
+	require.NoError(t, err)
+	require.NoError(t, comp.MergeEntity(ctx, entity))
+	assert.InDelta(t, before, testutil.ToFloat64(counter), 0.0001,
+		"re-arrival of an already-profiled entity must NOT increment the default-floor metric")
+}
+
+func TestIndexingProfileMetricLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		mt   message.Type
+		want string
+	}{
+		{"zero", message.Type{}, "unknown"},
+		{"missing-domain", message.Type{Category: "widget", Version: "v1"}, "unknown"},
+		{"missing-version", message.Type{Domain: "test", Category: "widget"}, "unknown"},
+		{"complete", message.Type{Domain: "test", Category: "widget", Version: "v1"}, "test.widget.v1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, indexingProfileMetricLabel(tc.mt))
+		})
+	}
+}
+
+func TestStampExplicitIndexingProfile_IgnoresInvalid(t *testing.T) {
+	es := &graph.EntityState{ID: testProfileEntityID}
+	stampExplicitIndexingProfile(es, "garbage")
+	assert.Empty(t, profileValues(es), "invalid explicit profile must be ignored (fall through to floor)")
+
+	stampExplicitIndexingProfile(es, vocabulary.IndexingProfileSignal)
+	assert.Equal(t, []string{vocabulary.IndexingProfileSignal}, profileValues(es))
+
+	// Re-stamping replaces (single-valued).
+	stampExplicitIndexingProfile(es, vocabulary.IndexingProfileContent)
+	assert.Equal(t, []string{vocabulary.IndexingProfileContent}, profileValues(es))
+}

--- a/processor/graph-ingest/indexing_profile_test.go
+++ b/processor/graph-ingest/indexing_profile_test.go
@@ -38,6 +38,20 @@ func storedEntity(t *testing.T, comp *Component, id string) *graph.EntityState {
 	return &es
 }
 
+// nonProfileTripleCount counts an entity's triples EXCLUDING the framework-
+// stamped entity.indexing.profile (ADR-054). Count-based assertions that
+// predate the stamp use it so they stay robust to the reserved triple instead
+// of hard-coding "+1". Shared with the integration tests (same package).
+func nonProfileTripleCount(es *graph.EntityState) int {
+	n := 0
+	for _, tr := range es.Triples {
+		if tr.Predicate != vocabulary.EntityIndexingProfile {
+			n++
+		}
+	}
+	return n
+}
+
 // profileValues returns every entity.indexing.profile object on the entity, so
 // tests can assert the single-valued invariant (len must be exactly 1).
 func profileValues(es *graph.EntityState) []string {
@@ -75,6 +89,7 @@ func TestIndexingProfile_CreateWithTriples_DefaultsToControlFloor(t *testing.T) 
 	es := storedEntity(t, comp, testProfileEntityID)
 	assert.Equal(t, []string{vocabulary.IndexingProfileControl}, profileValues(es),
 		"undeclared entity must default to exactly one control-floor profile")
+	assert.Equal(t, 1, nonProfileTripleCount(es), "the stamp must not displace the user triple")
 }
 
 func TestIndexingProfile_CreateWithTriples_EnvelopeProfileWins(t *testing.T) {

--- a/processor/graph-ingest/merge_entity_integration_test.go
+++ b/processor/graph-ingest/merge_entity_integration_test.go
@@ -58,7 +58,7 @@ func TestIntegration_MergeEntity_FirstWriteCreatesAtomically(t *testing.T) {
 	stored, _, err := c.fetchEntityState(ctx, entityID)
 	require.NoError(t, err)
 	require.NotNil(t, stored)
-	assert.Len(t, stored.Triples, 1)
+	assert.Equal(t, 1, nonProfileTripleCount(stored), "ADR-054 profile stamp excluded from the seed-triple count")
 	assert.Equal(t, "merge.kind", stored.Triples[0].Predicate)
 	assert.Equal(t, "alpha", stored.Triples[0].Object)
 }

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -12,6 +12,7 @@ import (
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/retry"
+	"github.com/c360studio/semstreams/vocabulary"
 )
 
 const (
@@ -369,6 +370,11 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 		req.Entity.Triples = req.Triples
 	}
 
+	// ADR-054 channel (b): stamp an explicitly declared indexing profile from
+	// the mutation envelope (highest precedence). Empty/invalid is ignored and
+	// the createEntity seam applies the fallback floor instead.
+	stampExplicitIndexingProfile(req.Entity, req.IndexingProfile)
+
 	if err := c.CreateEntityStrict(ctx, req.Entity); err != nil {
 		if errors.Is(err, natsclient.ErrKVKeyExists) {
 			return marshalCreateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeEntityExists,
@@ -499,6 +505,28 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	if req.Entity == nil {
 		return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeInvalidRequest,
 			"entity cannot be nil")
+	}
+
+	// ADR-054 §5: the indexing profile is immutable after creation EXCEPT via
+	// an explicit envelope override here. Inject it as a replace-by-predicate
+	// delta (RemoveTriples drops the prior value; AddTriples/MergeTriples adds
+	// the new one) so BOTH the CAS and UpdateWithRetry sub-paths apply it and
+	// the single-valued predicate stays unique. A later triple.add by a
+	// different writer must NOT change the profile — only this envelope does.
+	if req.IndexingProfile != "" {
+		if !vocabulary.IsValidIndexingProfile(req.IndexingProfile) {
+			return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeInvalidRequest,
+				fmt.Sprintf("invalid indexing_profile %q (want content|control|signal|trace)", req.IndexingProfile))
+		}
+		req.RemoveTriples = append(req.RemoveTriples, vocabulary.EntityIndexingProfile)
+		req.AddTriples = append(req.AddTriples, message.Triple{
+			Subject:    req.Entity.ID,
+			Predicate:  vocabulary.EntityIndexingProfile,
+			Object:     req.IndexingProfile,
+			Source:     "graph-ingest-indexing-profile",
+			Timestamp:  time.Now(),
+			Confidence: 1.0,
+		})
 	}
 
 	// ADR-049: CAS-on-condition path. Non-zero ExpectedRevision means

--- a/processor/graph-ingest/query_test.go
+++ b/processor/graph-ingest/query_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
@@ -972,8 +973,14 @@ func TestComponent_HandleQueryPrefix_ReturnsFullEntities(t *testing.T) {
 
 	// Verify it's a full entity with all data
 	assert.Equal(t, entity.ID, resp.Entities[0].ID)
-	assert.Len(t, resp.Entities[0].Triples, 2, "should have 2 triples")
+	// 2 user triples + the ADR-054 entity.indexing.profile stamp (appended at
+	// creation). No producer declared a profile here, so it defaults to the
+	// control floor; the user triples keep their original leading order.
+	assert.Len(t, resp.Entities[0].Triples, 3, "should have 2 user triples + the indexing-profile stamp")
 	assert.Equal(t, "robotics.status.armed", resp.Entities[0].Triples[0].Predicate)
+	profile, ok := resp.Entities[0].GetPropertyValue(vocabulary.EntityIndexingProfile)
+	assert.True(t, ok, "created entity should carry entity.indexing.profile")
+	assert.Equal(t, vocabulary.IndexingProfileControl, profile)
 }
 
 func TestComponent_HandleQueryPrefix_InvalidRequest(t *testing.T) {

--- a/vocabulary/indexing_profile_test.go
+++ b/vocabulary/indexing_profile_test.go
@@ -1,0 +1,32 @@
+package vocabulary
+
+import "testing"
+
+func TestIsValidIndexingProfile(t *testing.T) {
+	valid := []string{
+		IndexingProfileContent,
+		IndexingProfileControl,
+		IndexingProfileSignal,
+		IndexingProfileTrace,
+	}
+	for _, v := range valid {
+		if !IsValidIndexingProfile(v) {
+			t.Errorf("IsValidIndexingProfile(%q) = false, want true", v)
+		}
+	}
+
+	invalid := []string{"", "Content", "CONTROL", "audit", "lifecycle", " content", "content "}
+	for _, v := range invalid {
+		if IsValidIndexingProfile(v) {
+			t.Errorf("IsValidIndexingProfile(%q) = true, want false", v)
+		}
+	}
+}
+
+// The reserved predicate must stay on the documented dotted path so consumers
+// and the grammar-collision audit agree on it.
+func TestEntityIndexingProfilePredicate(t *testing.T) {
+	if EntityIndexingProfile != "entity.indexing.profile" {
+		t.Errorf("EntityIndexingProfile = %q, want entity.indexing.profile", EntityIndexingProfile)
+	}
+}

--- a/vocabulary/predicates.go
+++ b/vocabulary/predicates.go
@@ -290,6 +290,47 @@ const (
 	HierarchyTypeContains = "hierarchy.type.contains"
 )
 
+// Indexing Eligibility (ADR-054)
+// The producer's hint for which semantic substrates should index an entity.
+// Single-valued, stamped once at entity creation by graph-ingest. Gates ONLY
+// the embedding/community/search substrates — never the structural graph,
+// which stays queryable/traversable regardless of profile.
+
+// EntityIndexingProfile is the reserved single-valued predicate carrying an
+// entity's indexing profile (one of the IndexingProfile* values below).
+// Stamped at entity creation (replace-on-write); read by indexing consumers.
+const EntityIndexingProfile = "entity.indexing.profile"
+
+const (
+	// IndexingProfileContent is the retrieval corpus (embed yes, community yes):
+	// memory, documents, research facts, lessons, prose-bearing entities.
+	IndexingProfileContent = "content"
+	// IndexingProfileControl is low-cardinality lifecycle/harness/run machinery
+	// (embed yes — the cardinality guard excludes high-fan-out control types —
+	// community yes). The substrate stays semantically reachable. Default floor.
+	IndexingProfileControl = "control"
+	// IndexingProfileSignal is telemetry readings (embed only summarized
+	// rollups, community aggregate only). Raw readings stay graph-visible, not
+	// embedded.
+	IndexingProfileSignal = "signal"
+	// IndexingProfileTrace is mechanically generated audit/trace entities (embed
+	// no, community no). Fully graph-visible and queryable, but never embedded.
+	IndexingProfileTrace = "trace"
+)
+
+// IsValidIndexingProfile reports whether s is one of the four recognized
+// indexing profiles. Empty and unrecognized strings are invalid (callers
+// treat invalid as "absent" and fall through to the fallback floor rather
+// than failing, per ADR-054 lenient Phase 1 semantics).
+func IsValidIndexingProfile(s string) bool {
+	switch s {
+	case IndexingProfileContent, IndexingProfileControl, IndexingProfileSignal, IndexingProfileTrace:
+		return true
+	default:
+		return false
+	}
+}
+
 // NOTE: The predicates in this file are EXAMPLES for demonstration purposes.
 // SemStreams is a framework - applications should define their own domain-specific
 // vocabulary in their own packages and register predicates using the vocabulary registry.


### PR DESCRIPTION
ADR-054 Phase 1. **"Graph visibility is storage; indexing is policy."**

## What & why

`ENTITY_STATES` is overloaded: the embedding + community-clustering substrates enumerate the whole bucket and try to index *everything*, including telemetry/control/trace entities with no useful prose (the anomaly-storm root cause). This adds a producer **indexing profile** so those substrates can later index by policy.

graph-ingest now stamps a single-valued reserved triple **`entity.indexing.profile`** (`content|control|signal|trace`) at every entity-creation seam.

**Phase 1 is LENIENT** — consumers read the profile but **never exclude** (zero behavior change). The strict Phase-3 flip is cost-ledger-gated and out of scope here.

## Declaration channels (precedence)

1. **Mutation envelope** — `indexing_profile` on `create_with_triples` / `update_with_triples` (channel b)
2. **Graphable `IndexingProfiler`** interface (channel a)
3. **Fallback floor** → default `control` + `indexing_profile_default_total{message_type}` metric (channel c)

## Forward-compatible with ADR-055 (the design crux)

ADR-054's *"stamp the profile at entity birth"* and ADR-055's *"entity birth requires a semantic envelope"* are the **same seam** — the profile rides the envelope. So the profile is stamped only where an envelope-bearing entity is born (Graphable arrival, `create_with_triples`, stub→real upgrade). The `triple.add`/`add_batch` **auto-vivify paths that ADR-055 deletes are deliberately NOT stamp points** — no profile param is threaded through them, so nothing here unwinds when 055 lands. The envelope field is likewise omitted from `AddTripleRequest`/`AddTriplesBatchRequest` (born-dead post-055).

## Invariants

- **Single-valued** — `reconcileIndexingProfile` keep-first dedup; explicit stamp is replace-on-write.
- **Immutable after create** — except the explicit `update_with_triples` override; a later `triple.add` by a different writer never re-profiles.
- **Stubs deferred** — referential-integrity stubs carry no profile; the real producer's arrival stamps (handled in MergeEntity's merge branch).
- **Structural graph NEVER gated by profile** — query paths unchanged; locked by a trace-entity-stays-queryable test (ADR §1).

## Consumers (provable no-op)

`graph-embedding.indexingEligible` always returns true; the `graph-clustering` observation never filters/mutates and sits off the LPA hot path (gh#238 RED LINE). **No skip toggle ships** — per `gate-silent-exclusion-flips-with-cost-ledger`, strict exclusion must not be a bare flip.

## Tests

Drive the **production mutation handlers + MergeEntity** against mock KV: floor / envelope-wins / Graphable / invalid-lenient / override-replace / override-invalid-rejected / stub-upgrade / re-arrival-no-accumulate; the single-valued + immutability invariants; the structural-query invariant; consumer leniency (every profile stays eligible); and the default-floor **metric fires exactly on floor, not on declared/re-arrival**.

## Review

Pre-merge adversarial 5-lens review (invariants, CAS-callback + slice-aliasing, ADR-055 forward-compat, consumer/cost-ledger, metric/test-rigor): **0 blocking/high**. The 3 concurrency/aliasing findings were verified-and-rejected (single-valued invariant holds across all CAS-retry paths; residual is pre-existing hierarchy behavior). Folded 3 confirmed metric-test-hardening findings (assert the metric delta; `IsValid` label guard for partial MessageTypes; re-arrival no-fire assertion).

## Gates (all green locally)

`go build` · `go test -race ./...` (123 pkgs) · `task lint` (revive) · `gofmt` · `go vet -tags=integration/live_llm` · `task schema:generate` no-drift · contract tests.

Not Phase 1: strict flip, producer migrations (Phase 2), backfill, skipped-entity metrics (Phase 3). ADR-054 §4/§5 amended with the envelope-seam + 055 forward-compat framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)