### PR TITLE
chore(ci): bump artifact actions to Node 24 (upload v6, download v7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: semstreams-${{ matrix.goos }}-${{ matrix.goarch }}
           path: |
@@ -98,7 +98,7 @@ jobs:
           echo "TAG=${PREV_TAG}" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ./release-artifacts
 


### PR DESCRIPTION
Completes the Node 20 → Node 24 action migration started in #262. `upload-artifact@v4` / `download-artifact@v4` (release.yml only) are the last JS actions on the deprecated Node 20 runtime.

- `actions/upload-artifact@v4` → `@v6` (v4/v5 are Node 20; v6 is the first Node-24 major)
- `actions/download-artifact@v4` → `@v7` (v4/v5/v6 are Node 20; v7 is the first Node-24 major)

**Verified before bumping** (release.yml is tag-triggered, so a PR's CI can't exercise it):
- Inputs unchanged for our usage — upload uses `name`+`path`; download uses `path`-only "download all" (`name` stays `required: false` in v7), default `merge-multiple: false` preserves the v4 subdirectory-per-artifact layout.
- Both ride the same v4+ artifact backend → `upload@v6` and `download@v7` interoperate.
- Tags resolve (action.yml fetched at both refs; `runs.using: node24`).

Real validation is the next release tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)