### PR TITLE
feat(graph-ingest): ADR-054 Phase 2a — type-aware indexing-profile registry floor

### DIFF
--- a/docs/adr/054-semantic-indexing-eligibility.md
+++ b/docs/adr/054-semantic-indexing-eligibility.md
@@ -183,8 +183,14 @@ returns.)
   set). See §5 forward-compatibility note.
 
 - **(c) graph-ingest fallback** — when neither (a) nor (b) supplies a profile,
-  graph-ingest derives a *floor* from `message.Type` (registry) and the parsed
-  `EntityID` type segment, defaulting to `control`, and records a metric (§5).
+  graph-ingest derives a *floor* from `message.Type` via the framework registry
+  seed (`processor/graph-ingest/indexing_profile_registry.go`, Phase 2): a
+  `message.Type.Key()` → profile map that classifies the high-cardinality trace
+  storm (`agentic.request`/`response`/`tool_*`/`context_event`,
+  `research.*_output`) OUT and obvious machinery as `control`/`signal`/`content`.
+  A type absent from the seed falls to `control` (fail-safe toward reachable)
+  AND fires `indexing_profile_default_total{message_type}` (§5) — that metric now
+  means "an unclassified registry GAP", not merely "no explicit declaration".
   Consumers **never** re-derive profile from ID deny-lists.
 
 ### 5. graph-ingest enforcement mechanics
@@ -348,8 +354,22 @@ never discovered in production. If we cannot produce the ledger, we do not flip.
 2. **This ADR, phase 1:** add `IndexingProfiler` interface + mutation-envelope
    field + graph-ingest stamp (replace-semantics) + defaulting metric.
    Consumers honor profile in **lenient** mode (absent = legacy-embed).
-3. **This ADR, phase 2:** migrate `research-graph-llmwrap` + `agentic-memory` to
-   declare `content`; seed the framework registry; backfill existing entities.
+3. **This ADR, phase 2:** seed the framework registry (the type-aware floor,
+   §4c) + migrate the `content` producers. Phase 2a (shipped) is the registry
+   seed. Scoping corrected the producer list:
+   - **`research-graph-llmwrap` needs NO change** — it stamps orchestration
+     triples (`control`) on a *pre-existing, already-profiled* loop-execution
+     entity; its `SearchResult` lives only in `AGENT_LOOPS` KV, never as a graph
+     entity. It is not a `content` producer.
+   - **`agentic-memory`** (the real `content` producer: lessons + layer
+     checkpoints) writes via the `triple.add` **auto-vivify** path, which is
+     exactly the envelope-less entity creation **ADR-055** removes. Its `content`
+     declaration is therefore deferred and designed *jointly* with the ADR-055
+     `add_triples`→`create_with_triples` migration (one rework, not two).
+   - **Backfill** of pre-Phase-1 entities is **deferred to Phase 3** as a
+     strict-flip precondition (there is no existing KV-sweep pattern;
+     stamp-on-touch + the gap metric give Phase-3 planning visibility without a
+     sweep).
 4. **This ADR, phase 3 — gated, not a flag flip.** Flip `strict_indexing_profile`
    ONLY after ALL of the following hold (the cost-ledger / measured-migration
    gate). This phase MUST NOT ship as a bare config toggle:

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -23,7 +23,6 @@ import (
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/cache"
 	"github.com/c360studio/semstreams/pkg/errs"
-	"github.com/c360studio/semstreams/pkg/types"
 	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/prometheus/client_golang/prometheus"
@@ -83,7 +82,7 @@ func getIndexingProfileDefaultMetric(registry *metric.MetricsRegistry) *promethe
 			Namespace: "semstreams",
 			Subsystem: "graph_ingest",
 			Name:      "indexing_profile_default_total",
-			Help:      "Entities whose indexing profile fell back to the default floor (no producer declaration)",
+			Help:      "Entities whose message type was unclassified (no producer declaration AND not in the indexing-profile registry) and defaulted to control — a registry gap",
 		}, []string{"message_type"})
 		if registry != nil {
 			_ = registry.RegisterCounterVec("graph-ingest", "indexing_profile_default_total", indexingProfileDefaultVec)
@@ -979,8 +978,10 @@ func stampExplicitIndexingProfile(entity *graph.EntityState, profile string) {
 //   - ≥1 profile triple present (an explicit declaration was stamped upstream,
 //     or a real producer is upgrading a profile-less stub): keep the FIRST and
 //     drop any duplicates. No floor, no metric.
-//   - 0 profile triples present: derive the floor (deriveIndexingProfileFloor),
-//     append it, and increment indexing_profile_default_total{message_type}.
+//   - 0 profile triples present: apply the registry floor
+//     (indexingProfileFloorFor) and append it; increment
+//     indexing_profile_default_total{message_type} ONLY when the type was not in
+//     the registry (an unclassified gap, not a deliberate registered floor).
 func (c *Component) reconcileIndexingProfile(entity *graph.EntityState) {
 	if entity == nil {
 		return
@@ -1000,26 +1001,16 @@ func (c *Component) reconcileIndexingProfile(entity *graph.EntityState) {
 	if kept {
 		return
 	}
-	appendIndexingProfileTriple(entity, deriveIndexingProfileFloor(entity))
-	if c.indexingProfileDefault != nil {
+	// No explicit declaration → apply the registry floor (ADR-054 channel c).
+	// The default-fallback metric fires ONLY on a registry MISS — a type that is
+	// neither producer-declared nor classified in the seed and silently took the
+	// control default. A registered floor (e.g. agentic.request → trace) is a
+	// deliberate classification, not an operator gap.
+	profile, registered := indexingProfileFloorFor(entity.MessageType)
+	appendIndexingProfileTriple(entity, profile)
+	if !registered && c.indexingProfileDefault != nil {
 		c.indexingProfileDefault.WithLabelValues(indexingProfileMetricLabel(entity.MessageType)).Inc()
 	}
-}
-
-// deriveIndexingProfileFloor returns the floor profile for an entity that
-// declared none (ADR-054 channel c). Phase 1 is deliberately minimal: it
-// defaults to "control" — the policy "fail toward keeping the substrate
-// reachable" — for every undeclared entity. The EntityID type-segment
-// (parsed below) and the MessageType registry are the seam where Phase 2 adds
-// type-aware floors (telemetry → signal, audit → trace); until then the
-// default-fallback metric surfaces which producers still need a declaration.
-func deriveIndexingProfileFloor(entity *graph.EntityState) string {
-	// Phase 2 hook: branch on parsed.Type / entity.MessageType here. Parsing is
-	// kept now so the floor is computed from the same inputs Phase 2 will use.
-	if _, err := types.ParseEntityID(entity.ID); err != nil {
-		return vocabulary.IndexingProfileControl
-	}
-	return vocabulary.IndexingProfileControl
 }
 
 // indexingProfileMetricLabel renders a message.Type as a stable, low-cardinality

--- a/processor/graph-ingest/indexing_profile_registry.go
+++ b/processor/graph-ingest/indexing_profile_registry.go
@@ -1,0 +1,78 @@
+package graphingest
+
+import (
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/vocabulary"
+)
+
+// indexingProfileDefaults is the ADR-054 Phase 2 framework-registry seed: it
+// maps a message type (message.Type.Key() == "domain.category.version") to the
+// indexing profile graph-ingest stamps when a producer of that type declares
+// none (channel c, the fallback floor). A type that is absent here falls
+// through to control (fail-safe toward keeping the substrate reachable) and the
+// indexing_profile_default_total{message_type} metric fires — that metric now
+// means "a registry GAP", the operator signal ADR-054 §5 calls for.
+//
+// Deliberately keyed by STRING, not by importing the agentic/research/
+// operating-model domain packages into the generic graph-ingest layer (which
+// imports none of them today). A key that drifts — e.g. a future schema-version
+// bump — simply degrades to the control default and is surfaced by the metric:
+// graceful, self-revealing, never a hard failure. The keys were verified
+// against the domain constants (agentic.SchemaVersion / research.SchemaVersion /
+// operating_model.SchemaVersion are all "v1").
+//
+// These values are LENIENT in Phase 1/2 — no consumer acts on the profile yet.
+// They shape the metric/dry-run data and the Phase-3 strict-exclusion policy.
+// "content" entries are NOT exhaustive (most content is producer-declared via
+// the envelope/IndexingProfiler channels); this seed is about classifying the
+// high-cardinality trace storm OUT and the obvious low-cardinality machinery as
+// control, so Phase 3 has sane defaults for the undeclared tail.
+var indexingProfileDefaults = map[string]string{
+	// content — prose-bearing retrieval corpus (embed yes, community yes).
+	"agentic.user_message.v1":            vocabulary.IndexingProfileContent,
+	"agentic.user_response.v1":           vocabulary.IndexingProfileContent,
+	"research.result.v1":                 vocabulary.IndexingProfileContent,
+	"operating_model.layer_approved.v1":  vocabulary.IndexingProfileContent,
+	"operating_model.profile_context.v1": vocabulary.IndexingProfileContent,
+
+	// control — low-cardinality lifecycle/harness/run machinery (embed yes).
+	// (control is also the unlisted default; listing these documents intent and
+	// distinguishes "deliberately control" from "unclassified gap" in review.)
+	"agentic.task.v1":              vocabulary.IndexingProfileControl,
+	"agentic.loop_created.v1":      vocabulary.IndexingProfileControl,
+	"agentic.loop_completed.v1":    vocabulary.IndexingProfileControl,
+	"agentic.loop_failed.v1":       vocabulary.IndexingProfileControl,
+	"agentic.loop_cancelled.v1":    vocabulary.IndexingProfileControl,
+	"agentic.approval_pending.v1":  vocabulary.IndexingProfileControl,
+	"agentic.approval_response.v1": vocabulary.IndexingProfileControl,
+	"research.intent.v1":           vocabulary.IndexingProfileControl,
+
+	// signal — control/telemetry signals (embed only summarized rollups).
+	"agentic.signal.v1":         vocabulary.IndexingProfileSignal,
+	"agentic.signal_message.v1": vocabulary.IndexingProfileSignal,
+
+	// trace — high-cardinality, mechanically generated execution detail (the
+	// storm; embed no, community no). This is the load-bearing classification:
+	// these default OUT of embedding once Phase 3 flips, without each producer
+	// needing to declare.
+	"agentic.request.v1":            vocabulary.IndexingProfileTrace,
+	"agentic.response.v1":           vocabulary.IndexingProfileTrace,
+	"agentic.tool_call.v1":          vocabulary.IndexingProfileTrace,
+	"agentic.tool_result.v1":        vocabulary.IndexingProfileTrace,
+	"agentic.context_event.v1":      vocabulary.IndexingProfileTrace,
+	"research.route_decision.v1":    vocabulary.IndexingProfileTrace,
+	"research.classifier_output.v1": vocabulary.IndexingProfileTrace,
+	"research.execution_output.v1":  vocabulary.IndexingProfileTrace,
+	"research.assessment_output.v1": vocabulary.IndexingProfileTrace,
+}
+
+// indexingProfileFloorFor returns the registry default profile for a message
+// type and whether the type was found. A miss returns (control, false) — the
+// fail-safe floor plus the signal that this type is an unclassified registry
+// gap the default-fallback metric should surface (ADR-054 §5).
+func indexingProfileFloorFor(mt message.Type) (profile string, registered bool) {
+	if p, ok := indexingProfileDefaults[mt.Key()]; ok {
+		return p, true
+	}
+	return vocabulary.IndexingProfileControl, false
+}

--- a/processor/graph-ingest/indexing_profile_registry_test.go
+++ b/processor/graph-ingest/indexing_profile_registry_test.go
@@ -1,0 +1,158 @@
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/agentic"
+	operatingmodel "github.com/c360studio/semstreams/agentic/operating-model"
+	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/vocabulary"
+)
+
+// ADR-054 Phase 2: deriveIndexingProfileFloor consults a type-aware registry
+// (indexingProfileDefaults) instead of always returning control. The floor is
+// still LENIENT (no consumer acts on it); these tests lock the registry values
+// + the metric-on-miss semantics.
+
+func TestIndexingProfileRegistry_AllValuesValid(t *testing.T) {
+	require.NotEmpty(t, indexingProfileDefaults, "registry seed must not be empty")
+	for key, value := range indexingProfileDefaults {
+		assert.True(t, vocabulary.IsValidIndexingProfile(value),
+			"registry value for %q must be a valid indexing profile, got %q", key, value)
+	}
+}
+
+func TestIndexingProfileFloorFor(t *testing.T) {
+	cases := []struct {
+		mt         message.Type
+		want       string
+		registered bool
+	}{
+		{message.Type{Domain: "agentic", Category: "request", Version: "v1"}, vocabulary.IndexingProfileTrace, true},
+		{message.Type{Domain: "agentic", Category: "tool_result", Version: "v1"}, vocabulary.IndexingProfileTrace, true},
+		{message.Type{Domain: "agentic", Category: "user_message", Version: "v1"}, vocabulary.IndexingProfileContent, true},
+		{message.Type{Domain: "agentic", Category: "loop_completed", Version: "v1"}, vocabulary.IndexingProfileControl, true},
+		{message.Type{Domain: "agentic", Category: "signal", Version: "v1"}, vocabulary.IndexingProfileSignal, true},
+		{message.Type{Domain: "research", Category: "result", Version: "v1"}, vocabulary.IndexingProfileContent, true},
+		{message.Type{Domain: "operating_model", Category: "layer_approved", Version: "v1"}, vocabulary.IndexingProfileContent, true},
+		// Misses fall to the control floor (fail-safe) and report registered=false.
+		{message.Type{Domain: "unknown", Category: "thing", Version: "v1"}, vocabulary.IndexingProfileControl, false},
+		{message.Type{}, vocabulary.IndexingProfileControl, false},
+	}
+	for _, tc := range cases {
+		profile, registered := indexingProfileFloorFor(tc.mt)
+		assert.Equal(t, tc.want, profile, "profile for %q", tc.mt.Key())
+		assert.Equal(t, tc.registered, registered, "registered for %q", tc.mt.Key())
+	}
+}
+
+// TestIndexingProfileRegistry_KeysTrackDomainVersionConstants is the
+// version-drift guard for the string-keyed registry. The production registry
+// can't import the domain packages (that would couple the generic graph-ingest
+// layer to agentic/research/operating-model), but this TEST can — so it rebuilds
+// canonical keys from the domain Domain/Category/SchemaVersion constants and
+// asserts the registry contains them. If a domain bumps SchemaVersion (v1→v2)
+// without updating the registry, the rebuilt key won't be found and this fails
+// at CI time — catching the silent control-default drift the metric would
+// otherwise only surface in production.
+func TestIndexingProfileRegistry_KeysTrackDomainVersionConstants(t *testing.T) {
+	key := func(domain, category, version string) string {
+		return message.Type{Domain: domain, Category: category, Version: version}.Key()
+	}
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{key(agentic.Domain, agentic.CategoryRequest, agentic.SchemaVersion), vocabulary.IndexingProfileTrace},
+		{key(agentic.Domain, agentic.CategoryToolResult, agentic.SchemaVersion), vocabulary.IndexingProfileTrace},
+		{key(agentic.Domain, agentic.CategoryUserMessage, agentic.SchemaVersion), vocabulary.IndexingProfileContent},
+		{key(agentic.Domain, agentic.CategoryLoopCompleted, agentic.SchemaVersion), vocabulary.IndexingProfileControl},
+		{key(agentic.Domain, agentic.CategorySignal, agentic.SchemaVersion), vocabulary.IndexingProfileSignal},
+		{key(research.Domain, research.CategoryResult, research.SchemaVersion), vocabulary.IndexingProfileContent},
+		{key(research.Domain, research.CategoryRouteDecision, research.SchemaVersion), vocabulary.IndexingProfileTrace},
+		{key(operatingmodel.Domain, operatingmodel.CategoryLayerApproved, operatingmodel.SchemaVersion), vocabulary.IndexingProfileContent},
+		{key(operatingmodel.Domain, operatingmodel.CategoryProfileContext, operatingmodel.SchemaVersion), vocabulary.IndexingProfileContent},
+	}
+	for _, tc := range cases {
+		got, ok := indexingProfileDefaults[tc.key]
+		assert.True(t, ok, "registry must contain key %q (rebuilt from domain constants — drift if missing)", tc.key)
+		assert.Equal(t, tc.want, got, "profile for %q", tc.key)
+	}
+}
+
+// TestIndexingProfile_AddTripleAutoVivify_DoesNotStamp locks the ADR-055
+// forward-compat decision: the triple.add auto-vivify path (which ADR-055 will
+// DELETE) is NOT a stamp seam. An entity born via triple.add carries no profile
+// triple — lenient consumers index it, and the floor metric never fires because
+// reconcileIndexingProfile is not on this path. If a future change wires
+// stamping into the auto-vivify branch (rather than removing it per ADR-055),
+// this fails.
+func TestIndexingProfile_AddTripleAutoVivify_DoesNotStamp(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	const id = "c360.platform.test.sys.widget.autovivify1"
+	tr := message.Triple{Subject: id, Predicate: "evidence.note", Object: "v", Confidence: 1.0}
+	require.NoError(t, comp.AddTriple(ctx, tr))
+
+	es := storedEntity(t, comp, id)
+	assert.Empty(t, profileValues(es),
+		"triple.add auto-vivify must NOT stamp an indexing profile (ADR-055 deletes that create path)")
+	assert.Equal(t, 1, nonProfileTripleCount(es), "the entity holds exactly the one added triple")
+}
+
+// End-to-end through the production create handler: a REGISTERED type floors to
+// its registry profile (here trace, not the old always-control) and, because a
+// registered floor is a deliberate classification rather than an operator gap,
+// the default-fallback metric must NOT fire.
+func TestIndexingProfile_RegistryFloor_RegisteredTypeNoMetric(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	mt := message.Type{Domain: "agentic", Category: "request", Version: "v1"}
+	counter := getIndexingProfileDefaultMetric(nil).WithLabelValues(mt.Key())
+	before := testutil.ToFloat64(counter)
+
+	const id = "c360.platform.agentic.sys.request.001"
+	req := graph.CreateEntityWithTriplesRequest{Entity: &graph.EntityState{ID: id, MessageType: mt}}
+	data, _ := json.Marshal(req)
+	_, err := comp.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, err)
+
+	es := storedEntity(t, comp, id)
+	assert.Equal(t, []string{vocabulary.IndexingProfileTrace}, profileValues(es),
+		"a registered type must floor to its registry profile (trace), not the old always-control")
+	assert.InDelta(t, before, testutil.ToFloat64(counter), 0.0001,
+		"a registered floor is NOT a registry gap → the default metric must NOT fire")
+}
+
+// The complement: an UNREGISTERED type floors to control AND fires the gap
+// metric (the ADR §5 "registry gap is visible" signal).
+func TestIndexingProfile_RegistryFloor_UnregisteredFiresMetric(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	mt := message.Type{Domain: "gapdomain", Category: "gapcat", Version: "v1"}
+	counter := getIndexingProfileDefaultMetric(nil).WithLabelValues(mt.Key())
+	before := testutil.ToFloat64(counter)
+
+	const id = "c360.platform.gapdomain.sys.gapcat.001"
+	req := graph.CreateEntityWithTriplesRequest{Entity: &graph.EntityState{ID: id, MessageType: mt}}
+	data, _ := json.Marshal(req)
+	_, err := comp.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, err)
+
+	es := storedEntity(t, comp, id)
+	assert.Equal(t, []string{vocabulary.IndexingProfileControl}, profileValues(es),
+		"an unregistered type floors to control (fail-safe)")
+	assert.InDelta(t, before+1, testutil.ToFloat64(counter), 0.0001,
+		"an unregistered floor IS a gap → the default metric must fire exactly once")
+}


### PR DESCRIPTION
ADR-054 **Phase 2a**. Makes the fallback floor type-aware. Still **LENIENT** — zero behavior change.

## What & why

Phase 1's floor was always `control`. Phase 2a seeds a **framework registry** (`processor/graph-ingest/indexing_profile_registry.go`) — a `message.Type.Key()` → profile map (ADR-054 channel c) that:
- classifies the **high-cardinality trace storm** OUT: `agentic.request`/`response`/`tool_call`/`tool_result`/`context_event`, `research.route_decision`/`classifier_output`/`execution_output`/`assessment_output` → **`trace`**
- tags obvious machinery: lifecycle/loop/approval/`research.intent` → `control`; `agentic.signal*` → `signal`; `agentic.user_message`/`user_response`, `research.result`, `operating_model.layer_approved`/`profile_context` → `content`

So Phase 3 gets sane defaults for the undeclared tail without every producer declaring.

## Metric refinement

`indexing_profile_default_total{message_type}` now fires **only on a registry MISS** — a truly unclassified type that silently took the `control` default. That's the operator "registry gap" signal ADR-054 §5 calls for, instead of firing on every floor application (a registered `agentic.request → trace` floor is a deliberate classification, not a gap).

## Decoupling + drift guard

The registry uses **string keys**, not domain-package imports, so the generic graph-ingest layer stays decoupled from `agentic`/`research`/`operating-model`. A **test** rebuilds canonical keys from those packages' `Domain`/`Category`/`SchemaVersion` constants and asserts the registry tracks them — so a future `SchemaVersion` bump that would silently drift a key to `control` **fails at CI time**.

## ADR scoping correction (in the doc)

The scoping pass corrected the ADR's Phase 2 producer list:
- **research-graph-llmwrap → no change.** It stamps `control` orchestration triples on an *already-profiled* loop-execution entity; `SearchResult` is KV-only, never a graph entity.
- **agentic-memory `content` → deferred to joint ADR-055.** It writes lessons/layers via the `triple.add` **auto-vivify** path — exactly the envelope-less creation ADR-055 removes — so its `content` declaration is the same rework as the `add_triples`→`create_with_triples` migration. Done together, not twice.
- **Backfill → deferred to Phase 3** (no sweep pattern; stamp-on-touch + the gap metric give Phase-3 visibility).

A test also **locks the ADR-055 forward-compat decision**: `triple.add` auto-vivify is *not* a stamp seam (entity born profile-less; metric never fires).

## Review

Pre-merge adversarial 3-lens review (metric-semantics, registry-values, design-coupling): **5 findings, all folded** — docstring + Help-text accuracy, the version-drift guard test, and the auto-vivify no-stamp lock.

## Gates (all green)

`go test -race ./...` (123 pkgs) · `task lint` · `gofmt` · schema no-drift · contract · **full `go test -tags=integration ./...` sweep (124 ok, 0 fail)** — the integration *tests* this time, not just `vet` (the #254 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)