### PR TITLE
feat(rule): ADR-055 §3a — governance verdict audit stream (retire rule-ID audit triple)

### DIFF
--- a/config/streams.go
+++ b/config/streams.go
@@ -135,6 +135,24 @@ var flowsStreamConfig = StreamConfig{
 	Replicas: 1,
 }
 
+// governanceVerdictAuditStreamConfig defines the GOVERNANCE_VERDICT_AUDIT stream
+// (ADR-055 §3a). It is the append-only home for governance deny/approve verdict
+// events, replacing the prior rule-ID audit triple. Each verdict is a new stream
+// sequence (append-only by construction — no key to overwrite, so last-write-wins
+// audit loss is structurally impossible). Subject pattern:
+// governance.verdict.{decision}.{rule_token} (decision ∈ deny|approve; rule_token
+// is a subject-safe hash of the rule ID, canonical rule_id in the payload).
+// File storage + a long MaxAge sized to the audit/compliance horizon — its own
+// knob, the reason for a dedicated stream rather than riding AGENT.
+var governanceVerdictAuditStreamConfig = StreamConfig{
+	Subjects:  []string{"governance.verdict.>"},
+	Storage:   "file",            // Durable: an audit trail must survive restarts
+	MaxAge:    "2160h",           // ~90 days audit/compliance horizon
+	MaxBytes:  500 * 1024 * 1024, // 500MB cap
+	Retention: "limits",          // Append-only event log (NOT interest/workqueue)
+	Replicas:  1,
+}
+
 // VerifyJetStreamLimits reads the operator's MaxMemory / MaxFileStore
 // hints from cfg.NATS.JetStream and logs a Warn for each value that
 // exceeds the server's actual account limit. JetStream account limits
@@ -225,8 +243,12 @@ func (sm *StreamsManager) EnsureStreams(ctx context.Context, cfg *Config) error 
 	streams["HEALTH"] = healthStreamConfig
 	streams["METRICS"] = metricsStreamConfig
 	streams["FLOWS"] = flowsStreamConfig
+	// GOVERNANCE_VERDICT_AUDIT is a framework guarantee (ADR-055 §3a): the
+	// append-only verdict audit must exist wherever the rule engine can issue
+	// deny/approve verdicts, independent of operator stream config.
+	streams["GOVERNANCE_VERDICT_AUDIT"] = governanceVerdictAuditStreamConfig
 	sm.logger.Debug("Adding system streams",
-		"streams", []string{"LOGS", "HEALTH", "METRICS", "FLOWS"})
+		"streams", []string{"LOGS", "HEALTH", "METRICS", "FLOWS", "GOVERNANCE_VERDICT_AUDIT"})
 
 	// 2. Explicit streams from config (can override system streams)
 	for name, sc := range cfg.Streams {

--- a/docs/adr/055-graph-write-intent-taxonomy.md
+++ b/docs/adr/055-graph-write-intent-taxonomy.md
@@ -449,10 +449,19 @@ migrate every producer to a birth lane first, then flip `triple.add`/`add_batch`
 must-exist last, so `main` is never broken in between.
 
 - **Wave 0 — framework primitives:**
-  - **B-1 governance-audit migration** (§3a) — move `rule.deny`/`rule.approve` from
-    the rule-ID triple write to the `GOVERNANCE_VERDICT_AUDIT` verdict-event stream
-    (registered payload, append-only) + failure metric + regression test + ops-doc
-    update. Gates the closing move.
+  - **B-1 governance-audit migration** (§3a) — **[IMPLEMENTED]** moved
+    `rule.deny`/`rule.approve` from the rule-ID triple write to the
+    `GOVERNANCE_VERDICT_AUDIT` verdict-event stream (registered
+    `governance.verdict.v1` payload in the new `governance` package, append-only,
+    subject `governance.verdict.{decision}.{rule_token}`) via a framework-owned
+    `VerdictAuditor` injected into the rule `ActionExecutor` (independent of the
+    operator `Publisher`). Adds `semstreams_rule_governance_verdict_audit_failures_total{decision}`,
+    deletes the dead `PredicateRuleDeny`/`PredicateRuleApprove` consts, and
+    redirects the ops-doc-17 read path to stream replay. The metric `mode`
+    dimension from the §3a sketch is deferred — the governance mode
+    (`audit`/`enforce`) is a loop-level setting not threaded to the rule-action
+    emit site, so a `mode` label would be permanently `unknown`; revisit if the
+    mode is propagated into the proposed-call message. Gates the closing move.
   - **T1 (three parts)** — `PublishToStreamWithMsgID` + `config.StreamConfig.Duplicates`
     plumbed into both builders + the existing-stream update path; decide the window
     size (Open Question #1). Optionally (s,p,o)-idempotent merge in `MergeEntity`.

--- a/docs/operations/17-tool-call-governance.md
+++ b/docs/operations/17-tool-call-governance.md
@@ -21,7 +21,8 @@ Use subject-mode governance when policy needs to:
 - Compose across signals (a deny condition depending on caller role
   AND tool name AND time-of-day).
 - Be operator-editable without a recompile.
-- Emit audit triples that downstream rules can match on.
+- Record an append-only audit trail of every deny/approve verdict
+  (the `GOVERNANCE_VERDICT_AUDIT` stream, ADR-055 §3a).
 - Vary across rule-engine deployments without code changes in
   agentic-loop.
 
@@ -154,7 +155,8 @@ pair.
 
 The `publish` action emits the rejection to the loop's verdict
 subject. `deny` short-circuits the rule's remaining actions and
-records an audit triple under `rule.deny`.
+emits a deny verdict event to the append-only `GOVERNANCE_VERDICT_AUDIT`
+stream (ADR-055 §3a; subject `governance.verdict.deny.{rule_token}`).
 
 ### Allow read-only tools
 
@@ -176,10 +178,11 @@ records an audit triple under `rule.deny`.
 }
 ```
 
-`approve` writes the audit triple (predicate `rule.approve`) AND
-publishes the verdict in one action. It does NOT short-circuit
-subsequent actions — operators may want to add metric-counter actions
-or downstream notifications on the same firing.
+`approve` emits an approve verdict event to the `GOVERNANCE_VERDICT_AUDIT`
+stream (subject `governance.verdict.approve.{rule_token}`, ADR-055 §3a)
+AND publishes the routing verdict to the loop in one action. It does NOT
+short-circuit subsequent actions — operators may want to add metric-counter
+actions or downstream notifications on the same firing.
 
 ### Consolidated blocklist with fallback approve (recommended)
 
@@ -312,6 +315,21 @@ Three Prometheus metrics drive the operational view:
 | `semstreams_agentic_loop_tool_call_governance_verdict_duration_seconds` | `decision`, `mode` | Buckets 1ms → 5s. Drives the timeout-tuning decision in beta.70 — set `timeout` after measuring p99 from this histogram. |
 | `semstreams_agentic_loop_tool_call_governance_verdict_total` | `decision`, `mode` | Sum of approved+rejected+timeout per mode. Sustained `decision=timeout` rate signals undersized timeout or stuck rule engine. |
 | `semstreams_agentic_loop_tool_call_governance_subscribe_before_publish_failures_total` | (none) | Increments when a verdict arrives without a registered waiter. Non-zero rate is the canonical signal that the subscribe-before-publish race-fix regressed; investigate immediately. |
+| `semstreams_rule_governance_verdict_audit_failures_total` | `decision` | A deny/approve verdict was applied but its append-only audit record failed to publish (ADR-055 §3a). The verdict still holds — but a non-zero value is a compliance-visibility gap, critical in `enforce` mode. |
+
+### Verdict audit trail
+
+Every explicit `deny`/`approve` verdict is recorded as a registered
+event on the append-only `GOVERNANCE_VERDICT_AUDIT` JetStream stream
+(ADR-055 §3a), subject `governance.verdict.{decision}.{rule_token}`
+(`rule_token` is a subject-safe hash of the rule ID; the canonical
+`rule_id` travels in the payload). This replaces the former
+`rule.deny`/`rule.approve` audit triples. To review verdict history,
+replay/filter the stream (e.g. `governance.verdict.deny.>` for all
+denials); the payload carries `{decision, rule_id, reason, entity_id,
+timestamp, loop_id?, call_id?}`. The audit emit is best-effort — a
+failed emit never flips a verdict — and lost records are surfaced via
+`semstreams_rule_governance_verdict_audit_failures_total`.
 
 ## Troubleshooting
 

--- a/governance/verdict.go
+++ b/governance/verdict.go
@@ -1,0 +1,140 @@
+// Package governance holds the framework's governance-audit payload types.
+//
+// A governance verdict (deny/approve, ADR-039) is an *event*: N verdicts occur
+// per rule over time. ADR-055 §3a retires the previous mechanism — a best-effort
+// audit triple written onto a phantom rule-ID "entity" via the graph-ingest
+// auto-vivify path that ADR-055 deletes — and replaces it with this registered
+// verdict-event payload published to the append-only GOVERNANCE_VERDICT_AUDIT
+// JetStream stream. The verdict thus carries its own producer contract (a
+// semantic envelope, §2) and lands on an honest, queryable event log instead of
+// a mutable, last-write-wins rule-ID record.
+package governance
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"time"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadregistry"
+)
+
+// Payload type coordinates (the semantic envelope, ADR-055 §2).
+const (
+	// Domain is the payload-registry domain for governance events.
+	Domain = "governance"
+	// CategoryVerdict is the payload-registry category for verdict events.
+	CategoryVerdict = "verdict"
+	// SchemaVersion is the current governance payload schema version.
+	SchemaVersion = "v1"
+)
+
+// Verdict decision values. These are the subject-safe tokens used in the
+// verdict subject (`governance.verdict.{decision}.{rule_token}`).
+const (
+	// DecisionDeny records an explicit tool-call/structural denial.
+	DecisionDeny = "deny"
+	// DecisionApprove records an explicit approval.
+	DecisionApprove = "approve"
+)
+
+// SubjectPrefix is the root of every verdict subject. The GOVERNANCE_VERDICT_AUDIT
+// stream captures `governance.verdict.>`.
+const SubjectPrefix = "governance.verdict"
+
+// VerdictEvent is the registered audit payload for a governance verdict.
+//
+// Always-present fields (RuleID, Reason, EntityID, Decision, Timestamp) come from
+// the rule action's execution context. LoopID/CallID are OPTIONAL — they are
+// echoed from the proposed-call message when the verdict fires on a tool-call
+// (ADR-055 §3a) and are empty for entity-state-driven or cron-fired rules, which
+// have no inbound call identity.
+type VerdictEvent struct {
+	// Decision is DecisionDeny or DecisionApprove.
+	Decision string `json:"decision"`
+	// RuleID is the canonical (un-encoded) rule identifier. Free-form config
+	// string; carried here verbatim because the subject token is a lossy hash.
+	RuleID string `json:"rule_id"`
+	// Reason is the operator-facing verdict reason (substituted).
+	Reason string `json:"reason"`
+	// EntityID is the entity the verdict concerns (may be empty for some rule
+	// contexts).
+	EntityID string `json:"entity_id,omitempty"`
+	// Timestamp is when the verdict was issued.
+	Timestamp time.Time `json:"timestamp"`
+	// LoopID is the agentic-loop id, when the verdict fired on a tool-call.
+	LoopID string `json:"loop_id,omitempty"`
+	// CallID is the tool-call id, when the verdict fired on a tool-call.
+	CallID string `json:"call_id,omitempty"`
+}
+
+// Validate implements message.Payload. It is deliberately lenient: the only hard
+// requirements are a recognized decision and a non-empty rule ID. The audit emit
+// is best-effort and must never block a structural verdict, so a permissive
+// Validate keeps a sparse-but-real verdict event readable rather than rejecting
+// it at decode.
+func (e *VerdictEvent) Validate() error {
+	switch e.Decision {
+	case DecisionDeny, DecisionApprove:
+	default:
+		return fmt.Errorf("invalid verdict decision %q (must be %q or %q)", e.Decision, DecisionDeny, DecisionApprove)
+	}
+	if e.RuleID == "" {
+		return fmt.Errorf("rule_id required")
+	}
+	return nil
+}
+
+// Schema implements message.Payload.
+func (e *VerdictEvent) Schema() message.Type {
+	return message.Type{Domain: Domain, Category: CategoryVerdict, Version: SchemaVersion}
+}
+
+// MarshalJSON implements json.Marshaler. The Alias indirection avoids infinite
+// recursion; the BaseMessage envelope is added by the publisher
+// (message.NewBaseMessage), not here.
+func (e *VerdictEvent) MarshalJSON() ([]byte, error) {
+	type Alias VerdictEvent
+	return json.Marshal((*Alias)(e))
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (e *VerdictEvent) UnmarshalJSON(data []byte) error {
+	type Alias VerdictEvent
+	return json.Unmarshal(data, (*Alias)(e))
+}
+
+// RuleToken returns a deterministic, subject-safe encoding of a rule ID for use
+// as a NATS subject token. Rule IDs are free-form config strings that can contain
+// `.` (the token separator), spaces, or `*`/`>` (wildcards) — any of which would
+// break subject publishing AND filtering. The token is a 64-bit FNV-1a hash in
+// hex (16 chars, always subject-safe). The canonical rule_id travels in the
+// payload for display/query, so the hash being lossy is acceptable (ADR-055 §3a).
+func RuleToken(ruleID string) string {
+	h := fnv.New64a()
+	// fnv.Write never returns an error.
+	_, _ = h.Write([]byte(ruleID))
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+// VerdictSubject builds the publish subject for a verdict event:
+// `governance.verdict.{decision}.{rule_token}`. decision should be DecisionDeny
+// or DecisionApprove (already subject-safe).
+func VerdictSubject(decision, ruleID string) string {
+	return fmt.Sprintf("%s.%s.%s", SubjectPrefix, decision, RuleToken(ruleID))
+}
+
+// RegisterPayloads registers the governance verdict-event payload with the
+// supplied registry. Called from payloadbuiltins.Register during bootstrap so
+// any registry-based decoder (audit/ops dashboards replaying the stream) can read
+// verdict events off the wire.
+func RegisterPayloads(reg *payloadregistry.Registry) error {
+	return reg.Register(&payloadregistry.Registration{
+		Domain:      Domain,
+		Category:    CategoryVerdict,
+		Version:     SchemaVersion,
+		Description: "Governance deny/approve verdict audit event (ADR-039 / ADR-055 §3a)",
+		Factory:     func() any { return &VerdictEvent{} },
+	})
+}

--- a/governance/verdict_test.go
+++ b/governance/verdict_test.go
@@ -1,0 +1,126 @@
+package governance_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/governance"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadbuiltins"
+)
+
+func TestVerdictEvent_Validate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		ev      governance.VerdictEvent
+		wantErr bool
+	}{
+		{"valid deny", governance.VerdictEvent{Decision: governance.DecisionDeny, RuleID: "r1"}, false},
+		{"valid approve", governance.VerdictEvent{Decision: governance.DecisionApprove, RuleID: "r1"}, false},
+		{"bad decision", governance.VerdictEvent{Decision: "maybe", RuleID: "r1"}, true},
+		{"empty decision", governance.VerdictEvent{RuleID: "r1"}, true},
+		{"empty rule_id", governance.VerdictEvent{Decision: governance.DecisionDeny}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.ev.Validate()
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRuleToken_SubjectSafe is the load-bearing guard: rule IDs are free-form
+// config strings that can contain the NATS token separator, wildcards, or
+// spaces. The token MUST be subject-safe (hex only) regardless of input so it
+// can never break subject publishing or filtering.
+func TestRuleToken_SubjectSafe(t *testing.T) {
+	t.Parallel()
+	adversarial := []string{
+		"role-gate-rule",
+		"architect_complete_spawn_editor",
+		"rule.with.dots",
+		"rule with spaces",
+		"rule*with>wildcards",
+		"product.ns.rule",
+		"",
+		">",
+		"*",
+	}
+	const hexDigits = "0123456789abcdef"
+	for _, id := range adversarial {
+		tok := governance.RuleToken(id)
+		assert.Len(t, tok, 16, "token must be a fixed 16-char hex string for %q", id)
+		for _, r := range tok {
+			assert.True(t, strings.ContainsRune(hexDigits, r),
+				"token for %q must be hex-only, got %q", id, tok)
+		}
+		assert.NotContains(t, tok, ".", "token must not contain the NATS separator")
+	}
+}
+
+func TestRuleToken_Deterministic(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, governance.RuleToken("role-gate-rule"), governance.RuleToken("role-gate-rule"))
+	assert.NotEqual(t, governance.RuleToken("rule-a"), governance.RuleToken("rule-b"),
+		"distinct rule IDs should (overwhelmingly) get distinct tokens")
+}
+
+func TestVerdictSubject_FourSegments(t *testing.T) {
+	t.Parallel()
+	// A rule ID full of subject-hostile characters must still yield a clean
+	// 4-token subject: governance . verdict . <decision> . <rule_token>.
+	subj := governance.VerdictSubject(governance.DecisionDeny, "rule.with.dots and *")
+	parts := strings.Split(subj, ".")
+	require.Len(t, parts, 4, "verdict subject must have exactly 4 dot-separated tokens, got %q", subj)
+	assert.Equal(t, "governance", parts[0])
+	assert.Equal(t, "verdict", parts[1])
+	assert.Equal(t, governance.DecisionDeny, parts[2])
+	assert.Equal(t, governance.RuleToken("rule.with.dots and *"), parts[3])
+	assert.True(t, strings.HasPrefix(subj, governance.SubjectPrefix+"."))
+}
+
+// TestVerdictEvent_ProductionRoundTrip wraps a verdict event in a BaseMessage
+// envelope and decodes it through the production registry decoder (the real
+// payloadbuiltins registration), proving an audit/ops reader can read verdict
+// events off the wire — the §2 semantic-envelope requirement.
+func TestVerdictEvent_ProductionRoundTrip(t *testing.T) {
+	t.Parallel()
+	ts := time.Date(2026, 6, 12, 10, 30, 0, 0, time.UTC)
+	original := &governance.VerdictEvent{
+		Decision:  governance.DecisionDeny,
+		RuleID:    "role-gate-rule",
+		Reason:    "user viewer-1 is not admin",
+		EntityID:  "acme.ops.test.svc.entity.001",
+		Timestamp: ts,
+		LoopID:    "loop-abc",
+		CallID:    "call-001",
+	}
+	baseMsg := message.NewBaseMessage(original.Schema(), original, "rule_engine")
+	data, err := json.Marshal(baseMsg)
+	require.NoError(t, err)
+
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	decoded, err := decoder.Decode(data)
+	require.NoError(t, err)
+	require.Equal(t, "governance.verdict.v1", decoded.Type().Key())
+
+	got, ok := decoded.Payload().(*governance.VerdictEvent)
+	require.True(t, ok, "decoded payload must be a *governance.VerdictEvent, got %T", decoded.Payload())
+	assert.Equal(t, original.Decision, got.Decision)
+	assert.Equal(t, original.RuleID, got.RuleID)
+	assert.Equal(t, original.Reason, got.Reason)
+	assert.Equal(t, original.EntityID, got.EntityID)
+	assert.Equal(t, original.LoopID, got.LoopID)
+	assert.Equal(t, original.CallID, got.CallID)
+	assert.True(t, got.Timestamp.Equal(ts), "timestamp must round-trip")
+}

--- a/payloadbuiltins/register.go
+++ b/payloadbuiltins/register.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/governance"
 	githubwebhook "github.com/c360studio/semstreams/input/github-webhook"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/message/oms"
@@ -50,6 +51,7 @@ func Register(reg *payloadregistry.Registry) error {
 	track(agenticdispatch.RegisterPayloads(reg))
 	track(githubwebhook.RegisterPayloads(reg))
 	track(objectstore.RegisterPayloads(reg))
+	track(governance.RegisterPayloads(reg))
 
 	return errors.Join(errs...)
 }

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -14,6 +14,7 @@ import (
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/agentic/agentrun"
 	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/governance"
 	gtypes "github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
@@ -60,16 +61,13 @@ const (
 	ActionTypeLifecycleFail = "lifecycle_fail"
 )
 
-// PredicateRuleDeny is the audit-triple predicate written by deny actions.
-// Downstream rules that gate on denials should match against this constant
-// so they stay in sync with any future rename.
-const PredicateRuleDeny = "rule.deny"
-
-// PredicateRuleApprove is the audit-triple predicate written by approve
-// actions. Downstream rules that gate on approvals (rate-limit a caller's
-// successful tool-call rate, audit-log every approve, etc.) should match
-// against this constant so they stay in sync with any future rename.
-const PredicateRuleApprove = "rule.approve"
+// NOTE: the former PredicateRuleDeny/PredicateRuleApprove audit-triple
+// predicates ("rule.deny"/"rule.approve") were retired in ADR-055 §3a. Deny and
+// approve no longer write an audit triple onto a phantom rule-ID entity (that
+// rode the graph-ingest auto-vivify path ADR-055 deletes); they emit a
+// registered verdict event to the append-only GOVERNANCE_VERDICT_AUDIT stream
+// (see VerdictAuditor + governance.VerdictEvent). This amends ADR-039's audit
+// mechanism while preserving its explicit-verdict-audit goal.
 
 // Action represents an action to execute when a rule fires.
 // Actions are triggered by state transitions (OnEnter, OnExit) or
@@ -407,6 +405,22 @@ type Publisher interface {
 	Publish(ctx context.Context, subject string, data []byte) error
 }
 
+// VerdictAuditor records a governance deny/approve verdict to the append-only
+// GOVERNANCE_VERDICT_AUDIT stream (ADR-055 §3a). It is a FRAMEWORK-owned
+// dependency, distinct from the operator-configured routing Publisher: piggy-
+// backing the Publisher would let config drift silently disable the audit trail,
+// so the audit emit has its own always-wired path. It REPLACES the prior
+// rule-ID audit triple (which rode the graph-ingest auto-vivify path ADR-055
+// deletes). The emit is best-effort — the caller must NOT flip a structural
+// verdict on an emit error — and increments a failure metric so a lost audit
+// record is observable rather than silent.
+type VerdictAuditor interface {
+	// EmitVerdict publishes a verdict event. Returns an error on emit failure;
+	// callers treat the error as a (metered, logged) audit gap, never a verdict
+	// change.
+	EmitVerdict(ctx context.Context, ev governance.VerdictEvent) error
+}
+
 // LifecycleManager is the subset of *lifecycle.Manager used by the
 // rule action executor for the lifecycle_* action family (ADR-047) and
 // the agent-run mint path (ADR-053 D4).
@@ -446,6 +460,10 @@ type ActionExecutor struct {
 	kvWriter      KVWriter                     // Optional: if nil, update_kv actions are logged but not executed
 	lifecycle     LifecycleManager             // Optional: if nil, lifecycle_* actions return an error explaining no Manager is wired
 	toolRegistry  component.ToolRegistryReader // Optional: if nil, publish_agent default_tools resolution returns empty
+	// verdictAuditor records governance deny/approve verdicts to the append-only
+	// audit stream (ADR-055 §3a). Optional: if nil, verdicts are still applied
+	// and logged but no audit event is emitted (e.g. NATS-less test executors).
+	verdictAuditor VerdictAuditor
 }
 
 // SetToolRegistry installs the shared tool registry used by
@@ -464,6 +482,15 @@ func (e *ActionExecutor) SetToolRegistry(r component.ToolRegistryReader) {
 // access to the registered Manager.
 func (e *ActionExecutor) SetLifecycleManager(m LifecycleManager) {
 	e.lifecycle = m
+}
+
+// SetVerdictAuditor installs the framework verdict auditor used by deny/approve
+// actions to record governance verdicts (ADR-055 §3a). nil-valued arg leaves
+// verdicts un-audited (still applied + logged). Set explicitly after
+// construction by the rule processor once it has a NATS client. It is wired
+// independently of the operator Publisher so config drift cannot disable audit.
+func (e *ActionExecutor) SetVerdictAuditor(a VerdictAuditor) {
+	e.verdictAuditor = a
 }
 
 // NewActionExecutor creates a new ActionExecutor with the given logger.
@@ -1391,31 +1418,49 @@ func (e *ActionExecutor) executeDeny(ctx context.Context, action Action, ec *Exe
 	reason := ec.SubstituteVariables(action.Reason)
 	ruleID := ec.RuleID()
 
-	// Best-effort audit triple. Mirror executePublishAgent's triple-write pattern.
-	// If AddTriple fails, we log Error but DO NOT return that error — the deny
-	// verdict is the structural outcome and must not be flipped to "allow" by
-	// an audit-write failure.
-	if e.tripleMutator != nil {
-		auditTriple := message.Triple{
-			Subject:    ruleID,
-			Predicate:  PredicateRuleDeny,
-			Object:     reason,
-			Source:     "rule_engine",
-			Timestamp:  time.Now(),
-			Confidence: 1.0,
-		}
-		if _, err := e.tripleMutator.AddTriple(ctx, ruleID, auditTriple); err != nil {
-			if e.logger != nil {
-				e.logger.Error("deny verdict audit triple write failed; verdict still applies",
-					"rule_id", ruleID,
-					"reason", reason,
-					"error", err)
-			}
-			// intentionally fall through — verdict is structural
-		}
-	}
+	// Best-effort governance audit (ADR-055 §3a): emit a registered verdict event
+	// to the append-only GOVERNANCE_VERDICT_AUDIT stream, replacing the prior
+	// rule-ID audit triple that rode graph-ingest's auto-vivify path. An emit
+	// failure is logged + metered but MUST NOT flip the verdict from deny to allow.
+	e.emitVerdictAudit(ctx, governance.DecisionDeny, ruleID, reason, ec)
 
 	return &DenyVerdict{RuleID: ruleID, Reason: reason}
+}
+
+// emitVerdictAudit records a governance verdict to the append-only audit stream
+// (ADR-055 §3a). Best-effort by construction: a nil auditor (NATS-less executor)
+// is a no-op, and an emit error is logged at Error level so operators see the
+// audit gap — but the caller's structural verdict is NEVER changed by an audit
+// failure. The auditor meters failures via governance_verdict_audit_failures_total.
+func (e *ActionExecutor) emitVerdictAudit(ctx context.Context, decision, ruleID, reason string, ec *ExecutionContext) {
+	if e.verdictAuditor == nil {
+		return
+	}
+	ev := governance.VerdictEvent{
+		Decision:  decision,
+		RuleID:    ruleID,
+		Reason:    reason,
+		EntityID:  ec.EntityID,
+		Timestamp: time.Now(),
+	}
+	// loop_id/call_id are OPTIONAL — echoed from the proposed-call message when
+	// the verdict fires on a tool-call. Nil MessageData (entity-state-driven or
+	// cron-fired rules) leaves them empty; the audit record stays valid.
+	if ec.MessageData != nil {
+		if v, ok := ec.MessageData["loop_id"].(string); ok {
+			ev.LoopID = v
+		}
+		if v, ok := ec.MessageData["call_id"].(string); ok {
+			ev.CallID = v
+		}
+	}
+	if err := e.verdictAuditor.EmitVerdict(ctx, ev); err != nil && e.logger != nil {
+		e.logger.Error("governance verdict audit emit failed; verdict still applies",
+			"decision", decision,
+			"rule_id", ruleID,
+			"reason", reason,
+			"error", err)
+	}
 }
 
 // executeApprove issues an approve verdict — writes a best-effort audit triple
@@ -1442,29 +1487,11 @@ func (e *ActionExecutor) executeApprove(ctx context.Context, action Action, ec *
 	ruleID := ec.RuleID()
 	entityID := ec.EntityID
 
-	// Best-effort audit triple. Mirror executeDeny's pattern: audit-write
-	// failure must NOT change the verdict — approve still proceeds to
-	// publish so downstream consumers see the decision.
-	if e.tripleMutator != nil {
-		auditTriple := message.Triple{
-			Subject:    ruleID,
-			Predicate:  PredicateRuleApprove,
-			Object:     reason,
-			Source:     "rule_engine",
-			Timestamp:  time.Now(),
-			Confidence: 1.0,
-		}
-		if _, err := e.tripleMutator.AddTriple(ctx, ruleID, auditTriple); err != nil {
-			if e.logger != nil {
-				e.logger.Error("approve verdict audit triple write failed; verdict still applies",
-					"rule_id", ruleID,
-					"subject", subject,
-					"reason", reason,
-					"error", err)
-			}
-			// fall through — verdict is structural, publish below must run
-		}
-	}
+	// Best-effort governance audit (ADR-055 §3a): same mechanism as deny — emit
+	// a verdict event to the audit stream. Audit failure must NOT change the
+	// verdict; approve still proceeds to the routing publish below so downstream
+	// consumers see the decision.
+	e.emitVerdictAudit(ctx, governance.DecisionApprove, ruleID, reason, ec)
 
 	// Publish the verdict payload. The subject itself carries the routing
 	// identity (e.g. `agent.toolcall.approved.<loop_id>.<call_id>`); the

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/governance"
 	gtypes "github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/payloadregistry"
@@ -406,6 +407,22 @@ func (m *mockPublisher) Publish(_ context.Context, subject string, data []byte) 
 		return m.err
 	}
 	m.published = append(m.published, publishedMessage{subject: subject, data: data})
+	return nil
+}
+
+// mockVerdictAuditor captures emitted governance verdict events (ADR-055 §3a),
+// or fails when err is set, so tests can assert the deny/approve audit emit and
+// the best-effort "audit failure never flips the verdict" invariant.
+type mockVerdictAuditor struct {
+	emitted []governance.VerdictEvent
+	err     error
+}
+
+func (m *mockVerdictAuditor) EmitVerdict(_ context.Context, ev governance.VerdictEvent) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.emitted = append(m.emitted, ev)
 	return nil
 }
 
@@ -2541,8 +2558,9 @@ func TestExecuteDeny_AuditFailureDoesNotFlipDeny(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	mut := &mockTripleMutator{addErr: errors.New("nats unavailable")}
-	executor := NewActionExecutorWithMutator(slog.Default(), mut)
+	aud := &mockVerdictAuditor{err: errors.New("nats unavailable")}
+	executor := NewActionExecutor(slog.Default())
+	executor.SetVerdictAuditor(aud)
 	ec := newDenyTestEC("deny-rule-audit-fail", nil)
 	action := Action{Type: ActionTypeDeny, Reason: "must deny"}
 
@@ -2559,36 +2577,39 @@ func TestExecuteDeny_AuditFailureDoesNotFlipDeny(t *testing.T) {
 	assert.Equal(t, "must deny", dv.Reason)
 }
 
-// TestExecuteDeny_WritesAuditTriple verifies that executeDeny calls
-// tripleMutator.AddTriple with predicate "rule.deny" and the expected reason object.
-func TestExecuteDeny_WritesAuditTriple(t *testing.T) {
+// TestExecuteDeny_EmitsVerdictAudit verifies that executeDeny emits a governance
+// verdict event (ADR-055 §3a) carrying decision=deny, the rule ID, the reason,
+// and the entity ID — replacing the prior rule.deny audit triple.
+func TestExecuteDeny_EmitsVerdictAudit(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	mut := &mockTripleMutator{}
-	executor := NewActionExecutorWithMutator(slog.Default(), mut)
+	aud := &mockVerdictAuditor{}
+	executor := NewActionExecutor(slog.Default())
+	executor.SetVerdictAuditor(aud)
 	ec := newDenyTestEC("deny-rule-audit", nil)
 	action := Action{Type: ActionTypeDeny, Reason: "blocked by policy"}
 
 	_ = executor.executeDeny(ctx, action, ec)
 
-	require.Len(t, mut.addedTriples, 1, "AddTriple must be called exactly once")
-	triple := mut.addedTriples[0]
-	assert.Equal(t, PredicateRuleDeny, triple.Predicate,
-		"audit triple predicate must be %q", PredicateRuleDeny)
-	assert.Equal(t, "blocked by policy", triple.Object,
-		"audit triple object must be the reason string")
+	require.Len(t, aud.emitted, 1, "EmitVerdict must be called exactly once")
+	ev := aud.emitted[0]
+	assert.Equal(t, governance.DecisionDeny, ev.Decision)
+	assert.Equal(t, "deny-rule-audit", ev.RuleID)
+	assert.Equal(t, "blocked by policy", ev.Reason)
+	assert.Equal(t, "acme.ops.test.svc.entity.001", ev.EntityID)
 }
 
 // TestExecuteDeny_VariableSubstitutionInReason verifies that $caller.role and
 // other template variables are substituted into the reason before it travels
-// in the DenyVerdict and the audit triple.
+// in the DenyVerdict and the emitted verdict event.
 func TestExecuteDeny_VariableSubstitutionInReason(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	mut := &mockTripleMutator{}
-	executor := NewActionExecutorWithMutator(slog.Default(), mut)
+	aud := &mockVerdictAuditor{}
+	executor := NewActionExecutor(slog.Default())
+	executor.SetVerdictAuditor(aud)
 	ec := newDenyTestEC("deny-rule-subst", &CallerContext{ID: "alice", Role: "viewer", Org: "acme"})
 	action := Action{Type: ActionTypeDeny, Reason: "caller $caller.id with role $caller.role is denied"}
 
@@ -2599,15 +2620,15 @@ func TestExecuteDeny_VariableSubstitutionInReason(t *testing.T) {
 	require.True(t, errors.As(err, &dv))
 	assert.Equal(t, "caller alice with role viewer is denied", dv.Reason)
 
-	require.Len(t, mut.addedTriples, 1)
-	assert.Equal(t, "caller alice with role viewer is denied", mut.addedTriples[0].Object)
+	require.Len(t, aud.emitted, 1)
+	assert.Equal(t, "caller alice with role viewer is denied", aud.emitted[0].Reason)
 }
 
 // --- executeApprove tests ---
 //
 // Approve is asymmetric to deny: it returns nil (does NOT short-circuit
 // subsequent actions), publishes a verdict payload to the configured
-// Subject, and writes an audit triple under PredicateRuleApprove. These
+// Subject, and emits an approve verdict audit event (ADR-055 §3a). These
 // tests pin those invariants and the parity with deny on audit-failure
 // handling.
 
@@ -2696,17 +2717,17 @@ func TestExecuteApprove_PublishesVerdictPayload(t *testing.T) {
 	assert.Equal(t, "policy permits", envelope.Payload.Data["reason"])
 }
 
-// TestExecuteApprove_WritesAuditTriple verifies the audit triple is written
-// with PredicateRuleApprove and the substituted reason as the object.
-// Downstream rules that count approvals by caller can match on this
-// predicate.
-func TestExecuteApprove_WritesAuditTriple(t *testing.T) {
+// TestExecuteApprove_EmitsVerdictAudit verifies approve emits a governance
+// verdict event (ADR-055 §3a) with decision=approve and the substituted reason,
+// in addition to (and independent of) the routing publish.
+func TestExecuteApprove_EmitsVerdictAudit(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	mut := &mockTripleMutator{}
+	aud := &mockVerdictAuditor{}
 	pub := &mockPublisher{}
-	executor := NewActionExecutorFull(slog.Default(), mut, pub)
+	executor := NewActionExecutorFull(slog.Default(), nil, pub)
+	executor.SetVerdictAuditor(aud)
 	ec := newApproveTestEC("approve-rule-audit", nil, nil)
 	action := Action{
 		Type:    ActionTypeApprove,
@@ -2716,12 +2737,11 @@ func TestExecuteApprove_WritesAuditTriple(t *testing.T) {
 
 	require.NoError(t, executor.executeApprove(ctx, action, ec))
 
-	require.Len(t, mut.addedTriples, 1, "AddTriple must be called exactly once")
-	triple := mut.addedTriples[0]
-	assert.Equal(t, PredicateRuleApprove, triple.Predicate,
-		"audit triple predicate must be %q", PredicateRuleApprove)
-	assert.Equal(t, "policy permits", triple.Object,
-		"audit triple object must be the substituted reason")
+	require.Len(t, aud.emitted, 1, "EmitVerdict must be called exactly once")
+	ev := aud.emitted[0]
+	assert.Equal(t, governance.DecisionApprove, ev.Decision)
+	assert.Equal(t, "approve-rule-audit", ev.RuleID)
+	assert.Equal(t, "policy permits", ev.Reason)
 }
 
 // TestExecuteApprove_AuditFailureDoesNotBlockPublish is the deny-parity
@@ -2734,9 +2754,10 @@ func TestExecuteApprove_AuditFailureDoesNotBlockPublish(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	mut := &mockTripleMutator{addErr: errors.New("nats unavailable")}
+	aud := &mockVerdictAuditor{err: errors.New("nats unavailable")}
 	pub := &mockPublisher{}
-	executor := NewActionExecutorFull(slog.Default(), mut, pub)
+	executor := NewActionExecutorFull(slog.Default(), nil, pub)
+	executor.SetVerdictAuditor(aud)
 	ec := newApproveTestEC("approve-rule-audit-fail", nil, nil)
 	action := Action{
 		Type:    ActionTypeApprove,
@@ -2747,6 +2768,32 @@ func TestExecuteApprove_AuditFailureDoesNotBlockPublish(t *testing.T) {
 	err := executor.executeApprove(ctx, action, ec)
 	assert.NoError(t, err, "audit failure must NOT propagate; publish ran")
 	require.Len(t, pub.published, 1, "publish must still fire when audit fails")
+}
+
+// TestEmitVerdictAudit_EchoesLoopAndCallID verifies the OPTIONAL identifiers are
+// sourced from MessageData (the proposed-call message) when present, and left
+// empty otherwise (entity-state / cron rules have no inbound call identity).
+func TestEmitVerdictAudit_EchoesLoopAndCallID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	withMsg := &mockVerdictAuditor{}
+	exec1 := NewActionExecutor(slog.Default())
+	exec1.SetVerdictAuditor(withMsg)
+	ecWith := newApproveTestEC("rule-echo", nil, map[string]any{"loop_id": "loop-abc", "call_id": "call-001"})
+	exec1.emitVerdictAudit(ctx, governance.DecisionApprove, "rule-echo", "ok", ecWith)
+	require.Len(t, withMsg.emitted, 1)
+	assert.Equal(t, "loop-abc", withMsg.emitted[0].LoopID)
+	assert.Equal(t, "call-001", withMsg.emitted[0].CallID)
+
+	noMsg := &mockVerdictAuditor{}
+	exec2 := NewActionExecutor(slog.Default())
+	exec2.SetVerdictAuditor(noMsg)
+	ecNone := newDenyTestEC("rule-no-msg", nil) // nil MessageData
+	exec2.emitVerdictAudit(ctx, governance.DecisionDeny, "rule-no-msg", "blocked", ecNone)
+	require.Len(t, noMsg.emitted, 1)
+	assert.Empty(t, noMsg.emitted[0].LoopID, "no MessageData → empty loop_id")
+	assert.Empty(t, noMsg.emitted[0].CallID, "no MessageData → empty call_id")
 }
 
 // TestExecuteApprove_PublishFailureReturnsError diverges from audit-failure
@@ -2791,19 +2838,20 @@ func TestExecuteApprove_RequiresSubject(t *testing.T) {
 
 // TestExecuteApprove_NoPublisherIsNoOp covers the early-boot or
 // publisher-not-configured scenario: approve must still complete (return
-// nil) and write the audit triple. The publish step is skipped without
+// nil) and emit the verdict audit event. The publish step is skipped without
 // error so dev/test environments without a NATS publisher don't break.
 func TestExecuteApprove_NoPublisherIsNoOp(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	mut := &mockTripleMutator{}
-	executor := NewActionExecutorWithMutator(slog.Default(), mut)
+	aud := &mockVerdictAuditor{}
+	executor := NewActionExecutor(slog.Default())
+	executor.SetVerdictAuditor(aud)
 	ec := newApproveTestEC("approve-no-pub", nil, nil)
 	action := Action{Type: ActionTypeApprove, Subject: "agent.toolcall.approved.x", Reason: "permit"}
 
 	assert.NoError(t, executor.executeApprove(ctx, action, ec))
-	assert.Len(t, mut.addedTriples, 1, "audit triple still written without publisher")
+	assert.Len(t, aud.emitted, 1, "verdict audit still emitted without publisher")
 }
 
 // --- ADR-053 Pass A: RunID inheritance in executePublishAgent ---

--- a/processor/rule/deny_integration_test.go
+++ b/processor/rule/deny_integration_test.go
@@ -1,9 +1,11 @@
 //go:build integration
 
-// Integration tests for the deny action against real NATS + KV.
+// Integration tests for the deny/approve actions against real NATS + JetStream.
 //
-// These tests exercise the full deny machinery end-to-end: CallerContext
-// substitution, action short-circuit, and audit triple write.
+// These exercise the full verdict machinery end-to-end: CallerContext
+// substitution, action short-circuit, and the governance verdict audit
+// (ADR-055 §3a) — a registered verdict event published to the append-only
+// GOVERNANCE_VERDICT_AUDIT stream, replacing the prior rule-ID audit triple.
 //
 // Per-rule revision guard against cascade-fires is unit-tested separately in
 // revision_tracking_test.go (shouldSkipRule, ownRevisions injection).
@@ -16,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -24,22 +27,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/config"
+	"github.com/c360studio/semstreams/governance"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/payloadbuiltins"
 	"github.com/c360studio/semstreams/processor/rule"
 )
 
-// natsTripleMutator is a test-only implementation of rule.TripleMutator
-// that performs real NATS request/reply against a test responder.
-type natsTripleMutator struct {
-	natsClient *natsclient.Client
-}
-
-// natsPublisher is a test-only implementation of rule.Publisher that
-// publishes to a real NATS connection. Used in TestIntegration_DenyFlow to
-// let publish actions actually reach the NATS broker so the test can count
-// deliveries via a subscription.
+// natsPublisher is a test-only implementation of rule.Publisher that publishes
+// to a real NATS connection so the test can count deliveries via a subscription.
 type natsPublisher struct {
 	natsClient *natsclient.Client
 }
@@ -48,117 +45,21 @@ func (p *natsPublisher) Publish(ctx context.Context, subject string, data []byte
 	return p.natsClient.Publish(ctx, subject, data)
 }
 
-func (m *natsTripleMutator) AddTriple(ctx context.Context, _ string, triple message.Triple) (uint64, error) {
-	req := gtypes.AddTripleRequest{Triple: triple}
-	data, err := json.Marshal(req)
-	if err != nil {
-		return 0, err
-	}
-
-	respData, err := m.natsClient.RequestWithRetry(
-		ctx,
-		rule.SubjectTripleAdd,
-		data,
-		5*time.Second,
-		natsclient.DefaultRetryConfig(),
-	)
-	if err != nil {
-		return 0, err
-	}
-
-	var resp gtypes.AddTripleResponse
-	if err := json.Unmarshal(respData, &resp); err != nil {
-		return 0, err
-	}
-	if !resp.Success {
-		return 0, errors.New(resp.Error)
-	}
-
-	return resp.KVRevision, nil
+// denyTestVerdictAuditor is a test rule.VerdictAuditor that publishes verdict
+// events to the real GOVERNANCE_VERDICT_AUDIT stream via PublishToStream — the
+// same wire (subject + BaseMessage envelope) the production auditor uses
+// (ADR-055 §3a).
+type denyTestVerdictAuditor struct {
+	nc *natsclient.Client
 }
 
-func (m *natsTripleMutator) RemoveTriple(ctx context.Context, _ string, subject, predicate string) (uint64, error) {
-	req := gtypes.RemoveTripleRequest{Subject: subject, Predicate: predicate}
-	data, err := json.Marshal(req)
+func (a *denyTestVerdictAuditor) EmitVerdict(ctx context.Context, ev governance.VerdictEvent) error {
+	baseMsg := message.NewBaseMessage(ev.Schema(), &ev, "rule_engine")
+	data, err := json.Marshal(baseMsg)
 	if err != nil {
-		return 0, err
+		return err
 	}
-
-	respData, err := m.natsClient.RequestWithRetry(
-		ctx,
-		rule.SubjectTripleRemove,
-		data,
-		5*time.Second,
-		natsclient.DefaultRetryConfig(),
-	)
-	if err != nil {
-		return 0, err
-	}
-
-	var resp gtypes.RemoveTripleResponse
-	if err := json.Unmarshal(respData, &resp); err != nil {
-		return 0, err
-	}
-	if !resp.Success {
-		return 0, errors.New(resp.Error)
-	}
-	return resp.KVRevision, nil
-}
-
-// startGraphResponder registers NATS request/reply responders for both
-// triple mutation subjects. The add-responder stores triples in collector
-// and returns a synthetic KVRevision (auto-incrementing). The remove-
-// responder simply acknowledges. Both reply with Success=true.
-//
-// Returns a channel that receives every triple added (for assertions).
-// Cleanup is handled by testcontainer teardown at test end.
-func startGraphResponder(t *testing.T, nc *natsclient.Client) (added chan message.Triple) {
-	t.Helper()
-	ctx := context.Background()
-
-	ch := make(chan message.Triple, 64)
-	var revision atomic.Uint64
-
-	addHandler := func(_ context.Context, data []byte) ([]byte, error) {
-		var req gtypes.AddTripleRequest
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-		rev := revision.Add(1)
-		ch <- req.Triple
-		resp := gtypes.AddTripleResponse{
-			MutationResponse: gtypes.MutationResponse{
-				Success:    true,
-				KVRevision: rev,
-				Timestamp:  time.Now().UnixNano(),
-			},
-		}
-		return json.Marshal(resp)
-	}
-
-	removeHandler := func(_ context.Context, data []byte) ([]byte, error) {
-		var req gtypes.RemoveTripleRequest
-		if err := json.Unmarshal(data, &req); err != nil {
-			return nil, err
-		}
-		rev := revision.Add(1)
-		resp := gtypes.RemoveTripleResponse{
-			MutationResponse: gtypes.MutationResponse{
-				Success:    true,
-				KVRevision: rev,
-				Timestamp:  time.Now().UnixNano(),
-			},
-		}
-		return json.Marshal(resp)
-	}
-
-	_, err := nc.SubscribeForRequests(ctx, rule.SubjectTripleAdd, addHandler)
-	require.NoError(t, err, "failed to subscribe to triple add subject")
-
-	_, err = nc.SubscribeForRequests(ctx, rule.SubjectTripleRemove, removeHandler)
-	require.NoError(t, err, "failed to subscribe to triple remove subject")
-
-	return ch
+	return a.nc.PublishToStream(ctx, governance.VerdictSubject(ev.Decision, ev.RuleID), data)
 }
 
 // publishActionForTest returns a publish action scoped to subject so test
@@ -182,60 +83,63 @@ func makeEC(ruleID, entityID string, caller *rule.CallerContext) *rule.Execution
 	}
 }
 
-// drainTriples reads up to n triples from ch within timeout, returning
-// however many arrived. Used to assert both "some triples arrived" and
-// "no triples arrived" without relying on arbitrary sleeps.
-func drainTriples(ch chan message.Triple, n int, timeout time.Duration) []message.Triple {
-	var out []message.Triple
-	deadline := time.After(timeout)
-	for {
-		if len(out) >= n {
-			return out
-		}
-		select {
-		case t := <-ch:
-			out = append(out, t)
-		case <-deadline:
-			return out
-		}
-	}
-}
-
 // ----- Test 1: end-to-end deny flow ----------------------------------------
 
 // TestIntegration_DenyFlow exercises the full deny action pipeline against
 // real NATS + JetStream. Two sub-cases:
 //
 //   - Case A (admin caller): action list [publish, publish, publish] — no deny.
-//     All 3 reach NATS, zero audit triples written. Verifies the executor +
-//     publisher + triple mutator are all correctly wired to real NATS.
+//     All 3 reach NATS, zero verdict events emitted.
 //
 //   - Case B (viewer caller): action list [publish, deny, publish]. The deny is
 //     the second action. It fires unconditionally, short-circuits the third
 //     publish, returns *DenyVerdict with $caller.id substituted into the reason,
-//     and writes exactly one rule.deny audit triple to the graph responder.
+//     and emits exactly one deny verdict event to GOVERNANCE_VERDICT_AUDIT.
 //
-// "Graph integration" is provided by a lightweight in-process NATS responder
-// (startGraphResponder) — no graph-gateway process is needed.
+// The audit stream is provisioned via the real config.StreamsManager, which also
+// live-validates the GOVERNANCE_VERDICT_AUDIT stream config (createStream must
+// accept it). Verdict events are checked two ways: a core subscription on the
+// stream subject proves live delivery + decode (and lets the admin case assert
+// NO verdict), and a JetStream GetLastMsgForSubject read-back proves the deny
+// verdict is durably persisted and replayable — the actual audit guarantee, not
+// just that a publish went out.
 //
 // Why two different action lists instead of a single list with a When-guarded
 // deny: ActionExecutor.Execute does not evaluate When clauses — that is the
-// StatefulEvaluator.runActions responsibility. Calling Execute directly (Option
-// A from the chunk spec) bypasses When evaluation. Using two purpose-built
-// action lists keeps the integration boundary clean and the assertions precise.
+// StatefulEvaluator.runActions responsibility. Calling Execute directly bypasses
+// When evaluation. Using two purpose-built action lists keeps the integration
+// boundary clean and the assertions precise.
 func TestIntegration_DenyFlow(t *testing.T) {
 	nc := getTestNATSClient(t)
 	ctx := context.Background()
 
-	addedCh := startGraphResponder(t, nc)
+	// ADR-055 §3a: provision the audit stream and wire the framework verdict
+	// auditor so deny/approve emit verdict events. EnsureStreams is idempotent
+	// and live-validates the GOVERNANCE_VERDICT_AUDIT stream config.
+	sm := config.NewStreamsManager(nc, slog.Default())
+	require.NoError(t, sm.EnsureStreams(ctx, &config.Config{}))
 
-	mut := &natsTripleMutator{natsClient: nc}
 	pub := &natsPublisher{natsClient: nc}
-	executor := rule.NewActionExecutorFull(nil, mut, pub)
+	executor := rule.NewActionExecutorFull(nil, nil, pub)
+	executor.SetVerdictAuditor(&denyTestVerdictAuditor{nc: nc})
+
+	// Capture verdict events landing on the audit stream subject.
+	verdictCh := make(chan *governance.VerdictEvent, 8)
+	decoder := payloadbuiltins.NewTestDecoder(t)
+	_, err := nc.Subscribe(ctx, "governance.verdict.>", func(_ context.Context, m *nats.Msg) {
+		bm, derr := decoder.Decode(m.Data)
+		if derr != nil {
+			return
+		}
+		if ev, ok := bm.Payload().(*governance.VerdictEvent); ok {
+			verdictCh <- ev
+		}
+	})
+	require.NoError(t, err)
 
 	// Track publish dispatches via a NATS subscription.
 	var publishCount atomic.Int64
-	_, err := nc.Subscribe(ctx, "deny.test.publish", func(_ context.Context, _ *nats.Msg) {
+	_, err = nc.Subscribe(ctx, "deny.test.publish", func(_ context.Context, _ *nats.Msg) {
 		publishCount.Add(1)
 	})
 	require.NoError(t, err)
@@ -266,9 +170,14 @@ func TestIntegration_DenyFlow(t *testing.T) {
 			return publishCount.Load() == 3
 		}, 2*time.Second, 25*time.Millisecond, "expected 3 NATS publish deliveries for admin caller")
 
-		// No audit triple must have been written.
-		written := drainTriples(addedCh, 1, 200*time.Millisecond)
-		assert.Empty(t, written, "admin caller must not produce a rule.deny audit triple")
+		// No verdict event must be emitted for an allowed (admin) caller. There
+		// is no positive signal to wait for, so a bounded negative window is the
+		// correct technique here.
+		select {
+		case ev := <-verdictCh:
+			t.Fatalf("admin caller must not emit a verdict event, got %+v", ev)
+		case <-time.After(300 * time.Millisecond):
+		}
 	})
 
 	// ---- Case B: viewer caller — deny short-circuits in middle of chain -----
@@ -326,17 +235,41 @@ func TestIntegration_DenyFlow(t *testing.T) {
 		assert.Equal(t, int64(1), publishCount.Load(),
 			"exactly one publish must run; the action after deny must be skipped")
 
-		// Exactly one rule.deny audit triple must reach the graph responder.
-		auditTriples := drainTriples(addedCh, 1, 2*time.Second)
-		require.Len(t, auditTriples, 1,
-			"deny action must write exactly one audit triple")
+		// Exactly one deny verdict event must be delivered live on the audit
+		// subject, carrying the substituted reason + the originating rule and
+		// entity (ADR-055 §3a).
+		select {
+		case ev := <-verdictCh:
+			assert.Equal(t, governance.DecisionDeny, ev.Decision,
+				"verdict event decision must be deny")
+			assert.Equal(t, "role-gate-rule", ev.RuleID,
+				"verdict event must carry the originating rule ID")
+			assert.Equal(t, "user viewer-user-1 is not admin", ev.Reason,
+				"verdict event reason must carry the substituted reason")
+			assert.Equal(t, "acme.ops.test.svc.entity.002", ev.EntityID,
+				"verdict event must carry the entity ID")
+		case <-time.After(2 * time.Second):
+			t.Fatal("deny action must emit exactly one verdict event to the audit stream")
+		}
 
-		at := auditTriples[0]
-		assert.Equal(t, rule.PredicateRuleDeny, at.Predicate,
-			"audit triple predicate must be %q", rule.PredicateRuleDeny)
-		assert.Equal(t, "user viewer-user-1 is not admin", at.Object,
-			"audit triple object must carry the substituted reason")
-		assert.Equal(t, "role-gate-rule", at.Subject,
-			"audit triple subject must be the rule ID (from ec.RuleID())")
+		// Persistence gate: the verdict must be DURABLY recorded on the stream,
+		// not merely published. PublishToStream returns only after the PubAck, so
+		// by now the record is persisted; read the last message on the deny
+		// subject back and decode it. Robust to testcontainer reuse —
+		// GetLastMsgForSubject returns the most recent (this run's) event, and
+		// the reason is deterministic.
+		js, jerr := nc.JetStream()
+		require.NoError(t, jerr)
+		stream, serr := js.Stream(ctx, "GOVERNANCE_VERDICT_AUDIT")
+		require.NoError(t, serr)
+		raw, gerr := stream.GetLastMsgForSubject(ctx, governance.VerdictSubject(governance.DecisionDeny, "role-gate-rule"))
+		require.NoError(t, gerr, "deny verdict must be persisted + replayable on the audit stream")
+		persisted, derr := decoder.Decode(raw.Data)
+		require.NoError(t, derr, "persisted record must decode through the production registry")
+		pev, ok := persisted.Payload().(*governance.VerdictEvent)
+		require.True(t, ok, "persisted payload must be a *VerdictEvent, got %T", persisted.Payload())
+		assert.Equal(t, governance.DecisionDeny, pev.Decision)
+		assert.Equal(t, "user viewer-user-1 is not admin", pev.Reason,
+			"the persisted (replayable) record must carry this run's deny reason")
 	})
 }

--- a/processor/rule/metrics.go
+++ b/processor/rule/metrics.go
@@ -21,6 +21,12 @@ type Metrics struct {
 	activeRules           prometheus.Gauge
 	stateTransitionsTotal *prometheus.CounterVec // OnEnter/OnExit transitions
 	debounceDelaysTotal   prometheus.Counter     // Coalesced updates due to debouncing
+	// governanceVerdictAuditFailures counts failed governance verdict-audit
+	// emits (ADR-055 §3a). A non-zero value means a deny/approve verdict was
+	// applied but its append-only audit record was lost — observable so the gap
+	// is not silent (critical in enforce mode). The emit is best-effort: a
+	// failure increments this counter but NEVER flips the verdict.
+	governanceVerdictAuditFailures *prometheus.CounterVec
 }
 
 // Package-level singleton (registered once to avoid duplicate registration panics)
@@ -123,6 +129,13 @@ func newRuleMetrics(registry *metric.MetricsRegistry, _ string) *Metrics {
 				Name:      "debounce_delays_total",
 				Help:      "Total number of debounced rule evaluations (coalesced updates)",
 			}),
+
+			governanceVerdictAuditFailures: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "rule",
+				Name:      "governance_verdict_audit_failures_total",
+				Help:      "Governance verdict-audit emits that failed (verdict applied but audit record lost; ADR-055 §3a)",
+			}, []string{"decision"}),
 		}
 
 		registry.PrometheusRegistry().MustRegister(
@@ -138,6 +151,7 @@ func newRuleMetrics(registry *metric.MetricsRegistry, _ string) *Metrics {
 			ruleMetrics.activeRules,
 			ruleMetrics.stateTransitionsTotal,
 			ruleMetrics.debounceDelaysTotal,
+			ruleMetrics.governanceVerdictAuditFailures,
 		)
 	})
 

--- a/processor/rule/processor.go
+++ b/processor/rule/processor.go
@@ -567,6 +567,20 @@ func (rp *Processor) initializeStateTracker(ctx context.Context) error {
 		}
 	}
 
+	// ADR-055 §3a: wire the framework verdict auditor so deny/approve actions
+	// record governance verdicts to the append-only GOVERNANCE_VERDICT_AUDIT
+	// stream. Wired independently of the operator Publisher — audit is a
+	// framework guarantee, not an operator opt-in, so config drift cannot
+	// silently disable it. Only when a NATS client is present (the auditor
+	// publishes to a stream).
+	if rp.natsClient != nil {
+		if setter, ok := actionExecutor.(interface {
+			SetVerdictAuditor(VerdictAuditor)
+		}); ok {
+			setter.SetVerdictAuditor(newVerdictAuditor(rp))
+		}
+	}
+
 	// Persist the executor on the processor so the cron scheduler
 	// (initializeCronScheduler) can dispatch through the same instance
 	// the StatefulEvaluator uses. Single shared executor keeps publishing

--- a/processor/rule/verdict_auditor.go
+++ b/processor/rule/verdict_auditor.go
@@ -1,0 +1,80 @@
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/c360studio/semstreams/governance"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// streamVerdictAuditor is the concrete VerdictAuditor (ADR-055 §3a). It wraps a
+// verdict event in a BaseMessage envelope (so registry-based readers — audit/ops
+// dashboards replaying the stream — can decode it off the wire) and publishes to
+// the GOVERNANCE_VERDICT_AUDIT stream via JetStream. On failure it increments the
+// failure metric and returns the error; it does NOT log (the caller logs at Error
+// with full verdict context) and NEVER changes a verdict.
+//
+// It deliberately depends on a minimal publish func + a counter rather than the
+// whole Processor, so the emit path is unit-testable without a NATS client.
+type streamVerdictAuditor struct {
+	publish  func(ctx context.Context, subject string, data []byte) error
+	failures *prometheus.CounterVec
+}
+
+// newVerdictAuditor builds a verdict auditor that publishes to the audit stream
+// via the processor's NATS client. The publish func always targets JetStream
+// (PublishToStream) because governance.verdict.> is a stream subject. Requires a
+// non-nil natsClient (the rule processor only wires the auditor when one exists).
+func newVerdictAuditor(rp *Processor) *streamVerdictAuditor {
+	var failures *prometheus.CounterVec
+	if rp.metrics != nil {
+		failures = rp.metrics.governanceVerdictAuditFailures
+	}
+	return &streamVerdictAuditor{
+		publish:  rp.natsClient.PublishToStream,
+		failures: failures,
+	}
+}
+
+// EmitVerdict implements VerdictAuditor.
+func (a *streamVerdictAuditor) EmitVerdict(ctx context.Context, ev governance.VerdictEvent) error {
+	// Never publish an event that fails its own envelope contract (e.g. a blank
+	// rule ID from a misconfigured rule) — an un-attributable audit record is
+	// worse than a metered gap, and would not survive a registry decode on read.
+	// A reject here counts as an audit failure like any other.
+	if err := ev.Validate(); err != nil {
+		a.recordFailure(ev.Decision)
+		return errs.WrapInvalid(err, "verdictAuditor", "EmitVerdict", "invalid verdict event")
+	}
+
+	subject := governance.VerdictSubject(ev.Decision, ev.RuleID)
+
+	// Wrap in a BaseMessage envelope so registry decoders can read the verdict
+	// off the wire (the §2 semantic-envelope requirement; also
+	// feedback_nats_publishes_use_payload_registry).
+	baseMsg := message.NewBaseMessage(ev.Schema(), &ev, "rule_engine")
+	data, err := json.Marshal(baseMsg)
+	if err != nil {
+		a.recordFailure(ev.Decision)
+		return errs.Wrap(err, "verdictAuditor", "EmitVerdict", "marshal verdict envelope")
+	}
+
+	if err := a.publish(ctx, subject, data); err != nil {
+		a.recordFailure(ev.Decision)
+		return errs.WrapTransient(err, "verdictAuditor", "EmitVerdict", fmt.Sprintf("publish to %s", subject))
+	}
+	return nil
+}
+
+// recordFailure increments the audit-failure counter (nil-safe for NATS-less or
+// metric-less test wiring).
+func (a *streamVerdictAuditor) recordFailure(decision string) {
+	if a.failures != nil {
+		a.failures.WithLabelValues(decision).Inc()
+	}
+}

--- a/processor/rule/verdict_auditor_test.go
+++ b/processor/rule/verdict_auditor_test.go
@@ -1,0 +1,117 @@
+package rule
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/governance"
+	"github.com/c360studio/semstreams/payloadbuiltins"
+)
+
+func testVerdictFailuresCounter() *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "test_governance_verdict_audit_failures_total"},
+		[]string{"decision"},
+	)
+}
+
+// TestStreamVerdictAuditor_EmitsEnvelopeToCorrectSubject drives the real auditor
+// through its injected-publish seam: it must publish to the verdict subject and
+// the bytes must decode through the production registry decoder back into a
+// *governance.VerdictEvent (the §2 envelope contract over the wire).
+func TestStreamVerdictAuditor_EmitsEnvelopeToCorrectSubject(t *testing.T) {
+	var gotSubject string
+	var gotData []byte
+	a := &streamVerdictAuditor{
+		failures: testVerdictFailuresCounter(),
+		publish: func(_ context.Context, subject string, data []byte) error {
+			gotSubject = subject
+			gotData = data
+			return nil
+		},
+	}
+	ev := governance.VerdictEvent{
+		Decision: governance.DecisionApprove,
+		RuleID:   "approve-rule",
+		Reason:   "policy permits",
+		EntityID: "acme.ops.test.svc.entity.001",
+	}
+	require.NoError(t, a.EmitVerdict(context.Background(), ev))
+
+	assert.Equal(t, governance.VerdictSubject(governance.DecisionApprove, "approve-rule"), gotSubject,
+		"must publish to governance.verdict.{decision}.{rule_token}")
+
+	decoded, err := payloadbuiltins.NewTestDecoder(t).Decode(gotData)
+	require.NoError(t, err, "published bytes must be a decodable BaseMessage envelope")
+	got, ok := decoded.Payload().(*governance.VerdictEvent)
+	require.True(t, ok, "payload must decode to *VerdictEvent, got %T", decoded.Payload())
+	assert.Equal(t, governance.DecisionApprove, got.Decision)
+	assert.Equal(t, "approve-rule", got.RuleID)
+	assert.Equal(t, "policy permits", got.Reason)
+	assert.Equal(t, "acme.ops.test.svc.entity.001", got.EntityID)
+}
+
+// TestStreamVerdictAuditor_PublishFailureMetersAndReturnsError pins the
+// best-effort observability contract: a failed publish increments the
+// decision-labelled failure counter and returns the error (so the caller logs
+// it), but never panics or blocks.
+func TestStreamVerdictAuditor_PublishFailureMetersAndReturnsError(t *testing.T) {
+	failures := testVerdictFailuresCounter()
+	a := &streamVerdictAuditor{
+		failures: failures,
+		publish: func(_ context.Context, _ string, _ []byte) error {
+			return errors.New("jetstream down")
+		},
+	}
+	err := a.EmitVerdict(context.Background(), governance.VerdictEvent{
+		Decision: governance.DecisionDeny,
+		RuleID:   "deny-rule",
+	})
+	require.Error(t, err)
+	assert.InDelta(t, 1.0, testutil.ToFloat64(failures.WithLabelValues(governance.DecisionDeny)), 0.0001,
+		"a failed emit must increment the failure counter for that decision")
+	assert.InDelta(t, 0.0, testutil.ToFloat64(failures.WithLabelValues(governance.DecisionApprove)), 0.0001,
+		"the other decision label must be untouched")
+}
+
+// TestStreamVerdictAuditor_NilCounterIsSafe guards the metric-less wiring path
+// (no metrics registry): a failure must still return the error without a panic.
+func TestStreamVerdictAuditor_NilCounterIsSafe(t *testing.T) {
+	a := &streamVerdictAuditor{
+		failures: nil,
+		publish: func(_ context.Context, _ string, _ []byte) error {
+			return errors.New("boom")
+		},
+	}
+	assert.Error(t, a.EmitVerdict(context.Background(), governance.VerdictEvent{
+		Decision: governance.DecisionDeny,
+		RuleID:   "deny-rule",
+	}))
+}
+
+// TestStreamVerdictAuditor_RejectsInvalidEventWithoutPublishing pins the guard
+// that an event failing its own envelope contract (e.g. a blank rule ID from a
+// misconfigured rule) is NOT published — an un-attributable audit record is
+// worse than a metered gap — and is metered as a failure.
+func TestStreamVerdictAuditor_RejectsInvalidEventWithoutPublishing(t *testing.T) {
+	failures := testVerdictFailuresCounter()
+	published := false
+	a := &streamVerdictAuditor{
+		failures: failures,
+		publish: func(_ context.Context, _ string, _ []byte) error {
+			published = true
+			return nil
+		},
+	}
+	err := a.EmitVerdict(context.Background(), governance.VerdictEvent{Decision: governance.DecisionDeny}) // empty RuleID
+	require.Error(t, err)
+	assert.False(t, published, "an invalid event must never reach the wire")
+	assert.InDelta(t, 1.0, testutil.ToFloat64(failures.WithLabelValues(governance.DecisionDeny)), 0.0001,
+		"a rejected invalid event must meter as an audit failure")
+}


### PR DESCRIPTION
## What

ADR-055 **§3a**: migrate the ADR-039 deny/approve verdict audit off the graph and onto a dedicated append-only JetStream stream. The prior mechanism wrote an audit triple onto a phantom non-6-part rule-ID "entity" via graph-ingest's **auto-vivify** path — the exact envelope-less entity creation ADR-055 retires — and **no code read it back**. This is the remaining Wave 0 piece that **gates the closing-move flip** (`triple.add`/`add_batch` → must-exist).

## Changes

- **New `governance` package** — `VerdictEvent` payload (`governance.verdict.v1`, registered via `payloadbuiltins`) + subject-safe `RuleToken` (FNV-1a hash of free-form rule IDs; canonical `rule_id` travels in the payload) + `VerdictSubject` (`governance.verdict.{decision}.{rule_token}`). (Naming mirrors the existing `agentic` + `vocabulary/agentic` convention.)
- **`GOVERNANCE_VERDICT_AUDIT` system stream** (`config/streams.go` `EnsureStreams`) — file storage, append-only (`retention=limits`), 90d `MaxAge`. Provisioned at boot wherever the rule engine can run; `publishToStream` is a bare `js.PublishMsg` (no auto-create/derive) so there's no stream-name collision.
- **Framework-owned `VerdictAuditor`** injected into the rule `ActionExecutor`, independent of the operator `Publisher` so config drift can't silently disable audit. `executeDeny`/`executeApprove` emit a verdict event instead of an audit triple. Best-effort: the auditor validates the event before publish (never records an un-attributable verdict) and a failed emit is **metered + logged but NEVER flips a structural verdict**.
- **`semstreams_rule_governance_verdict_audit_failures_total{decision}`** counter.
- **Deleted** the dead `PredicateRuleDeny`/`PredicateRuleApprove` consts (no readers).

## Deliberate deviation

The §3a sketch spec'd a `{decision,mode}` metric. The governance mode (`audit`/`enforce`) is a **loop-level** setting not threaded to the rule-action emit site (confirmed: not on `ToolCall`, not in the proposed-call message that becomes rule `MessageData`), so a `mode` label would be permanently `unknown`. Shipped `{decision}` only; documented in the ADR for revisit if the mode is later propagated.

## Testing

- **`governance`**: `VerdictEvent` Validate, `RuleToken` subject-safety (adversarial rule IDs with `.`/`*`/`>`/spaces → hex-only token, 4-segment subject), production round-trip through the real `payloadbuiltins` decoder.
- **`rule` unit**: the real `streamVerdictAuditor` via its injected-publish seam — subject correctness, production-decoder envelope, failure metric, invalid-event reject; deny/approve emit + audit-failure-never-flips + `loop_id`/`call_id` echo.
- **Live integration gate** (`deny_integration_test.go`): provisions the stream via the real `StreamsManager`, fires a deny end-to-end, and **reads the verdict back from the stream via `GetLastMsgForSubject`** — proving durable persistence + replay (the actual audit guarantee), not just that a publish went out.

**Gates (all green):** full unit `-race`, full integration sweep `-tags=integration`, the live deny gate, lint, vet (both tags), gofmt, no schema drift.

**Review:** go-reviewer — APPROVE, all 9 design points verified adversarially; M1 (persistence read-back), M2 (metric-name doc fix), M3 (Validate guard), N1/N2 (cleanups) folded.

## Relationship

- Amends [ADR-039](docs/adr/039-tool-call-governance-rule-driven.md)'s audit mechanism (Status banner already in place); preserves the explicit-verdict-audit goal, retires the phantom-rule-ID-entity read path.
- Independent of #264 (the other open Wave 0 PR — graph-ingest Fact-lane consumer guards); different files, different ADR sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)