### PR TITLE
ADR-056 W0: authoritative semantic state — owner registry + projection + lifecycle.Manager first consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ The graph builds situational awareness; rules and agents close the loop.
 Two core patterns power this:
 - **Graphable** — Your types become graph entities ([docs](docs/basics/03-graphable-interface.md))
 - **Payload Registry** — Messages serialize with type discrimination ([docs](docs/concepts/15-payload-registry.md))
+- **Governed Semantic State** — Shared graph facts declare who may replace them, who may append evidence, and how
+  cross-entity edges are handled ([docs](docs/concepts/28-governed-semantic-state.md))
+
+`Graphable` is enough for simple fact ingestion. Domains with multiple writers, lifecycle state, regulated audit, or
+agentic automation also need ownership for stateful predicate groups. That keeps `ENTITY_STATES` queryable without
+letting unrelated components silently overwrite each other's facts.
 
 ## Progressive Capabilities
 

--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/c360studio/semstreams/payloadregistry"
 	"github.com/c360studio/semstreams/persona"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
+	"github.com/c360studio/semstreams/pkg/ownership"
 	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
 	"github.com/c360studio/semstreams/processor/agentic-tools/executors"
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
@@ -151,7 +152,15 @@ func run() error {
 	// emit retry holds the goroutine that would otherwise call
 	// StartAll, so the responder we are waiting for can never come
 	// up. The seed is run as a post-start hook below. See gh#170.
-	if err := wireLifecycleManager(ctx, svcDeps, natsClient, logger); err != nil {
+	// The heartbeat goroutine AttachOwnership spawns must stop on shutdown.
+	// `ctx` is context.Background() (the signal-cancelled context is a downstream
+	// child created in runWithSignalHandling), so derive a cancellable context
+	// here and cancel it as run() unwinds. Registered after natsClient.Close's
+	// defer, so by LIFO it fires FIRST — the heartbeat stops before the client
+	// closes. Threaded through wireLifecycleManager to AttachOwnership.
+	hbCtx, hbCancel := context.WithCancel(ctx)
+	defer hbCancel()
+	if err := wireLifecycleManager(hbCtx, svcDeps, natsClient, logger); err != nil {
 		return err
 	}
 
@@ -221,8 +230,21 @@ func buildPayloadRegistry() (*payloadregistry.Registry, error) {
 // bucket provisioning. State changes emit through graph-ingest like
 // every other write; reads project triples into the registered
 // Schema struct.
-func wireLifecycleManager(_ context.Context, svcDeps *service.Dependencies, _ *natsclient.Client, _ *slog.Logger) error {
+func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ *natsclient.Client, _ *slog.Logger) error {
 	svcDeps.LifecycleManager = lifecycle.NewManager(svcDeps.NATSClient, svcDeps.Logger)
+
+	// ADR-056 Decision 5 — attach the owner registry BEFORE Register so each
+	// workflow's claim registers through the shared epoch (cross-process overlap
+	// surfaced, observe-only for the first consumer). EnsureBuckets is eager:
+	// graph-ingest (which creates the other framework buckets) boots later than
+	// this wiring, so the ownership buckets must be created here. A NATS hiccup
+	// logs + skips — ownership is best-effort observe-only, never a boot gate.
+	if ownerReg, err := ownership.EnsureBuckets(ctx, svcDeps.NATSClient, svcDeps.Logger); err != nil {
+		svcDeps.Logger.Warn("ownership: bucket bootstrap failed — lifecycle ownership disabled this boot", slog.Any("error", err))
+	} else {
+		svcDeps.LifecycleManager.AttachOwnership(ctx, ownerReg)
+	}
+
 	if err := svcDeps.LifecycleManager.Register(mission.WorkflowDeclaration()); err != nil {
 		return fmt.Errorf("register mission workflow: %w", err)
 	}

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/c360studio/semstreams/payloadregistry"
 	"github.com/c360studio/semstreams/persona"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
+	"github.com/c360studio/semstreams/pkg/ownership"
 	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
 	"github.com/c360studio/semstreams/processor/agentic-tools/executors"
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
@@ -184,6 +185,29 @@ func run() error {
 	// [[feedback_verify_main_go_wire_for_sister_asks]] —
 	// half-migrated framework binaries silently break workflows.
 	svcDeps.LifecycleManager = lifecycle.NewManager(natsClient, logger)
+
+	// 10b. ADR-056 Decision 5 — attach the owner registry BEFORE Register so the
+	// agent-run workflow's claim registers through the shared OWNER_CLAIMS epoch
+	// (cross-process overlap surfaced, observe-only for the first consumer).
+	// EnsureBuckets is EAGER and deliberately here, not in graph-ingest:
+	// graph-ingest's initStorage runs only after services start
+	// (configureAndCreateServices below), long after this Register — so creating
+	// the ownership buckets there would make every registration a silent no-op.
+	// A NATS hiccup logs + skips; ownership is best-effort observe-only, never a
+	// boot gate ([[feedback_unconditional_resource_wiring_breaks_resourceless_deploys]]).
+	if ownerReg, err := ownership.EnsureBuckets(ctx, natsClient, logger); err != nil {
+		logger.Warn("ownership: bucket bootstrap failed — lifecycle ownership disabled this boot", slog.Any("error", err))
+	} else {
+		// The heartbeat goroutine must stop on shutdown. `ctx` here is
+		// context.Background() (the signal-cancelled context is a downstream
+		// CHILD created in runWithSignalHandling, and a child cancelling never
+		// cancels its parent), so derive a cancellable context and cancel it as
+		// run() unwinds. Registered after natsClient.Close's defer, so by LIFO it
+		// fires FIRST — the heartbeat stops before the client closes.
+		hbCtx, hbCancel := context.WithCancel(ctx)
+		defer hbCancel()
+		svcDeps.LifecycleManager.AttachOwnership(hbCtx, ownerReg)
+	}
 
 	// 10c. Register the agent-run workflow (ADR-053 D2). Must come after
 	// the Manager is constructed so lifecycle_* actions that reference

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@
 - [Rules Engine](advanced/06-rules-engine.md) - Condition-based actions
 - [Community Detection](concepts/07-community-detection.md) - LPA algorithm
 - [Query Access](concepts/11-query-access.md) - GraphQL and MCP gateway
+- [Governed Semantic State](concepts/28-governed-semantic-state.md) - Ownership for shared graph facts
 
 ## Vocabulary & Standards
 

--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -2,7 +2,22 @@
 
 ## Status
 
-**Proposed** — 2026-06-13 (v5, final precision pass; Accept pending human sign-off).
+**Accepted** — 2026-06-13 (v6, post-merge review thread closed; human sign-off received).
+v6 threads the final pre-Accept review (2 P1 + 1 P2): the fourth-path stub-lane
+self-contradiction is resolved (the no-birth referential stub is promoted to a first-class,
+envelope-bearing framework artifact with a named `ForeignEdgeClaim` owner — Decision 4 lane ii —
+reconciled across the framework-surface summary and the ADR-055 narrowing); the write-time
+owner-token lease check is given a concrete WIRE CONTRACT (`OwnerToken` field on the graph-ingest
+mutation request structs + `ErrorCodeOwnerLeaseStale`, Decision 2); and the stale "sensorml
+declares `hosts`/`isHostedBy`" changelog line is corrected to "only `isHostedBy`." No
+architectural change — these are contract-precision fixes at the enforcement points. v6 also adds
+**two acceptance fixtures** (Consequences §) on complementary axes: **semconnect cs-api** (gateway-write,
+Decisions 1–4) and **semteams** (rule/lifecycle, Decision 5 + "rules observe, don't own"). Both are run
+against the real consumers' ownership surfaces and described exactly with no Decision re-architecture;
+the only thing either forced is prose (a shared-vocabulary-ownership note, and a predicate-group-scoped
+correction to "rules observe, don't own" that the semteams run-entity pattern falsified the old wording
+of). The gate Coby set for Accept ("if 056 can describe how the consumers register their claims, the
+design is real") is passed on both axes.
 The architecture is VALIDATED across four adversarial rounds (verdict: 6/6 no hard FAIL);
 v5 pins the remaining **implementation contracts** the v4 review (Codex 1 BLOCKING + P1s)
 and the verification gate flagged — these are contract-precision fixes, **no architectural
@@ -16,15 +31,68 @@ the flip-gate predicate sharpened to hatch-empty). No new architectural forks. E
 load-bearing claim cites `file:line` against code read on 2026-06-13. Where this ADR
 disagrees with a summary in `CLAUDE.md` or `MEMORY.md`, the cited code wins.
 
-The Status flip to Proposed and the eventual git commit are the human author's call; this
-revision sets Proposed because every v5 punch-list item is pinned with **no remaining
-BLOCKING** — see the v4 → v5 changelog. **Accept pending human sign-off.**
+v5 set Proposed with every punch-list item pinned and **no remaining BLOCKING** (see the
+v4 → v5 changelog). v6 flips to **Accepted**: the human author signed off conditional on
+threading the post-merge review (2 P1 + 1 P2), and that thread is now closed in this revision
+(see the v5 → v6 changelog below). No BLOCKING remains.
 
 This ADR **does not supersede** ADR-049 or ADR-055. It is the missing parent. ADR-049's
 `Manager` is one *implementation* of the contract; ADR-055 **narrows** to a single
 enforcement rule under it (see "How ADR-055 narrows under this parent"). The
 cryptographic-provenance follow-up is scoped (not designed) in
 [ADR-057](057-cryptographic-provenance.md).
+
+### v5 → v6: post-merge review thread closed (2 P1 + 1 P2; no architectural change)
+
+ADR-056 merged to main (PR #270) at Status Proposed. The pre-Accept review raised three findings,
+all at enforcement points; v6 threads them and flips Status to **Accepted**. No Decision changes
+shape.
+
+- **P1 — the fourth auto-vivify path contradicted itself across three places.** Decision 4 lane (ii)
+  said no-birth targets "keep an EXPLICIT referential-stub lane with a must-exist exemption"; the
+  framework-surface summary said `ensureReferencedEntityExists → enqueue, not stub Put`; the ADR-055
+  narrowing said "no envelope-less stub." Load-bearing, not cosmetic. **Closed by choosing horn (a):**
+  the no-birth referential stub is **promoted to a first-class, envelope-bearing framework artifact**
+  with a named owner/claim — `MessageType = core.identity.stub` (domain `core`/category `identity`),
+  creating owner recorded as the producer's registered `ForeignEdgeClaim` in a `core.identity.stub_owner`
+  triple. Horn (b) (remove the lane) is rejected because sensorml's child has no birth to drain and no
+  registered inverse to backfill, so removal would dangle the edge forever. The framework-surface
+  summary and the ADR-055 narrowing are reworded to match (both lanes named; "no ENVELOPE-LESS stub"
+  is now literally true — the surviving stub carries an envelope).
+- **P1 — the write-time owner-token check asserted enforcement but named no wire surface.** Decision 2
+  now pins it: `OwnerToken` is a typed field on `Update`/`CreateEntityWithTriplesRequest`
+  (`graph/mutation_requests.go:80,38`) — the registry-exempt point-to-point structs that already carry
+  `ExpectedRevision`/`TraceID` — NOT a NATS header and NOT a `BaseMessage` envelope. The value is the
+  lease handle minted at `RegisterOwner`; graph-ingest rejects a mismatch with a new
+  `ErrorCodeOwnerLeaseStale` through the same response path `ErrorCodeRevisionMismatch` uses
+  (`pkg/lifecycle/graph_emit.go:134-139`).
+- **P2 — stale sensorml changelog line.** The BLOCKING-B changelog said sensorml declares both
+  `hosts` and `isHostedBy` as `ForeignEdgeClaim`s; the corrected design (056:872) says only
+  `isHostedBy` is the foreign-subject claim (`hosts` carries the parent's own id as Subject). The
+  changelog line is corrected to match.
+- **Acceptance fixtures added — semconnect cs-api AND semteams (the gate Coby set for Accept).** A new
+  "Consequences → Acceptance fixture" subsection runs the design against TWO real consumers on
+  complementary axes, both read 2026-06-13.
+  - **semconnect (`../semconnect/gateway/cs-api/`) — gateway-write axis (Decisions 1–4).** 11 entity
+    types, ~30 `cs-api.*` predicates plus shared `sensorml.*`/`csapi.*`/`sosa:*` vocabulary. 056
+    describes the registrations EXACTLY with no new mechanism. Four sharpenings: (1) owned sets are
+    dominated by shared vocabulary predicates owned-by-the-writer not the vocab package; (2)
+    disjoint-id-space is the cross-producer contract, overlap-reject is the design working; (3)
+    `sensorml.component.isHostedBy` is owned AND foreign by subject position, no collision because
+    subject-partitioned, no-birth-stub lane because no inverse; (4) two named cs-api migration sites
+    (`systems_crd.go:145` blanket replace, `systems_post.go:317` single-subject ingest).
+  - **semteams (`../semteams/`) — rule/lifecycle axis (Decision 5 + "rules observe, don't own").**
+    Q1 dual-write probe CLEAN (no private `*_STATES` mirror; Decision 5 grounded in a 2nd consumer).
+    Q2 found 22 agent-run rules stamping the FOREIGN run entity — correct ADR-053 coordination, but
+    it **falsified the ADR's own prose** ("rules cleared only because they stamp their trigger
+    entity"). Fixed: *For the architectural identity* now states the invariant is
+    PREDICATE-GROUP-scoped — the run entity is **multi-owned** (lifecycle-Manager phase + a disjoint
+    rule-marker group), the anti-pattern is REPLACING another owner's group, not writing a foreign
+    entity. semteams's marker-group classification (append-evidence vs registered rule-pack owner) is
+    its migration question, expressible today.
+  - **Both fixtures pass with NO Decision re-architecture** — the only changes either forced are
+    prose (the two ownership clarifications). The "if it can describe the consumers, the design is
+    real" gate is passed on both the write axis and the rule/lifecycle axis.
 
 ### v4 → v5: implementation contracts pinned (1 BLOCKING + P1s; no architectural forks)
 
@@ -131,8 +199,10 @@ mechanisms (no new architectural fork) and folds three MEDIUMs.
   emits a foreign-subject triple MUST have declared that predicate as a
   `ForeignEdgeClaim` (validated at boot the same way payload registration is); a
   foreign-subject triple with no registered claim is the reject (or a flagged,
-  deprecated-on-arrival migration escape hatch). sensorml declares `hosts`/`isHostedBy`
-  as `ForeignEdgeClaim`s. v4 also (1) **enumerates `ensureReferencedEntityExists`
+  deprecated-on-arrival migration escape hatch). sensorml declares ONLY `isHostedBy` as a
+  `ForeignEdgeClaim` — the child-subject edge; `hosts` carries the parent's OWN id as Subject
+  (`Subject == entityID`), so it files as `own` and is NOT a foreign edge (corrected in
+  Decision 4, 056:872). v4 also (1) **enumerates `ensureReferencedEntityExists`
   (`component.go:1424-1525`) as a FOURTH auto-vivify path** that survives ADR-055's flip
   (the flip deletes only the `AddTriple`/`AddTriples` branches, `:1691-1698`/`:1790-1796`)
   and rules on its fate; (2) **strikes the physically-impossible "single-revision-atomic
@@ -627,6 +697,26 @@ unconditional third-party delete:
   been re-claimed **fails the write at the write seam** (a cheap epoch read, cache-friendly), not
   only at its next registration or Watch fire. This is the chosen close — a lightweight write-time
   lease verified against the epoch — over merely declaring the window an accepted availability cost.
+- **Where the `owner_token` lives — the WIRE CONTRACT, not prose (P1 close).** The token is a
+  new typed field `OwnerToken string` on the graph-ingest mutation request structs —
+  `UpdateEntityWithTriplesRequest` and `CreateEntityWithTriplesRequest`
+  (`graph/mutation_requests.go:80,38`), the SAME point-to-point request/reply structs that already
+  carry `ExpectedRevision`, `IndexingProfile`, and `TraceID`. It is **NOT a NATS header and NOT a
+  `BaseMessage` envelope field**: graph mutation request/reply is intentionally registry-exempt
+  (`graph/mutation_requests.go:7-10`) because the subject already selects the handler, so the
+  authorization context rides as a typed request field exactly like the CAS condition
+  (`ExpectedRevision`) does — no envelope, no header indirection, one struct the handler already
+  deserializes. The token's VALUE is the lease handle minted at `RegisterOwner` time (the owner's
+  entry in the `OWNER_CLAIMS` epoch for that `(pattern, predicate)` cell). graph-ingest's
+  `update_with_triples` / `create_with_triples` handler reads the current epoch, looks up the live
+  owner of the target cell, and rejects with a new `ErrorCodeOwnerLeaseStale` when the request's
+  `OwnerToken` does not match — surfaced through the **same response-classification path**
+  `ErrorCodeRevisionMismatch` already uses (`pkg/lifecycle/graph_emit.go:134-139`), so the lifecycle
+  `Manager` (which already emits through these exact subjects — `graph_emit.go:12-15`) gets the
+  check for free. Append-evidence (`triple.add`/`add_batch`) and unowned writes carry no token and
+  skip the lookup — only `replace-owned` / `cas-transition` writes (Decision 1's two owning modes)
+  are gated. This is the enforcement point the reviewer flagged: the lease check is now a wire field
+  with a named owner, a named handler seam, and a named error code, not a sentence.
 - **The availability-vs-safety tradeoff, stated.** Compaction prioritizes *availability* (a
   crashed owner's claim must not block a restart forever) at the cost of a bounded *registration*
   window: during `[entry compacted, owner revives + Watch halt]` a freed cell could be re-claimed
@@ -1072,10 +1162,23 @@ ADR-055's "no ownerless births" closing move is **incomplete** until it accounts
 > package defines only ONE `EntityID()` (`parser/sensorml/graphable.go:37`, `Asset` returns the
 > PARENT id); a child id comes only from the optional `ChildIDFn` (`:166-175`) and is never the
 > subject of its own published Graphable. For this subclass the stub IS load-bearing — it is the
-> only thing that ever materializes the child node — so it stays as an EXPLICIT referential-stub
-> lane carrying a **must-exist EXEMPTION** in ADR-055's flip text (the stub-creating write is
-> named and exempted, not silently surviving). The exemption is bounded to no-birth targets and is
-> declared, not a blanket carve-out.
+> only thing that ever materializes the child node — so it stays, but it is **promoted from the
+> envelope-less ownerless `Put` it is today (`component.go:1488-1519`: Version 1, no `MessageType`,
+> no envelope, last-writer-wins) to a FIRST-CLASS, ENVELOPE-BEARING framework artifact with a named
+> owner/claim.** This resolves the reviewer's first horn — we choose horn (a) (first-class stub),
+> not horn (b) (remove the lane), because removal would dangle sensorml's child edge forever
+> (no birth to drain, no registered inverse to backfill). Concretely, the referential-stub creator
+> (`ensureReferencedEntityExists`) stamps the stub `EntityState` with a framework semantic envelope
+> — `MessageType = core.identity.stub`, domain `core` / category `identity` / version, the same
+> discriminator shape the payload registry uses — and records the CREATING owner (the producer's
+> registered `ForeignEdgeClaim` `MessageType`) in a `core.identity.stub_owner` triple alongside the
+> existing `core.identity.referenced_by`. The stub is therefore **NOT "an envelope-less ownerless
+> stub that silently survives the flip"**; it is a NAMED framework birth lane (the referential-
+> integrity producer) whose creation is AUTHORIZED by a registered `ForeignEdgeClaim` declaring
+> `edge-mode` with the **must-exist EXEMPTION** in ADR-055's flip text. The exemption is bounded to
+> no-birth targets whose producer registered that `edge-mode` claim — declared, not a blanket
+> carve-out: a foreign edge whose producer registered NO no-birth claim still trips the
+> unclaimed-foreign reject (Decision 4 BLOCKING-B) and never reaches the stub lane.
 
 How the seam decides which subclass a target is in: a referenced target whose `(message_type)`
 maps to a registered birth-producer (it WILL be born) takes lane (i); a target with no registered
@@ -1228,14 +1331,21 @@ not a parallel path. **New framework surface flagged for the final review:**
   CAS-write-at-read-revision → retry-on-mismatch-against-the-now-larger-epoch; plus the
   **post-registration epoch Watch** that re-checks overlap if a compacted-then-revived owner
   reappears — **a re-detected overlap there is a FATAL HALT of the revived process (v5), not a log**;
-  plus the **write-time owner-token lease check** (v5) verifying the writer against the epoch's owner
-  of the `(pattern, predicate)` cell to close the double-WRITE window.
+  plus the **write-time owner-token lease check** (v5; wire surface pinned v6) verifying the writer
+  against the epoch's owner of the `(pattern, predicate)` cell to close the double-WRITE window — the
+  token rides as the `OwnerToken` field on `Update`/`CreateEntityWithTriplesRequest` (NOT a header or
+  `BaseMessage` envelope; the structs are registry-exempt), rejected with `ErrorCodeOwnerLeaseStale`
+  through graph-ingest's existing response-classification path (Decision 2, "Where the `owner_token`
+  lives").
 - **The T2-seam foreign-edge enforcement** (Decision 4 BLOCKING-B): the unclaimed-foreign-edge
   reject at `ingestEntity`/`partitionTriplesBySubject` (`component.go:917-955,1031-1040`),
   boot-time `ForeignEdgeClaim` validation including the **inverse-gate** (`Conditional` requires
   a registered `InverseOf` — `vocabulary/registry.go:368-381` — else `Strict`), the
   delete-after-apply drain + boot re-drain sweep, and the **fourth-path fold**
-  (`ensureReferencedEntityExists` → enqueue, not stub `Put`).
+  (`ensureReferencedEntityExists`): enqueue into `PENDING_EDGES` for birth-bearing targets (lane i),
+  OR materialize via the framework's envelope-bearing referential-stub lane — named owner = the
+  producer's registered `ForeignEdgeClaim`, `MessageType = core.identity.stub` — for no-birth
+  targets like sensorml children (lane ii). Never an anonymous, envelope-less, ownerless `Put`.
 - **The base `OwnerRegistry` type** and the `RegisterOwner` entrypoint; the overlap algorithm
   (glob-vs-glob *entity-ID-pattern* intersection × exact-string *predicate* intersection,
   over the epoch union).
@@ -1387,8 +1497,13 @@ that rule gets *more* teeth, not less:
 > `triple.add`/`add_batch` auto-vivify branches (`component.go:1691-1698`, `1790-1796`) are
 > deleted (`triple.add`/`add_batch` become must-exist), AND the FOURTH auto-vivify path
 > `ensureReferencedEntityExists` (`component.go:1424-1525`) is covered — folded into the
-> Decision-4 pending-edge buffer (enqueue, don't `Put` a stub), or explicitly exempted in this
-> flip text. No ownerless births; no auto-vivify producer path; no envelope-less stub.**
+> Decision-4 pending-edge buffer (enqueue) for birth-bearing targets, OR materialized via the
+> framework's envelope-bearing referential-stub lane (named owner = the producer's registered
+> `ForeignEdgeClaim`, `MessageType = core.identity.stub`) for no-birth targets like sensorml
+> children. No ownerless births; no auto-vivify PRODUCER path; no ENVELOPE-LESS stub — the only
+> stub that survives is the framework's own referential-stub artifact, which now carries a semantic
+> envelope and a named creating claim (Decision 4 lane ii), not the anonymous envelope-less `Put`
+> the flip deletes.**
 
 What moves OUT of ADR-055 and INTO 056 (this ADR), making 055 narrower:
 
@@ -1442,8 +1557,10 @@ concern (above), not an owned-predicate concern. No conflict.
   final review.
 - All FOUR auto-vivify paths are accounted for by ADR-055's closing move, now gated on Decision
   4: the two `AddTriple`/`AddTriples` branches (`component.go:1691-1698`, `1790-1796`) are
-  deleted, and the fourth path `ensureReferencedEntityExists` (`component.go:1424-1525`) is
-  folded into the pending-edge buffer (enqueue, not stub `Put`).
+  deleted, and the fourth path `ensureReferencedEntityExists` (`component.go:1424-1525`) is folded
+  into the pending-edge buffer (enqueue) for birth-bearing targets, or routed through the
+  envelope-bearing referential-stub lane for no-birth targets (Decision 4 lane ii) — never an
+  anonymous, envelope-less `Put`.
 
 ### For lifecycle (`pkg/lifecycle`)
 
@@ -1461,16 +1578,140 @@ concern (above), not an owned-predicate concern. No conflict.
   the Decision-3 escape hatch, one site at a time, then registry-backed). The cost is real and
   per-producer; the value is stopping the next reinvention.
 
+### Acceptance fixture — semconnect cs-api (the design, made concrete)
+
+> **The gate (Coby, 2026-06-13): if 056 cannot describe EXACTLY how semconnect registers claims
+> for its entity types, the ADR is still too abstract.** This subsection runs that gate against the
+> real code (`../semconnect/gateway/cs-api/`, read 2026-06-13). It is the worked example, not an
+> abstraction — every claim cites `file:line`.
+
+semconnect's cs-api gateway writes **11 entity types** into `ENTITY_STATES` through
+`graph.mutation.entity.create_with_triples` / `update_with_triples` (`systems_post.go:27-30`).
+Under 056 each becomes one `OwnerClaim` keyed to its entity-ID glob (the per-type prefix from
+`config.go:180-190`, e.g. `c360.semconnect.systems.csapi.system.*`) enumerating its full predicate
+set. Representative registrations (the rest follow the same shape):
+
+| Entity (glob) | `OwnerClaim` predicate set (exact strings) | Write mode | Foreign-subject edge → `ForeignEdgeClaim` |
+|---|---|---|---|
+| System `…csapi.system.*` | `sensorml.process.{type,uid,label,description,position}`, `sensorml.component.isHostedBy` (own→parent) | replace-owned | YES (SensorML path only — see below) |
+| Deployment `…csapi.deployment.*` | `cs-api.deployment.{parent,deployedSystems}` + `sensorml.process.{type,uid,label,description,position}` | replace-owned | none (object-only refs) |
+| Datastream `…csapi.datastream.*` | `cs-api.datastream.{phenomenonTime,resultTime}` + `csapi.{ProducedBy,HasResultSchema}` + `sensorml.process.{label,description}` + `sosa:observedProperty` | replace-owned | none (object-only refs) |
+| SchemaArtifact `…csapi.schema.*` | `sensorml.process.type` (=`SWESchemaDocument`) | replace-owned (cs-api-created target) | none |
+
+This worked example surfaces four things the abstract design only implied — all **resolved by the
+existing mechanism**, which is exactly why the gate is passed and not failed:
+
+1. **A consumer's owned set is DOMINATED by shared vocabulary predicates, not its own namespace.**
+   cs-api's System claim is six `sensorml.*` predicates and ZERO `cs-api.*` ones; the owner is the
+   **writing component (cs-api), not the `parser/sensorml` package** whose constants it reuses
+   (`systems_post.go:209-237`). The design already supports this because a claim is
+   `(entity-ID glob × EXACT predicate string)` (Decision 1/2) — cs-api owns `sensorml.process.label`
+   *only on `…csapi.system.*`*; an input-component SensorML-ingest path owning the same predicate on
+   a **disjoint** id-glob does NOT collide. **This must be stated or a reader concludes shared
+   predicates are unownable.** (Stated here.)
+
+2. **Disjoint-id-space is the cross-producer contract, and overlap rejection is the design WORKING.**
+   If a non-cs-api SensorML-ingest path were ever configured to mint entity IDs under
+   `…csapi.system.*` AND own `sensorml.process.label` there, registration is rejected at boot
+   (Decision 2) — the correct outcome, because two producers replace-owning the same cell is the
+   dual-write 056 exists to retire. cs-api owns its id-space exclusively; that is its half of the
+   contract.
+
+3. **The SensorML child edge is the flagship `ForeignEdgeClaim` — and `isHostedBy` is owned AND
+   foreign, disambiguated by SUBJECT position.** On the GeoJSON-Feature path cs-api emits
+   `{Subject: <own System>, isHostedBy, Object: parent}` — an OWN edge to a foreign object
+   (`systems_post.go:237`), governed by the System `OwnerClaim`, its object a fourth-path reference
+   target. On the SensorML path `buildSystemTriplesFromSensorML` calls `asset.Triples()`
+   (`systems_post.go:151`), which for a `PhysicalSystem` with `Components` emits
+   `{Subject: childID, isHostedBy, Object: <System>}` — a FOREIGN-subject edge
+   (`parser/sensorml/graphable.go:124`). The same predicate is therefore in BOTH cs-api's
+   `OwnerClaim` (own→parent) and a `ForeignEdgeClaim` (child→System); they do **not** trip the
+   Owner×FE collision check (Decision 2 MEDIUM) because `partitionTriplesBySubject` files them on
+   **different subject entities** — replace-owned on the System never touches the child. The
+   `ForeignEdgeClaim` is the **no-birth referential-stub lane** (Decision 4 lane ii): the child has
+   no independent birth (sensorml defines one `EntityID()`, the parent — `graphable.go:37`) and
+   `sensorml.component.isHostedBy` carries **no registered inverse** (`predicates.go:97`,
+   `WithIRI` only), so neither the pending-edge drain nor backfill can reconstruct it — the
+   envelope-bearing stub is load-bearing.
+
+4. **Two concrete cs-api migration sites, named.** (a) The blanket replace — `replaceEntityTriples`
+   sets `RemoveTriples: uniquePredicates(current.Triples)` (`systems_crd.go:145`; same shape in the
+   PATCH paths), which today erases EVERY predicate on the entity including lifecycle/provenance/
+   inferred/foreign facts from other owners. Under 056 it becomes replace-**owned**: `RemoveTriples`
+   = the System claim's declared set (Decision 3). (b) The single-subject assumption — `ingestTriples`
+   runs `singleSubject(triples)` (`systems_post.go:317`) and **errors** on the multi-subject set a
+   rich SensorML hierarchy produces, so cs-api cannot round-trip embedded `Components` at all today;
+   the `ForeignEdgeClaim` + T2-regroup seam (Decision 4) is the path that makes it work.
+
+**Verdict: the gate is PASSED.** 056 describes semconnect's registrations exactly — one `OwnerClaim`
+per entity-type id-glob, the shared-vocabulary-owned-by-writer rule, one `ForeignEdgeClaim` for the
+SensorML child edge in no-birth-stub mode, and two named replace/ingest migration sites — without a
+single new mechanism beyond Decisions 1–4. The cs-api migration is real, per-site, and breaking-ish
+(boot-time claim failures and write-time lease failures replace silent corruption); it needs tests
+and a compatibility window, tracked as the first 056 consumer-migration.
+
+#### Second fixture — semteams (the rule/lifecycle axis semconnect didn't exercise)
+
+semconnect grounds the **gateway-write** axis (Decisions 1–4). semteams — the heaviest rule/lifecycle
+consumer — grounds the axis 056 made its strongest *unverified* claims about: Decision 5 (product
+buckets ≠ a second authoritative source) and "rules observe, don't own." A bounded two-question probe
+(`../semteams/`, read 2026-06-13):
+
+- **Q1 — dual-write / private-authoritative bucket: CLEAN.** semteams creates **no** state bucket of
+  its own. Every KV bucket it touches is a framework read-cache / work-queue / config (`PERSONAS`,
+  `FLOW_TEMPLATES`, `AGENT_LOOPS`, `RULES`, `semstreams_config`); there is **no `*_STATES`-style
+  authoritative-mirror** like semspec's `PLAN_STATES`. All entity state flows through graph-ingest.
+  Decision 5 is now grounded in a **second independent consumer**, not just asserted.
+
+- **Q2 — foreign-subject rule writes: FOUND (22 agent-run rules), and they are CORRECT — but they
+  falsified the ADR's prose, now fixed above.** The rules stamp coordination markers
+  (`agent.run.outcome`, `agent.run.handoff`, `agent.run.clarification_pending`, the per-pack
+  `*.completed`/`*.task_failed`) onto the **run entity** while firing on a different loop, then a
+  sibling rule consumes the marker and triggers the lifecycle Manager's `lifecycle_transition`
+  (`configs/rules/agent-run/04-*.json`). Phase moves **only** through the Manager; the markers are a
+  **disjoint predicate group**. This is the **multi-owned-by-predicate-group** pattern — load-bearing
+  ADR-053 coordination, not the anti-pattern — and it forced the "rules observe, don't own"
+  correction in *For the architectural identity* above (the old "cleared only because they stamp
+  their trigger entity" rationale would have wrongly flagged 22 production rules).
+
+- **semteams's migration question** (its half of the contract, for the semteams team — recorded here
+  for ground truth, not actioned): the run-marker predicate group needs a 056 classification —
+  **append-evidence exemption** (the natural fit: write-once trigger conditions, and two
+  mutually-exclusive rules can write the same marker) **or** a registered rule-pack owner. Either is
+  expressible today (Decision 2's append-evidence exemption already exists); nothing new is required.
+
+**Both fixtures pass with no Decision re-architecture.** semconnect exercised replace-owned +
+foreign-edge + the fourth-path stub; semteams exercised Decision 5 + multi-owner-per-entity + the
+rules-don't-own boundary. The only design-doc change either forced is **prose** (the shared-vocabulary
+ownership note, and the predicate-group-scoped correction to "rules observe, don't own"). The design
+center — authoritative semantic state, owned per `(entity × predicate-group)` — held against both.
+
 ### For the architectural identity
 
 KV-twofer preserved (single-revision replace, atomicity section). Facts-vs-Requests preserved.
 State ownership exclusive — **sharpened from "only graph-ingest writes" to "exactly one
-registered owner per predicate group, overlap rejected at registration."** Rules trigger, they
-don't own — a rule action writing authoritative state (vs requesting a transition through the
-owner) makes the rule a second owner and is the anti-pattern; the ADR-055 audit cleared the
-rule-engine derived-fact stamps (`actions.go:600/684/821/1353`) *only* because they stamp the
-rule's own trigger entity, which already exists (`graphable-bypass-audit.md:240-244`) — that
-clearance depends on this rule.
+registered owner per predicate group, overlap rejected at registration."**
+
+**"Rules observe, don't own" is PREDICATE-GROUP-scoped, not entity-scoped or
+trigger-entity-scoped (semteams correction).** An earlier draft cleared the rule-engine
+derived-fact stamps (`actions.go:600/684/821/1353`) *"only because they stamp the rule's own
+trigger entity"* (`graphable-bypass-audit.md:240-244`). The semteams acceptance probe (below)
+falsifies that rationale as a general principle: **22 production agent-run rules deliberately
+stamp a FOREIGN entity** — the run entity, via `$entity.triple.agent.run.entity_id`, while firing
+on a coordinator/reviewer/execute loop (`configs/rules/agent-run/05-*.json`). That is not the
+anti-pattern; it is the load-bearing ADR-053 coordination pattern. The correct invariant is
+therefore: a rule may write a predicate group on **any** entity, including one it does not own,
+**provided** (a) that group is registered to the rule pack as an owner OR is append-evidence
+(multi-writer, Decision 2 exemption), and (b) it is **disjoint** from every other owner's group on
+that entity. The actual anti-pattern is narrower and sharper: **a rule REPLACING another owner's
+owned group** — e.g. writing `agent.run.phase` directly instead of requesting the transition
+through the lifecycle Manager's `lifecycle_transition` action. semteams obeys exactly this line:
+phase moves *only* through the Manager (the registered owner), while the rule markers
+(`agent.run.outcome`, `agent.run.clarification_pending`, …) are a **disjoint coordination group**
+on the same entity, consumed by a sibling rule that then triggers the owner's transition. The run
+entity is thus **MULTI-OWNED by predicate group** (lifecycle-Manager phase + rule-pack marker
+group), which the predicate-group ownership model already expresses — "single ownership per
+entity" was never the rule; "single ownership per `(entity × predicate-group)`" always was.
 
 ## Open Questions (genuinely deferrable only — none of Decisions 1–5 or the BLOCKING fixes are here)
 

--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -115,6 +115,29 @@ shape.
   increments (named in `pkg/ownership/doc.go`): the T2-seam reject + inverse-gate, the PENDING_EDGES
   buffer + crash-recovery flip-gate, the `OwnerToken` wire field + handler lease check, and the
   graph-ingest boot wiring + projection-contract derivation (Decision 6).
+- **W0 first consumer landed — the `lifecycle.Manager` embed (Decision 5).** Increment 2: the Manager
+  is the first framework consumer of the registry. A pre-implementation architect review reshaped the
+  seam around a confirmed boot-ordering hazard — in every binary, `NewManager`/`Register` run BEFORE
+  the flow service (and graph-ingest) starts (`cmd/semstreams/main.go:186,193` vs `:220,:225`), so
+  creating the ownership buckets in graph-ingest's `initStorage` would make every registration a
+  silent no-op. The increment therefore: (1) **`ownership.EnsureBuckets`** creates OWNER_CLAIMS
+  (history, no TTL) + OWNER_PRESENCE (bucket TTL = `PresenceTTL`, the whole staleness backstop) and
+  is called EAGERLY in the boot path BEFORE `Register`, not in graph-ingest; (2) **`Manager.AttachOwnership(ctx, reg)`**
+  embeds the registry and derives each `Workflow` into TWO claims by mode (phase = `cas-transition`;
+  audit + writable projected fields = `replace-owned`; read-only/reference/child-link predicates the
+  Manager does not author are NOT claimed); (3) the **owner id is the workflow Name** (the workflow
+  TYPE is the owner, shared idempotently across processes; presence reflects "≥1 process of this type
+  live"); (4) a substrate-owned **`Heartbeater`** ticks liveness over the **app-root ctx** (cancellation
+  stops it — no `Close` for sister repos to adopt); (5) the runtime posture is **OBSERVE-ONLY** — a
+  cross-owner overlap is LOGGED, not bricked (consistent with Decision 5's observe-only runtime
+  enforcement; the substrate still rejects it, the Manager swallows the rejection), while a malformed
+  self-claim stays fatal. The hard-fail flip + the `OwnerToken` write-lease + the Watch-revival are the
+  deferred write-gating half (an evicted-then-revived owner only churns the epoch until then — no
+  dropped writes — which is why observe-only is safe to ship first). Sister repos (semspec/semteams/
+  semconnect) opt in by adding the same `EnsureBuckets` + `AttachOwnership` pair; absent it, behaviour
+  is exactly pre-ADR-056 (graceful-skip for resourceless/unmigrated deploys). Pure-logic + testcontainer
+  tested through `Manager.Register` (the production entry), `task lint` clean; an `e2e:lifecycle` tier
+  run gates the merge (Manager boot-surface change).
 
 ### v4 → v5: implementation contracts pinned (1 BLOCKING + P1s; no architectural forks)
 

--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -23,7 +23,9 @@ v5 pins the remaining **implementation contracts** the v4 review (Codex 1 BLOCKI
 and the verification gate flagged — these are contract-precision fixes, **no architectural
 forks**. This ADR names and **enforces** a responsibility the framework has been carrying
 implicitly since ADR-049 and patching symptomatically through ADR-055. The architecture is
-SETTLED — Decisions 1–5 are unchanged from v3/v4; v5 makes the load-bearing mechanisms
+SETTLED — Decisions 1–5 are unchanged from v3/v4 (v6 ADDS Decision 6 — claims derive from graph
+projection contracts — which is additive and constrains the layer ABOVE the substrate, not 1–5);
+v5 makes the load-bearing mechanisms
 *mechanically buildable* (valid NATS KV keys + a real TTL bucket split; producer identity
 threaded to the T2 seam; the hosts-vs-isHostedBy foreign-edge distinction corrected;
 the crash-recovery drain made exactly-once-asserting; the Watch-revival made fatal-halt;
@@ -93,6 +95,26 @@ shape.
   - **Both fixtures pass with NO Decision re-architecture** — the only changes either forced are
     prose (the two ownership clarifications). The "if it can describe the consumers, the design is
     real" gate is passed on both the write axis and the rule/lifecycle axis.
+- **Decision 6 ADDED — claims derive from graph projection contracts (review concern, 2026-06-13).**
+  A reviewer flagged the real risk that ADR-056 could become "…also register your ownership strings
+  over here" — a parallel semantic registry that drifts from the flow-based design and rots. Closed
+  by naming the three layers as ONE declarative chain (payload-type registry → graph projection
+  contract → ownership enforcement) and making it a HARD requirement that ownership claims DERIVE
+  from a registered projection contract (declared beside the type/Graphable/resource-projection),
+  with manual `RegisterOwner` only as the low-level escape hatch (lifecycle `Manager` dynamic
+  patterns; migration scaffolding). `pkg/ownership` is the enforcement substrate ONLY. Additive —
+  constrains the layer ABOVE the substrate, changes none of Decisions 1–5.
+- **W0 spine implemented + reviewed (`pkg/ownership`).** Increment 1 of the implementation landed
+  alongside this revision: the claim types, the single-epoch-key registry with overlap rejection
+  (glob × exact-predicate, incl. Owner×ForeignEdge cross-type), stale-owner compaction, and the
+  `OwnerOf` lease lookup — pure-logic + testcontainer-integration tested, `task lint` clean. A
+  pre-merge go-reviewer pass hardened it: liveness/lease keyed on the canonical owner id (no FNV
+  hash on the correctness path), waivers moved to epoch scope with MUTUAL consent (neither owner can
+  unilaterally waive into the other's cell), presence rolled back on a fresh owner's failed
+  registration, and compaction grace pinned to the OWNER_PRESENCE bucket TTL. Deferred to later
+  increments (named in `pkg/ownership/doc.go`): the T2-seam reject + inverse-gate, the PENDING_EDGES
+  buffer + crash-recovery flip-gate, the `OwnerToken` wire field + handler lease check, and the
+  graph-ingest boot wiring + projection-contract derivation (Decision 6).
 
 ### v4 → v5: implementation contracts pinned (1 BLOCKING + P1s; no architectural forks)
 
@@ -1354,6 +1376,72 @@ not a parallel path. **New framework surface flagged for the final review:**
 
 These are additive but they are genuinely new spine, not "rename an existing field." Target
 all of them in the final review.
+
+### Decision 6 — Claims DERIVE from graph projection contracts (one declarative chain, not a parallel registry)
+
+> **Ownership claims MUST be derived from a registered graph projection contract wherever the
+> owner is driven by a payload type / Graphable. A hand-maintained list of ownership strings,
+> registered in a boot block divorced from the projection that emits the facts, is the
+> anti-pattern this decision forbids. `pkg/ownership` is the distributed-ENFORCEMENT substrate
+> only — never a second user-facing model.**
+
+The concern this closes (raised in review, 2026-06-13): if ADR-056 lands as "…and also register
+your ownership strings over here," we will have built a **parallel semantic registry** that drifts
+from the flow-based design and rots — the registry and the projection saying different things,
+maintained in different places, by hand. That is exactly the failure mode the framework's existing
+registries were designed to avoid.
+
+The fix is to see that these are **three layers of ONE declarative chain**, not three registries:
+
+| Layer | Question it answers | Where it lives today |
+|---|---|---|
+| **Payload type registration** | "When I see `agentic.task.v1`, what Go type do I decode?" — in-process type dispatch | `payloadregistry/registry.go` (point-to-point graph mutation request/reply is intentionally exempt, `graph/mutation_requests.go:7`) |
+| **Graph projection contract** | "What graph facts does this type emit, and in what write mode is each predicate group?" | THE MISSING LAYER — today `Graphable.Triples()` (`graph/messagemanager/processor.go:259`) is treated as the whole truth; it says *what* triples but not whether they are append-evidence, owned current state, CAS-transition state, or foreign edges |
+| **Ownership enforcement** | "Who may author/reconcile those facts at runtime, and is anyone else already there?" | `pkg/ownership` (this ADR) — substrate only |
+
+The missing middle layer is the **graph projection contract**, declared ONCE beside the type /
+Graphable / gateway-resource projection code, co-locating:
+
+- the **entity-ID pattern** the projection writes,
+- the **emitted predicates** grouped by **write mode** (replace-owned / cas-transition /
+  append-evidence — Decision 1),
+- the **foreign-edge claims** it produces (Decision 4),
+- and the **indexing profile** (ADR-054 — already a per-type declaration, so the projection
+  contract subsumes a thing that already exists rather than inventing a new surface).
+
+The runtime chain is then **derivation, not duplication**:
+
+```text
+payload type registration
+  └─ optionally declares a graph projection contract
+       (entity pattern · predicates × write mode · foreign-edge claims · indexing profile)
+component / gateway boot
+  └─ binds each projection to an OWNER ID and DERIVES the OwnerClaim/ForeignEdgeClaim set,
+     registering it with pkg/ownership.RegisterOwner
+graph-ingest
+  └─ enforces the registered claims at the write boundary (overlap reject, lease check, T2 seam)
+```
+
+**Manual `RegisterOwner` is the low-level ESCAPE HATCH, not the default.** Two legitimate
+escape-hatch users: (1) owners whose entity-ID pattern is not derivable from a single payload type
+(the lifecycle `Manager`'s `Workflow.Schema` — already claim-shaped, Decision 1 §500-503 — registers
+directly), and (2) migration scaffolding before a producer has declared its projection contract
+(the Decision-3 / Decision-4 deprecated-on-arrival hatch). Everything else derives.
+
+**Why this is now a HARD requirement, not a nicety.** The semconnect acceptance fixture is the
+proof and the cautionary tale at once: cs-api's System claim is six `sensorml.*` vocabulary
+predicates over `…csapi.system.*` (Consequences → Acceptance fixture). If those live as a
+hand-edited slice in a boot function, the day someone adds a predicate to the System triple-builder
+(`systems_post.go`) and forgets the slice, the projection emits a fact the registry doesn't know is
+owned — silent drift. Derived from a projection contract declared *beside the builder*, the claim
+and the emission cannot disagree. semconnect should declare "the CS-API System projection owns these
+predicates on this pattern; the Deployment projection owns these; SensorML emits this foreign
+edge" next to the resource projection code — never as a parallel hand-maintained registry.
+
+This decision does **not** change `pkg/ownership` (the W0 spine is correctly substrate-only); it
+constrains the **layer above** it. The projection-contract type and the boot-time derivation are a
+named deliverable of the enforcement-wiring increment, and graph-ingest enforces what derivation
+registers. The spine's `RegisterOwner` is the seam both the derivation and the escape hatch call.
 
 ### The CQRS boundary, made explicit
 

--- a/docs/basics/01-what-is-semstreams.md
+++ b/docs/basics/01-what-is-semstreams.md
@@ -102,6 +102,19 @@ Entities stored in NATS KV with version tracking:
 }
 ```
 
+### Governed Semantic State
+
+For single-writer ingestion, triples can simply be merged into the entity. For shared graph state, SemStreams treats
+predicate groups as owned state: a component declares which predicates it may replace, which facts it only appends as
+evidence, and which cross-entity edges it can produce.
+
+This matters for domains where graph facts are operational state, not just observations: lifecycle phases, resource
+PATCH/PUT fields, command status, mission progress, quality records, topology, or agent-written findings. The graph
+remains the queryable audit trail, while the write contract prevents unrelated components from silently overwriting each
+other.
+
+See [Governed Semantic State](../concepts/28-governed-semantic-state.md) for the contract.
+
 ### Indexes
 
 **Core Indexes** (always available):

--- a/docs/basics/03-graphable-interface.md
+++ b/docs/basics/03-graphable-interface.md
@@ -204,6 +204,10 @@ The core Graphable interface intentionally excludes:
 
 This keeps the interface minimal. Additional capabilities are added via separate interfaces when needed.
 
+Graphable also does not declare ownership. A payload can say "these are the triples I emit"; a graph projection contract
+says whether those predicates are replace-owned state, CAS-transition state, append-only evidence, or foreign edges. See
+[Governed Semantic State](../concepts/28-governed-semantic-state.md) for how shared graph writes are governed.
+
 ## Interface Composition
 
 Graphable is the foundation of a composable interface hierarchy:

--- a/docs/concepts/28-governed-semantic-state.md
+++ b/docs/concepts/28-governed-semantic-state.md
@@ -1,0 +1,75 @@
+# Governed Semantic State
+
+SemStreams stores domain facts in `ENTITY_STATES` so they can be queried, watched, indexed, and replayed. For simple
+fact ingestion, a `Graphable` payload can emit triples and the graph can merge them.
+
+That is not enough once the same entity is written by more than one component.
+
+## The Problem
+
+A predicate can mean different things operationally:
+
+| Predicate shape | Write meaning |
+|---|---|
+| Current phase, status, location, configuration | One owner replaces the current value |
+| Lifecycle transition state | One owner changes state under compare-and-swap |
+| Observation, finding, backlink, evidence | Many writers append facts |
+| Foreign edge onto another entity | A producer writes a relationship whose subject is not its primary entity |
+
+If all of these arrive as undifferentiated triples, the graph cannot tell whether a write should replace, append, wait
+for a target entity, or be rejected. The failure mode is silent corruption: a gateway update, rule action, lifecycle
+transition, or agent tool can remove a fact that another component owns.
+
+## The Contract
+
+Governed semantic state adds an ownership contract above raw triples:
+
+```text
+payload type -> graph projection -> predicate-group ownership -> graph-ingest enforcement
+```
+
+- **Payload type** tells the system what kind of message or request is flowing.
+- **Graph projection** declares the entity pattern and predicates the type can emit.
+- **Predicate-group ownership** declares whether those predicates are replaced, CAS-transitioned, appended, or emitted
+  as foreign edges.
+- **graph-ingest enforcement** rejects overlapping owners and stale owner leases at the write boundary.
+
+The payload registry and ownership registry are not competing systems. The payload registry is local type lookup for
+`BaseMessage` decoding. The ownership registry is distributed arbitration for shared graph state. Projection contracts
+are the bridge between them.
+
+## When It Matters
+
+Use governed semantic state when a domain has:
+
+- more than one writer for the same entity family
+- lifecycle or workflow state stored as graph facts
+- PATCH/PUT style replacement of resource fields
+- rules or agents that write triples back into the graph
+- regulated or operator-facing audit requirements
+- cross-entity edges produced during ingestion
+
+Do not use it for high-volume opaque execution traces, raw telemetry streams, or one-shot requests. Those belong in
+JetStream streams, ObjectStore, or component-specific buckets with graph references when needed.
+
+## Why It Is Still Flow-Based
+
+The flow does not change: components still emit messages, `Graphable` still describes entities, and graph processors
+still react through KV watches. The added contract makes the write side explicit before data enters shared state.
+
+The practical rule is:
+
+```text
+Facts can flow freely after their write semantics are declared.
+```
+
+That keeps the graph usable as shared state without requiring every consumer to build a private CQRS mirror.
+
+## Related Documents
+
+- [Graphable Interface](../basics/03-graphable-interface.md)
+- [Payload Registry](15-payload-registry.md)
+- [KV Twofer](02-kv-twofer.md)
+- [Streams vs KV Watches](03-streams-vs-kv-watches.md)
+- [Orchestration Layers](14-orchestration-layers.md)
+- [ADR-056: Authoritative Semantic State](../adr/056-authoritative-semantic-state.md)

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/ownership"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -52,6 +53,21 @@ type Manager struct {
 
 	mu            sync.RWMutex
 	registrations map[string]*registration
+
+	// Ownership wiring (ADR-056 Decision 5 embed). Set via AttachOwnership in
+	// the framework boot path, AFTER ownership.EnsureBuckets and BEFORE the
+	// first Register. All three are written once at attach time and read under
+	// m.mu. A nil ownerRegistry — the default, and every nil-client / test /
+	// unmigrated-deploy path — makes the ownership axis a pure no-op, so
+	// Register behaves exactly as it did pre-ADR-056.
+	//
+	// Runtime posture for the first consumer is OBSERVE-ONLY: a cross-owner
+	// overlap is logged, not bricked (Decision 5 — a partial migration must not
+	// fail boot). The hard-fail flip and the write-time owner-lease check are a
+	// later increment (see pkg/ownership/doc.go).
+	ownerRegistry *ownership.Registry
+	ownerCtx      context.Context // app-root ctx; its cancellation stops the heartbeat (no Close needed)
+	heartbeater   *ownership.Heartbeater
 
 	// driftSeen memoizes phase-drift Warn-log emissions so List
 	// callers polling at dashboard frequencies don't generate
@@ -122,13 +138,62 @@ func (m *Manager) Register(workflow Workflow) error {
 		return err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if _, exists := m.registrations[workflow.Name]; exists {
+	// Snapshot the ownership wiring + check for a duplicate name under the lock,
+	// then RELEASE it before any NATS I/O. RegisterOwner is a CAS loop with
+	// network round-trips; holding the registrations RWMutex across it would
+	// serialize every concurrent Get/Transition (all take RLock) behind it.
+	m.mu.RLock()
+	reg := m.ownerRegistry
+	ownerCtx := m.ownerCtx
+	hb := m.heartbeater
+	_, dup := m.registrations[workflow.Name]
+	m.mu.RUnlock()
+	if dup {
 		return fmt.Errorf("%w: workflow %q", ErrWorkflowAlreadyRegistered, workflow.Name)
 	}
 
+	// Ownership registration (Decision 5 embed) — outside the lock. Only on
+	// success is the local registration committed below, so a registry-rejected
+	// owner never half-lands; an observe-only overlap still commits (the workflow
+	// must keep working through a partial migration).
+	if reg != nil {
+		if ownerCtx == nil {
+			ownerCtx = context.Background()
+		}
+		regn := deriveOwnerRegistration(workflow, meta)
+		switch err := reg.RegisterOwner(ownerCtx, regn); {
+		case err == nil:
+			hb.Add(workflow.Name)
+		case errors.Is(err, ownership.ErrOwnershipOverlap):
+			// Cross-owner collision. OBSERVE-ONLY for the first consumer: the
+			// claim is not recorded in the epoch, but the workflow still
+			// registers locally and functions (Decision 5 — do not brick a
+			// partial migration). Logged loud so the collision is visible now;
+			// the hard-fail flip is the enforcement increment.
+			m.logger.Warn("lifecycle: ownership overlap registering workflow — observe-only (claim NOT recorded; resolve before the enforcement increment)",
+				slog.String("workflow", workflow.Name),
+				slog.String("pattern", workflow.EntityIDPattern),
+				slog.Any("error", err))
+		case errors.Is(err, ownership.ErrInvalidClaim):
+			// A malformed claim is a bug in THIS workflow's own declaration
+			// (e.g. a Name that is not a subject-safe owner id) — not a
+			// partial-migration condition. Always fatal.
+			return fmt.Errorf("lifecycle: register %q ownership: %w", workflow.Name, err)
+		default:
+			// Transient NATS/registry error. Don't brick the workflow in
+			// observe-only mode; the claim simply isn't recorded this boot and
+			// is re-asserted on the next registrant pass or redeploy.
+			m.logger.Warn("lifecycle: ownership registration failed — continuing without claim record",
+				slog.String("workflow", workflow.Name),
+				slog.Any("error", err))
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.registrations[workflow.Name]; exists {
+		return fmt.Errorf("%w: workflow %q", ErrWorkflowAlreadyRegistered, workflow.Name)
+	}
 	m.registrations[workflow.Name] = &registration{
 		workflow: workflow,
 		meta:     meta,
@@ -140,8 +205,43 @@ func (m *Manager) Register(workflow Workflow) error {
 		slog.Int("operator_writable_predicates", len(workflow.OperatorWritablePredicates)),
 		slog.Int("child_workflows", len(workflow.ChildWorkflows)),
 		slog.Int("reference_predicates", len(workflow.ReferencePredicates)),
+		slog.Bool("ownership_attached", reg != nil),
 	)
 	return nil
+}
+
+// AttachOwnership wires the Manager to the ADR-056 owner registry (Decision 5
+// embed). Call it in the framework boot path AFTER ownership.EnsureBuckets and
+// BEFORE the first Register, passing a context that is CANCELLED ON SHUTDOWN:
+// AttachOwnership spawns a heartbeat goroutine bound to it, and ctx cancellation
+// (not a separate Close) is what stops that goroutine. context.Background() will
+// LEAK the goroutine until process exit — derive a cancellable context and
+// cancel it on the way down (see cmd/semstreams/main.go). A Manager with no
+// registry attached (the default, and every nil-client / test / unmigrated-deploy
+// path) treats ownership as a pure no-op.
+//
+// Each subsequently-registered workflow derives an owner claim (deriveOwnerRegistration),
+// registers it through the shared epoch (cross-process overlap surfaced —
+// Decision 2, observe-only for the first consumer), and is enrolled for liveness
+// heartbeating so a later-booting registrant never falsely compacts it.
+//
+// A nil registry is a no-op (so callers can pass the result of EnsureBuckets
+// unconditionally — a resourceless deploy that skipped EnsureBuckets passes nil).
+// Idempotent only in the trivial sense; call it once at boot.
+func (m *Manager) AttachOwnership(ctx context.Context, reg *ownership.Registry) {
+	if reg == nil {
+		return
+	}
+	m.mu.Lock()
+	m.ownerRegistry = reg
+	m.ownerCtx = ctx
+	m.heartbeater = reg.NewHeartbeater(ownership.HeartbeatInterval)
+	hb := m.heartbeater
+	m.mu.Unlock()
+
+	// One heartbeat goroutine ticks every enrolled owner's presence key until
+	// ctx is cancelled. Started here with no owners yet; Register enrolls each.
+	go hb.Run(ctx)
 }
 
 // lookupByWorkflow finds the registration for the given workflow type.

--- a/pkg/lifecycle/ownership.go
+++ b/pkg/lifecycle/ownership.go
@@ -1,0 +1,95 @@
+// Package lifecycle — ownership-claim derivation (ADR-056 Decision 5 embed).
+//
+// The lifecycle Manager is the first framework consumer of the pkg/ownership
+// registry. A registered Workflow IS an owner claim of the Decision-1 shape
+// (an EntityIDPattern + the predicate groups the Manager authors) — this file
+// derives that claim so Manager.Register can register it through the shared
+// epoch and have cross-process overlap surfaced (Decision 2).
+package lifecycle
+
+import (
+	"sort"
+
+	"github.com/c360studio/semstreams/pkg/ownership"
+)
+
+// deriveOwnerRegistration builds the ownership.Registration a registered
+// Workflow asserts — TWO OwnerClaims over the workflow's EntityIDPattern, split
+// by the write discipline each predicate group actually uses (mode is a property
+// of the group, not of the single CAS wire-call the Manager batches them into):
+//
+//   - Claim 1 (cas-transition): {PhasePredicate}. The phase write is conditional
+//     on a declared transitions-table edge and carries ExpectedRevision
+//     (manager.go:445,:505) — a genuine read-modify-write transition.
+//   - Claim 2 (replace-owned): {non-empty audit predicates ∪ writable projected
+//     field predicates}. Single-valued remove+add (manager.go:484-506); they
+//     ride the same CAS wire-call but their discipline is replace, not
+//     transition. Splitting keeps the mode honest for the Decision-3
+//     schema-derived reconcile (whose remove-set semantics differ by mode), even
+//     though both modes are isOwning() so Decision-2 overlap detection is
+//     identical either way.
+//
+// EXCLUDED from both claims: read-only, reference, and ID predicates. The
+// Manager never authors them (projectStructToTriples / diffProjectedTriples skip
+// read-only non-phase fields — projection.go:209, manager.go:554), so claiming
+// them would falsely collide with their real writer (a foreign-edge producer, an
+// upstream processor) rather than protect anything the Manager owns. Child-link
+// and reference predicates are read by Manager.Children/References, never
+// written — so they are app/foreign-owned, not the Manager's claim.
+//
+// The owner id is the workflow Name: the stable LOGICAL identity of this writer.
+// A redeploy — or a second binary implementing the same workflow type — re-
+// registers the same owner idempotently (the workflow TYPE is the owner, not the
+// process; presence then reflects "≥1 process of this type is live"). Two
+// DIFFERENT workflow owners selecting an overlapping (pattern, predicate) cell is
+// the cross-process collision Decision 2 detects.
+func deriveOwnerRegistration(w Workflow, meta *structMeta) ownership.Registration {
+	claims := make([]ownership.OwnerClaim, 0, 2)
+
+	// Claim 1 — phase, cas-transition.
+	claims = append(claims, ownership.OwnerClaim{
+		Owner:      w.Name,
+		Pattern:    w.EntityIDPattern,
+		Predicates: []string{w.PhasePredicate},
+		Mode:       ownership.ModeCASTransition,
+	})
+
+	// Claim 2 — audit + writable projected fields, replace-owned.
+	seen := map[string]struct{}{w.PhasePredicate: {}} // phase belongs to claim 1
+	var replace []string
+	add := func(p string) {
+		if p == "" {
+			return
+		}
+		if _, dup := seen[p]; dup {
+			return
+		}
+		seen[p] = struct{}{}
+		replace = append(replace, p)
+	}
+	add(w.AuditPredicates.Source)
+	add(w.AuditPredicates.At)
+	add(w.AuditPredicates.From)
+	add(w.AuditPredicates.Note)
+	for predicate, fm := range meta.FieldsByPredicate {
+		if fm.ReadOnly {
+			continue // phase (implicitly read-only) is claim 1; reference/read-only fields the Manager never authors
+		}
+		add(predicate)
+	}
+	// Deterministic order so the stored epoch value (and tests) don't flap on
+	// Go's randomized map iteration; the overlap check is set-based and
+	// order-immaterial, but a stable claim keeps the epoch revision quiet.
+	sort.Strings(replace)
+
+	if len(replace) > 0 {
+		claims = append(claims, ownership.OwnerClaim{
+			Owner:      w.Name,
+			Pattern:    w.EntityIDPattern,
+			Predicates: replace,
+			Mode:       ownership.ModeReplaceOwned,
+		})
+	}
+
+	return ownership.Registration{Owner: w.Name, Claims: claims}
+}

--- a/pkg/lifecycle/ownership_integration_test.go
+++ b/pkg/lifecycle/ownership_integration_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+// Integration test for the ADR-056 Decision 5 embed: the lifecycle Manager as
+// the FIRST framework consumer of pkg/ownership. Drives the production path —
+// ownership.EnsureBuckets → Manager.AttachOwnership → Manager.Register — through
+// a real NATS testcontainer, exercising the shared OWNER_CLAIMS epoch and the
+// observe-only cross-owner overlap posture. Unit coverage of the pure derivation
+// lives in ownership_test.go; this proves the wire.
+//
+// Run with `go test -tags=integration -race ./pkg/lifecycle/...`.
+
+package lifecycle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/stretchr/testify/require"
+)
+
+const ownershipTestEntity = "c360.p.lifecycle.gcs.mission.001"
+
+// A Manager attached to the registry lands its workflow's claim in the shared
+// epoch (OwnerOf resolves it), and a SECOND owner claiming the same cell is
+// rejected by the substrate while the Manager stays observe-only (logs, still
+// registers locally, does NOT mutate the incumbent's epoch entry).
+func TestIntegration_ManagerOwnership_FirstConsumerEndToEnd(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	// Cancellable so the heartbeat goroutines AttachOwnership spawns are reaped
+	// when the test ends (exercising the ctx-cancel shutdown path).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reg, err := ownership.EnsureBuckets(ctx, tc.Client, nil)
+	require.NoError(t, err, "EnsureBuckets must create the framework buckets against real NATS")
+
+	// Process A registers the fixture workflow through the registry.
+	mgrA := NewManager(tc.Client, nil)
+	mgrA.AttachOwnership(ctx, reg)
+	require.NoError(t, mgrA.Register(lifecycle{}.fixtureWorkflow()))
+
+	// The phase cell is now owned in the shared epoch.
+	owner, ok, err := reg.OwnerOf(ctx, ownershipTestEntity, "mission.phase")
+	require.NoError(t, err)
+	require.True(t, ok, "phase cell must be owned after registration")
+	require.Equal(t, "fixture", owner, "owner id is the workflow Name")
+
+	// Process B: a DIFFERENT owner claiming the SAME pattern + phase predicate.
+	// A separate Registry over the same (idempotently re-ensured) buckets
+	// simulates a second process.
+	regB, err := ownership.EnsureBuckets(ctx, tc.Client, nil)
+	require.NoError(t, err)
+	mgrB := NewManager(tc.Client, nil)
+	mgrB.AttachOwnership(ctx, regB)
+
+	rival := lifecycle{}.fixtureWorkflow()
+	rival.Name = "fixture-rival" // distinct owner, same EntityIDPattern + PhasePredicate ⇒ overlap
+
+	// Observe-only: the Manager does NOT error on the cross-owner overlap (a
+	// partial migration must not brick — Decision 5 runtime posture)…
+	require.NoError(t, mgrB.Register(rival), "Manager registration is observe-only on cross-owner overlap")
+	// …the workflow IS locally registered and functions…
+	_, err = mgrB.lookupByWorkflow("fixture-rival")
+	require.NoError(t, err, "rival workflow must still register locally")
+	// …and the incumbent keeps the contested cell — the rival's claim never
+	// entered the epoch.
+	owner, ok, err = regB.OwnerOf(ctx, ownershipTestEntity, "mission.phase")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "fixture", owner, "the incumbent owner must keep the contested cell")
+
+	// Prove the Manager swallowed a REAL ErrOwnershipOverlap, not a no-op: the
+	// substrate rejects the rival's derived registration outright.
+	meta, err := parseSchemaType(rival.Schema)
+	require.NoError(t, err)
+	err = regB.RegisterOwner(ctx, deriveOwnerRegistration(rival, meta))
+	require.ErrorIs(t, err, ownership.ErrOwnershipOverlap, "substrate must reject the cross-owner overlap")
+}
+
+// A second owner whose EntityIDPattern is DISJOINT from the incumbent registers
+// cleanly and both claims coexist in the shared epoch — overlap rejection fires
+// only on a genuine cell collision, not on every co-registration.
+func TestIntegration_ManagerOwnership_DisjointOwnersCoexist(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	reg, err := ownership.EnsureBuckets(ctx, tc.Client, nil)
+	require.NoError(t, err)
+
+	mgr := NewManager(tc.Client, nil)
+	mgr.AttachOwnership(ctx, reg)
+	require.NoError(t, mgr.Register(lifecycle{}.fixtureWorkflow())) // mission pattern
+
+	// A disjoint workflow type (different `type` segment ⇒ patterns never intersect).
+	other := lifecycle{}.fixtureWorkflow()
+	other.Name = "other"
+	other.EntityIDPattern = "*.*.lifecycle.gcs.sensor.*"
+	other.PhasePredicate = "sensor.phase"
+	require.NoError(t, mgr.Register(other))
+
+	missionOwner, ok, err := reg.OwnerOf(ctx, ownershipTestEntity, "mission.phase")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "fixture", missionOwner)
+
+	sensorOwner, ok, err := reg.OwnerOf(ctx, "c360.p.lifecycle.gcs.sensor.001", "sensor.phase")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "other", sensorOwner)
+}

--- a/pkg/lifecycle/ownership_test.go
+++ b/pkg/lifecycle/ownership_test.go
@@ -1,0 +1,171 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/ownership"
+)
+
+// deriveOwnerRegistration is the load-bearing seam of the ADR-056 Decision 5
+// embed: it must claim EXACTLY what the Manager authors, split by write mode,
+// and the result must pass ownership.Registration.Validate (or RegisterOwner
+// would reject a real workflow at boot). These are pure-logic assertions — no
+// NATS — over the same fixture the projection/manager tests use.
+func TestDeriveOwnerRegistration_SplitsByModeAndExcludesUnauthored(t *testing.T) {
+	t.Parallel()
+	w := lifecycle{}.fixtureWorkflow()
+	meta, err := parseSchemaType(w.Schema)
+	if err != nil {
+		t.Fatalf("parseSchemaType: %v", err)
+	}
+
+	regn := deriveOwnerRegistration(w, meta)
+
+	if regn.Owner != "fixture" {
+		t.Errorf("registration owner = %q, want %q (the workflow Name)", regn.Owner, "fixture")
+	}
+	// A real workflow must derive a VALID registration, or RegisterOwner fails boot.
+	if err := regn.Validate(); err != nil {
+		t.Fatalf("derived registration must be valid: %v", err)
+	}
+
+	var casClaim, replaceClaim *ownership.OwnerClaim
+	for i := range regn.Claims {
+		c := &regn.Claims[i]
+		if c.Pattern != w.EntityIDPattern {
+			t.Errorf("claim pattern = %q, want %q", c.Pattern, w.EntityIDPattern)
+		}
+		if c.Owner != "fixture" {
+			t.Errorf("claim owner = %q, want fixture", c.Owner)
+		}
+		switch c.Mode {
+		case ownership.ModeCASTransition:
+			casClaim = c
+		case ownership.ModeReplaceOwned:
+			replaceClaim = c
+		default:
+			t.Errorf("unexpected claim mode %q", c.Mode)
+		}
+	}
+
+	if casClaim == nil {
+		t.Fatal("expected a cas-transition claim for the phase predicate")
+	}
+	if got := casClaim.Predicates; !slices.Equal(got, []string{"mission.phase"}) {
+		t.Errorf("cas claim predicates = %v, want [mission.phase]", got)
+	}
+
+	if replaceClaim == nil {
+		t.Fatal("expected a replace-owned claim for audit + writable fields")
+	}
+	// Audit predicates (4) + writable projected fields (owner_org_id, note).
+	// EXCLUDED: mission.phase (claim 1), mission.assigned_drone (reference),
+	// and the bare readonly LastAt predicate (it equals AuditPredicates.At, so
+	// it survives only via the audit add, not the field — and is not duplicated).
+	want := []string{
+		"mission.last_transition_at",
+		"mission.last_transition_from",
+		"mission.last_transition_note",
+		"mission.last_transition_source",
+		"mission.note",
+		"mission.owner_org_id",
+	}
+	if got := replaceClaim.Predicates; !slices.Equal(got, want) {
+		t.Errorf("replace claim predicates =\n  %v\nwant (sorted)\n  %v", got, want)
+	}
+
+	// The reference predicate must NOT be claimed — the Manager never authors it.
+	for _, c := range regn.Claims {
+		if slices.Contains(c.Predicates, "mission.assigned_drone") {
+			t.Errorf("reference predicate mission.assigned_drone must not be claimed (mode %q)", c.Mode)
+		}
+	}
+}
+
+// A phase-only workflow (no audit, no writable scalar fields) derives a single
+// cas-transition claim and no empty replace-owned claim (OwnerClaim.Validate
+// rejects an empty predicate set).
+func TestDeriveOwnerRegistration_PhaseOnlyWorkflowYieldsSingleClaim(t *testing.T) {
+	t.Parallel()
+	w := Workflow{
+		Name:            "phaseonly",
+		EntityIDPattern: "*.*.lifecycle.gcs.phaseonly.*",
+		Transitions:     Transitions{"a": {"b"}, "b": {}},
+		PhasePredicate:  "phaseonly.phase",
+		Schema:          reflect.TypeOf(phaseOnlyState{}),
+	}
+	meta, err := parseSchemaType(w.Schema)
+	if err != nil {
+		t.Fatalf("parseSchemaType: %v", err)
+	}
+
+	regn := deriveOwnerRegistration(w, meta)
+	if err := regn.Validate(); err != nil {
+		t.Fatalf("derived registration must be valid: %v", err)
+	}
+	if len(regn.Claims) != 1 {
+		t.Fatalf("phase-only workflow: got %d claims, want 1", len(regn.Claims))
+	}
+	if regn.Claims[0].Mode != ownership.ModeCASTransition {
+		t.Errorf("sole claim mode = %q, want cas-transition", regn.Claims[0].Mode)
+	}
+}
+
+type phaseOnlyState struct {
+	ID     string `json:"entity_id" lifecycle:"id"`
+	PhaseF string `json:"phase" lifecycle:"phase,predicate=phaseonly.phase"`
+}
+
+func (s *phaseOnlyState) EntityID() string       { return s.ID }
+func (s *phaseOnlyState) Workflow() string       { return "phaseonly" }
+func (s *phaseOnlyState) Phase() string          { return s.PhaseF }
+func (s *phaseOnlyState) IsTerminal() bool       { return false }
+func (s *phaseOnlyState) ParentEntityID() string { return "" }
+
+// With no registry attached (the default, every nil-client / unmigrated-deploy
+// path), Register is a pure no-op on the ownership axis: it still validates,
+// commits the local registration, and never touches NATS. This is the
+// graceful-skip contract — a deploy that did not call AttachOwnership behaves
+// exactly as it did pre-ADR-056.
+func TestRegister_NoOwnershipAttached_IsNoOp(t *testing.T) {
+	t.Parallel()
+	// nil client, nil emitter, nil bucket — a Manager that cannot do any NATS
+	// I/O. If Register tried to register ownership it would panic on the nil
+	// registry; the no-op path must leave it untouched.
+	mgr := newManagerForTest(nil, nil, nil)
+	if mgr.ownerRegistry != nil {
+		t.Fatal("a Manager built without AttachOwnership must have a nil ownerRegistry")
+	}
+	if err := mgr.Register(lifecycle{}.fixtureWorkflow()); err != nil {
+		t.Fatalf("Register with no ownership must succeed: %v", err)
+	}
+	if _, err := mgr.lookupByWorkflow("fixture"); err != nil {
+		t.Fatalf("workflow must be locally registered: %v", err)
+	}
+}
+
+// AttachOwnership(nil) is a no-op — callers may pass the result of EnsureBuckets
+// unconditionally, and a resourceless deploy that skipped bucket bootstrap
+// passes a nil registry.
+func TestAttachOwnership_NilRegistryIsNoOp(t *testing.T) {
+	t.Parallel()
+	mgr := newManagerForTest(nil, nil, nil)
+	mgr.AttachOwnership(context.Background(), nil)
+	if mgr.ownerRegistry != nil || mgr.heartbeater != nil {
+		t.Fatal("AttachOwnership(nil) must leave the Manager unwired")
+	}
+}
+
+// Guard the sentinel the Manager branches on for observe-only vs fatal, so a
+// future errors.go refactor that renames it trips here rather than silently
+// turning a cross-owner overlap into a fatal boot (or vice-versa).
+func TestOwnershipSentinelsExist(t *testing.T) {
+	t.Parallel()
+	if !errors.Is(&ownership.OverlapError{}, ownership.ErrOwnershipOverlap) {
+		t.Error("OverlapError must match ErrOwnershipOverlap via errors.Is")
+	}
+}

--- a/pkg/ownership/bootstrap.go
+++ b/pkg/ownership/bootstrap.go
@@ -1,0 +1,68 @@
+package ownership
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// ownerClaimsHistory is how many past epoch revisions OWNER_CLAIMS retains.
+// The epoch write IS the registration audit trail (the KV-twofer), so a modest
+// history depth answers "who registered what, when" across the last several
+// deploys without unbounded growth on a single small key.
+const ownerClaimsHistory = 10
+
+// EnsureBuckets idempotently creates the framework-owned ownership buckets and
+// returns a Registry over them.
+//
+// Call this EAGERLY in the framework boot path, BEFORE any
+// lifecycle.Manager.Register — registration heartbeats into OWNER_PRESENCE and
+// CAS-writes OWNER_CLAIMS, so both buckets must already exist. graph-ingest's
+// initStorage runs AFTER registration in every binary's wiring (NewManager →
+// Register → service start), so creating these alongside ENTITY_STATES there
+// would make every registration a silent no-op (the buckets would not yet
+// exist). That is why this is a standalone eager call, not graph-ingest work.
+//
+// Bucket layout (ADR-056 Decision 2):
+//   - OWNER_CLAIMS — the single `_registry` epoch key; History for audit, NO
+//     TTL (a TTL would age out the durable epoch between deploys).
+//   - OWNER_PRESENCE — per-owner heartbeat keys; a bucket-level TTL = PresenceTTL
+//     IS the entire staleness backstop (an absent presence key means the owner
+//     has been silent beyond the grace window and is compactable). Without this
+//     TTL a crashed owner is never reaped and its stale claim blocks every future
+//     registrant forever — so the TTL is not optional.
+//
+// PENDING_EDGES (BucketPendingEdges) is deliberately NOT created here: its
+// consumer (the Decision-4 foreign-edge buffer) is a later increment, and a
+// bucket created with no reader reads as a half-wired bug.
+func EnsureBuckets(ctx context.Context, client *natsclient.Client, logger *slog.Logger) (*Registry, error) {
+	if client == nil {
+		return nil, fmt.Errorf("ownership: EnsureBuckets requires a non-nil NATS client")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	claims, err := client.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      BucketOwnerClaims,
+		Description: "ADR-056 owner-claim registry — single _registry epoch key (no TTL)",
+		History:     ownerClaimsHistory,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ownership: create %s bucket: %w", BucketOwnerClaims, err)
+	}
+
+	presence, err := client.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      BucketOwnerPresence,
+		Description: "ADR-056 owner liveness heartbeats — bucket-TTL staleness backstop",
+		TTL:         PresenceTTL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("ownership: create %s bucket: %w", BucketOwnerPresence, err)
+	}
+
+	return NewRegistry(client.NewKVStore(claims), client.NewKVStore(presence), logger), nil
+}

--- a/pkg/ownership/bootstrap_integration_test.go
+++ b/pkg/ownership/bootstrap_integration_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package ownership
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// EnsureBuckets must create both framework buckets with the load-bearing
+// config: OWNER_PRESENCE with the PresenceTTL backstop (an unset TTL means a
+// crashed owner is NEVER reaped and blocks every future registrant forever),
+// and OWNER_CLAIMS with NO TTL (a TTL there would age out the durable epoch).
+// It must also return a Registry that actually works end-to-end.
+func TestIntegration_EnsureBuckets_ConfigAndUsable(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	ctx := context.Background()
+
+	r, err := EnsureBuckets(ctx, tc.Client, nil)
+	if err != nil {
+		t.Fatalf("EnsureBuckets: %v", err)
+	}
+
+	presence, err := tc.Client.GetKeyValueBucket(ctx, BucketOwnerPresence)
+	if err != nil {
+		t.Fatalf("open %s: %v", BucketOwnerPresence, err)
+	}
+	pStatus, err := presence.Status(ctx)
+	if err != nil {
+		t.Fatalf("status %s: %v", BucketOwnerPresence, err)
+	}
+	if pStatus.TTL() != PresenceTTL {
+		t.Errorf("%s TTL = %v, want %v (the staleness backstop)", BucketOwnerPresence, pStatus.TTL(), PresenceTTL)
+	}
+
+	claims, err := tc.Client.GetKeyValueBucket(ctx, BucketOwnerClaims)
+	if err != nil {
+		t.Fatalf("open %s: %v", BucketOwnerClaims, err)
+	}
+	cStatus, err := claims.Status(ctx)
+	if err != nil {
+		t.Fatalf("status %s: %v", BucketOwnerClaims, err)
+	}
+	if cStatus.TTL() != 0 {
+		t.Errorf("%s TTL = %v, want 0 (a TTL would age out the durable epoch)", BucketOwnerClaims, cStatus.TTL())
+	}
+	if cStatus.History() != ownerClaimsHistory {
+		t.Errorf("%s History = %d, want %d (registration audit trail)", BucketOwnerClaims, cStatus.History(), ownerClaimsHistory)
+	}
+
+	// The returned Registry is usable.
+	if err := r.RegisterOwner(ctx, reg("cs-api", sysPat, "sensorml.process.label")); err != nil {
+		t.Fatalf("RegisterOwner through EnsureBuckets registry: %v", err)
+	}
+	// EnsureBuckets is idempotent — a second call (a second process) returns a
+	// working Registry over the same buckets and sees the first's claim.
+	r2, err := EnsureBuckets(ctx, tc.Client, nil)
+	if err != nil {
+		t.Fatalf("EnsureBuckets (2nd): %v", err)
+	}
+	owner, ok, err := r2.OwnerOf(ctx, "c360.semconnect.systems.csapi.system.001", "sensorml.process.label")
+	if err != nil || !ok || owner != "cs-api" {
+		t.Fatalf("second registry must see first's claim: owner=%q ok=%v err=%v", owner, ok, err)
+	}
+}
+
+// The Heartbeater ticks Registry.Heartbeat for every enrolled owner until its
+// context is cancelled, at which point Run returns promptly (the lifecycle the
+// Manager relies on instead of a Close method).
+func TestIntegration_Heartbeater_BumpsThenStopsOnCancel(t *testing.T) {
+	r, _, _ := newTestRegistry(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	const owner = "hb-owner"
+	hb := r.NewHeartbeater(40 * time.Millisecond)
+	hb.Add(owner)
+
+	done := make(chan struct{})
+	go func() { hb.Run(ctx); close(done) }()
+
+	// The presence key appears after the first tick (condition-based wait, not a
+	// duration assertion — robust to host-load variation).
+	first := waitForPresence(t, r, owner, 3*time.Second)
+	// And gets re-bumped on a later tick (the value is a fresh unix-nanos stamp).
+	waitForPresenceChange(t, r, owner, first, 3*time.Second)
+
+	// Cancellation stops the loop: Run returns promptly. This is the
+	// deterministic substitute for a Close() — the app root ctx drives the
+	// heartbeat lifetime.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Heartbeater.Run did not return within 2s of ctx cancel")
+	}
+}
+
+// waitForPresence polls until the owner's presence key exists, returning its
+// value. Fails the test if it never appears within timeout.
+func waitForPresence(t *testing.T, r *Registry, owner string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		entry, err := r.presence.Get(context.Background(), presenceKeyPrefix+owner)
+		if err == nil {
+			return string(entry.Value)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("presence key for %q never appeared within %v", owner, timeout)
+	return ""
+}
+
+// waitForPresenceChange polls until the owner's presence value differs from
+// prev, proving a re-bump tick fired.
+func waitForPresenceChange(t *testing.T, r *Registry, owner, prev string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		entry, err := r.presence.Get(context.Background(), presenceKeyPrefix+owner)
+		if err == nil && string(entry.Value) != prev {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("presence key for %q never re-bumped within %v", owner, timeout)
+}

--- a/pkg/ownership/buckets.go
+++ b/pkg/ownership/buckets.go
@@ -1,0 +1,32 @@
+package ownership
+
+// KV bucket names for the ownership substrate (ADR-056 Decision 2/4). These
+// are framework-owned buckets, created at graph-ingest boot (a later W0
+// increment wires creation; the names are fixed here so the registry and the
+// boot wiring agree on one source of truth).
+const (
+	// BucketOwnerClaims holds the single `_registry` epoch key — the union of
+	// every registered owner's claims, advanced under UpdateWithRetry CAS.
+	BucketOwnerClaims = "OWNER_CLAIMS"
+
+	// BucketOwnerPresence holds per-owner heartbeat keys
+	// (`heartbeat.<owner_token>`) with a bucket-level TTL backstop, so a
+	// crashed owner's claims are compacted out of the epoch by the next
+	// registrant (availability over a dead owner's stale claim).
+	BucketOwnerPresence = "OWNER_PRESENCE"
+
+	// BucketPendingEdges buffers Conditional foreign edges whose target has not
+	// yet been born (Decision 4). Declared here for the boot wiring; the buffer
+	// itself lands in a later W0 increment.
+	BucketPendingEdges = "PENDING_EDGES"
+)
+
+// registryKey is the single epoch key in BucketOwnerClaims. The bare
+// `_registry` (no slashes — NATS KV keys permit only alphanumerics + `-` `_`
+// `=` `.`, and the rest of the codebase keys with dots).
+const registryKey = "_registry"
+
+// presenceKeyPrefix prefixes per-owner heartbeat keys in BucketOwnerPresence,
+// dot-segmented as `heartbeat.<owner_token>` where owner_token is the
+// subject-safe FNV-1a hex of the owner id (see Token).
+const presenceKeyPrefix = "heartbeat."

--- a/pkg/ownership/claim.go
+++ b/pkg/ownership/claim.go
@@ -1,0 +1,185 @@
+package ownership
+
+import (
+	"fmt"
+	"strings"
+)
+
+// idArity is the fixed segment count of a 6-part federated entity ID
+// (org.platform.domain.system.type.instance). Owner-claim patterns are
+// 6-part globs over this shape, matched the same way as
+// pkg/lifecycle.matchPattern (manager_query.go:428).
+const idArity = 6
+
+// WriteMode is the mode a claim's predicate group is written in (ADR-056
+// Decision 1 — the ADR-055 per-predicate matrix promoted to the ownership
+// primitive). Only the two OWNING modes participate in overlap rejection;
+// append-evidence has no single owner and is exempt.
+type WriteMode string
+
+const (
+	// ModeReplaceOwned — single-valued, re-emitted: the owner reconciles its
+	// whole owned predicate group on every write (RemoveOwned + Add).
+	ModeReplaceOwned WriteMode = "replace-owned"
+	// ModeCASTransition — ExpectedRevision phase/read-modify-write (the
+	// lifecycle Manager.Transition shape).
+	ModeCASTransition WriteMode = "cas-transition"
+	// ModeAppendEvidence — multi-valued, must-exist, NO owner: many writers may
+	// append (web/ops back-links). Exempt from the overlap check.
+	ModeAppendEvidence WriteMode = "append-evidence"
+)
+
+// isOwning reports whether this mode participates in overlap rejection — the
+// two modes where a second writer silently clobbers (Decision 2).
+func (m WriteMode) isOwning() bool {
+	return m == ModeReplaceOwned || m == ModeCASTransition
+}
+
+func (m WriteMode) valid() bool {
+	return m == ModeReplaceOwned || m == ModeCASTransition || m == ModeAppendEvidence
+}
+
+// EdgeMode is the mode of a ForeignEdgeClaim (Decision 4). It governs the
+// inverse-gate / pending-edge behaviour, NOT the Decision-2 overlap check.
+type EdgeMode string
+
+const (
+	// EdgeConditional — deferred-apply via the pending-edge buffer; requires a
+	// registered inverse predicate (Decision 4 inverse-gate).
+	EdgeConditional EdgeMode = "conditional"
+	// EdgeBackfill — the inverse is re-derivable from the forward edge.
+	EdgeBackfill EdgeMode = "backfill"
+	// EdgeStrict — the edge is dropped if its target does not yet exist
+	// (edge-presence-insensitive consumers).
+	EdgeStrict EdgeMode = "strict"
+	// EdgeNoBirthStub — the target has no independent producer, so the edge is
+	// materialised via the framework's envelope-bearing referential-stub lane
+	// (Decision 4 lane ii — sensorml children). Load-bearing: the stub is the
+	// only thing that ever materialises the target node.
+	EdgeNoBirthStub EdgeMode = "no-birth-stub"
+)
+
+func (m EdgeMode) valid() bool {
+	switch m {
+	case EdgeConditional, EdgeBackfill, EdgeStrict, EdgeNoBirthStub:
+		return true
+	default:
+		return false
+	}
+}
+
+// OwnerClaim is owned current state: for entities matching Pattern, Owner is
+// responsible for the current value of exactly Predicates, written in Mode
+// (ADR-056 Decision 1). This is the claim Decisions 2/3/5 arbitrate.
+type OwnerClaim struct {
+	Owner      string    `json:"owner"`
+	Pattern    string    `json:"pattern"`    // 6-part entity-ID glob
+	Predicates []string  `json:"predicates"` // EXACT strings (no prefix/glob on predicates)
+	Mode       WriteMode `json:"mode"`
+}
+
+// Validate checks the claim is well-formed: a 6-part glob pattern, a non-empty
+// exact-string predicate set, a valid mode, and a non-empty owner.
+func (c OwnerClaim) Validate() error {
+	if !validOwnerID(c.Owner) {
+		return fmt.Errorf("%w: owner %q is empty or not subject-safe", ErrInvalidClaim, c.Owner)
+	}
+	if !validPattern(c.Pattern) {
+		return fmt.Errorf("%w: pattern %q is not a %d-part entity-ID glob", ErrInvalidClaim, c.Pattern, idArity)
+	}
+	if len(c.Predicates) == 0 {
+		return fmt.Errorf("%w: claim by %q on %q has no predicates", ErrInvalidClaim, c.Owner, c.Pattern)
+	}
+	for _, p := range c.Predicates {
+		if strings.TrimSpace(p) == "" {
+			return fmt.Errorf("%w: claim by %q on %q has an empty predicate", ErrInvalidClaim, c.Owner, c.Pattern)
+		}
+		if strings.ContainsAny(p, "*>") {
+			return fmt.Errorf("%w: predicate %q must be an exact string (no wildcards)", ErrInvalidClaim, p)
+		}
+	}
+	if !c.Mode.valid() {
+		return fmt.Errorf("%w: claim by %q has invalid write mode %q", ErrInvalidClaim, c.Owner, c.Mode)
+	}
+	return nil
+}
+
+// ForeignEdgeClaim is a relationship-producer claim (ADR-056 Decision 1): the
+// producer asserts an edge with Predicate whose Subject is a DIFFERENT entity
+// than the one it owns. It carries a single edge predicate and an edge-mode,
+// and is governed by Decision 4's inverse-gate — NOT by Decision 2's overlap
+// check. Two ForeignEdgeClaims never overlap each other (both legitimately add
+// edges); the cross-type Owner×ForeignEdge check (Decision 2 MEDIUM) is what
+// stops an OwnerClaim's reconcile from silently stripping a foreign edge.
+type ForeignEdgeClaim struct {
+	Owner     string   `json:"owner"`
+	Predicate string   `json:"predicate"` // single edge predicate
+	Mode      EdgeMode `json:"mode"`
+	// TargetPattern is the 6-part glob of entities the edge lands on (its
+	// foreign Subject). Empty means match-any — the conservative default for
+	// the cross-type check. cs-api declares its target pattern so its OwnerClaim
+	// and ForeignEdgeClaim on the same predicate (isHostedBy own→parent vs
+	// child→System) are not mistaken for a self-collision (same owner is always
+	// exempt; see checkOverlap).
+	TargetPattern string `json:"target_pattern,omitempty"`
+}
+
+// Validate checks the foreign-edge claim is well-formed.
+func (f ForeignEdgeClaim) Validate() error {
+	if !validOwnerID(f.Owner) {
+		return fmt.Errorf("%w: foreign-edge owner %q is empty or not subject-safe", ErrInvalidClaim, f.Owner)
+	}
+	if strings.TrimSpace(f.Predicate) == "" {
+		return fmt.Errorf("%w: foreign-edge claim by %q has no predicate", ErrInvalidClaim, f.Owner)
+	}
+	if strings.ContainsAny(f.Predicate, "*>") {
+		return fmt.Errorf("%w: foreign-edge predicate %q must be exact (no wildcards)", ErrInvalidClaim, f.Predicate)
+	}
+	if !f.Mode.valid() {
+		return fmt.Errorf("%w: foreign-edge claim by %q has invalid edge mode %q", ErrInvalidClaim, f.Owner, f.Mode)
+	}
+	if f.TargetPattern != "" && !validPattern(f.TargetPattern) {
+		return fmt.Errorf("%w: foreign-edge target pattern %q is not a %d-part glob", ErrInvalidClaim, f.TargetPattern, idArity)
+	}
+	return nil
+}
+
+// CoordinationWaiver records a deliberate, predicate-scoped exemption from the
+// overlap check between two owners (ADR-056 Decision 2). It is audit-stored at
+// EPOCH scope (epoch.Waivers, not nested under an owner) so it survives the
+// compaction of either party. A waiver covers a contested cell only when BOTH
+// owners have declared a matching waiver (mutual consent — neither owner can
+// unilaterally waive itself into the other's cell); see waived() in overlap.go.
+//
+// ReviewBy is intended to be the expiry boundary enforced at the next
+// registration (a review-obligation forcing function). NOTE: expiry parsing /
+// enforcement is DEFERRED to the enforcement-wiring increment — the format
+// (RFC3339 date vs release tag) is not yet pinned, so today an unexpired and an
+// expired waiver are treated identically. Do not rely on ReviewBy to auto-lapse
+// a waiver yet.
+type CoordinationWaiver struct {
+	Owner      string   `json:"owner"`      // the owner declaring this half of the waiver
+	With       string   `json:"with"`       // the other owner of the contested cell
+	Predicates []string `json:"predicates"` // the exact predicates the waiver covers
+	Reason     string   `json:"reason"`
+	ReviewBy   string   `json:"review_by,omitempty"` // expiry boundary (format TBD; not yet enforced)
+	Ref        string   `json:"ref,omitempty"`       // link to the design/issue justifying it
+}
+
+// Validate checks the waiver names both owners, at least one predicate, and a
+// reason — an unexplained waiver is not a waiver.
+func (w CoordinationWaiver) Validate() error {
+	if !validOwnerID(w.Owner) || !validOwnerID(w.With) {
+		return fmt.Errorf("%w: waiver must name two subject-safe owners (owner=%q with=%q)", ErrInvalidClaim, w.Owner, w.With)
+	}
+	if w.Owner == w.With {
+		return fmt.Errorf("%w: waiver owner and with are the same (%q)", ErrInvalidClaim, w.Owner)
+	}
+	if len(w.Predicates) == 0 {
+		return fmt.Errorf("%w: waiver between %q and %q covers no predicates", ErrInvalidClaim, w.Owner, w.With)
+	}
+	if strings.TrimSpace(w.Reason) == "" {
+		return fmt.Errorf("%w: waiver between %q and %q has no reason", ErrInvalidClaim, w.Owner, w.With)
+	}
+	return nil
+}

--- a/pkg/ownership/claim.go
+++ b/pkg/ownership/claim.go
@@ -41,6 +41,9 @@ func (m WriteMode) valid() bool {
 
 // EdgeMode is the mode of a ForeignEdgeClaim (Decision 4). It governs the
 // inverse-gate / pending-edge behaviour, NOT the Decision-2 overlap check.
+// Decision 4 names three modes (Conditional / Backfill / Strict); the fourth,
+// EdgeNoBirthStub, is the no-birth-target lane added by the fourth-path ruling
+// (lane ii — sensorml children that have no independent birth to drain against).
 type EdgeMode string
 
 const (
@@ -66,6 +69,16 @@ func (m EdgeMode) valid() bool {
 	default:
 		return false
 	}
+}
+
+// requiresInverse reports whether this edge mode reconstructs the inverse edge
+// and therefore requires the predicate to have a registered inverse (the
+// Decision-4 inverse-gate). Conditional defers-and-applies and Backfill
+// re-derives — both unrecoverable after a birth race without a registered
+// inverse. Strict drops-if-absent and NoBirthStub materialises a stub, so
+// neither needs an inverse. See ownership.CheckInverseGate.
+func (m EdgeMode) requiresInverse() bool {
+	return m == EdgeConditional || m == EdgeBackfill
 }
 
 // OwnerClaim is owned current state: for entities matching Pattern, Owner is
@@ -115,6 +128,12 @@ type ForeignEdgeClaim struct {
 	Owner     string   `json:"owner"`
 	Predicate string   `json:"predicate"` // single edge predicate
 	Mode      EdgeMode `json:"mode"`
+	// Producer is the payload MessageType whose Graphable emits this foreign
+	// edge. The T2-regroup seam keys its reject on (message_type, predicate)
+	// (ADR-056 Decision 4), so a fully-specified claim names the producing type.
+	// Empty means "any producer" — the transitional shape before a producer has
+	// declared its type; ForeignEdgeClaimFor prefers an exact producer match.
+	Producer string `json:"producer,omitempty"`
 	// TargetPattern is the 6-part glob of entities the edge lands on (its
 	// foreign Subject). Empty means match-any — the conservative default for
 	// the cross-type check. cs-api declares its target pattern so its OwnerClaim

--- a/pkg/ownership/claim_test.go
+++ b/pkg/ownership/claim_test.go
@@ -1,0 +1,157 @@
+package ownership
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestOwnerClaim_Validate(t *testing.T) {
+	good := oc("cs-api", "c360.semconnect.systems.csapi.system.*", ModeReplaceOwned, "sensorml.process.label")
+	if err := good.Validate(); err != nil {
+		t.Fatalf("well-formed claim should validate: %v", err)
+	}
+
+	bad := []struct {
+		name  string
+		claim OwnerClaim
+	}{
+		{"empty owner", oc("", "a.b.c.d.e.f", ModeReplaceOwned, "p")},
+		{"5-part pattern", oc("o", "a.b.c.d.e", ModeReplaceOwned, "p")},
+		{"bare star pattern", oc("o", "*", ModeReplaceOwned, "p")},
+		{"no predicates", oc("o", "a.b.c.d.e.f", ModeReplaceOwned)},
+		{"empty predicate", oc("o", "a.b.c.d.e.f", ModeReplaceOwned, "")},
+		{"wildcard predicate", oc("o", "a.b.c.d.e.f", ModeReplaceOwned, "agent.*")},
+		{"invalid mode", oc("o", "a.b.c.d.e.f", WriteMode("bogus"), "p")},
+	}
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.claim.Validate(); !errors.Is(err, ErrInvalidClaim) {
+				t.Errorf("want ErrInvalidClaim, got %v", err)
+			}
+		})
+	}
+}
+
+func TestForeignEdgeClaim_Validate(t *testing.T) {
+	good := fe("cs-api", "sensorml.component.isHostedBy", "c360.semconnect.systems.csapi.system.*", EdgeNoBirthStub)
+	if err := good.Validate(); err != nil {
+		t.Fatalf("well-formed foreign-edge claim should validate: %v", err)
+	}
+	// Empty target pattern (match-any) is valid.
+	if err := fe("o", "p", "", EdgeConditional).Validate(); err != nil {
+		t.Errorf("empty target pattern should be valid (match-any): %v", err)
+	}
+
+	bad := []struct {
+		name string
+		fec  ForeignEdgeClaim
+	}{
+		{"empty owner", fe("", "p", "", EdgeConditional)},
+		{"empty predicate", fe("o", "", "", EdgeConditional)},
+		{"wildcard predicate", fe("o", "p.*", "", EdgeConditional)},
+		{"invalid mode", fe("o", "p", "", EdgeMode("bogus"))},
+		{"bad target pattern", fe("o", "p", "a.b.c", EdgeConditional)},
+	}
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.fec.Validate(); !errors.Is(err, ErrInvalidClaim) {
+				t.Errorf("want ErrInvalidClaim, got %v", err)
+			}
+		})
+	}
+}
+
+func TestCoordinationWaiver_Validate(t *testing.T) {
+	good := CoordinationWaiver{Owner: "a", With: "b", Predicates: []string{"p"}, Reason: "because"}
+	if err := good.Validate(); err != nil {
+		t.Fatalf("well-formed waiver should validate: %v", err)
+	}
+	bad := []struct {
+		name string
+		w    CoordinationWaiver
+	}{
+		{"no with", CoordinationWaiver{Owner: "a", Predicates: []string{"p"}, Reason: "r"}},
+		{"no predicates", CoordinationWaiver{Owner: "a", With: "b", Reason: "r"}},
+		{"no reason", CoordinationWaiver{Owner: "a", With: "b", Predicates: []string{"p"}}},
+	}
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.w.Validate(); !errors.Is(err, ErrInvalidClaim) {
+				t.Errorf("want ErrInvalidClaim, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEpoch_OwnerOf(t *testing.T) {
+	ep := newEpoch()
+	ep.Owners["cs-api"] = ownerEntry{Claims: []OwnerClaim{
+		oc("cs-api", "c360.semconnect.systems.csapi.system.*", ModeReplaceOwned, "sensorml.process.label"),
+		oc("cs-api", "c360.semconnect.systems.csapi.system.*", ModeAppendEvidence, "evidence.note"),
+	}}
+
+	owner, ok := ep.ownerOf("c360.semconnect.systems.csapi.system.drone-001", "sensorml.process.label")
+	if !ok || owner != "cs-api" {
+		t.Errorf("ownerOf owning predicate = %q,%v, want cs-api,true", owner, ok)
+	}
+	// append-evidence predicate has no owner (exempt from the lease check).
+	if _, ok := ep.ownerOf("c360.semconnect.systems.csapi.system.drone-001", "evidence.note"); ok {
+		t.Error("append-evidence predicate must not report an owner")
+	}
+	// unclaimed predicate, and non-matching entity.
+	if _, ok := ep.ownerOf("c360.semconnect.systems.csapi.system.drone-001", "unclaimed"); ok {
+		t.Error("unclaimed predicate must not report an owner")
+	}
+	if _, ok := ep.ownerOf("c360.other.x.y.z.1", "sensorml.process.label"); ok {
+		t.Error("non-matching entity must not report an owner")
+	}
+}
+
+func TestEpoch_CompactStale(t *testing.T) {
+	ep := newEpoch()
+	ep.Owners["live"] = ownerEntry{Claims: []OwnerClaim{oc("live", "a.b.c.d.e.f", ModeReplaceOwned, "p")}}
+	ep.Owners["dead"] = ownerEntry{Claims: []OwnerClaim{oc("dead", "a.b.c.d.e.g", ModeReplaceOwned, "p")}}
+	ep.Owners["registrant"] = ownerEntry{Claims: []OwnerClaim{oc("registrant", "a.b.c.d.e.h", ModeReplaceOwned, "p")}}
+
+	// Only "live" has presence; "registrant" is exempt; "dead" gets evicted.
+	live := map[string]struct{}{"live": {}}
+	evicted := ep.compactStale("registrant", live)
+
+	if len(evicted) != 1 || evicted[0] != "dead" {
+		t.Fatalf("evicted = %v, want [dead]", evicted)
+	}
+	if _, ok := ep.Owners["dead"]; ok {
+		t.Error("dead owner should have been compacted out")
+	}
+	if _, ok := ep.Owners["live"]; !ok {
+		t.Error("live owner must survive")
+	}
+	if _, ok := ep.Owners["registrant"]; !ok {
+		t.Error("registrant must never be compacted (it is registering now)")
+	}
+}
+
+func TestEpoch_RoundTrip(t *testing.T) {
+	ep := newEpoch()
+	ep.Version = 7
+	ep.Owners["cs-api"] = ownerEntry{
+		Claims:       []OwnerClaim{oc("cs-api", "a.b.c.d.e.f", ModeReplaceOwned, "p")},
+		ForeignEdges: []ForeignEdgeClaim{fe("cs-api", "edge", "a.b.c.d.e.*", EdgeConditional)},
+	}
+	b, err := ep.encode()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := decodeEpoch(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Version != 7 || len(got.Owners) != 1 {
+		t.Errorf("round-trip mismatch: version=%d owners=%d", got.Version, len(got.Owners))
+	}
+	// Empty bytes decode to a fresh epoch, not an error.
+	fresh, err := decodeEpoch(nil)
+	if err != nil || fresh.Owners == nil {
+		t.Errorf("empty decode should yield fresh epoch: %v", err)
+	}
+}

--- a/pkg/ownership/claim_test.go
+++ b/pkg/ownership/claim_test.go
@@ -107,6 +107,62 @@ func TestEpoch_OwnerOf(t *testing.T) {
 	}
 }
 
+func TestEpoch_ForeignEdgeClaimFor(t *testing.T) {
+	ep := newEpoch()
+	ep.Owners["p"] = ownerEntry{ForeignEdges: []ForeignEdgeClaim{
+		{Owner: "p", Predicate: "edge.specific", Mode: EdgeConditional, Producer: "type.a"},
+		{Owner: "p", Predicate: "edge.any", Mode: EdgeStrict, Producer: ""},
+	}}
+
+	if c, ok := ep.foreignEdgeClaimFor("type.a", "edge.specific"); !ok || c.Producer != "type.a" {
+		t.Errorf("exact producer match: got %+v ok=%v", c, ok)
+	}
+	if _, ok := ep.foreignEdgeClaimFor("type.b", "edge.specific"); ok {
+		t.Error("a producer-specific claim must not match a different producer")
+	}
+	if _, ok := ep.foreignEdgeClaimFor("any.type.at.all", "edge.any"); !ok {
+		t.Error("an empty-producer (any) claim should match any message type")
+	}
+	if _, ok := ep.foreignEdgeClaimFor("type.a", "edge.unknown"); ok {
+		t.Error("an unknown predicate must not match")
+	}
+}
+
+func TestEpoch_ForeignEdgeClaimFor_ExactBeatsAny(t *testing.T) {
+	ep := newEpoch()
+	ep.Owners["p1"] = ownerEntry{ForeignEdges: []ForeignEdgeClaim{{Owner: "p1", Predicate: "e", Mode: EdgeStrict, Producer: ""}}}
+	ep.Owners["p2"] = ownerEntry{ForeignEdges: []ForeignEdgeClaim{{Owner: "p2", Predicate: "e", Mode: EdgeConditional, Producer: "type.x"}}}
+	c, ok := ep.foreignEdgeClaimFor("type.x", "e")
+	if !ok || c.Producer != "type.x" {
+		t.Errorf("an exact producer match must win over an any-producer claim, got %+v ok=%v", c, ok)
+	}
+}
+
+// TestEpoch_ForeignEdgeClaimFor_Deterministic: two owners legitimately register
+// the same predicate as a foreign edge (FE×FE is allowed) with DIFFERENT modes.
+// The returned claim — whose Mode the seam consumer branches on — must be stable
+// across calls (sorted-owner scan), not a map-iteration coin-flip.
+func TestEpoch_ForeignEdgeClaimFor_Deterministic(t *testing.T) {
+	ep := newEpoch()
+	ep.Owners["zeta"] = ownerEntry{ForeignEdges: []ForeignEdgeClaim{{Owner: "zeta", Predicate: "e", Mode: EdgeStrict, Producer: ""}}}
+	ep.Owners["alpha"] = ownerEntry{ForeignEdges: []ForeignEdgeClaim{{Owner: "alpha", Predicate: "e", Mode: EdgeConditional, Producer: ""}}}
+
+	first, ok := ep.foreignEdgeClaimFor("any.type", "e")
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	for i := 0; i < 50; i++ {
+		got, _ := ep.foreignEdgeClaimFor("any.type", "e")
+		if got.Owner != first.Owner || got.Mode != first.Mode {
+			t.Fatalf("non-deterministic foreign-edge lookup: got %+v, first %+v", got, first)
+		}
+	}
+	// Sorted-owner scan ⇒ "alpha" wins over "zeta".
+	if first.Owner != "alpha" {
+		t.Errorf("deterministic pick should be the sorted-first owner (alpha), got %q", first.Owner)
+	}
+}
+
 func TestEpoch_CompactStale(t *testing.T) {
 	ep := newEpoch()
 	ep.Owners["live"] = ownerEntry{Claims: []OwnerClaim{oc("live", "a.b.c.d.e.f", ModeReplaceOwned, "p")}}

--- a/pkg/ownership/doc.go
+++ b/pkg/ownership/doc.go
@@ -20,17 +20,41 @@
 //     make), and OwnerOf, the write-time lease lookup the graph-ingest
 //     mutation handlers consult.
 //
+// W0 first consumer (landed — Decision 5 embed):
+//
+//   - EnsureBuckets creates the two framework buckets (OWNER_CLAIMS with audit
+//     history; OWNER_PRESENCE with the PresenceTTL staleness backstop) and
+//     returns a Registry. It is called EAGERLY in the framework boot path,
+//     before lifecycle registration — NOT in graph-ingest, which boots after.
+//   - Heartbeater is the substrate-owned liveness ticker an embedder drives over
+//     its app-root context (no Close to adopt; ctx cancellation stops it).
+//   - lifecycle.Manager embeds the registry via AttachOwnership: each registered
+//     Workflow derives an owner claim (phase=cas-transition, audit+writable
+//     fields=replace-owned) and registers through the shared epoch. The first
+//     consumer's runtime posture is OBSERVE-ONLY — a cross-owner overlap is
+//     logged, not bricked (Decision 5); the substrate still REJECTS it (the
+//     Manager swallows the rejection deliberately).
+//
 // What is deliberately NOT here yet (later W0 increments, each with its own
 // review):
 //
-//   - The ForeignEdgeClaim T2-regroup-seam reject + inverse-gate in
-//     graph-ingest (Decision 4 BLOCKING-B).
+//   - The ForeignEdgeClaim T2-regroup-seam reject in graph-ingest (Decision 4
+//     BLOCKING-B). The registration-time inverse-gate (CheckInverseGate) is
+//     pure-logic-present; the graph-ingest write-boundary wiring is deferred.
 //   - The PENDING_EDGES Conditional-edge buffer + delete-after-apply drain +
 //     boot re-drain + the counting crash-recovery flip-gate test (Decision 4).
+//     EnsureBuckets does NOT create PENDING_EDGES yet (no consumer).
 //   - The OwnerToken wire field on the graph mutation requests + the handler
-//     lease check returning ErrorCodeOwnerLeaseStale (Decision 2 write seam).
-//   - graph-ingest boot wiring (bucket creation, Registry instantiation) and
-//     the lifecycle.Manager embedding (Decision 5).
+//     lease check returning ErrorCodeOwnerLeaseStale (Decision 2 write seam),
+//     and the post-registration Watch-revival fatal-halt. These two are the
+//     write-gating half of the story; until they land, an evicted-then-revived
+//     owner only churns the epoch (no dropped writes), which is why the embed
+//     ships observe-only rather than hard-fail.
+//   - The hard-fail-on-overlap flip + observability metric for the Manager embed
+//     (gated behind explicit enforcement, alongside the write-lease above).
+//   - The projection-contract auto-derivation wiring into graph-ingest boot
+//     (Decision 6): pkg/projection.Bind exists; graph-ingest does not yet call
+//     it.
 //
 // See docs/adr/056-authoritative-semantic-state.md.
 package ownership

--- a/pkg/ownership/doc.go
+++ b/pkg/ownership/doc.go
@@ -1,0 +1,36 @@
+// Package ownership implements the ADR-056 authoritative-semantic-state
+// owner registry: the framework substrate that names exactly one owner per
+// (entity-ID pattern, predicate group) and rejects two owners selecting the
+// same cell in an owning write mode.
+//
+// This is the W0 spine. It provides:
+//
+//   - The claim types — OwnerClaim (owned current state) and ForeignEdgeClaim
+//     (a relationship-producer claim), plus CoordinationWaiver — modelling the
+//     Decision-1 tuple (entity-ID pattern, predicate set, write mode, owner id).
+//   - A SINGLE-EPOCH-KEY registry (the bare `_registry` key in the OWNER_CLAIMS
+//     bucket) advanced under UpdateWithRetry CAS, so cross-process overlap is
+//     detected: every registrant of ANY claim serializes through one key
+//     (Decision 2).
+//   - Glob-vs-glob entity-ID-pattern intersection × exact-string predicate
+//     intersection (the overlap algorithm), including the Owner×ForeignEdge
+//     cross-type check (Decision 2 MEDIUM).
+//   - Stale-owner compaction via a separate OWNER_PRESENCE heartbeat bucket
+//     (liveness over a dead owner's stale claim — the same call NATS KV TTLs
+//     make), and OwnerOf, the write-time lease lookup the graph-ingest
+//     mutation handlers consult.
+//
+// What is deliberately NOT here yet (later W0 increments, each with its own
+// review):
+//
+//   - The ForeignEdgeClaim T2-regroup-seam reject + inverse-gate in
+//     graph-ingest (Decision 4 BLOCKING-B).
+//   - The PENDING_EDGES Conditional-edge buffer + delete-after-apply drain +
+//     boot re-drain + the counting crash-recovery flip-gate test (Decision 4).
+//   - The OwnerToken wire field on the graph mutation requests + the handler
+//     lease check returning ErrorCodeOwnerLeaseStale (Decision 2 write seam).
+//   - graph-ingest boot wiring (bucket creation, Registry instantiation) and
+//     the lifecycle.Manager embedding (Decision 5).
+//
+// See docs/adr/056-authoritative-semantic-state.md.
+package ownership

--- a/pkg/ownership/epoch.go
+++ b/pkg/ownership/epoch.go
@@ -1,0 +1,126 @@
+package ownership
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ownerEntry is one owner's slice of the epoch: its owned-state claims and its
+// foreign-edge claims. Waivers are NOT nested here — they live at epoch scope
+// (epoch.Waivers) so the compaction of either party to a waiver does not
+// silently drop it.
+type ownerEntry struct {
+	Claims       []OwnerClaim       `json:"claims,omitempty"`
+	ForeignEdges []ForeignEdgeClaim `json:"foreign_edges,omitempty"`
+}
+
+// epoch is the single value stored at the `_registry` key in OWNER_CLAIMS — the
+// UNION of every registered owner's claims, advanced under UpdateWithRetry CAS.
+// Version is a monotonic counter bumped on every successful registration so a
+// compacted-then-revived owner's post-registration Watch (a later increment)
+// can detect that the epoch moved (Decision 2). The KV revision is the CAS
+// token; Version is the human/audit-facing epoch number.
+//
+// Waivers live at epoch scope (not per-owner) so neither party's compaction
+// drops them; they lapse only on explicit re-registration of their declarer or
+// on expiry (ReviewBy, deferred).
+type epoch struct {
+	Version uint64                `json:"version"`
+	Owners  map[string]ownerEntry `json:"owners"`
+	Waivers []CoordinationWaiver  `json:"waivers,omitempty"`
+}
+
+func newEpoch() *epoch {
+	return &epoch{Owners: make(map[string]ownerEntry)}
+}
+
+// decodeEpoch parses the epoch value. An empty/absent value (first
+// registration) decodes to a fresh empty epoch, not an error.
+func decodeEpoch(b []byte) (*epoch, error) {
+	if len(b) == 0 {
+		return newEpoch(), nil
+	}
+	var e epoch
+	if err := json.Unmarshal(b, &e); err != nil {
+		return nil, fmt.Errorf("ownership: decode epoch: %w", err)
+	}
+	if e.Owners == nil {
+		e.Owners = make(map[string]ownerEntry)
+	}
+	return &e, nil
+}
+
+func (e *epoch) encode() ([]byte, error) {
+	b, err := json.Marshal(e)
+	if err != nil {
+		return nil, fmt.Errorf("ownership: encode epoch: %w", err)
+	}
+	return b, nil
+}
+
+// setWaiversFor replaces the declarer's half of the epoch's waiver set: drop
+// every waiver previously declared by `declarer`, then append its fresh set.
+// Idempotent re-registration thus updates a declarer's waivers without
+// disturbing the other party's half (mutual consent is preserved across
+// re-registrations).
+func (e *epoch) setWaiversFor(declarer string, waivers []CoordinationWaiver) {
+	kept := e.Waivers[:0:0]
+	for _, w := range e.Waivers {
+		if w.Owner != declarer {
+			kept = append(kept, w)
+		}
+	}
+	e.Waivers = append(kept, waivers...)
+}
+
+// compactStale drops every owner ABSENT from the live-presence set, EXCEPT the
+// registrant (live by definition — it is registering now). Liveness is keyed on
+// the canonical owner id (NOT a hash), and the live set is derived from
+// OWNER_PRESENCE keys whose existence is itself the grace window: a key is
+// present only while its owner has heartbeated within the bucket TTL, so an
+// absent key means the owner has been silent BEYOND the grace window
+// (ttl_hint ≥ 3×max(boot, gc-pause), set at bucket creation). Returns evicted
+// owner ids for logging. This trades a brief, observable double-CLAIM window
+// for never blocking a restart on a dead owner's stale claim (Decision 2).
+func (e *epoch) compactStale(registrant string, livePresence map[string]struct{}) []string {
+	var evicted []string
+	for owner := range e.Owners {
+		if owner == registrant {
+			continue
+		}
+		if _, live := livePresence[owner]; live {
+			continue
+		}
+		evicted = append(evicted, owner)
+	}
+	for _, owner := range evicted {
+		delete(e.Owners, owner)
+	}
+	sortStrings(evicted)
+	return evicted
+}
+
+// ownerOf returns the owner id of the OwnerClaim that, in an OWNING mode,
+// governs (entityID, predicate) — the write-time lease lookup. ok is false when
+// no owner claims that cell (an un-claimed predicate, or an append-evidence
+// predicate). The first owning match wins; the overlap check guarantees at most
+// one owning owner per cell, so the order is immaterial for a well-formed
+// epoch.
+func (e *epoch) ownerOf(entityID, predicate string) (owner string, ok bool) {
+	for ownerID, entry := range e.Owners {
+		for _, c := range entry.Claims {
+			if !c.Mode.isOwning() {
+				continue
+			}
+			if !patternMatches(c.Pattern, entityID) {
+				continue
+			}
+			for _, p := range c.Predicates {
+				if p == predicate {
+					return ownerID, true
+				}
+			}
+		}
+	}
+	return "", false
+}

--- a/pkg/ownership/epoch.go
+++ b/pkg/ownership/epoch.go
@@ -100,6 +100,39 @@ func (e *epoch) compactStale(registrant string, livePresence map[string]struct{}
 	return evicted
 }
 
+// foreignEdgeClaimFor returns the ForeignEdgeClaim covering a foreign-subject
+// triple emitted by `messageType` carrying `predicate` — the T2-seam reject
+// lookup (ADR-056 Decision 4). An exact Producer match wins; a Producer-empty
+// ("any producer", transitional) claim is the fallback. ok=false means the edge
+// is UNCLAIMED (the seam rejects / routes deprecated-on-arrival).
+//
+// Owners are scanned in SORTED order so the returned claim is DETERMINISTIC.
+// FE×FE is allowed (two producers may both claim a predicate), so >1 claim can
+// match; the allow/deny (ok) is order-immaterial, but the returned claim's Mode
+// is what the seam consumer branches on (Conditional→buffer, Strict→drop,
+// NoBirthStub→stub), so a stable pick matters.
+func (e *epoch) foreignEdgeClaimFor(messageType, predicate string) (ForeignEdgeClaim, bool) {
+	var anyProducer ForeignEdgeClaim
+	haveAny := false
+	for _, owner := range sortedOwners(e.Owners) {
+		for _, f := range e.Owners[owner].ForeignEdges {
+			if f.Predicate != predicate {
+				continue
+			}
+			if f.Producer == messageType {
+				return f, true // exact producer match wins
+			}
+			if f.Producer == "" && !haveAny {
+				anyProducer, haveAny = f, true
+			}
+		}
+	}
+	if haveAny {
+		return anyProducer, true
+	}
+	return ForeignEdgeClaim{}, false
+}
+
 // ownerOf returns the owner id of the OwnerClaim that, in an OWNING mode,
 // governs (entityID, predicate) — the write-time lease lookup. ok is false when
 // no owner claims that cell (an un-claimed predicate, or an append-evidence

--- a/pkg/ownership/errors.go
+++ b/pkg/ownership/errors.go
@@ -1,0 +1,46 @@
+package ownership
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrInvalidClaim is returned when a claim or waiver is malformed (bad pattern,
+// empty predicate set, invalid mode). Registration fails fast — a malformed
+// claim is a programming error, not a runtime condition.
+var ErrInvalidClaim = errors.New("ownership: invalid claim")
+
+// ErrOwnershipOverlap is returned (wrapped in *OverlapError) when two claims
+// select an overlapping (entity-ID pattern, predicate) cell in an owning write
+// mode. Registration FAILS — no silent coexistence (ADR-056 Decision 2). Match
+// with errors.Is; inspect the named owners/pattern/predicates via
+// errors.As(&OverlapError{}).
+var ErrOwnershipOverlap = errors.New("ownership: claim overlap")
+
+// OverlapError names both owners, the overlapping pattern, and the overlapping
+// predicates of a rejected registration. CrossType is true when the collision
+// is Owner×ForeignEdge (an OwnerClaim reconcile would strip a foreign edge)
+// rather than OwnerClaim×OwnerClaim.
+type OverlapError struct {
+	Owner       string   // the registrant whose claim was rejected
+	With        string   // the incumbent owner it collides with
+	Pattern     string   // the registrant's pattern (the one that intersects)
+	WithPattern string   // the incumbent's pattern
+	Predicates  []string // the exact predicates in both sets
+	CrossType   bool     // true: Owner×ForeignEdge; false: OwnerClaim×OwnerClaim
+}
+
+func (e *OverlapError) Error() string {
+	kind := "owner/owner"
+	if e.CrossType {
+		kind = "owner/foreign-edge"
+	}
+	return fmt.Sprintf(
+		"ownership: claim overlap (%s): owner %q pattern %q overlaps owner %q pattern %q on predicate(s) [%s]",
+		kind, e.Owner, e.Pattern, e.With, e.WithPattern, strings.Join(e.Predicates, ", "),
+	)
+}
+
+// Unwrap lets errors.Is(err, ErrOwnershipOverlap) match an *OverlapError.
+func (e *OverlapError) Unwrap() error { return ErrOwnershipOverlap }

--- a/pkg/ownership/glob.go
+++ b/pkg/ownership/glob.go
@@ -1,0 +1,123 @@
+package ownership
+
+import "strings"
+
+// validPattern reports whether p is a 6-part dotted entity-ID glob. Bare "*"
+// (match-any) is intentionally NOT a valid OwnerClaim pattern — an owner
+// claiming every entity is almost always a bug; patternsIntersect still
+// handles "*" for the ForeignEdgeClaim match-any default.
+func validPattern(p string) bool {
+	return len(strings.Split(p, ".")) == idArity
+}
+
+// validOwnerID reports whether an owner id is usable directly as a NATS KV key
+// segment (alphanumerics + `-` `_` `=` `.`, no `*`/`>`). Owner identity is
+// compared as the canonical string everywhere — presence keys, liveness, the
+// write-time lease handle — so it must be subject-safe with NO hashing: a hash
+// would put a (tiny but silent) birthday-collision on the OWNERSHIP correctness
+// path (two owners colliding ⇒ one masks the other's liveness or forges its
+// lease). Component/gateway/owner ids are already short identifiers in this
+// shape; enforcing it here keeps identity exact.
+func validOwnerID(s string) bool {
+	if s == "" || len(s) > 256 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '-', r == '_', r == '=', r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// patternMatches reports whether a concrete 6-part entity id matches a glob
+// pattern. Mirrors pkg/lifecycle.matchPattern (manager_query.go:428) so the
+// registry's OwnerOf lookup classifies an entity the same way the lifecycle
+// query layer does.
+func patternMatches(pattern, id string) bool {
+	if pattern == "" {
+		return false
+	}
+	if pattern == id || pattern == "*" {
+		return true
+	}
+	pParts := strings.Split(pattern, ".")
+	iParts := strings.Split(id, ".")
+	if len(pParts) != len(iParts) {
+		return false
+	}
+	for i := range pParts {
+		if pParts[i] == "*" {
+			continue
+		}
+		if pParts[i] != iParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// patternsIntersect reports whether two globs can match the same concrete
+// entity id — the core of the Decision-2 overlap check. Two patterns intersect
+// iff, segment-by-segment, every position is compatible: either side is "*" or
+// the literals are equal. Differing arity cannot share an id (unless one side
+// is the bare "*" match-any). This is consistent with patternMatches: if id m
+// matches both A and B, then A and B intersect.
+func patternsIntersect(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	if a == "*" || b == "*" || a == b {
+		return true
+	}
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	if len(aParts) != len(bParts) {
+		return false
+	}
+	for i := range aParts {
+		if aParts[i] == "*" || bParts[i] == "*" || aParts[i] == bParts[i] {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// predicatesIntersection returns the sorted set of exact predicate strings
+// present in both sets. Empty result means no overlap. Used both to detect a
+// collision and to name the offending predicates in the error.
+func predicatesIntersection(a, b []string) []string {
+	set := make(map[string]struct{}, len(a))
+	for _, p := range a {
+		set[p] = struct{}{}
+	}
+	var out []string
+	seen := make(map[string]struct{})
+	for _, p := range b {
+		if _, ok := set[p]; !ok {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	sortStrings(out)
+	return out
+}
+
+// sortStrings is a tiny insertion sort to keep error messages deterministic
+// without pulling sort into a hot, allocation-light path (overlap sets are
+// small — a handful of predicates).
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/pkg/ownership/glob_test.go
+++ b/pkg/ownership/glob_test.go
@@ -1,0 +1,121 @@
+package ownership
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPatternsIntersect(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical", "c360.semconnect.systems.csapi.system.x", "c360.semconnect.systems.csapi.system.x", true},
+		{"same-prefix-wildcard-tail", "c360.semconnect.systems.csapi.system.*", "c360.semconnect.systems.csapi.system.drone-001", true},
+		{"both-wildcard-tail", "c360.semconnect.systems.csapi.system.*", "c360.semconnect.systems.csapi.system.*", true},
+		{"wildcard-vs-wildcard-mid", "*.semconnect.systems.csapi.system.*", "c360.*.systems.csapi.system.*", true},
+		// cs-api disjoint id-spaces: System vs Deployment differ at segment 5.
+		{"csapi-system-vs-deployment-disjoint", "c360.semconnect.systems.csapi.system.*", "c360.semconnect.systems.csapi.deployment.*", false},
+		{"one-literal-segment-differs", "a.b.c.d.e.f", "a.b.c.d.e.g", false},
+		{"literal-differs-under-wildcards", "a.b.*.d.e.f", "a.b.*.d.e.g", false},
+		{"differing-arity", "a.b.c.d.e.f", "a.b.c.d.e", false},
+		{"bare-star-left", "*", "a.b.c.d.e.f", true},
+		{"bare-star-right", "a.b.c.d.e.f", "*", true},
+		{"empty-left", "", "a.b.c.d.e.f", false},
+		{"empty-right", "a.b.c.d.e.f", "", false},
+		{"wildcard-bridges-mismatch-elsewhere", "a.*.c.d.e.f", "a.b.c.d.e.g", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := patternsIntersect(tt.a, tt.b); got != tt.want {
+				t.Errorf("patternsIntersect(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+			// Intersection is symmetric.
+			if got := patternsIntersect(tt.b, tt.a); got != tt.want {
+				t.Errorf("patternsIntersect(%q, %q) [reversed] = %v, want %v", tt.b, tt.a, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPatternsIntersectConsistentWithMatch is the load-bearing invariant: if a
+// concrete id matches BOTH patterns, the patterns MUST intersect. A registry
+// that violated this would let two owners co-own a cell some entity falls into.
+func TestPatternsIntersectConsistentWithMatch(t *testing.T) {
+	patterns := []string{
+		"c360.semconnect.systems.csapi.system.*",
+		"c360.semconnect.systems.csapi.*.drone-001",
+		"*.semconnect.systems.csapi.system.drone-001",
+		"a.b.c.d.e.f",
+		"a.b.c.d.e.*",
+	}
+	ids := []string{
+		"c360.semconnect.systems.csapi.system.drone-001",
+		"c360.semconnect.systems.csapi.system.x",
+		"a.b.c.d.e.f",
+		"a.b.c.d.e.zzz",
+	}
+	for _, a := range patterns {
+		for _, b := range patterns {
+			for _, id := range ids {
+				if patternMatches(a, id) && patternMatches(b, id) && !patternsIntersect(a, b) {
+					t.Errorf("id %q matches both %q and %q but patternsIntersect=false", id, a, b)
+				}
+			}
+		}
+	}
+}
+
+func TestPatternMatches(t *testing.T) {
+	tests := []struct {
+		pattern, id string
+		want        bool
+	}{
+		{"c360.semconnect.systems.csapi.system.*", "c360.semconnect.systems.csapi.system.drone-001", true},
+		{"c360.semconnect.systems.csapi.system.*", "c360.semconnect.systems.csapi.deployment.d1", false},
+		{"a.b.c.d.e.f", "a.b.c.d.e.f", true},
+		{"a.b.c.d.e.f", "a.b.c.d.e.g", false},
+		{"a.b.c.d.e", "a.b.c.d.e.f", false}, // arity
+		{"*", "anything.at.all", true},
+		{"", "a.b.c.d.e.f", false},
+	}
+	for _, tt := range tests {
+		if got := patternMatches(tt.pattern, tt.id); got != tt.want {
+			t.Errorf("patternMatches(%q, %q) = %v, want %v", tt.pattern, tt.id, got, tt.want)
+		}
+	}
+}
+
+func TestPredicatesIntersection(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []string
+		want []string
+	}{
+		{"overlap-sorted", []string{"b.p", "a.p", "c.p"}, []string{"c.p", "a.p"}, []string{"a.p", "c.p"}},
+		{"no-overlap", []string{"a.p"}, []string{"b.p"}, nil},
+		{"dedupe-from-b", []string{"a.p"}, []string{"a.p", "a.p"}, []string{"a.p"}},
+		{"empty", nil, nil, nil},
+		{"identical", []string{"x", "y"}, []string{"y", "x"}, []string{"x", "y"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := predicatesIntersection(tt.a, tt.b); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("predicatesIntersection(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidPattern(t *testing.T) {
+	if !validPattern("a.b.c.d.e.f") {
+		t.Error("6-part pattern should be valid")
+	}
+	if validPattern("a.b.c.d.e") {
+		t.Error("5-part pattern should be invalid")
+	}
+	if validPattern("*") {
+		t.Error("bare * should not be a valid 6-part owner pattern")
+	}
+}

--- a/pkg/ownership/heartbeat.go
+++ b/pkg/ownership/heartbeat.go
@@ -1,0 +1,100 @@
+package ownership
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Liveness tuning (ADR-056 Decision 2 staleness lifecycle). These are the
+// values graph-ingest stamps as the OWNER_PRESENCE bucket TTL and that an
+// embedder ticks Heartbeat on.
+const (
+	// PresenceTTL is the bucket-level TTL on OWNER_PRESENCE, set at bucket
+	// creation. A presence key not re-bumped within this window ages out, and
+	// its owner becomes compactable out of the epoch by the next registrant.
+	// It is the staleness floor the ADR pins at ttl_hint ≥ 3×max(boot_time,
+	// gc_pause_budget): 120s comfortably exceeds a slow service boot or a long
+	// GC pause, so a live owner mid-pause is never falsely evicted, while a
+	// genuinely dead owner's claim frees within ~one TTL of the next boot.
+	PresenceTTL = 120 * time.Second
+
+	// HeartbeatInterval is how often a live owner re-bumps its presence key —
+	// well under PresenceTTL (4 beats per window), so losing up to 3
+	// consecutive beats does not cross the staleness floor.
+	HeartbeatInterval = 30 * time.Second
+)
+
+// Heartbeater periodically refreshes the OWNER_PRESENCE keys of a set of owners
+// so a live process is never compacted out of the epoch by a later registrant
+// (ADR-056 Decision 2). Registry.Heartbeat's contract is "the caller runs this
+// on a ticker"; Heartbeater is that ticker — a small substrate helper the
+// embedder (lifecycle.Manager today; future non-Manager owners next) drives over
+// its own lifetime context, so each embedder does not reinvent the loop.
+//
+// Owners are added incrementally (one per registration) via Add, which is safe
+// to call before or during Run. Run blocks until its context is cancelled.
+type Heartbeater struct {
+	reg      *Registry
+	interval time.Duration
+	logger   *slog.Logger
+
+	mu     sync.Mutex
+	owners map[string]struct{}
+}
+
+// NewHeartbeater builds a Heartbeater over the registry. A non-positive
+// interval falls back to HeartbeatInterval.
+func (reg *Registry) NewHeartbeater(interval time.Duration) *Heartbeater {
+	if interval <= 0 {
+		interval = HeartbeatInterval
+	}
+	return &Heartbeater{
+		reg:      reg,
+		interval: interval,
+		logger:   reg.logger,
+		owners:   make(map[string]struct{}),
+	}
+}
+
+// Add enrolls an owner id for heartbeating on every subsequent tick. Idempotent.
+func (h *Heartbeater) Add(owner string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.owners[owner] = struct{}{}
+}
+
+// snapshot copies the enrolled owner set under lock for lock-free tick iteration.
+func (h *Heartbeater) snapshot() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]string, 0, len(h.owners))
+	for o := range h.owners {
+		out = append(out, o)
+	}
+	return out
+}
+
+// Run ticks until ctx is cancelled, re-bumping every enrolled owner's presence
+// key each tick. Blocks — run it in a goroutine. A failed bump is LOGGED, never
+// returned: a single missed tick is absorbed by the TTL margin, and a loop that
+// exited on the first transient blip would defeat the liveness it exists to
+// maintain.
+func (h *Heartbeater) Run(ctx context.Context) {
+	ticker := time.NewTicker(h.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			for _, owner := range h.snapshot() {
+				if err := h.reg.Heartbeat(ctx, owner); err != nil {
+					h.logger.Warn("ownership: heartbeat tick failed",
+						slog.String("owner", owner), slog.Any("error", err))
+				}
+			}
+		}
+	}
+}

--- a/pkg/ownership/inverse_gate.go
+++ b/pkg/ownership/inverse_gate.go
@@ -1,0 +1,38 @@
+package ownership
+
+import "fmt"
+
+// InverseResolver reports whether a predicate has a registered inverse predicate
+// (the vocabulary registry's GetInversePredicate returns non-empty). It is
+// INJECTED so this package stays free of the vocabulary dependency and the
+// inverse-gate is unit-testable with a fake. graph-ingest boot passes an adapter
+// over vocabulary.GetInversePredicate.
+type InverseResolver func(predicate string) (inverse string, ok bool)
+
+// CheckInverseGate enforces ADR-056 Decision 4's inverse-gate: a ForeignEdgeClaim
+// whose mode reconstructs the inverse edge after a birth race
+// (Conditional defers-and-applies, Backfill re-derives) REQUIRES the predicate to
+// have a registered inverse — otherwise the inverse edge is unrecoverable and the
+// graph silently loses a traversal edge (BLOCKING-B). Such a claim must instead
+// be declared Strict (drop-if-absent) or NoBirthStub (materialise a stub). Strict
+// and NoBirthStub modes need no inverse and are never gated.
+//
+// Intended to run at boot, the same way payload registration is validated, over
+// every registered ForeignEdgeClaim (graph-ingest wires it with a
+// vocabulary-backed resolver). Returns the FIRST offending claim's error.
+func CheckInverseGate(resolve InverseResolver, claims ...ForeignEdgeClaim) error {
+	if resolve == nil {
+		return fmt.Errorf("%w: CheckInverseGate needs a non-nil InverseResolver", ErrInvalidClaim)
+	}
+	for _, c := range claims {
+		if !c.Mode.requiresInverse() {
+			continue
+		}
+		if _, ok := resolve(c.Predicate); !ok {
+			return fmt.Errorf("%w: foreign-edge predicate %q (mode %q, producer %q) has no registered inverse — "+
+				"declare it Strict/NoBirthStub or register an inverse (Decision 4 inverse-gate)",
+				ErrInvalidClaim, c.Predicate, c.Mode, c.Producer)
+		}
+	}
+	return nil
+}

--- a/pkg/ownership/inverse_gate_test.go
+++ b/pkg/ownership/inverse_gate_test.go
@@ -1,0 +1,73 @@
+package ownership
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestEdgeMode_requiresInverse(t *testing.T) {
+	if !EdgeConditional.requiresInverse() {
+		t.Error("conditional must require an inverse (deferred-apply)")
+	}
+	if !EdgeBackfill.requiresInverse() {
+		t.Error("backfill must require an inverse (re-derives from forward)")
+	}
+	if EdgeStrict.requiresInverse() {
+		t.Error("strict drops-if-absent — no inverse needed")
+	}
+	if EdgeNoBirthStub.requiresInverse() {
+		t.Error("no-birth-stub materialises a stub — no inverse needed (the sensorml case)")
+	}
+}
+
+func TestCheckInverseGate(t *testing.T) {
+	// A resolver that knows one predicate's inverse (mirrors the 8 hierarchy/
+	// delegation predicates that actually carry WithInverseOf).
+	resolve := func(p string) (string, bool) {
+		if p == "sensorml.system.hosts" {
+			return "sensorml.component.isHostedBy", true
+		}
+		return "", false
+	}
+	const noInverse = "sensorml.component.isHostedBy" // WithIRI only, no inverse
+
+	t.Run("conditional with registered inverse passes", func(t *testing.T) {
+		if err := CheckInverseGate(resolve, fe("o", "sensorml.system.hosts", sysPat, EdgeConditional)); err != nil {
+			t.Errorf("want nil, got %v", err)
+		}
+	})
+	t.Run("conditional without inverse fails", func(t *testing.T) {
+		if err := CheckInverseGate(resolve, fe("o", noInverse, sysPat, EdgeConditional)); !errors.Is(err, ErrInvalidClaim) {
+			t.Errorf("want ErrInvalidClaim, got %v", err)
+		}
+	})
+	t.Run("backfill without inverse fails", func(t *testing.T) {
+		if err := CheckInverseGate(resolve, fe("o", noInverse, sysPat, EdgeBackfill)); !errors.Is(err, ErrInvalidClaim) {
+			t.Errorf("want ErrInvalidClaim, got %v", err)
+		}
+	})
+	t.Run("strict without inverse passes (not gated)", func(t *testing.T) {
+		if err := CheckInverseGate(resolve, fe("o", noInverse, sysPat, EdgeStrict)); err != nil {
+			t.Errorf("strict must never be gated, got %v", err)
+		}
+	})
+	t.Run("no-birth-stub without inverse passes (the sensorml case)", func(t *testing.T) {
+		if err := CheckInverseGate(resolve, fe("o", noInverse, sysPat, EdgeNoBirthStub)); err != nil {
+			t.Errorf("no-birth-stub must never be gated, got %v", err)
+		}
+	})
+	t.Run("nil resolver errors", func(t *testing.T) {
+		if err := CheckInverseGate(nil, fe("o", "p", sysPat, EdgeConditional)); !errors.Is(err, ErrInvalidClaim) {
+			t.Errorf("nil resolver must error, got %v", err)
+		}
+	})
+	t.Run("first offending claim in a batch is reported", func(t *testing.T) {
+		err := CheckInverseGate(resolve,
+			fe("o", "sensorml.system.hosts", sysPat, EdgeConditional), // ok
+			fe("o", noInverse, sysPat, EdgeConditional),               // offends
+		)
+		if !errors.Is(err, ErrInvalidClaim) {
+			t.Errorf("want ErrInvalidClaim for the offending claim, got %v", err)
+		}
+	})
+}

--- a/pkg/ownership/overlap.go
+++ b/pkg/ownership/overlap.go
@@ -1,0 +1,148 @@
+package ownership
+
+import (
+	"slices"
+	"sort"
+)
+
+// checkOverlap rejects a candidate registration that would put two owners on
+// the same (entity-ID pattern, predicate) cell in an owning mode (ADR-056
+// Decision 2). It runs three checks against the OTHER owners already in the
+// epoch (the registrant's own claims never collide with themselves — cs-api's
+// isHostedBy is legitimately both an OwnerClaim own→parent edge and a
+// ForeignEdgeClaim child→System edge, same owner, exempt):
+//
+//  1. OwnerClaim × OwnerClaim — two owning-mode claims selecting an overlapping
+//     pattern×predicate cell (the load-bearing case).
+//  2. registrant OwnerClaim × incumbent ForeignEdgeClaim (different owner) — the
+//     owner's reconcile would strip the foreign edge (Decision 2 MEDIUM).
+//  3. registrant ForeignEdgeClaim × incumbent OwnerClaim (different owner) — the
+//     same collision discovered from the other direction.
+//
+// Two ForeignEdgeClaims never collide (both legitimately add edges), and
+// append-evidence claims are exempt (no single owner). A collision is waived
+// only when EVERY overlapping predicate is covered by a CoordinationWaiver
+// naming both owners.
+//
+// `others` must NOT contain the registrant (the caller removes the registrant's
+// prior entry before calling, so re-registration is idempotent). Returns the
+// first collision in deterministic (sorted-owner) order, or nil.
+func checkOverlap(registrant string, cand ownerEntry, others map[string]ownerEntry, waivers []CoordinationWaiver) error {
+	for _, incumbent := range sortedOwners(others) {
+		if incumbent == registrant {
+			continue
+		}
+		entry := others[incumbent]
+
+		// 1. OwnerClaim × OwnerClaim (owning modes only).
+		for _, c := range cand.Claims {
+			if !c.Mode.isOwning() {
+				continue
+			}
+			for _, d := range entry.Claims {
+				if !d.Mode.isOwning() {
+					continue
+				}
+				if !patternsIntersect(c.Pattern, d.Pattern) {
+					continue
+				}
+				if hit := unwaived(predicatesIntersection(c.Predicates, d.Predicates), registrant, incumbent, waivers); len(hit) > 0 {
+					return &OverlapError{
+						Owner: registrant, With: incumbent,
+						Pattern: c.Pattern, WithPattern: d.Pattern,
+						Predicates: hit,
+					}
+				}
+			}
+		}
+
+		// 2. registrant OwnerClaim × incumbent ForeignEdgeClaim.
+		if err := crossType(registrant, cand.Claims, incumbent, entry.ForeignEdges, waivers); err != nil {
+			return err
+		}
+		// 3. registrant ForeignEdgeClaim × incumbent OwnerClaim (symmetric).
+		if err := crossType(incumbent, entry.Claims, registrant, cand.ForeignEdges, waivers); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// crossType checks owning OwnerClaims (held by ownerA) against ForeignEdgeClaims
+// (held by ownerB) for a shared predicate over an overlapping pattern. The
+// returned OverlapError always names the registrant first; the caller passes
+// the pair in whichever order matches the direction being checked, and we
+// normalise by reporting ownerA as Owner (it holds the OwnerClaim whose
+// reconcile would strip the edge).
+func crossType(ownerA string, claims []OwnerClaim, ownerB string, edges []ForeignEdgeClaim, waivers []CoordinationWaiver) error {
+	if ownerA == ownerB {
+		return nil // same owner: legitimate dual use (isHostedBy own + foreign)
+	}
+	for _, c := range claims {
+		if !c.Mode.isOwning() {
+			continue
+		}
+		for _, f := range edges {
+			target := f.TargetPattern
+			if target == "" {
+				target = "*" // match-any: conservative default
+			}
+			if !patternsIntersect(c.Pattern, target) {
+				continue
+			}
+			if !slices.Contains(c.Predicates, f.Predicate) {
+				continue
+			}
+			if hit := unwaived([]string{f.Predicate}, ownerA, ownerB, waivers); len(hit) > 0 {
+				return &OverlapError{
+					Owner: ownerA, With: ownerB,
+					Pattern: c.Pattern, WithPattern: target,
+					Predicates: hit, CrossType: true,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// unwaived returns the predicates in `preds` NOT exempted by a mutual-consent
+// waiver between a and b. An empty result means the whole collision is waived.
+func unwaived(preds []string, a, b string, waivers []CoordinationWaiver) []string {
+	if len(preds) == 0 {
+		return nil
+	}
+	var out []string
+	for _, p := range preds {
+		if !waived(a, b, p, waivers) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// waived reports whether the (a,b) collision on predicate p is exempted by
+// MUTUAL CONSENT: BOTH owners must have declared a matching waiver (ADR-056
+// 056:759 — "both overlapping owners carry a matching waiver"). Neither owner
+// can unilaterally waive itself into the other's owned cell — a one-sided
+// waiver is no waiver.
+func waived(a, b, p string, waivers []CoordinationWaiver) bool {
+	return hasWaiver(waivers, a, b, p) && hasWaiver(waivers, b, a, p)
+}
+
+func hasWaiver(waivers []CoordinationWaiver, owner, with, p string) bool {
+	for _, w := range waivers {
+		if w.Owner == owner && w.With == with && slices.Contains(w.Predicates, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedOwners(m map[string]ownerEntry) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/ownership/overlap_test.go
+++ b/pkg/ownership/overlap_test.go
@@ -1,0 +1,219 @@
+package ownership
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// oc is a terse OwnerClaim constructor for tests.
+func oc(owner, pattern string, mode WriteMode, preds ...string) OwnerClaim {
+	return OwnerClaim{Owner: owner, Pattern: pattern, Predicates: preds, Mode: mode}
+}
+
+func fe(owner, predicate, targetPattern string, mode EdgeMode) ForeignEdgeClaim {
+	return ForeignEdgeClaim{Owner: owner, Predicate: predicate, TargetPattern: targetPattern, Mode: mode}
+}
+
+const (
+	sysPat = "c360.semconnect.systems.csapi.system.*"
+	depPat = "c360.semconnect.systems.csapi.deployment.*"
+)
+
+func TestCheckOverlap_OwnerVsOwner(t *testing.T) {
+	others := map[string]ownerEntry{
+		"cs-api": {Claims: []OwnerClaim{oc("cs-api", sysPat, ModeReplaceOwned, "sensorml.process.label")}},
+	}
+
+	t.Run("same cell, owning modes, different owners → reject", func(t *testing.T) {
+		cand := ownerEntry{Claims: []OwnerClaim{oc("other", sysPat, ModeReplaceOwned, "sensorml.process.label")}}
+		err := checkOverlap("other", cand, others, nil)
+		var oe *OverlapError
+		if !errors.As(err, &oe) {
+			t.Fatalf("want *OverlapError, got %v", err)
+		}
+		if !errors.Is(err, ErrOwnershipOverlap) {
+			t.Error("want errors.Is ErrOwnershipOverlap")
+		}
+		if oe.CrossType {
+			t.Error("owner/owner collision must not be flagged CrossType")
+		}
+		if !reflect.DeepEqual(oe.Predicates, []string{"sensorml.process.label"}) {
+			t.Errorf("predicates = %v", oe.Predicates)
+		}
+	})
+
+	t.Run("disjoint id-space (System vs Deployment) → allowed", func(t *testing.T) {
+		cand := ownerEntry{Claims: []OwnerClaim{oc("other", depPat, ModeReplaceOwned, "sensorml.process.label")}}
+		if err := checkOverlap("other", cand, others, nil); err != nil {
+			t.Errorf("disjoint patterns must not collide: %v", err)
+		}
+	})
+
+	t.Run("disjoint predicates → allowed", func(t *testing.T) {
+		cand := ownerEntry{Claims: []OwnerClaim{oc("other", sysPat, ModeReplaceOwned, "other.predicate")}}
+		if err := checkOverlap("other", cand, others, nil); err != nil {
+			t.Errorf("disjoint predicates must not collide: %v", err)
+		}
+	})
+
+	t.Run("append-evidence is exempt", func(t *testing.T) {
+		cand := ownerEntry{Claims: []OwnerClaim{oc("other", sysPat, ModeAppendEvidence, "sensorml.process.label")}}
+		if err := checkOverlap("other", cand, others, nil); err != nil {
+			t.Errorf("append-evidence candidate must be exempt: %v", err)
+		}
+		// And exempt when the INCUMBENT is append-evidence.
+		othersAppend := map[string]ownerEntry{
+			"cs-api": {Claims: []OwnerClaim{oc("cs-api", sysPat, ModeAppendEvidence, "sensorml.process.label")}},
+		}
+		cand2 := ownerEntry{Claims: []OwnerClaim{oc("other", sysPat, ModeReplaceOwned, "sensorml.process.label")}}
+		if err := checkOverlap("other", cand2, othersAppend, nil); err != nil {
+			t.Errorf("append-evidence incumbent must be exempt: %v", err)
+		}
+	})
+
+	t.Run("cas-transition counts as owning", func(t *testing.T) {
+		cand := ownerEntry{Claims: []OwnerClaim{oc("other", sysPat, ModeCASTransition, "sensorml.process.label")}}
+		if err := checkOverlap("other", cand, others, nil); !errors.Is(err, ErrOwnershipOverlap) {
+			t.Errorf("cas-transition vs replace-owned on same cell must collide, got %v", err)
+		}
+	})
+
+	t.Run("same owner re-registering does not self-collide", func(t *testing.T) {
+		// `others` excludes the registrant by contract; prove a candidate that
+		// would collide with itself is fine because it's filtered upstream.
+		cand := ownerEntry{Claims: []OwnerClaim{oc("cs-api", sysPat, ModeReplaceOwned, "sensorml.process.label")}}
+		if err := checkOverlap("cs-api", cand, map[string]ownerEntry{}, nil); err != nil {
+			t.Errorf("empty others must not collide: %v", err)
+		}
+	})
+}
+
+func TestCheckOverlap_PartialPredicateCollision(t *testing.T) {
+	others := map[string]ownerEntry{
+		"cs-api": {Claims: []OwnerClaim{oc("cs-api", sysPat, ModeReplaceOwned, "p.a", "p.b")}},
+	}
+	cand := ownerEntry{Claims: []OwnerClaim{oc("other", sysPat, ModeReplaceOwned, "p.b", "p.c")}}
+	err := checkOverlap("other", cand, others, nil)
+	var oe *OverlapError
+	if !errors.As(err, &oe) {
+		t.Fatalf("want *OverlapError, got %v", err)
+	}
+	if !reflect.DeepEqual(oe.Predicates, []string{"p.b"}) {
+		t.Errorf("only the shared predicate p.b should be reported, got %v", oe.Predicates)
+	}
+}
+
+// TestCheckOverlap_CrossType covers the Owner×ForeignEdge MEDIUM (Decision 2):
+// an OwnerClaim reconcile must not silently strip a DIFFERENT owner's foreign
+// edge, but the SAME owner using a predicate as both own and foreign (cs-api's
+// isHostedBy) is legitimate.
+func TestCheckOverlap_CrossType(t *testing.T) {
+	const isHostedBy = "sensorml.component.isHostedBy"
+
+	t.Run("different owner: OwnerClaim strips foreign edge → reject", func(t *testing.T) {
+		others := map[string]ownerEntry{
+			"producer": {ForeignEdges: []ForeignEdgeClaim{fe("producer", isHostedBy, sysPat, EdgeNoBirthStub)}},
+		}
+		cand := ownerEntry{Claims: []OwnerClaim{oc("cs-api", sysPat, ModeReplaceOwned, isHostedBy)}}
+		err := checkOverlap("cs-api", cand, others, nil)
+		var oe *OverlapError
+		if !errors.As(err, &oe) {
+			t.Fatalf("want *OverlapError, got %v", err)
+		}
+		if !oe.CrossType {
+			t.Error("Owner×ForeignEdge collision must be flagged CrossType")
+		}
+	})
+
+	t.Run("same owner: isHostedBy as own AND foreign → allowed (cs-api dual use)", func(t *testing.T) {
+		// Registrant cs-api holds BOTH an OwnerClaim listing isHostedBy (own→parent)
+		// AND a ForeignEdgeClaim for isHostedBy (child→System). They never collide.
+		cand := ownerEntry{
+			Claims:       []OwnerClaim{oc("cs-api", sysPat, ModeReplaceOwned, isHostedBy)},
+			ForeignEdges: []ForeignEdgeClaim{fe("cs-api", isHostedBy, sysPat, EdgeNoBirthStub)},
+		}
+		if err := checkOverlap("cs-api", cand, map[string]ownerEntry{}, nil); err != nil {
+			t.Errorf("same-owner dual use of isHostedBy must be allowed: %v", err)
+		}
+	})
+
+	t.Run("two ForeignEdgeClaims on same predicate → allowed (FE×FE)", func(t *testing.T) {
+		others := map[string]ownerEntry{
+			"p1": {ForeignEdges: []ForeignEdgeClaim{fe("p1", isHostedBy, sysPat, EdgeConditional)}},
+		}
+		cand := ownerEntry{ForeignEdges: []ForeignEdgeClaim{fe("p2", isHostedBy, sysPat, EdgeConditional)}}
+		if err := checkOverlap("p2", cand, others, nil); err != nil {
+			t.Errorf("two foreign-edge producers must not collide: %v", err)
+		}
+	})
+
+	t.Run("cross-type with disjoint target pattern → allowed", func(t *testing.T) {
+		others := map[string]ownerEntry{
+			"producer": {ForeignEdges: []ForeignEdgeClaim{fe("producer", isHostedBy, depPat, EdgeConditional)}},
+		}
+		cand := ownerEntry{Claims: []OwnerClaim{oc("cs-api", sysPat, ModeReplaceOwned, isHostedBy)}}
+		if err := checkOverlap("cs-api", cand, others, nil); err != nil {
+			t.Errorf("disjoint owner pattern vs FE target pattern must not collide: %v", err)
+		}
+	})
+
+	t.Run("FE with empty target pattern matches any owner pattern → reject", func(t *testing.T) {
+		others := map[string]ownerEntry{
+			"producer": {ForeignEdges: []ForeignEdgeClaim{fe("producer", isHostedBy, "", EdgeConditional)}},
+		}
+		cand := ownerEntry{Claims: []OwnerClaim{oc("cs-api", sysPat, ModeReplaceOwned, isHostedBy)}}
+		if err := checkOverlap("cs-api", cand, others, nil); !errors.Is(err, ErrOwnershipOverlap) {
+			t.Errorf("empty FE target (match-any) must collide with any owner pattern, got %v", err)
+		}
+	})
+}
+
+func TestCheckOverlap_Waiver(t *testing.T) {
+	others := map[string]ownerEntry{
+		"cs-api": {Claims: []OwnerClaim{oc("cs-api", sysPat, ModeReplaceOwned, "p.a", "p.b")}},
+	}
+	cand := ownerEntry{Claims: []OwnerClaim{oc("other", sysPat, ModeReplaceOwned, "p.a", "p.b")}}
+
+	t.Run("MUTUAL waiver covering all overlapping predicates → allowed", func(t *testing.T) {
+		w := []CoordinationWaiver{
+			{Owner: "other", With: "cs-api", Predicates: []string{"p.a", "p.b"}, Reason: "shared by design"},
+			{Owner: "cs-api", With: "other", Predicates: []string{"p.a", "p.b"}, Reason: "shared by design"},
+		}
+		if err := checkOverlap("other", cand, others, w); err != nil {
+			t.Errorf("fully mutually-waived collision must be allowed: %v", err)
+		}
+	})
+
+	t.Run("ONE-SIDED waiver does not exempt (mutual consent required)", func(t *testing.T) {
+		w := []CoordinationWaiver{{Owner: "other", With: "cs-api", Predicates: []string{"p.a", "p.b"}, Reason: "unilateral"}}
+		if err := checkOverlap("other", cand, others, w); !errors.Is(err, ErrOwnershipOverlap) {
+			t.Errorf("a one-sided waiver must NOT exempt — both owners must consent, got %v", err)
+		}
+	})
+
+	t.Run("mutual waiver covering only some predicates → reject the rest", func(t *testing.T) {
+		w := []CoordinationWaiver{
+			{Owner: "other", With: "cs-api", Predicates: []string{"p.a"}, Reason: "partial"},
+			{Owner: "cs-api", With: "other", Predicates: []string{"p.a"}, Reason: "partial"},
+		}
+		err := checkOverlap("other", cand, others, w)
+		var oe *OverlapError
+		if !errors.As(err, &oe) {
+			t.Fatalf("want *OverlapError, got %v", err)
+		}
+		if !reflect.DeepEqual(oe.Predicates, []string{"p.b"}) {
+			t.Errorf("only the un-waived p.b should remain, got %v", oe.Predicates)
+		}
+	})
+
+	t.Run("waiver for the wrong owner pair → no effect", func(t *testing.T) {
+		w := []CoordinationWaiver{
+			{Owner: "other", With: "someone-else", Predicates: []string{"p.a", "p.b"}, Reason: "wrong pair"},
+			{Owner: "someone-else", With: "other", Predicates: []string{"p.a", "p.b"}, Reason: "wrong pair"},
+		}
+		if err := checkOverlap("other", cand, others, w); !errors.Is(err, ErrOwnershipOverlap) {
+			t.Errorf("waiver naming the wrong pair must not exempt, got %v", err)
+		}
+	})
+}

--- a/pkg/ownership/registry.go
+++ b/pkg/ownership/registry.go
@@ -51,11 +51,78 @@ type Registration struct {
 	Waivers      []CoordinationWaiver
 }
 
-// validate checks structural well-formedness AND owner consistency: every claim
-// must name the registering owner (a registration cannot smuggle in a claim
-// attributed to someone else). Waivers must be declared BY the registrant (its
-// half of a mutual-consent waiver).
-func (r Registration) validate() error {
+// Validate checks structural well-formedness AND internal consistency: every
+// claim names the registering owner, and no two of the registration's OWN
+// owning claims select an overlapping (pattern, predicate) cell (a single owner
+// declaring the same cell twice in an owning mode is ambiguous — which claim
+// reconciles it?). Cross-OWNER overlap is checked separately at RegisterOwner
+// against the epoch. Callers that DERIVE a registration (pkg/projection) call
+// this at boot for early, owner-bound feedback.
+func (r Registration) Validate() error {
+	if err := r.validateStructural(); err != nil {
+		return err
+	}
+	if err := r.selfOverlap(); err != nil {
+		return err
+	}
+	return r.modeConsistency()
+}
+
+// modeConsistency rejects a predicate declared in BOTH an owning mode and
+// append-evidence over INTERSECTING patterns within one registration — "P is
+// single-valued owned" and "P is multi-valued append" cannot both hold for one
+// owner on the same entities. Disjoint patterns are fine (P may be owned on one
+// entity type and appended on another). This catches across the aggregated
+// claims of pkg/projection.Derive, where the per-contract one-mode check can't
+// see the other contract.
+func (r Registration) modeConsistency() error {
+	for i := range r.Claims {
+		for j := i + 1; j < len(r.Claims); j++ {
+			a, b := r.Claims[i], r.Claims[j]
+			if a.Mode.isOwning() == b.Mode.isOwning() {
+				continue // both owning (selfOverlap's job) or both append (legitimate)
+			}
+			if !patternsIntersect(a.Pattern, b.Pattern) {
+				continue
+			}
+			if hit := predicatesIntersection(a.Predicates, b.Predicates); len(hit) > 0 {
+				return fmt.Errorf("%w: owner %q declares predicate(s) %v in both an owning and an append-evidence mode over overlapping patterns %q / %q",
+					ErrInvalidClaim, r.Owner, hit, a.Pattern, b.Pattern)
+			}
+		}
+	}
+	return nil
+}
+
+// selfOverlap reports an *OverlapError (Owner == With == r.Owner) when two of the
+// registration's own owning OwnerClaims select an overlapping cell.
+func (r Registration) selfOverlap() error {
+	for i := range r.Claims {
+		a := r.Claims[i]
+		if !a.Mode.isOwning() {
+			continue
+		}
+		for j := i + 1; j < len(r.Claims); j++ {
+			b := r.Claims[j]
+			if !b.Mode.isOwning() {
+				continue
+			}
+			if !patternsIntersect(a.Pattern, b.Pattern) {
+				continue
+			}
+			if hit := predicatesIntersection(a.Predicates, b.Predicates); len(hit) > 0 {
+				return &OverlapError{
+					Owner: r.Owner, With: r.Owner,
+					Pattern: a.Pattern, WithPattern: b.Pattern,
+					Predicates: hit,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (r Registration) validateStructural() error {
 	if !validOwnerID(r.Owner) {
 		return fmt.Errorf("%w: registration owner %q is empty or not subject-safe", ErrInvalidClaim, r.Owner)
 	}
@@ -118,7 +185,7 @@ func (r Registration) hasNoEnforceableClaim() bool {
 // Returns a *OverlapError (errors.Is(err, ErrOwnershipOverlap)) on collision,
 // or ErrInvalidClaim on a malformed registration.
 func (reg *Registry) RegisterOwner(ctx context.Context, r Registration) error {
-	if err := r.validate(); err != nil {
+	if err := r.Validate(); err != nil {
 		return err
 	}
 	if r.hasNoEnforceableClaim() {

--- a/pkg/ownership/registry.go
+++ b/pkg/ownership/registry.go
@@ -1,0 +1,264 @@
+package ownership
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/retry"
+)
+
+// Registry is the KV-backed owner registry (ADR-056 Decision 2): a single
+// `_registry` epoch key in OWNER_CLAIMS advanced under CAS, plus a separate
+// OWNER_PRESENCE heartbeat bucket for stale-owner compaction.
+//
+// This is the distributed-enforcement SUBSTRATE only. Owners do not hand-build
+// claims here as a parallel registry — claims are DERIVED from registered graph
+// projection contracts and bound to an owner id at boot (ADR-056 Decision 6);
+// RegisterOwner is the low-level entrypoint the derivation calls (and the
+// escape hatch for owners with dynamic patterns, e.g. the lifecycle Manager).
+type Registry struct {
+	claims   *natsclient.KVStore // OWNER_CLAIMS — the single `_registry` epoch key
+	presence *natsclient.KVStore // OWNER_PRESENCE — heartbeat.<owner> keys (TTL = grace window)
+	logger   *slog.Logger
+}
+
+// NewRegistry constructs a Registry over the two pre-opened KV stores. The
+// caller (graph-ingest boot, a later increment) creates the buckets:
+// OWNER_CLAIMS with history for audit, and — critically — OWNER_PRESENCE with a
+// bucket TTL that IS the compaction grace window. That TTL must be
+// ttl_hint ≥ 3×max(boot_time, gc_pause_budget) so a single missed heartbeat
+// never evicts a live owner (compactStale treats presence-key absence as
+// "silent beyond grace"; the TTL is what makes absence mean that).
+func NewRegistry(claims, presence *natsclient.KVStore, logger *slog.Logger) *Registry {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Registry{claims: claims, presence: presence, logger: logger}
+}
+
+// Registration is one owner's full set of claims, registered atomically against
+// the epoch.
+type Registration struct {
+	Owner        string
+	Claims       []OwnerClaim
+	ForeignEdges []ForeignEdgeClaim
+	Waivers      []CoordinationWaiver
+}
+
+// validate checks structural well-formedness AND owner consistency: every claim
+// must name the registering owner (a registration cannot smuggle in a claim
+// attributed to someone else). Waivers must be declared BY the registrant (its
+// half of a mutual-consent waiver).
+func (r Registration) validate() error {
+	if !validOwnerID(r.Owner) {
+		return fmt.Errorf("%w: registration owner %q is empty or not subject-safe", ErrInvalidClaim, r.Owner)
+	}
+	if len(r.Claims) == 0 && len(r.ForeignEdges) == 0 {
+		return fmt.Errorf("%w: registration by %q declares no claims", ErrInvalidClaim, r.Owner)
+	}
+	for _, c := range r.Claims {
+		if err := c.Validate(); err != nil {
+			return err
+		}
+		if c.Owner != r.Owner {
+			return fmt.Errorf("%w: claim owner %q != registration owner %q", ErrInvalidClaim, c.Owner, r.Owner)
+		}
+	}
+	for _, f := range r.ForeignEdges {
+		if err := f.Validate(); err != nil {
+			return err
+		}
+		if f.Owner != r.Owner {
+			return fmt.Errorf("%w: foreign-edge owner %q != registration owner %q", ErrInvalidClaim, f.Owner, r.Owner)
+		}
+	}
+	for _, w := range r.Waivers {
+		if err := w.Validate(); err != nil {
+			return err
+		}
+		if w.Owner != r.Owner {
+			return fmt.Errorf("%w: waiver owner %q != registration owner %q", ErrInvalidClaim, w.Owner, r.Owner)
+		}
+	}
+	return nil
+}
+
+// hasNoEnforceableClaim reports whether the registration consists ENTIRELY of
+// non-owning (append-evidence) OwnerClaims and has no foreign edges — a registration the
+// registry will store but never act on (no overlap protection, no lease). That
+// is almost always a misconfiguration (an owner that meant to own a group but
+// fluffed the mode), so RegisterOwner logs a Warn rather than silently
+// accepting a no-op.
+func (r Registration) hasNoEnforceableClaim() bool {
+	if len(r.ForeignEdges) > 0 {
+		return false
+	}
+	for _, c := range r.Claims {
+		if c.Mode.isOwning() {
+			return false
+		}
+	}
+	return true
+}
+
+// RegisterOwner registers (or re-registers, idempotently) an owner's claims
+// against the single epoch key. Inside one UpdateWithRetry CAS callback
+// (ADR-056 Decision 2): read epoch → compact stale owners by presence → drop
+// the registrant's prior entry → update the registrant's half of the waiver set
+// → check overlap of the candidate against every OTHER owner → on overlap FAIL
+// (non-retryable), else merge + bump epoch → CAS-write at the read revision →
+// retry on a concurrent registrant's write.
+//
+// Returns a *OverlapError (errors.Is(err, ErrOwnershipOverlap)) on collision,
+// or ErrInvalidClaim on a malformed registration.
+func (reg *Registry) RegisterOwner(ctx context.Context, r Registration) error {
+	if err := r.validate(); err != nil {
+		return err
+	}
+	if r.hasNoEnforceableClaim() {
+		reg.logger.Warn("ownership: registration has no enforceable (owning or foreign-edge) claim — it will not be protected",
+			slog.String("owner", r.Owner))
+	}
+
+	// Heartbeat first: mark this owner live BEFORE the CAS reads presence for
+	// compaction, so a concurrent registrant cannot see us as stale mid-flight.
+	if err := reg.Heartbeat(ctx, r.Owner); err != nil {
+		return fmt.Errorf("ownership: heartbeat before register %q: %w", r.Owner, err)
+	}
+
+	var (
+		overlapErr error
+		preExisted bool
+		cand       = ownerEntry{Claims: r.Claims, ForeignEdges: r.ForeignEdges}
+	)
+	err := reg.claims.UpdateWithRetry(ctx, registryKey, func(current []byte) ([]byte, error) {
+		ep, err := decodeEpoch(current)
+		if err != nil {
+			return nil, retry.NonRetryable(err)
+		}
+		_, preExisted = ep.Owners[r.Owner]
+
+		live, err := reg.livePresence(ctx)
+		if err != nil {
+			return nil, err // retryable: a transient presence-read blip
+		}
+		if evicted := ep.compactStale(r.Owner, live); len(evicted) > 0 {
+			reg.logger.Warn("ownership: compacted stale owner claims",
+				slog.String("registrant", r.Owner),
+				slog.Any("evicted", evicted))
+		}
+
+		// Idempotent re-registration: drop the registrant's prior entry so the
+		// overlap check never compares the candidate against itself, and update
+		// only the registrant's half of the epoch-scoped waiver set.
+		delete(ep.Owners, r.Owner)
+		ep.setWaiversFor(r.Owner, r.Waivers)
+
+		if oerr := checkOverlap(r.Owner, cand, ep.Owners, ep.Waivers); oerr != nil {
+			overlapErr = oerr
+			return nil, retry.NonRetryable(oerr) // never retry an overlap — it would just re-detect
+		}
+
+		ep.Owners[r.Owner] = cand
+		ep.Version++
+		return ep.encode()
+	})
+
+	if overlapErr != nil {
+		reg.rollbackPresence(ctx, r.Owner, preExisted)
+		return overlapErr // clean *OverlapError for errors.As, not the retry-wrapped form
+	}
+	if err != nil {
+		reg.rollbackPresence(ctx, r.Owner, preExisted)
+		return fmt.Errorf("ownership: register %q: %w", r.Owner, err)
+	}
+	return nil
+}
+
+// rollbackPresence drops the heartbeat key written by a registration that then
+// failed — but ONLY for an owner that had no prior epoch entry. A re-registration
+// failure must NOT resign a still-live owner whose existing claims remain in the
+// epoch (that would get them compacted on the next pass). Best-effort.
+func (reg *Registry) rollbackPresence(ctx context.Context, owner string, preExisted bool) {
+	if preExisted {
+		return
+	}
+	if err := reg.Resign(ctx, owner); err != nil {
+		reg.logger.Warn("ownership: failed to roll back presence after registration failure",
+			slog.String("owner", owner), slog.Any("error", err))
+	}
+}
+
+// Heartbeat (re)writes the owner's presence key, refreshing the bucket TTL. The
+// caller runs this on a ticker (interval well under the TTL); a crashed owner
+// stops, its key TTL-expires, and the next registrant compacts its claims. The
+// value is the heartbeat unix-nanos timestamp, carried for observability and
+// the later Watch-revival check.
+func (reg *Registry) Heartbeat(ctx context.Context, owner string) error {
+	if !validOwnerID(owner) {
+		return fmt.Errorf("%w: heartbeat owner %q not subject-safe", ErrInvalidClaim, owner)
+	}
+	key := presenceKeyPrefix + owner
+	val := []byte(strconv.FormatInt(time.Now().UnixNano(), 10))
+	if _, err := reg.presence.Put(ctx, key, val); err != nil {
+		return fmt.Errorf("ownership: heartbeat %q: %w", owner, err)
+	}
+	return nil
+}
+
+// Resign deletes the owner's presence key, voluntarily releasing its claims at
+// the next registrant's compaction (clean shutdown). Best-effort; a missing key
+// is not an error.
+func (reg *Registry) Resign(ctx context.Context, owner string) error {
+	key := presenceKeyPrefix + owner
+	if err := reg.presence.Delete(ctx, key); err != nil && !errors.Is(err, natsclient.ErrKVKeyNotFound) {
+		return fmt.Errorf("ownership: resign %q: %w", owner, err)
+	}
+	return nil
+}
+
+// OwnerOf returns the owner of the (entityID, predicate) cell — the write-time
+// lease lookup a mutation handler runs to verify a writer's owner identity
+// against the live owner (ADR-056 Decision 2 write seam). The returned owner id
+// IS the lease handle (no hash — identity is exact). ok is false when no owner
+// claims that cell (un-claimed or append-evidence).
+func (reg *Registry) OwnerOf(ctx context.Context, entityID, predicate string) (owner string, ok bool, err error) {
+	entry, err := reg.claims.Get(ctx, registryKey)
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return "", false, nil // empty registry: nothing is owned yet
+		}
+		return "", false, fmt.Errorf("ownership: read epoch for OwnerOf: %w", err)
+	}
+	ep, err := decodeEpoch(entry.Value)
+	if err != nil {
+		return "", false, err
+	}
+	o, found := ep.ownerOf(entityID, predicate)
+	if !found {
+		return "", false, nil
+	}
+	return o, true, nil
+}
+
+// livePresence returns the set of live owner ids — each OWNER_PRESENCE key minus
+// its prefix. Liveness is the canonical owner id (no hash); compactStale tests
+// membership directly. Keys() ignores deletes/expiry, so an absent key is a
+// genuinely silent (beyond-TTL-grace) owner.
+func (reg *Registry) livePresence(ctx context.Context) (map[string]struct{}, error) {
+	keys, err := reg.presence.Keys(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("ownership: list presence: %w", err)
+	}
+	live := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		live[strings.TrimPrefix(k, presenceKeyPrefix)] = struct{}{}
+	}
+	return live, nil
+}

--- a/pkg/ownership/registry.go
+++ b/pkg/ownership/registry.go
@@ -314,6 +314,27 @@ func (reg *Registry) OwnerOf(ctx context.Context, entityID, predicate string) (o
 	return o, true, nil
 }
 
+// ForeignEdgeClaimFor returns the ForeignEdgeClaim covering a foreign-subject
+// triple emitted by a Graphable of `messageType` carrying `predicate` — the
+// T2-regroup seam reject lookup (ADR-056 Decision 4). ok=false means the foreign
+// edge is UNCLAIMED, which the seam rejects (or routes deprecated-on-arrival
+// with the foreign_edge_unclaimed_total metric until the producer migrates).
+func (reg *Registry) ForeignEdgeClaimFor(ctx context.Context, messageType, predicate string) (ForeignEdgeClaim, bool, error) {
+	entry, err := reg.claims.Get(ctx, registryKey)
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return ForeignEdgeClaim{}, false, nil // empty registry: nothing claimed yet
+		}
+		return ForeignEdgeClaim{}, false, fmt.Errorf("ownership: read epoch for ForeignEdgeClaimFor: %w", err)
+	}
+	ep, err := decodeEpoch(entry.Value)
+	if err != nil {
+		return ForeignEdgeClaim{}, false, err
+	}
+	c, ok := ep.foreignEdgeClaimFor(messageType, predicate)
+	return c, ok, nil
+}
+
 // livePresence returns the set of live owner ids — each OWNER_PRESENCE key minus
 // its prefix. Liveness is the canonical owner id (no hash); compactStale tests
 // membership directly. Keys() ignores deletes/expiry, so an absent key is a

--- a/pkg/ownership/registry_integration_test.go
+++ b/pkg/ownership/registry_integration_test.go
@@ -130,6 +130,34 @@ func TestRegistry_OwnerOf(t *testing.T) {
 	}
 }
 
+// TestRegistry_ForeignEdgeClaimFor proves the T2-seam reject lookup: a
+// registered ForeignEdgeClaim is found by (producer message type, predicate),
+// and an unclaimed foreign edge reports ok=false (the seam rejects it).
+func TestRegistry_ForeignEdgeClaimFor(t *testing.T) {
+	r, _, ctx := newTestRegistry(t)
+	const isHostedBy = "sensorml.component.isHostedBy"
+	if err := r.RegisterOwner(ctx, Registration{
+		Owner: "sensorml-producer",
+		ForeignEdges: []ForeignEdgeClaim{{
+			Owner: "sensorml-producer", Predicate: isHostedBy, Mode: EdgeNoBirthStub,
+			Producer: "sensorml.asset.v1", TargetPattern: sysPat,
+		}},
+	}); err != nil {
+		t.Fatalf("register foreign-edge claim: %v", err)
+	}
+
+	c, ok, err := r.ForeignEdgeClaimFor(ctx, "sensorml.asset.v1", isHostedBy)
+	if err != nil || !ok || c.Owner != "sensorml-producer" {
+		t.Errorf("ForeignEdgeClaimFor(claimed) = %+v,%v,%v", c, ok, err)
+	}
+	if _, ok, _ := r.ForeignEdgeClaimFor(ctx, "sensorml.asset.v1", "unclaimed.edge"); ok {
+		t.Error("an unclaimed foreign edge must report ok=false (the seam rejects it)")
+	}
+	if _, ok, _ := r.ForeignEdgeClaimFor(ctx, "other.type.v1", isHostedBy); ok {
+		t.Error("a producer-specific claim must not cover a different producer")
+	}
+}
+
 // TestRegistry_StaleCompaction proves a crashed owner's claim is compacted out
 // by the next registrant — the availability-over-stale-claim call. We simulate
 // the crash by deleting the dead owner's presence key (TTL expiry, sans wait).

--- a/pkg/ownership/registry_integration_test.go
+++ b/pkg/ownership/registry_integration_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+
+package ownership
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// newTestRegistry spins up a real NATS KV (testcontainer) with the two
+// ownership buckets and returns a Registry plus the claims KVStore (so tests
+// can read the epoch back through the in-package helpers).
+func newTestRegistry(t *testing.T) (*Registry, *natsclient.KVStore, context.Context) {
+	t.Helper()
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	ctx := context.Background()
+
+	claimsBucket, err := tc.CreateKVBucket(ctx, BucketOwnerClaims)
+	if err != nil {
+		t.Fatalf("create OWNER_CLAIMS: %v", err)
+	}
+	presenceBucket, err := tc.CreateKVBucket(ctx, BucketOwnerPresence)
+	if err != nil {
+		t.Fatalf("create OWNER_PRESENCE: %v", err)
+	}
+	claims := tc.Client.NewKVStore(claimsBucket)
+	presence := tc.Client.NewKVStore(presenceBucket)
+	return NewRegistry(claims, presence, nil), claims, ctx
+}
+
+func reg(owner, pattern string, preds ...string) Registration {
+	return Registration{Owner: owner, Claims: []OwnerClaim{oc(owner, pattern, ModeReplaceOwned, preds...)}}
+}
+
+// readEpoch reads and decodes the current epoch for assertions.
+func readEpoch(t *testing.T, claims *natsclient.KVStore, ctx context.Context) *epoch {
+	t.Helper()
+	entry, err := claims.Get(ctx, registryKey)
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return newEpoch()
+		}
+		t.Fatalf("read epoch: %v", err)
+	}
+	ep, err := decodeEpoch(entry.Value)
+	if err != nil {
+		t.Fatalf("decode epoch: %v", err)
+	}
+	return ep
+}
+
+func TestRegistry_RegisterAndReject(t *testing.T) {
+	r, claims, ctx := newTestRegistry(t)
+
+	if err := r.RegisterOwner(ctx, reg("cs-api", sysPat, "sensorml.process.label")); err != nil {
+		t.Fatalf("first registration should succeed: %v", err)
+	}
+
+	// Overlapping owner on the same cell → reject, epoch unchanged.
+	err := r.RegisterOwner(ctx, reg("other", sysPat, "sensorml.process.label"))
+	if !errors.Is(err, ErrOwnershipOverlap) {
+		t.Fatalf("overlapping registration should fail with ErrOwnershipOverlap, got %v", err)
+	}
+	var oe *OverlapError
+	if !errors.As(err, &oe) || oe.With != "cs-api" {
+		t.Errorf("OverlapError should name incumbent cs-api, got %+v", oe)
+	}
+
+	// Disjoint id-space → allowed.
+	if err := r.RegisterOwner(ctx, reg("other", depPat, "sensorml.process.label")); err != nil {
+		t.Fatalf("disjoint registration should succeed: %v", err)
+	}
+
+	ep := readEpoch(t, claims, ctx)
+	if _, ok := ep.Owners["cs-api"]; !ok {
+		t.Error("cs-api should be in the epoch")
+	}
+	if _, ok := ep.Owners["other"]; !ok {
+		t.Error("other should be in the epoch (disjoint claim landed)")
+	}
+	if ep.Version < 2 {
+		t.Errorf("epoch version should have advanced past 2 successful registrations, got %d", ep.Version)
+	}
+}
+
+func TestRegistry_Idempotent(t *testing.T) {
+	r, _, ctx := newTestRegistry(t)
+	entity := "c360.semconnect.systems.csapi.system.drone-001"
+
+	if err := r.RegisterOwner(ctx, reg("cs-api", sysPat, "p.a")); err != nil {
+		t.Fatal(err)
+	}
+	// Re-register the SAME owner with a different predicate set → replaces, no overlap.
+	if err := r.RegisterOwner(ctx, reg("cs-api", sysPat, "p.b")); err != nil {
+		t.Fatalf("re-registration of same owner should succeed: %v", err)
+	}
+
+	if _, ok, _ := r.OwnerOf(ctx, entity, "p.a"); ok {
+		t.Error("p.a should no longer be owned after re-registration replaced it")
+	}
+	owner, ok, err := r.OwnerOf(ctx, entity, "p.b")
+	if err != nil || !ok || owner != "cs-api" {
+		t.Errorf("OwnerOf(p.b) = %q,%v,%v want cs-api,true,nil", owner, ok, err)
+	}
+}
+
+func TestRegistry_OwnerOf(t *testing.T) {
+	r, _, ctx := newTestRegistry(t)
+	entity := "c360.semconnect.systems.csapi.system.drone-001"
+
+	// Empty registry: nothing owned.
+	if _, ok, err := r.OwnerOf(ctx, entity, "p"); ok || err != nil {
+		t.Errorf("empty registry OwnerOf should be false,nil; got ok=%v err=%v", ok, err)
+	}
+
+	if err := r.RegisterOwner(ctx, reg("cs-api", sysPat, "sensorml.process.label")); err != nil {
+		t.Fatal(err)
+	}
+	owner, ok, err := r.OwnerOf(ctx, entity, "sensorml.process.label")
+	if err != nil || !ok {
+		t.Fatalf("OwnerOf after registration: ok=%v err=%v", ok, err)
+	}
+	if owner != "cs-api" {
+		t.Errorf("OwnerOf = %q want cs-api (the owner id is the lease handle)", owner)
+	}
+}
+
+// TestRegistry_StaleCompaction proves a crashed owner's claim is compacted out
+// by the next registrant — the availability-over-stale-claim call. We simulate
+// the crash by deleting the dead owner's presence key (TTL expiry, sans wait).
+func TestRegistry_StaleCompaction(t *testing.T) {
+	r, claims, ctx := newTestRegistry(t)
+	entity := "c360.semconnect.systems.csapi.system.drone-001"
+
+	if err := r.RegisterOwner(ctx, reg("owner-a", sysPat, "p")); err != nil {
+		t.Fatal(err)
+	}
+	// owner-a "crashes": its heartbeat key disappears.
+	if err := r.Resign(ctx, "owner-a"); err != nil {
+		t.Fatalf("resign owner-a: %v", err)
+	}
+
+	// owner-b claims the SAME cell. Without compaction this overlaps owner-a;
+	// with compaction owner-a is evicted first and owner-b succeeds.
+	if err := r.RegisterOwner(ctx, reg("owner-b", sysPat, "p")); err != nil {
+		t.Fatalf("owner-b should claim the freed cell after owner-a compaction: %v", err)
+	}
+
+	ep := readEpoch(t, claims, ctx)
+	if _, ok := ep.Owners["owner-a"]; ok {
+		t.Error("owner-a should have been compacted out of the epoch")
+	}
+	owner, ok, _ := r.OwnerOf(ctx, entity, "p")
+	if !ok || owner != "owner-b" {
+		t.Errorf("cell should now be owned by owner-b, got %q,%v", owner, ok)
+	}
+}
+
+// TestRegistry_ConcurrentDisjoint proves the single-epoch CAS serializes
+// concurrent registrants with no lost update: N disjoint owners registered in
+// parallel all land in the epoch.
+func TestRegistry_ConcurrentDisjoint(t *testing.T) {
+	r, claims, ctx := newTestRegistry(t)
+	const n = 8
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			owner := fmt.Sprintf("owner-%d", i)
+			pattern := fmt.Sprintf("c360.semconnect.systems.csapi.type%d.*", i)
+			errs[i] = r.RegisterOwner(ctx, reg(owner, pattern, "p"))
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("concurrent registration %d failed: %v", i, err)
+		}
+	}
+	ep := readEpoch(t, claims, ctx)
+	if len(ep.Owners) != n {
+		t.Errorf("epoch should hold all %d disjoint owners (no lost update), got %d", n, len(ep.Owners))
+	}
+}

--- a/pkg/projection/bind_integration_test.go
+++ b/pkg/projection/bind_integration_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+package projection
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/ownership"
+)
+
+func newOwnershipRegistry(t *testing.T) (*ownership.Registry, context.Context) {
+	t.Helper()
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	ctx := context.Background()
+	cb, err := tc.CreateKVBucket(ctx, ownership.BucketOwnerClaims)
+	if err != nil {
+		t.Fatalf("create OWNER_CLAIMS: %v", err)
+	}
+	pb, err := tc.CreateKVBucket(ctx, ownership.BucketOwnerPresence)
+	if err != nil {
+		t.Fatalf("create OWNER_PRESENCE: %v", err)
+	}
+	return ownership.NewRegistry(tc.Client.NewKVStore(cb), tc.Client.NewKVStore(pb), nil), ctx
+}
+
+// TestBind_DerivesAndRegisters exercises the full Decision-6 chain: a projection
+// contract → derived claims → registered with the ownership substrate → visible
+// to the write-time lease lookup.
+func TestBind_DerivesAndRegisters(t *testing.T) {
+	reg, ctx := newOwnershipRegistry(t)
+	if err := Bind(ctx, reg, "cs-api", csapiSystem()); err != nil {
+		t.Fatalf("bind cs-api System projection: %v", err)
+	}
+	owner, ok, err := reg.OwnerOf(ctx, "c360.semconnect.systems.csapi.system.drone-001", "sensorml.process.label")
+	if err != nil || !ok || owner != "cs-api" {
+		t.Errorf("OwnerOf after Bind = %q,%v,%v want cs-api,true,nil", owner, ok, err)
+	}
+}
+
+// TestBind_CrossOwnerOverlapRejected proves a second owner cannot bind a
+// projection that claims a cell cs-api already owns — the derivation feeds the
+// substrate's epoch overlap check. (Cross-PROCESS overlap is the substrate's own
+// concern, covered in pkg/ownership's integration tests; here both owners share
+// one Registry, so this proves cross-OWNER rejection.)
+func TestBind_CrossOwnerOverlapRejected(t *testing.T) {
+	reg, ctx := newOwnershipRegistry(t)
+	if err := Bind(ctx, reg, "cs-api", csapiSystem()); err != nil {
+		t.Fatal(err)
+	}
+	poacher := Contract{
+		Name:          "poacher.system",
+		EntityPattern: sysPat,
+		Groups:        []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"sensorml.process.label"}}},
+	}
+	if err := Bind(ctx, reg, "other", poacher); !errors.Is(err, ownership.ErrOwnershipOverlap) {
+		t.Errorf("cross-owner overlap via Bind should reject with ErrOwnershipOverlap, got %v", err)
+	}
+}

--- a/pkg/projection/contract.go
+++ b/pkg/projection/contract.go
@@ -48,6 +48,12 @@ type Contract struct {
 	// co-located with, or a logical projection name. Used as the registry key
 	// and in error messages.
 	Name string `json:"name"`
+	// MessageType is the payload type whose Graphable this contract projects for.
+	// Stamped onto every derived ForeignEdgeClaim as its Producer so the T2-seam
+	// reject can key on (message_type, predicate) (ADR-056 Decision 4). Optional:
+	// empty derives Producer-empty ("any producer") foreign edges — the
+	// transitional shape. A contract WITH foreign edges should name its type.
+	MessageType string `json:"message_type,omitempty"`
 	// EntityPattern is the 6-part entity-ID glob the projection writes (the
 	// entity it owns).
 	EntityPattern string `json:"entity_pattern"`
@@ -120,6 +126,7 @@ func (c Contract) registration(owner string) ownership.Registration {
 			Owner:         owner,
 			Predicate:     f.Predicate,
 			Mode:          f.Mode,
+			Producer:      c.MessageType,
 			TargetPattern: f.TargetPattern,
 		})
 	}

--- a/pkg/projection/contract.go
+++ b/pkg/projection/contract.go
@@ -1,0 +1,169 @@
+package projection
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/c360studio/semstreams/pkg/ownership"
+)
+
+// validIndexingProfiles are the ADR-054 channel-b profile values a contract may
+// declare. The contract subsumes the indexing-profile declaration rather than
+// inventing a new surface; stamping it onto create_with_triples is a later
+// (wiring) increment.
+var validIndexingProfiles = map[string]struct{}{
+	"content": {}, "control": {}, "signal": {}, "trace": {},
+}
+
+// validationOwner is a subject-safe placeholder owner used only to run a
+// Contract's derived claims through the ownership validators (which require an
+// owner) without binding it to a real owner. Never registered.
+const validationOwner = "projection-validation-probe"
+
+// PredicateGroup is a set of predicates a projection emits in ONE write mode
+// (ADR-056 Decision 1). A predicate appears in exactly one group per contract —
+// one predicate, one write mode per owner.
+type PredicateGroup struct {
+	Mode       ownership.WriteMode `json:"mode"`
+	Predicates []string            `json:"predicates"`
+}
+
+// ForeignEdge is a relationship edge the projection writes onto a DIFFERENT
+// entity than the one it owns (ADR-056 Decision 4). TargetPattern is the 6-part
+// glob of entities the edge lands on (empty = match-any).
+type ForeignEdge struct {
+	Predicate     string             `json:"predicate"`
+	Mode          ownership.EdgeMode `json:"mode"`
+	TargetPattern string             `json:"target_pattern,omitempty"`
+}
+
+// Contract is the graph projection contract for one entity type / Graphable /
+// gateway resource (ADR-056 Decision 6). It is OWNER-LESS — it declares the
+// SHAPE of what a projection emits; the owner id is bound at Derive/Bind time,
+// because the same projection shape may be emitted by different owners in
+// different deployments.
+type Contract struct {
+	// Name identifies the projection — typically the payload MessageType it is
+	// co-located with, or a logical projection name. Used as the registry key
+	// and in error messages.
+	Name string `json:"name"`
+	// EntityPattern is the 6-part entity-ID glob the projection writes (the
+	// entity it owns).
+	EntityPattern string `json:"entity_pattern"`
+	// Groups are the owned/append predicate groups by write mode.
+	Groups []PredicateGroup `json:"groups,omitempty"`
+	// ForeignEdges are the relationship edges the projection writes onto other
+	// entities.
+	ForeignEdges []ForeignEdge `json:"foreign_edges,omitempty"`
+	// IndexingProfile (ADR-054, optional): one of content|control|signal|trace.
+	IndexingProfile string `json:"indexing_profile,omitempty"`
+}
+
+// Validate checks the contract is well-formed. It runs the contract-specific
+// checks (name, one-write-mode-per-predicate, indexing profile) and then defers
+// pattern / predicate / mode / foreign-edge / self-overlap validation to the
+// ownership validators by deriving claims under a placeholder owner — so the
+// projection layer never re-implements (and never drifts from) ownership's
+// rules.
+func (c Contract) Validate() error {
+	if strings.TrimSpace(c.Name) == "" {
+		return fmt.Errorf("%w: contract has no name", ErrInvalidContract)
+	}
+	if len(c.Groups) == 0 && len(c.ForeignEdges) == 0 {
+		return fmt.Errorf("%w: contract %q declares no predicate groups or foreign edges", ErrInvalidContract, c.Name)
+	}
+
+	// A predicate must have exactly one write mode within a contract (one owner):
+	// the same predicate in replace-owned and append-evidence is contradictory.
+	seen := make(map[string]ownership.WriteMode)
+	for _, g := range c.Groups {
+		for _, p := range g.Predicates {
+			if prev, dup := seen[p]; dup {
+				return fmt.Errorf("%w: contract %q lists predicate %q in two write modes (%q and %q)",
+					ErrInvalidContract, c.Name, p, prev, g.Mode)
+			}
+			seen[p] = g.Mode
+		}
+	}
+
+	if c.IndexingProfile != "" {
+		if _, ok := validIndexingProfiles[c.IndexingProfile]; !ok {
+			return fmt.Errorf("%w: contract %q has unknown indexing profile %q (want content|control|signal|trace)",
+				ErrInvalidContract, c.Name, c.IndexingProfile)
+		}
+	}
+
+	// Full field validation via the ownership validators (pattern, predicates,
+	// modes, foreign edges, intra-registration self-overlap).
+	if err := c.registration(validationOwner).Validate(); err != nil {
+		return fmt.Errorf("%w: contract %q: %w", ErrInvalidContract, c.Name, err)
+	}
+	return nil
+}
+
+// registration builds (without validating) the ownership.Registration this
+// contract derives for the given owner: one OwnerClaim per predicate group, one
+// ForeignEdgeClaim per foreign edge.
+func (c Contract) registration(owner string) ownership.Registration {
+	reg := ownership.Registration{Owner: owner}
+	for _, g := range c.Groups {
+		reg.Claims = append(reg.Claims, ownership.OwnerClaim{
+			Owner:      owner,
+			Pattern:    c.EntityPattern,
+			Predicates: g.Predicates,
+			Mode:       g.Mode,
+		})
+	}
+	for _, f := range c.ForeignEdges {
+		reg.ForeignEdges = append(reg.ForeignEdges, ownership.ForeignEdgeClaim{
+			Owner:         owner,
+			Predicate:     f.Predicate,
+			Mode:          f.Mode,
+			TargetPattern: f.TargetPattern,
+		})
+	}
+	return reg
+}
+
+// Derive binds one or more contracts to an owner id and returns the aggregated
+// ownership.Registration — the claims that owner registers (one OwnerClaim per
+// group across all contracts, one ForeignEdgeClaim per foreign edge). Every
+// contract is validated, and the AGGREGATE is checked for self-overlap (two of
+// the owner's own contracts claiming the same cell — a config bug). Cross-OWNER
+// overlap is left to ownership.RegisterOwner against the live epoch.
+func Derive(owner string, contracts ...Contract) (ownership.Registration, error) {
+	if len(contracts) == 0 {
+		return ownership.Registration{}, fmt.Errorf("%w: no contracts to derive for owner %q", ErrInvalidContract, owner)
+	}
+	reg := ownership.Registration{Owner: owner}
+	seen := make(map[string]struct{}, len(contracts))
+	for _, c := range contracts {
+		if _, dup := seen[c.Name]; dup {
+			return ownership.Registration{}, fmt.Errorf("%w: owner %q derives contract %q more than once", ErrInvalidContract, owner, c.Name)
+		}
+		seen[c.Name] = struct{}{}
+		if err := c.Validate(); err != nil {
+			return ownership.Registration{}, err
+		}
+		derived := c.registration(owner)
+		reg.Claims = append(reg.Claims, derived.Claims...)
+		reg.ForeignEdges = append(reg.ForeignEdges, derived.ForeignEdges...)
+	}
+	if err := reg.Validate(); err != nil {
+		return ownership.Registration{}, fmt.Errorf("%w: deriving owner %q: %w", ErrInvalidContract, owner, err)
+	}
+	return reg, nil
+}
+
+// Bind is the component/gateway boot step: derive the owner's claims from its
+// contracts and register them with the ownership substrate. Returns
+// ownership.ErrOwnershipOverlap (wrapped) when another owner already holds a
+// derived cell.
+func Bind(ctx context.Context, ownerReg *ownership.Registry, owner string, contracts ...Contract) error {
+	registration, err := Derive(owner, contracts...)
+	if err != nil {
+		return err
+	}
+	return ownerReg.RegisterOwner(ctx, registration)
+}

--- a/pkg/projection/contract_test.go
+++ b/pkg/projection/contract_test.go
@@ -17,6 +17,7 @@ const sysPat = "c360.semconnect.systems.csapi.system.*"
 func csapiSystem() Contract {
 	return Contract{
 		Name:          "cs-api.system",
+		MessageType:   "sensorml.asset.v1",
 		EntityPattern: sysPat,
 		Groups: []PredicateGroup{{
 			Mode: ownership.ModeReplaceOwned,
@@ -77,6 +78,11 @@ func TestContract_Derive_Single(t *testing.T) {
 	}
 	if len(reg.ForeignEdges) != 1 || reg.ForeignEdges[0].Owner != "cs-api" {
 		t.Errorf("expected one ForeignEdgeClaim bound to cs-api, got %+v", reg.ForeignEdges)
+	}
+	// The contract's MessageType is stamped onto the derived foreign edge as its
+	// Producer, so the T2-seam can key its reject on (message_type, predicate).
+	if reg.ForeignEdges[0].Producer != "sensorml.asset.v1" {
+		t.Errorf("derived foreign edge Producer = %q, want sensorml.asset.v1", reg.ForeignEdges[0].Producer)
 	}
 	// The dual-use isHostedBy (owned + foreign, same owner) derives cleanly:
 	// Derive runs the self-overlap validator (OwnerClaim×OwnerClaim only), and

--- a/pkg/projection/contract_test.go
+++ b/pkg/projection/contract_test.go
@@ -1,0 +1,149 @@
+package projection
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/ownership"
+)
+
+const sysPat = "c360.semconnect.systems.csapi.system.*"
+
+// csapiSystem is the cs-api System projection from the ADR-056 acceptance
+// fixture: six shared sensorml.* vocabulary predicates owned on the System
+// id-glob, plus isHostedBy as BOTH an owned edge (System→parent) and a
+// no-birth-stub foreign edge (child→System) — same owner, so the cross-type
+// check must not flag it.
+func csapiSystem() Contract {
+	return Contract{
+		Name:          "cs-api.system",
+		EntityPattern: sysPat,
+		Groups: []PredicateGroup{{
+			Mode: ownership.ModeReplaceOwned,
+			Predicates: []string{
+				"sensorml.process.type", "sensorml.process.uid", "sensorml.process.label",
+				"sensorml.process.description", "sensorml.process.position", "sensorml.component.isHostedBy",
+			},
+		}},
+		ForeignEdges: []ForeignEdge{{
+			Predicate: "sensorml.component.isHostedBy", Mode: ownership.EdgeNoBirthStub, TargetPattern: sysPat,
+		}},
+		IndexingProfile: "control",
+	}
+}
+
+func TestContract_Validate(t *testing.T) {
+	if err := csapiSystem().Validate(); err != nil {
+		t.Fatalf("the cs-api System contract should validate: %v", err)
+	}
+
+	bad := []struct {
+		name string
+		c    Contract
+	}{
+		{"no name", Contract{EntityPattern: sysPat, Groups: []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"p"}}}}},
+		{"no groups or edges", Contract{Name: "x", EntityPattern: sysPat}},
+		{"bad pattern", Contract{Name: "x", EntityPattern: "a.b.c", Groups: []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"p"}}}}},
+		{"bad mode", Contract{Name: "x", EntityPattern: sysPat, Groups: []PredicateGroup{{Mode: ownership.WriteMode("bogus"), Predicates: []string{"p"}}}}},
+		{"bad indexing profile", Contract{Name: "x", EntityPattern: sysPat, Groups: []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"p"}}}, IndexingProfile: "nonsense"}},
+		{"predicate in two groups", Contract{Name: "x", EntityPattern: sysPat, Groups: []PredicateGroup{
+			{Mode: ownership.ModeReplaceOwned, Predicates: []string{"p"}},
+			{Mode: ownership.ModeAppendEvidence, Predicates: []string{"p"}},
+		}}},
+		{"bad foreign edge target", Contract{Name: "x", EntityPattern: sysPat, ForeignEdges: []ForeignEdge{{Predicate: "e", Mode: ownership.EdgeConditional, TargetPattern: "a.b"}}}},
+	}
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.c.Validate(); !errors.Is(err, ErrInvalidContract) {
+				t.Errorf("want ErrInvalidContract, got %v", err)
+			}
+		})
+	}
+}
+
+func TestContract_Derive_Single(t *testing.T) {
+	reg, err := Derive("cs-api", csapiSystem())
+	if err != nil {
+		t.Fatalf("derive cs-api System: %v", err)
+	}
+	if reg.Owner != "cs-api" {
+		t.Errorf("owner = %q, want cs-api", reg.Owner)
+	}
+	if len(reg.Claims) != 1 || len(reg.Claims[0].Predicates) != 6 {
+		t.Errorf("expected one OwnerClaim with 6 predicates, got %d claims", len(reg.Claims))
+	}
+	if reg.Claims[0].Owner != "cs-api" || reg.Claims[0].Pattern != sysPat {
+		t.Errorf("derived claim not bound to owner/pattern: %+v", reg.Claims[0])
+	}
+	if len(reg.ForeignEdges) != 1 || reg.ForeignEdges[0].Owner != "cs-api" {
+		t.Errorf("expected one ForeignEdgeClaim bound to cs-api, got %+v", reg.ForeignEdges)
+	}
+	// The dual-use isHostedBy (owned + foreign, same owner) derives cleanly:
+	// Derive runs the self-overlap validator (OwnerClaim×OwnerClaim only), and
+	// the cross-type Owner×ForeignEdge check exempts the same owner — so this is
+	// exercised end-to-end in the Bind integration test, not flagged here.
+}
+
+func TestContract_Derive_Aggregate(t *testing.T) {
+	deployment := Contract{
+		Name:          "cs-api.deployment",
+		EntityPattern: "c360.semconnect.systems.csapi.deployment.*",
+		Groups: []PredicateGroup{{
+			Mode:       ownership.ModeReplaceOwned,
+			Predicates: []string{"cs-api.deployment.parent", "cs-api.deployment.deployedSystems"},
+		}},
+	}
+	reg, err := Derive("cs-api", csapiSystem(), deployment)
+	if err != nil {
+		t.Fatalf("aggregate derive (System + Deployment, disjoint): %v", err)
+	}
+	if len(reg.Claims) != 2 {
+		t.Errorf("expected 2 OwnerClaims from 2 contracts, got %d", len(reg.Claims))
+	}
+}
+
+func TestContract_Derive_CrossContractSelfOverlap(t *testing.T) {
+	// Two contracts of the SAME owner claiming the SAME cell in owning mode — a
+	// config bug Derive must catch (cross-owner overlap is RegisterOwner's job).
+	a := Contract{Name: "a", EntityPattern: sysPat, Groups: []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"dup.predicate"}}}}
+	b := Contract{Name: "b", EntityPattern: sysPat, Groups: []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"dup.predicate"}}}}
+	_, err := Derive("cs-api", a, b)
+	if !errors.Is(err, ownership.ErrOwnershipOverlap) {
+		t.Errorf("two same-owner contracts on one cell must self-overlap, got %v", err)
+	}
+	if !errors.Is(err, ErrInvalidContract) {
+		t.Errorf("the derivation error should also wrap ErrInvalidContract, got %v", err)
+	}
+}
+
+func TestDerive_Empty(t *testing.T) {
+	if _, err := Derive("cs-api"); !errors.Is(err, ErrInvalidContract) {
+		t.Errorf("deriving with no contracts should error, got %v", err)
+	}
+}
+
+func TestDerive_DuplicateContractName(t *testing.T) {
+	c := csapiSystem()
+	if _, err := Derive("cs-api", c, c); !errors.Is(err, ErrInvalidContract) {
+		t.Errorf("deriving the same-named contract twice should error, got %v", err)
+	}
+}
+
+// TestDerive_CrossContractModeContradiction: one owner declaring a predicate as
+// replace-owned in one contract and append-evidence in another, over
+// INTERSECTING patterns, is a contradiction the per-contract check can't see but
+// Derive's aggregate validation must reject.
+func TestDerive_CrossContractModeContradiction(t *testing.T) {
+	owned := Contract{Name: "owned", EntityPattern: sysPat, Groups: []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"shared.p"}}}}
+	appended := Contract{Name: "appended", EntityPattern: sysPat, Groups: []PredicateGroup{{Mode: ownership.ModeAppendEvidence, Predicates: []string{"shared.p"}}}}
+	if _, err := Derive("cs-api", owned, appended); !errors.Is(err, ownership.ErrInvalidClaim) {
+		t.Errorf("owned+append of the same predicate over intersecting patterns must error, got %v", err)
+	}
+
+	// Disjoint patterns: the same predicate may be owned on one entity type and
+	// appended on another — legitimate, no error.
+	appendedElsewhere := Contract{Name: "appended", EntityPattern: "c360.semconnect.systems.csapi.deployment.*", Groups: []PredicateGroup{{Mode: ownership.ModeAppendEvidence, Predicates: []string{"shared.p"}}}}
+	if _, err := Derive("cs-api", owned, appendedElsewhere); err != nil {
+		t.Errorf("owned + append on DISJOINT patterns must be allowed, got %v", err)
+	}
+}

--- a/pkg/projection/doc.go
+++ b/pkg/projection/doc.go
@@ -1,0 +1,33 @@
+// Package projection implements the ADR-056 Decision 6 graph projection
+// contract — the missing middle layer between "what type is flowing" (the
+// payload registry) and "who may author these facts at runtime" (pkg/ownership).
+//
+// A Contract is declared ONCE, beside the type / Graphable / gateway-resource
+// projection code, and answers: "what graph facts does this projection emit,
+// and in what write mode is each predicate group?" Ownership claims are then
+// DERIVED from the contract and bound to an owner id at boot — they are not
+// hand-maintained as a parallel registry that drifts from the projection.
+//
+//	payload type registration
+//	  └─ optionally declares a projection.Contract
+//	       (entity pattern · predicates × write mode · foreign-edge claims · indexing profile)
+//	component / gateway boot
+//	  └─ projection.Bind(ctx, ownerRegistry, ownerID, contracts...)
+//	       derives the ownership.OwnerClaim/ForeignEdgeClaim set and registers it
+//	graph-ingest
+//	  └─ enforces the registered claims at the write boundary (a later increment)
+//
+// This package is the DERIVATION + DECLARATION layer. It does not enforce
+// anything — pkg/ownership is the enforcement substrate, and graph-ingest is the
+// write-boundary enforcer. Manual ownership.RegisterOwner remains the low-level
+// escape hatch for owners whose pattern is not derivable from a single payload
+// type (the lifecycle Manager) or for migration scaffolding.
+//
+// A Contract carries no CoordinationWaiver: a legitimately-overlapping
+// projection (the cross-product / mutual-consent case) is an explicit NON-GOAL
+// of the contract layer and drops to manual ownership.RegisterOwner. If
+// contract-declared overlaps ever become common, that is a signal to add waiver
+// support here rather than let owners drift off the derivation path.
+//
+// See docs/adr/056-authoritative-semantic-state.md Decision 6.
+package projection

--- a/pkg/projection/errors.go
+++ b/pkg/projection/errors.go
@@ -1,0 +1,9 @@
+package projection
+
+import "errors"
+
+// ErrInvalidContract is returned when a projection contract is malformed, or
+// when deriving claims from it produces an inconsistent registration. It wraps
+// the underlying ownership error (errors.Is still matches ownership.ErrInvalidClaim
+// / ownership.ErrOwnershipOverlap) so callers can branch on the precise cause.
+var ErrInvalidContract = errors.New("projection: invalid contract")

--- a/pkg/projection/registry.go
+++ b/pkg/projection/registry.go
@@ -1,0 +1,69 @@
+package projection
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// The global projection-contract registry. Types/components declare their
+// contracts here (typically from init(), co-located with payload registration);
+// component boot enumerates and derives them per owner. Mirrors the
+// payloadregistry idiom the design references.
+var (
+	registryMu sync.RWMutex
+	registry   = make(map[string]Contract)
+)
+
+// Register adds a contract to the global registry, keyed by Name. Validates the
+// contract and rejects a duplicate name. Co-locate the call with the payload
+// type's registration so the projection and the type are declared together.
+func Register(c Contract) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if _, dup := registry[c.Name]; dup {
+		return fmt.Errorf("%w: contract %q already registered", ErrInvalidContract, c.Name)
+	}
+	registry[c.Name] = c
+	return nil
+}
+
+// MustRegister is Register that panics on error — for init()-time registration
+// where a malformed or duplicate contract is a programming error.
+func MustRegister(c Contract) {
+	if err := Register(c); err != nil {
+		panic(fmt.Sprintf("projection.MustRegister(%q): %v", c.Name, err))
+	}
+}
+
+// Lookup returns a registered contract by name.
+func Lookup(name string) (Contract, bool) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	c, ok := registry[name]
+	return c, ok
+}
+
+// Registered returns every registered contract, name-sorted for deterministic
+// enumeration.
+func Registered() []Contract {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	out := make([]Contract, 0, len(registry))
+	for _, c := range registry {
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// resetRegistry clears the global registry — test-only, to isolate cases that
+// exercise registration without leaking state across tests.
+func resetRegistry() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = make(map[string]Contract)
+}

--- a/pkg/projection/registry_test.go
+++ b/pkg/projection/registry_test.go
@@ -1,0 +1,74 @@
+package projection
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/ownership"
+)
+
+func TestRegistry(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	if err := Register(csapiSystem()); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	got, ok := Lookup("cs-api.system")
+	if !ok || got.EntityPattern != sysPat {
+		t.Errorf("lookup after register failed: ok=%v pattern=%q", ok, got.EntityPattern)
+	}
+
+	// Duplicate name is rejected.
+	if err := Register(csapiSystem()); !errors.Is(err, ErrInvalidContract) {
+		t.Errorf("duplicate registration should error, got %v", err)
+	}
+
+	// Invalid contract is rejected at registration time.
+	if err := Register(Contract{Name: "bad"}); !errors.Is(err, ErrInvalidContract) {
+		t.Errorf("invalid contract registration should error, got %v", err)
+	}
+
+	if got := Registered(); len(got) != 1 || got[0].Name != "cs-api.system" {
+		t.Errorf("Registered() = %d contracts, want exactly cs-api.system", len(got))
+	}
+}
+
+func TestRegistered_SortedDeterministic(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	mk := func(name, typeSeg string) Contract {
+		return Contract{
+			Name:          name,
+			EntityPattern: "c360.semconnect.systems.csapi." + typeSeg + ".*",
+			Groups:        []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"p"}}},
+		}
+	}
+	for _, c := range []Contract{mk("z", "ztype"), mk("a", "atype"), mk("m", "mtype")} {
+		if err := Register(c); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := Registered()
+	want := []string{"a", "m", "z"}
+	for i, c := range got {
+		if c.Name != want[i] {
+			t.Errorf("Registered()[%d] = %q, want %q (name-sorted)", i, c.Name, want[i])
+		}
+	}
+}
+
+func TestMustRegister_PanicsOnDuplicate(t *testing.T) {
+	resetRegistry()
+	t.Cleanup(resetRegistry)
+
+	MustRegister(csapiSystem())
+	defer func() {
+		if recover() == nil {
+			t.Error("MustRegister should panic on a duplicate name")
+		}
+	}()
+	MustRegister(csapiSystem())
+}


### PR DESCRIPTION
## ADR-056 W0 — Authoritative Semantic State: the predicate-group ownership contract

Lands [ADR-056](docs/adr/056-authoritative-semantic-state.md) (Accepted, v6) and its **Wave 0**: the framework substrate that names exactly one owner per `(entity-ID pattern, predicate group)` and rejects two owners selecting the same cell in an owning write mode — plus its **first real consumer**, the lifecycle `Manager`.

ADR-056 names a responsibility the framework has carried implicitly since ADR-049 and patched symptomatically through ADR-055: `ENTITY_STATES` is no longer just a fact-materialization surface — for a growing class of entities it is the framework's **authoritative state store**, and nothing arbitrated who may write which predicate group. W0 makes that arbitration real.

### What's in this PR

**Substrate (`pkg/ownership`) — the W0 spine + Decision 4/6 logic**
- Claim types (`OwnerClaim`, `ForeignEdgeClaim`, `CoordinationWaiver`) modelling the Decision-1 tuple.
- A **single-epoch-key registry** advanced under `UpdateWithRetry` CAS, so cross-process overlap is detected (every registrant of any claim serializes through one `_registry` key) — glob×exact-predicate intersection incl. the Owner×ForeignEdge cross-type check.
- Stale-owner compaction via a separate `OWNER_PRESENCE` heartbeat bucket; `OwnerOf` lease lookup; registration-time inverse-gate (`CheckInverseGate`).

**Projection layer (`pkg/projection`) — Decision 6**
- A `Contract` declared beside the type/Graphable/resource projection; ownership claims **derive** from it (`Bind`) rather than being hand-maintained as a parallel registry that drifts.

**First consumer (`pkg/lifecycle.Manager`) — Decision 5 embed** *(new in this increment)*
- `ownership.EnsureBuckets` — **eager**, idempotent bucket creation (`OWNER_CLAIMS` audit-history/no-TTL; `OWNER_PRESENCE` bucket-TTL = the staleness backstop), returns a `Registry`. Deliberately **not** in graph-ingest: a pre-implementation architect review found that `NewManager`/`Register` run *before* the flow service (and graph-ingest) boot in every binary, so co-locating creation there would make every registration a silent no-op.
- `ownership.Heartbeater` — substrate-owned liveness ticker, driven over a shutdown-cancelled context (no `Close` for sister repos to adopt).
- `Manager.AttachOwnership(ctx, reg)` — embeds the registry; each `Workflow` derives **two mode-faithful claims** (phase = `cas-transition`; audit + writable projected fields = `replace-owned`). Read-only / reference / child-link predicates the Manager doesn't author are not claimed.
- `Register` runs `RegisterOwner` outside the lock; a cross-owner overlap is **observe-only** (logged, still registers — Decision 5 no-brick posture; the substrate still rejects it), a malformed self-claim is fatal, a nil registry is a pure no-op (**graceful-skip** for resourceless/unmigrated deploys). Owner id = workflow Name.
- Wired into `cmd/semstreams` + `cmd/e2e-semstreams` before `Register`.

### Posture & what's deferred

The first consumer is **observe-only** at runtime, consistent with Decision 5 (a partial migration must not brick boot). The **write-gating half** is deferred, each its own increment (named in `pkg/ownership/doc.go`): the `OwnerToken` write-lease check + `ErrorCodeOwnerLeaseStale`, the Watch-revival fatal-halt, the hard-fail-on-overlap flip + metric, the Decision-4 T2-seam reject + `PENDING_EDGES` buffer + crash-recovery flip-gate, and the Decision-6 projection-contract derivation wiring into graph-ingest boot. Until the lease/Watch land, an evicted-then-revived owner only churns the epoch (no dropped writes) — which is why observe-only is safe to ship first.

Sister repos (semspec/semteams/semconnect) opt in by adding the `EnsureBuckets` + `AttachOwnership` pair; absent it, behaviour is exactly pre-ADR-056.

### Verification

- `task lint` clean (revive) · `go test -race ./...` · `go test -race -tags=integration ./...` (one failure was a confirmed testcontainer Docker-contention flake — passes in isolation; `graph-ingest` doesn't import the changed packages) · `task schema:generate` no drift · contract tests green.
- **`task e2e:lifecycle` green** — the ADR-047 harness gateway + rule round-trip scenario passes against the rebuilt binary that now calls `EnsureBuckets` + `AttachOwnership` before `Register` (the Manager boot-surface change this PR makes).
- New tests: unit (mode-split derivation, graceful-skip, nil-registry no-op) + integration (Manager-driven cross-process overlap end-to-end, disjoint coexistence, `EnsureBuckets` TTL/history config, `Heartbeater` bump + stop-on-cancel).
- Adversarial **architect** review reshaped the embed seam pre-implementation (the boot-ordering hazard above); a pre-merge **go-reviewer** pass verified every design invariant and flagged one HIGH (heartbeat ctx never cancelled → goroutine leak + false "no Close" contract), **fixed here** — both mains pass a shutdown-cancelled context, LIFO-ordered to stop the heartbeat before the NATS client closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
