### PR TITLE
ADR-056 4c-pre-1: typed loop-execution origin contract

### DIFF
--- a/agentic/agentrun/agentrun.go
+++ b/agentic/agentrun/agentrun.go
@@ -267,7 +267,7 @@ const maxAncestryHops = 32
 //
 // Resolution order:
 //  1. Typed-first: read the loop entity's agent.run triple (the RunID stamped at
-//     spawn by buildSpawnIdentityTriples). If present, construct the run entity ID
+//     spawn by LoopExecutionEntity.Triples()). If present, construct the run entity ID
 //     directly.
 //  2. Ancestry-walk fallback (for pre-migration / un-threaded loops): walk
 //     agent.loop.parent triples up to the root (bounded at maxAncestryHops), then

--- a/agentic/loop_execution_entity.go
+++ b/agentic/loop_execution_entity.go
@@ -1,0 +1,174 @@
+package agentic
+
+import (
+	"time"
+	"unicode/utf8"
+
+	"github.com/c360studio/semstreams/message"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+const (
+	// CategoryLoopExecution is the message category for the loop-execution
+	// entity origin contract (ADR-056 W0 4c-pre-1). Distinct from
+	// CategoryLoopCreated (the event payload) — this category names the
+	// entity type, not the event.
+	CategoryLoopExecution = "loop_execution"
+
+	// loopExecutionSource is the Source stamped on all origin triples
+	// produced by LoopExecutionEntity.Triples(). Matches graphWriterSource
+	// in processor/agentic-loop so provenance attribution is unchanged.
+	loopExecutionSource = "agentic-loop"
+
+	// loopExecutionMaxPromptTripleBytes caps the size of the prompt stored
+	// as the agent.loop.description triple, including the truncation marker.
+	// Must match processor/agentic-loop's maxPromptTripleBytes constant.
+	loopExecutionMaxPromptTripleBytes = 8 * 1024
+
+	// loopExecutionTruncationMarker is appended to a truncated prompt.
+	// Must match processor/agentic-loop's truncationMarker constant.
+	loopExecutionTruncationMarker = "…[truncated]"
+)
+
+// truncateLoopDescription returns s capped at maxBytes bytes total
+// (including the truncation marker, if appended). It is UTF-8 safe —
+// the cut point is walked back to the nearest rune boundary.
+//
+// This function mirrors truncateForTriple in processor/agentic-loop;
+// it lives here so LoopExecutionEntity.Triples() can be self-contained
+// without importing the processor package (which would create a cycle).
+func truncateLoopDescription(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	budget := maxBytes - len(loopExecutionTruncationMarker)
+	if budget <= 0 {
+		return loopExecutionTruncationMarker[:maxBytes]
+	}
+	cut := budget
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + loopExecutionTruncationMarker
+}
+
+// LoopExecutionEntity is the Graphable origin contract for an agentic loop
+// execution entity (ADR-056 W0 4c-pre-1). It encodes the spawn-identity
+// triples that give the entity its typed origin: role, task, parent,
+// run, reply_to, workflow, workflow_step, user, and description.
+//
+// EntityID() and Triples() together form the typed origin contract — the
+// same data set that processor/agentic-loop's buildSpawnIdentityTriples
+// emitted, now expressed through graph.Graphable so it can be born via
+// create_with_triples instead of triple.add_batch auto-vivification.
+//
+// This type lives in the agentic package (below processor/agentic-loop in
+// the import graph) to keep the dependency direction agentic → processor
+// (never the reverse).
+type LoopExecutionEntity struct {
+	Org      string
+	Platform string
+	LoopID   string
+	Task     *TaskMessage
+}
+
+// EntityID returns the canonical 6-part entity ID for this loop execution.
+func (e *LoopExecutionEntity) EntityID() string {
+	return LoopExecutionEntityID(e.Org, e.Platform, e.LoopID)
+}
+
+// Triples returns the spawn-identity origin triples for this loop execution.
+// The predicate set is identical to what buildSpawnIdentityTriples in
+// processor/agentic-loop produced: always-on (role, task), conditionally-on
+// (parent, run, run.entity_id, reply_to, workflow, workflow_step, user,
+// description) when the corresponding TaskMessage field is non-empty.
+//
+// All triples share a single timestamp (captured once at call time) so that
+// every triple in one batch is guaranteed to have the same wall-clock value —
+// mirrors the shared-timestamp invariant preserved by buildSpawnIdentityTriples.
+//
+// Returns nil when Task is nil.
+func (e *LoopExecutionEntity) Triples() []message.Triple {
+	if e.Task == nil {
+		return nil
+	}
+
+	loopEntityID := e.EntityID()
+	now := time.Now()
+
+	triple := func(predicate string, object any) message.Triple {
+		return message.Triple{
+			Subject:    loopEntityID,
+			Predicate:  predicate,
+			Object:     object,
+			Source:     loopExecutionSource,
+			Timestamp:  now,
+			Confidence: 1.0,
+		}
+	}
+
+	triples := make([]message.Triple, 0, 10)
+
+	if e.Task.Role != "" {
+		triples = append(triples, triple(agvocab.LoopRole, e.Task.Role))
+	}
+	if e.Task.TaskID != "" {
+		triples = append(triples, triple(agvocab.LoopTask, e.Task.TaskID))
+	}
+	if e.Task.ParentLoopID != "" {
+		parentEntityID := LoopExecutionEntityID(e.Org, e.Platform, e.Task.ParentLoopID)
+		triples = append(triples, triple(agvocab.LoopParent, parentEntityID))
+	}
+	// Stamp the run anchor when the loop belongs to a run (ADR-053 D7).
+	// Two triples: agent.run = bare RunID; agent.run.entity_id = the full
+	// 6-part chain.execution ID for rule substitution.
+	if e.Task.RunID != "" {
+		triples = append(triples, triple(agvocab.LoopRun, e.Task.RunID))
+		if runEntityID, err := TryChainExecutionEntityID(e.Org, e.Platform, e.Task.RunID); err == nil {
+			triples = append(triples, triple(agvocab.LoopRunEntityID, runEntityID))
+		}
+	}
+	// Stamp the reply pointer when this loop is a reply (gh#256).
+	if e.Task.InReplyTo != "" {
+		replyEntityID := LoopExecutionEntityID(e.Org, e.Platform, e.Task.InReplyTo)
+		triples = append(triples, triple(agvocab.LoopReplyTo, replyEntityID))
+	}
+	if e.Task.WorkflowSlug != "" {
+		triples = append(triples, triple(agvocab.LoopWorkflow, e.Task.WorkflowSlug))
+	}
+	if e.Task.WorkflowStep != "" {
+		triples = append(triples, triple(agvocab.LoopWorkflowStep, e.Task.WorkflowStep))
+	}
+	if e.Task.UserID != "" {
+		triples = append(triples, triple(agvocab.LoopUser, e.Task.UserID))
+	}
+	if e.Task.Prompt != "" {
+		triples = append(triples, triple(agvocab.LoopDescription,
+			truncateLoopDescription(e.Task.Prompt, loopExecutionMaxPromptTripleBytes)))
+	}
+
+	return triples
+}
+
+// LoopExecutionMessageType returns the message.Type for the loop-execution
+// entity origin contract — key "agentic.loop_execution.v1" (snake_case category,
+// matching the agentic convention: tool_call, loop_created, approval_pending).
+//
+// Registry decision (ADR-056, intentionally pinned — not implicit): this type is
+// MUTATION-ONLY. It is stamped on CreateEntityWithTriplesRequest.Entity.MessageType
+// at birth purely as PRODUCER IDENTITY for ownership arbitration; it is NEVER
+// published as a BaseMessage payload and is therefore NOT registered in the
+// payload registry (payload_registry.go) and never round-trips through
+// payload decoding. This mirrors core.identity.stub.v1 (the referential-integrity
+// stub envelope): both are envelope-bearing graph-origin markers, not wire
+// payloads. If a future producer needs to PUBLISH a loop_execution message over
+// NATS (not merely stamp it at create), that producer must add the init()
+// registration at that point — until then, registering it would advertise a
+// decode path that does not exist.
+func LoopExecutionMessageType() message.Type {
+	return message.Type{
+		Domain:   Domain,
+		Category: CategoryLoopExecution,
+		Version:  SchemaVersion,
+	}
+}

--- a/agentic/loop_execution_entity_test.go
+++ b/agentic/loop_execution_entity_test.go
@@ -1,0 +1,360 @@
+package agentic_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/message"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+// --- LoopExecutionEntity.EntityID ---
+
+func TestLoopExecutionEntity_EntityID(t *testing.T) {
+	e := &agentic.LoopExecutionEntity{
+		Org:      "acme",
+		Platform: "ops",
+		LoopID:   "loop-abc123",
+		Task:     &agentic.TaskMessage{TaskID: "t", Role: "r"},
+	}
+	got := e.EntityID()
+	want := "acme.ops.agent.agentic-loop.execution.loop-abc123"
+	if got != want {
+		t.Errorf("EntityID() = %q, want %q", got, want)
+	}
+	if !message.IsValidEntityID(got) {
+		t.Errorf("EntityID() %q is not a valid 6-part entity ID", got)
+	}
+}
+
+// --- LoopExecutionEntity.Triples ---
+
+func triples(org, platform, loopID string, task *agentic.TaskMessage) []message.Triple {
+	e := &agentic.LoopExecutionEntity{Org: org, Platform: platform, LoopID: loopID, Task: task}
+	return e.Triples()
+}
+
+func predSet(ts []message.Triple) map[string]bool {
+	s := make(map[string]bool, len(ts))
+	for _, t := range ts {
+		s[t.Predicate] = true
+	}
+	return s
+}
+
+func objFor(ts []message.Triple, pred string) any {
+	for _, t := range ts {
+		if t.Predicate == pred {
+			return t.Object
+		}
+	}
+	return nil
+}
+
+func TestLoopExecutionEntity_Triples_NilTask(t *testing.T) {
+	e := &agentic.LoopExecutionEntity{Org: "acme", Platform: "ops", LoopID: "loop-1"}
+	if got := e.Triples(); got != nil {
+		t.Errorf("Triples() with nil Task should return nil, got %d triples", len(got))
+	}
+}
+
+func TestLoopExecutionEntity_Triples_RequiredFields(t *testing.T) {
+	task := &agentic.TaskMessage{
+		TaskID: "task-001",
+		Role:   "researcher",
+	}
+	ts := triples("acme", "ops", "loop-001", task)
+
+	loopEntityID := "acme.ops.agent.agentic-loop.execution.loop-001"
+	for _, tr := range ts {
+		if tr.Subject != loopEntityID {
+			t.Errorf("triple subject = %q, want %q", tr.Subject, loopEntityID)
+		}
+		if tr.Confidence != 1.0 {
+			t.Errorf("triple confidence = %v, want 1.0", tr.Confidence)
+		}
+		if tr.Source != "agentic-loop" {
+			t.Errorf("triple source = %q, want agentic-loop", tr.Source)
+		}
+		if tr.Timestamp.IsZero() {
+			t.Error("triple timestamp is zero")
+		}
+	}
+
+	ps := predSet(ts)
+	if !ps[agvocab.LoopRole] {
+		t.Errorf("missing required predicate: %s", agvocab.LoopRole)
+	}
+	if !ps[agvocab.LoopTask] {
+		t.Errorf("missing required predicate: %s", agvocab.LoopTask)
+	}
+	if got := objFor(ts, agvocab.LoopRole); got != "researcher" {
+		t.Errorf("LoopRole = %v, want researcher", got)
+	}
+	if got := objFor(ts, agvocab.LoopTask); got != "task-001" {
+		t.Errorf("LoopTask = %v, want task-001", got)
+	}
+}
+
+func TestLoopExecutionEntity_Triples_AllOptionalPresent(t *testing.T) {
+	task := &agentic.TaskMessage{
+		TaskID:       "task-full",
+		Role:         "architect",
+		ParentLoopID: "parent-uuid",
+		RunID:        "run-anchor-uuid",
+		InReplyTo:    "reply-loop-uuid",
+		WorkflowSlug: "code-review",
+		WorkflowStep: "draft",
+		UserID:       "user-xyz",
+		Prompt:       "Design the new auth flow",
+	}
+	ts := triples("acme", "ops", "loop-full", task)
+	ps := predSet(ts)
+
+	// 10 triples: role, task, parent, run, run.entity_id, reply_to, workflow, workflow_step, user, description
+	want := 10
+	if len(ts) != want {
+		preds := make([]string, 0, len(ts))
+		for _, tr := range ts {
+			preds = append(preds, tr.Predicate)
+		}
+		t.Errorf("expected %d triples, got %d: %v", want, len(ts), preds)
+	}
+
+	optional := []string{
+		agvocab.LoopParent,
+		agvocab.LoopRun,
+		agvocab.LoopRunEntityID,
+		agvocab.LoopReplyTo,
+		agvocab.LoopWorkflow,
+		agvocab.LoopWorkflowStep,
+		agvocab.LoopUser,
+		agvocab.LoopDescription,
+	}
+	for _, pred := range optional {
+		if !ps[pred] {
+			t.Errorf("expected optional predicate %s to be present when field is set", pred)
+		}
+	}
+}
+
+func TestLoopExecutionEntity_Triples_OptionalOmittedWhenEmpty(t *testing.T) {
+	task := &agentic.TaskMessage{
+		TaskID: "task-min",
+		Role:   "researcher",
+		// all optional fields empty
+	}
+	ts := triples("acme", "ops", "loop-min", task)
+	ps := predSet(ts)
+
+	optional := []string{
+		agvocab.LoopParent,
+		agvocab.LoopRun,
+		agvocab.LoopRunEntityID,
+		agvocab.LoopReplyTo,
+		agvocab.LoopWorkflow,
+		agvocab.LoopWorkflowStep,
+		agvocab.LoopUser,
+		agvocab.LoopDescription,
+	}
+	for _, pred := range optional {
+		if ps[pred] {
+			t.Errorf("expected %s to be omitted when field is empty", pred)
+		}
+	}
+}
+
+// Parent triple must be a full 6-part entity ID (the navigable reference
+// shape that semteams ADR-038 ancestry-walk and rule substitution rely on).
+func TestLoopExecutionEntity_Triples_ParentIsEntityID(t *testing.T) {
+	task := &agentic.TaskMessage{
+		TaskID:       "task-parent",
+		Role:         "gather",
+		ParentLoopID: "parent-loop-uuid",
+	}
+	ts := triples("acme", "ops", "loop-child", task)
+
+	parent, ok := objFor(ts, agvocab.LoopParent).(string)
+	if !ok {
+		t.Fatal("LoopParent object is not a string")
+	}
+	want := "acme.ops.agent.agentic-loop.execution.parent-loop-uuid"
+	if parent != want {
+		t.Errorf("LoopParent = %q, want %q", parent, want)
+	}
+	if !message.IsValidEntityID(parent) {
+		t.Errorf("LoopParent %q is not a valid 6-part entity ID", parent)
+	}
+}
+
+// ReplyTo triple must be a full 6-part loop entity ID.
+func TestLoopExecutionEntity_Triples_ReplyToIsEntityID(t *testing.T) {
+	task := &agentic.TaskMessage{
+		TaskID:    "task-reply",
+		Role:      "coordinator",
+		InReplyTo: "asking-loop-uuid",
+	}
+	ts := triples("acme", "ops", "loop-reply", task)
+
+	replyTo, ok := objFor(ts, agvocab.LoopReplyTo).(string)
+	if !ok {
+		t.Fatal("LoopReplyTo object is not a string")
+	}
+	want := "acme.ops.agent.agentic-loop.execution.asking-loop-uuid"
+	if replyTo != want {
+		t.Errorf("LoopReplyTo = %q, want %q", replyTo, want)
+	}
+	if !message.IsValidEntityID(replyTo) {
+		t.Errorf("LoopReplyTo %q is not a valid 6-part entity ID", replyTo)
+	}
+}
+
+// RunID: LoopRun must be the bare ID (not the 6-part), LoopRunEntityID the 6-part.
+func TestLoopExecutionEntity_Triples_RunIDShape(t *testing.T) {
+	task := &agentic.TaskMessage{
+		TaskID: "task-run",
+		Role:   "researcher",
+		RunID:  "run-uuid",
+	}
+	ts := triples("acme", "ops", "loop-run", task)
+
+	runID, ok := objFor(ts, agvocab.LoopRun).(string)
+	if !ok {
+		t.Fatal("LoopRun object is not a string")
+	}
+	if runID != "run-uuid" {
+		t.Errorf("LoopRun = %q, want bare UUID", runID)
+	}
+	if strings.Contains(runID, ".") {
+		t.Errorf("LoopRun %q contains dots — must be bare, not 6-part", runID)
+	}
+
+	runEntityID, ok := objFor(ts, agvocab.LoopRunEntityID).(string)
+	if !ok {
+		t.Fatal("LoopRunEntityID object is not a string")
+	}
+	wantEntityID := "acme.ops.agent.chain.execution.run-uuid"
+	if runEntityID != wantEntityID {
+		t.Errorf("LoopRunEntityID = %q, want %q", runEntityID, wantEntityID)
+	}
+}
+
+// All triples in one Triples() call must share the same wall-clock timestamp
+// (captured once at call time, not per-triple).
+func TestLoopExecutionEntity_Triples_SharedTimestamp(t *testing.T) {
+	task := &agentic.TaskMessage{
+		TaskID:       "task-ts",
+		Role:         "researcher",
+		ParentLoopID: "parent-id",
+		WorkflowSlug: "wf",
+		WorkflowStep: "step",
+		UserID:       "user",
+		Prompt:       "prompt",
+	}
+	ts := triples("acme", "ops", "loop-ts", task)
+	if len(ts) < 2 {
+		t.Fatalf("expected multiple triples, got %d", len(ts))
+	}
+	first := ts[0].Timestamp
+	for i, tr := range ts[1:] {
+		if !tr.Timestamp.Equal(first) {
+			t.Errorf("triple[%d] timestamp %v != triple[0] timestamp %v", i+1, tr.Timestamp, first)
+		}
+	}
+}
+
+// Timestamp must be recent (not zero, not stale).
+func TestLoopExecutionEntity_Triples_TimestampNotZero(t *testing.T) {
+	task := &agentic.TaskMessage{TaskID: "t", Role: "r"}
+	ts := triples("acme", "ops", "loop-tts", task)
+	if len(ts) == 0 {
+		t.Fatal("expected at least one triple")
+	}
+	if ts[0].Timestamp.IsZero() {
+		t.Error("timestamp is zero")
+	}
+	if time.Since(ts[0].Timestamp) > time.Minute {
+		t.Errorf("timestamp %v is suspiciously old", ts[0].Timestamp)
+	}
+}
+
+// Long prompts must be truncated to loopExecutionMaxPromptTripleBytes (8KB).
+func TestLoopExecutionEntity_Triples_LongPromptTruncated(t *testing.T) {
+	longPrompt := strings.Repeat("a", 10_000) // 10KB — above 8KB cap
+	task := &agentic.TaskMessage{TaskID: "t", Role: "r", Prompt: longPrompt}
+	ts := triples("acme", "ops", "loop-lp", task)
+
+	desc, ok := objFor(ts, agvocab.LoopDescription).(string)
+	if !ok {
+		t.Fatal("LoopDescription is not a string")
+	}
+	const maxBytes = 8 * 1024
+	if len(desc) > maxBytes {
+		t.Errorf("LoopDescription length %d exceeds cap %d", len(desc), maxBytes)
+	}
+	if !strings.HasSuffix(desc, "…[truncated]") {
+		t.Errorf("truncated description missing marker suffix: %q", desc[max(0, len(desc)-20):])
+	}
+}
+
+// UTF-8 safety: truncation must not split a multi-byte rune.
+func TestLoopExecutionEntity_Triples_TruncationUTF8Safe(t *testing.T) {
+	// Each "日" is 3 bytes; build a prompt that forces a mid-rune boundary.
+	longPrompt := strings.Repeat("日", 3000) // 9000 bytes
+	task := &agentic.TaskMessage{TaskID: "t", Role: "r", Prompt: longPrompt}
+	ts := triples("acme", "ops", "loop-utf8", task)
+
+	desc, ok := objFor(ts, agvocab.LoopDescription).(string)
+	if !ok {
+		t.Fatal("LoopDescription is not a string")
+	}
+	if !utf8.ValidString(desc) {
+		t.Errorf("truncated LoopDescription is not valid UTF-8")
+	}
+}
+
+// --- LoopExecutionMessageType ---
+
+func TestLoopExecutionMessageType_Valid(t *testing.T) {
+	mt := agentic.LoopExecutionMessageType()
+	if mt.Domain == "" {
+		t.Error("MessageType.Domain is empty")
+	}
+	if mt.Category == "" {
+		t.Error("MessageType.Category is empty")
+	}
+	if mt.Version == "" {
+		t.Error("MessageType.Version is empty")
+	}
+	if !mt.IsValid() {
+		t.Errorf("MessageType %v is not valid (IsValid() returned false)", mt)
+	}
+}
+
+func TestLoopExecutionMessageType_Distinct(t *testing.T) {
+	// Must not collide with any other category constant.
+	mt := agentic.LoopExecutionMessageType()
+	others := []string{
+		agentic.CategoryLoopCreated,
+		agentic.CategoryLoopCompleted,
+		agentic.CategoryLoopFailed,
+		agentic.CategoryLoopCancelled,
+		agentic.CategoryTask,
+	}
+	for _, cat := range others {
+		if mt.Category == cat {
+			t.Errorf("CategoryLoopExecution collides with existing category %q", cat)
+		}
+	}
+}
+
+func TestLoopExecutionMessageType_KeyFormat(t *testing.T) {
+	key := agentic.LoopExecutionMessageType().Key()
+	want := "agentic.loop_execution.v1"
+	if key != want {
+		t.Errorf("MessageType.Key() = %q, want %q", key, want)
+	}
+}

--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/agentic/agentrun"
 	"github.com/c360studio/semstreams/cmd/e2e-semstreams/mission"
 	"github.com/c360studio/semstreams/component"
@@ -34,12 +35,14 @@ import (
 	"github.com/c360studio/semstreams/persona"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
 	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/c360studio/semstreams/pkg/projection"
 	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
 	"github.com/c360studio/semstreams/processor/agentic-tools/executors"
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/service"
 	"github.com/c360studio/semstreams/types"
 	"github.com/c360studio/semstreams/vocabulary"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
 
 const (
@@ -244,6 +247,14 @@ func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ 
 		svcDeps.Logger.Warn("ownership: bucket bootstrap failed — lifecycle ownership disabled this boot", slog.Any("error", err))
 	} else {
 		svcDeps.LifecycleManager.AttachOwnership(ctx, ownerReg)
+
+		// ADR-056 4c-pre-1: register the loop-execution entity projection contract.
+		// Mirrors cmd/semstreams wiring — best-effort, never a boot gate.
+		if err := projection.Bind(ctx, ownerReg, "agentic-loop-graph-writer",
+			loopExecutionProjectionContract()); err != nil {
+			svcDeps.Logger.Warn("ownership: loop-execution projection contract registration failed",
+				slog.Any("error", err))
+		}
 	}
 
 	if err := svcDeps.LifecycleManager.Register(mission.WorkflowDeclaration()); err != nil {
@@ -775,5 +786,31 @@ func startPProfServer(port int) {
 	fmt.Printf("Starting pprof server on %s\n", addr)
 	if err := http.ListenAndServe(addr, nil); err != nil && err != http.ErrServerClosed {
 		fmt.Printf("pprof server error: %v\n", err)
+	}
+}
+
+// loopExecutionProjectionContract returns the graph projection contract for
+// loop-execution entities (ADR-056 W0 4c-pre-1). Mirrors cmd/semstreams/main.go.
+// See that function's godoc for the full rationale.
+func loopExecutionProjectionContract() projection.Contract {
+	return projection.Contract{
+		Name:          "agentic.loop-execution",
+		MessageType:   agentic.LoopExecutionMessageType().Key(),
+		EntityPattern: "*.*.agent.agentic-loop.execution.*",
+		Groups: []projection.PredicateGroup{{
+			Mode: ownership.ModeReplaceOwned,
+			Predicates: []string{
+				agvocab.LoopRole,
+				agvocab.LoopTask,
+				agvocab.LoopParent,
+				agvocab.LoopRun,
+				agvocab.LoopRunEntityID,
+				agvocab.LoopReplyTo,
+				agvocab.LoopWorkflow,
+				agvocab.LoopWorkflowStep,
+				agvocab.LoopUser,
+				agvocab.LoopDescription,
+			},
+		}},
 	}
 }

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/agentic/agentrun"
 	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/componentregistry"
@@ -32,12 +33,14 @@ import (
 	"github.com/c360studio/semstreams/persona"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
 	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/c360studio/semstreams/pkg/projection"
 	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
 	"github.com/c360studio/semstreams/processor/agentic-tools/executors"
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/service"
 	"github.com/c360studio/semstreams/types"
 	"github.com/c360studio/semstreams/vocabulary"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
 
 // Build information constants
@@ -208,6 +211,17 @@ func run() error {
 		hbCtx, hbCancel := context.WithCancel(ctx)
 		defer hbCancel()
 		svcDeps.LifecycleManager.AttachOwnership(hbCtx, ownerReg)
+
+		// ADR-056 4c-pre-1: register the loop-execution entity projection contract.
+		// This declares that "agentic-loop-graph-writer" owns the spawn-identity
+		// origin predicates on every loop-execution entity (*.*.agent.agentic-loop.execution.*)
+		// in replace-owned mode. Best-effort: a registration failure logs a warning
+		// but does not block boot — ownership is observe-only, never a boot gate.
+		if err := projection.Bind(ctx, ownerReg, "agentic-loop-graph-writer",
+			loopExecutionProjectionContract()); err != nil {
+			logger.Warn("ownership: loop-execution projection contract registration failed",
+				slog.Any("error", err))
+		}
 	}
 
 	// 10c. Register the agent-run workflow (ADR-053 D2). Must come after
@@ -761,6 +775,40 @@ func registerPayloads() (*payloadregistry.Registry, error) {
 		return nil, fmt.Errorf("register document payloads: %w", err)
 	}
 	return reg, nil
+}
+
+// loopExecutionProjectionContract returns the graph projection contract for
+// loop-execution entities (ADR-056 W0 4c-pre-1). The contract declares that
+// the "agentic-loop-graph-writer" owner holds the spawn-identity origin
+// predicates on every entity matching *.*.agent.agentic-loop.execution.* in
+// replace-owned mode.
+//
+// The predicate list matches exactly what LoopExecutionEntity.Triples() can
+// emit (always-on + conditional). Conditional predicates (parent, run,
+// run.entity_id, reply_to, workflow, workflow_step, user, description) are
+// included in the owned set even though they are not emitted on every birth —
+// ownership declares authority over the cell, not guaranteed emission.
+func loopExecutionProjectionContract() projection.Contract {
+	return projection.Contract{
+		Name:          "agentic.loop-execution",
+		MessageType:   agentic.LoopExecutionMessageType().Key(),
+		EntityPattern: "*.*.agent.agentic-loop.execution.*",
+		Groups: []projection.PredicateGroup{{
+			Mode: ownership.ModeReplaceOwned,
+			Predicates: []string{
+				agvocab.LoopRole,
+				agvocab.LoopTask,
+				agvocab.LoopParent,
+				agvocab.LoopRun,
+				agvocab.LoopRunEntityID,
+				agvocab.LoopReplyTo,
+				agvocab.LoopWorkflow,
+				agvocab.LoopWorkflowStep,
+				agvocab.LoopUser,
+				agvocab.LoopDescription,
+			},
+		}},
+	}
 }
 
 // startPProfServer starts the pprof HTTP server for profiling.

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -846,12 +846,17 @@ func (c *Component) handleTaskMessage(ctx context.Context, data []byte) {
 		slog.String("loop_id", result.LoopID),
 		slog.String("task_id", task.TaskID))
 
-	// Stamp the loop's canonical identity triples (parent, role, task,
-	// workflow, workflow_step, user, description) at spawn time so
-	// rules + tools observe them throughout the loop's lifetime, not
-	// just after completion. gh#159 — closes the agent.loop.outcome
-	// vs agent.loop.parent race that made ADR-046 Phase 1's example-
-	// fan-out reference pattern unwritable for real-LLM consumers.
+	// Birth the loop-execution entity via create_with_triples (ADR-056 4c-pre-1):
+	// gives the entity a typed MessageType envelope and a proper origin contract
+	// instead of the old triple.add_batch auto-vivify path.
+	//
+	// WriteSpawnIdentity returns an error on genuine birth failure (not
+	// already-exists — idempotent re-spawn is fine). A failed birth means graph
+	// semantics are NOT intact for this loop: subsequent completion/failure/
+	// trajectory writes would reference an entity the ownership substrate cannot
+	// attribute. We treat this as a hard precondition failure and halt the loop
+	// so it enters a clean failure state rather than silently producing
+	// unattributed graph mutations.
 	//
 	// Stamp cross-arc lineage triples (Metadata[MetadataKeyRelatedLoops]
 	// set by rule.executePublishAgent from rule.Action.RelatedLoops)
@@ -859,7 +864,13 @@ func (c *Component) handleTaskMessage(ctx context.Context, data []byte) {
 	// read both families via the existing $entity.triple.<predicate>
 	// substitution. No-op when the producer didn't set RelatedLoops.
 	if c.graphWriter != nil {
-		c.graphWriter.WriteSpawnIdentity(ctx, result.LoopID, task)
+		if err := c.graphWriter.WriteSpawnIdentity(ctx, result.LoopID, task); err != nil {
+			c.logger.Error("graph_writer: loop-execution entity birth failed — halting loop spawn",
+				"loop_id", result.LoopID, "task_id", task.TaskID, "error", err)
+			entity, _ := c.handler.GetLoop(result.LoopID)
+			c.handleLoopFailure(ctx, result.LoopID, entity, "spawn_identity_birth_failed", err)
+			return
+		}
 		if rawLineage, ok := task.Metadata[agentic.MetadataKeyRelatedLoops].(map[string]any); ok {
 			c.graphWriter.WriteLineageTriples(ctx, result.LoopID, rawLineage)
 		}

--- a/processor/agentic-loop/export_test.go
+++ b/processor/agentic-loop/export_test.go
@@ -51,6 +51,6 @@ func (g *GraphWriterForTest) WriteTrajectorySteps(ctx context.Context, loopID st
 func (g *GraphWriterForTest) WriteLineageTriples(ctx context.Context, loopID string, related map[string]any) {
 	g.w.WriteLineageTriples(ctx, loopID, related)
 }
-func (g *GraphWriterForTest) WriteSpawnIdentity(ctx context.Context, loopID string, task *agentic.TaskMessage) {
-	g.w.WriteSpawnIdentity(ctx, loopID, task)
+func (g *GraphWriterForTest) WriteSpawnIdentity(ctx context.Context, loopID string, task *agentic.TaskMessage) error {
+	return g.w.WriteSpawnIdentity(ctx, loopID, task)
 }

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -552,13 +552,17 @@ func buildLineageTriples(loopEntityID string, related map[string]any) []message.
 // Idempotency: an already-exists response is treated as success — re-spawn
 // and retry are safe (the entity is born either way).
 //
-// Returns an error on genuine birth failure. The caller MUST NOT proceed
-// as if graph semantics are intact when an error is returned — the loop
-// must be halted. The pre-4c-pre-1 best-effort-Warn behaviour is now a
-// hard precondition at the call site.
+// Returns an error ONLY on genuine birth failure (the create_with_triples
+// round-trip — transport error, a non-idempotent failure, or an EntityExists
+// that is not our typed origin). The caller MUST NOT proceed as if graph
+// semantics are intact when an error is returned — the loop must be halted.
+// The pre-4c-pre-1 best-effort-Warn behaviour is now a hard precondition at
+// the call site, but ONLY for that birth-failure class.
 //
-// Nil natsClient or nil task are no-ops (return nil), matching the previous
-// caller guards.
+// No-op skips (return nil), matching the previous caller guards and every
+// sibling graph-write method: nil natsClient, nil task, empty triples, and
+// missing platform identity (no valid 6-part entity ID to build → nothing to
+// birth). These are NOT failures and MUST NOT halt the loop.
 func (w *graphWriter) WriteSpawnIdentity(ctx context.Context, loopID string, task *agentic.TaskMessage) error {
 	if w.natsClient == nil {
 		return nil
@@ -566,10 +570,18 @@ func (w *graphWriter) WriteSpawnIdentity(ctx context.Context, loopID string, tas
 	if task == nil {
 		return nil
 	}
+	// Platform identity missing = there is no valid 6-part entity ID to build,
+	// so there is NOTHING to birth — a graceful skip, NOT a birth failure. This
+	// matches every sibling graph-write method (WriteSyntheticDecide /
+	// WriteModelEndpoints / WriteLoopCompletion / WriteLoopFailure /
+	// WriteTrajectory all Warn+return here) and the nil-client / nil-task /
+	// empty-triples guards above. An ERROR from this method is reserved for a
+	// genuine birth FAILURE (the create_with_triples round-trip below); only
+	// that halts the loop at the caller.
 	if w.platform.Org == "" || w.platform.Platform == "" {
 		w.logger.Warn("graph_writer: cannot write spawn identity, platform identity missing",
 			"loop_id", loopID, "org", w.platform.Org, "platform", w.platform.Platform)
-		return fmt.Errorf("spawn identity: platform identity missing (org=%q platform=%q)", w.platform.Org, w.platform.Platform)
+		return nil
 	}
 
 	entity := &agentic.LoopExecutionEntity{

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	graphMutationSubject      = "graph.mutation.triple.add"
-	graphMutationBatchSubject = "graph.mutation.triple.add_batch"
-	graphWriterTimeout        = 5 * time.Second
-	graphWriterSource         = "agentic-loop"
+	graphMutationSubject               = "graph.mutation.triple.add"
+	graphMutationBatchSubject          = "graph.mutation.triple.add_batch"
+	graphMutationCreateWithTriplesSubj = "graph.mutation.entity.create_with_triples"
+	graphWriterTimeout                 = 5 * time.Second
+	graphWriterSource                  = "agentic-loop"
 	// syntheticDecideSource is the Source on triples emitted by
 	// WriteSyntheticDecide (#133). Distinct from graphWriterSource
 	// ("agentic-loop") and decideToolSource ("coordinator-decide") so
@@ -151,6 +152,99 @@ func (w *graphWriter) writeBatch(ctx context.Context, triples []message.Triple) 
 	}
 
 	return nil
+}
+
+// createEntityWithTriples sends a CreateEntityWithTriplesRequest to
+// graph.mutation.entity.create_with_triples via NATS request/reply, using the
+// same transport config (timeout, retry) as writeBatch.
+//
+// Idempotency contract (ADR-056 typed-origin): a response with ErrorCode ==
+// graph.ErrorCodeEntityExists is treated as success ONLY after a read-back
+// confirms the existing entity is the SAME typed origin (MessageType) the spawn
+// intended — a genuine re-spawn / retry. If the pre-existing entity is an
+// envelope-less auto-vivified shell or a foreign entity colliding on the id,
+// EntityExists is a birth FAILURE, never a silent "born." See
+// verifyExistingLoopOrigin.
+//
+// Returns a non-nil error only on genuine birth failures (transport error,
+// handler-internal error, an EntityExists that is not our typed origin, any
+// other non-success failure). The caller must not proceed as if graph semantics
+// are intact when an error is returned.
+func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtypes.EntityState, triples []message.Triple) error {
+	req := gtypes.CreateEntityWithTriplesRequest{
+		Entity:  entity,
+		Triples: triples,
+	}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal create_with_triples request: %w", err)
+	}
+
+	respData, err := w.natsClient.RequestWithRetry(ctx, graphMutationCreateWithTriplesSubj, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig())
+	if err != nil {
+		return fmt.Errorf("NATS create_with_triples request failed: %w", err)
+	}
+
+	var resp gtypes.CreateEntityWithTriplesResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return fmt.Errorf("unmarshal create_with_triples response: %w", err)
+	}
+
+	if !resp.Success {
+		// EntityExists is idempotent-success ONLY if the existing entity is
+		// already this typed origin (same MessageType) — a genuine retry /
+		// redelivery / re-spawn of OUR origin. Blessing any EntityExists blindly
+		// would launder a pre-existing auto-vivified shell (Version-0 / no
+		// envelope) or a foreign entity into a "born" loop origin, defeating the
+		// typed-origin contract (ADR-056). Read + verify before treating it as born.
+		if resp.ErrorCode == gtypes.ErrorCodeEntityExists {
+			return w.verifyExistingLoopOrigin(ctx, entity.ID, entity.MessageType)
+		}
+		return fmt.Errorf("create_with_triples failed (code=%s): %s", resp.ErrorCode, resp.Error)
+	}
+
+	return nil
+}
+
+// verifyExistingLoopOrigin guards the EntityExists idempotency path: it reads the
+// already-existing entity and confirms it carries the SAME typed origin
+// MessageType the spawn intended. A match means a safe idempotent re-birth
+// (retry / redelivery / re-spawn). A mismatch (an envelope-less auto-vivified
+// shell, or a foreign entity colliding on the id) or an unreadable entity is a
+// birth FAILURE the caller halts on — never a silent "born." Reuses the
+// same-package graph.ingest.query.entity read surface (see todos.go).
+//
+// Canonicality note (gh#276): a same-MessageType match treats the
+// FIRST spawn's identity triples as canonical — a divergent re-spawn that reuses
+// the same loop_id under a DIFFERENT task_id is accepted as idempotent and its
+// new identity triples are NOT written (create_with_triples returns before any
+// merge on EntityExists). This is intentional: refusing a same-MessageType match
+// would break genuine retry/redelivery, and the normal redelivery path is already
+// short-circuited upstream by the task_id dedup before birth is reached. The only
+// trigger is a producer contract violation (loop_id reuse), and this is strictly
+// safer than the pre-4c-pre-1 triple.add_batch path, which would have APPENDED
+// conflicting role/parent values onto the existing entity.
+func (w *graphWriter) verifyExistingLoopOrigin(ctx context.Context, entityID string, want message.Type) error {
+	reqData, err := json.Marshal(struct {
+		ID string `json:"id"`
+	}{ID: entityID})
+	if err != nil {
+		return fmt.Errorf("marshal origin-verify query for %s: %w", entityID, err)
+	}
+	respData, err := w.natsClient.RequestClassified(ctx, queryEntitySubject, reqData, graphWriterTimeout)
+	if err != nil {
+		// Cannot confirm the existing entity is our origin → do not bless it.
+		return fmt.Errorf("create_with_triples returned entity_exists for %s but the read-back to verify the typed origin failed: %w", entityID, err)
+	}
+	var existing gtypes.EntityState
+	if err := json.Unmarshal(respData, &existing); err != nil {
+		return fmt.Errorf("create_with_triples entity_exists: unmarshal existing entity %s: %w", entityID, err)
+	}
+	if existing.MessageType == want {
+		return nil // same typed origin — idempotent re-birth, safe to treat as born
+	}
+	return fmt.Errorf("create_with_triples: %s already exists but is NOT a %s typed origin (existing message_type=%q) — refusing to bless a non-origin shell as born",
+		entityID, want.Key(), existing.MessageType.Key())
 }
 
 // WriteSyntheticDecide stamps the synthetic decide triples (#133) onto
@@ -448,119 +542,59 @@ func buildLineageTriples(loopEntityID string, related map[string]any) []message.
 	return triples
 }
 
-// WriteSpawnIdentity stamps the loop's canonical identity triples on
-// its execution entity at spawn time. These predicates are known the
-// moment the TaskMessage arrives at the loop component, so deferring
-// them to completion (the pre-gh#159 shape) creates two problems:
+// WriteSpawnIdentity births the loop-execution entity via a typed origin
+// contract (ADR-056 W0 4c-pre-1). It constructs a LoopExecutionEntity from
+// the spawn parameters, gets the full origin triple set from its Triples()
+// method (IDENTICAL predicate set to the pre-4c-pre-1 buildSpawnIdentityTriples),
+// and sends a synchronous create_with_triples request so the entity is born
+// with a proper MessageType envelope rather than auto-vivified by triple.add_batch.
 //
-//   - Mid-loop reads can't observe them. Trajectory inspection,
-//     ancestry walks from a still-running child, and rules firing
-//     on intermediate signals all see the loop entity without
-//     these attributes until completion.
-//   - Completion-path stamping arrives staggered across N events
-//     (per-triple writes), letting rules fire on agent.loop.outcome
-//     before agent.loop.parent lands — the gh#159 race that breaks
-//     ADR-046 Phase 1's example-fan-out reference pattern.
+// Idempotency: an already-exists response is treated as success — re-spawn
+// and retry are safe (the entity is born either way).
 //
-// Atomic-batch stamp on the loop entity. Conditional triples (parent,
-// workflow, workflow_step, user, description) are omitted when their
-// TaskMessage source field is empty so the entity isn't polluted with
-// zero-value triples.
+// Returns an error on genuine birth failure. The caller MUST NOT proceed
+// as if graph semantics are intact when an error is returned — the loop
+// must be halted. The pre-4c-pre-1 best-effort-Warn behaviour is now a
+// hard precondition at the call site.
 //
-// Failure handling matches WriteLineageTriples: log and continue. A
-// failed stamp surfaces downstream as $entity.triple.agent.loop.parent
-// (etc.) tripping the unresolvedTemplateVarRe warning — same shape
-// rule authors already debug.
-func (w *graphWriter) WriteSpawnIdentity(ctx context.Context, loopID string, task *agentic.TaskMessage) {
+// Nil natsClient or nil task are no-ops (return nil), matching the previous
+// caller guards.
+func (w *graphWriter) WriteSpawnIdentity(ctx context.Context, loopID string, task *agentic.TaskMessage) error {
 	if w.natsClient == nil {
-		return
+		return nil
 	}
 	if task == nil {
-		return
+		return nil
 	}
 	if w.platform.Org == "" || w.platform.Platform == "" {
 		w.logger.Warn("graph_writer: cannot write spawn identity, platform identity missing",
 			"loop_id", loopID, "org", w.platform.Org, "platform", w.platform.Platform)
-		return
+		return fmt.Errorf("spawn identity: platform identity missing (org=%q platform=%q)", w.platform.Org, w.platform.Platform)
 	}
 
-	loopEntityID := agentic.LoopExecutionEntityID(w.platform.Org, w.platform.Platform, loopID)
-	triples := buildSpawnIdentityTriples(loopEntityID, task, w.platform.Org, w.platform.Platform)
+	entity := &agentic.LoopExecutionEntity{
+		Org:      w.platform.Org,
+		Platform: w.platform.Platform,
+		LoopID:   loopID,
+		Task:     task,
+	}
+
+	triples := entity.Triples()
 	if len(triples) == 0 {
-		return
-	}
-	if err := w.writeBatch(ctx, triples); err != nil {
-		w.logger.Warn("graph_writer: failed to write spawn identity batch",
-			"loop_id", loopID, "predicate_count", len(triples), "error", err)
-	}
-}
-
-// buildSpawnIdentityTriples constructs the spawn-time identity triples
-// on the loop-execution entity. Pure (clock-injection via time.Now is
-// the same shape as buildLoopCompletionTriples), so it's unit-testable
-// without NATS.
-//
-// Always emits: agent.loop.role, agent.loop.task. Conditionally emits
-// parent, workflow, workflow_step, user, description when the
-// corresponding TaskMessage field is non-empty.
-func buildSpawnIdentityTriples(loopEntityID string, task *agentic.TaskMessage, org, platform string) []message.Triple {
-	now := time.Now()
-	triple := func(predicate string, object any) message.Triple {
-		return message.Triple{
-			Subject:    loopEntityID,
-			Predicate:  predicate,
-			Object:     object,
-			Source:     graphWriterSource,
-			Timestamp:  now,
-			Confidence: 1.0,
-		}
+		return nil
 	}
 
-	triples := make([]message.Triple, 0, 8)
-	if task.Role != "" {
-		triples = append(triples, triple(agvocab.LoopRole, task.Role))
+	entityState := &gtypes.EntityState{
+		ID:          entity.EntityID(),
+		MessageType: agentic.LoopExecutionMessageType(),
+		Triples:     triples,
 	}
-	if task.TaskID != "" {
-		triples = append(triples, triple(agvocab.LoopTask, task.TaskID))
+
+	if err := w.createEntityWithTriples(ctx, entityState, triples); err != nil {
+		return fmt.Errorf("spawn identity birth failed for loop %s: %w", loopID, err)
 	}
-	if task.ParentLoopID != "" {
-		parentEntityID := agentic.LoopExecutionEntityID(org, platform, task.ParentLoopID)
-		triples = append(triples, triple(agvocab.LoopParent, parentEntityID))
-	}
-	// Stamp the run anchor when the loop belongs to a run (ADR-053 D7).
-	// Two triples: agent.run = bare RunID (used by ResolveRun/RunID());
-	// agent.run.entity_id = the full 6-part chain.execution ID, the
-	// rule-addressable upsert SUBJECT (rules cannot derive the 6-part from
-	// the bare id — substitution is string interpolation, not function calls).
-	if task.RunID != "" {
-		triples = append(triples, triple(agvocab.LoopRun, task.RunID))
-		if runEntityID, err := agentic.TryChainExecutionEntityID(org, platform, task.RunID); err == nil {
-			triples = append(triples, triple(agvocab.LoopRunEntityID, runEntityID))
-		}
-	}
-	// Stamp the reply pointer when this loop is a reply (gh#256). Mirrors
-	// LoopParent: a 6-part loop entity reference, so a resume rule reading
-	// $entity.triple.agent.loop.reply_to gets a navigable reference, not a bare
-	// id. Distinct from RunID (which run this loop belongs to) — reply_to marks
-	// THIS loop as the reply so a marker rule can fire on it and drive the run
-	// from awaiting_approval back to executing (ADR-053 §4b-2).
-	if task.InReplyTo != "" {
-		replyEntityID := agentic.LoopExecutionEntityID(org, platform, task.InReplyTo)
-		triples = append(triples, triple(agvocab.LoopReplyTo, replyEntityID))
-	}
-	if task.WorkflowSlug != "" {
-		triples = append(triples, triple(agvocab.LoopWorkflow, task.WorkflowSlug))
-	}
-	if task.WorkflowStep != "" {
-		triples = append(triples, triple(agvocab.LoopWorkflowStep, task.WorkflowStep))
-	}
-	if task.UserID != "" {
-		triples = append(triples, triple(agvocab.LoopUser, task.UserID))
-	}
-	if task.Prompt != "" {
-		triples = append(triples, triple(agvocab.LoopDescription, truncateForTriple(task.Prompt, maxPromptTripleBytes)))
-	}
-	return triples
+
+	return nil
 }
 
 // WriteLoopCancellation emits triples for a loop that was cancelled.

--- a/processor/agentic-loop/graph_writer_integration_test.go
+++ b/processor/agentic-loop/graph_writer_integration_test.go
@@ -600,6 +600,31 @@ func TestWriteSpawnIdentity_NilTask_Integration(t *testing.T) {
 	}
 }
 
+// ADR-056 4c-pre-1: missing platform identity is a graceful SKIP (return nil,
+// no request), NOT a birth failure — there is no valid 6-part entity ID to
+// build, so there is nothing to birth. Matches every sibling graph-write method
+// and the nil-client / nil-task / empty-triples guards. Regression guard: a
+// missing-platform error here would hard-halt every loop in a degenerate/test
+// config (the CI failure that surfaced this).
+func TestWriteSpawnIdentity_MissingPlatformSkipsWithoutError_Integration(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
+	ctx := context.Background()
+
+	responder := &createWithTriplesResponder{}
+	responder.subscribe(t, ctx, tc.Client)
+
+	// Empty PlatformMeta — no org/platform → no valid entity ID.
+	w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{})
+	task := &agentic.TaskMessage{TaskID: "task-noplat", Role: "researcher"}
+
+	if err := w.WriteSpawnIdentity(ctx, "loop-noplat", task); err != nil {
+		t.Errorf("missing platform identity must be a graceful skip (nil), got error: %v", err)
+	}
+	if got := len(responder.getReceived()); got != 0 {
+		t.Errorf("missing platform identity must send zero create_with_triples requests, got %d", got)
+	}
+}
+
 func TestWriteLoopCancellation_Integration(t *testing.T) {
 	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
 	ctx := context.Background()

--- a/processor/agentic-loop/graph_writer_integration_test.go
+++ b/processor/agentic-loop/graph_writer_integration_test.go
@@ -113,6 +113,89 @@ func (tc *tripleCollector) predicateSet() map[string]bool {
 	return s
 }
 
+// createWithTriplesResponder is a NATS responder for
+// graph.mutation.entity.create_with_triples requests (ADR-056 4c-pre-1).
+// It captures the triples from the request body and replies with success
+// (or with ErrorCodeEntityExists when alreadyExists is set, to exercise
+// the idempotency path).
+type createWithTriplesResponder struct {
+	mu            sync.Mutex
+	received      []gtypes.CreateEntityWithTriplesRequest
+	alreadyExists bool   // when true, reply with ErrorCodeEntityExists
+	failWith      string // when non-empty, reply with this error (and ErrorCodeInternal)
+}
+
+func (r *createWithTriplesResponder) handler(_ context.Context, data []byte) ([]byte, error) {
+	var req gtypes.CreateEntityWithTriplesRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+
+	r.mu.Lock()
+	r.received = append(r.received, req)
+	r.mu.Unlock()
+
+	resp := gtypes.CreateEntityWithTriplesResponse{}
+	switch {
+	case r.alreadyExists:
+		resp.MutationResponse = gtypes.MutationResponse{
+			Success:   false,
+			Error:     "entity already exists",
+			ErrorCode: gtypes.ErrorCodeEntityExists,
+			Timestamp: time.Now().UnixNano(),
+		}
+	case r.failWith != "":
+		resp.MutationResponse = gtypes.MutationResponse{
+			Success:   false,
+			Error:     r.failWith,
+			ErrorCode: gtypes.ErrorCodeInternal,
+			Timestamp: time.Now().UnixNano(),
+		}
+	default:
+		resp.MutationResponse = gtypes.MutationResponse{
+			Success:   true,
+			Timestamp: time.Now().UnixNano(),
+		}
+		resp.TriplesAdded = len(req.Triples)
+	}
+	return json.Marshal(resp)
+}
+
+func (r *createWithTriplesResponder) subscribe(t *testing.T, ctx context.Context, client *natsclient.Client) {
+	t.Helper()
+	if _, err := client.SubscribeForRequests(ctx, "graph.mutation.entity.create_with_triples", r.handler); err != nil {
+		t.Fatalf("subscribe create_with_triples: %v", err)
+	}
+}
+
+func (r *createWithTriplesResponder) getReceived() []gtypes.CreateEntityWithTriplesRequest {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]gtypes.CreateEntityWithTriplesRequest, len(r.received))
+	copy(out, r.received)
+	return out
+}
+
+// queryEntityResponder is a NATS responder for graph.ingest.query.entity reads
+// (ADR-056 4c-pre-1 EntityExists guardrail). It replies with a fixed EntityState
+// so verifyExistingLoopOrigin can read back the existing entity's MessageType and
+// decide whether an EntityExists response is a safe same-origin re-birth or a
+// non-origin shell it must refuse to bless.
+type queryEntityResponder struct {
+	entity gtypes.EntityState
+}
+
+func (r *queryEntityResponder) handler(_ context.Context, _ []byte) ([]byte, error) {
+	return json.Marshal(r.entity)
+}
+
+func (r *queryEntityResponder) subscribe(t *testing.T, ctx context.Context, client *natsclient.Client) {
+	t.Helper()
+	if _, err := client.SubscribeForRequests(ctx, "graph.ingest.query.entity", r.handler); err != nil {
+		t.Fatalf("subscribe query.entity: %v", err)
+	}
+}
+
 // newTestGraphWriter creates a graphWriter wired to a real NATS test client.
 // Exported fields are accessed via the agenticloop package's NewGraphWriter constructor
 // which we can't use from _test package, so we test via the exported Write* methods
@@ -323,18 +406,23 @@ func TestWriteLoopFailure_Integration(t *testing.T) {
 	}
 }
 
-// gh#159: WriteSpawnIdentity stamps all canonical identity triples on
-// the loop-execution entity in one atomic batch at spawn time.
-// Reproduces the production wire path so a refactor that splits the
-// stamp back into per-triple writes (re-introducing the
-// agent.loop.outcome <-> agent.loop.parent race that broke ADR-046
-// Phase 1's example-fan-out reference pattern) fails this test.
+// ADR-056 4c-pre-1: WriteSpawnIdentity births the loop-execution entity via
+// create_with_triples so it has a typed origin contract (MessageType = agentic.loop_execution.v1)
+// instead of being auto-vivified by triple.add_batch. This test verifies:
+//   - The request goes to graph.mutation.entity.create_with_triples (not add_batch).
+//   - The Entity.ID is the correct 6-part loop-execution entity ID.
+//   - The MessageType key is "agentic.loop_execution.v1".
+//   - The Triples body carries all expected spawn-identity predicates.
+//   - Parent triple is a valid 6-part entity ID.
+//   - The call returns nil (success) on a clean responder.
 func TestWriteSpawnIdentity_Integration(t *testing.T) {
 	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
 	ctx := context.Background()
 
-	collector := &tripleCollector{}
-	collector.subscribeMutations(t, ctx, tc.Client)
+	// Wire create_with_triples responder. The old tripleCollector
+	// (add/add_batch) is NOT wired — the birth must NOT touch those subjects.
+	responder := &createWithTriplesResponder{}
+	responder.subscribe(t, ctx, tc.Client)
 
 	w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
 
@@ -348,9 +436,36 @@ func TestWriteSpawnIdentity_Integration(t *testing.T) {
 		Prompt:       "Investigate MQTT retained messages",
 	}
 
-	w.WriteSpawnIdentity(ctx, "loop-spawn-int", task)
+	if err := w.WriteSpawnIdentity(ctx, "loop-spawn-int", task); err != nil {
+		t.Fatalf("WriteSpawnIdentity: unexpected error: %v", err)
+	}
 
-	preds := collector.predicateSet()
+	received := responder.getReceived()
+	if len(received) != 1 {
+		t.Fatalf("expected exactly 1 create_with_triples request, got %d", len(received))
+	}
+	req := received[0]
+
+	// Entity ID must be the loop-execution 6-part ID.
+	wantEntityID := "acme.ops.agent.agentic-loop.execution.loop-spawn-int"
+	if req.Entity == nil {
+		t.Fatal("Entity field is nil in create_with_triples request")
+	}
+	if req.Entity.ID != wantEntityID {
+		t.Errorf("Entity.ID = %q, want %q", req.Entity.ID, wantEntityID)
+	}
+
+	// MessageType must be agentic.loop_execution.v1.
+	wantMsgType := "agentic.loop_execution.v1"
+	if got := req.Entity.MessageType.Key(); got != wantMsgType {
+		t.Errorf("MessageType.Key() = %q, want %q", got, wantMsgType)
+	}
+
+	// Verify the required predicates are present in the Triples body.
+	predSet := make(map[string]bool, len(req.Triples))
+	for _, tr := range req.Triples {
+		predSet[tr.Predicate] = true
+	}
 	required := []string{
 		agvocab.LoopRole,
 		agvocab.LoopTask,
@@ -361,13 +476,13 @@ func TestWriteSpawnIdentity_Integration(t *testing.T) {
 		agvocab.LoopDescription,
 	}
 	for _, pred := range required {
-		if !preds[pred] {
-			t.Errorf("expected %s in spawn identity stamp", pred)
+		if !predSet[pred] {
+			t.Errorf("expected predicate %s in create_with_triples Triples body", pred)
 		}
 	}
 
 	// Parent must be a valid 6-part entity ID.
-	for _, tr := range collector.getTriples() {
+	for _, tr := range req.Triples {
 		if tr.Predicate != agvocab.LoopParent {
 			continue
 		}
@@ -383,37 +498,105 @@ func TestWriteSpawnIdentity_Integration(t *testing.T) {
 			t.Errorf("LoopParent = %q, want %q", parent, want)
 		}
 	}
+}
 
-	// gh#159 atomicity: all 7 identity triples land in exactly ONE
-	// batch request.
-	single, batch, sizes := collector.requestCounts()
-	if single != 0 {
-		t.Errorf("expected zero single-triple add requests, got %d", single)
-	}
-	if batch != 1 {
-		t.Errorf("expected exactly one batch request, got %d (sizes=%v)", batch, sizes)
-	}
-	if batch == 1 && sizes[0] != len(required) {
-		t.Errorf("expected batch size %d, got %d", len(required), sizes[0])
+// ADR-056 4c-pre-1: WriteSpawnIdentity treats an already-exists response as
+// success ONLY after the read-back guardrail confirms the existing entity is the
+// SAME typed origin (MessageType == agentic.loop_execution.v1). Re-spawn / retry
+// / redelivery on our own loop origin must not fail.
+func TestWriteSpawnIdentity_IdempotentOnSameTypedOrigin_Integration(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
+	ctx := context.Background()
+
+	responder := &createWithTriplesResponder{alreadyExists: true}
+	responder.subscribe(t, ctx, tc.Client)
+
+	// The read-back must find the SAME typed origin for EntityExists to count
+	// as a safe idempotent re-birth.
+	q := &queryEntityResponder{entity: gtypes.EntityState{
+		ID:          "acme.ops.agent.agentic-loop.execution.loop-idem",
+		MessageType: agentic.LoopExecutionMessageType(),
+	}}
+	q.subscribe(t, ctx, tc.Client)
+
+	w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
+	task := &agentic.TaskMessage{TaskID: "task-idem", Role: "researcher"}
+
+	if err := w.WriteSpawnIdentity(ctx, "loop-idem", task); err != nil {
+		t.Errorf("WriteSpawnIdentity should return nil on already-exists SAME typed origin, got: %v", err)
 	}
 }
 
-// gh#159: WriteSpawnIdentity must no-op for a nil task without
-// panicking. Callers (component.go's handleTaskMessage path) guard with
-// nil checks but the helper should be robust to the contract anyway.
+// ADR-056 4c-pre-1 guardrail: EntityExists is success ONLY when the existing
+// entity is the SAME typed origin. If the pre-existing entity is an envelope-less
+// auto-vivified shell (empty MessageType) or a foreign entity colliding on the id
+// (different MessageType), WriteSpawnIdentity must return an error so the caller
+// halts — never silently bless a non-origin as "born."
+func TestWriteSpawnIdentity_EntityExistsNotOurTypedOrigin_Integration(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing message.Type
+	}{
+		{"envelope-less auto-vivified shell", message.Type{}},
+		{"foreign entity colliding on id", message.Type{Domain: "cs", Category: "system", Version: "v1"}},
+	}
+	for _, tcase := range cases {
+		t.Run(tcase.name, func(t *testing.T) {
+			tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
+			ctx := context.Background()
+
+			responder := &createWithTriplesResponder{alreadyExists: true}
+			responder.subscribe(t, ctx, tc.Client)
+
+			q := &queryEntityResponder{entity: gtypes.EntityState{
+				ID:          "acme.ops.agent.agentic-loop.execution.loop-shell",
+				MessageType: tcase.existing,
+			}}
+			q.subscribe(t, ctx, tc.Client)
+
+			w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
+			task := &agentic.TaskMessage{TaskID: "task-shell", Role: "researcher"}
+
+			if err := w.WriteSpawnIdentity(ctx, "loop-shell", task); err == nil {
+				t.Error("WriteSpawnIdentity must return an error when the existing entity is NOT our typed origin (refuse to bless a shell/foreign as born)")
+			}
+		})
+	}
+}
+
+// ADR-056 4c-pre-1: WriteSpawnIdentity returns an error on genuine birth failure
+// (non-already-exists). The caller must be able to detect and halt.
+func TestWriteSpawnIdentity_ReturnsErrorOnGenuineFailure_Integration(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
+	ctx := context.Background()
+
+	responder := &createWithTriplesResponder{failWith: "disk full"}
+	responder.subscribe(t, ctx, tc.Client)
+
+	w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
+	task := &agentic.TaskMessage{TaskID: "task-fail", Role: "researcher"}
+
+	if err := w.WriteSpawnIdentity(ctx, "loop-fail", task); err == nil {
+		t.Error("WriteSpawnIdentity should return an error on genuine failure, got nil")
+	}
+}
+
+// ADR-056 4c-pre-1 / gh#159: WriteSpawnIdentity must no-op for a nil task
+// without panicking (returns nil — caller already checked).
 func TestWriteSpawnIdentity_NilTask_Integration(t *testing.T) {
 	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
 	ctx := context.Background()
 
-	collector := &tripleCollector{}
-	collector.subscribeMutations(t, ctx, tc.Client)
+	responder := &createWithTriplesResponder{}
+	responder.subscribe(t, ctx, tc.Client)
 
 	w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
-	w.WriteSpawnIdentity(ctx, "loop-nil", nil)
+	if err := w.WriteSpawnIdentity(ctx, "loop-nil", nil); err != nil {
+		t.Errorf("expected nil for nil task, got: %v", err)
+	}
 
-	single, batch, _ := collector.requestCounts()
-	if single+batch != 0 {
-		t.Errorf("expected zero requests for nil task, got single=%d batch=%d", single, batch)
+	if got := len(responder.getReceived()); got != 0 {
+		t.Errorf("expected zero requests for nil task, got %d", got)
 	}
 }
 

--- a/processor/agentic-loop/graph_writer_ops_test.go
+++ b/processor/agentic-loop/graph_writer_ops_test.go
@@ -81,7 +81,7 @@ func TestOpsQuery_LoopOutcomeByRole(t *testing.T) {
 		// the loop entity from KV which carries BOTH spawn-time and
 		// completion-time triples; simulate the same union here.
 		spawnTask := &agentic.TaskMessage{TaskID: "task-" + r.loopID, Role: r.role}
-		allTriples = append(allTriples, buildSpawnIdentityTriples(entityID, spawnTask, testOrg, testPlatform)...)
+		allTriples = append(allTriples, buildSpawnTriples(entityID, spawnTask, testOrg, testPlatform)...)
 		if r.outcome == "success" {
 			event := &agentic.LoopCompletedEvent{
 				LoopID:      r.loopID,
@@ -247,7 +247,7 @@ func TestOpsQuery_IterationDistribution(t *testing.T) {
 		entityID := testLoopEntityID(r.loopID)
 		// gh#159: role is now spawn-stamped; mirror production flow.
 		spawnTask := &agentic.TaskMessage{TaskID: "task-" + r.loopID, Role: r.role}
-		allTriples = append(allTriples, buildSpawnIdentityTriples(entityID, spawnTask, testOrg, testPlatform)...)
+		allTriples = append(allTriples, buildSpawnTriples(entityID, spawnTask, testOrg, testPlatform)...)
 		event := &agentic.LoopCompletedEvent{
 			LoopID:      r.loopID,
 			TaskID:      "task-" + r.loopID,

--- a/processor/agentic-loop/spawn_identity_test.go
+++ b/processor/agentic-loop/spawn_identity_test.go
@@ -9,11 +9,42 @@ import (
 	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
 
-// gh#159: WriteSpawnIdentity stamps the loop's canonical identity
-// predicates at spawn time so rules + tools observe them throughout
-// the loop's lifetime, not just after completion. These tests cover
-// the pure builder; the wire-level atomic-batch behaviour is exercised
-// by the spawn site's integration test.
+// gh#159 / ADR-056 4c-pre-1: WriteSpawnIdentity births the loop-execution
+// entity via create_with_triples using LoopExecutionEntity.Triples() as the
+// origin triple set. These tests exercise the pure predicate-set contract on
+// LoopExecutionEntity directly — the same contract that was previously tested
+// through buildSpawnIdentityTriples before it was removed (the logic moved to
+// agentic.LoopExecutionEntity). The wire-level birth behaviour (create_with_triples
+// request/response, idempotency on already-exists) is covered by the integration
+// tests in graph_writer_integration_test.go.
+//
+// Helper: buildSpawnTriples delegates to LoopExecutionEntity.Triples() so
+// the tests read identically to the old buildSpawnIdentityTriples-based
+// tests with minimal churn.
+func buildSpawnTriples(loopEntityID string, task *agentic.TaskMessage, org, platform string) []message.Triple {
+	e := &agentic.LoopExecutionEntity{
+		Org:      org,
+		Platform: platform,
+		// extract the loopID from the 6-part entity ID — tests pass it
+		// directly so we reconstruct the struct fields from the caller args.
+		// LoopExecutionEntityID format: org.platform.agent.agentic-loop.execution.loopID
+		// The LoopID field is not strictly needed since EntityID() is
+		// computed from it, but it must be set to produce a valid EntityID.
+		LoopID: loopIDFromEntityID(loopEntityID, org, platform),
+		Task:   task,
+	}
+	return e.Triples()
+}
+
+// loopIDFromEntityID extracts the loopID segment from a pre-built entity ID.
+// Used only by the test helper above.
+func loopIDFromEntityID(entityID, org, platform string) string {
+	prefix := org + "." + platform + ".agent.agentic-loop.execution."
+	if len(entityID) > len(prefix) {
+		return entityID[len(prefix):]
+	}
+	return entityID
+}
 
 func TestBuildSpawnIdentityTriples_RequiredFields(t *testing.T) {
 	loopEntityID := "acme.ops.agent.agentic-loop.execution.spawn-001"
@@ -23,7 +54,7 @@ func TestBuildSpawnIdentityTriples_RequiredFields(t *testing.T) {
 		Prompt: "Investigate the deployment failure",
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 
 	for _, tr := range triples {
 		if tr.Subject != loopEntityID {
@@ -32,8 +63,8 @@ func TestBuildSpawnIdentityTriples_RequiredFields(t *testing.T) {
 		if tr.Confidence != 1.0 {
 			t.Errorf("unexpected confidence: got %v, want 1.0", tr.Confidence)
 		}
-		if tr.Source != graphWriterSource {
-			t.Errorf("unexpected source: got %q, want %q", tr.Source, graphWriterSource)
+		if tr.Source != "agentic-loop" {
+			t.Errorf("unexpected source: got %q, want %q", tr.Source, "agentic-loop")
 		}
 	}
 
@@ -69,7 +100,7 @@ func TestBuildSpawnIdentityTriples_StampsParent(t *testing.T) {
 		ParentLoopID: "parent-loop-uuid",
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 	predicates := predicateSet(triples)
 
 	if !predicates[agvocab.LoopParent] {
@@ -101,7 +132,7 @@ func TestBuildSpawnIdentityTriples_OptionalFieldsPresentWhenSet(t *testing.T) {
 		Prompt:       "Design the new auth flow",
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 	predicates := predicateSet(triples)
 
 	optional := []string{
@@ -135,7 +166,7 @@ func TestBuildSpawnIdentityTriples_OptionalFieldsOmittedWhenEmpty(t *testing.T) 
 		// ParentLoopID, WorkflowSlug, WorkflowStep, UserID, Prompt all empty
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 	predicates := predicateSet(triples)
 
 	optional := []string{
@@ -175,7 +206,7 @@ func TestBuildSpawnIdentityTriples_LongPromptTruncated(t *testing.T) {
 		Prompt: longPrompt,
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 
 	desc, ok := objectFor(triples, agvocab.LoopDescription).(string)
 	if !ok {
@@ -190,8 +221,8 @@ func TestBuildSpawnIdentityTriples_LongPromptTruncated(t *testing.T) {
 // expectation downstream — none of the rule-engine semantics depend
 // on it, but it makes diff/inspection cleaner. Pin the property so a
 // refactor that reaches for time.Now() in the per-triple constructor
-// (instead of once at the top of buildSpawnIdentityTriples) fails this
-// test.
+// (instead of once at the top of LoopExecutionEntity.Triples()) fails
+// this test.
 func TestBuildSpawnIdentityTriples_SharedTimestamp(t *testing.T) {
 	task := &agentic.TaskMessage{
 		TaskID:       "task-shared-ts",
@@ -203,7 +234,7 @@ func TestBuildSpawnIdentityTriples_SharedTimestamp(t *testing.T) {
 		Prompt:       "prompt",
 	}
 
-	triples := buildSpawnIdentityTriples("acme.ops.agent.agentic-loop.execution.spawn-shared", task, "acme", "ops")
+	triples := buildSpawnTriples("acme.ops.agent.agentic-loop.execution.spawn-shared", task, "acme", "ops")
 	if len(triples) < 2 {
 		t.Fatalf("expected multiple triples, got %d", len(triples))
 	}
@@ -217,9 +248,9 @@ func TestBuildSpawnIdentityTriples_SharedTimestamp(t *testing.T) {
 }
 
 // Pin a regression guard: future Edits that add new spawn-known fields
-// to TaskMessage should also add them to buildSpawnIdentityTriples. The
+// to TaskMessage should also add them to LoopExecutionEntity.Triples(). The
 // counter test surfaces missed coverage when a TaskMessage field with
-// a vocab-defined predicate gets added but the builder doesn't emit it.
+// a vocab-defined predicate gets added but the entity doesn't emit it.
 func TestBuildSpawnIdentityTriples_TripleCountWithFullTask(t *testing.T) {
 	task := &agentic.TaskMessage{
 		TaskID:       "task-count",
@@ -233,7 +264,7 @@ func TestBuildSpawnIdentityTriples_TripleCountWithFullTask(t *testing.T) {
 		Prompt:       "prompt",
 	}
 
-	triples := buildSpawnIdentityTriples("acme.ops.agent.agentic-loop.execution.spawn-count", task, "acme", "ops")
+	triples := buildSpawnTriples("acme.ops.agent.agentic-loop.execution.spawn-count", task, "acme", "ops")
 	want := 10 // role, task, parent, run, run.entity_id, reply_to, workflow, workflow_step, user, description
 	if len(triples) != want {
 		preds := make([]string, 0, len(triples))
@@ -247,7 +278,7 @@ func TestBuildSpawnIdentityTriples_TripleCountWithFullTask(t *testing.T) {
 // Sanity check: now-vs-past timestamps are sensible (not zero).
 func TestBuildSpawnIdentityTriples_TimestampPopulated(t *testing.T) {
 	task := &agentic.TaskMessage{TaskID: "task-ts", Role: "researcher"}
-	triples := buildSpawnIdentityTriples("acme.ops.agent.agentic-loop.execution.spawn-ts", task, "acme", "ops")
+	triples := buildSpawnTriples("acme.ops.agent.agentic-loop.execution.spawn-ts", task, "acme", "ops")
 
 	if len(triples) == 0 {
 		t.Fatal("expected at least one triple")
@@ -272,7 +303,7 @@ func TestBuildSpawnIdentityTriples_StampsRunID(t *testing.T) {
 		RunID:  "root-loop-uuid",
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 	predicates := predicateSet(triples)
 
 	if !predicates[agvocab.LoopRun] {
@@ -312,7 +343,7 @@ func TestBuildSpawnIdentityTriples_OmitsRunIDWhenEmpty(t *testing.T) {
 		// RunID empty
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 	predicates := predicateSet(triples)
 
 	if predicates[agvocab.LoopRun] {
@@ -335,7 +366,7 @@ func TestBuildSpawnIdentityTriples_RunIDIsNotEntityID(t *testing.T) {
 		RunID:  "bare-run-uuid",
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 	runID, ok := objectFor(triples, agvocab.LoopRun).(string)
 	if !ok {
 		t.Fatal("LoopRun object is not a string")
@@ -369,7 +400,7 @@ func TestBuildSpawnIdentityTriples_StampsReplyTo(t *testing.T) {
 		InReplyTo: "asking-loop-uuid",
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 	predicates := predicateSet(triples)
 
 	if !predicates[agvocab.LoopReplyTo] {
@@ -400,7 +431,7 @@ func TestBuildSpawnIdentityTriples_OmitsReplyToWhenEmpty(t *testing.T) {
 		// InReplyTo empty
 	}
 
-	triples := buildSpawnIdentityTriples(loopEntityID, task, "acme", "ops")
+	triples := buildSpawnTriples(loopEntityID, task, "acme", "ops")
 	if predicateSet(triples)[agvocab.LoopReplyTo] {
 		t.Errorf("expected agent.loop.reply_to triple to be omitted when InReplyTo is empty")
 	}
@@ -420,7 +451,7 @@ func TestBuildSpawnIdentityTriples_SharedTimestamp_WithRunID(t *testing.T) {
 		Prompt:       "prompt",
 	}
 
-	triples := buildSpawnIdentityTriples("acme.ops.agent.agentic-loop.execution.spawn-shared-run", task, "acme", "ops")
+	triples := buildSpawnTriples("acme.ops.agent.agentic-loop.execution.spawn-shared-run", task, "acme", "ops")
 	if len(triples) < 2 {
 		t.Fatalf("expected multiple triples, got %d", len(triples))
 	}

--- a/vocabulary/agentic/predicates.go
+++ b/vocabulary/agentic/predicates.go
@@ -457,7 +457,7 @@ const (
 	LoopParent = "agent.loop.parent"
 
 	// LoopReplyTo is an entity reference to the loop this loop is a reply to
-	// (gh#256). Stamped at spawn time by buildSpawnIdentityTriples when
+	// (gh#256). Stamped at spawn time by LoopExecutionEntity.Triples() when
 	// TaskMessage.InReplyTo is non-empty. Distinct from LoopParent (tree
 	// ancestry): a reply re-enters a paused run (ADR-053 §4b-2 interactive
 	// clarification) rather than nesting under a parent. A resume rule fires on
@@ -470,7 +470,7 @@ const (
 	LoopReplyTo = "agent.loop.reply_to"
 
 	// LoopRun is the bare run loop-id this loop belongs to (ADR-053 D7).
-	// Stamped at spawn time by buildSpawnIdentityTriples when TaskMessage.RunID is non-empty.
+	// Stamped at spawn time by LoopExecutionEntity.Triples() when TaskMessage.RunID is non-empty.
 	// Rules can read this via $entity.triple.agent.run. Grammar-collision-free:
 	// no existing $-regex matches agent.run.* (audited at ADR-053 implementation).
 	// Example: "loop-uuid-of-the-root-coordinator"


### PR DESCRIPTION
## What

Gives the agentic **loop-execution entity a typed origin contract** (ADR-056 W0). Before, the loop entity was auto-vivified by a freehand `triple.add_batch` — a metadata-less, ownerless birth. After, it is born via a synchronous `create_with_triples` adapter that stamps a producer `MessageType` and carries its spawn-identity triples through a `graph.Graphable` projection.

ADR-056's design center is *"owned semantic entities have a typed origin contract."* The invariant here is **typed origin contract first**, not merely "create_with_triples first" — `LoopExecutionEntity` is the canonical projection; `create_with_triples` is just the synchronous birth adapter.

## How

- **`agentic/loop_execution_entity.go` (new)** — `LoopExecutionEntity` Graphable. `EntityID()` + `Triples()` are the typed origin (byte-for-byte equivalent to the removed `buildSpawnIdentityTriples`: same predicate set, conditional-emit rules, shared-timestamp invariant, UTF-8-safe truncation). `LoopExecutionMessageType()` → key `agentic.loop_execution.v1`.
- **`processor/agentic-loop/graph_writer.go`** — `WriteSpawnIdentity` builds the `LoopExecutionEntity` and births it via `create_with_triples`; it now **returns an error**. `buildSpawnIdentityTriples` removed.
- **`processor/agentic-loop/component.go`** — caller **enforces** the birth error (`handleLoopFailure` + `return`) instead of best-effort ignoring it. An origin-birth failure no longer leaves downstream writers depending on a non-existent root.
- **`cmd/semstreams/main.go` + `cmd/e2e-semstreams/main.go`** — `projection.Bind(...)` wires the loop-execution projection contract (observe-only at W0).

## Guardrails (review-driven)

- **EntityExists read/verify guardrail** — `EntityExists` is an idempotent re-birth **only** after a read-back (`graph.ingest.query.entity`) confirms the existing entity is the **same typed origin** (`MessageType == agentic.loop_execution.v1`). A shell (empty MessageType), a foreign entity colliding on the id, or an unreadable entity is a **birth failure**, never a silent "born." Only this writer stamps that MessageType, so a foreign collision can never carry a matching type.
- **Registry decision pinned (not implicit)** — `agentic.loop_execution.v1` is **mutation-only**: stamped at create as producer identity, *not* registered in `agentic/payload_registry.go`, never decoded as a `BaseMessage` payload (the `core.identity.stub.v1` precedent). Grep-verified.

## Tests / gates

- `TestWriteSpawnIdentity*` (integration, `-race`), driven through the production `WriteSpawnIdentity` wire: success / EntityExists-same-origin / EntityExists-not-our-origin (shell + foreign, table) / genuine-failure / nil-task.
- Unit tests for `LoopExecutionEntity` projection/triples/messagetype.
- ✅ `task lint`, gofmt, `go test -race ./agentic/... ./processor/agentic-loop/...`, both mains build, no schema drift.
- ✅ **e2e:agentic** green — `loops_completed:2`, `graph_loop_triples:23`, clean teardown.
- ✅ **Phase-boundary go-reviewer: approved, no blockers.**

## Follow-up

- **gh#276** — re-spawn reusing `loop_id` under a different `task_id` keeps the first spawn's identity (the guardrail behaving as-designed; strictly safer than the old append path). Documented as a canonicality note; low priority.

Part of the ADR-056 W0 arc (#270–#275). Additive; observe-only enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)