### PR TITLE
chore(ci): bump checkout v4→v5 and setup-go v5→v6 (Node 24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -84,10 +84,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -106,10 +106,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -131,10 +131,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,7 +27,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Use the commit from the triggering workflow for workflow_run events
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,12 @@ jobs:
             goarch: amd64
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: true
@@ -83,7 +83,7 @@ jobs:
     needs: build-binaries
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/semspec-validation.yml
+++ b/.github/workflows/semspec-validation.yml
@@ -17,19 +17,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout semstreams
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: semstreams
 
       - name: Checkout semspec
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: C360Studio/semspec
           path: semspec
           ref: ${{ inputs.semspec_ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true


### PR DESCRIPTION
Clears the Node 20 deprecation annotation on every CI run. GitHub forces JS actions to Node 24 on 2026-06-16 and removes Node 20 from runners on 2026-09-16.

- `actions/checkout@v4` → `@v5` (×9, all workflows)
- `actions/setup-go@v5` → `@v6` (×6, all workflows)

Each bumped to its lowest Node-24 major. Usage is vanilla (default inputs + `fetch-depth` / `go-version` / `cache`), unaffected by the major bumps. **This PR's own CI run is the validation** — it executes `ci.yml` with the new versions.

Deferred: `upload-artifact@v4` / `download-artifact@v4` (release.yml only) are also Node 20, but their current majors (v7/v8) are a 3–4 major jump with historical breaking changes and need separate mutual-compatibility validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)