### PR TITLE
fix(ownership): heartbeat-enroll static projection owners (Codex #277 P2)

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -250,7 +250,16 @@ func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ 
 
 		// ADR-056 4c-pre-1: register the loop-execution entity projection contract.
 		// Mirrors cmd/semstreams wiring — best-effort, never a boot gate.
-		if err := projection.Bind(ctx, ownerReg, "agentic-loop-graph-writer",
+		//
+		// Static projection owners (not lifecycle.Manager workflows) need their OWN
+		// heartbeater: they derive a real OwnerClaim, so without ongoing heartbeats
+		// their OWNER_PRESENCE key ages out after PresenceTTL and the next registrant
+		// compacts the claim out of the epoch (Codex review of #277). ctx here is the
+		// shutdown-cancellable context (hbCtx, threaded from run()), so the ticker
+		// stops on shutdown.
+		staticOwnerHB := ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
+		go staticOwnerHB.Run(ctx)
+		if err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
 			loopExecutionProjectionContract()); err != nil {
 			svcDeps.Logger.Warn("ownership: loop-execution projection contract registration failed",
 				slog.Any("error", err))

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -217,7 +217,15 @@ func run() error {
 		// origin predicates on every loop-execution entity (*.*.agent.agentic-loop.execution.*)
 		// in replace-owned mode. Best-effort: a registration failure logs a warning
 		// but does not block boot — ownership is observe-only, never a boot gate.
-		if err := projection.Bind(ctx, ownerReg, "agentic-loop-graph-writer",
+		//
+		// Static projection owners (not lifecycle.Manager workflows) need their OWN
+		// heartbeater: they derive a real OwnerClaim, so without ongoing heartbeats
+		// their OWNER_PRESENCE key ages out after PresenceTTL and the next registrant
+		// compacts the claim out of the epoch (Codex review of #277). Run on hbCtx so
+		// the ticker stops on shutdown; the one-shot Bind itself uses ctx.
+		staticOwnerHB := ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
+		go staticOwnerHB.Run(hbCtx)
+		if err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
 			loopExecutionProjectionContract()); err != nil {
 			logger.Warn("ownership: loop-execution projection contract registration failed",
 				slog.Any("error", err))

--- a/pkg/ownership/heartbeat.go
+++ b/pkg/ownership/heartbeat.go
@@ -65,6 +65,16 @@ func (h *Heartbeater) Add(owner string) {
 	h.owners[owner] = struct{}{}
 }
 
+// IsEnrolled reports whether owner is currently enrolled for heartbeating.
+// Enrollment is the property that keeps a live owner's OWNER_PRESENCE key fresh
+// (and therefore its claim compaction-safe); used by observability and tests.
+func (h *Heartbeater) IsEnrolled(owner string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	_, ok := h.owners[owner]
+	return ok
+}
+
 // snapshot copies the enrolled owner set under lock for lock-free tick iteration.
 func (h *Heartbeater) snapshot() []string {
 	h.mu.Lock()

--- a/pkg/ownership/registry_integration_test.go
+++ b/pkg/ownership/registry_integration_test.go
@@ -189,6 +189,45 @@ func TestRegistry_StaleCompaction(t *testing.T) {
 	}
 }
 
+// TestRegistry_HeartbeatedOwnerSurvivesCompaction is the inverse of
+// TestRegistry_StaleCompaction and the durability property the static-projection
+// heartbeat fix depends on (Codex review of #277): an owner whose presence key
+// ages out but is RE-BUMPED (as a live owner's Heartbeater does each tick) is NOT
+// compacted by the next registrant. owner-a holds a real OwnerClaim, so it is not
+// covered by the FE-only compaction exemption — heartbeating is the only thing
+// keeping its claim alive.
+func TestRegistry_HeartbeatedOwnerSurvivesCompaction(t *testing.T) {
+	r, claims, ctx := newTestRegistry(t)
+	entity := "c360.semconnect.systems.csapi.system.drone-001"
+
+	if err := r.RegisterOwner(ctx, reg("owner-a", sysPat, "p")); err != nil {
+		t.Fatal(err)
+	}
+	// owner-a's presence key ages out (TTL expiry, sans wait)...
+	if err := r.Resign(ctx, "owner-a"); err != nil {
+		t.Fatalf("resign owner-a: %v", err)
+	}
+	// ...but owner-a is still ALIVE: its Heartbeater re-bumps the presence key.
+	if err := r.Heartbeat(ctx, "owner-a"); err != nil {
+		t.Fatalf("heartbeat owner-a: %v", err)
+	}
+
+	// owner-b registers on a DISJOINT cell, triggering a compaction sweep.
+	// owner-a's presence is live again → it must survive.
+	if err := r.RegisterOwner(ctx, reg("owner-b", depPat, "p")); err != nil {
+		t.Fatalf("register owner-b: %v", err)
+	}
+
+	ep := readEpoch(t, claims, ctx)
+	if _, ok := ep.Owners["owner-a"]; !ok {
+		t.Error("heartbeated owner-a must NOT be compacted out of the epoch")
+	}
+	owner, ok, _ := r.OwnerOf(ctx, entity, "p")
+	if !ok || owner != "owner-a" {
+		t.Errorf("owner-a should still own its cell, got %q,%v", owner, ok)
+	}
+}
+
 // TestRegistry_ConcurrentDisjoint proves the single-epoch CAS serializes
 // concurrent registrants with no lost update: N disjoint owners registered in
 // parallel all land in the epoch.

--- a/pkg/projection/bind_integration_test.go
+++ b/pkg/projection/bind_integration_test.go
@@ -59,3 +59,46 @@ func TestBind_CrossOwnerOverlapRejected(t *testing.T) {
 		t.Errorf("cross-owner overlap via Bind should reject with ErrOwnershipOverlap, got %v", err)
 	}
 }
+
+// TestBindAndHeartbeat_EnrollsOnSuccess proves a static projection owner is
+// enrolled for heartbeating on a successful Bind — the durability fix for a
+// process-lifetime OwnerClaim (Codex review of #277). Without enrollment the
+// owner's presence key ages out after PresenceTTL and the next registrant
+// compacts its claim (see ownership.TestRegistry_HeartbeatedOwnerSurvivesCompaction).
+func TestBindAndHeartbeat_EnrollsOnSuccess(t *testing.T) {
+	reg, ctx := newOwnershipRegistry(t)
+	hb := reg.NewHeartbeater(ownership.HeartbeatInterval)
+
+	if err := BindAndHeartbeat(ctx, reg, hb, "cs-api", csapiSystem()); err != nil {
+		t.Fatalf("BindAndHeartbeat: %v", err)
+	}
+	if !hb.IsEnrolled("cs-api") {
+		t.Error("BindAndHeartbeat must enroll the owner in the heartbeater on a successful Bind")
+	}
+	owner, ok, err := reg.OwnerOf(ctx, "c360.semconnect.systems.csapi.system.drone-001", "sensorml.process.label")
+	if err != nil || !ok || owner != "cs-api" {
+		t.Errorf("OwnerOf after BindAndHeartbeat = %q,%v,%v want cs-api,true,nil", owner, ok, err)
+	}
+}
+
+// TestBindAndHeartbeat_SkipsEnrollOnBindFailure proves a rejected/overlapping
+// owner is NOT enrolled — there is no recorded claim to keep alive, and enrolling
+// it would heartbeat a presence key for a non-owner.
+func TestBindAndHeartbeat_SkipsEnrollOnBindFailure(t *testing.T) {
+	reg, ctx := newOwnershipRegistry(t)
+	if err := Bind(ctx, reg, "cs-api", csapiSystem()); err != nil {
+		t.Fatal(err)
+	}
+	hb := reg.NewHeartbeater(ownership.HeartbeatInterval)
+	poacher := Contract{
+		Name:          "poacher.system",
+		EntityPattern: sysPat,
+		Groups:        []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"sensorml.process.label"}}},
+	}
+	if err := BindAndHeartbeat(ctx, reg, hb, "other", poacher); !errors.Is(err, ownership.ErrOwnershipOverlap) {
+		t.Fatalf("overlap should reject with ErrOwnershipOverlap, got %v", err)
+	}
+	if hb.IsEnrolled("other") {
+		t.Error("a rejected owner must NOT be enrolled in the heartbeater")
+	}
+}

--- a/pkg/projection/contract.go
+++ b/pkg/projection/contract.go
@@ -174,3 +174,28 @@ func Bind(ctx context.Context, ownerReg *ownership.Registry, owner string, contr
 	}
 	return ownerReg.RegisterOwner(ctx, registration)
 }
+
+// BindAndHeartbeat is Bind plus liveness enrollment for a STATIC projection owner
+// — one registered once at boot for the whole process lifetime (a graph-writer, a
+// rule pack), as opposed to a lifecycle.Manager workflow owner (which the Manager
+// enrolls into its own heartbeater). A static owner that derives a real OwnerClaim
+// MUST heartbeat: RegisterOwner bumps its OWNER_PRESENCE key once at registration,
+// but without ongoing heartbeats that key ages out after ownership.PresenceTTL and
+// the next registrant compacts the claim out of the epoch — the FE-only compaction
+// exemption (epoch.go) does NOT cover an owning claim.
+//
+// Enrollment happens ONLY on a successful Bind: a rejected/overlapping owner holds
+// no recorded claim to keep alive. A nil hb binds without enrolling (caller opted
+// out of liveness, e.g. FE-only owners). The caller owns the Heartbeater's lifetime
+// — build it once at the composition root (ownerReg.NewHeartbeater), run it on a
+// shutdown-cancelled context (go hb.Run(ctx)), and pass it here for every static
+// owner it binds.
+func BindAndHeartbeat(ctx context.Context, ownerReg *ownership.Registry, hb *ownership.Heartbeater, owner string, contracts ...Contract) error {
+	if err := Bind(ctx, ownerReg, owner, contracts...); err != nil {
+		return err
+	}
+	if hb != nil {
+		hb.Add(owner)
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Follow-up to #277. Codex found a P2 durability gap: the loop-execution projection owner's `OwnerClaim` can be compacted out of the epoch in a long-running process.

`projection.Bind(..., "agentic-loop-graph-writer", ...)` → `RegisterOwner` heartbeats the owner's `OWNER_PRESENCE` key **once** at registration but never enrolls it in a `Heartbeater`. Because this owner derives a **real `OwnerClaim`** (not foreign-edge-only), the FE-only compaction exemption in `pkg/ownership/epoch.go` does **not** cover it: after `PresenceTTL` (120s) the presence key ages out, and the next registrant's `compactStale` sweep evicts the claim from `OWNER_CLAIMS`. The `epoch.go` "KNOWN FOLLOW-UP (4b/4c)" comment predicted exactly this. It matters more once owner-token / write-lease enforcement lands.

Lifecycle Manager owners avoid this — `AttachOwnership` creates a `Heartbeater` and enrolls each workflow via `hb.Add(workflow.Name)`. Static projection owners had no equivalent.

## Fix

- **`pkg/projection`**: `BindAndHeartbeat(ctx, ownerReg, hb, owner, contracts...)` — `Bind` then `hb.Add(owner)` **only on Bind success** (a rejected/overlapping owner holds no claim to keep alive; `nil` hb = bind without liveness).
- **`pkg/ownership`**: `(*Heartbeater) IsEnrolled(owner) bool` — observability + test assertion.
- **both mains**: create a dedicated static-owner `Heartbeater` (`ownerReg.NewHeartbeater(...)`), `go staticOwnerHB.Run(hbCtx)` on the shutdown-cancellable context, and use `BindAndHeartbeat`.

### Design choice
A **separate** static-owner heartbeater (not unifying into the lifecycle Manager's) — decouples the graph-writer's liveness from a lifecycle it doesn't participate in, avoids churning `AttachOwnership`'s 5+ call sites, and scales to the incoming **#278** rule-pack owners (they enroll in the same static-owner heartbeater). Both tickers run on `hbCtx`, cancelled before `natsClient.Close` by LIFO.

## Tests

- `pkg/ownership`: `TestRegistry_HeartbeatedOwnerSurvivesCompaction` — deterministic inverse of `TestRegistry_StaleCompaction`: a re-heartbeated owner survives a later registrant's compaction (disjoint pattern → pure compaction-survival, isolated from overlap).
- `pkg/projection`: `TestBindAndHeartbeat_EnrollsOnSuccess` + `TestBindAndHeartbeat_SkipsEnrollOnBindFailure`.

## Gates

✅ `task lint`, full `go test -race ./...`, `go test -tags=integration -race ./pkg/ownership/... ./pkg/projection/... ./pkg/lifecycle/...`, both mains build, no schema drift. ✅ **go-reviewer phase-boundary review: approved, no blockers.**

## Follow-up

**#279** — `Heartbeater.Run` goroutines are signalled (ctx cancel) but not joined on shutdown; the right fix is uniform across both call sites (Manager + static), so it's deferred rather than one-sided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)