### PR TITLE
docs(adr-056): Identity vs Type vs Ownership layering + governance non-goals

### DIFF
--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -364,9 +364,13 @@ and a review obligation and cannot silently become permanent — this also resol
 deferred waiver-audit OQ; (P2) Decision 5 sharpened with the explicit invariant *"a
 product bucket may be authoritative ONLY for data that is NOT also authoritative state
 in `ENTITY_STATES`"*; (P2) **cryptographic provenance is RESERVED, not implemented** —
-owner registration is an AUTHORIZATION/provenance contract, NOT cryptographic proof of
-authorship (today's envelope is unauthenticated — `message/base_message.go:158-180`, a
-SHA256 of type+payload with no signing), and the follow-up is scoped in ADR-057.
+owner registration is a **provenance + write-semantics** contract (an authorization MODEL whose
+runtime enforcement is **observe-only on the current tag** — overlaps and unclaimed foreign edges
+are metered/logged, not rejected; the hard reject + owner-token write lease are later increments,
+so this is NOT yet an enforced authorization gate), and it is NOT cryptographic proof of authorship
+(today's envelope is unauthenticated — `message/base_message.go:158-180`, a SHA256 of type+payload
+with no signing); the signing follow-up is scoped in ADR-057. (Don't overclaim security: per the
+semconnect review, label this provenance + write-semantics discipline, not authorization-enforced.)
 
 Folded **re-review HIGHs**: predicate sets are **exact-string enumeration only — no
 prefix/namespace/glob on predicates** (wildcards apply to the entity-ID pattern only);
@@ -835,6 +839,13 @@ explicitly. Without this rule the *first* namespace-registration attempt would s
 false-negative (a glob predicate would fail to intersect a sibling glob, or over-match), and
 the check would ship feeling-like-coverage while catching nothing — the exact failure class
 MEMORY.md warns about. Exact-string is verifiable and total.
+
+**Corollary — aliases are read-compatibility, NOT equal write/ownership keys (semconnect review).**
+Because ownership claims AND indexes are exact-predicate driven, two predicates that mean the same
+thing semantically (e.g. `rdf.type` ↔ `sensorml.process.type`) are NOT interchangeable here. A read
+path may resolve both, but a producer MUST write the canonical framework constant — an alias is a
+*read*-compatibility shim, never an equal write contract or an equal ownership key. Owning `rdf.type`
+does not own `sensorml.process.type`; writing the alias bypasses the claim that names the constant.
 
 **Append-evidence is exempt.** Multi-valued evidence predicates have no single owner by
 design; many writers may append (web/ops back-links). The overlap check covers only the two
@@ -1575,6 +1586,14 @@ The framework owns deterministic projection; products do not hand-roll mirrors.
 | **Events / work items** (tasks, requests) | JetStream streams or product command buckets | producers; consumed via ack | n/a (different substrate) |
 | **Product private bucket** (PLAN_STATES) | product KV | product | NO (honest) — but its `ENTITY_STATES` mirror leg IS (Decision 5) |
 
+**Ownership arbitration is NOT a domain fact — but provenance CAN be (semconnect review).** Sharpened
+two-part rule: (1) *Do not* encode ownership ARBITRATION as domain triples — who-may-write lives in the
+`OWNER_CLAIMS` substrate, never as facts on the entity. (2) *Do* allow explicit provenance triples when
+they describe entity **materialization, source, audit, or lineage**. `core.identity.stub_owner` (the 4b
+fold) and `core.identity.referenced_by` are provenance-on-entity — facts about *how a node came to exist*
+— NOT ownership claims and NOT enforcement rules. The distinction matters for graph readers: CS API clients
+will see provenance-like facts and must not read them as authorization or write ownership.
+
 ## The atomicity guarantee (the KV-twofer is preserved)
 
 Replace-owned does **not** break "the write IS the event." `RemoveTriples` + `AddTriples`
@@ -1971,6 +1990,16 @@ sequencing:
    (does the base `OwnerRegistry` + `OWNER_CLAIMS`/`PENDING_EDGES` land in a 056 Wave 0 before
    ADR-055 Wave 1 pilots, or alongside?) is a sequencing call for the implementation plan, not a
    design decision. Naming the responsibility does not reorder the producer migrations.
+6. **Explicit NON-GOAL — semantic dedupe (semconnect review).** Ownership arbitrates *writes* over
+   `(entity-ID pattern, predicate)` cells; it does NOT reconcile two distinct entity IDs that denote
+   the same real-world object. Flagship case: a no-birth child gets a deterministic child ID under
+   its parent's instance token (Decision 4 lane-ii stub), but a later client that posts that same
+   physical object as a *standalone* entity under a DIFFERENT id/UID creates a SECOND graph entity
+   for one real thing — and governance will NOT merge them. Id-canonicalization / `sameAs`
+   reconciliation is a separate concern, out of scope here. This ADR guarantees only that a
+   referenced id resolves to a node and that writes to a given `(id, predicate)` cell are arbitrated
+   — not that two ids for one object are unified. (Listed as a non-goal so it is labeled, not implied
+   solved.)
 
 > Confirmed: **none of Decisions 1–5 (ownership granularity, overlap rejection, schema-backed
 > reconcile, foreign-edge birth, product-bucket enforcement), neither v3 BLOCKING fix, NOR either

--- a/docs/concepts/28-governed-semantic-state.md
+++ b/docs/concepts/28-governed-semantic-state.md
@@ -5,6 +5,25 @@ fact ingestion, a `Graphable` payload can emit triples and the graph can merge t
 
 That is not enough once the same entity is written by more than one component.
 
+## Identity, Facts, and Governance Are Different Layers
+
+Graph governance is a contract *about* writes — **not a new metadata model and not a second graph**. It is a
+governed projection over the canonical graph identity you already have. Three (really four) layers answer
+distinct questions and do not compete:
+
+| Layer | Answers | Mechanism |
+|---|---|---|
+| **Entity ID** | "What entity is this?" | the stable 6-part address `org.platform.domain.system.type.instance` |
+| **rdf/type facts** | "What does it classify as; how does it export/read?" | RDF / SOSA / SensorML triples |
+| **MessageType + projection contract** | "Which producer is writing, with what write semantics?" | the payload type + its declared graph projection |
+| **Ownership** | "Who may write which predicate groups and foreign edges, and how?" | runtime arbitration over predicate-group claims |
+
+IDs and RDF facts remain the **portable semantic shape** — what external tools and other systems read.
+Governance adds the **operational contract** for safely *producing and updating* those facts. A producer still
+writes `sensorml.process.type`, `uid`, `label`, `isHostedBy`, …; the new bit is that the write is stamped with a
+producer MessageType and an ownership claim that says "this producer owns these predicates; this foreign edge is
+expected; route it to its subject." That is governance *around* the graph, not a competing canon.
+
 ## The Problem
 
 A predicate can mean different things operationally:
@@ -37,6 +56,31 @@ payload type -> graph projection -> predicate-group ownership -> graph-ingest en
 The payload registry and ownership registry are not competing systems. The payload registry is local type lookup for
 `BaseMessage` decoding. The ownership registry is distributed arbitration for shared graph state. Projection contracts
 are the bridge between them.
+
+## What Governance Does Not Do
+
+Keep these edges sharp:
+
+- **It is not semantic dedupe.** Ownership arbitrates *writes* over `(entity-ID pattern, predicate)` cells; it does
+  not reconcile two IDs that denote the same real-world object. If one component mints a deterministic child ID and a
+  later client posts that same object as a standalone entity under a different ID/UID, the graph holds two entities —
+  governance will not merge them. Dedupe is a separate concern.
+- **Aliases are read compatibility, not equal write contracts.** Ownership and indexes are exact-predicate driven. A
+  read path may understand both a canonical predicate and an alias (e.g. `rdf.type` ↔ `sensorml.process.type`), but
+  writers must emit the canonical framework constant — an alias is not an interchangeable write/ownership key.
+- **It is not authorization (yet).** On the current release this is provenance + write-semantics discipline with
+  **observe-only** enforcement: overlaps and unclaimed foreign edges are metered and logged, not rejected. Hard
+  rejection and owner-token write leases are later increments; cryptographic authentication of authorship is reserved
+  (ADR-057).
+- **Ownership arbitration is not a domain fact — but provenance can be.** Two halves:
+  - *Do not* encode ownership arbitration as domain triples. Ownership claims live in the `OWNER_CLAIMS` substrate and
+    arbitrate who may write predicate groups; they are never facts on the entity.
+  - *Do* allow explicit provenance triples when they describe entity **materialization, source, audit, or lineage**.
+    For example, `core.identity.stub_owner` records which producer caused a referential-integrity stub to be
+    materialized — that is provenance-on-entity, **not** an ownership claim and **not** an enforcement rule.
+
+  This matters for readers: graph consumers (e.g. CS API clients) will see provenance-like facts in the graph and must
+  not mistake them for authorization or write ownership.
 
 ## When It Matters
 


### PR DESCRIPTION
## ADR-056: Identity vs Type vs Ownership layering + governance non-goals

Captures the semconnect architectural-review feedback as **clarifications** of ADR-056 — no new decision, no code change. The framing semconnect landed on: graph governance is a **governed projection over canonical graph identity**, *not* a new metadata model and *not* a second graph.

### Concepts doc (`docs/concepts/28-governed-semantic-state.md`, user-facing)

- **"Identity, Facts, and Governance Are Different Layers"** — a table situating ownership against what already exists, so it doesn't read as a competing canon:

  | Layer | Answers |
  |---|---|
  | Entity ID | "What entity is this?" (6-part address) |
  | rdf/type facts | "What does it classify as / how does it export?" |
  | MessageType + projection | "Which producer is writing, with what write semantics?" |
  | Ownership | "Who may write which predicate groups + foreign edges?" |

- **"What Governance Does Not Do"** — the four sharp edges to keep labeled: not semantic dedupe, aliases-are-read-compat (not write/ownership keys), not-authorization-yet (observe-only), and the provenance-vs-ownership rule.

### ADR-056 (design-level)

- Softened the "**AUTHORIZATION**/provenance" wording → provenance + write-semantics, observe-only, not yet an enforced authorization gate.
- **Alias-read-compat corollary** in the exact-string predicate section.
- **Semantic dedupe** added as an explicit non-goal (Open Questions).
- The **ownership-arbitration-vs-provenance two-part rule** in the CQRS-boundary section: *do not* encode arbitration as domain triples; *do* allow provenance triples (materialization/source/audit/lineage) — `core.identity.stub_owner` (4b fold) is provenance-on-entity, not an ownership claim.

Pure docs — no code/schema/test impact. Clarifies ADR-056 + the concepts doc; no new ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
