### PR TITLE
fix(graph-ingest): preserve stored entity envelope on bare update_with_triples

### DIFF
--- a/graph/mutation_requests.go
+++ b/graph/mutation_requests.go
@@ -69,6 +69,14 @@ type CreateEntityWithTriplesRequest struct {
 // semantics: re-read + re-apply the delta on each retry until the
 // CAS succeeds or the retry budget is exhausted. This is correct for
 // the "facts accumulate" model the graph layer was built around.
+//
+// Entity metadata (MessageType / Version / StorageRef) is PRESERVE-WHEN-ZERO:
+// to change one, send a non-zero value (it wins); leaving it zero keeps the
+// stored value, so a bare Entity{ID} delta does not erase the envelope (see
+// graphingest.preserveStoredEntityMetadata). Corollary: there is no way to
+// deliberately CLEAR a metadata field through this lane (gh#260) — that is the
+// desired invariant for MessageType/Version; StorageRef is the only plausible
+// future clear case. Triples ARE clearable: name predicates in RemoveTriples.
 type UpdateEntityWithTriplesRequest struct {
 	Entity *EntityState `json:"entity"`
 	// AddTriples are applied with REPLACE-by-(subject,predicate) semantics

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -477,6 +477,16 @@ func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte
 // StorageRef on the request as "keep the stored value". Callers that genuinely
 // set these (e.g. pkg/lifecycle.Manager, which passes an explicit MessageType and
 // Version+1 on every transition) are unaffected — their non-zero values win.
+//
+// KNOWN LIMITATION (gh#260): this overloads the zero value to mean "preserve",
+// so there is NO way to deliberately CLEAR these fields to their zero value
+// through update_with_triples — sending zero means "leave as-is". That is the
+// desired invariant for MessageType (the envelope must persist — ADR-055) and
+// Version (monotonic). The only field with a plausible deliberate-clear case is
+// StorageRef (e.g. its offloaded content was GC'd); no caller needs it today. If
+// one ever does, add an explicit signal (a ClearFields list / pointer-optional
+// fields) rather than un-overloading zero. (Triples are unaffected — clear a
+// predicate via UpdateEntityWithTriplesRequest.RemoveTriples.)
 func preserveStoredEntityMetadata(newEntity, stored *graph.EntityState) {
 	if newEntity == nil || stored == nil {
 		return

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -462,12 +462,44 @@ func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte
 	})
 }
 
+// preserveStoredEntityMetadata backfills entity metadata the caller left unset
+// from the stored state, so a triple-delta update never silently erases the
+// entity envelope.
+//
+// update_with_triples writes req.Entity wholesale (only its triples are
+// replaced by the merge). A caller that sends a bare EntityState{ID} — carrying
+// just the triple delta, which is a natural shape for "append/replace some
+// predicates" — would otherwise CLOBBER the stored semantic envelope:
+// MessageType (the ADR-055 provenance + ADR-054 indexing-profile registry key)
+// would reset to the zero Type, Version would reset to 0 (breaking
+// optimistic-concurrency monotonicity), and StorageRef (offloaded ContentStorable
+// content) would be dropped. Treat a zero MessageType / zero Version / nil
+// StorageRef on the request as "keep the stored value". Callers that genuinely
+// set these (e.g. pkg/lifecycle.Manager, which passes an explicit MessageType and
+// Version+1 on every transition) are unaffected — their non-zero values win.
+func preserveStoredEntityMetadata(newEntity, stored *graph.EntityState) {
+	if newEntity == nil || stored == nil {
+		return
+	}
+	if newEntity.MessageType == (message.Type{}) {
+		newEntity.MessageType = stored.MessageType
+	}
+	if newEntity.Version == 0 {
+		newEntity.Version = stored.Version
+	}
+	if newEntity.StorageRef == nil {
+		newEntity.StorageRef = stored.StorageRef
+	}
+}
+
 // handleEntityUpdateWithTriples applies a triple-set delta to an
 // existing entity: appends AddTriples, removes triples whose Predicate
 // is named in RemoveTriples, and writes the result via CAS-with-retry.
-// Entity metadata (MessageType, Version, StorageRef) from the request
-// flows through verbatim; the merged triple set replaces what's in
-// req.Entity.Triples.
+// Entity metadata (MessageType, Version, StorageRef) from the request is
+// written, but any field the caller leaves at its zero value is preserved
+// from the stored entity (see preserveStoredEntityMetadata) so a bare
+// triple-delta update does not erase the entity envelope. The merged triple
+// set replaces what's in req.Entity.Triples.
 //
 // PR-B: the delta apply runs inside natsclient.KVStore.UpdateWithRetry,
 // so concurrent writes that bump the entity revision between read
@@ -604,6 +636,7 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		// caller-owned pointer (see PR-A go-reviewer F2 finding).
 		newEntity := *req.Entity
 		newEntity.Triples = merged
+		preserveStoredEntityMetadata(&newEntity, &currentState)
 
 		return json.Marshal(&newEntity)
 	})
@@ -702,6 +735,7 @@ func (c *Component) handleEntityUpdateWithTriplesCAS(ctx context.Context, req *g
 	// Shallow-copy so we don't mutate the caller-owned pointer.
 	newEntity := *req.Entity
 	newEntity.Triples = merged
+	preserveStoredEntityMetadata(&newEntity, current)
 
 	// Single-pass CAS via the existing updateEntityAtRevision
 	// primitive. A concurrent writer between our read and write

--- a/processor/graph-ingest/update_preserve_metadata_test.go
+++ b/processor/graph-ingest/update_preserve_metadata_test.go
@@ -1,0 +1,115 @@
+package graphingest
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// update_with_triples writes req.Entity wholesale; a caller sending a bare
+// EntityState{ID} (just a triple delta) must NOT clobber the stored envelope.
+// These tests lock preserveStoredEntityMetadata: MessageType (ADR-055 provenance
+// + ADR-054 registry key), Version (optimistic-concurrency), and StorageRef
+// (offloaded content) survive a metadata-less update, while an explicitly-set
+// field on the request still wins (the pkg/lifecycle.Manager contract).
+
+func bornEntity(t *testing.T, comp *Component, id string) (message.Type, *message.StorageReference, uint64) {
+	t.Helper()
+	mt := message.Type{Domain: "lifecycle", Category: "harness", Version: "v1"}
+	sref := &message.StorageReference{StorageInstance: "objectstore", Key: "blobs/1", ContentType: "application/json"}
+	createReq := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{
+			ID:          id,
+			MessageType: mt,
+			Version:     1,
+			StorageRef:  sref,
+		},
+		Triples: []message.Triple{{Subject: id, Predicate: "harness.phase", Object: "active", Confidence: 1.0}},
+	}
+	data, err := json.Marshal(createReq)
+	require.NoError(t, err)
+	respBytes, err := comp.handleEntityCreateWithTriples(t.Context(), data)
+	require.NoError(t, err)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	require.True(t, resp.Success, "create failed: %s", resp.Error)
+	return mt, sref, resp.KVRevision
+}
+
+func applyUpdate(t *testing.T, comp *Component, req graph.UpdateEntityWithTriplesRequest) {
+	t.Helper()
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	respBytes, err := comp.handleEntityUpdateWithTriples(t.Context(), data)
+	require.NoError(t, err)
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	require.Truef(t, resp.Success, "update failed (code=%q): %s", resp.ErrorCode, resp.Error)
+}
+
+func TestUpdateWithTriples_BareEntityPreservesEnvelope_NonCAS(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	const id = "c360.platform.lifecycle.sys.mission.001"
+
+	mt, sref, _ := bornEntity(t, comp, id)
+
+	// Bare update (no MessageType/Version/StorageRef), ExpectedRevision=0 → the
+	// UpdateWithRetry merge path.
+	applyUpdate(t, comp, graph.UpdateEntityWithTriplesRequest{
+		Entity:     &graph.EntityState{ID: id},
+		AddTriples: []message.Triple{{Subject: id, Predicate: "harness.phase", Object: "done", Confidence: 1.0}},
+	})
+
+	es := storedEntity(t, comp, id)
+	assert.Equal(t, mt, es.MessageType, "MessageType envelope must survive a bare-entity update")
+	require.NotNil(t, es.StorageRef, "StorageRef must survive a bare-entity update")
+	assert.Equal(t, sref.Key, es.StorageRef.Key)
+	assert.EqualValues(t, 1, es.Version, "Version must not reset to 0 on a bare-entity update")
+	// The triple delta still applied (replace-by-predicate).
+	phase, _ := es.GetPropertyValue("harness.phase")
+	assert.Equal(t, "done", phase)
+}
+
+func TestUpdateWithTriples_BareEntityPreservesEnvelope_CAS(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	const id = "c360.platform.lifecycle.sys.mission.002"
+
+	mt, sref, rev := bornEntity(t, comp, id)
+
+	// Bare update on the CAS-on-condition path (ExpectedRevision > 0).
+	applyUpdate(t, comp, graph.UpdateEntityWithTriplesRequest{
+		Entity:           &graph.EntityState{ID: id},
+		AddTriples:       []message.Triple{{Subject: id, Predicate: "harness.phase", Object: "done", Confidence: 1.0}},
+		ExpectedRevision: rev,
+	})
+
+	es := storedEntity(t, comp, id)
+	assert.Equal(t, mt, es.MessageType, "CAS path must also preserve the MessageType envelope")
+	require.NotNil(t, es.StorageRef)
+	assert.Equal(t, sref.Key, es.StorageRef.Key)
+	assert.EqualValues(t, 1, es.Version)
+}
+
+func TestUpdateWithTriples_ExplicitMetadataStillWins(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	const id = "c360.platform.lifecycle.sys.mission.003"
+
+	bornEntity(t, comp, id)
+
+	// A caller that DOES set MessageType + Version (the pkg/lifecycle.Manager
+	// shape) must have its explicit values written, not the stored ones —
+	// otherwise the preserve logic would block legitimate envelope transitions.
+	newType := message.Type{Domain: "lifecycle", Category: "harness", Version: "v2"}
+	applyUpdate(t, comp, graph.UpdateEntityWithTriplesRequest{
+		Entity:     &graph.EntityState{ID: id, MessageType: newType, Version: 7},
+		AddTriples: []message.Triple{{Subject: id, Predicate: "harness.phase", Object: "done", Confidence: 1.0}},
+	})
+
+	es := storedEntity(t, comp, id)
+	assert.Equal(t, newType, es.MessageType, "an explicitly-set MessageType must win over the stored one")
+	assert.EqualValues(t, 7, es.Version, "an explicitly-set Version must win")
+}


### PR DESCRIPTION
## Problem

`handleEntityUpdateWithTriples` (both the `UpdateWithRetry` and CAS paths) wrote `req.Entity` **wholesale** — only its triples were replaced by the merge. A caller sending a bare `EntityState{ID}` (carrying just a triple delta — the natural shape for "append/replace some predicates") therefore **clobbered the stored envelope**:

- `MessageType` reset to the zero `Type` — erasing the **ADR-055** semantic envelope and the **ADR-054** indexing-profile registry key (`mt.Key()`)
- `Version` reset to `0` — breaking optimistic-concurrency monotonicity
- `StorageRef` dropped — losing offloaded `ContentStorable` content

`pkg/lifecycle.Manager` only escapes this by hand-rolling an explicit `MessageType` + `Version+1` on every transition. Any other caller sending a metadata-less delta silently loses the envelope.

## Fix

`preserveStoredEntityMetadata` backfills `MessageType`/`Version`/`StorageRef` from the stored state whenever the request leaves them at their **zero value** ("zero means keep"). Explicitly-set values still win, so lifecycle and any future envelope-transition caller are unaffected. Removes the bare-`EntityState` footgun class for **every** `update_with_triples` caller.

## Tests

`update_preserve_metadata_test.go` drives the real handlers via the mock-KV harness:
- non-CAS bare update preserves `MessageType`/`Version`/`StorageRef`
- CAS path (`ExpectedRevision > 0`) preserves the same
- explicitly-set metadata still wins (locks the lifecycle contract)

## Gates

lint clean · `go test -race ./...` clean · `-tags=integration ./processor/graph-ingest/...` (lifecycle/CS-API update paths) green · schema no drift · contract green.

Surfaced by adversarial review during ADR-054 Phase 2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)