### PR TITLE
ADR-056 W0 Decision-4 4a: T2-seam foreign-edge reject (observe-only)

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -39,6 +39,7 @@ import (
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/service"
 	"github.com/c360studio/semstreams/types"
+	"github.com/c360studio/semstreams/vocabulary"
 )
 
 const (
@@ -239,7 +240,7 @@ func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ 
 	// graph-ingest (which creates the other framework buckets) boots later than
 	// this wiring, so the ownership buckets must be created here. A NATS hiccup
 	// logs + skips — ownership is best-effort observe-only, never a boot gate.
-	if ownerReg, err := ownership.EnsureBuckets(ctx, svcDeps.NATSClient, svcDeps.Logger); err != nil {
+	if ownerReg, err := ownership.EnsureBuckets(ctx, svcDeps.NATSClient, svcDeps.Logger, vocabulary.InverseResolver); err != nil {
 		svcDeps.Logger.Warn("ownership: bucket bootstrap failed — lifecycle ownership disabled this boot", slog.Any("error", err))
 	} else {
 		svcDeps.LifecycleManager.AttachOwnership(ctx, ownerReg)

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -37,6 +37,7 @@ import (
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/service"
 	"github.com/c360studio/semstreams/types"
+	"github.com/c360studio/semstreams/vocabulary"
 )
 
 // Build information constants
@@ -195,7 +196,7 @@ func run() error {
 	// the ownership buckets there would make every registration a silent no-op.
 	// A NATS hiccup logs + skips; ownership is best-effort observe-only, never a
 	// boot gate ([[feedback_unconditional_resource_wiring_breaks_resourceless_deploys]]).
-	if ownerReg, err := ownership.EnsureBuckets(ctx, natsClient, logger); err != nil {
+	if ownerReg, err := ownership.EnsureBuckets(ctx, natsClient, logger, vocabulary.InverseResolver); err != nil {
 		logger.Warn("ownership: bucket bootstrap failed — lifecycle ownership disabled this boot", slog.Any("error", err))
 	} else {
 		// The heartbeat goroutine must stop on shutdown. `ctx` here is

--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -138,6 +138,28 @@ shape.
   is exactly pre-ADR-056 (graceful-skip for resourceless/unmigrated deploys). Pure-logic + testcontainer
   tested through `Manager.Register` (the production entry), `task lint` clean; an `e2e:lifecycle` tier
   run gates the merge (Manager boot-surface change).
+- **W0 4a landed — the T2-seam reject (OBSERVE-ONLY).** Increment 3: the foreign-routing seam
+  (`ingestEntity`, `component.go`) now CLASSIFIES each foreign-subject edge against the registered
+  `ForeignEdgeClaim`s and counts the unclaimed ones on `foreign_edge_unclaimed_total{message_type,predicate}`
+  with a one-time WARN per `(message_type,predicate)` — **it does NOT change routing** (edges are
+  still appended, deprecated-on-arrival; the hard reject + the ADR-055 must-exist flip are 4c).
+  graph-ingest is a **reader** of `OWNER_CLAIMS` via a read-only `ownership.ClaimReader` (one epoch
+  read per foreign-bearing ingest; graceful-skip to no-classification when the bucket is absent).
+  The boot-time **inverse-gate** is wired (`RegisterOwner` runs `CheckInverseGate` over the
+  registration's foreign edges using a `vocabulary.InverseResolver` injected at `EnsureBuckets`;
+  nil-resolver → skip-with-WARN), and the **FE-claim-only compaction exemption** (an FE claim is not
+  a lease — it contests nothing — so it is not liveness-reaped, which otherwise made the metric flap
+  every `PresenceTTL`). sensorml's `WithInverseOf` is registered. **Two caveats pinned by a
+  pre-implementation architect review and load-bearing for 4c's gate:** (1) **No production producer
+  emits foreign edges today** — OMS and StoredMessage (the Graphables that reach the seam in
+  `cmd/semstreams`) emit none, and sensorml is not a registered payload nor ingested by any binary.
+  So `foreign_edge_unclaimed_total` reads **zero in production BY ABSENCE**, NOT because producers
+  migrated — 4c's "hatch-empty over a bake window" gate must not read this zero as "migrated," and
+  the seam is exercised by a **registered test-fixture producer**, not sensorml-in-prod (wiring
+  sensorml into the framework binary would be the framework-vs-product boundary trap). A real
+  SensorML ingest path is separate, larger work. (2) The metric counts edges **CLASSIFIED-unclaimed
+  at the seam**, NOT routing failures (it fires before `AddTriples`' all-or-nothing batch), which is
+  the semantics 4c's gate must assume.
 
 ### v4 → v5: implementation contracts pinned (1 BLOCKING + P1s; no architectural forks)
 
@@ -1067,19 +1089,26 @@ broken; this ADR fixes both (KV-backed pending buffer + the registration-time in
    foreign-edge predicate with no registered inverse and no KV-durable producer guarantee
    lands HERE by the gate, not in a silent Conditional drop.
 
-**BLOCKING-B fix part 4 — wire `WithInverseOf` for sensorml (change described, not
-implemented).** `parser/sensorml/predicates.go:96-97` registers `PredHosts`/`PredIsHostedBy`
-with `WithIRI` only. The change: add `WithInverseOf(PredIsHostedBy)` to the `PredHosts`
-registration and `WithInverseOf(PredHosts)` to the `PredIsHostedBy` registration (mirroring
-the 6 hierarchy predicates at `vocabulary/hierarchy.go:25-64` and the 2 delegation predicates at
+**BLOCKING-B fix part 4 — wire `WithInverseOf` for sensorml (landed in W0 4a).**
+`parser/sensorml/predicates.go:96-97` registered `PredHosts`/`PredIsHostedBy` with `WithIRI`
+only. The change: add `WithInverseOf(PredIsHostedBy)` to the `PredHosts` registration and
+`WithInverseOf(PredHosts)` to the `PredIsHostedBy` registration (mirroring the 6 hierarchy
+predicates at `vocabulary/hierarchy.go:25-64` and the 2 delegation predicates at
 `vocabulary/agentic/register.go:162,168`, the only existing inverse-bearing predicates). Then
 `GetInversePredicate("sensorml.system.hosts") == "sensorml.component.isHostedBy"` and vice
-versa, so sensorml's foreign `isHostedBy` edge becomes genuinely Backfill-recoverable AND
-passes the inverse-gate as `Conditional`. (This honors the doc-comment at
-`predicates.go:29-30` that already *asserts* the inverse relationship the registration omitted.
-sensorml already emits both directions explicitly at parse time, `graphable.go:122-125`, so
-the registered inverse is also the correct semantic backstop if the explicit child-subject
-write ever races.)
+versa, so sensorml's foreign `isHostedBy` edge becomes genuinely Backfill-recoverable.
+
+**The registered inverse makes `Conditional` LEGAL for this edge — it does NOT make it the
+edge's mode (contradiction resolved).** An earlier draft said the edge "passes the inverse-gate
+*as Conditional*," which read as a mode recommendation and contradicted the fourth-path ruling
+above (the sensorml child has no independent birth, so its correct mode is **`NoBirthStub`** —
+lane ii — which `requiresInverse() == false` and passes the gate trivially, with or without the
+inverse). The `WithInverseOf` change is about gate *eligibility* (Conditional/Backfill become
+permissible should the edge ever be re-classified) and about the **Backfill recoverability
+floor**, not about declaring the no-birth child Conditional. (It also honors the doc-comment at
+`predicates.go:29-30` that already *asserted* the inverse the registration omitted; sensorml
+emits both directions explicitly at parse time, `graphable.go:122-125`, so the registered inverse
+is the correct semantic backstop if the explicit child-subject write ever races.)
 
 **Fix part 5 — the sharpened flip-gate predicate (hatch-empty, not merely wired).** ADR-055's
 closing move (delete both auto-vivify branches, flip `triple.add`/`add_batch` to must-exist) must

--- a/parser/sensorml/predicates.go
+++ b/parser/sensorml/predicates.go
@@ -93,8 +93,19 @@ func init() {
 	vocabulary.Register(PredDefinition,
 		vocabulary.WithIRI("http://www.w3.org/2000/01/rdf-schema#isDefinedBy"))
 
-	vocabulary.Register(PredHosts, vocabulary.WithIRI(sosa.Hosts))
-	vocabulary.Register(PredIsHostedBy, vocabulary.WithIRI(sosa.IsHostedBy))
+	// PredHosts/PredIsHostedBy are mutual inverses (the doc-comment above has
+	// asserted this since the start; the registration now honors it — ADR-056
+	// Decision 4). The registered inverse is the Backfill recoverability floor for
+	// the foreign isHostedBy edge and lets it pass the inverse-gate should it ever
+	// be declared Conditional/Backfill. (The no-birth sensorml child's correct
+	// edge-mode is NoBirthStub, which needs no inverse; the inverse is correct and
+	// free regardless.)
+	vocabulary.Register(PredHosts,
+		vocabulary.WithIRI(sosa.Hosts),
+		vocabulary.WithInverseOf(PredIsHostedBy))
+	vocabulary.Register(PredIsHostedBy,
+		vocabulary.WithIRI(sosa.IsHostedBy),
+		vocabulary.WithInverseOf(PredHosts))
 	vocabulary.Register(PredHasSubSystem, vocabulary.WithIRI(sosa.SSNHasSubSystem))
 	vocabulary.Register(PredUsedProcedure, vocabulary.WithIRI(sosa.UsedProcedure))
 	vocabulary.Register(PredAttachedTo, vocabulary.WithIRI(sosa.IsHostedBy))

--- a/parser/sensorml/predicates_test.go
+++ b/parser/sensorml/predicates_test.go
@@ -1,0 +1,21 @@
+package sensorml
+
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/vocabulary"
+)
+
+// ADR-056 Decision-4 BLOCKING-B part 4: PredHosts/PredIsHostedBy are registered
+// as mutual inverses (predicates.go init()), so GetInversePredicate resolves both
+// ways — the Backfill recoverability floor for the foreign isHostedBy edge.
+// Before the fix it returned "" (the false backstop the original design rested
+// on), even though the constant doc-comment asserted the inverse.
+func TestHostsIsHostedByMutualInverse(t *testing.T) {
+	if got := vocabulary.GetInversePredicate(PredHosts); got != PredIsHostedBy {
+		t.Errorf("GetInversePredicate(%q) = %q, want %q", PredHosts, got, PredIsHostedBy)
+	}
+	if got := vocabulary.GetInversePredicate(PredIsHostedBy); got != PredHosts {
+		t.Errorf("GetInversePredicate(%q) = %q, want %q", PredIsHostedBy, got, PredHosts)
+	}
+}

--- a/pkg/lifecycle/ownership_integration_test.go
+++ b/pkg/lifecycle/ownership_integration_test.go
@@ -33,7 +33,7 @@ func TestIntegration_ManagerOwnership_FirstConsumerEndToEnd(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	reg, err := ownership.EnsureBuckets(ctx, tc.Client, nil)
+	reg, err := ownership.EnsureBuckets(ctx, tc.Client, nil, nil)
 	require.NoError(t, err, "EnsureBuckets must create the framework buckets against real NATS")
 
 	// Process A registers the fixture workflow through the registry.
@@ -50,7 +50,7 @@ func TestIntegration_ManagerOwnership_FirstConsumerEndToEnd(t *testing.T) {
 	// Process B: a DIFFERENT owner claiming the SAME pattern + phase predicate.
 	// A separate Registry over the same (idempotently re-ensured) buckets
 	// simulates a second process.
-	regB, err := ownership.EnsureBuckets(ctx, tc.Client, nil)
+	regB, err := ownership.EnsureBuckets(ctx, tc.Client, nil, nil)
 	require.NoError(t, err)
 	mgrB := NewManager(tc.Client, nil)
 	mgrB.AttachOwnership(ctx, regB)
@@ -87,7 +87,7 @@ func TestIntegration_ManagerOwnership_DisjointOwnersCoexist(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	reg, err := ownership.EnsureBuckets(ctx, tc.Client, nil)
+	reg, err := ownership.EnsureBuckets(ctx, tc.Client, nil, nil)
 	require.NoError(t, err)
 
 	mgr := NewManager(tc.Client, nil)

--- a/pkg/ownership/bootstrap.go
+++ b/pkg/ownership/bootstrap.go
@@ -38,7 +38,13 @@ const ownerClaimsHistory = 10
 // PENDING_EDGES (BucketPendingEdges) is deliberately NOT created here: its
 // consumer (the Decision-4 foreign-edge buffer) is a later increment, and a
 // bucket created with no reader reads as a half-wired bug.
-func EnsureBuckets(ctx context.Context, client *natsclient.Client, logger *slog.Logger) (*Registry, error) {
+//
+// resolver is the Decision-4 inverse-gate's InverseResolver (an adapter over
+// vocabulary.GetInversePredicate, wired by the caller so this package stays free
+// of the vocabulary dependency). Pass nil to skip the gate (observe-only / read-
+// only consumers) — RegisterOwner then warns once if a would-be-gated claim is
+// registered, rather than silently admitting an unrecoverable foreign edge.
+func EnsureBuckets(ctx context.Context, client *natsclient.Client, logger *slog.Logger, resolver InverseResolver) (*Registry, error) {
 	if client == nil {
 		return nil, fmt.Errorf("ownership: EnsureBuckets requires a non-nil NATS client")
 	}
@@ -64,5 +70,7 @@ func EnsureBuckets(ctx context.Context, client *natsclient.Client, logger *slog.
 		return nil, fmt.Errorf("ownership: create %s bucket: %w", BucketOwnerPresence, err)
 	}
 
-	return NewRegistry(client.NewKVStore(claims), client.NewKVStore(presence), logger), nil
+	reg := NewRegistry(client.NewKVStore(claims), client.NewKVStore(presence), logger)
+	reg.inverseResolver = resolver
+	return reg, nil
 }

--- a/pkg/ownership/bootstrap_integration_test.go
+++ b/pkg/ownership/bootstrap_integration_test.go
@@ -19,7 +19,7 @@ func TestIntegration_EnsureBuckets_ConfigAndUsable(t *testing.T) {
 	tc := natsclient.NewTestClient(t, natsclient.WithKV())
 	ctx := context.Background()
 
-	r, err := EnsureBuckets(ctx, tc.Client, nil)
+	r, err := EnsureBuckets(ctx, tc.Client, nil, nil)
 	if err != nil {
 		t.Fatalf("EnsureBuckets: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestIntegration_EnsureBuckets_ConfigAndUsable(t *testing.T) {
 	}
 	// EnsureBuckets is idempotent — a second call (a second process) returns a
 	// working Registry over the same buckets and sees the first's claim.
-	r2, err := EnsureBuckets(ctx, tc.Client, nil)
+	r2, err := EnsureBuckets(ctx, tc.Client, nil, nil)
 	if err != nil {
 		t.Fatalf("EnsureBuckets (2nd): %v", err)
 	}

--- a/pkg/ownership/claim_reader.go
+++ b/pkg/ownership/claim_reader.go
@@ -1,0 +1,102 @@
+package ownership
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// ClaimReader is a READ-ONLY view of the registered ForeignEdgeClaims, for the
+// ADR-056 Decision-4 T2-seam reject. graph-ingest is the WRITER of ENTITY_STATES
+// but a READER of OWNER_CLAIMS: at the foreign-routing seam it classifies a
+// producer's foreign-subject predicates as claimed or unclaimed, emitting the
+// unclaimed reject metric.
+//
+// Unlike Registry, a ClaimReader NEVER creates the bucket and NEVER registers —
+// a reader must not conjure the substrate (that is EnsureBuckets' eager-boot
+// job). It opens the existing OWNER_CLAIMS read-only and reads the epoch on
+// demand. Production foreign-edge volume is zero today (OMS/StoredMessage emit no
+// foreign edges), so the per-call epoch read costs nothing in production; a
+// Watch-backed cache is a later (4b) optimisation for when foreign edges flow.
+type ClaimReader struct {
+	claims *natsclient.KVStore
+	logger *slog.Logger
+}
+
+// NewClaimReader opens OWNER_CLAIMS read-only. It returns an error (the caller
+// graceful-skips classification — the seam stays observe-only) when the bucket
+// cannot be opened: a resourceless / unmigrated deploy that never ran
+// EnsureBuckets, or a transient connection blip at boot. It does NOT create the
+// bucket.
+func NewClaimReader(ctx context.Context, client *natsclient.Client, logger *slog.Logger) (*ClaimReader, error) {
+	if client == nil {
+		return nil, fmt.Errorf("ownership: NewClaimReader requires a non-nil NATS client")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	bucket, err := client.GetKeyValueBucket(ctx, BucketOwnerClaims)
+	if err != nil {
+		return nil, fmt.Errorf("ownership: open %s read-only: %w", BucketOwnerClaims, err)
+	}
+	return &ClaimReader{claims: client.NewKVStore(bucket), logger: logger}, nil
+}
+
+// UnclaimedForeignEdges reads the epoch ONCE and returns the deduped, sorted
+// subset of `predicates` that have NO registered ForeignEdgeClaim covering
+// (producer, predicate) — the foreign edges the T2-seam flags as unclaimed. An
+// exact-producer claim wins; a Producer-empty ("any producer") claim is the
+// fallback (epoch.foreignEdgeClaimFor). An empty/absent registry means nothing
+// is claimed → every predicate is unclaimed. The classification is read-only and
+// allocates nothing on the no-foreign-edges happy path (callers pass a non-empty
+// predicates slice only when foreign triples exist).
+func (cr *ClaimReader) UnclaimedForeignEdges(ctx context.Context, producer string, predicates []string) ([]string, error) {
+	uniq := dedupeStrings(predicates)
+	if len(uniq) == 0 {
+		return nil, nil
+	}
+
+	entry, err := cr.claims.Get(ctx, registryKey)
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return uniq, nil // empty registry: nothing claimed yet → all unclaimed
+		}
+		return nil, fmt.Errorf("ownership: read epoch for foreign-edge classification: %w", err)
+	}
+	ep, err := decodeEpoch(entry.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	var unclaimed []string
+	for _, p := range uniq {
+		if _, ok := ep.foreignEdgeClaimFor(producer, p); !ok {
+			unclaimed = append(unclaimed, p)
+		}
+	}
+	return unclaimed, nil
+}
+
+// dedupeStrings returns the sorted, de-duplicated set of non-empty strings.
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sortStrings(out)
+	return out
+}

--- a/pkg/ownership/claim_reader_integration_test.go
+++ b/pkg/ownership/claim_reader_integration_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package ownership
+
+import (
+	"context"
+	"testing"
+
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// ClaimReader classifies a producer's foreign-edge predicates against the live
+// epoch: exact-producer match wins, a Producer-empty claim is the any-producer
+// fallback, an empty/absent registry means everything is unclaimed, and an
+// absent bucket errors so the caller graceful-skips.
+func TestIntegration_ClaimReader_Classification(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	ctx := context.Background()
+
+	reg, err := EnsureBuckets(ctx, tc.Client, nil, nil)
+	if err != nil {
+		t.Fatalf("EnsureBuckets: %v", err)
+	}
+
+	cr, err := NewClaimReader(ctx, tc.Client, nil)
+	if err != nil {
+		t.Fatalf("NewClaimReader: %v", err)
+	}
+
+	// Empty registry → everything is unclaimed (deduped, sorted).
+	got, err := cr.UnclaimedForeignEdges(ctx, "test.fixture.v1", []string{"b.edge", "a.edge", "a.edge"})
+	if err != nil {
+		t.Fatalf("UnclaimedForeignEdges (empty): %v", err)
+	}
+	if len(got) != 2 || got[0] != "a.edge" || got[1] != "b.edge" {
+		t.Fatalf("empty registry: got %v, want [a.edge b.edge] (deduped, sorted)", got)
+	}
+
+	// Register an exact-producer claim on claimed.edge and a Producer-empty
+	// (any-producer) claim on shared.edge.
+	if err := reg.RegisterOwner(ctx, Registration{
+		Owner: "producer-a",
+		ForeignEdges: []ForeignEdgeClaim{
+			{Owner: "producer-a", Predicate: "claimed.edge", Mode: EdgeNoBirthStub, Producer: "test.fixture.v1"},
+		},
+	}); err != nil {
+		t.Fatalf("register producer-a: %v", err)
+	}
+	if err := reg.RegisterOwner(ctx, Registration{
+		Owner: "any-producer-owner",
+		ForeignEdges: []ForeignEdgeClaim{
+			{Owner: "any-producer-owner", Predicate: "shared.edge", Mode: EdgeNoBirthStub, Producer: ""},
+		},
+	}); err != nil {
+		t.Fatalf("register any-producer-owner: %v", err)
+	}
+
+	// Exact producer: claimed.edge is covered; unclaimed.edge is not.
+	got, err = cr.UnclaimedForeignEdges(ctx, "test.fixture.v1", []string{"claimed.edge", "unclaimed.edge"})
+	if err != nil {
+		t.Fatalf("UnclaimedForeignEdges (exact): %v", err)
+	}
+	if len(got) != 1 || got[0] != "unclaimed.edge" {
+		t.Fatalf("exact producer: got %v, want [unclaimed.edge]", got)
+	}
+
+	// A DIFFERENT producer does not match producer-a's exact claim, but DOES
+	// match the any-producer shared.edge claim.
+	got, err = cr.UnclaimedForeignEdges(ctx, "other.type.v1", []string{"claimed.edge", "shared.edge"})
+	if err != nil {
+		t.Fatalf("UnclaimedForeignEdges (other producer): %v", err)
+	}
+	if len(got) != 1 || got[0] != "claimed.edge" {
+		t.Fatalf("other producer: got %v, want [claimed.edge] (shared.edge covered by any-producer claim)", got)
+	}
+}
+
+// NewClaimReader on a deploy that never created OWNER_CLAIMS returns an error so
+// the caller (graph-ingest) graceful-skips classification.
+func TestIntegration_ClaimReader_AbsentBucketErrors(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	if _, err := NewClaimReader(context.Background(), tc.Client, nil); err == nil {
+		t.Fatal("NewClaimReader must error when OWNER_CLAIMS is absent (graceful-skip signal)")
+	}
+}

--- a/pkg/ownership/claim_test.go
+++ b/pkg/ownership/claim_test.go
@@ -2,6 +2,7 @@ package ownership
 
 import (
 	"errors"
+	"log/slog"
 	"testing"
 )
 
@@ -184,6 +185,79 @@ func TestEpoch_CompactStale(t *testing.T) {
 	}
 	if _, ok := ep.Owners["registrant"]; !ok {
 		t.Error("registrant must never be compacted (it is registering now)")
+	}
+}
+
+// A dead owner whose entry is FE-claim-ONLY is exempt from compaction: a
+// ForeignEdgeClaim is not a lease and is not heartbeat-enrolled, so reaping it
+// on liveness only makes the T2-seam reject flap. A dead owner that ALSO holds
+// an OwnerClaim is still reaped (it holds a contested cell).
+func TestEpoch_CompactStale_ExemptsForeignEdgeOnlyOwners(t *testing.T) {
+	ep := newEpoch()
+	ep.Owners["fe-only"] = ownerEntry{ForeignEdges: []ForeignEdgeClaim{fe("fe-only", "x.edge", "", EdgeNoBirthStub)}}
+	ep.Owners["mixed"] = ownerEntry{
+		Claims:       []OwnerClaim{oc("mixed", "a.b.c.d.e.f", ModeReplaceOwned, "p")},
+		ForeignEdges: []ForeignEdgeClaim{fe("mixed", "y.edge", "", EdgeStrict)},
+	}
+	ep.Owners["owning-dead"] = ownerEntry{Claims: []OwnerClaim{oc("owning-dead", "a.b.c.d.e.g", ModeReplaceOwned, "p")}}
+	// A degenerate empty entry (no claims, no edges) is NOT exempt — the
+	// exemption guards FE-claim-only owners, not empties. validateStructural
+	// prevents registering one, so this is defense-in-depth.
+	ep.Owners["empty-dead"] = ownerEntry{}
+
+	// No owner has presence — all are "dead". Registrant is a fresh fifth owner.
+	evicted := ep.compactStale("registrant", map[string]struct{}{})
+
+	if _, ok := ep.Owners["fe-only"]; !ok {
+		t.Error("FE-claim-only owner must be exempt from compaction")
+	}
+	if _, ok := ep.Owners["mixed"]; ok {
+		t.Error("owner with an OwnerClaim (even alongside a foreign edge) must still be compacted when dead")
+	}
+	if _, ok := ep.Owners["owning-dead"]; ok {
+		t.Error("dead owning owner must be compacted")
+	}
+	if _, ok := ep.Owners["empty-dead"]; ok {
+		t.Error("a degenerate empty entry must still be compacted (the exemption is FE-only, not empty)")
+	}
+	// evicted names the three non-exempt owners, not the FE-only one.
+	if len(evicted) != 3 {
+		t.Fatalf("evicted = %v, want [empty-dead mixed owning-dead]", evicted)
+	}
+}
+
+// The Registry-level inverse-gate (Decision 4): with a resolver wired,
+// RegisterOwner rejects a Conditional/Backfill foreign edge lacking a registered
+// inverse; NoBirthStub/Strict pass; with NO resolver the gate is skipped
+// (observe-only fail-open). Exercises the wrapper without NATS — checkInverseGate
+// touches only the resolver + logger, not the buckets.
+func TestRegistry_checkInverseGate(t *testing.T) {
+	resolve := func(p string) (string, bool) {
+		if p == "has.inverse" {
+			return "inv.of.it", true
+		}
+		return "", false
+	}
+	withResolver := &Registry{logger: slog.Default(), inverseResolver: resolve}
+
+	condNoInv := fe("o", "no.inverse", "", EdgeConditional)
+	if err := withResolver.checkInverseGate([]ForeignEdgeClaim{condNoInv}); !errors.Is(err, ErrInvalidClaim) {
+		t.Errorf("Conditional edge without a registered inverse must fail the gate; got %v", err)
+	}
+	condWithInv := fe("o", "has.inverse", "", EdgeConditional)
+	if err := withResolver.checkInverseGate([]ForeignEdgeClaim{condWithInv}); err != nil {
+		t.Errorf("Conditional edge WITH a registered inverse must pass; got %v", err)
+	}
+	stub := fe("o", "no.inverse", "", EdgeNoBirthStub)
+	if err := withResolver.checkInverseGate([]ForeignEdgeClaim{stub}); err != nil {
+		t.Errorf("NoBirthStub needs no inverse, must pass; got %v", err)
+	}
+
+	// No resolver wired: the gate is skipped (fail-open), even for a Conditional
+	// edge that would otherwise be rejected.
+	noResolver := &Registry{logger: slog.Default()}
+	if err := noResolver.checkInverseGate([]ForeignEdgeClaim{condNoInv}); err != nil {
+		t.Errorf("nil resolver must skip the gate (observe-only); got %v", err)
 	}
 }
 

--- a/pkg/ownership/doc.go
+++ b/pkg/ownership/doc.go
@@ -35,15 +35,30 @@
 //     logged, not bricked (Decision 5); the substrate still REJECTS it (the
 //     Manager swallows the rejection deliberately).
 //
+// W0 4a landed (Decision 4 T2-seam reject, OBSERVE-ONLY):
+//
+//   - The inverse-gate is now ENFORCED at registration: RegisterOwner runs
+//     CheckInverseGate over the registration's foreign edges using an injected
+//     InverseResolver (set via EnsureBuckets; nil → skip-with-warn-once).
+//   - FE-claim-only owners are EXEMPT from liveness compaction (see compactStale)
+//     — they are not leases. KNOWN 4b/4c follow-up: a dead FE-only owner now
+//     persists, so the cross-type overlap check could strand a live owning-claim
+//     registrant against it (not reachable today; see the compactStale comment).
+//   - ClaimReader is the read-only view graph-ingest uses to classify foreign
+//     edges at the T2-seam (observe-only: meter unclaimed + route anyway). The
+//     graph-ingest seam wiring + the foreign_edge_unclaimed_total metric live in
+//     processor/graph-ingest.
+//
 // What is deliberately NOT here yet (later W0 increments, each with its own
 // review):
 //
-//   - The ForeignEdgeClaim T2-regroup-seam reject in graph-ingest (Decision 4
-//     BLOCKING-B). The registration-time inverse-gate (CheckInverseGate) is
-//     pure-logic-present; the graph-ingest write-boundary wiring is deferred.
+//   - The HARD T2-seam reject (4c) — 4a routes unclaimed foreign edges
+//     deprecated-on-arrival; the hard reject is gated on the metric reading zero
+//     over a bake window.
 //   - The PENDING_EDGES Conditional-edge buffer + delete-after-apply drain +
-//     boot re-drain + the counting crash-recovery flip-gate test (Decision 4).
-//     EnsureBuckets does NOT create PENDING_EDGES yet (no consumer).
+//     boot re-drain + the fourth-path (ensureReferencedEntityExists) fold + the
+//     counting crash-recovery flip-gate test (Decision 4 / 4b). EnsureBuckets
+//     does NOT create PENDING_EDGES yet (no consumer).
 //   - The OwnerToken wire field on the graph mutation requests + the handler
 //     lease check returning ErrorCodeOwnerLeaseStale (Decision 2 write seam),
 //     and the post-registration Watch-revival fatal-halt. These two are the

--- a/pkg/ownership/epoch.go
+++ b/pkg/ownership/epoch.go
@@ -84,11 +84,34 @@ func (e *epoch) setWaiversFor(declarer string, waivers []CoordinationWaiver) {
 // for never blocking a restart on a dead owner's stale claim (Decision 2).
 func (e *epoch) compactStale(registrant string, livePresence map[string]struct{}) []string {
 	var evicted []string
-	for owner := range e.Owners {
+	for owner, entry := range e.Owners {
 		if owner == registrant {
 			continue
 		}
 		if _, live := livePresence[owner]; live {
+			continue
+		}
+		// FE-claim-only owners are exempt from liveness compaction. A
+		// ForeignEdgeClaim is NOT a lease — it contests nothing (FE×FE never
+		// overlap; the inverse-gate, not the Decision-2 overlap check, governs
+		// it), so reaping a dead FE-claim owner frees no contested cell. It is
+		// registered once at boot from a static contract and is NOT enrolled in
+		// any heartbeater (unlike a lifecycle.Manager OwnerClaim), so without this
+		// exemption its presence key TTL-expires after PresenceTTL and the next
+		// registrant evicts it — making the T2-seam reject flap (claim seen for
+		// ~120s after each boot, then gone). An owner holding ANY OwnerClaim is
+		// still reaped: those DO hold contested cells a live owner may need.
+		//
+		// KNOWN FOLLOW-UP (4b/4c): a dead FE-only owner now persists indefinitely
+		// (nothing heartbeats the projection/Bind path — only lifecycle.Manager
+		// enrolls a Heartbeater), so the cross-type check (checkOverlap #2,
+		// overlap.go) could later flag a LIVE owning-claim registrant against this
+		// DEAD FE incumbent — the "stale claim blocks a restart" shape for the
+		// OwnerClaim-vs-dead-FE direction. Not reachable today (no production FE
+		// producer; Bind has no production caller). The fix — skip dead incumbents
+		// in the cross-type check, heartbeat-enroll FE owners, or declare FE claims
+		// permanent-until-resign — is a 4b/4c decision.
+		if len(entry.Claims) == 0 && len(entry.ForeignEdges) > 0 {
 			continue
 		}
 		evicted = append(evicted, owner)

--- a/pkg/ownership/registry.go
+++ b/pkg/ownership/registry.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/c360studio/semstreams/natsclient"
@@ -26,6 +27,15 @@ type Registry struct {
 	claims   *natsclient.KVStore // OWNER_CLAIMS — the single `_registry` epoch key
 	presence *natsclient.KVStore // OWNER_PRESENCE — heartbeat.<owner> keys (TTL = grace window)
 	logger   *slog.Logger
+
+	// inverseResolver, when non-nil, enforces the Decision-4 inverse-gate over
+	// every registered ForeignEdgeClaim (a Conditional/Backfill edge predicate
+	// must have a registered inverse). Injected so pkg/ownership stays free of
+	// the vocabulary dependency; set by EnsureBuckets. nil = gate skipped (with a
+	// one-time WARN if a claim would have been gated) — the observe-only / read-
+	// only / test default.
+	inverseResolver    InverseResolver
+	noResolverWarnOnce sync.Once
 }
 
 // NewRegistry constructs a Registry over the two pre-opened KV stores. The
@@ -188,6 +198,14 @@ func (reg *Registry) RegisterOwner(ctx context.Context, r Registration) error {
 	if err := r.Validate(); err != nil {
 		return err
 	}
+	// Decision-4 inverse-gate: a Conditional/Backfill foreign edge with no
+	// registered inverse is unrecoverable after a birth race. Enforce before any
+	// KV I/O so a gated violation fails the registration cleanly (ErrInvalidClaim
+	// — a config bug, fatal at the caller). Skipped (warn-once) when no resolver
+	// is wired.
+	if err := reg.checkInverseGate(r.ForeignEdges); err != nil {
+		return err
+	}
 	if r.hasNoEnforceableClaim() {
 		reg.logger.Warn("ownership: registration has no enforceable (owning or foreign-edge) claim — it will not be protected",
 			slog.String("owner", r.Owner))
@@ -244,6 +262,27 @@ func (reg *Registry) RegisterOwner(ctx context.Context, r Registration) error {
 	if err != nil {
 		reg.rollbackPresence(ctx, r.Owner, preExisted)
 		return fmt.Errorf("ownership: register %q: %w", r.Owner, err)
+	}
+	return nil
+}
+
+// checkInverseGate runs the Decision-4 inverse-gate over the registration's
+// foreign edges using the Registry's injected resolver. With a resolver, a
+// Conditional/Backfill edge predicate lacking a registered inverse FAILS
+// (ErrInvalidClaim). With no resolver wired, the gate is skipped — a deploy that
+// SHOULD enforce but forgot the resolver is surfaced by a one-time WARN the first
+// time a would-be-gated claim is seen, not silently.
+func (reg *Registry) checkInverseGate(edges []ForeignEdgeClaim) error {
+	if reg.inverseResolver != nil {
+		return CheckInverseGate(reg.inverseResolver, edges...)
+	}
+	for _, e := range edges {
+		if e.Mode.requiresInverse() {
+			reg.noResolverWarnOnce.Do(func() {
+				reg.logger.Warn("ownership: no inverse-resolver wired — Decision-4 inverse-gate SKIPPED for inverse-requiring foreign-edge claims (wire one via EnsureBuckets to enforce)")
+			})
+			break
+		}
 	}
 	return nil
 }

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -23,6 +23,7 @@ import (
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/cache"
 	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/pkg/ownership"
 	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,6 +45,9 @@ var (
 
 	mutationRejectionsOnce sync.Once
 	mutationRejectionsVec  *prometheus.CounterVec
+
+	foreignEdgeUnclaimedOnce sync.Once
+	foreignEdgeUnclaimedVec  *prometheus.CounterVec
 )
 
 // entityIDRegex validates entity ID format: org.platform.domain.system.type.instance
@@ -119,6 +123,34 @@ func getMutationRejectionsMetric(registry *metric.MetricsRegistry) *prometheus.C
 		}
 	})
 	return mutationRejectionsVec
+}
+
+// getForeignEdgeUnclaimedMetric returns the process-wide counter for the
+// ADR-056 Decision-4 T2-seam reject: a foreign-subject edge (Subject != the
+// ingested entity) whose producing (message_type, predicate) has no registered
+// ForeignEdgeClaim. For W0 increment 4a this is OBSERVE-ONLY — the edge is still
+// routed (deprecated-on-arrival); the metric counts edges CLASSIFIED-unclaimed at
+// the seam, NOT routing failures. The hard reject + the ADR-055 must-exist flip
+// are gated on this reading zero over a bake window (4c). NOTE: today no
+// production producer emits foreign edges (OMS/StoredMessage emit none), so this
+// reads zero in cmd/semstreams BY ABSENCE, not because producers migrated.
+// Labels: message_type (the dotted registry key, '_invalid' for an unregistered/
+// zero type — both bounded, closed sets) and predicate (exact vocabulary string).
+func getForeignEdgeUnclaimedMetric(registry *metric.MetricsRegistry) *prometheus.CounterVec {
+	foreignEdgeUnclaimedOnce.Do(func() {
+		foreignEdgeUnclaimedVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "graph_ingest",
+			Name:      "foreign_edge_unclaimed_total",
+			Help:      "Unclaimed foreign-subject (message_type,predicate) pairs at the T2-seam — no registered ForeignEdgeClaim (ADR-056 Decision 4; observe-only, edge still routed). Counted once per ingest per pair (deduped), so it is a hatch-not-empty signal, not a per-edge volume",
+		}, []string{"message_type", "predicate"})
+		if registry != nil {
+			_ = registry.RegisterCounterVec("graph-ingest", "foreign_edge_unclaimed_total", foreignEdgeUnclaimedVec)
+		} else {
+			_ = prometheus.DefaultRegisterer.Register(foreignEdgeUnclaimedVec)
+		}
+	})
+	return foreignEdgeUnclaimedVec
 }
 
 // Config holds configuration for graph-ingest component
@@ -217,6 +249,15 @@ func (a *tripleAdderAdapter) AddTriple(ctx context.Context, triple message.Tripl
 	return a.component.AddTriple(ctx, triple)
 }
 
+// foreignEdgeClassifier classifies a producer's foreign-edge predicates against
+// the registered ForeignEdgeClaims (ADR-056 Decision 4): it returns the subset
+// with no covering claim. *ownership.ClaimReader is the production
+// implementation (one epoch read per call); tests inject a fake. Kept as an
+// interface so the observe-only seam is unit-testable without NATS.
+type foreignEdgeClassifier interface {
+	UnclaimedForeignEdges(ctx context.Context, producer string, predicates []string) ([]string, error)
+}
+
 // Component implements the graph-ingest processor
 type Component struct {
 	// Component metadata
@@ -233,6 +274,15 @@ type Component struct {
 	entityCache  cache.Cache[graph.EntityState] // Read-through cache for query handlers
 	suffixBucket *natsclient.KVStore            // KV suffix index: suffix → fullID
 	suffixCache  cache.Cache[string]            // TTL cache for suffix resolution
+
+	// ADR-056 Decision-4 T2-seam: read-only view of registered ForeignEdgeClaims.
+	// nil when OWNER_CLAIMS is absent (resourceless/unmigrated deploy) — the seam
+	// then skips classification (observe-only graceful-skip). An interface so the
+	// seam is unit-testable with a fake; *ownership.ClaimReader is production.
+	// foreignEdgeWarnedKeys dedupes the one-time WARN per (message_type|predicate)
+	// so an unclaimed producer logs once, not per message.
+	claimReader           foreignEdgeClassifier
+	foreignEdgeWarnedKeys sync.Map
 
 	// Inference components
 	hierarchyInference *inference.HierarchyInference
@@ -255,6 +305,7 @@ type Component struct {
 	entitiesUpdated        prometheus.Counter
 	indexingProfileDefault *prometheus.CounterVec
 	mutationRejections     *prometheus.CounterVec
+	foreignEdgeUnclaimed   *prometheus.CounterVec
 	metricsRegistry        *metric.MetricsRegistry
 
 	// Lifecycle reporting
@@ -301,6 +352,7 @@ func CreateGraphIngest(rawConfig json.RawMessage, deps component.Dependencies) (
 		entitiesUpdated:        getEntitiesUpdatedMetric(deps.MetricsRegistry),
 		indexingProfileDefault: getIndexingProfileDefaultMetric(deps.MetricsRegistry),
 		mutationRejections:     getMutationRejectionsMetric(deps.MetricsRegistry),
+		foreignEdgeUnclaimed:   getForeignEdgeUnclaimedMetric(deps.MetricsRegistry),
 		metricsRegistry:        deps.MetricsRegistry,
 	}
 
@@ -673,6 +725,19 @@ func (c *Component) initStorage(ctx context.Context) error {
 	}
 	c.suffixCache = suffixCacheInst
 
+	// ADR-056 Decision-4 T2-seam: open OWNER_CLAIMS read-only to classify
+	// foreign-subject edges against registered ForeignEdgeClaims. graph-ingest
+	// boots AFTER main's EnsureBuckets, so in an ownership-enabled deploy the
+	// bucket exists. If it is absent (resourceless / unmigrated deploy) or
+	// transiently unopenable, graceful-skip: leave claimReader nil and the seam
+	// routes without classifying (observe-only, no behavior change).
+	if reader, err := ownership.NewClaimReader(ctx, c.natsClient, c.logger); err != nil {
+		c.logger.Info("graph-ingest: ownership claim reader unavailable — foreign-edge classification disabled this boot (observe-only seam skipped)",
+			slog.Any("error", err))
+	} else {
+		c.claimReader = reader
+	}
+
 	return nil
 }
 
@@ -947,6 +1012,11 @@ func (c *Component) ingestEntity(ctx context.Context, entity *graph.EntityState)
 	// whole foreign batch; no current producer emits one, but a future
 	// multi-edge producer should not assume partial routing.
 	if len(foreign) > 0 {
+		// ADR-056 Decision-4 T2-seam (observe-only, 4a): classify each foreign
+		// edge against the registered ForeignEdgeClaims and meter the unclaimed
+		// ones. This does NOT change routing — the edges are still appended below
+		// (deprecated-on-arrival); the hard reject + must-exist flip are 4c.
+		c.classifyForeignEdges(ctx, entity.MessageType, foreign)
 		if _, failed, aerr := c.AddTriples(ctx, foreign); aerr != nil {
 			c.logger.Warn("Failed to regroup cross-entity edges onto their subjects",
 				slog.String("entity_id", entity.ID),
@@ -958,6 +1028,52 @@ func (c *Component) ingestEntity(ctx context.Context, entity *graph.EntityState)
 	c.logger.Debug("Entity ingested",
 		slog.String("entity_id", entity.ID),
 		slog.Int("triples", len(entity.Triples)))
+}
+
+// classifyForeignEdges runs the ADR-056 Decision-4 T2-seam reject in OBSERVE-ONLY
+// mode (W0 increment 4a): it classifies the foreign-subject edges' predicates
+// against the registered ForeignEdgeClaims for this producer (one epoch read) and
+// counts the unclaimed ones on foreign_edge_unclaimed_total, with a one-time WARN
+// per (message_type,predicate). It does NOT change routing — the edges are still
+// appended by the caller's AddTriples (deprecated-on-arrival). The hard reject +
+// the ADR-055 must-exist flip are 4c. No-op when no claim reader is wired
+// (graceful-skip). The metric counts edges CLASSIFIED-unclaimed at the seam, NOT
+// routing failures (relevant to 4c's hatch-empty gate semantics).
+func (c *Component) classifyForeignEdges(ctx context.Context, mt message.Type, foreign []message.Triple) {
+	if c.claimReader == nil {
+		return
+	}
+	// Producer key = the dotted registry MessageType. An invalid/zero type (a
+	// producer that registered none) cannot match an exact-producer claim; bound
+	// its metric label to "_invalid" so a malformed producer can't smear
+	// cardinality, but still classify (a Producer-empty claim may cover it).
+	producer := mt.Key()
+	label := producer
+	if !mt.IsValid() {
+		label = "_invalid"
+	}
+
+	preds := make([]string, 0, len(foreign))
+	for _, t := range foreign {
+		preds = append(preds, t.Predicate)
+	}
+	unclaimed, err := c.claimReader.UnclaimedForeignEdges(ctx, producer, preds)
+	if err != nil {
+		// Read blip — stay observe-only and fail-open (never block ingest). One
+		// log, no metric (this batch could not be classified).
+		c.logger.Warn("graph-ingest: foreign-edge claim classification failed — routing without classifying (observe-only)",
+			slog.String("message_type", label), slog.Any("error", err))
+		return
+	}
+	for _, p := range unclaimed {
+		c.foreignEdgeUnclaimed.WithLabelValues(label, p).Inc()
+		warnKey := label + "|" + p
+		if _, warned := c.foreignEdgeWarnedKeys.LoadOrStore(warnKey, struct{}{}); !warned {
+			c.logger.Warn("graph-ingest: foreign-subject edge has no registered ForeignEdgeClaim — routed deprecated-on-arrival (ADR-056 Decision 4; register a claim before the must-exist flip)",
+				slog.String("message_type", label),
+				slog.String("predicate", p))
+		}
+	}
 }
 
 // extractEntityFromMessage extracts an EntityState from a BaseMessage

--- a/processor/graph-ingest/foreign_edge_seam_test.go
+++ b/processor/graph-ingest/foreign_edge_seam_test.go
@@ -1,0 +1,139 @@
+package graphingest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+)
+
+// fakeClassifier is an injected foreignEdgeClassifier for unit-testing the
+// observe-only T2-seam (ADR-056 Decision 4) without NATS. It records what the
+// seam asked and returns a configured unclaimed set.
+type fakeClassifier struct {
+	unclaimed   map[string]bool // predicate -> reported unclaimed
+	err         error
+	gotProducer string
+	gotPreds    []string
+}
+
+func (f *fakeClassifier) UnclaimedForeignEdges(_ context.Context, producer string, preds []string) ([]string, error) {
+	f.gotProducer = producer
+	f.gotPreds = preds
+	if f.err != nil {
+		return nil, f.err
+	}
+	var out []string
+	for _, p := range preds {
+		if f.unclaimed[p] {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// The seam meters an unclaimed foreign edge, leaves a claimed one quiet, never
+// classifies an own-subject triple (it is not foreign), and does NOT change
+// routing — the edges still flow through AddTriples below (observe-only).
+func TestForeignEdgeSeam_MetersUnclaimedOnly(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	fake := &fakeClassifier{unclaimed: map[string]bool{"unclaimed.edge": true}}
+	comp.claimReader = fake
+
+	mt := message.Type{Domain: "test", Category: "fixture", Version: "v1"}
+	label := mt.Key()
+	entity := &graph.EntityState{
+		ID:          flParentID,
+		MessageType: mt,
+		Version:     1,
+		Triples: []message.Triple{
+			{Subject: flParentID, Predicate: "own.p", Object: "x"},                // own — never foreign
+			{Subject: flChildID, Predicate: "claimed.edge", Object: flParentID},   // foreign, claimed
+			{Subject: flChildID, Predicate: "unclaimed.edge", Object: flParentID}, // foreign, unclaimed
+		},
+	}
+
+	beforeUnclaimed := testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues(label, "unclaimed.edge"))
+	beforeClaimed := testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues(label, "claimed.edge"))
+
+	comp.ingestEntity(context.Background(), entity)
+
+	assert.InDelta(t, beforeUnclaimed+1, testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues(label, "unclaimed.edge")), 0.0001,
+		"an unclaimed foreign edge must increment foreign_edge_unclaimed_total")
+	assert.InDelta(t, beforeClaimed, testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues(label, "claimed.edge")), 0.0001,
+		"a claimed foreign edge must NOT be metered")
+	assert.Equal(t, label, fake.gotProducer, "producer key = MessageType.Key()")
+	assert.ElementsMatch(t, []string{"claimed.edge", "unclaimed.edge"}, fake.gotPreds,
+		"only foreign-subject predicates reach the classifier; the own-subject triple does not")
+	assert.NotContains(t, fake.gotPreds, "own.p")
+}
+
+// No claim reader wired (resourceless/unmigrated deploy): the seam is a pure
+// no-op — no panic, ingest proceeds, the foreign edge is still routed.
+func TestForeignEdgeSeam_GracefulSkipWhenNoReader(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.claimReader = nil
+
+	entity := &graph.EntityState{
+		ID:          flParentID,
+		MessageType: message.Type{Domain: "test", Category: "fixture", Version: "v1"},
+		Version:     1,
+		Triples:     []message.Triple{{Subject: flChildID, Predicate: "x.edge", Object: flParentID}},
+	}
+	comp.ingestEntity(context.Background(), entity) // must not panic
+
+	// The foreign edge still landed on its subject (routing unchanged).
+	child := storedEntity(t, comp, flChildID)
+	assert.True(t, hasPredicate(child, "x.edge"), "graceful-skip must not change routing — the foreign edge is still appended")
+}
+
+// A producer with an invalid/zero MessageType is metered under a bounded
+// "_invalid" label (cardinality guard), while the classifier still receives the
+// raw producer key so a Producer-empty claim could match.
+func TestForeignEdgeSeam_InvalidMessageTypeLabel(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	fake := &fakeClassifier{unclaimed: map[string]bool{"x.edge": true}}
+	comp.claimReader = fake
+
+	entity := &graph.EntityState{
+		ID:          flParentID,
+		MessageType: message.Type{}, // zero / invalid
+		Version:     1,
+		Triples:     []message.Triple{{Subject: flChildID, Predicate: "x.edge", Object: flParentID}},
+	}
+	before := testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues("_invalid", "x.edge"))
+	comp.ingestEntity(context.Background(), entity)
+
+	assert.InDelta(t, before+1, testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues("_invalid", "x.edge")), 0.0001,
+		"an invalid MessageType must meter under the bounded _invalid label")
+	assert.Equal(t, message.Type{}.Key(), fake.gotProducer,
+		"the classifier still receives the raw producer key, so a Producer-empty claim can match")
+}
+
+// A classifier read error is fail-open: the seam logs and routes anyway (no
+// metric, no panic, ingest not blocked).
+func TestForeignEdgeSeam_ClassifierErrorFailsOpen(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.claimReader = &fakeClassifier{err: assertErr}
+
+	entity := &graph.EntityState{
+		ID:          flParentID,
+		MessageType: message.Type{Domain: "test", Category: "fixture", Version: "v1"},
+		Version:     1,
+		Triples:     []message.Triple{{Subject: flChildID, Predicate: "x.edge", Object: flParentID}},
+	}
+	comp.ingestEntity(context.Background(), entity) // must not panic
+
+	child := storedEntity(t, comp, flChildID)
+	assert.True(t, hasPredicate(child, "x.edge"), "a classifier error must not block routing (fail-open)")
+}
+
+var assertErr = errForTest("classifier read blip")
+
+type errForTest string
+
+func (e errForTest) Error() string { return string(e) }

--- a/vocabulary/registry.go
+++ b/vocabulary/registry.go
@@ -380,6 +380,16 @@ func GetInversePredicate(predicate string) string {
 	return meta.InverseOf
 }
 
+// InverseResolver reports a predicate's registered inverse in the (inverse, ok)
+// shape the ADR-056 Decision-4 inverse-gate expects (assignable to
+// ownership.InverseResolver). ok is false when no inverse is registered. Wiring
+// this into ownership.EnsureBuckets keeps pkg/ownership free of the vocabulary
+// dependency while the gate consults the real registry.
+func InverseResolver(predicate string) (inverse string, ok bool) {
+	inv := GetInversePredicate(predicate)
+	return inv, inv != ""
+}
+
 // IsRuleOpaque reports whether a predicate is marked rule-opaque.
 // Returns false for unregistered predicates so that vocabulary
 // registration is the only path to opacity — undeclared predicates


### PR DESCRIPTION
## ADR-056 W0 — Decision-4 increment 4a: the T2-seam foreign-edge reject (OBSERVE-ONLY)

Builds on the merged W0 spine + first-consumer embed (#270, #271). This is the **classify seam** of [Decision 4](docs/adr/056-authoritative-semantic-state.md): graph-ingest's foreign-routing path now classifies each foreign-subject edge (Subject ≠ the ingested entity) against the registered `ForeignEdgeClaim`s and meters the unclaimed ones — **observe-only, no routing change**. The hard reject + the `PENDING_EDGES` buffer + the ADR-055 must-exist flip are deliberately deferred (4b/4c).

### What an architect review changed before any code

A pre-implementation review confirmed a load-bearing fact: **sensorml is not a registered payload and no binary ingests it**, and the production Graphables that *do* reach the seam (OMS, StoredMessage) emit **zero foreign edges**. So 4a is honest **substrate** — the classify seam + metric + inverse-gate, exercised by a registered **test-fixture** producer, not sensorml-in-prod (wiring sensorml into the framework binary would be the framework-vs-product boundary trap). The production metric reads **zero by absence**, not because producers migrated — pinned in the ADR so 4c's hatch-empty gate doesn't misread it.

### What's in this PR

- **`ownership.ClaimReader`** — read-only view of `OWNER_CLAIMS` (one epoch read per foreign-bearing ingest; errors when the bucket is absent → graceful-skip; never *creates* the bucket).
- **The seam** (`classifyForeignEdges` in `ingestEntity`) — keys on `MessageType.Key()` (invalid → bounded `_invalid` label), meters `foreign_edge_unclaimed_total{message_type,predicate}` + one-time WARN per pair, **routes anyway**, fail-open on read error, zero cost when no foreign edges. `claimReader` is an interface so the seam is unit-testable without NATS.
- **Inverse-gate enforced at registration** — `RegisterOwner` runs `CheckInverseGate` over the registration's foreign edges via an injected `InverseResolver` (wired through `EnsureBuckets` from `vocabulary.InverseResolver`; nil → skip-with-warn-once). A Conditional/Backfill FE-claim without a registered inverse fails *before* any KV I/O. No-op for the lifecycle `Manager` (OwnerClaim-only) path.
- **FE-claim-only compaction exemption** — FE claims aren't leases (they contest nothing), so reaping a dead FE-only owner only made the metric flap. Exempt them. **Known 4b/4c follow-up** (documented at the exemption + in `doc.go`): a dead FE-only owner now persists, so the cross-type overlap check could later strand a live owning registrant against it — not reachable today.
- **sensorml `WithInverseOf`** both ways (the Backfill recoverability floor; honors the long-standing doc-comment). Not bound into a binary.
- **ADR text** — the NoBirthStub-vs-Conditional self-contradiction resolved; metric semantics (classified-not-routed, zero-by-absence) pinned for 4c.

### Verification

- `task lint` clean (revive) · `go test -race ./...` · **`go test -race -tags=integration ./...` green** (full branch sweep, no flakes) · schema no-drift · **`task e2e:lifecycle` green** (regression — the additive seam + graph-ingest `ClaimReader`-open + `EnsureBuckets`-with-resolver don't break full-stack boot).
- Tests: unit (compaction exemption incl. empty-entry, inverse-gate, seam ×4) + integration (`ClaimReader` classification / any-producer fallback / absent-bucket, sensorml inverse).
- Adversarial **architect** review (verified facts + ruled the seam design) and a pre-merge **go-reviewer** pass = **APPROVE, no BLOCKING/HIGH**; its 2 LOW fixed, 1 MEDIUM documented as the 4b/4c follow-up above.

### Deferred (each its own increment)

4b: `PENDING_EDGES` buffer + de-dupe-merge drain + boot re-drain + the `ensureReferencedEntityExists` fourth-path fold + the counting crash-recovery flip-gate. 4c: the hard T2-seam reject + the ADR-055 must-exist flip (gated on `foreign_edge_unclaimed_total` zero over a bake window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
