### PR TITLE
feat(rule): ADR-056 #278 inc 2 — main-side rule-pack projection contract binding

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -164,7 +164,8 @@ func run() error {
 	// closes. Threaded through wireLifecycleManager to AttachOwnership.
 	hbCtx, hbCancel := context.WithCancel(ctx)
 	defer hbCancel()
-	if err := wireLifecycleManager(hbCtx, svcDeps, natsClient, logger); err != nil {
+	ownerReg, staticOwnerHB, err := wireLifecycleManager(hbCtx, svcDeps, natsClient, logger)
+	if err != nil {
 		return err
 	}
 
@@ -189,6 +190,16 @@ func run() error {
 
 	if err := configureAndCreateServices(cfg, manager, svcDeps); err != nil {
 		return err
+	}
+
+	// ADR-056 #278 inc 2 — bind each rule pack's projection contracts under the
+	// ownership substrate. Done HERE (after configureAndCreateServices constructs
+	// the rule processors) and BEFORE StartAll runs inside runWithSignalHandling.
+	// SAME shared helper as cmd/semstreams. Pack contracts are read ONCE,
+	// statically; this is the ONLY rule-pack bind site and must NEVER be invoked
+	// from the hot-reload path. Best-effort / observe-only.
+	if ownerReg != nil {
+		service.BindRulePackContracts(hbCtx, manager, ownerReg, staticOwnerHB, logger)
 	}
 
 	return runWithSignalHandling(ctx, manager, cliCfg.ShutdownTimeout, func(seedCtx context.Context) error {
@@ -234,8 +245,15 @@ func buildPayloadRegistry() (*payloadregistry.Registry, error) {
 // bucket provisioning. State changes emit through graph-ingest like
 // every other write; reads project triples into the registered
 // Schema struct.
-func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ *natsclient.Client, _ *slog.Logger) error {
+// It returns the owner registry and static heartbeater (nil when ownership is
+// disabled this boot) so run() can bind rule-pack projection contracts AFTER
+// the rule processors are constructed (ADR-056 #278 inc 2) using the same
+// registry/heartbeater.
+func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ *natsclient.Client, _ *slog.Logger) (*ownership.Registry, *ownership.Heartbeater, error) {
 	svcDeps.LifecycleManager = lifecycle.NewManager(svcDeps.NATSClient, svcDeps.Logger)
+
+	var ownerReg *ownership.Registry
+	var staticOwnerHB *ownership.Heartbeater
 
 	// ADR-056 Decision 5 — attach the owner registry BEFORE Register so each
 	// workflow's claim registers through the shared epoch (cross-process overlap
@@ -243,9 +261,10 @@ func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ 
 	// graph-ingest (which creates the other framework buckets) boots later than
 	// this wiring, so the ownership buckets must be created here. A NATS hiccup
 	// logs + skips — ownership is best-effort observe-only, never a boot gate.
-	if ownerReg, err := ownership.EnsureBuckets(ctx, svcDeps.NATSClient, svcDeps.Logger, vocabulary.InverseResolver); err != nil {
+	if reg, err := ownership.EnsureBuckets(ctx, svcDeps.NATSClient, svcDeps.Logger, vocabulary.InverseResolver); err != nil {
 		svcDeps.Logger.Warn("ownership: bucket bootstrap failed — lifecycle ownership disabled this boot", slog.Any("error", err))
 	} else {
+		ownerReg = reg
 		svcDeps.LifecycleManager.AttachOwnership(ctx, ownerReg)
 
 		// ADR-056 4c-pre-1: register the loop-execution entity projection contract.
@@ -257,7 +276,7 @@ func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ 
 		// compacts the claim out of the epoch (Codex review of #277). ctx here is the
 		// shutdown-cancellable context (hbCtx, threaded from run()), so the ticker
 		// stops on shutdown.
-		staticOwnerHB := ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
+		staticOwnerHB = ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
 		go staticOwnerHB.Run(ctx)
 		if err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
 			loopExecutionProjectionContract()); err != nil {
@@ -267,13 +286,13 @@ func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ 
 	}
 
 	if err := svcDeps.LifecycleManager.Register(mission.WorkflowDeclaration()); err != nil {
-		return fmt.Errorf("register mission workflow: %w", err)
+		return nil, nil, fmt.Errorf("register mission workflow: %w", err)
 	}
 	// Register the agent-run workflow (ADR-053 D2). Mirrors cmd/semstreams wiring.
 	if err := agentrun.Register(svcDeps.LifecycleManager); err != nil {
-		return fmt.Errorf("register agent-run workflow: %w", err)
+		return nil, nil, fmt.Errorf("register agent-run workflow: %w", err)
 	}
-	return nil
+	return ownerReg, staticOwnerHB, nil
 }
 
 // seedMission Creates a mission Participant at the given entity ID

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -199,16 +199,27 @@ func run() error {
 	// the ownership buckets there would make every registration a silent no-op.
 	// A NATS hiccup logs + skips; ownership is best-effort observe-only, never a
 	// boot gate ([[feedback_unconditional_resource_wiring_breaks_resourceless_deploys]]).
-	if ownerReg, err := ownership.EnsureBuckets(ctx, natsClient, logger, vocabulary.InverseResolver); err != nil {
+	//
+	// ownerReg/staticOwnerHB/hbCtx are lifted to run() scope (nil/ctx until the
+	// EnsureBuckets else-branch assigns them) so the rule-pack contract bind
+	// below — which must run AFTER configureAndCreateServices has constructed the
+	// rule processors — can reuse the same registry and heartbeater (ADR-056 #278
+	// inc 2).
+	var ownerReg *ownership.Registry
+	var staticOwnerHB *ownership.Heartbeater
+	hbCtx := ctx
+	if reg, err := ownership.EnsureBuckets(ctx, natsClient, logger, vocabulary.InverseResolver); err != nil {
 		logger.Warn("ownership: bucket bootstrap failed — lifecycle ownership disabled this boot", slog.Any("error", err))
 	} else {
+		ownerReg = reg
 		// The heartbeat goroutine must stop on shutdown. `ctx` here is
 		// context.Background() (the signal-cancelled context is a downstream
 		// CHILD created in runWithSignalHandling, and a child cancelling never
 		// cancels its parent), so derive a cancellable context and cancel it as
 		// run() unwinds. Registered after natsClient.Close's defer, so by LIFO it
 		// fires FIRST — the heartbeat stops before the client closes.
-		hbCtx, hbCancel := context.WithCancel(ctx)
+		var hbCancel context.CancelFunc
+		hbCtx, hbCancel = context.WithCancel(ctx)
 		defer hbCancel()
 		svcDeps.LifecycleManager.AttachOwnership(hbCtx, ownerReg)
 
@@ -223,7 +234,7 @@ func run() error {
 		// their OWNER_PRESENCE key ages out after PresenceTTL and the next registrant
 		// compacts the claim out of the epoch (Codex review of #277). Run on hbCtx so
 		// the ticker stops on shutdown; the one-shot Bind itself uses ctx.
-		staticOwnerHB := ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
+		staticOwnerHB = ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
 		go staticOwnerHB.Run(hbCtx)
 		if err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
 			loopExecutionProjectionContract()); err != nil {
@@ -266,6 +277,18 @@ func run() error {
 	// 11. Configure and create services
 	if err := configureAndCreateServices(cfg, manager, svcDeps); err != nil {
 		return err
+	}
+
+	// 11b. ADR-056 #278 inc 2 — bind each rule pack's projection contracts under
+	// the ownership substrate. Done HERE (after the rule processors are
+	// constructed by configureAndCreateServices) and BEFORE StartAll runs inside
+	// runWithSignalHandling. Pack contracts are read ONCE, statically — this is
+	// the ONLY rule-pack bind site, and it must NEVER be called from the
+	// hot-reload path (re-binding would self-overlap the pack's own claims and
+	// churn the ownership epoch). Best-effort / observe-only: a nil registry is a
+	// no-op and per-pack errors are logged, never a boot gate.
+	if ownerReg != nil {
+		service.BindRulePackContracts(hbCtx, manager, ownerReg, staticOwnerHB, logger)
 	}
 
 	// 12. Run application with signal handling

--- a/processor/rule/config.go
+++ b/processor/rule/config.go
@@ -2,10 +2,12 @@ package rule
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/pkg/cache"
+	"github.com/c360studio/semstreams/pkg/projection"
 )
 
 // Config holds configuration for the RuleProcessor
@@ -52,6 +54,20 @@ type Config struct {
 		MaxDeliver     int    `json:"max_deliver"`      // Max delivery attempts
 		ReplayPolicy   string `json:"replay_policy"`    // "instant" or "original"
 	} `json:"consumer"`
+
+	// PackID identifies this rule pack as a graph-projection PRODUCER
+	// (ADR-056 #278 inc 2). When set, the composition root binds the pack's
+	// ProjectionContracts under the ownership substrate as owner
+	// "rule-pack.<PackID>". The id must be subject-safe (see Validate); it is
+	// read ONCE at bind time, before the watcher starts — pack-level and
+	// STATIC, never per-rule and never re-derived on hot-reload.
+	PackID string `json:"pack_id,omitempty" schema:"type:string,category:advanced,description:owner = rule-pack.<pack_id>"`
+
+	// ProjectionContracts are the graph-projection contracts this rule pack
+	// owns (ADR-056 Decision 6). Bound to owner "rule-pack.<PackID>" at the
+	// composition root before StartAll. Pack-level and static: the binding is
+	// derived once and is NOT re-bound when rules hot-reload.
+	ProjectionContracts []projection.Contract `json:"projection_contracts,omitempty" schema:"type:array,category:advanced"`
 }
 
 // MarshalJSON implements custom JSON marshaling for Config
@@ -79,6 +95,32 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	c.DebounceDelayMs = time.Duration(aux.DebounceDelayMs) * time.Millisecond
+	return nil
+}
+
+// packIDCharset is the subject-safe charset a PackID may use. It mirrors
+// pkg/ownership.validOwnerID exactly (glob.go) so a config that passes this
+// check can never be rejected later by RegisterOwner — the owner id is
+// "rule-pack.<PackID>", and the "rule-pack." prefix plus any char in this set
+// is itself subject-safe.
+const packIDCharset = "[A-Za-z0-9._=-]"
+
+// Validate checks pack-level invariants on the rule config. Today it only
+// guards PackID: a non-empty PackID must be subject-safe so the derived owner
+// id "rule-pack.<PackID>" is usable directly as a NATS KV key segment (no
+// hashing — ownership identity is compared as the canonical string). An empty
+// PackID is valid (the pack declares no projection ownership).
+func (c Config) Validate() error {
+	for _, r := range c.PackID {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '-', r == '_', r == '=', r == '.':
+		default:
+			return fmt.Errorf(
+				"rule config: invalid pack_id %q — owner id rule-pack.%s must use only %s (offending char %q)",
+				c.PackID, c.PackID, packIDCharset, string(r))
+		}
+	}
 	return nil
 }
 

--- a/processor/rule/config_projection_test.go
+++ b/processor/rule/config_projection_test.go
@@ -1,0 +1,112 @@
+package rule
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/c360studio/semstreams/pkg/projection"
+)
+
+// TestConfigPackIDProjectionContractsRoundTrip locks the operator-reachable
+// pack_id + projection_contracts fields through the Config custom
+// Marshal/Unmarshal alias path. ADR-056 #278 inc 2 +
+// [[feedback_polymorphic_config_needs_json_roundtrip_test]]: every
+// operator-reachable field must survive a JSON round trip with no shadow
+// struct silently dropping it.
+func TestConfigPackIDProjectionContractsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	original := Config{
+		PackID: "drone-ops.v1",
+		ProjectionContracts: []projection.Contract{
+			{
+				Name:          "drone.status",
+				MessageType:   "telemetry.robotics.drone-status.v1",
+				EntityPattern: "acme.ops.robotics.gcs.drone.*",
+				Groups: []projection.PredicateGroup{
+					{
+						Mode:       ownership.ModeReplaceOwned,
+						Predicates: []string{"drone.status.state", "drone.status.battery"},
+					},
+					{
+						Mode:       ownership.ModeAppendEvidence,
+						Predicates: []string{"drone.status.note"},
+					},
+				},
+				ForeignEdges: []projection.ForeignEdge{
+					{
+						Predicate:     "drone.assigned_to",
+						Mode:          ownership.EdgeConditional,
+						TargetPattern: "acme.ops.robotics.gcs.mission.*",
+					},
+				},
+				IndexingProfile: "signal",
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	// pack_id must be present in the wire form (it rides the alias).
+	if !strings.Contains(string(data), `"pack_id":"drone-ops.v1"`) {
+		t.Errorf("marshaled JSON missing pack_id: %s", data)
+	}
+
+	var restored Config
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if restored.PackID != original.PackID {
+		t.Errorf("PackID round-trip: got %q want %q", restored.PackID, original.PackID)
+	}
+	if !reflect.DeepEqual(restored.ProjectionContracts, original.ProjectionContracts) {
+		t.Errorf("ProjectionContracts round-trip mismatch:\n got %#v\nwant %#v",
+			restored.ProjectionContracts, original.ProjectionContracts)
+	}
+}
+
+// TestConfigPackIDValidation pins the subject-safe charset guard on pack_id so
+// the derived owner id "rule-pack.<pack_id>" can never be rejected later by
+// ownership.RegisterOwner on charset.
+func TestConfigPackIDValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid pack_id passes", func(t *testing.T) {
+		t.Parallel()
+		cfg := Config{PackID: "my-pack.v1"}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("valid pack_id rejected: %v", err)
+		}
+	})
+
+	t.Run("empty pack_id is a no-op", func(t *testing.T) {
+		t.Parallel()
+		cfg := Config{PackID: ""}
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("empty pack_id rejected: %v", err)
+		}
+	})
+
+	t.Run("invalid pack_id rejected with charset + owner id in message", func(t *testing.T) {
+		t.Parallel()
+		cfg := Config{PackID: "my:pack"}
+		err := cfg.Validate()
+		if err == nil {
+			t.Fatal("invalid pack_id my:pack must be rejected")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "rule-pack.my:pack") {
+			t.Errorf("error must name the derived owner id rule-pack.my:pack, got: %s", msg)
+		}
+		if !strings.Contains(msg, "[A-Za-z0-9._=-]") {
+			t.Errorf("error must name the allowed charset, got: %s", msg)
+		}
+	})
+}

--- a/processor/rule/factory.go
+++ b/processor/rule/factory.go
@@ -69,7 +69,20 @@ func CreateRuleProcessor(rawConfig json.RawMessage, deps component.Dependencies)
 		}
 		ruleConfig.Consumer = userConfig.Consumer
 
+		// ADR-056 #278 inc 2: the pack-level projection-producer declaration.
+		// These ride the operator config through to ProjectionBindings(), which
+		// the composition root reads ONCE before StartAll to bind ownership.
+		ruleConfig.PackID = userConfig.PackID
+		ruleConfig.ProjectionContracts = userConfig.ProjectionContracts
+
 		// Note: InputSubjects no longer supported - use Ports configuration only
+	}
+
+	// Fail fast on a malformed pack_id: the derived owner id "rule-pack.<id>"
+	// must be subject-safe, and a config-time reject is far clearer than a
+	// silent RegisterOwner failure at the composition root.
+	if err := ruleConfig.Validate(); err != nil {
+		return nil, errs.WrapInvalid(err, "rule-processor-factory", "create", "validate config")
 	}
 
 	// Create processor with metrics if available

--- a/processor/rule/processor.go
+++ b/processor/rule/processor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/cache"
 	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/pkg/projection"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -332,6 +333,22 @@ func (rp *Processor) OutputPorts() []component.Port {
 // ConfigSchema returns configuration schema for component interface
 func (rp *Processor) ConfigSchema() component.ConfigSchema {
 	return schema
+}
+
+// ProjectionBindings returns the pack-level ownership declaration for this rule
+// processor: the pack id (owner becomes "rule-pack.<packID>") and the
+// projection contracts the pack owns.
+//
+// INVARIANT (ADR-056 #278 inc 2): this is read ONCE at the composition root,
+// BEFORE manager.StartAll, and the binding is NEVER re-derived on hot-reload.
+// Rule-pack contracts are PACK-LEVEL and STATIC — they are not per-rule and do
+// not change when the rule set hot-reloads. Adding a re-bind call anywhere
+// downstream of StartAll would violate the ownership-epoch invariant.
+//
+// The processor is substrate-agnostic: it returns a declaration and never
+// touches the ownership registry. All binding happens main-side.
+func (rp *Processor) ProjectionBindings() (packID string, contracts []projection.Contract) {
+	return rp.config.PackID, rp.config.ProjectionContracts
 }
 
 // Health returns current health status

--- a/processor/rule/projection_bindings_test.go
+++ b/processor/rule/projection_bindings_test.go
@@ -1,0 +1,66 @@
+package rule
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/c360studio/semstreams/pkg/projection"
+)
+
+// TestProcessorProjectionBindings verifies the processor returns the pack-level
+// ownership declaration it was constructed with, unchanged. The processor is
+// substrate-agnostic: ProjectionBindings is a pure read of the stored config
+// (ADR-056 #278 inc 2).
+func TestProcessorProjectionBindings(t *testing.T) {
+	t.Parallel()
+
+	contracts := []projection.Contract{
+		{
+			Name:          "drone.status",
+			MessageType:   "telemetry.robotics.drone-status.v1",
+			EntityPattern: "acme.ops.robotics.gcs.drone.*",
+			Groups: []projection.PredicateGroup{{
+				Mode:       ownership.ModeReplaceOwned,
+				Predicates: []string{"drone.status.state"},
+			}},
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.PackID = "drone-ops.v1"
+	cfg.ProjectionContracts = contracts
+
+	rp, err := NewProcessor(nil, &cfg)
+	if err != nil {
+		t.Fatalf("NewProcessor: %v", err)
+	}
+
+	gotPack, gotContracts := rp.ProjectionBindings()
+	if gotPack != "drone-ops.v1" {
+		t.Errorf("packID: got %q want %q", gotPack, "drone-ops.v1")
+	}
+	if !reflect.DeepEqual(gotContracts, contracts) {
+		t.Errorf("contracts mismatch:\n got %#v\nwant %#v", gotContracts, contracts)
+	}
+}
+
+// TestProcessorProjectionBindings_NoPack verifies the no-pack case returns an
+// empty declaration so the composition root binds nothing.
+func TestProcessorProjectionBindings_NoPack(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig() // no PackID, no contracts
+	rp, err := NewProcessor(nil, &cfg)
+	if err != nil {
+		t.Fatalf("NewProcessor: %v", err)
+	}
+
+	gotPack, gotContracts := rp.ProjectionBindings()
+	if gotPack != "" {
+		t.Errorf("packID: got %q want empty", gotPack)
+	}
+	if len(gotContracts) != 0 {
+		t.Errorf("contracts: got %d want 0", len(gotContracts))
+	}
+}

--- a/schemas/rule-processor.v1.json
+++ b/schemas/rule-processor.v1.json
@@ -1093,10 +1093,82 @@
       },
       "category": "basic"
     },
+    "pack_id": {
+      "type": "string",
+      "description": "owner = rule-pack.\u003cpack_id\u003e",
+      "category": "advanced"
+    },
     "ports": {
       "type": "string",
       "description": "Port configuration for inputs (KV watch: ENTITY_STATES PREDICATE_INDEX) and outputs (NATS: control commands)",
       "category": "basic"
+    },
+    "projection_contracts": {
+      "type": "array",
+      "description": "projection_contracts",
+      "items": {
+        "type": "object",
+        "properties": {
+          "entity_pattern": {
+            "type": "string",
+            "description": "entity_pattern"
+          },
+          "foreign_edges": {
+            "type": "array",
+            "description": "foreign_edges",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "description": "mode"
+                },
+                "predicate": {
+                  "type": "string",
+                  "description": "predicate"
+                },
+                "target_pattern": {
+                  "type": "string",
+                  "description": "target_pattern"
+                }
+              }
+            }
+          },
+          "groups": {
+            "type": "array",
+            "description": "groups",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "type": "string",
+                  "description": "mode"
+                },
+                "predicates": {
+                  "type": "array",
+                  "description": "predicates",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "indexing_profile": {
+            "type": "string",
+            "description": "indexing_profile"
+          },
+          "message_type": {
+            "type": "string",
+            "description": "message_type"
+          },
+          "name": {
+            "type": "string",
+            "description": "name"
+          }
+        }
+      },
+      "category": "advanced"
     },
     "rules": {
       "type": "object",

--- a/service/rule_pack_bind.go
+++ b/service/rule_pack_bind.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/c360studio/semstreams/pkg/projection"
+)
+
+// ProjectionBinder is implemented by components that declare a pack-level graph
+// projection ownership (today: rule.Processor). It is defined as an interface
+// here, rather than importing processor/rule directly, ON PURPOSE: a
+// service→processor/rule import would close a TEST-ONLY cycle
+// (processor/rule's actions_test.go imports processor/agentic-tools, which
+// imports service), so the enumeration is duck-typed instead.
+//
+// ProjectionBindings returns the pack id (owner becomes "rule-pack.<packID>")
+// and the contracts the pack owns. Read ONCE at the composition root before
+// StartAll; never re-derived on hot-reload (ADR-056 #278 inc 2).
+type ProjectionBinder interface {
+	ProjectionBindings() (packID string, contracts []projection.Contract)
+}
+
+// ProjectionBinders enumerates every managed component that implements
+// ProjectionBinder. Returns nil when the ComponentManager is not yet available.
+// Mirrors the GetManagedComponents enumeration idiom used by
+// registerComponentHandlers.
+func (m *Manager) ProjectionBinders() []ProjectionBinder {
+	cmService, exists := m.services["component-manager"]
+	if !exists {
+		return nil
+	}
+	cm, ok := cmService.(*ComponentManager)
+	if !ok {
+		return nil
+	}
+
+	var out []ProjectionBinder
+	for _, mc := range cm.GetManagedComponents() {
+		if b, ok := mc.Component.(ProjectionBinder); ok {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// BindRulePackContracts binds the projection contracts of every rule pack the
+// manager holds under the ownership substrate (ADR-056 #278 inc 2).
+//
+// INVARIANT — call this ONCE at the composition root, BEFORE manager.StartAll.
+// Rule-pack contracts are PACK-LEVEL and STATIC: they are read once here and
+// the binding is NEVER re-derived. NEVER call this from a hot-reload path —
+// hot-reload must not re-bind ownership (a re-bind would self-overlap against
+// the pack's own already-registered claims and would churn the ownership
+// epoch). The only entry point that reads the contracts is
+// ProjectionBinder.ProjectionBindings(), which carries the same invariant.
+//
+// Binding is best-effort / observe-only, matching the rest of the ADR-056
+// rollout: a nil registry is a no-op (ownership disabled this boot), and any
+// per-pack bind error is logged and skipped — it never aborts boot. An owner id
+// is "rule-pack.<pack_id>"; the pack_id is validated subject-safe at config
+// time (rule.Config.Validate), so RegisterOwner cannot reject it on charset.
+func BindRulePackContracts(ctx context.Context, manager *Manager, ownerReg *ownership.Registry, hb *ownership.Heartbeater, logger *slog.Logger) {
+	if ownerReg == nil {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	bound := make(map[string]struct{}) // pack_id set, for duplicate detection
+	for _, b := range manager.ProjectionBinders() {
+		packID, contracts := b.ProjectionBindings()
+		if packID == "" {
+			continue
+		}
+		if _, exists := bound[packID]; exists {
+			logger.Error("duplicate rule pack_id across components — skipping second bind",
+				"pack_id", packID)
+			continue
+		}
+		bound[packID] = struct{}{}
+
+		if len(contracts) == 0 {
+			// A pack_id with no contracts declares ownership identity but emits
+			// nothing — nothing to bind. Recorded above so a duplicate id still
+			// trips the guard.
+			continue
+		}
+
+		ownerID := "rule-pack." + packID
+		if err := projection.BindAndHeartbeat(ctx, ownerReg, hb, ownerID, contracts...); err != nil {
+			if errors.Is(err, ownership.ErrOwnershipOverlap) {
+				logger.Warn("ownership overlap on rule pack bind — continuing (observe-only)",
+					"owner_id", ownerID, "err", err)
+			} else {
+				logger.Warn("rule pack bind error — continuing (observe-only)",
+					"owner_id", ownerID, "err", err)
+			}
+		}
+	}
+}

--- a/service/rule_pack_bind_integration_test.go
+++ b/service/rule_pack_bind_integration_test.go
@@ -1,0 +1,308 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/config"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/c360studio/semstreams/pkg/projection"
+	rule "github.com/c360studio/semstreams/processor/rule"
+	"github.com/c360studio/semstreams/service"
+	"github.com/c360studio/semstreams/types"
+	"github.com/c360studio/semstreams/vocabulary"
+	"github.com/stretchr/testify/require"
+)
+
+// ruleComponentConfig builds the operator-facing component config for a rule
+// processor carrying a pack_id and projection contracts. The Config field is a
+// rule.Config JSON; the rule factory copies pack_id/projection_contracts off it
+// (the production wire under test).
+func ruleComponentConfig(t *testing.T, packID string, contracts []projection.Contract) types.ComponentConfig {
+	t.Helper()
+	rc := rule.DefaultConfig()
+	rc.EnableGraphIntegration = false // keep the (unstarted) processor lean
+	rc.PackID = packID
+	rc.ProjectionContracts = contracts
+	raw, err := json.Marshal(rc)
+	require.NoError(t, err)
+	return types.ComponentConfig{
+		Type:    types.ComponentTypeProcessor,
+		Name:    "rule-processor",
+		Enabled: true,
+		Config:  raw,
+	}
+}
+
+// newManagerWithRuleComponents drives the PRODUCTION wire: a real config
+// Manager holding the given rule component configs, a component registry with
+// the real rule processor registered, and a service.Manager whose mandatory
+// "component-manager" service constructs (but does NOT Start) those rule
+// processors. Returns the wired service.Manager. NOTHING is started — so
+// ProjectionBindings is read on freshly-constructed, never-Started processors,
+// matching the composition-root bind-before-StartAll invariant.
+func newManagerWithRuleComponents(t *testing.T, ctx context.Context, tc *natsclient.TestClient, comps config.ComponentConfigs) *service.Manager {
+	t.Helper()
+
+	cfgManager, err := config.NewConfigManager(&config.Config{
+		Platform: config.PlatformConfig{
+			Org: "test", ID: "test-platform", InstanceID: "test-001", Environment: "test",
+		},
+		Components: comps,
+	}, tc.Client, slog.Default())
+	require.NoError(t, err)
+	require.NoError(t, cfgManager.PushToKV(ctx))
+	require.NoError(t, cfgManager.Start(ctx))
+	t.Cleanup(func() { _ = cfgManager.Stop(5 * time.Second) })
+
+	compRegistry := componentRegistryWithRule(t)
+
+	deps := &service.Dependencies{
+		NATSClient:        tc.Client,
+		Manager:           cfgManager,
+		Logger:            slog.Default(),
+		ComponentRegistry: compRegistry,
+	}
+
+	svcRegistry := service.NewServiceRegistry()
+	svcRegistry.Register("component-manager", service.NewComponentManager)
+	manager := service.NewServiceManager(svcRegistry)
+	require.NoError(t, manager.ConfigureFromServices(
+		map[string]types.ServiceConfig{}, deps))
+
+	// CreateService("component-manager") runs the ComponentManager constructor,
+	// which constructs every enabled component (the rule processors) WITHOUT
+	// starting them. After this, manager.ProjectionBinders() returns them.
+	_, err = manager.CreateService("component-manager",
+		json.RawMessage(`{"watch_config": false}`), deps)
+	require.NoError(t, err)
+
+	return manager
+}
+
+// componentRegistryWithRule returns a component registry with the real rule
+// processor factory registered.
+func componentRegistryWithRule(t *testing.T) *component.Registry {
+	t.Helper()
+	r := component.NewRegistry()
+	require.NoError(t, rule.Register(r))
+	return r
+}
+
+func newOwnershipRegistryForBind(t *testing.T, ctx context.Context, tc *natsclient.TestClient) *ownership.Registry {
+	t.Helper()
+	reg, err := ownership.EnsureBuckets(ctx, tc.Client, slog.Default(), vocabulary.InverseResolver)
+	require.NoError(t, err)
+	return reg
+}
+
+func droneStatusContract() projection.Contract {
+	return projection.Contract{
+		Name:          "drone.status",
+		MessageType:   "telemetry.robotics.drone-status.v1",
+		EntityPattern: "acme.ops.robotics.gcs.drone.*",
+		Groups: []projection.PredicateGroup{{
+			Mode:       ownership.ModeReplaceOwned,
+			Predicates: []string{"drone.status.state"},
+		}},
+	}
+}
+
+// TestBindRulePackContracts_ClaimInEpochBeforeStart drives the production entry
+// service.BindRulePackContracts (NOT a hand-rolled bind, per
+// [[feedback_integration_tests_must_drive_production_wire]]) and proves the
+// rule pack's claim lands in the ownership epoch BEFORE any processor Start().
+func TestBindRulePackContracts_ClaimInEpochBeforeStart(t *testing.T) {
+	ctx := context.Background()
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	defer tc.Terminate()
+
+	ownerReg := newOwnershipRegistryForBind(t, ctx, tc)
+	hb := ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
+
+	manager := newManagerWithRuleComponents(t, ctx, tc, config.ComponentConfigs{
+		"rule-processor": ruleComponentConfig(t, "drone-ops.v1",
+			[]projection.Contract{droneStatusContract()}),
+	})
+
+	// Production entry. No Start() / StartAll() anywhere in this test.
+	service.BindRulePackContracts(ctx, manager, ownerReg, hb, slog.Default())
+
+	owner, ok, err := ownerReg.OwnerOf(ctx,
+		"acme.ops.robotics.gcs.drone.001", "drone.status.state")
+	require.NoError(t, err)
+	require.True(t, ok, "claim must be in the epoch after bind")
+	require.Equal(t, "rule-pack.drone-ops.v1", owner)
+	require.True(t, hb.IsEnrolled("rule-pack.drone-ops.v1"),
+		"a bound static owner must be heartbeat-enrolled")
+}
+
+// TestBindRulePackContracts_OverlapLoggedNotAborted proves a second pack whose
+// contract overlaps an already-claimed cell is rejected by the substrate with
+// ErrOwnershipOverlap, the helper logs+continues (observe-only), and the FIRST
+// owner still holds the cell.
+func TestBindRulePackContracts_OverlapLoggedNotAborted(t *testing.T) {
+	ctx := context.Background()
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	defer tc.Terminate()
+
+	ownerReg := newOwnershipRegistryForBind(t, ctx, tc)
+	hb := ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
+
+	// Pre-bind pack-a directly through the production helper.
+	managerA := newManagerWithRuleComponents(t, ctx, tc, config.ComponentConfigs{
+		"rule-processor": ruleComponentConfig(t, "pack-a",
+			[]projection.Contract{droneStatusContract()}),
+	})
+	service.BindRulePackContracts(ctx, managerA, ownerReg, hb, slog.Default())
+
+	// pack-b declares the SAME owned cell — overlap.
+	overlapping := droneStatusContract()
+	overlapping.Name = "drone.status.poach"
+	managerB := newManagerWithRuleComponents(t, ctx, tc, config.ComponentConfigs{
+		"rule-processor": ruleComponentConfig(t, "pack-b",
+			[]projection.Contract{overlapping}),
+	})
+
+	// Must NOT panic / abort — helper swallows the overlap as observe-only.
+	service.BindRulePackContracts(ctx, managerB, ownerReg, hb, slog.Default())
+
+	// The cell still belongs to pack-a; pack-b was rejected.
+	owner, ok, err := ownerReg.OwnerOf(ctx,
+		"acme.ops.robotics.gcs.drone.001", "drone.status.state")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "rule-pack.pack-a", owner)
+	require.False(t, hb.IsEnrolled("rule-pack.pack-b"),
+		"a rejected (overlapping) owner must not be heartbeat-enrolled")
+
+	// Sanity: the substrate genuinely treats this as an overlap (the helper hides
+	// it, so assert against a direct derive to keep the test honest).
+	_, derr := projection.Derive("rule-pack.pack-b", overlapping)
+	require.NoError(t, derr, "derive itself is valid; the overlap is cross-owner at register time")
+	berr := projection.Bind(ctx, ownerReg, "rule-pack.pack-c", overlapping)
+	require.True(t, errors.Is(berr, ownership.ErrOwnershipOverlap),
+		"a fresh owner binding the same cell must hit ErrOwnershipOverlap")
+}
+
+// TestBindRulePackContracts_MultiPackAndDuplicate proves: (1) two rule
+// components with DISTINCT pack_ids bind two distinct owners; (2) a duplicate
+// pack_id across components is logged + skipped, not double-bound; (3) a rule
+// component with NO pack_id binds nothing.
+func TestBindRulePackContracts_MultiPackAndDuplicate(t *testing.T) {
+	ctx := context.Background()
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	defer tc.Terminate()
+
+	ownerReg := newOwnershipRegistryForBind(t, ctx, tc)
+	hb := ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
+
+	missionContract := projection.Contract{
+		Name:          "mission.status",
+		EntityPattern: "acme.ops.robotics.gcs.mission.*",
+		Groups: []projection.PredicateGroup{{
+			Mode:       ownership.ModeReplaceOwned,
+			Predicates: []string{"mission.status.phase"},
+		}},
+	}
+
+	// Two distinct pack_ids + one no-pack component, all in one manager.
+	manager := newManagerWithRuleComponents(t, ctx, tc, config.ComponentConfigs{
+		"rule-drones":   ruleComponentConfig(t, "drone-ops.v1", []projection.Contract{droneStatusContract()}),
+		"rule-missions": ruleComponentConfig(t, "mission-ops.v1", []projection.Contract{missionContract}),
+		"rule-nopack":   ruleComponentConfig(t, "", nil),
+	})
+
+	service.BindRulePackContracts(ctx, manager, ownerReg, hb, slog.Default())
+
+	require.True(t, hb.IsEnrolled("rule-pack.drone-ops.v1"))
+	require.True(t, hb.IsEnrolled("rule-pack.mission-ops.v1"))
+
+	dOwner, dOK, err := ownerReg.OwnerOf(ctx, "acme.ops.robotics.gcs.drone.001", "drone.status.state")
+	require.NoError(t, err)
+	require.True(t, dOK)
+	require.Equal(t, "rule-pack.drone-ops.v1", dOwner)
+
+	mOwner, mOK, err := ownerReg.OwnerOf(ctx, "acme.ops.robotics.gcs.mission.alpha", "mission.status.phase")
+	require.NoError(t, err)
+	require.True(t, mOK)
+	require.Equal(t, "rule-pack.mission-ops.v1", mOwner)
+
+	// Duplicate pack_id across two components in a second manager: second is
+	// skipped (logged), and re-running bind for an already-bound owner is a
+	// no-op observe-only (the owner already holds the cell). The helper must
+	// not panic and the cell ownership stays put.
+	dupManager := newManagerWithRuleComponents(t, ctx, tc, config.ComponentConfigs{
+		"rule-a": ruleComponentConfig(t, "dup-pack", []projection.Contract{missionContract2()}),
+		"rule-b": ruleComponentConfig(t, "dup-pack", []projection.Contract{missionContract2()}),
+	})
+	service.BindRulePackContracts(ctx, dupManager, ownerReg, hb, slog.Default())
+	require.True(t, hb.IsEnrolled("rule-pack.dup-pack"))
+}
+
+// TestRulePackInvalidPackID_RejectedAtFactory proves an illegal pack_id is
+// rejected by the production rule factory (config validation) — it never
+// reaches the bind helper / RegisterOwner. Drives CreateRuleProcessor, the
+// production component-construction entry, through CreateService.
+func TestRulePackInvalidPackID_RejectedAtFactory(t *testing.T) {
+	ctx := context.Background()
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	defer tc.Terminate()
+
+	cfgManager, err := config.NewConfigManager(&config.Config{
+		Platform: config.PlatformConfig{
+			Org: "test", ID: "test-platform", InstanceID: "test-001", Environment: "test",
+		},
+		Components: config.ComponentConfigs{
+			"rule-processor": ruleComponentConfig(t, "bad:pack",
+				[]projection.Contract{droneStatusContract()}),
+		},
+	}, tc.Client, slog.Default())
+	require.NoError(t, err)
+	require.NoError(t, cfgManager.PushToKV(ctx))
+	require.NoError(t, cfgManager.Start(ctx))
+	t.Cleanup(func() { _ = cfgManager.Stop(5 * time.Second) })
+
+	deps := &service.Dependencies{
+		NATSClient:        tc.Client,
+		Manager:           cfgManager,
+		Logger:            slog.Default(),
+		ComponentRegistry: componentRegistryWithRule(t),
+	}
+	svcRegistry := service.NewServiceRegistry()
+	svcRegistry.Register("component-manager", service.NewComponentManager)
+	manager := service.NewServiceManager(svcRegistry)
+	require.NoError(t, manager.ConfigureFromServices(map[string]types.ServiceConfig{}, deps))
+
+	// The ComponentManager constructor builds components; the rule factory must
+	// reject the illegal pack_id. Whether the rejection surfaces as a
+	// CreateService error or a never-constructed component, the invariant is the
+	// same: no rule.Processor with pack_id "bad:pack" exists to bind.
+	_, _ = manager.CreateService("component-manager",
+		json.RawMessage(`{"watch_config": false}`), deps)
+
+	for _, b := range manager.ProjectionBinders() {
+		packID, _ := b.ProjectionBindings()
+		require.NotEqual(t, "bad:pack", packID,
+			"an illegal pack_id must never reach a constructed processor / the bind helper")
+	}
+}
+
+func missionContract2() projection.Contract {
+	return projection.Contract{
+		Name:          "dup.status",
+		EntityPattern: "acme.ops.robotics.gcs.sensor.*",
+		Groups: []projection.PredicateGroup{{
+			Mode:       ownership.ModeReplaceOwned,
+			Predicates: []string{"sensor.status.calibrated"},
+		}},
+	}
+}


### PR DESCRIPTION
## What

#278 **increment 2** of 3. Rule packs become a config-level projection producer (ADR-056 Decision 6a, merged in #281). A pack declares `PackID` + `ProjectionContracts` at the pack/config level (`rule.Config`); the **composition root** binds `rule-pack.<pack_id>` via `projection.BindAndHeartbeat` **before the rule watcher starts**. The `RuleProcessor` stays substrate-agnostic — ownership is process composition, not rule execution.

## Honors the four hard constraints (Coby's design tightening)

1. **No registry injection into `RuleProcessor`** — `ProjectionBindings()` returns a *declaration*; the processor never touches `ownership.Registry`. All binding is main-side.
2. **Pack-level, static contracts; NO re-bind on hot-reload** — the load-bearing invariant. The hot-reload manager reconciles `rules.*` Definitions only; `pack_id`/`projection_contracts` are structurally unreachable from the reload path (verified: `ApplyConfigUpdate`/`ValidateConfigUpdate` touch only `rules`/watch-patterns/`enable_graph_integration`). Runtime `rules.*` CRUD changes **behavior, not ownership shape**.
3. **Bind before the watcher starts** — `BindRulePackContracts` runs in the `configureAndCreateServices → StartAll` window in **both** mains (one shared `service.BindRulePackContracts`, no copy-paste drift).
4. **Owner id `rule-pack.<pack_id>`** — `rule.Config.Validate()` rejects anything outside `[A-Za-z0-9._=-]` at config time.

## Changes

- `rule.Config`: `PackID` + `ProjectionContracts` (`omitempty` — existing configs untouched) + `Validate()`.
- `factory.go`: copies the fields (load-bearing — the factory builds from `DefaultConfig`, not the parsed config) + fail-fast `Validate`.
- `Processor.ProjectionBindings()`: returns the retained config's pack + contracts.
- `service.BindRulePackContracts` + a **duck-typed `ProjectionBinder` interface** — deliberately avoids a *test-only* `service → processor/rule` import cycle (`actions_test.go → agentic-tools → service`). Enumerates rule components, binds each `rule-pack.<id>`, detects duplicate `pack_id`, logs overlap **observe-only** (never aborts boot).
- both mains: `ownerReg`/`staticOwnerHB` lifted to `run()` scope (reusing #280's static-owner heartbeater + shutdown-ctx discipline).
- `schemas/rule-processor.v1.json` regenerated.

## Tests

config round-trip (custom Marshal/Unmarshal alias path), `ProjectionBindings` retention + no-pack, **bind-before-watcher** (claim in epoch *before* `Start()`), overlap-logged-not-aborted, multi-pack + duplicate, illegal `pack_id` rejected at the factory — all driving the production `BindRulePackContracts` wire.

## Review

**go-reviewer: approved, no Critical/Important.** All six constraints verified (constraint 2 confirmed four ways as airtight); duck-typed interface confirmed the right call against a real cycle; #280 shutdown discipline preserved across the lift. One cosmetic nit applied (factory field-copy symmetry); one skipped (Debug log for an absent component-manager — can't happen in the real mains).

## Deferred to increment 3

The `replace-owned` rule action + envelope validation (a replace-owned write inside the contract succeeds / outside fails). Increment 2 only guarantees hot-reload *structurally cannot* re-bind ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)