### PR TITLE
ADR-056 W0 4b: envelope-bearing referential-integrity stub (fourth-path fold)

### DIFF
--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -174,6 +174,24 @@ shape.
   batches), so this is a behavioural no-op today and the foundation semconnect builds on when it drops
   `singleSubject` (`systems_post.go:317`, a migration guard for the previously-missing framework
   support, NOT the desired architecture). See the "Lane-independence correction" note under Decision 4.
+- **W0 4b fourth-path fold landed — envelope-bearing referential stub (re-evaluated WITH the consumer
+  correction).** `ensureReferencedEntityExists`'s envelope-less stub `Put` is promoted to a
+  first-class envelope-bearing artifact: `MessageType = core.identity.stub.v1` + a
+  `core.identity.stub_owner` triple (the reachable SOURCE `MessageType`; the ADR's "producer's
+  `ForeignEdgeClaim` `MessageType`" was unreachable at this seam — corrected above). The stub stays
+  PROFILE-LESS, so `MergeEntity`'s true-birth detection (profile-absence keyed) is intact — directly
+  unit-tested (`TestReferentialStub_RealMergeStillDetectsTrueBirth`, the architect's flagged risk).
+  This is the lane-ii fold ONLY; the `PENDING_EDGES`/lane-i buffer is still deferred, and the
+  re-evaluation against the semconnect-consumer correction CONFIRMS that's right: cs-api's single
+  `POST /systems` references the no-birth child via the parent's own `hosts` edge, so the stub
+  materializes it BEFORE `routeForeignEdges` lands the foreign `isHostedBy` — no future-birth drain
+  (lane-i) is triggered. This fold is what makes cs-api's no-birth children survive the eventual
+  must-exist flip (4c). **E2E coverage gap (tracked, gated to 4c):** no e2e tier drives a production
+  Graphable through the fourth path today (OMS relationship objects are IRIs, not entity IDs; mission
+  uses literal-string objects), so the stub-shape change is unit + integration covered but not yet
+  e2e-exercised end-to-end. Closing it (a relationship-target-bearing e2e fixture) is a prerequisite
+  for the 4c must-exist flip, NOT for this additive fold — the fold keeps auto-vivify working, so it
+  does not change observable behaviour for any current path.
 
 ### v4 → v5: implementation contracts pinned (1 BLOCKING + P1s; no architectural forks)
 
@@ -1286,13 +1304,21 @@ ADR-055's "no ownerless births" closing move is **incomplete** until it accounts
 > not horn (b) (remove the lane), because removal would dangle sensorml's child edge forever
 > (no birth to drain, no registered inverse to backfill). Concretely, the referential-stub creator
 > (`ensureReferencedEntityExists`) stamps the stub `EntityState` with a framework semantic envelope
-> — `MessageType = core.identity.stub`, domain `core` / category `identity` / version, the same
-> discriminator shape the payload registry uses — and records the CREATING owner (the producer's
-> registered `ForeignEdgeClaim` `MessageType`) in a `core.identity.stub_owner` triple alongside the
-> existing `core.identity.referenced_by`. The stub is therefore **NOT "an envelope-less ownerless
-> stub that silently survives the flip"**; it is a NAMED framework birth lane (the referential-
-> integrity producer) whose creation is AUTHORIZED by a registered `ForeignEdgeClaim` declaring
-> `edge-mode` with the **must-exist EXEMPTION** in ADR-055's flip text. The exemption is bounded to
+> — `MessageType` from the framework stub family (`{Domain: core, Category: identity.stub, Version:
+> v1}`, Key `core.identity.stub.v1`), the same discriminator shape the payload registry uses — and
+> records the referencing producer in a `core.identity.stub_owner` triple alongside the existing
+> `core.identity.referenced_by`. **Implementation precision (4b fold landed — the cited code wins,
+> 056:34):** the original prose said `stub_owner` is "the producer's registered `ForeignEdgeClaim`
+> `MessageType`," but that is NOT reachable at this seam — `ensureReferencedEntityExists` holds only
+> the target id + the SOURCE `EntityState`'s `MessageType` (the entity that referenced it), never a
+> `ForeignEdgeClaim`. So `stub_owner` records the reachable SOURCE `MessageType` (`referencedByType.Key()`);
+> an untyped source (a gateway that does not stamp `Entity.MessageType`, e.g. cs-api today) attributes
+> to the framework referential producer (`graph-ingest-referential-integrity`). The stub also stays
+> **profile-less** so a real producer's later merge is still detected as the entity's true birth
+> (`reconcileIndexingProfile` keys on profile-absence). The stub is therefore **NOT "an envelope-less
+> ownerless stub that silently survives the flip"**; it is a NAMED framework birth lane (the
+> referential-integrity producer) carrying a valid envelope, eligible for the **must-exist EXEMPTION**
+> in ADR-055's flip text. The exemption is bounded to
 > no-birth targets whose producer registered that `edge-mode` claim — declared, not a blanket
 > carve-out: a foreign edge whose producer registered NO no-birth claim still trips the
 > unclaimed-foreign reject (Decision 4 BLOCKING-B) and never reaches the stub lane.

--- a/docs/operations/01-local-monitoring.md
+++ b/docs/operations/01-local-monitoring.md
@@ -78,6 +78,21 @@ Access dashboards: Grafana sidebar > Dashboards > SemStreams folder.
 
 Index types: `predicate`, `incoming`, `outgoing`, `alias`, `spatial`, `temporal`, `structural`, `embedding`, `community`.
 
+### Graph-Ingest Ownership / Foreign Edges (ADR-056)
+
+| Metric | Description | Useful query |
+|--------|-------------|--------------|
+| `semstreams_graph_ingest_foreign_edge_unclaimed_total{message_type,predicate}` | Foreign-subject edges (Subject ≠ the written entity) classified at the graph-ingest write boundary with **no registered `ForeignEdgeClaim`** for the producing `(message_type, predicate)` | `sum by (message_type, predicate) (increase(semstreams_graph_ingest_foreign_edge_unclaimed_total[1h]))` → which producers emit unclaimed foreign edges |
+
+**What it means.** When a producer writes a relationship edge whose Subject is a *different* entity than the one it owns (e.g. a SensorML `isHostedBy` edge from a child component onto its parent system), graph-ingest classifies it against the registered foreign-edge claims at the shared write boundary (fact-arrival *and* the mutation API). This counter increments — once per `(message_type, predicate)` per ingest — when no claim covers it. It is **observe-only today**: the edge is still routed to its subject (deprecated-on-arrival); nothing is dropped or rejected.
+
+**How to read it.**
+
+- **Zero = healthy** — either no producer emits foreign edges, or every foreign-edge producer has registered its `ForeignEdgeClaim` (the migrated/conformant state). A conformant gateway (e.g. semconnect cs-api once it registers its `isHostedBy` claim + stamps `Entity.MessageType`) reads zero here.
+- **Non-zero = a producer is emitting foreign edges without a declared claim.** Action: that producer registers a `ForeignEdgeClaim` (via a `projection.Contract` bound at boot) for the named `(message_type, predicate)`. If `message_type` shows as `_invalid`, the producer is not stamping `Entity.MessageType` on its mutation requests — a prerequisite for the claim to match.
+
+**Why it matters.** A future release adds a HARD reject for unclaimed foreign edges (the ADR-055 must-exist closing move). That flip is gated on this counter reading **zero over a bake window**, so a non-zero value is the pre-flip migration signal: it names exactly which producers must register claims before strict enforcement turns on. Watch it after any new foreign-edge-emitting producer ships.
+
 ### Rules Engine
 
 | Metric | Description |

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -1596,7 +1596,7 @@ func (c *Component) ensureRelationshipTargetsExist(ctx context.Context, entity *
 				return
 			}
 
-			if err := c.ensureReferencedEntityExists(ctx, id, entity.ID); err != nil {
+			if err := c.ensureReferencedEntityExists(ctx, id, entity.ID, entity.MessageType); err != nil {
 				c.logger.Debug("failed to ensure referenced entity exists",
 					slog.String("target", id),
 					slog.String("referenced_by", entity.ID),
@@ -1608,43 +1608,60 @@ func (c *Component) ensureRelationshipTargetsExist(ctx context.Context, entity *
 	wg.Wait()
 }
 
-// ensureReferencedEntityExists creates a stub entity if the referenced entity doesn't exist.
-// This is a fallback mechanism to guarantee referential integrity - if an entity references
-// another entity by ID, that entity must exist in the graph.
-func (c *Component) ensureReferencedEntityExists(ctx context.Context, entityID, referencedBy string) error {
+// Referential-integrity stub identity (ADR-056 Decision 4 lane-ii). The stub is
+// the framework's no-birth referential producer: a referenced target with no
+// independent producer (e.g. sensorml/cs-api children, only ever referenced via
+// a parent's hierarchy) is materialized here. The stub is now a FIRST-CLASS,
+// ENVELOPE-BEARING artifact — it carries stubMessageType so the ADR-055
+// "no envelope-less ownerless births" invariant is literally true — but it stays
+// PROFILE-LESS so MergeEntity still detects the real producer's later merge as
+// the entity's true birth (reconcileIndexingProfile keys on profile-absence,
+// component.go:1414-1419).
+var stubMessageType = message.Type{Domain: "core", Category: "identity.stub", Version: "v1"}
+
+const (
+	predStubMarker        = "core.identity.stub"
+	predStubReferencedBy  = "core.identity.referenced_by"
+	predStubOwner         = "core.identity.stub_owner"
+	stubReferentialSource = "graph-ingest-referential-integrity"
+)
+
+// ensureReferencedEntityExists creates a stub entity if the referenced entity
+// doesn't exist — the referential-integrity guarantee that a referenced ID
+// always resolves to a node (ADR-056 Decision 4 lane-ii). referencedByType is
+// the MessageType of the entity that referenced it (the reachable producer
+// identity at this seam); the ADR's "the producer's registered ForeignEdgeClaim
+// MessageType" is NOT reachable here (we hold only the source entity, not a
+// claim), so the stub records the source type — or, for an untyped source (a
+// gateway that does not stamp MessageType), the framework referential producer.
+func (c *Component) ensureReferencedEntityExists(ctx context.Context, entityID, referencedBy string, referencedByType message.Type) error {
 	// Check if entity already exists
 	_, err := c.entityBucket.Get(ctx, entityID)
 	if err == nil {
 		return nil // Entity exists, nothing to do
 	}
 
-	// Entity doesn't exist - create a stub.
+	stubOwner := stubReferentialSource
+	if referencedByType.IsValid() {
+		stubOwner = referencedByType.Key()
+	}
+
+	// Entity doesn't exist - create an envelope-bearing stub.
 	// Version is set to 1 to match the invariant held by every other
 	// EntityState write path (see component.go:872, messagemanager/
 	// processor.go:276, datamanager/manager.go:792). When the real entity
-	// later arrives, the merge path increments Version to 2.
+	// later arrives, the merge path increments Version to 2 and overwrites
+	// MessageType with the real producer's (component.go:1410).
 	now := time.Now()
 	stub := &graph.EntityState{
-		ID:        entityID,
-		Version:   1,
-		UpdatedAt: now,
+		ID:          entityID,
+		Version:     1,
+		UpdatedAt:   now,
+		MessageType: stubMessageType,
 		Triples: []message.Triple{
-			{
-				Subject:    entityID,
-				Predicate:  "core.identity.stub",
-				Object:     true,
-				Source:     "graph-ingest-referential-integrity",
-				Timestamp:  now,
-				Confidence: 1.0,
-			},
-			{
-				Subject:    entityID,
-				Predicate:  "core.identity.referenced_by",
-				Object:     referencedBy,
-				Source:     "graph-ingest-referential-integrity",
-				Timestamp:  now,
-				Confidence: 1.0,
-			},
+			{Subject: entityID, Predicate: predStubMarker, Object: true, Source: stubReferentialSource, Timestamp: now, Confidence: 1.0},
+			{Subject: entityID, Predicate: predStubReferencedBy, Object: referencedBy, Source: stubReferentialSource, Timestamp: now, Confidence: 1.0},
+			{Subject: entityID, Predicate: predStubOwner, Object: stubOwner, Source: stubReferentialSource, Timestamp: now, Confidence: 1.0},
 		},
 	}
 
@@ -1657,9 +1674,10 @@ func (c *Component) ensureReferencedEntityExists(ctx context.Context, entityID, 
 		return fmt.Errorf("store stub entity: %w", err)
 	}
 
-	c.logger.Debug("created stub entity for referential integrity",
+	c.logger.Debug("created envelope-bearing referential-integrity stub",
 		slog.String("entity_id", entityID),
-		slog.String("referenced_by", referencedBy))
+		slog.String("referenced_by", referencedBy),
+		slog.String("stub_owner", stubOwner))
 
 	return nil
 }

--- a/processor/graph-ingest/referential_stub_test.go
+++ b/processor/graph-ingest/referential_stub_test.go
@@ -1,0 +1,92 @@
+package graphingest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/vocabulary"
+)
+
+func stringObject(es *graph.EntityState, predicate string) string {
+	for _, t := range es.Triples {
+		if t.Predicate == predicate {
+			if s, ok := t.Object.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// ADR-056 Decision-4 lane-ii fold: the referential-integrity stub is now a
+// first-class ENVELOPE-BEARING artifact — it carries a valid stubMessageType (so
+// "no envelope-less ownerless births" is literally true) + records the
+// referencing producer in core.identity.stub_owner — while staying PROFILE-LESS.
+func TestReferentialStub_EnvelopeBearing(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	const target = "c360.platform.test.sys.child.001"
+	srcType := message.Type{Domain: "test", Category: "fixture", Version: "v1"}
+
+	require.NoError(t, comp.ensureReferencedEntityExists(context.Background(), target, "c360.platform.test.sys.parent.001", srcType))
+
+	es := storedEntity(t, comp, target)
+	assert.True(t, es.MessageType.IsValid(), "stub must carry a valid MessageType (envelope-bearing)")
+	assert.Equal(t, stubMessageType, es.MessageType)
+	assert.True(t, hasPredicate(es, predStubMarker), "core.identity.stub marker retained")
+	assert.True(t, hasPredicate(es, predStubReferencedBy))
+	assert.Equal(t, srcType.Key(), stringObject(es, predStubOwner),
+		"stub_owner records the reachable referencing-producer MessageType")
+	assert.False(t, hasPredicate(es, vocabulary.EntityIndexingProfile),
+		"stub MUST stay profile-less so the real merge is detected as the true birth")
+}
+
+// An untyped source (a gateway that does not stamp Entity.MessageType, e.g.
+// cs-api today) attributes the stub to the framework referential producer rather
+// than fabricating an invalid producer key.
+func TestReferentialStub_UntypedSourceAttributesToFramework(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	const target = "c360.platform.test.sys.child.002"
+
+	require.NoError(t, comp.ensureReferencedEntityExists(context.Background(), target, "c360.platform.test.sys.parent.001", message.Type{}))
+
+	es := storedEntity(t, comp, target)
+	assert.Equal(t, stubReferentialSource, stringObject(es, predStubOwner),
+		"untyped source → framework referential producer, not an invalid key")
+}
+
+// THE no-regression guard (the architect's flagged risk): promoting the stub to
+// envelope-bearing must NOT break MergeEntity's "real producer merging into a
+// profile-less stub is the true birth" detection — it keys on profile-absence,
+// not MessageType. The real merge must overwrite MessageType, increment Version,
+// and stamp the indexing profile.
+func TestReferentialStub_RealMergeStillDetectsTrueBirth(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+	const target = "c360.platform.test.sys.child.003"
+
+	require.NoError(t, comp.ensureReferencedEntityExists(ctx, target, "c360.platform.test.sys.parent.001",
+		message.Type{Domain: "test", Category: "fixture", Version: "v1"}))
+	stub := storedEntity(t, comp, target)
+	require.Equal(t, uint64(1), stub.Version)
+	require.False(t, hasPredicate(stub, vocabulary.EntityIndexingProfile))
+
+	// The real producer is born by merging onto the stub.
+	realType := message.Type{Domain: "test", Category: "real", Version: "v1"}
+	require.NoError(t, comp.MergeEntity(ctx, &graph.EntityState{
+		ID: target, MessageType: realType, Version: 1,
+		Triples: []message.Triple{{Subject: target, Predicate: "real.label", Object: "Born", Timestamp: time.Now(), Confidence: 1.0}},
+	}))
+
+	born := storedEntity(t, comp, target)
+	assert.Equal(t, realType, born.MessageType, "real merge overwrites the stub's MessageType")
+	assert.Greater(t, born.Version, uint64(1), "real merge increments Version past the stub's 1")
+	assert.True(t, hasPredicate(born, "real.label"))
+	assert.True(t, hasPredicate(born, vocabulary.EntityIndexingProfile),
+		"merging a real producer onto the profile-less stub is the true birth → profile stamped")
+}


### PR DESCRIPTION
## ADR-056 W0 4b — envelope-bearing referential-integrity stub (fourth-path fold)

Builds on the merged W0 work (#270–#273, beta.108). The **fourth auto-vivify path** — `ensureReferencedEntityExists`, which stubs a relationship target whose Object names an absent entity — survives ADR-055's must-exist flip and was an envelope-less, ownerless `Put`. This fold makes it a first-class, envelope-bearing artifact (ADR-056 Decision 4 lane-ii), so the "no envelope-less ownerless births" invariant becomes literally true.

### What changed

- **Stub gains an envelope:** `MessageType = core.identity.stub.v1` + a `core.identity.stub_owner` triple recording the **reachable source `MessageType`** (threaded from `ensureRelationshipTargetsExist`). The ADR's "the producer's registered `ForeignEdgeClaim` MessageType" is *not* reachable at this seam (only the source entity is in scope), so the stub records the source type — or the framework referential producer (`graph-ingest-referential-integrity`) for an untyped source. **ADR Decision 4 corrected to match** (the cited code wins).
- **Stub stays profile-less**, so `MergeEntity`'s "real producer merging into a profile-less stub is the true birth" detection (profile-absence keyed, *not* MessageType) is intact — the architect's flagged risk, directly unit-tested.
- **Operator note** for `foreign_edge_unclaimed_total` (the 4a metric, live since beta.108) added to `docs/operations/01-local-monitoring.md` — meaning, zero-vs-nonzero, the action (register a `ForeignEdgeClaim` / stamp `Entity.MessageType`), and its role as the 4c hatch-empty gate signal. *(semconnect operator ask, bundled here.)*

### Why fold-only (re-evaluated with the consumer correction)

semconnect cs-api is now a confirmed conformant foreign-edge consumer on beta.108. Its flow is a single `POST /systems` with an embedded hierarchy: the parent's own `hosts` edge references the no-birth child, so the stub materializes the child *before* `routeForeignEdges` lands the foreign `isHostedBy` on it. No future-birth drain (lane-i `PENDING_EDGES`) is triggered — so deferring the buffer is correct, and the **fold is what makes cs-api's no-birth children survive the eventual 4c must-exist flip**.

### Verification

- `task lint` clean · `-race` unit (incl. the no-regression guard) · full **`-race -tags=integration ./...` sweep** green (no flakes) · **`e2e:lifecycle` green**.
- Tests: envelope-bearing stub shape; untyped-source → framework attribution; `TestReferentialStub_RealMergeStillDetectsTrueBirth` (real merge still overwrites MessageType, increments Version, stamps the profile).
- Pre-merge **go-reviewer: APPROVE, no BLOCKING/HIGH** — birth-detection verified profile-keyed; 5 also-verify items confirmed; 1 LOW tracked (a latent `preserveStoredEntityMetadata` stub-type interaction, harmless today, noted for 4c).

### Tracked for 4c (not this additive fold)

- E2E coverage gap: no tier drives a production Graphable through the fourth path today (OMS objects are IRIs, not entity IDs); a relationship-target-bearing fixture is a prerequisite for the 4c must-exist flip.
- The LOW: if 4c routes a real birth through `update_with_triples` *with* profile-stamping, register `core.identity.stub.v1 → control` in `indexingProfileDefaults`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
