### PR TITLE
fix(agentic-model): summarize debug request payloads instead of dumping the body (semspec#165)

### DIFF
--- a/processor/agentic-model/client.go
+++ b/processor/agentic-model/client.go
@@ -2,6 +2,8 @@ package agenticmodel
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -456,9 +458,21 @@ func (c *Client) ChatCompletion(ctx context.Context, req agentic.AgentRequest) (
 	})
 }
 
+// fullPayloadLogEnvVar gates emission of the entire serialized request
+// body in debug logs. Off by default: a deep agent loop accumulates the
+// whole conversation (system prompt + every turn + tool results) into the
+// payload, so dumping it on every model call produces multi-GB logs and
+// grep-poisons docker logs (prompt text matches event patterns). Set to
+// "1" only for targeted repros. See semspec#165.
+const fullPayloadLogEnvVar = "SEMSTREAMS_LOG_FULL_PAYLOAD"
+
 // debugLogRequest emits a debug log of the outgoing chat completion
 // payload when logger debug is enabled. Generic across SDK and wire
 // payload shapes via json.Marshal.
+//
+// By default it logs only the size, a short content hash, and the message
+// count — enough to correlate and dedup requests without the volume. The
+// full body is emitted only when SEMSTREAMS_LOG_FULL_PAYLOAD=1.
 func (c *Client) debugLogRequest(requestID, model string, messageCount int, payload any) {
 	if c.logger == nil || !c.logger.Enabled(context.Background(), slog.LevelDebug) {
 		return
@@ -467,11 +481,18 @@ func (c *Client) debugLogRequest(requestID, model string, messageCount int, payl
 	if err != nil {
 		return
 	}
-	c.logger.Debug("OpenAI API request payload",
+	sum := sha256.Sum256(body)
+	attrs := []any{
 		slog.String("request_id", requestID),
 		slog.String("model", model),
 		slog.Int("message_count", messageCount),
-		slog.String("payload", string(body)))
+		slog.Int("payload_bytes", len(body)),
+		slog.String("payload_sha8", hex.EncodeToString(sum[:])[:8]),
+	}
+	if os.Getenv(fullPayloadLogEnvVar) == "1" {
+		attrs = append(attrs, slog.String("payload", string(body)))
+	}
+	c.logger.Debug("OpenAI API request payload", attrs...)
 }
 
 // runRetryLoop drives the two-curve backoff for transient errors and

--- a/processor/agentic-model/debug_log_request_test.go
+++ b/processor/agentic-model/debug_log_request_test.go
@@ -1,0 +1,120 @@
+package agenticmodel
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// debugTestPayload is a stand-in for an outgoing chat request. The Secret
+// field stands in for the full conversation body we must NOT dump by
+// default (semspec#165 grep-poison + multi-GB volume).
+type debugTestPayload struct {
+	Model  string `json:"model"`
+	Secret string `json:"secret"`
+}
+
+func newBufferDebugClient(buf *bytes.Buffer) *Client {
+	return &Client{
+		logger: slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+}
+
+func TestDebugLogRequest_DefaultOmitsBody(t *testing.T) {
+	const secret = "FULL-CONVERSATION-BODY-DO-NOT-DUMP"
+	payload := debugTestPayload{Model: "test-model", Secret: secret}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	sum := sha256.Sum256(body)
+	wantSha8 := hex.EncodeToString(sum[:])[:8]
+
+	var buf bytes.Buffer
+	c := newBufferDebugClient(&buf)
+	c.debugLogRequest("req-1", "test-model", 7, &payload)
+
+	out := buf.String()
+	if out == "" {
+		t.Fatal("expected a debug line, got none")
+	}
+	if strings.Contains(out, secret) {
+		t.Errorf("default debug line leaked the full payload body:\n%s", out)
+	}
+	for _, want := range []string{
+		"payload_bytes=" + strconv.Itoa(len(body)),
+		"payload_sha8=" + wantSha8,
+		"message_count=7",
+		"request_id=req-1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("debug line missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "payload=") {
+		t.Errorf("default debug line should not carry a payload= attr:\n%s", out)
+	}
+}
+
+func TestDebugLogRequest_FullPayloadGated(t *testing.T) {
+	const secret = "FULL-CONVERSATION-BODY-WHEN-GATED"
+	payload := debugTestPayload{Model: "test-model", Secret: secret}
+	body, err := json.Marshal(&payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+
+	t.Setenv(fullPayloadLogEnvVar, "1")
+
+	var buf bytes.Buffer
+	c := newBufferDebugClient(&buf)
+	c.debugLogRequest("req-2", "test-model", 3, &payload)
+
+	out := buf.String()
+	if !strings.Contains(out, secret) {
+		t.Errorf("gated debug line should carry the full body but did not:\n%s", out)
+	}
+	if !strings.Contains(out, "payload_sha8=") {
+		t.Errorf("gated debug line should still carry the size/hash summary:\n%s", out)
+	}
+	// The summary's byte count must describe the same body that got dumped.
+	if !strings.Contains(out, "payload_bytes="+strconv.Itoa(len(body))) {
+		t.Errorf("gated debug line payload_bytes should equal len(body)=%d:\n%s", len(body), out)
+	}
+}
+
+func TestDebugLogRequest_GateMustBeExactlyOne(t *testing.T) {
+	const secret = "BODY-SHOULD-STAY-HIDDEN"
+	payload := debugTestPayload{Model: "test-model", Secret: secret}
+
+	// Any value other than "1" leaves the body redacted — a truthy-looking
+	// "true"/"yes" must not accidentally enable the firehose.
+	t.Setenv(fullPayloadLogEnvVar, "true")
+
+	var buf bytes.Buffer
+	c := newBufferDebugClient(&buf)
+	c.debugLogRequest("req-3", "test-model", 1, &payload)
+
+	if strings.Contains(buf.String(), secret) {
+		t.Errorf("env=%q should not enable full payload logging:\n%s", "true", buf.String())
+	}
+}
+
+func TestDebugLogRequest_SkipsWhenDebugDisabled(t *testing.T) {
+	payload := debugTestPayload{Model: "test-model", Secret: "x"}
+
+	var buf bytes.Buffer
+	c := &Client{
+		logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+	c.debugLogRequest("req-4", "test-model", 1, &payload)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output when debug disabled, got:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## Problem

`debugLogRequest` (`processor/agentic-model/client.go`) json.Marshaled the **entire** outgoing chat payload — system prompt + every accumulated message + tool results — into one slog Debug `payload` attr on **every** model call. In a deep agent loop `message_count` climbs to ~110 and ~600 dispatches/run produced a **~2.2 GB** `semspec.log`. The embedded conversation JSON also **grep-poisoned `docker logs`**: any event pattern (e.g. `rejection_type=restructure`) matched against prompt text, not real events.

Filed as **C360Studio/semspec#165** (items #1/#2, tagged "semstreams ask" — the headline volume win lands here). Security sweep there already confirmed: no credential leaks.

## Fix

`debugLogRequest` now logs **`payload_bytes` + `payload_sha8` + `message_count`** by default — enough to correlate and dedup requests without the volume. The full body is emitted only when **`SEMSTREAMS_LOG_FULL_PAYLOAD=1`**, for targeted repros.

- One shared function → fixes all **three** backends in one place (SDK `client.go:447`, wire `client_wire.go:455`, responses `client_responses.go:31`). Note: the wire caller is new since beta.103, so this is broader than the issue's original 2-caller scope.
- slog has no TRACE level and there's no prior env-gate convention in prod code, hence the dedicated env var.
- Gate is exact-match `== "1"` (truthy values like `true` stay redacted), locked by a test.
- The existing `logger.Enabled(LevelDebug)` early-return is preserved, so the marshal still only runs when debug is on — zero added cost on the production (non-debug) path.

## Correction to the issue

Item **#3** (the 5 timeout-precedence Debug lines in `component.go`) is **overstated** — those are mutually-exclusive branches, each `return`s immediately, so exactly **one** line fires per request, not five. Near-zero volume contribution; not addressed here. The semspec-side items (#4–#6) belong in that repo.

## Tests

New `debug_log_request_test.go` (internal package):
- default omits the body, emits the summary (`payload_bytes`/`payload_sha8`/`message_count`)
- gated (`=1`) emits the full body **and** retains the summary; `payload_bytes` matches `len(body)`
- truthy-but-not-`1` (`true`) stays redacted
- debug-disabled produces zero output

## Gates

- `go test -race ./processor/agentic-model/` ✅
- `go vet -tags=integration ./...` ✅
- `go test -race -tags=integration ./processor/...` ✅
- `task lint` (revive) ✅ clean
- go-reviewer: **clean / approve as-is**, no blocking findings
- Schema gate: N/A (no payload/config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)