### PR TITLE
feat(agentic-dispatch): resumable reply path — run anchor + reply identity (gh#256)

### DIFF
--- a/agentic/reply_to_test.go
+++ b/agentic/reply_to_test.go
@@ -1,0 +1,126 @@
+package agentic_test
+
+// gh#256 — resumable-reply wire plumbing tests.
+// Covers the two fields a reply must carry to re-enter and resume a paused run
+// (ADR-053 §4b-2): the run anchor (RunID, already exercised by run_id_test.go)
+// and the reply marker (InReplyTo, new here). Asserts:
+//  1. TaskMessage.InReplyTo JSON round-trip + omitempty discipline.
+//  2. TaskMessage.InReplyTo survives the PRODUCTION wire (BaseMessage +
+//     registered decoder) — the path agentic-loop actually decodes a task off,
+//     per feedback_production_decoder_round_trip_required.
+//  3. UserMessage.RunID + InReplyTo JSON round-trip + omitempty discipline —
+//     the dispatch-inbound shape that threads into the TaskMessage.
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadbuiltins"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- TaskMessage.InReplyTo ---
+
+func TestTaskMessage_InReplyTo_RoundTrip(t *testing.T) {
+	t.Parallel()
+	task := agentic.TaskMessage{
+		TaskID:    "task-001",
+		Role:      "coordinator",
+		Model:     "model-a",
+		Prompt:    "here is my clarification answer",
+		RunID:     "paused-run-uuid",
+		InReplyTo: "asking-loop-uuid",
+	}
+	data, err := json.Marshal(&task)
+	require.NoError(t, err)
+
+	var got agentic.TaskMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "asking-loop-uuid", got.InReplyTo)
+	assert.Equal(t, "paused-run-uuid", got.RunID)
+}
+
+func TestTaskMessage_InReplyTo_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	task := agentic.TaskMessage{
+		TaskID: "task-002",
+		Role:   "researcher",
+		Model:  "model-b",
+		Prompt: "investigate X",
+		// InReplyTo deliberately empty
+	}
+	data, err := json.Marshal(&task)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"in_reply_to"`)
+}
+
+// TestTaskMessage_InReplyTo_ProductionWire round-trips a TaskMessage carrying
+// InReplyTo through the production decode path (BaseMessage envelope + the full
+// builtin registry decoder) — the exact path agentic-loop's handler uses to
+// decode an inbound task. A struct-level round-trip alone would not catch an
+// envelope/registration regression.
+func TestTaskMessage_InReplyTo_ProductionWire(t *testing.T) {
+	t.Parallel()
+	task := &agentic.TaskMessage{
+		TaskID:    "task-wire-001",
+		Role:      "coordinator",
+		Model:     "model-a",
+		Prompt:    "resume the paused run",
+		RunID:     "paused-run-uuid",
+		InReplyTo: "asking-loop-uuid",
+	}
+	envelope := message.NewBaseMessage(task.Schema(), task, "agentic-dispatch-test")
+	data, err := json.Marshal(envelope)
+	require.NoError(t, err)
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(data)
+	require.NoError(t, err)
+
+	got, ok := decoded.Payload().(*agentic.TaskMessage)
+	require.True(t, ok, "decoded payload is not *agentic.TaskMessage")
+	assert.Equal(t, "asking-loop-uuid", got.InReplyTo)
+	assert.Equal(t, "paused-run-uuid", got.RunID)
+}
+
+// --- UserMessage.RunID + InReplyTo (dispatch-inbound shape) ---
+
+func TestUserMessage_RunID_InReplyTo_RoundTrip(t *testing.T) {
+	t.Parallel()
+	msg := agentic.UserMessage{
+		MessageID: "msg-001",
+		UserID:    "operator-1",
+		Content:   "the answer is blue",
+		ReplyTo:   "asking-loop-uuid", // routes to the loop to continue
+		RunID:     "paused-run-uuid",  // re-attaches the resumed loop to its run
+		InReplyTo: "asking-loop-uuid", // marks this message as a reply
+		Timestamp: time.Now().UTC(),
+	}
+	data, err := json.Marshal(&msg)
+	require.NoError(t, err)
+
+	var got agentic.UserMessage
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Equal(t, "paused-run-uuid", got.RunID)
+	assert.Equal(t, "asking-loop-uuid", got.InReplyTo)
+	assert.Equal(t, "asking-loop-uuid", got.ReplyTo)
+}
+
+func TestUserMessage_RunID_InReplyTo_OmittedWhenEmpty(t *testing.T) {
+	t.Parallel()
+	msg := agentic.UserMessage{
+		MessageID: "msg-002",
+		UserID:    "operator-1",
+		Content:   "start a fresh task",
+		Timestamp: time.Now().UTC(),
+		// RunID + InReplyTo deliberately empty
+	}
+	data, err := json.Marshal(&msg)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"run_id"`)
+	assert.NotContains(t, string(data), `"in_reply_to"`)
+}

--- a/agentic/user_types.go
+++ b/agentic/user_types.go
@@ -38,6 +38,23 @@ type UserMessage struct {
 	Metadata         map[string]string `json:"metadata,omitempty"`           // channel-specific
 	ContextRequestID string            `json:"context_request_id,omitempty"` // links to assembled context
 
+	// Resumable-reply context (gh#256). These are distinct from ReplyTo:
+	// ReplyTo routes the message to a loop to continue; the two below let a
+	// reply re-enter and resume a *paused run*.
+	//
+	// RunID is the bare run anchor the reply should re-attach to. A client
+	// resuming a paused run (ADR-053) echoes the RunID it held from the pause
+	// state so the resumed loop carries agent.run / agent.run.entity_id even
+	// when the prior loop entity was evicted during the pause. Empty for
+	// non-run submissions.
+	RunID string `json:"run_id,omitempty"`
+	// InReplyTo marks this message as a reply to a specific loop's question
+	// (e.g. an ask_user clarification), stamped onto the resumed loop as the
+	// agent.loop.reply_to triple so a rule can fire on it. Deliberately
+	// separate from ReplyTo so ordinary continuations are NOT marked as
+	// replies. Empty for non-reply submissions.
+	InReplyTo string `json:"in_reply_to,omitempty"`
+
 	// Timing
 	Timestamp time.Time `json:"timestamp"`
 }
@@ -265,6 +282,14 @@ type TaskMessage struct {
 	RunID    string `json:"run_id,omitempty"`
 	Depth    int    `json:"depth,omitempty"`     // Current depth in agent tree (0 = root)
 	MaxDepth int    `json:"max_depth,omitempty"` // Maximum allowed depth
+
+	// InReplyTo is the bare loop-id this task is a reply to (gh#256). When
+	// set, agentic-loop stamps an agent.loop.reply_to triple (a 6-part loop
+	// entity reference, mirroring agent.loop.parent) on the spawned loop so a
+	// rule can detect a reply via $entity.triple.agent.loop.reply_to. Empty
+	// for non-reply tasks. Distinct from ParentLoopID (tree ancestry) — a
+	// reply re-enters a paused run rather than nesting under a parent.
+	InReplyTo string `json:"in_reply_to,omitempty"`
 
 	// Pre-constructed context (optional, skips discovery if present)
 	// When set, the agent loop uses this context directly instead of hydrating

--- a/processor/agentic-dispatch/build_task_message_test.go
+++ b/processor/agentic-dispatch/build_task_message_test.go
@@ -1,0 +1,71 @@
+package agenticdispatch
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/stretchr/testify/assert"
+)
+
+// newBuildTaskTestComponent builds the minimal Component buildTaskMessage needs:
+// a config (DefaultRole + nil DefaultTools so scopeTaskTools is a no-op) and a
+// model registry (resolveModel). No NATS — buildTaskMessage is pure assembly.
+func newBuildTaskTestComponent() *Component {
+	return &Component{
+		config:        DefaultConfig(),
+		modelRegistry: newTestRegistry(),
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+// TestBuildTaskMessage_PropagatesResumableReplyAnchors is the gh#256 regression
+// guard: both the bus path and the HTTP sync path now go through buildTaskMessage,
+// so a reply's run anchor (RunID) and reply marker (InReplyTo) must reach the
+// TaskMessage. Before the fix the reply branch dropped both, leaving the resumed
+// loop run-orphaned and unrecognisable as a reply.
+func TestBuildTaskMessage_PropagatesResumableReplyAnchors(t *testing.T) {
+	t.Parallel()
+	c := newBuildTaskTestComponent()
+
+	msg := agentic.UserMessage{
+		MessageID: "msg-1",
+		UserID:    "operator-1",
+		Content:   "the answer is blue",
+		ReplyTo:   "asking-loop-uuid", // routes to the loop to continue
+		RunID:     "paused-run-uuid",  // re-attaches the resumed loop to its run
+		InReplyTo: "asking-loop-uuid", // marks this message as a reply
+	}
+
+	task := c.buildTaskMessage(context.Background(), msg, "asking-loop-uuid", "task-1")
+
+	assert.Equal(t, "paused-run-uuid", task.RunID, "RunID must propagate UserMessage → TaskMessage")
+	assert.Equal(t, "asking-loop-uuid", task.InReplyTo, "InReplyTo must propagate UserMessage → TaskMessage")
+	// The rest of the contract still holds.
+	assert.Equal(t, "asking-loop-uuid", task.LoopID)
+	assert.Equal(t, "task-1", task.TaskID)
+	assert.Equal(t, "the answer is blue", task.Prompt)
+	assert.Equal(t, c.config.DefaultRole, task.Role)
+}
+
+// TestBuildTaskMessage_OrdinarySubmissionCarriesNoAnchors pins the omitempty
+// contract: a fresh (non-reply) submission must not carry a run anchor or a
+// reply marker, so an ordinary continuation is never mis-stamped as a reply.
+func TestBuildTaskMessage_OrdinarySubmissionCarriesNoAnchors(t *testing.T) {
+	t.Parallel()
+	c := newBuildTaskTestComponent()
+
+	msg := agentic.UserMessage{
+		MessageID: "msg-2",
+		UserID:    "operator-1",
+		Content:   "start a fresh task",
+		// RunID + InReplyTo deliberately empty
+	}
+
+	task := c.buildTaskMessage(context.Background(), msg, "loop-new", "task-2")
+
+	assert.Empty(t, task.RunID, "fresh submission must not carry a run anchor")
+	assert.Empty(t, task.InReplyTo, "fresh submission must not be marked as a reply")
+}

--- a/processor/agentic-dispatch/component.go
+++ b/processor/agentic-dispatch/component.go
@@ -612,6 +612,41 @@ func (c *Component) resolveModel() string {
 	return c.modelRegistry.GetDefault()
 }
 
+// buildTaskMessage assembles the TaskMessage published to agentic-loop from an
+// inbound UserMessage. Shared by the bus path (handleTaskSubmission) and the
+// HTTP sync path (processTaskSubmissionSync) so the propagation contract is
+// identical regardless of dispatch surface — a single place that can't drift on
+// which fields a reply carries (the gh#256 defect class: the reply path silently
+// dropping RunID + the reply marker the other path would have carried).
+func (c *Component) buildTaskMessage(ctx context.Context, msg agentic.UserMessage, loopID, taskID string) agentic.TaskMessage {
+	task := agentic.TaskMessage{
+		LoopID:           loopID,
+		TaskID:           taskID,
+		Role:             c.config.DefaultRole,
+		Model:            c.resolveModel(),
+		Prompt:           msg.Content,
+		ContextRequestID: msg.ContextRequestID,
+		// Resumable-reply anchors (gh#256). Both omitempty and client-set, so an
+		// ordinary submission carries neither: RunID re-attaches the resumed loop
+		// to its paused run (→ agent.run / agent.run.entity_id), InReplyTo marks
+		// it as a reply (→ agent.loop.reply_to) so a resume rule can fire on it.
+		RunID:     msg.RunID,
+		InReplyTo: msg.InReplyTo,
+	}
+
+	// Propagate inbound trace_id onto TaskMessage.Metadata so the downstream
+	// LoopEntity.Metadata surfaces it for wedge investigation
+	// (curl /loops/<id> → metadata.trace_id → message-logger lookup).
+	stampTraceIDFromCtx(ctx, &task)
+
+	// Scope the initial agent's tools to DefaultTools when configured, so an
+	// HTTP- or bus-spawned loop honors the operator default_tools contract
+	// instead of falling back to global discovery.
+	c.scopeTaskTools(&task)
+
+	return task
+}
+
 // handleTaskSubmission creates a new agent task
 func (c *Component) handleTaskSubmission(ctx context.Context, msg agentic.UserMessage) {
 	// Check submit permission
@@ -643,25 +678,8 @@ func (c *Component) handleTaskSubmission(ctx context.Context, msg agentic.UserMe
 
 	taskID := uuid.New().String()
 
-	// Create task message
-	task := agentic.TaskMessage{
-		LoopID:           loopID,
-		TaskID:           taskID,
-		Role:             c.config.DefaultRole,
-		Model:            c.resolveModel(),
-		Prompt:           msg.Content,
-		ContextRequestID: msg.ContextRequestID,
-	}
-
-	// Propagate inbound trace_id onto TaskMessage.Metadata so the
-	// downstream LoopEntity.Metadata surfaces it for wedge investigation
-	// (curl /loops/<id> → metadata.trace_id → message-logger lookup).
-	stampTraceIDFromCtx(ctx, &task)
-
-	// Scope the initial agent's tools to DefaultTools when configured.
-	// Bus and HTTP paths share scopeTaskTools so the scoping contract
-	// is identical regardless of dispatch surface.
-	c.scopeTaskTools(&task)
+	// Create task message (shared builder — see buildTaskMessage; gh#256).
+	task := c.buildTaskMessage(ctx, msg, loopID, taskID)
 
 	// Track the loop
 	c.loopTracker.Track(&LoopInfo{

--- a/processor/agentic-dispatch/http.go
+++ b/processor/agentic-dispatch/http.go
@@ -36,6 +36,14 @@ type HTTPMessageRequest struct {
 	ChannelID   string            `json:"channel_id,omitempty"`
 	ReplyTo     string            `json:"reply_to,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+
+	// Resumable-reply anchors (gh#256). Distinct from ReplyTo (which routes to
+	// a loop to continue): these let a reply re-enter and resume a paused run.
+	// RunID is the bare run anchor the resumed loop re-attaches to; InReplyTo
+	// marks the message as a reply to a specific loop's question so a rule can
+	// fire on the resumed loop. Both optional; absent for ordinary submissions.
+	RunID     string `json:"run_id,omitempty"`
+	InReplyTo string `json:"in_reply_to,omitempty"`
 }
 
 // HTTPMessageResponse represents the response from the HTTP message endpoint.
@@ -144,6 +152,8 @@ func (c *Component) handleHTTPMessage(w http.ResponseWriter, r *http.Request) {
 		Content:     req.Content,
 		ReplyTo:     req.ReplyTo,
 		Metadata:    req.Metadata,
+		RunID:       req.RunID,
+		InReplyTo:   req.InReplyTo,
 		Timestamp:   time.Now(),
 	}
 
@@ -298,28 +308,8 @@ func (c *Component) processTaskSubmissionSync(ctx context.Context, msg agentic.U
 
 	taskID := uuid.New().String()
 
-	// Create task message
-	task := agentic.TaskMessage{
-		LoopID:           loopID,
-		TaskID:           taskID,
-		Role:             c.config.DefaultRole,
-		Model:            c.resolveModel(),
-		Prompt:           msg.Content,
-		ContextRequestID: msg.ContextRequestID,
-	}
-
-	// Propagate inbound trace_id onto TaskMessage.Metadata so the
-	// downstream LoopEntity.Metadata surfaces it for wedge investigation.
-	// See stampTraceIDFromCtx in component.go.
-	stampTraceIDFromCtx(ctx, &task)
-
-	// Scope the initial agent's tools to DefaultTools when configured.
-	// Mirrors the bus-dispatch path in handleTaskSubmission so HTTP-
-	// spawned loops honor the same scoping contract — pre-fix the HTTP
-	// path left task.Tools nil and the spawned loop fell back to global
-	// discovery, sending the full agentic-tools registry to the LLM
-	// regardless of operator default_tools configuration.
-	c.scopeTaskTools(&task)
+	// Create task message (shared builder — see buildTaskMessage; gh#256).
+	task := c.buildTaskMessage(ctx, msg, loopID, taskID)
 
 	// Track the loop
 	c.loopTracker.Track(&LoopInfo{

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -538,6 +538,16 @@ func buildSpawnIdentityTriples(loopEntityID string, task *agentic.TaskMessage, o
 			triples = append(triples, triple(agvocab.LoopRunEntityID, runEntityID))
 		}
 	}
+	// Stamp the reply pointer when this loop is a reply (gh#256). Mirrors
+	// LoopParent: a 6-part loop entity reference, so a resume rule reading
+	// $entity.triple.agent.loop.reply_to gets a navigable reference, not a bare
+	// id. Distinct from RunID (which run this loop belongs to) — reply_to marks
+	// THIS loop as the reply so a marker rule can fire on it and drive the run
+	// from awaiting_approval back to executing (ADR-053 §4b-2).
+	if task.InReplyTo != "" {
+		replyEntityID := agentic.LoopExecutionEntityID(org, platform, task.InReplyTo)
+		triples = append(triples, triple(agvocab.LoopReplyTo, replyEntityID))
+	}
 	if task.WorkflowSlug != "" {
 		triples = append(triples, triple(agvocab.LoopWorkflow, task.WorkflowSlug))
 	}

--- a/processor/agentic-loop/spawn_identity_test.go
+++ b/processor/agentic-loop/spawn_identity_test.go
@@ -226,6 +226,7 @@ func TestBuildSpawnIdentityTriples_TripleCountWithFullTask(t *testing.T) {
 		Role:         "researcher",
 		ParentLoopID: "parent-id",
 		RunID:        "run-anchor-uuid",
+		InReplyTo:    "asking-loop-uuid",
 		WorkflowSlug: "wf",
 		WorkflowStep: "step",
 		UserID:       "user",
@@ -233,7 +234,7 @@ func TestBuildSpawnIdentityTriples_TripleCountWithFullTask(t *testing.T) {
 	}
 
 	triples := buildSpawnIdentityTriples("acme.ops.agent.agentic-loop.execution.spawn-count", task, "acme", "ops")
-	want := 9 // role, task, parent, run, run.entity_id, workflow, workflow_step, user, description
+	want := 10 // role, task, parent, run, run.entity_id, reply_to, workflow, workflow_step, user, description
 	if len(triples) != want {
 		preds := make([]string, 0, len(triples))
 		for _, tr := range triples {
@@ -350,6 +351,58 @@ func TestBuildSpawnIdentityTriples_RunIDIsNotEntityID(t *testing.T) {
 			t.Errorf("LoopRun %q contains dots — must be bare loop UUID, not a 6-part entity ID", runID)
 			break
 		}
+	}
+}
+
+// --- gh#256: agent.loop.reply_to in spawn identity ---
+
+// TestBuildSpawnIdentityTriples_StampsReplyTo verifies that agent.loop.reply_to
+// is stamped as a valid 6-part loop entity reference (mirroring agent.loop.parent)
+// when TaskMessage.InReplyTo is set, so a resume rule reading
+// $entity.triple.agent.loop.reply_to gets a navigable reference and can fire on
+// the reply (ADR-053 §4b-2 clarification resume).
+func TestBuildSpawnIdentityTriples_StampsReplyTo(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.reply-001"
+	task := &agentic.TaskMessage{
+		TaskID:    "task-reply-001",
+		Role:      "coordinator",
+		InReplyTo: "asking-loop-uuid",
+	}
+
+	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	predicates := predicateSet(triples)
+
+	if !predicates[agvocab.LoopReplyTo] {
+		t.Fatalf("expected agent.loop.reply_to triple; got predicates: %v", predicates)
+	}
+
+	replyTo, ok := objectFor(triples, agvocab.LoopReplyTo).(string)
+	if !ok {
+		t.Fatal("LoopReplyTo object is not a string")
+	}
+	want := "acme.ops.agent.agentic-loop.execution.asking-loop-uuid"
+	if replyTo != want {
+		t.Errorf("LoopReplyTo = %q, want %q", replyTo, want)
+	}
+	if !message.IsValidEntityID(replyTo) {
+		t.Errorf("LoopReplyTo %q is not a valid 6-part entity ID", replyTo)
+	}
+}
+
+// TestBuildSpawnIdentityTriples_OmitsReplyToWhenEmpty verifies that
+// agent.loop.reply_to is NOT emitted for a non-reply loop — an ordinary
+// continuation must not be mis-marked as a reply.
+func TestBuildSpawnIdentityTriples_OmitsReplyToWhenEmpty(t *testing.T) {
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.non-reply"
+	task := &agentic.TaskMessage{
+		TaskID: "task-non-reply",
+		Role:   "researcher",
+		// InReplyTo empty
+	}
+
+	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	if predicateSet(triples)[agvocab.LoopReplyTo] {
+		t.Errorf("expected agent.loop.reply_to triple to be omitted when InReplyTo is empty")
 	}
 }
 

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1483,11 +1483,15 @@ components:
                     type: string
                 content:
                     type: string
+                in_reply_to:
+                    type: string
                 metadata:
                     additionalProperties:
                         type: string
                     type: object
                 reply_to:
+                    type: string
+                run_id:
                     type: string
                 user_id:
                     type: string

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -456,6 +456,19 @@ const (
 	// DataType: string (entity ID)
 	LoopParent = "agent.loop.parent"
 
+	// LoopReplyTo is an entity reference to the loop this loop is a reply to
+	// (gh#256). Stamped at spawn time by buildSpawnIdentityTriples when
+	// TaskMessage.InReplyTo is non-empty. Distinct from LoopParent (tree
+	// ancestry): a reply re-enters a paused run (ADR-053 §4b-2 interactive
+	// clarification) rather than nesting under a parent. A resume rule fires on
+	// $entity.triple.agent.loop.reply_to to distinguish a reply from any other
+	// run loop, then drives the run entity back from awaiting_approval to
+	// executing. Grammar-collision-free: agent.loop.* is already a substitution
+	// namespace; reply_to adds no new $-prefix token.
+	// Example: "org.platform.agent.agentic-loop.execution.<askingLoopID>"
+	// DataType: string (6-part entity ID)
+	LoopReplyTo = "agent.loop.reply_to"
+
 	// LoopRun is the bare run loop-id this loop belongs to (ADR-053 D7).
 	// Stamped at spawn time by buildSpawnIdentityTriples when TaskMessage.RunID is non-empty.
 	// Rules can read this via $entity.triple.agent.run. Grammar-collision-free:


### PR DESCRIPTION
Closes #256.

## Problem

The HTTP/bus message-reply path dropped everything that lets a reply re-enter and resume a *paused run*: the run anchor (`RunID`) and any reply-identity signal. On a reply it built a `TaskMessage` with no `RunID` (→ resumed loop **run-orphaned**) and no reply marker (→ no loop-local signal a rule can fire on). This is the symmetric counterpart to gh#250/#253 — there the framework hands the anchor *out* on `ToolCall.Metadata`; here the reply needs to bring it *back* and mark itself.

## Change

**Thread 1 — run anchor (explicit `run_id` on the wire).** `HTTPMessageRequest.run_id` → `UserMessage.RunID` → `TaskMessage.RunID`. The reply client echoes the `RunID` it held from the pause state, so the resumed loop carries `agent.run` / `agent.run.entity_id` even when the prior loop entity was evicted during the pause — the case a framework-side lookup could not recover. (Existing ADR-053 plumbing then stamps the anchor: `SetRunID` + `buildSpawnIdentityTriples`.)

**Thread 2 — reply identity (typed field + first-class triple).** New `TaskMessage.InReplyTo` → `agent.loop.reply_to` triple stamped in `buildSpawnIdentityTriples`, mirroring `agent.loop.parent` (6-part loop entity reference). A resume rule fires on `$entity.triple.agent.loop.reply_to` to distinguish a reply from any other run loop. Deliberately a typed pointer, **not** a third overload of the `lineage.*` namespace. New vocab const `agvocab.LoopReplyTo`.

**Bonus — kill the drift source.** The two byte-identical task-build sites (`processTaskSubmissionSync` + `handleTaskSubmission`) are consolidated into one shared `buildTaskMessage` helper. That duplication was the exact mechanism by which the reply path silently diverged. The helper is unit-testable without NATS.

## Backward compatibility

Non-breaking — every new field is `omitempty`. A reply carrying neither anchor behaves exactly as before (covered by tests).

## Tests

- `agentic/reply_to_test.go` — `TaskMessage.InReplyTo` + `UserMessage.RunID/InReplyTo` JSON round-trip + omitempty discipline, plus a **production-decoder** round-trip (`BaseMessage` + registered decoder — the path agentic-loop actually decodes a task off).
- `spawn_identity_test.go` — `StampsReplyTo` (valid 6-part entity ref) + `OmitsReplyToWhenEmpty`; triple-count regression guard bumped 9 → 10.
- `build_task_message_test.go` — the helper propagates `RunID`/`InReplyTo` and a fresh submission carries neither.

## Acceptance criteria (issue)

- [x] Reply with `run_id` → resumed loop carries `agent.run` + `agent.run.entity_id`
- [x] Reply with reply-identity signal → resumed loop carries `agent.loop.reply_to`
- [x] Reply with neither behaves exactly as today (both fields `omitempty`)
- [x] Round-trip test for the new `HTTPMessageRequest`/`TaskMessage` field(s) mirroring `run_id_test.go`

## Gate

`task lint` (vet/fmt/revive + port guard) · unit + `-race` · `go vet -tags=integration,live_llm` · contract tests · `task schema:generate` (only the 2 new optional fields) · full `go test -race -tags=integration ./...` green except one pre-existing `graph-ingest` testcontainer-startup timeout under parallel load, confirmed passing in isolation (3.2s) — substrate flake, untouched by this PR.

## Unblocks

semteams ADR-053 §4b-2 interactive clarification pause/resume — the product-shell resume rules can be authored against `$entity.triple.agent.run.entity_id` + `$entity.triple.agent.loop.reply_to`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)