### PR TITLE
feat(graph-ingest): ADR-055 Wave 0 — Fact-lane consumer guards (StorageRef + T2 regroup)

### DIFF
--- a/docs/adr/055-graph-write-intent-taxonomy.md
+++ b/docs/adr/055-graph-write-intent-taxonomy.md
@@ -371,6 +371,14 @@ create-or-fail lane (§6) and is exempt.
   (`sensorml.Asset` is currently unwired — no `MarshalJSON`, no payload registration
   — so the regression is latent-on-wiring, not live-on-main; that is why the guard
   must regroup rather than reject before the ADR-044 Phase 5 bridge lands.)
+  **Sibling consumer — `graph/messagemanager`.** `Manager.ProcessMessage`
+  (`graph/messagemanager/processor.go:274`) is a second Graphable→EntityState
+  consumer that files all `triples` under one `actualEntityID` with the same
+  single-key misfiling; it ALREADY lifts `StorageRef` via the `Storable` assertion
+  (`:200-204`), so the StorageRef half is at parity there, but the T2 regroup is
+  not. It must receive the same WARN-and-regroup under this ADR so the two
+  consumers do not drift. (graph-ingest is migrated first — Wave 0; messagemanager
+  follows.)
 - **StorageRef extraction (two halves).** Consumer side: `extractEntityFromMessage`
   must type-assert `ContentStorable` and set `StorageRef` (MergeEntity merges it on
   the existing branch, `:1008-1009`). Producer side: the canonical pilot

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -865,6 +865,34 @@ func (c *Component) handleMessage(ctx context.Context, subject string, data []by
 		return
 	}
 
+	c.ingestEntity(ctx, entity)
+}
+
+// ingestEntity merges an extracted Graphable entity into ENTITY_STATES and
+// regroups any cross-entity edges onto their own subjects (ADR-055 §5 T2). It is
+// the orchestration the Fact-arrival consumer runs once decode+extract have
+// produced an EntityState: split foreign-subject edges off the primary, merge
+// the primary (envelope-bearing), then route the edges via the evidence-append
+// path. Exposed as a method so the merge+regroup wire is testable end-to-end
+// without standing up the decoder.
+func (c *Component) ingestEntity(ctx context.Context, entity *graph.EntityState) {
+	// ADR-055 §5 T2: a Graphable may legitimately emit cross-entity edges whose
+	// Subject != EntityID() (sensorml inverse isHostedBy, federation/objectstore
+	// pass-throughs). extractEntityFromMessage files every triple under the
+	// primary key, silently misfiling those edges onto the wrong entity. Split
+	// them off so the primary merges only its own facts, then route each edge to
+	// its correct subject below — WARN-and-regroup, never reject (multi-Subject
+	// producers stay correct; single-Subject is the target invariant for NEW
+	// Graphables).
+	own, foreign := partitionTriplesBySubject(entity.ID, entity.Triples)
+	if len(foreign) > 0 {
+		entity.Triples = own
+		c.logger.Warn("Graphable emitted cross-entity edges; regrouping onto their subjects",
+			slog.String("entity_id", entity.ID),
+			slog.Int("foreign_triples", len(foreign)),
+			slog.Any("foreign_subjects", distinctSubjects(foreign)))
+	}
+
 	// Store entity in KV bucket — MERGE semantics (gh#177). Earlier code
 	// used CreateEntity (Put = full-replace) here, which clobbered any
 	// pre-existing triples on the entity. The atomic mutation handlers
@@ -877,6 +905,24 @@ func (c *Component) handleMessage(ctx context.Context, subject string, data []by
 			slog.String("entity_id", entity.ID),
 			slog.Any("error", err))
 		return
+	}
+
+	// Route cross-entity edges to their own subject. These are edges onto
+	// entities that own their own envelope, so they ride the evidence-append
+	// path (AddTriples = append-by-subject, no MessageType restamp) rather than
+	// MergeEntity (which would stamp the primary's provenance onto a foreign
+	// entity). Best-effort: a failed edge is logged, not fatal to the primary
+	// ingest that already succeeded. Note AddTriples validates the batch
+	// all-or-nothing — one malformed foreign edge (empty Predicate) drops the
+	// whole foreign batch; no current producer emits one, but a future
+	// multi-edge producer should not assume partial routing.
+	if len(foreign) > 0 {
+		if _, failed, aerr := c.AddTriples(ctx, foreign); aerr != nil {
+			c.logger.Warn("Failed to regroup cross-entity edges onto their subjects",
+				slog.String("entity_id", entity.ID),
+				slog.Int("failed_subjects", len(failed)),
+				slog.Any("error", aerr))
+		}
 	}
 
 	c.logger.Debug("Entity ingested",
@@ -917,6 +963,20 @@ func (c *Component) extractEntityFromMessage(msg *message.BaseMessage) (*graph.E
 		Version:     1,
 	}
 
+	// ADR-055 §5 StorageRef extraction (consumer half): a Graphable payload that
+	// also implements message.Storable carries an ObjectStore reference to its
+	// offloaded content. Lift it onto the EntityState so MergeEntity persists it
+	// (the create branch marshals it verbatim; the existing-entity branch merges
+	// it onto the stored copy). Without this, a ContentStorable producer's offloaded
+	// content (tool results, model responses, document bodies) loses its storage
+	// pointer at the ingest seam and the embedding worker can never find the
+	// text — the "offloaded content stops embedding" gap.
+	if storable, ok := payload.(message.Storable); ok {
+		if ref := storable.StorageRef(); ref != nil {
+			entity.StorageRef = ref
+		}
+	}
+
 	// ADR-054 channel (a): a Graphable payload MAY also declare its indexing
 	// profile via the optional IndexingProfiler interface. Stamp it explicitly
 	// here so it's present on entity.Triples by the time MergeEntity reaches
@@ -927,6 +987,41 @@ func (c *Component) extractEntityFromMessage(msg *message.BaseMessage) (*graph.E
 	}
 
 	return entity, nil
+}
+
+// partitionTriplesBySubject splits a Graphable's triples into those belonging to
+// the primary entity and "foreign" triples whose Subject names a DIFFERENT
+// entity. A triple is primary when its Subject equals entityID, or is empty (the
+// historical filing target — extractEntityFromMessage has always placed
+// subject-less triples on the primary). Foreign triples are cross-entity edges —
+// e.g. sensorml's inverse isHostedBy stamped on the child subject — that the
+// single-key filing in extractEntityFromMessage would otherwise misfile under the
+// primary entity (ADR-055 §5 T2). This function only classifies; the caller
+// routes foreign triples to their correct subject.
+func partitionTriplesBySubject(entityID string, triples []message.Triple) (own, foreign []message.Triple) {
+	for _, t := range triples {
+		if t.Subject == "" || t.Subject == entityID {
+			own = append(own, t)
+			continue
+		}
+		foreign = append(foreign, t)
+	}
+	return own, foreign
+}
+
+// distinctSubjects returns the sorted set of distinct Subjects across the triples,
+// for low-cardinality operator logging of where regrouped edges were routed.
+func distinctSubjects(triples []message.Triple) []string {
+	seen := make(map[string]struct{}, len(triples))
+	for _, t := range triples {
+		seen[t.Subject] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for s := range seen {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // removeIndexingProfileTriples drops every entity.indexing.profile triple from

--- a/processor/graph-ingest/fact_lane_guards_test.go
+++ b/processor/graph-ingest/fact_lane_guards_test.go
@@ -1,0 +1,210 @@
+package graphingest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/vocabulary"
+)
+
+// ADR-055 Wave 0 — Fact-arrival consumer guards in graph-ingest:
+//   - §5 StorageRef extraction (consumer half): a ContentStorable/Storable
+//     Graphable's ObjectStore pointer is lifted onto the EntityState so
+//     offloaded content stays linked and embeddable.
+//   - §5 T2 WARN-and-regroup: a Graphable's cross-entity edges (Subject !=
+//     EntityID) are routed onto their correct subject instead of being misfiled
+//     under the primary key.
+// These drive the production extract → ingest wire (extractEntityFromMessage +
+// ingestEntity), the same orchestration handleMessage runs after decode.
+
+const (
+	flParentID = "c360.platform.test.sys.widget.001"
+	flChildID  = "c360.platform.test.sys.widget.002"
+)
+
+// testStorablePayload implements message.ContentStorable (Storable + content
+// maps) so the consumer can lift its StorageRef. It is a valid message.Payload.
+type testStorablePayload struct {
+	id      string
+	triples []message.Triple
+	ref     *message.StorageReference
+}
+
+func (p *testStorablePayload) EntityID() string                      { return p.id }
+func (p *testStorablePayload) Triples() []message.Triple             { return p.triples }
+func (p *testStorablePayload) StorageRef() *message.StorageReference { return p.ref }
+func (p *testStorablePayload) Validate() error                       { return nil }
+func (p *testStorablePayload) MarshalJSON() ([]byte, error)          { return []byte("{}"), nil }
+func (p *testStorablePayload) UnmarshalJSON([]byte) error            { return nil }
+func (p *testStorablePayload) Schema() message.Type {
+	return message.Type{Domain: "test", Category: "storable", Version: "v1"}
+}
+func (p *testStorablePayload) ContentFields() map[string]string {
+	return map[string]string{message.ContentRoleBody: "body"}
+}
+func (p *testStorablePayload) RawContent() map[string]string {
+	return map[string]string{"body": "offloaded text"}
+}
+
+func hasPredicate(es *graph.EntityState, predicate string) bool {
+	for _, t := range es.Triples {
+		if t.Predicate == predicate {
+			return true
+		}
+	}
+	return false
+}
+
+// --- §5 T2 partition helper (pure) ---
+
+func TestPartitionTriplesBySubject(t *testing.T) {
+	primary := flParentID
+	triples := []message.Triple{
+		{Subject: primary, Predicate: "own.a", Object: 1},
+		{Subject: flChildID, Predicate: "foreign.b", Object: 2},
+		{Subject: "", Predicate: "empty.subject.files.onto.primary", Object: 3},
+		{Subject: primary, Predicate: "own.c", Object: 4},
+		{Subject: "c360.platform.test.sys.widget.003", Predicate: "foreign.d", Object: 5},
+	}
+
+	own, foreign := partitionTriplesBySubject(primary, triples)
+
+	require.Len(t, own, 3, "own = subject==entityID plus the empty-subject (historical primary filing)")
+	require.Len(t, foreign, 2, "foreign = every triple naming a different subject")
+	assert.True(t, hasPredicateInTriples(own, "empty.subject.files.onto.primary"),
+		"an empty Subject must stay on the primary (preserves pre-ADR filing)")
+	assert.True(t, hasPredicateInTriples(foreign, "foreign.b"))
+	assert.True(t, hasPredicateInTriples(foreign, "foreign.d"))
+}
+
+func TestPartitionTriplesBySubject_AllOwn(t *testing.T) {
+	own, foreign := partitionTriplesBySubject(flParentID, []message.Triple{
+		{Subject: flParentID, Predicate: "a"},
+		{Subject: flParentID, Predicate: "b"},
+	})
+	assert.Len(t, own, 2)
+	assert.Empty(t, foreign, "a single-Subject Graphable produces no foreign edges")
+}
+
+func TestDistinctSubjects_SortedAndDeduped(t *testing.T) {
+	got := distinctSubjects([]message.Triple{
+		{Subject: "b"}, {Subject: "a"}, {Subject: "b"}, {Subject: "c"}, {Subject: "a"},
+	})
+	assert.Equal(t, []string{"a", "b", "c"}, got)
+}
+
+func hasPredicateInTriples(triples []message.Triple, predicate string) bool {
+	for _, t := range triples {
+		if t.Predicate == predicate {
+			return true
+		}
+	}
+	return false
+}
+
+// --- §5 StorageRef extraction (consumer half) ---
+
+func TestStorageRefExtraction_ConsumerLiftsRefOntoEntity(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ref := &message.StorageReference{
+		StorageInstance: "objectstore-primary",
+		Key:             "2026/06/12/step-001",
+		ContentType:     "application/json",
+		Size:            128,
+	}
+	payload := &testStorablePayload{
+		id:      flParentID,
+		triples: []message.Triple{{Subject: flParentID, Predicate: "doc.body.ref", Object: "body", Timestamp: time.Now()}},
+		ref:     ref,
+	}
+	msg := message.NewBaseMessage(payload.Schema(), payload, "test")
+
+	entity, err := comp.extractEntityFromMessage(msg)
+	require.NoError(t, err)
+	require.NotNil(t, entity.StorageRef, "a Storable payload's ref must be lifted onto the EntityState at extract")
+	assert.Equal(t, ref.Key, entity.StorageRef.Key)
+
+	// And it must survive the merge into the bucket (create-branch marshal).
+	comp.ingestEntity(context.Background(), entity)
+	es := storedEntity(t, comp, flParentID)
+	require.NotNil(t, es.StorageRef, "StorageRef must persist through MergeEntity to the stored entity")
+	assert.Equal(t, "objectstore-primary", es.StorageRef.StorageInstance)
+	assert.Equal(t, ref.Key, es.StorageRef.Key)
+	assert.Equal(t, int64(128), es.StorageRef.Size)
+}
+
+func TestStorageRefExtraction_NonStorablePayloadLeavesRefNil(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	// testGraphablePayload (indexing_profile_test.go) is Graphable but NOT Storable.
+	payload := &testGraphablePayload{id: flParentID, triples: []message.Triple{userTriple("k", "v")}}
+	msg := message.NewBaseMessage(payload.Schema(), payload, "test")
+
+	entity, err := comp.extractEntityFromMessage(msg)
+	require.NoError(t, err)
+	assert.Nil(t, entity.StorageRef, "a plain Graphable carries no StorageRef")
+}
+
+// --- §5 T2 WARN-and-regroup through the ingest wire ---
+
+func TestIngestEntity_RegroupsForeignSubjectEdgeOntoChild(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	// A parent Graphable that, like sensorml.Asset, emits an inverse edge whose
+	// Subject is the CHILD, not the parent (its EntityID).
+	entity := &graph.EntityState{
+		ID:          flParentID,
+		MessageType: testWidgetMessageType(),
+		Version:     1,
+		Triples: []message.Triple{
+			{Subject: flParentID, Predicate: "rel.hosts", Object: flChildID, Timestamp: time.Now()},
+			{Subject: flChildID, Predicate: "rel.isHostedBy", Object: flParentID, Timestamp: time.Now()},
+		},
+	}
+
+	comp.ingestEntity(ctx, entity)
+
+	// Parent keeps only its own fact (+ the framework profile stamp); the inverse
+	// edge must NOT be misfiled onto it.
+	parent := storedEntity(t, comp, flParentID)
+	assert.True(t, hasPredicate(parent, "rel.hosts"), "parent keeps its own forward edge")
+	assert.False(t, hasPredicate(parent, "rel.isHostedBy"),
+		"the child-subject inverse edge must not stay misfiled on the parent")
+
+	// The inverse edge lands on the CHILD entity, under the correct subject.
+	child := storedEntity(t, comp, flChildID)
+	require.True(t, hasPredicate(child, "rel.isHostedBy"), "the inverse edge must be regrouped onto its own subject")
+	for _, tr := range child.Triples {
+		if tr.Predicate == "rel.isHostedBy" {
+			assert.Equal(t, flChildID, tr.Subject, "the regrouped edge keeps its child Subject")
+		}
+	}
+}
+
+func TestIngestEntity_SingleSubjectNoForeignEntityCreated(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+
+	entity := &graph.EntityState{
+		ID:          flParentID,
+		MessageType: testWidgetMessageType(),
+		Version:     1,
+		Triples:     []message.Triple{{Subject: flParentID, Predicate: "rel.hosts", Object: "x", Timestamp: time.Now()}},
+	}
+	comp.ingestEntity(ctx, entity)
+
+	parent := storedEntity(t, comp, flParentID)
+	assert.True(t, hasPredicate(parent, "rel.hosts"))
+	assert.Equal(t, []string{vocabulary.IndexingProfileControl}, profileValues(parent),
+		"a single-Subject entity still gets the floor profile and is otherwise unchanged")
+
+	// No phantom child entity should have been conjured.
+	_, err := comp.entityBucket.Get(ctx, flChildID)
+	assert.Error(t, err, "a single-Subject Graphable must not create any other entity")
+}


### PR DESCRIPTION
## What

ADR-055 Wave 0 framework substrate: two guards on graph-ingest's Graphable **Fact-arrival** consumer. This is the piece that **unblocks ADR-054 Phase 2b** (offloaded content was silently un-embeddable).

### 1. StorageRef consumer extraction (ADR-055 §5)
`extractEntityFromMessage` now type-asserts `message.Storable` and lifts `StorageRef()` onto the `EntityState`. It was dropped at the ingest seam, so a `ContentStorable` producer's offloaded ObjectStore content lost its pointer and the embedding worker could never find the text — the "offloaded content stops embedding" gap. `MergeEntity` already persisted the ref; it simply never arrived.

This brings graph-ingest to **parity** with `graph/messagemanager`, which already lifts StorageRef via the same `Storable` assertion.

### 2. T2 WARN-and-regroup-by-Subject (ADR-055 §5 T2)
`extractEntityFromMessage` filed every `Triples()` triple under one key = `EntityID()`, silently misfiling cross-entity edges whose `Subject != EntityID()` (sensorml inverse `isHostedBy`, federation/objectstore pass-throughs). The merge orchestration is pulled out of `handleMessage` into a new testable `ingestEntity(ctx, entity)`:

- `partitionTriplesBySubject` — own = `Subject==""` or `==entityID`; foreign = else
- WARN + strip foreign edges off the primary
- `MergeEntity` the primary (envelope-bearing)
- route foreign edges via `AddTriples` (evidence-append, **no** MessageType restamp)

**WARN-and-regroup, not reject** — multi-Subject producers stay correct; single-Subject is the target invariant for *new* Graphables.

## Scope boundaries
- **Deferred to Wave 1:** producer-side `TrajectoryStepEntity` exported-field fix (`writeTrajectorySteps` discards the entity today, so nothing round-trips until its Fact-stream publish leg exists).
- **Tracked in ADR-055 §5 T2:** `graph/messagemanager.ProcessMessage` is a sibling consumer with the *same* single-key misfiling (StorageRef already at parity; T2 regroup to follow) so the two consumers don't drift.

## Testing
New `fact_lane_guards_test.go` (7 tests) drives the production extract → ingest wire: partition correctness (incl. empty-subject → primary), `distinctSubjects`, StorageRef lift + persistence through merge, non-Storable leaves ref nil, foreign edge lands on the child under the correct Subject, single-Subject conjures no phantom child.

**Gates (all green):** full unit suite `-race`, graph-ingest integration `-race` (testcontainers), contract tests, no schema drift, lint/vet/fmt clean.

**Review:** go-reviewer pass — clean, no blocking/high findings (all claims adversarially verified; `own`/`foreign` are disjoint allocations, no aliasing). Two nits folded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)