### PR TITLE
ADR-056 Decision 4: shared projection-normalization seam (lane-independent)

### DIFF
--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -160,6 +160,20 @@ shape.
   SensorML ingest path is separate, larger work. (2) The metric counts edges **CLASSIFIED-unclaimed
   at the seam**, NOT routing failures (it fires before `AddTriples`' all-or-nothing batch), which is
   the semantics 4c's gate must assume.
+- **Shared projection-normalization seam landed — 4a RELOCATED, lane-independence corrected (Coby,
+  post-4a).** The 4a hook lived only on the fact-arrival `ingestEntity` lane, so its zero metric did
+  NOT prove "no consumer" — it proved the observation point missed the **mutation API**, which is how
+  the framework's real consumers write (semconnect cs-api `POST /systems` → `create_with_triples`;
+  semteams rules → `triple.add`). The "no production producer" caveat above is corrected: it was a
+  fact-arrival-only artefact. The fix is one **shared `normalizeProjection`** seam (partition against
+  the primary subject + classify foreign edges) called from `ingestEntity`, `create_with_triples`,
+  AND `update_with_triples` (bare `triple.add` stays a direct ownership-checked write to its subject,
+  not a foreign-edge producer, until the request grows origin context). A foreign edge sent via the
+  mutation API is now partitioned off the primary (no longer misfiled onto `Entity.ID`), classified,
+  and routed onto its own subject — for every current caller `foreign` is empty (single-subject
+  batches), so this is a behavioural no-op today and the foundation semconnect builds on when it drops
+  `singleSubject` (`systems_post.go:317`, a migration guard for the previously-missing framework
+  support, NOT the desired architecture). See the "Lane-independence correction" note under Decision 4.
 
 ### v4 → v5: implementation contracts pinned (1 BLOCKING + P1s; no architectural forks)
 
@@ -949,12 +963,36 @@ wire-level caller must *opt in* to removal by sending a non-nil set.
 > legitimate cross-entity write (a `ForeignEdgeClaim`, Decision 1) that may RACE the target's
 > birth. It does NOT ride the owner-reconcile contract (it is not the writer's owned state),
 > and it must NOT silently vanish under must-exist. The framework enforces this at the
-> ONE seam every foreign edge already flows through — the T2-regroup foreign-routing path —
-> NOT at claim registration (which a no-claim Graphable like sensorml bypasses): a
-> foreign-subject triple with no registered `ForeignEdgeClaim` is rejected at the seam. The
-> edge survives a restart (KV-backed `PENDING_EDGES` buffer) and is reconstructable (the
-> inverse-gate). ADR-055's closing-move flip (delete auto-vivify) is GATED on this contract
-> shipping.**
+> SHARED projection-normalization seam every graph-ingest write path passes through before the
+> `ENTITY_STATES` mutation — fact-arrival Graphable ingestion AND the mutation API
+> (`create_with_triples`/`update_with_triples`) — NOT at claim registration (which a no-claim
+> producer bypasses) and NOT on the fact-arrival lane alone (which the real gateway consumers,
+> writing via the mutation API, bypass): a foreign-subject triple with no registered
+> `ForeignEdgeClaim` is rejected at the seam, on whichever lane it arrives. The edge survives a
+> restart (KV-backed `PENDING_EDGES` buffer) and is reconstructable (the inverse-gate). ADR-055's
+> closing-move flip (delete auto-vivify) is GATED on this contract shipping.**
+
+> **Lane-independence correction (post-4a, the cited code wins — 056:34).** An earlier draft called
+> the fact-arrival `ingestEntity`/T2-regroup path "the ONE seam every foreign edge already flows
+> through." That is FALSE: it is the one seam every *Graphable* foreign edge flows through, but the
+> framework's real consumers are GATEWAYS (semconnect cs-api `POST /systems`, semteams rules) that
+> write through the **mutation API** (`graph.mutation.entity.create_with_triples` /
+> `update_with_triples` / `triple.add`), which never reached `ingestEntity` and so were classified by
+> nothing. A foreign edge sent via `create_with_triples` was silently MISfiled onto the request's
+> primary `Entity.ID` (cs-api's `singleSubject()` guard, `systems_post.go:317`, is a *migration
+> guard* for this missing support, not the desired architecture). The mutation API is a graph WRITE
+> API, not a bypass; it must participate in the same projection/ownership/foreign-edge enforcement.
+> The canonical seam is therefore **not `ingestEntity`** — it is the **shared projection-
+> normalization step** (`normalizeProjection`, `processor/graph-ingest/component.go`) that
+> partitions a projected triple set against its primary subject and classifies the foreign-subject
+> edges, called from EVERY write path that accepts projected triples (fact-arrival ingestEntity,
+> `create_with_triples`, `update_with_triples`; bare `triple.add` is a direct write to
+> `Triple.Subject`, ownership-checked per (subject,predicate), and is NOT treated as a foreign-edge
+> producer unless the request grows explicit origin/projection context). 4a's observe-only
+> classification reruns inside this shared seam (lane-independent). Once mutation-lane normalization
+> exists, cs-api drops `singleSubject` for registered foreign-edge projections — its blocked
+> SensorML-hierarchy round-trip is the immediate consumer, making the "no producer" reading a
+> fact-arrival-only artefact, not a real absence of consumers.**
 
 The problem must-exist creates: today these edges auto-vivify the target if it is absent. Two
 live sources:

--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -1017,26 +1017,31 @@ live sources:
   and the least-observable of the two (container) has no metric at all, which strengthens the
   case that this is a correctness bug, not a degradation knob.**
 
-**The enforcement seam is T2-regroup, not claim-registration (BLOCKING-B fix part 1 — the core
-bypass).** v3 placed the inverse-gate on `ForeignEdgeClaim` REGISTRATION. But registration is
-not on the path a raw foreign triple takes: `ingestEntity` calls `partitionTriplesBySubject`
-(`component.go:1031-1040`), which classifies **any** triple whose `Subject != entity.ID` as
-foreign by pure string comparison, then routes the whole foreign batch via `AddTriples`
-(`component.go:950`) — **with no claim lookup whatsoever.** A Graphable that never registers a
-`ForeignEdgeClaim` flows straight through. sensorml is exactly this: it emits
-`{Subject: childID, Predicate: PredIsHostedBy, Object: parentID}`
-(`parser/sensorml/graphable.go:122-125`) as part of the *parent's* Graphable, registers **no**
-claim, and its `isHostedBy` edge is routed at the seam — so v3's registration-time gate
-**never sees it.** The flagship motivating edge bypassed the flagship fix.
+**The enforcement seam is the SHARED projection-normalization step, not claim-registration
+(BLOCKING-B fix part 1 — the core bypass) and not one lane (the lane-independence correction
+above).** v3 placed the inverse-gate on `ForeignEdgeClaim` REGISTRATION. But registration is not on
+the path a raw foreign triple takes: every graph-ingest write path that accepts projected triples
+calls `normalizeProjection` (`processor/graph-ingest/component.go`), which classifies **any** triple
+whose `Subject != primaryID` as foreign by pure string comparison, then `routeForeignEdges` routes
+the whole foreign batch via `AddTriples` — **with no claim lookup gating it.** A producer that never
+registers a `ForeignEdgeClaim` flows straight through. sensorml is exactly this on the fact-arrival
+lane: it emits `{Subject: childID, Predicate: PredIsHostedBy, Object: parentID}`
+(`parser/sensorml/graphable.go:122-125`) as part of the *parent's* Graphable, registers **no** claim,
+and its `isHostedBy` edge is routed at the seam — so v3's registration-time gate **never sees it.**
+And cs-api emits the same edge on the MUTATION lane (`create_with_triples`), which v3's gate — and
+4a's fact-arrival-only hook — also never saw. The flagship motivating edge bypassed the flagship fix,
+on every lane.
 
-**Fix: make the T2-regroup foreign-routing path THE enforcement seam.** The classification at
-`component.go:917-955,1031-1040` is exactly where a foreign edge is *recognized as foreign*, so
-it is exactly where the claim contract must bind:
+**Fix: make the SHARED projection-normalization step THE enforcement seam — `normalizeProjection`,
+called from `ingestEntity`, `create_with_triples`, AND `update_with_triples` (bare `triple.add`
+stays a direct ownership-checked write to its subject).** That step is exactly where a foreign edge
+is *recognized as foreign* on any lane, so it is exactly where the claim contract must bind:
 
-> **A Graphable that emits a foreign-subject triple MUST have declared that predicate as a
-> `ForeignEdgeClaim`, validated at boot the same way payload registration is. At the
-> T2-regroup seam, a foreign-subject triple whose `(message_type, predicate)` has NO registered
-> `ForeignEdgeClaim` covering the producer is the REJECT** — counted on a
+> **A producer that emits a foreign-subject triple MUST have declared that predicate as a
+> `ForeignEdgeClaim`, validated at boot the same way payload registration is. At the shared
+> projection-normalization seam — on whichever lane the write arrives (fact-arrival Graphable
+> ingestion OR the mutation API) — a foreign-subject triple whose `(message_type, predicate)` has
+> NO registered `ForeignEdgeClaim` covering the producer is the REJECT** — counted on a
 > `foreign_edge_unclaimed_total{message_type,predicate}` metric, dropped-loud, never silently
 > routed.
 
@@ -1819,7 +1824,17 @@ existing mechanism**, which is exactly why the gate is passed and not failed:
    = the System claim's declared set (Decision 3). (b) The single-subject assumption — `ingestTriples`
    runs `singleSubject(triples)` (`systems_post.go:317`) and **errors** on the multi-subject set a
    rich SensorML hierarchy produces, so cs-api cannot round-trip embedded `Components` at all today;
-   the `ForeignEdgeClaim` + T2-regroup seam (Decision 4) is the path that makes it work.
+   the `ForeignEdgeClaim` + the shared projection-normalization seam (Decision 4, now lane-independent
+   — it covers cs-api's `create_with_triples` lane, not just fact-arrival) is the path that makes it
+   work. **Migration rider (open question, named for the fixture):** dropping `singleSubject` is
+   necessary but not sufficient — the seam keys the foreign-edge claim lookup + the metric on
+   `req.Entity.MessageType`, and cs-api's `createEntityWithTriples` builds the request with a
+   MessageType-less `&graph.EntityState{ID, Triples}` (`systems_post.go:321`). A zero MessageType is
+   metered as `message_type="_invalid"` and can only match a `Producer:""` (any-producer) claim, never
+   cs-api's exact-producer `ForeignEdgeClaim`. So the cs-api migration MUST also STAMP a non-zero
+   `Entity.MessageType` (the cs-api System producer type it registers its claim under) on its mutation
+   requests, or its foreign edges read as unclaimed forever. This belongs in the semconnect migration
+   fixture explicitly.
 
 **Verdict: the gate is PASSED.** 056 describes semconnect's registrations exactly — one `OwnerClaim`
 per entity-type id-glob, the shared-vocabulary-owned-by-writer rule, one `ForeignEdgeClaim` for the

--- a/processor/graph-ingest/cas_integration_test.go
+++ b/processor/graph-ingest/cas_integration_test.go
@@ -343,3 +343,81 @@ func TestIntegration_CASRetryBehavior(t *testing.T) {
 			"all triples should be present; ADR-054 profile stamp excluded")
 	})
 }
+
+// TestIntegration_SharedSeam_CASFailureDoesNotRouteForeign locks the ADR-056
+// Decision-4 invariant that routeForeignEdges runs ONLY after the primary commit
+// succeeds — on the CAS lane too. A stale ExpectedRevision fails the primary
+// update_with_triples; the foreign edge it carried must NOT be routed onto the
+// child subject (the bug: routing on err==nil instead of decoded Success).
+func TestIntegration_SharedSeam_CASFailureDoesNotRouteForeign(t *testing.T) {
+	ctx := context.Background()
+	streams := []natsclient.TestStreamConfig{{Name: "ENTITY", Subjects: []string{"entity.>"}}}
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+
+	config := DefaultConfig()
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+	comp, err := CreateGraphIngest(configJSON, component.Dependencies{NATSClient: testClient.Client})
+	require.NoError(t, err)
+	c := comp.(*Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	defer func() { _ = c.Stop(5 * time.Second) }()
+	time.Sleep(100 * time.Millisecond)
+
+	const parentID = "c360.test.seam.cas.system.001"
+	const childID = "c360.test.seam.cas.child.001"
+
+	require.NoError(t, c.CreateEntity(ctx, &graph.EntityState{
+		ID: parentID, Version: 1, UpdatedAt: time.Now(),
+		Triples: []message.Triple{{Subject: parentID, Predicate: "system.label", Object: "P", Timestamp: time.Now(), Confidence: 1}},
+	}))
+
+	foreignEdge := message.Triple{Subject: childID, Predicate: "child.isHostedBy", Object: parentID, Timestamp: time.Now(), Confidence: 1}
+
+	t.Run("stale_revision_does_not_route_foreign", func(t *testing.T) {
+		req := graph.UpdateEntityWithTriplesRequest{
+			Entity: &graph.EntityState{ID: parentID},
+			AddTriples: []message.Triple{
+				{Subject: parentID, Predicate: "system.note", Object: "n", Timestamp: time.Now(), Confidence: 1}, // own
+				foreignEdge, // foreign
+			},
+			ExpectedRevision: 9999, // stale → CAS fails
+		}
+		data, _ := json.Marshal(req)
+		respData, err := c.handleEntityUpdateWithTriples(ctx, data)
+		require.NoError(t, err)
+		var resp graph.UpdateEntityWithTriplesResponse
+		require.NoError(t, json.Unmarshal(respData, &resp))
+		require.False(t, resp.Success, "stale-revision CAS must fail")
+
+		// The failed primary write must NOT have routed the foreign edge — the
+		// child was never created.
+		_, getErr := c.entityBucket.Get(ctx, childID)
+		assert.ErrorIs(t, getErr, natsclient.ErrKVKeyNotFound,
+			"foreign edge must NOT be routed when the CAS primary write failed")
+	})
+
+	t.Run("correct_revision_routes_foreign", func(t *testing.T) {
+		_, rev, err := c.fetchEntityState(ctx, parentID)
+		require.NoError(t, err)
+		req := graph.UpdateEntityWithTriplesRequest{
+			Entity:           &graph.EntityState{ID: parentID},
+			AddTriples:       []message.Triple{foreignEdge},
+			ExpectedRevision: rev, // current → CAS succeeds
+		}
+		data, _ := json.Marshal(req)
+		respData, err := c.handleEntityUpdateWithTriples(ctx, data)
+		require.NoError(t, err)
+		var resp graph.UpdateEntityWithTriplesResponse
+		require.NoError(t, json.Unmarshal(respData, &resp))
+		require.True(t, resp.Success, "current-revision CAS must succeed: %s", resp.Error)
+
+		// On success the foreign edge IS routed onto the child.
+		entry, getErr := c.entityBucket.Get(ctx, childID)
+		require.NoError(t, getErr, "foreign edge must be routed onto the child when the CAS primary write committed")
+		var child graph.EntityState
+		require.NoError(t, json.Unmarshal(entry.Value, &child))
+		assert.True(t, hasPredicate(&child, "child.isHostedBy"))
+	})
+}

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -971,22 +971,15 @@ func (c *Component) handleMessage(ctx context.Context, subject string, data []by
 // path. Exposed as a method so the merge+regroup wire is testable end-to-end
 // without standing up the decoder.
 func (c *Component) ingestEntity(ctx context.Context, entity *graph.EntityState) {
-	// ADR-055 §5 T2: a Graphable may legitimately emit cross-entity edges whose
-	// Subject != EntityID() (sensorml inverse isHostedBy, federation/objectstore
-	// pass-throughs). extractEntityFromMessage files every triple under the
-	// primary key, silently misfiling those edges onto the wrong entity. Split
-	// them off so the primary merges only its own facts, then route each edge to
-	// its correct subject below — WARN-and-regroup, never reject (multi-Subject
-	// producers stay correct; single-Subject is the target invariant for NEW
-	// Graphables).
-	own, foreign := partitionTriplesBySubject(entity.ID, entity.Triples)
-	if len(foreign) > 0 {
-		entity.Triples = own
-		c.logger.Warn("Graphable emitted cross-entity edges; regrouping onto their subjects",
-			slog.String("entity_id", entity.ID),
-			slog.Int("foreign_triples", len(foreign)),
-			slog.Any("foreign_subjects", distinctSubjects(foreign)))
-	}
+	// ADR-055 §5 T2 + ADR-056 Decision 4: a Graphable may legitimately emit
+	// cross-entity edges whose Subject != EntityID() (sensorml inverse isHostedBy,
+	// federation/objectstore pass-throughs); extractEntityFromMessage files every
+	// triple under the primary key. Normalize at the shared write boundary (split
+	// the foreign-subject edges off the primary + classify them), merge only the
+	// primary's own facts (envelope-bearing), then route the foreign edges onto
+	// their own subjects below.
+	own, foreign := c.normalizeProjection(ctx, entity.ID, entity.MessageType, entity.Triples)
+	entity.Triples = own
 
 	// Store entity in KV bucket — MERGE semantics (gh#177). Earlier code
 	// used CreateEntity (Put = full-replace) here, which clobbered any
@@ -1002,32 +995,62 @@ func (c *Component) ingestEntity(ctx context.Context, entity *graph.EntityState)
 		return
 	}
 
-	// Route cross-entity edges to their own subject. These are edges onto
-	// entities that own their own envelope, so they ride the evidence-append
-	// path (AddTriples = append-by-subject, no MessageType restamp) rather than
-	// MergeEntity (which would stamp the primary's provenance onto a foreign
-	// entity). Best-effort: a failed edge is logged, not fatal to the primary
-	// ingest that already succeeded. Note AddTriples validates the batch
-	// all-or-nothing — one malformed foreign edge (empty Predicate) drops the
-	// whole foreign batch; no current producer emits one, but a future
-	// multi-edge producer should not assume partial routing.
-	if len(foreign) > 0 {
-		// ADR-056 Decision-4 T2-seam (observe-only, 4a): classify each foreign
-		// edge against the registered ForeignEdgeClaims and meter the unclaimed
-		// ones. This does NOT change routing — the edges are still appended below
-		// (deprecated-on-arrival); the hard reject + must-exist flip are 4c.
-		c.classifyForeignEdges(ctx, entity.MessageType, foreign)
-		if _, failed, aerr := c.AddTriples(ctx, foreign); aerr != nil {
-			c.logger.Warn("Failed to regroup cross-entity edges onto their subjects",
-				slog.String("entity_id", entity.ID),
-				slog.Int("failed_subjects", len(failed)),
-				slog.Any("error", aerr))
-		}
-	}
+	c.routeForeignEdges(ctx, entity.ID, foreign)
 
 	c.logger.Debug("Entity ingested",
 		slog.String("entity_id", entity.ID),
 		slog.Int("triples", len(entity.Triples)))
+}
+
+// normalizeProjection is the SHARED projection-normalization seam (ADR-056
+// Decision 4): EVERY graph-ingest write path that accepts a set of projected
+// triples — fact-arrival ingestEntity AND the mutation API create_with_triples /
+// update_with_triples — passes them through here before committing to
+// ENTITY_STATES, so foreign-edge enforcement is LANE-INDEPENDENT (not
+// fact-arrival-only; the mutation API is a graph write API, not a bypass). It
+// splits the triples against their primary subject, classifies the foreign-
+// subject edges against the registered ForeignEdgeClaims (observe-only — the
+// foreign_edge_unclaimed_total metric + once-WARN; see classifyForeignEdges),
+// and returns the own-subject triples to commit on the primary plus the foreign
+// edges for the caller to route via routeForeignEdges AFTER the primary commit
+// (so a failed primary write never orphans a routed edge).
+//
+// primaryID is the entity the projected write targets (entity.ID for
+// fact-arrival, req.Entity.ID for the mutation API). mt is the producer identity
+// (entity.MessageType) for the claim lookup + metric label. For all current
+// callers foreign is empty (single-subject batches; cs-api's singleSubject guard
+// is a migration guard for missing framework support, not the desired shape) —
+// so this is a behavioural no-op today and the foundation a foreign-edge producer
+// (e.g. cs-api SensorML hierarchies, once it drops singleSubject) builds on.
+func (c *Component) normalizeProjection(ctx context.Context, primaryID string, mt message.Type, triples []message.Triple) (own, foreign []message.Triple) {
+	own, foreign = partitionTriplesBySubject(primaryID, triples)
+	if len(foreign) > 0 {
+		c.logger.Warn("projected write emitted cross-entity edges; regrouping onto their subjects",
+			slog.String("primary_id", primaryID),
+			slog.Int("foreign_triples", len(foreign)),
+			slog.Any("foreign_subjects", distinctSubjects(foreign)))
+		c.classifyForeignEdges(ctx, mt, foreign)
+	}
+	return own, foreign
+}
+
+// routeForeignEdges appends foreign-subject edges onto their own subjects via the
+// evidence-append path (AddTriples = append-by-subject, no MessageType restamp),
+// deprecated-on-arrival (observe-only; the hard reject + Conditional pending
+// buffer are 4b/4c). Best-effort and called AFTER the primary commit succeeds —
+// a failed edge is logged, not fatal to the primary write that already landed.
+// AddTriples validates the batch all-or-nothing, so one malformed foreign edge
+// drops the whole foreign batch; no current producer emits one.
+func (c *Component) routeForeignEdges(ctx context.Context, primaryID string, foreign []message.Triple) {
+	if len(foreign) == 0 {
+		return
+	}
+	if _, failed, aerr := c.AddTriples(ctx, foreign); aerr != nil {
+		c.logger.Warn("failed to regroup cross-entity edges onto their subjects",
+			slog.String("primary_id", primaryID),
+			slog.Int("failed_subjects", len(failed)),
+			slog.Any("error", aerr))
+	}
 }
 
 // classifyForeignEdges runs the ADR-056 Decision-4 T2-seam reject in OBSERVE-ONLY

--- a/processor/graph-ingest/foreign_edge_seam_test.go
+++ b/processor/graph-ingest/foreign_edge_seam_test.go
@@ -2,10 +2,12 @@ package graphingest
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
@@ -137,3 +139,76 @@ var assertErr = errForTest("classifier read blip")
 type errForTest string
 
 func (e errForTest) Error() string { return string(e) }
+
+// The SHARED projection-normalization seam (ADR-056 Decision 4) applies on the
+// MUTATION API lane too, not just fact-arrival: a create_with_triples carrying a
+// foreign-subject edge (Subject != Entity.ID) has it partitioned off the primary,
+// classified, and routed onto its own subject — instead of being misfiled onto
+// Entity.ID (the bug cs-api's singleSubject guard works around today).
+func TestSharedSeam_CreateWithTriples_PartitionsClassifiesRoutesForeign(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	fake := &fakeClassifier{unclaimed: map[string]bool{"child.isHostedBy": true}}
+	comp.claimReader = fake
+
+	mt := message.Type{Domain: "test", Category: "fixture", Version: "v1"}
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: flParentID, MessageType: mt},
+		Triples: []message.Triple{
+			{Subject: flParentID, Predicate: "system.label", Object: "Parent"},      // own
+			{Subject: flChildID, Predicate: "child.isHostedBy", Object: flParentID}, // foreign
+		},
+	}
+	data, _ := json.Marshal(req)
+
+	before := testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues(mt.Key(), "child.isHostedBy"))
+
+	respData, err := comp.handleEntityCreateWithTriples(context.Background(), data)
+	require.NoError(t, err)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "create should succeed: %s", resp.Error)
+
+	// The primary stores ONLY its own triple — the foreign edge is not misfiled.
+	parent := storedEntity(t, comp, flParentID)
+	assert.True(t, hasPredicate(parent, "system.label"))
+	assert.False(t, hasPredicate(parent, "child.isHostedBy"),
+		"foreign edge must NOT be misfiled onto the primary entity")
+
+	// The foreign edge was classified at the shared seam (metric fired)…
+	assert.InDelta(t, before+1, testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues(mt.Key(), "child.isHostedBy")), 0.0001,
+		"the mutation-lane foreign edge must be classified by the shared seam")
+	assert.Equal(t, mt.Key(), fake.gotProducer)
+	// …and routed onto its own subject (the child entity).
+	child := storedEntity(t, comp, flChildID)
+	assert.True(t, hasPredicate(child, "child.isHostedBy"),
+		"foreign edge must be routed onto its own subject, not dropped")
+}
+
+// A single-subject create_with_triples (every current caller) is a pure no-op for
+// the shared seam — no classification, no routing, behaviour identical to before.
+func TestSharedSeam_CreateWithTriples_SingleSubjectUnchanged(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	fake := &fakeClassifier{}
+	comp.claimReader = fake
+
+	mt := message.Type{Domain: "test", Category: "fixture", Version: "v1"}
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: flParentID, MessageType: mt},
+		Triples: []message.Triple{
+			{Subject: flParentID, Predicate: "system.label", Object: "Parent"},
+			{Subject: flParentID, Predicate: "system.uid", Object: "u-1"},
+		},
+	}
+	data, _ := json.Marshal(req)
+
+	respData, err := comp.handleEntityCreateWithTriples(context.Background(), data)
+	require.NoError(t, err)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success)
+
+	parent := storedEntity(t, comp, flParentID)
+	assert.True(t, hasPredicate(parent, "system.label"))
+	assert.True(t, hasPredicate(parent, "system.uid"))
+	assert.Nil(t, fake.gotPreds, "a single-subject batch must never reach the classifier")
+}

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -660,14 +660,12 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	// unchanged.
 	if req.ExpectedRevision > 0 {
 		resp, err := c.handleEntityUpdateWithTriplesCAS(ctx, &req)
-		// Route foreign edges only when the CAS call returned no transport error.
-		// A LOGICAL CAS failure (revision mismatch) returns (errorBytes, nil), so
-		// this would route foreign on a primary that did not land — harmless today
-		// because foreign is empty for every current caller (the lifecycle Manager's
-		// CAS deltas are single-subject).
-		// TODO(4b): gate on resp.Success (or a typed revision-mismatch sentinel) so
-		// a real foreign-edge producer never orphans an edge onto a failed-CAS primary.
-		if err == nil {
+		// Route foreign edges ONLY when the CAS primary write actually COMMITTED.
+		// A logical CAS failure (revision mismatch) returns (Success=false, nil
+		// err), so gating on err==nil alone would orphan a foreign edge onto a
+		// primary that never landed. Gate on the decoded Success; the unmarshal is
+		// skipped on the no-foreign-edge happy path (every current caller).
+		if err == nil && len(foreign) > 0 && casUpdateCommitted(resp) {
 			c.routeForeignEdges(ctx, req.Entity.ID, foreign)
 		}
 		return resp, err
@@ -771,6 +769,17 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		TriplesRemoved: triplesRemoved,
 		Version:        int64(stored.Version),
 	})
+}
+
+// casUpdateCommitted reports whether a handleEntityUpdateWithTriplesCAS response
+// represents an actually-committed primary write. The CAS handler returns
+// (Success=false, nil err) on a logical revision mismatch, so the shared-seam
+// foreign-edge routing must gate on this decoded Success — not on err==nil — or a
+// stale-CAS request carrying a foreign edge would orphan it onto a primary that
+// never landed (ADR-056 Decision 4).
+func casUpdateCommitted(resp []byte) bool {
+	var r graph.UpdateEntityWithTriplesResponse
+	return json.Unmarshal(resp, &r) == nil && r.Success
 }
 
 // handleEntityUpdateWithTriplesCAS is the CAS-on-condition branch of

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -428,6 +428,15 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 		req.Entity.Triples = req.Triples
 	}
 
+	// Shared projection-normalization seam (ADR-056 Decision 4): the mutation API
+	// is a graph write API, not a bypass — split off any foreign-subject edge
+	// (Subject != Entity.ID) before committing the primary, so it is classified
+	// and routed to its own subject instead of being misfiled onto Entity.ID.
+	// foreign is empty for every current caller (single-subject batches; cs-api's
+	// singleSubject guard blocks multi-subject today).
+	own, foreign := c.normalizeProjection(ctx, req.Entity.ID, req.Entity.MessageType, req.Entity.Triples)
+	req.Entity.Triples = own
+
 	// ADR-054 channel (b): stamp an explicitly declared indexing profile from
 	// the mutation envelope (highest precedence). Empty/invalid is ignored and
 	// the createEntity seam applies the fallback floor instead.
@@ -440,6 +449,10 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 		}
 		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
 	}
+
+	// Primary committed — route foreign edges onto their own subjects (after the
+	// commit so a failed create never orphans a routed edge).
+	c.routeForeignEdges(ctx, req.Entity.ID, foreign)
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
@@ -629,6 +642,15 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		})
 	}
 
+	// Shared projection-normalization seam (ADR-056 Decision 4): split off any
+	// foreign-subject edge from the AddTriples delta so it is classified + routed
+	// to its own subject instead of merged onto Entity.ID. Both the CAS and the
+	// UpdateWithRetry sub-paths apply req.AddTriples, so normalize once here.
+	// foreign is empty for every current caller (the lifecycle Manager's CAS
+	// deltas are single-subject; cs-api's singleSubject guard blocks multi-subject).
+	addOwn, foreign := c.normalizeProjection(ctx, req.Entity.ID, req.Entity.MessageType, req.AddTriples)
+	req.AddTriples = addOwn
+
 	// ADR-049: CAS-on-condition path. Non-zero ExpectedRevision means
 	// the caller requires the entity's current KV revision to match
 	// exactly; mismatch fails the request without silently merging.
@@ -637,7 +659,18 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	// callers pass zero and get the UpdateWithRetry merge behavior
 	// unchanged.
 	if req.ExpectedRevision > 0 {
-		return c.handleEntityUpdateWithTriplesCAS(ctx, &req)
+		resp, err := c.handleEntityUpdateWithTriplesCAS(ctx, &req)
+		// Route foreign edges only when the CAS call returned no transport error.
+		// A LOGICAL CAS failure (revision mismatch) returns (errorBytes, nil), so
+		// this would route foreign on a primary that did not land — harmless today
+		// because foreign is empty for every current caller (the lifecycle Manager's
+		// CAS deltas are single-subject).
+		// TODO(4b): gate on resp.Success (or a typed revision-mismatch sentinel) so
+		// a real foreign-edge producer never orphans an edge onto a failed-CAS primary.
+		if err == nil {
+			c.routeForeignEdges(ctx, req.Entity.ID, foreign)
+		}
+		return resp, err
 	}
 
 	// PR-B: the delta apply runs *inside* UpdateWithRetry's update
@@ -715,6 +748,9 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		}
 		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
 	}
+
+	// Primary update committed — route foreign edges onto their own subjects.
+	c.routeForeignEdges(ctx, req.Entity.ID, foreign)
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {


### PR DESCRIPTION
## ADR-056 Decision 4 — shared projection-normalization seam (lane-independent)

Builds on the merged W0 work (#270, #271, #272). **Corrects a seam-scope error in 4a**, surfaced by checking the real consumers.

### The problem

ADR-056 Decision 4 called the fact-arrival `ingestEntity`/T2-regroup path "the ONE seam every foreign edge already flows through." That's false: it's the one seam every *Graphable* foreign edge flows through, but the framework's real consumers are **gateways** that write through the **mutation API**:

- **semconnect cs-api** `POST /systems` with a SensorML document emits the foreign `isHostedBy` (child-subject) edge via `asset.Triples()`, then ingests through `graph.mutation.entity.create_with_triples` (`systems_post.go`). Its `singleSubject()` guard (`systems_post.go:317`) *rejects multi-subject batches* — so rich SensorML hierarchies can't round-trip today.
- **semteams** rules stamp the foreign run entity via `graph.mutation.triple.add`.

Neither reaches `ingestEntity`, so 4a's classifier never saw them — a foreign edge sent via `create_with_triples` was silently **misfiled onto the request's primary `Entity.ID`**. **4a's zero metric didn't prove "no consumer" — it proved the observation point missed the mutation API.**

### The correction

The mutation API is a graph **write** API, not a bypass; it must participate in the same projection/ownership/foreign-edge enforcement. The canonical seam is **not `ingestEntity`** — it's the shared projection-normalization step before the `ENTITY_STATES` mutation:

- **`normalizeProjection(primaryID, mt, triples) → (own, foreign)`** — partition the triples against their primary subject + classify the foreign-subject edges (observe-only 4a metric). **`routeForeignEdges`** routes them onto their own subjects *after* the primary commit (a failed primary never orphans a routed edge).
- Called from **`ingestEntity`** (fact-arrival, refactored to delegate — behaviour-identical), **`create_with_triples`**, and **`update_with_triples`**. Bare `triple.add` stays a direct ownership-checked write to its subject — **not** a foreign-edge producer unless the request grows explicit origin context.
- A foreign edge on the mutation API is now partitioned off the primary (no longer misfiled), classified, and routed to its own subject.

**Behavioural no-op today** — `foreign` is empty for every current caller (single-subject batches), so nothing changes now. It's the foundation semconnect builds on when it drops `singleSubject` for registered foreign-edge projections (its blocked SensorML-hierarchy round-trip is the immediate consumer). ADR-056 Decision 4 is reconciled with a **lane-independence correction** (the cited code wins).

### Why this matters for the roadmap

It reframes the "no consumer" reading as a fact-arrival-only artefact: 4b is no longer building ahead of a non-existent consumer — semconnect cs-api is the real one, on the mutation lane the seam now covers.

### Verification

- `task lint` clean · `go test -race ./...` · **`go test -race -tags=integration ./...` green** (no flakes) · schema unaffected.
- **`task e2e:lifecycle` green** — the highest-risk regression surface (the lifecycle Manager's `create_with_triples` + CAS `update_with_triples` path).
- New tests: mutation-lane partition+classify+route + single-subject-unchanged; the 4a fact-arrival seam tests still pass.
- Pre-merge **go-reviewer: APPROVE, no BLOCKING/HIGH** — verified the live lifecycle CAS write path is byte-identical for single-subject deltas (traced all 11 triple call sites). 2 LOW fixed; 1 LOW (surface the per-subject `failed` map for 4c's hatch-empty gate) filed for 4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
