### PR TITLE
test(inference): ADR-055 Wave 0 — in-process AddTriple caller audit (closing-move readiness)

### DIFF
--- a/docs/adr/055-graph-write-intent-taxonomy.md
+++ b/docs/adr/055-graph-write-intent-taxonomy.md
@@ -371,14 +371,16 @@ create-or-fail lane (§6) and is exempt.
   (`sensorml.Asset` is currently unwired — no `MarshalJSON`, no payload registration
   — so the regression is latent-on-wiring, not live-on-main; that is why the guard
   must regroup rather than reject before the ADR-044 Phase 5 bridge lands.)
-  **Sibling consumer — `graph/messagemanager`.** `Manager.ProcessMessage`
-  (`graph/messagemanager/processor.go:274`) is a second Graphable→EntityState
-  consumer that files all `triples` under one `actualEntityID` with the same
-  single-key misfiling; it ALREADY lifts `StorageRef` via the `Storable` assertion
-  (`:200-204`), so the StorageRef half is at parity there, but the T2 regroup is
-  not. It must receive the same WARN-and-regroup under this ADR so the two
-  consumers do not drift. (graph-ingest is migrated first — Wave 0; messagemanager
-  follows.)
+  **Sibling consumer — `graph/messagemanager` (DEAD, reclassified 2026-06-12).**
+  `Manager.ProcessMessage` (`graph/messagemanager/processor.go:274`) is a second
+  Graphable→EntityState consumer that files all `triples` under one `actualEntityID`
+  with the same single-key misfiling (it ALREADY lifts `StorageRef` via the
+  `Storable` assertion `:200-204`). The Wave-0 caller audit found it has **zero
+  non-test importers in semstreams** — it is dead/legacy, not a live ingest path.
+  Reclassified from "must regroup" to **removal candidate**: do NOT fix
+  speculatively (per `feedback_framework_vs_product_boundary` — unwired ≠ broken).
+  If a sister product wires it, it carries the same T2 defect, but that is its
+  call to make.
 - **StorageRef extraction (two halves).** Consumer side: `extractEntityFromMessage`
   must type-assert `ContentStorable` and set `StorageRef` (MergeEntity merges it on
   the existing branch, `:1008-1009`). Producer side: the canonical pilot

--- a/docs/proposals/graphable-fix-plan.md
+++ b/docs/proposals/graphable-fix-plan.md
@@ -264,6 +264,29 @@ design pass; effort S < M < L.
 4. **ADR-054 Phase 1** (IndexingProfiler, LENIENT) — soft; lands before B1/B2 so
    they carry the right envelope.
 
+**Wave 0 audit — in-process `Component.AddTriple` callers (CLEARED 2026-06-12).**
+ADR-055 §3 required a Wave-0 audit confirming no in-process `Component.AddTriple`
+caller relies on auto-vivify ordering before the must-exist flip. Result: **SAFE —
+the in-process bypass imposes no blocker on the closing move.**
+
+- The only production in-process caller via `tripleAdderAdapter` (`component.go:691`)
+  is `HierarchyInference`, and only for INVERSE edges onto OTHER subjects: sibling
+  back-edges (`hierarchy.go:313`, target listed via `ListWithPrefix` = pre-existing)
+  and container contains-edges (`hierarchy.go:368`, target pre-created by
+  `ensureContainerExists`). Both handle a write failure as Warn-only + `edgesFailed`
+  metric — NEVER propagated. So a future must-exist rejection on an inverse write
+  degrades gracefully: the entity's own forward triples still land and ingest does
+  not fail. Locked by `TestHierarchyInference_InverseEdgeWriteFailureIsNonFatal`.
+- `HierarchyInference.OnEntityCreated` (`hierarchy.go:239`, the legacy cascade path)
+  has NO production caller — test-only.
+- `DirectRelationshipApplier.ApplyRelationship` (`applier.go:193`) has ZERO production
+  wiring; production structural inference uses `MutationRelationshipApplier` (the NATS
+  `graph.mutation.*` path, subject to the flip at the consumer, not an in-process
+  bypass).
+- `graph/messagemanager.ProcessMessage` (a second Graphable→EntityState consumer with
+  the same T2 single-key misfiling) has ZERO non-test importers — dead/legacy.
+  Reclassified as a removal candidate, NOT a regroup target.
+
 **Wave 1 — pilots (parallel, prove the patterns):** B3 (lane-ii replace pilot),
 B2 (lane-i ContentStorable pilot, consumes T1/T2/StorageRef).
 

--- a/graph/inference/hierarchy_test.go
+++ b/graph/inference/hierarchy_test.go
@@ -110,6 +110,47 @@ func (m *mockEntityManager) addExistingEntity(id string) {
 	m.entities[id] = true
 }
 
+// TestHierarchyInference_InverseEdgeWriteFailureIsNonFatal locks the ADR-055 §3
+// in-process-bypass safety property. HierarchyInference is the only production
+// caller of the in-process Component.AddTriple (via tripleAdderAdapter), and it
+// uses it ONLY for inverse edges onto OTHER subjects — sibling back-edges
+// (hierarchy.go:313) and container contains-edges (hierarchy.go:368). Those
+// targets pre-exist (siblings via ListWithPrefix, containers via
+// ensureContainerExists), but the Wave-0 audit must ASSERT — not assume — that a
+// write failure on one of them is non-fatal: it degrades to a logged warning +
+// edgesFailed metric and NEVER propagates. This is what makes the closing-move
+// must-exist flip safe here — if a future must-exist rejection hits an inverse
+// write, the entity's own forward hierarchy triples still land and ingest does
+// not fail. A refactor that made these propagate would break the flip; this test
+// catches that.
+func TestHierarchyInference_InverseEdgeWriteFailureIsNonFatal(t *testing.T) {
+	// Every in-process inverse-edge write rejects — simulating a must-exist
+	// "entity not found" on the sibling/container target.
+	failingAdder := &hierarchyMockTripleAdder{err: errors.New("entity not found (simulated must-exist rejection)")}
+	entityManager := newMockEntityManager()
+	// An existing sibling so createSiblingEdges attempts an inverse back-edge.
+	entityManager.addExistingEntity("c360.logistics.environmental.sensor.temperature.temp-002")
+
+	config := HierarchyConfig{
+		Enabled:            true,
+		CreateTypeEdges:    true,
+		CreateSystemEdges:  true,
+		CreateDomainEdges:  true,
+		CreateTypeSiblings: true,
+	}
+	hi := NewHierarchyInference(entityManager, failingAdder, config, nil)
+
+	// GetHierarchyTriples is the production entry (graph-ingest MergeEntity calls
+	// it on the create branch). Every inverse-edge write inside it hits the
+	// failing adder; container creation goes through the (working) entityManager.
+	triples, err := hi.GetHierarchyTriples(context.Background(), "c360.logistics.environmental.sensor.temperature.temp-001")
+
+	require.NoError(t, err,
+		"inverse-edge write failures must NOT propagate — the forward hierarchy triples must still return")
+	assert.NotEmpty(t, triples,
+		"the entity's own forward hierarchy/sibling edges must still be produced despite the failing inverse writes")
+}
+
 func TestHierarchyInference_OnEntityCreated_Disabled(t *testing.T) {
 	tripleAdder := &hierarchyMockTripleAdder{}
 	entityManager := newMockEntityManager()


### PR DESCRIPTION
## What

ADR-055 **§3** required a Wave-0 audit confirming **no in-process `Component.AddTriple` caller relies on auto-vivify ordering** before the must-exist closing-move flip. This PR is that audit. **Result: SAFE** — no production code change is needed; the in-process bypass imposes no blocker on the flip.

## Findings

| Caller | Verdict |
|---|---|
| `HierarchyInference` inverse edges (`hierarchy.go:313` sibling, `:368` container) — the only production in-process caller via `tripleAdderAdapter` | **SAFE.** Targets pre-exist (`ListWithPrefix` siblings / `ensureContainerExists` containers) **and** failures are Warn-only + `edgesFailed` metric, never propagated. A future must-exist rejection degrades gracefully. |
| `HierarchyInference.OnEntityCreated` (`hierarchy.go:239`, legacy cascade) | No production caller — test-only. |
| `DirectRelationshipApplier.ApplyRelationship` (`applier.go:193`) | **Zero production wiring.** Production structural inference uses `MutationRelationshipApplier` (NATS `graph.mutation.*` path — subject to the flip at the consumer, not an in-process bypass). |
| `graph/messagemanager.ProcessMessage` (the #264-flagged sibling T2 consumer) | **Zero non-test importers — dead/legacy.** Reclassified in ADR §5 from "must regroup" to removal candidate. |

## Assert, don't assume

`TestHierarchyInference_InverseEdgeWriteFailureIsNonFatal` drives the production entry (`GetHierarchyTriples`, which graph-ingest `MergeEntity` calls on the create branch) with a **fully-failing** triple adder + an existing sibling, and asserts the entity's forward hierarchy/sibling triples **still return with no propagated error**. This locks the graceful-degradation property that makes the flip safe here — a refactor that made these inverse writes propagate would break the flip, and this test would catch it.

## Scope

Test + docs only — **no production code change** (the audit cleared the path). ADR-055 §5 messagemanager note corrected (it's dead, not "must regroup"); audit result recorded in `graphable-fix-plan.md`.

**Gates:** `graph/inference` `-race` green, full build, lint, vet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)