### PR TITLE
feat(graph-ingest): ADR-055 §3 — mutation rejection metric (Wave 0 closeout)

### DIFF
--- a/docs/adr/055-graph-write-intent-taxonomy.md
+++ b/docs/adr/055-graph-write-intent-taxonomy.md
@@ -472,14 +472,35 @@ must-exist last, so `main` is never broken in between.
     (`audit`/`enforce`) is a loop-level setting not threaded to the rule-action
     emit site, so a `mode` label would be permanently `unknown`; revisit if the
     mode is propagated into the proposed-call message. Gates the closing move.
-  - **T1 (three parts)** — `PublishToStreamWithMsgID` + `config.StreamConfig.Duplicates`
-    plumbed into both builders + the existing-stream update path; decide the window
-    size (Open Question #1). Optionally (s,p,o)-idempotent merge in `MergeEntity`.
-  - **T2** WARN-and-regroup-by-Subject + **StorageRef extraction** (both halves) in
-    `extractEntityFromMessage`.
-  - Lane naming + the §3 rejection metric + the body-prefix-error Wave-0 invariant.
-  - In-process `Component.AddTriple` caller audit (§3).
-  - **ADR-054 Phase 1** (IndexingProfiler, lenient) so birth envelopes carry it.
+  - **T1 (three parts)** — **[SHIPPED beta.105 / #251]** `PublishToStreamWithMsgID`
+    + `config.StreamConfig.Duplicates` plumbed into both builders + the
+    existing-stream update path. (s,p,o)-idempotent merge in `MergeEntity` remains
+    the Open Question #1 belt-and-suspenders follow-up.)
+  - **T2** WARN-and-regroup-by-Subject + **StorageRef extraction** (consumer half)
+    in `extractEntityFromMessage` — **[SHIPPED #264]** (`ingestEntity` partition +
+    `partitionTriplesBySubject` + StorageRef lift). Producer-side
+    `TrajectoryStepEntity` exported-field half is Wave 1 (no Fact-stream publish
+    leg exists yet).
+  - **§3 rejection metric** — **[SHIPPED]** `semstreams_graph_ingest_mutation_rejections_total{subject, reason}`
+    via the `meteredMutation` wrapper around every mutation handler; `reason` is the
+    bounded `MutationResponse.ErrorCode` (`entity_not_found` is the must-exist-flip
+    code), `unclassified` when absent. Meters existing rejections now; flip-ready.
+    The **body-prefix-error invariant** (every conjuror migrating to a mutation
+    lane must check the `error:`/`success:false` response, never treat rejection as
+    success) is a Wave-2-onward producer-migration discipline (documented §3).
+    **Lane naming** (subject rename to `state.transition`/`evidence.append`) is
+    **DEFERRED** — Open Question #5, a breaking rename separable from the
+    load-bearing must-exist change.
+  - In-process `Component.AddTriple` caller audit (§3) — **[DONE — SAFE, #267]** no
+    caller relies on auto-vivify ordering; hierarchy inverse-edge writes degrade
+    Warn-only (locked by a regression test). `DirectRelationshipApplier` +
+    `graph/messagemanager` confirmed dead (zero production wiring).
+  - **ADR-054 Phase 1** (IndexingProfiler, lenient) — **[SHIPPED #254 + Phase 2a #255]**
+    so birth envelopes carry the profile.
+
+  **Wave 0 framework substrate is COMPLETE** (2026-06-12): every primitive above is
+  shipped or deliberately deferred (lane-rename OQ#5; (s,p,o) merge OQ#1;
+  TrajectoryStep producer field → Wave 1). Next: the Wave 1 pilots.
 - **Wave 1 — pilots:** model-endpoint (mutation-replace pilot), trajectory-step
   (Fact-arrival + ContentStorable pilot).
 - **Wave 2:** loop-execution. **Precondition:** the agentic graph-ingest input is

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -41,6 +41,9 @@ var (
 
 	indexingProfileOnce       sync.Once
 	indexingProfileDefaultVec *prometheus.CounterVec
+
+	mutationRejectionsOnce sync.Once
+	mutationRejectionsVec  *prometheus.CounterVec
 )
 
 // entityIDRegex validates entity ID format: org.platform.domain.system.type.instance
@@ -91,6 +94,31 @@ func getIndexingProfileDefaultMetric(registry *metric.MetricsRegistry) *promethe
 		}
 	})
 	return indexingProfileDefaultVec
+}
+
+// getMutationRejectionsMetric returns the process-wide counter for rejected
+// graph-mutation requests, labelled by subject + reason (the MutationResponse
+// ErrorCode — a bounded closed set). It operationalizes ADR-055 §3's "loud
+// fail-fast" observability: when the closing-move must-exist flip lands, a
+// triple.add targeting a non-existent entity surfaces here as
+// reason=entity_not_found instead of silently auto-vivifying. Until the flip it
+// meters existing rejections (validation, CAS conflict, create-or-fail),
+// giving the ADR-054 cost-ledger discipline a pre-flip baseline.
+func getMutationRejectionsMetric(registry *metric.MetricsRegistry) *prometheus.CounterVec {
+	mutationRejectionsOnce.Do(func() {
+		mutationRejectionsVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "graph_ingest",
+			Name:      "mutation_rejections_total",
+			Help:      "Graph-mutation requests rejected (success=false), by subject and reason (MutationResponse ErrorCode; 'unclassified' when absent)",
+		}, []string{"subject", "reason"})
+		if registry != nil {
+			_ = registry.RegisterCounterVec("graph-ingest", "mutation_rejections_total", mutationRejectionsVec)
+		} else {
+			_ = prometheus.DefaultRegisterer.Register(mutationRejectionsVec)
+		}
+	})
+	return mutationRejectionsVec
 }
 
 // Config holds configuration for graph-ingest component
@@ -226,6 +254,7 @@ type Component struct {
 	// Prometheus metrics (for e2e test compatibility with datamanager metrics)
 	entitiesUpdated        prometheus.Counter
 	indexingProfileDefault *prometheus.CounterVec
+	mutationRejections     *prometheus.CounterVec
 	metricsRegistry        *metric.MetricsRegistry
 
 	// Lifecycle reporting
@@ -271,6 +300,7 @@ func CreateGraphIngest(rawConfig json.RawMessage, deps component.Dependencies) (
 		logger:                 logger,
 		entitiesUpdated:        getEntitiesUpdatedMetric(deps.MetricsRegistry),
 		indexingProfileDefault: getIndexingProfileDefaultMetric(deps.MetricsRegistry),
+		mutationRejections:     getMutationRejectionsMetric(deps.MetricsRegistry),
 		metricsRegistry:        deps.MetricsRegistry,
 	}
 

--- a/processor/graph-ingest/mutation_rejection_metric_test.go
+++ b/processor/graph-ingest/mutation_rejection_metric_test.go
@@ -1,0 +1,104 @@
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+)
+
+// ADR-055 §3: meteredMutation wraps every graph-mutation request handler and
+// meters rejections (success=false) by subject + reason (the bounded
+// MutationResponse ErrorCode), without ever altering the handler's verdict. The
+// metric is process-global, so these tests use UNIQUE per-case subjects to keep
+// their label series isolated.
+
+func rejectResponse(t *testing.T, code, msg string) []byte {
+	t.Helper()
+	data, err := json.Marshal(graph.MutationResponse{Success: false, Error: msg, ErrorCode: code})
+	require.NoError(t, err)
+	return data
+}
+
+func TestMeteredMutation_MetersRejectionByErrorCode(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	const subj = "test.mutation.metric.errorcode"
+
+	wrapped := comp.meteredMutation(subj, func(_ context.Context, _ []byte) ([]byte, error) {
+		return rejectResponse(t, graph.ErrorCodeEntityNotFound, "entity does not exist"), nil
+	})
+
+	counter := comp.mutationRejections.WithLabelValues(subj, graph.ErrorCodeEntityNotFound)
+	before := testutil.ToFloat64(counter)
+
+	resp, err := wrapped(context.Background(), nil)
+	require.NoError(t, err, "metering must not introduce an error")
+
+	// Pass-through: the response is returned unchanged.
+	var r graph.MutationResponse
+	require.NoError(t, json.Unmarshal(resp, &r))
+	assert.False(t, r.Success)
+	assert.Equal(t, graph.ErrorCodeEntityNotFound, r.ErrorCode)
+
+	assert.InDelta(t, before+1, testutil.ToFloat64(counter), 0.0001,
+		"a rejection must increment {subject, error_code} exactly once")
+}
+
+func TestMeteredMutation_SuccessDoesNotMeter(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	const subj = "test.mutation.metric.success"
+
+	wrapped := comp.meteredMutation(subj, func(_ context.Context, _ []byte) ([]byte, error) {
+		data, _ := json.Marshal(graph.MutationResponse{Success: true})
+		return data, nil
+	})
+
+	// A successful response must not increment ANY reason for this subject.
+	before := testutil.ToFloat64(comp.mutationRejections.WithLabelValues(subj, "unclassified")) +
+		testutil.ToFloat64(comp.mutationRejections.WithLabelValues(subj, graph.ErrorCodeInternal))
+	_, err := wrapped(context.Background(), nil)
+	require.NoError(t, err)
+	after := testutil.ToFloat64(comp.mutationRejections.WithLabelValues(subj, "unclassified")) +
+		testutil.ToFloat64(comp.mutationRejections.WithLabelValues(subj, graph.ErrorCodeInternal))
+	assert.InDelta(t, before, after, 0.0001, "a success must not be metered as a rejection")
+}
+
+func TestMeteredMutation_EmptyErrorCodeIsUnclassified(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	const subj = "test.mutation.metric.unclassified"
+
+	// A legacy rejection with no ErrorCode (e.g. today's triple.add error path).
+	wrapped := comp.meteredMutation(subj, func(_ context.Context, _ []byte) ([]byte, error) {
+		return rejectResponse(t, "", "some legacy error"), nil
+	})
+
+	counter := comp.mutationRejections.WithLabelValues(subj, "unclassified")
+	before := testutil.ToFloat64(counter)
+	_, err := wrapped(context.Background(), nil)
+	require.NoError(t, err)
+	assert.InDelta(t, before+1, testutil.ToFloat64(counter), 0.0001,
+		"a rejection with no ErrorCode must be labelled 'unclassified'")
+}
+
+func TestMeteredMutation_HandlerErrorMeteredAsInternal(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	const subj = "test.mutation.metric.internal"
+
+	sentinel := errors.New("handler blew up")
+	wrapped := comp.meteredMutation(subj, func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, sentinel
+	})
+
+	counter := comp.mutationRejections.WithLabelValues(subj, graph.ErrorCodeInternal)
+	before := testutil.ToFloat64(counter)
+	_, err := wrapped(context.Background(), nil)
+	require.ErrorIs(t, err, sentinel, "the handler error must pass through unchanged")
+	assert.InDelta(t, before+1, testutil.ToFloat64(counter), 0.0001,
+		"a non-nil handler error must be metered as reason=internal")
+}

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -2,10 +2,12 @@
 package graphingest
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
@@ -71,49 +73,49 @@ const (
 // These handlers allow the rule processor (and other components) to modify
 // entity triples via NATS request/reply.
 func (c *Component) setupMutationHandlers(ctx context.Context) error {
-	sub, err := c.natsClient.SubscribeForRequests(ctx, SubjectTripleAdd, c.handleTripleAdd)
+	sub, err := c.natsClient.SubscribeForRequests(ctx, SubjectTripleAdd, c.meteredMutation(SubjectTripleAdd, c.handleTripleAdd))
 	if err != nil {
 		return fmt.Errorf("subscribe triple add: %w", err)
 	}
 	c.subscriptions = append(c.subscriptions, sub)
 
-	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectTripleAddBatch, c.handleTripleAddBatch)
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectTripleAddBatch, c.meteredMutation(SubjectTripleAddBatch, c.handleTripleAddBatch))
 	if err != nil {
 		return fmt.Errorf("subscribe triple add_batch: %w", err)
 	}
 	c.subscriptions = append(c.subscriptions, sub)
 
-	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectTripleRemove, c.handleTripleRemove)
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectTripleRemove, c.meteredMutation(SubjectTripleRemove, c.handleTripleRemove))
 	if err != nil {
 		return fmt.Errorf("subscribe triple remove: %w", err)
 	}
 	c.subscriptions = append(c.subscriptions, sub)
 
-	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityCreate, c.handleEntityCreate)
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityCreate, c.meteredMutation(SubjectEntityCreate, c.handleEntityCreate))
 	if err != nil {
 		return fmt.Errorf("subscribe entity create: %w", err)
 	}
 	c.subscriptions = append(c.subscriptions, sub)
 
-	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityCreateWithTriples, c.handleEntityCreateWithTriples)
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityCreateWithTriples, c.meteredMutation(SubjectEntityCreateWithTriples, c.handleEntityCreateWithTriples))
 	if err != nil {
 		return fmt.Errorf("subscribe entity create_with_triples: %w", err)
 	}
 	c.subscriptions = append(c.subscriptions, sub)
 
-	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityUpdate, c.handleEntityUpdate)
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityUpdate, c.meteredMutation(SubjectEntityUpdate, c.handleEntityUpdate))
 	if err != nil {
 		return fmt.Errorf("subscribe entity update: %w", err)
 	}
 	c.subscriptions = append(c.subscriptions, sub)
 
-	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityUpdateWithTriples, c.handleEntityUpdateWithTriples)
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityUpdateWithTriples, c.meteredMutation(SubjectEntityUpdateWithTriples, c.handleEntityUpdateWithTriples))
 	if err != nil {
 		return fmt.Errorf("subscribe entity update_with_triples: %w", err)
 	}
 	c.subscriptions = append(c.subscriptions, sub)
 
-	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityDelete, c.handleEntityDelete)
+	sub, err = c.natsClient.SubscribeForRequests(ctx, SubjectEntityDelete, c.meteredMutation(SubjectEntityDelete, c.handleEntityDelete))
 	if err != nil {
 		return fmt.Errorf("subscribe entity delete: %w", err)
 	}
@@ -127,6 +129,62 @@ func (c *Component) setupMutationHandlers(ctx context.Context) error {
 			SubjectEntityDelete,
 		})
 	return nil
+}
+
+// mutationHandler is the NATS request/reply handler shape for graph mutations.
+type mutationHandler = func(ctx context.Context, data []byte) ([]byte, error)
+
+// meteredMutation wraps a mutation request handler to meter rejections
+// (ADR-055 §3 observability). A mutation handler encodes a rejection as a
+// MutationResponse with success=false (and a bounded ErrorCode); on that, this
+// increments mutation_rejections_total{subject, reason} and logs the reason at
+// Warn. The handler's (response, error) is passed through UNCHANGED — metering
+// never alters the verdict. The success path costs only one substring scan, no
+// unmarshal. A handler that returns a non-nil error (rare; handlers normally
+// encode failure in the body) is metered as reason="internal".
+func (c *Component) meteredMutation(subject string, h mutationHandler) mutationHandler {
+	return func(ctx context.Context, data []byte) ([]byte, error) {
+		resp, err := h(ctx, data)
+		if err != nil {
+			c.recordMutationRejection(subject, graph.ErrorCodeInternal, err.Error())
+			return resp, err
+		}
+		// A rejection always marshals `"success":false` (the field has no
+		// omitempty), so this cheap gate skips the unmarshal on the success path.
+		// The explicit !Success check below rejects a false-positive substring
+		// that happened to appear inside entity data.
+		if bytes.Contains(resp, []byte(`"success":false`)) {
+			var r struct {
+				Success   bool   `json:"success"`
+				ErrorCode string `json:"error_code"`
+				Error     string `json:"error"`
+			}
+			if json.Unmarshal(resp, &r) == nil && !r.Success {
+				reason := r.ErrorCode
+				if reason == "" {
+					reason = "unclassified"
+				}
+				c.recordMutationRejection(subject, reason, r.Error)
+			}
+		}
+		return resp, err
+	}
+}
+
+// recordMutationRejection increments the rejection counter and logs the
+// rejection so the reason is visible even before the must-exist flip. Both the
+// counter and the logger are nil-guarded so it is safe on a hand-built Component
+// (the test-construction pattern) that reaches it without full wiring.
+func (c *Component) recordMutationRejection(subject, reason, detail string) {
+	if c.mutationRejections != nil {
+		c.mutationRejections.WithLabelValues(subject, reason).Inc()
+	}
+	if c.logger != nil {
+		c.logger.Warn("graph mutation rejected",
+			slog.String("subject", subject),
+			slog.String("reason", reason),
+			slog.String("error", detail))
+	}
 }
 
 // handleTripleAdd handles add triple requests from rule processor and other components


### PR DESCRIPTION
## What

ADR-055 **§3** Wave-0 rejection metric — observability for graph-mutation rejections. Operationalizes the "loud fail-fast" so the future must-exist closing-move flip is observable from day one instead of landing a breaking change blind. **This closes out the Wave 0 framework substrate.**

- **`semstreams_graph_ingest_mutation_rejections_total{subject, reason}`** — process-global singleton, mirroring the existing `getIndexingProfileDefaultMetric` pattern.
- **`meteredMutation` wrapper** around every mutation request handler (triple `add`/`add_batch`/`remove`, entity `create`/`create_with_triples`/`update`/`update_with_triples`/`delete`). On a rejection it increments the counter + logs at Warn; it passes the handler's `(resp, err)` through **unchanged** — metering never alters the verdict.
- **`reason`** = the bounded `MutationResponse.ErrorCode` (`entity_not_found` — the must-exist-flip code — / `entity_already_exists` / `revision_mismatch` / `invalid_request` / `internal`), `"unclassified"` when absent. No unbounded label values; error text goes only to the Warn-log `detail` field.
- Success path costs one `bytes.Contains` scan (no unmarshal); the two-stage gate (substring → authoritative `!Success`) is immune to substring poisoning in entity data.

## Wave 0 is now complete

| Item | Status |
|---|---|
| T1 idempotent publish + dedup window | #251 |
| T2 regroup + StorageRef consumer | #264 |
| §3a governance verdict stream | #265 |
| In-process `AddTriple` caller audit | #267 (SAFE) |
| ADR-054 Phase 1 + 2a | #254 / #255 |
| **§3 rejection metric** | **this PR** |

Deferred by design: lane-rename (OQ#5, breaking), (s,p,o)-idempotent merge (OQ#1), TrajectoryStep producer field (Wave 1). Next: the Wave 1 pilots.

## Testing

4 unit tests: meters by ErrorCode + pass-through; success doesn't meter; empty ErrorCode → `unclassified`; handler-error → `internal` + error passes through. Process-global metric isolated via unique per-case subjects.

**Gates:** build, vet (both tags), lint, graph-ingest unit `-race` + integration `-race`, no schema drift.

**Review:** go-reviewer — clean, all 7 design points verified adversarially (verdict-preservation, gate soundness, cardinality, hot-path cost, no double-count, test isolation, nil-safety). Logger nil-guard + `ErrorCode` constant folded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)