### PR TITLE
feat(graph-ingest): ADR-056 4c-pre-2 — foreign-edge must-exist routing policy

### DIFF
--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -225,6 +225,30 @@ shape.
   e2e-exercised end-to-end. Closing it (a relationship-target-bearing e2e fixture) is a prerequisite
   for the 4c must-exist flip, NOT for this additive fold — the fold keeps auto-vivify working, so it
   does not change observable behaviour for any current path.
+- **W0 4c-pre-2 landed — `routeForeignEdges` per-edge must-exist policy (stub-materialize-or-loud-drop,
+  not bare `AddTriples`).** The routing seam now does its OWN target-existence check
+  (`foreignTargetExists`) and, for an ABSENT target, branches on the covering `ForeignEdgeClaim`'s
+  `EdgeMode` (a new `ClaimReader.ForeignEdgeMode` reader reusing `epoch.foreignEdgeClaimFor`):
+  `EdgeNoBirthStub` materializes the 4b stub then appends; `EdgeStrict` loud-drops (the new
+  `foreign_edge_dropped_total{message_type,predicate,reason=strict_absent_target}` metric — kept
+  DISTINCT from `foreign_edge_unclaimed_total` so a Strict drop can't corrupt the flip-gate's
+  hatch-empty signal); `EdgeConditional`/`EdgeBackfill` are DEFERRED (the `PENDING_EDGES` buffer is a
+  later increment) and route-with-warn + `reason=conditional_deferred` in the interim; an UNCLAIMED
+  edge stays routed deprecated-on-arrival so the hatch can still drain to zero. A PRESENT target
+  appends regardless of mode; `claimReader == nil` graceful-skips to the legacy bare append; a read
+  blip on either the existence check or the mode lookup fails OPEN (route-toward-append, never
+  Strict-drop on a transient error). The own existence check is what makes routing correct BOTH before
+  and after the eventual flip removes `AddTriples`' auto-vivify else-branch. **Lane-asymmetry note
+  (corrects the 4b "stub materializes BEFORE `routeForeignEdges`" claim):** that upstream stub
+  (`ensureRelationshipTargetsExist` walking the parent's own `hosts` edge) runs only on the
+  fact-arrival and `create_with_triples` lanes; `update_with_triples` does NOT call it, so on the
+  update lane `routeForeignEdges`'s own `ensureReferencedEntityExists` call for `EdgeNoBirthStub` is
+  load-bearing, not redundant. Additive / observe-leaning: only `EdgeStrict`+absent drops, and no live
+  producer registers `EdgeStrict` today (sensorml's `isHostedBy` is `EdgeNoBirthStub`). Does NOT by
+  itself enable the flip — that remains gated on the `PENDING_EDGES` increment (if any Conditional
+  producer ever ships), the bare-triple-lane precondition (Fix part 6), the hatch-empty bake, and the
+  e2e fourth-path fixture. *(Source-line anchors elsewhere in this Decision-4 section predate W0 and
+  have drifted; trust symbol names over line numbers when reading the code.)*
 
 ### v4 → v5: implementation contracts pinned (1 BLOCKING + P1s; no architectural forks)
 

--- a/pkg/ownership/claim_reader.go
+++ b/pkg/ownership/claim_reader.go
@@ -80,6 +80,34 @@ func (cr *ClaimReader) UnclaimedForeignEdges(ctx context.Context, producer strin
 	return unclaimed, nil
 }
 
+// ForeignEdgeMode returns the EdgeMode of the ForeignEdgeClaim covering a
+// foreign-subject triple emitted by `producer` carrying `predicate` — the
+// ADR-056 Decision-4 seam consumer's mode branch (NoBirthStub→stub,
+// Strict→drop, Conditional/Backfill→buffer). ok=false means the edge is
+// UNCLAIMED (no covering claim — the deprecated-on-arrival hatch). An empty/
+// absent registry is not an error: nothing is claimed yet, so ok=false. Reuses
+// the deterministic epoch.foreignEdgeClaimFor (an exact-producer claim wins; a
+// Producer-empty "any producer" claim is the fallback), one epoch read per call
+// (production foreign-edge volume is zero today; see the type doc).
+func (cr *ClaimReader) ForeignEdgeMode(ctx context.Context, producer, predicate string) (EdgeMode, bool, error) {
+	entry, err := cr.claims.Get(ctx, registryKey)
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return "", false, nil // empty registry: nothing claimed yet → unclaimed
+		}
+		return "", false, fmt.Errorf("ownership: read epoch for foreign-edge mode: %w", err)
+	}
+	ep, err := decodeEpoch(entry.Value)
+	if err != nil {
+		return "", false, err
+	}
+	claim, ok := ep.foreignEdgeClaimFor(producer, predicate)
+	if !ok {
+		return "", false, nil
+	}
+	return claim.Mode, true, nil
+}
+
 // dedupeStrings returns the sorted, de-duplicated set of non-empty strings.
 func dedupeStrings(in []string) []string {
 	if len(in) == 0 {

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -48,6 +48,9 @@ var (
 
 	foreignEdgeUnclaimedOnce sync.Once
 	foreignEdgeUnclaimedVec  *prometheus.CounterVec
+
+	foreignEdgeDroppedOnce sync.Once
+	foreignEdgeDroppedVec  *prometheus.CounterVec
 )
 
 // entityIDRegex validates entity ID format: org.platform.domain.system.type.instance
@@ -153,6 +156,35 @@ func getForeignEdgeUnclaimedMetric(registry *metric.MetricsRegistry) *prometheus
 	return foreignEdgeUnclaimedVec
 }
 
+// getForeignEdgeDroppedMetric returns the process-wide counter for foreign edges
+// the routing seam DROPPED rather than routed (ADR-056 Decision-4 4c-pre-2). It
+// is DISTINCT from foreign_edge_unclaimed_total on purpose: that counter is the
+// flip-gate's hatch-empty signal (a CLAIMED-as-unclaimed pair); this counter
+// meters a *claimed* edge that could not be routed because its target was absent
+// and its mode forbade materialising it. Folding the two would corrupt the
+// flip-gate reading (a Strict drop would keep the hatch counter non-zero for an
+// unrelated reason). Labels: message_type ('_invalid' for an unregistered/zero
+// type), predicate (exact vocabulary string), and reason — a bounded closed set:
+// 'strict_absent_target' (EdgeStrict, target absent) and 'conditional_deferred'
+// (EdgeConditional/EdgeBackfill, routed-with-warn until the PENDING_EDGES buffer
+// lands).
+func getForeignEdgeDroppedMetric(registry *metric.MetricsRegistry) *prometheus.CounterVec {
+	foreignEdgeDroppedOnce.Do(func() {
+		foreignEdgeDroppedVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "graph_ingest",
+			Name:      "foreign_edge_dropped_total",
+			Help:      "Foreign-subject edges dropped or deferred at the routing seam by claim mode (ADR-056 Decision 4). Labels: message_type, predicate, reason (strict_absent_target|conditional_deferred). DISTINCT from foreign_edge_unclaimed_total (the hatch-empty flip-gate signal)",
+		}, []string{"message_type", "predicate", "reason"})
+		if registry != nil {
+			_ = registry.RegisterCounterVec("graph-ingest", "foreign_edge_dropped_total", foreignEdgeDroppedVec)
+		} else {
+			_ = prometheus.DefaultRegisterer.Register(foreignEdgeDroppedVec)
+		}
+	})
+	return foreignEdgeDroppedVec
+}
+
 // Config holds configuration for graph-ingest component
 type Config struct {
 	Ports              *component.PortConfig `json:"ports" schema:"type:ports,description:Port configuration,category:basic"`
@@ -250,12 +282,16 @@ func (a *tripleAdderAdapter) AddTriple(ctx context.Context, triple message.Tripl
 }
 
 // foreignEdgeClassifier classifies a producer's foreign-edge predicates against
-// the registered ForeignEdgeClaims (ADR-056 Decision 4): it returns the subset
-// with no covering claim. *ownership.ClaimReader is the production
-// implementation (one epoch read per call); tests inject a fake. Kept as an
-// interface so the observe-only seam is unit-testable without NATS.
+// the registered ForeignEdgeClaims (ADR-056 Decision 4). UnclaimedForeignEdges
+// returns the subset with no covering claim (the observe-only seam metric);
+// ForeignEdgeMode returns one predicate's covering EdgeMode so the routing seam
+// can branch (NoBirthStub→stub, Strict→drop, Conditional/Backfill→deferred).
+// *ownership.ClaimReader is the production implementation (one epoch read per
+// call); tests inject a fake. Kept as an interface so the seam is unit-testable
+// without NATS.
 type foreignEdgeClassifier interface {
 	UnclaimedForeignEdges(ctx context.Context, producer string, predicates []string) ([]string, error)
+	ForeignEdgeMode(ctx context.Context, producer, predicate string) (ownership.EdgeMode, bool, error)
 }
 
 // Component implements the graph-ingest processor
@@ -306,6 +342,7 @@ type Component struct {
 	indexingProfileDefault *prometheus.CounterVec
 	mutationRejections     *prometheus.CounterVec
 	foreignEdgeUnclaimed   *prometheus.CounterVec
+	foreignEdgeDropped     *prometheus.CounterVec
 	metricsRegistry        *metric.MetricsRegistry
 
 	// Lifecycle reporting
@@ -353,6 +390,7 @@ func CreateGraphIngest(rawConfig json.RawMessage, deps component.Dependencies) (
 		indexingProfileDefault: getIndexingProfileDefaultMetric(deps.MetricsRegistry),
 		mutationRejections:     getMutationRejectionsMetric(deps.MetricsRegistry),
 		foreignEdgeUnclaimed:   getForeignEdgeUnclaimedMetric(deps.MetricsRegistry),
+		foreignEdgeDropped:     getForeignEdgeDroppedMetric(deps.MetricsRegistry),
 		metricsRegistry:        deps.MetricsRegistry,
 	}
 
@@ -995,7 +1033,7 @@ func (c *Component) ingestEntity(ctx context.Context, entity *graph.EntityState)
 		return
 	}
 
-	c.routeForeignEdges(ctx, entity.ID, foreign)
+	c.routeForeignEdges(ctx, entity.ID, entity.MessageType, foreign)
 
 	c.logger.Debug("Entity ingested",
 		slog.String("entity_id", entity.ID),
@@ -1034,14 +1072,134 @@ func (c *Component) normalizeProjection(ctx context.Context, primaryID string, m
 	return own, foreign
 }
 
-// routeForeignEdges appends foreign-subject edges onto their own subjects via the
+const (
+	// invalidMessageTypeLabel bounds the metric label for a producer that
+	// registered no/zero MessageType — it cannot match an exact-producer claim,
+	// so it gets a single bounded label rather than smearing cardinality.
+	invalidMessageTypeLabel = "_invalid"
+	// dropReasonStrictAbsent — an EdgeStrict foreign edge dropped because its
+	// target was absent (the target must pre-exist by causal ordering).
+	dropReasonStrictAbsent = "strict_absent_target"
+	// dropReasonConditionalDeferred — an EdgeConditional/EdgeBackfill foreign
+	// edge routed-with-warn pending the PENDING_EDGES buffer increment.
+	dropReasonConditionalDeferred = "conditional_deferred"
+)
+
+// foreignTargetExists reports whether a foreign-edge target entity already
+// exists, so routeForeignEdges can decide stub-vs-append-vs-drop WITHOUT relying
+// on AddTriples' auto-vivify else-branch (which the ADR-055 must-exist flip
+// later removes). A transient read error fails toward the LESS destructive
+// outcome — treat as "exists" so the edge is APPENDED (matching today's
+// best-effort behaviour) rather than DROPPED; a Strict drop on a read blip would
+// lose a legitimately-present edge. TOCTOU note: a concurrent DeleteEntity
+// between this Get and the AddTriples append is benign WHILE auto-vivify is
+// present (the append re-vivifies); the flip increment makes the post-check
+// append must-exist and owns closing that window.
+func (c *Component) foreignTargetExists(ctx context.Context, subject string) bool {
+	if _, err := c.entityBucket.Get(ctx, subject); err == nil {
+		return true
+	} else if natsclient.IsKVNotFoundError(err) {
+		return false
+	}
+	return true
+}
+
+// routeForeignEdges regroups foreign-subject edges onto their own subjects after
+// the primary commit (ADR-056 Decision 4). It is best-effort and called AFTER
+// the primary write succeeds — a failed edge is logged, not fatal to the primary
+// write that already landed.
+//
+// 4c-pre-2 replaces the old bare-AddTriples append with a per-edge must-exist
+// policy: for an absent target it branches on the covering ForeignEdgeClaim's
+// EdgeMode — NoBirthStub materialises the framework's referential-integrity stub
+// then appends (the only thing that ever births the sensorml-child target;
+// load-bearing especially on the update_with_triples lane, which — unlike the
+// fact-arrival/create_with_triples lanes — does NOT run ensureRelationshipTargetsExist
+// upstream); Strict drops the edge loudly (metric + one-time WARN); an UNCLAIMED
+// edge stays routed deprecated-on-arrival so the hatch-empty flip-gate can still
+// drain it; Conditional/Backfill are deferred to a later increment (PENDING_EDGES
+// buffer) and route-with-warn in the interim. A present target always appends,
+// regardless of mode. When no claim reader is wired (resourceless/unmigrated
+// deploy) the seam graceful-skips to the legacy bare append.
+//
+// mt is the producer identity (entity.MessageType) for the claim lookup + metric
+// label. AddTriples validates the batch all-or-nothing, so one malformed edge
+// drops the whole appended batch; no current producer emits one.
+func (c *Component) routeForeignEdges(ctx context.Context, primaryID string, mt message.Type, foreign []message.Triple) {
+	if len(foreign) == 0 {
+		return
+	}
+
+	// Graceful-skip: with no registered-claim view we cannot resolve modes, so
+	// fall back to the legacy bare append (preserves the observe-only contract on
+	// a resourceless/unmigrated deploy).
+	if c.claimReader == nil {
+		c.appendForeignEdges(ctx, primaryID, foreign)
+		return
+	}
+
+	label := mt.Key()
+	if !mt.IsValid() {
+		label = invalidMessageTypeLabel
+	}
+
+	toAppend := make([]message.Triple, 0, len(foreign))
+	for _, edge := range foreign {
+		// Present target: append regardless of mode. The own existence check
+		// makes this correct both before and after the flip removes auto-vivify.
+		if c.foreignTargetExists(ctx, edge.Subject) {
+			toAppend = append(toAppend, edge)
+			continue
+		}
+
+		mode, claimed, err := c.claimReader.ForeignEdgeMode(ctx, mt.Key(), edge.Predicate)
+		if err != nil {
+			// Read blip — fail-open (never block routing), route deprecated-on-arrival.
+			c.logger.Warn("graph-ingest: foreign-edge mode lookup failed — routing edge anyway (observe-only fail-open)",
+				slog.String("message_type", label), slog.String("predicate", edge.Predicate), slog.Any("error", err))
+			toAppend = append(toAppend, edge)
+			continue
+		}
+
+		switch {
+		case !claimed:
+			// UNCLAIMED + absent: the deprecated-on-arrival hatch. Stay routed so
+			// foreign_edge_unclaimed_total (metered upstream in classifyForeignEdges)
+			// can still reach zero over the flip-gate bake window.
+			toAppend = append(toAppend, edge)
+		case mode == ownership.EdgeNoBirthStub:
+			// Backstop: materialise the envelope-bearing stub then append. Idempotent
+			// (no-op if the upstream ensureRelationshipTargetsExist already won the race).
+			if serr := c.ensureReferencedEntityExists(ctx, edge.Subject, primaryID, mt); serr != nil {
+				c.logger.Warn("graph-ingest: no-birth-stub materialisation failed — routing edge anyway (target may dangle)",
+					slog.String("message_type", label), slog.String("predicate", edge.Predicate),
+					slog.String("target", edge.Subject), slog.Any("error", serr))
+			}
+			toAppend = append(toAppend, edge)
+		case mode == ownership.EdgeStrict:
+			// Loud-drop: a Strict edge's target must pre-exist by causal ordering.
+			c.foreignEdgeDropped.WithLabelValues(label, edge.Predicate, dropReasonStrictAbsent).Inc()
+			c.warnForeignEdgeDropOnce(dropReasonStrictAbsent, label, edge)
+			// NOT appended.
+		case mode == ownership.EdgeConditional || mode == ownership.EdgeBackfill:
+			// DEFERRED to the PENDING_EDGES increment. No live producer reaches here
+			// today; route-with-warn (keeps auto-vivify) so it is observable, not silent.
+			c.foreignEdgeDropped.WithLabelValues(label, edge.Predicate, dropReasonConditionalDeferred).Inc()
+			c.warnForeignEdgeDropOnce(dropReasonConditionalDeferred, label, edge)
+			toAppend = append(toAppend, edge)
+		default:
+			// Unknown/forward-compat mode: treat as hatch, route-with-warn.
+			toAppend = append(toAppend, edge)
+		}
+	}
+
+	c.appendForeignEdges(ctx, primaryID, toAppend)
+}
+
+// appendForeignEdges routes a foreign-edge batch onto its subjects via the
 // evidence-append path (AddTriples = append-by-subject, no MessageType restamp),
-// deprecated-on-arrival (observe-only; the hard reject + Conditional pending
-// buffer are 4b/4c). Best-effort and called AFTER the primary commit succeeds —
-// a failed edge is logged, not fatal to the primary write that already landed.
-// AddTriples validates the batch all-or-nothing, so one malformed foreign edge
-// drops the whole foreign batch; no current producer emits one.
-func (c *Component) routeForeignEdges(ctx context.Context, primaryID string, foreign []message.Triple) {
+// logging a partial failure without failing the primary write.
+func (c *Component) appendForeignEdges(ctx context.Context, primaryID string, foreign []message.Triple) {
 	if len(foreign) == 0 {
 		return
 	}
@@ -1051,6 +1209,21 @@ func (c *Component) routeForeignEdges(ctx context.Context, primaryID string, for
 			slog.Int("failed_subjects", len(failed)),
 			slog.Any("error", aerr))
 	}
+}
+
+// warnForeignEdgeDropOnce logs a one-time WARN per (reason, message_type,
+// predicate), deduped via foreignEdgeWarnedKeys with a distinct "fe-drop|" prefix
+// so it never collides with classifyForeignEdges' unclaimed-WARN keys.
+func (c *Component) warnForeignEdgeDropOnce(reason, label string, edge message.Triple) {
+	warnKey := "fe-drop|" + reason + "|" + label + "|" + edge.Predicate
+	if _, warned := c.foreignEdgeWarnedKeys.LoadOrStore(warnKey, struct{}{}); warned {
+		return
+	}
+	c.logger.Warn("graph-ingest: foreign-subject edge dropped/deferred at routing seam (ADR-056 Decision 4)",
+		slog.String("message_type", label),
+		slog.String("predicate", edge.Predicate),
+		slog.String("target", edge.Subject),
+		slog.String("reason", reason))
 }
 
 // classifyForeignEdges runs the ADR-056 Decision-4 T2-seam reject in OBSERVE-ONLY
@@ -1073,7 +1246,7 @@ func (c *Component) classifyForeignEdges(ctx context.Context, mt message.Type, f
 	producer := mt.Key()
 	label := producer
 	if !mt.IsValid() {
-		label = "_invalid"
+		label = invalidMessageTypeLabel
 	}
 
 	preds := make([]string, 0, len(foreign))

--- a/processor/graph-ingest/foreign_edge_route_test.go
+++ b/processor/graph-ingest/foreign_edge_route_test.go
@@ -1,0 +1,188 @@
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/ownership"
+)
+
+// routeTestComp builds a graph-ingest component over a mock KV bucket and returns
+// BOTH (unlike createTestComponentWithMockKV) so a test can pre-seed entities and
+// inject Get errors — the inputs the 4c-pre-2 routing policy branches on.
+func routeTestComp(t *testing.T) (*Component, *mockKVBucket) {
+	t.Helper()
+	mockBucket := newMockKVBucket()
+	natsClient, err := natsclient.NewClient("nats://localhost:4222")
+	require.NoError(t, err)
+	configJSON, err := json.Marshal(DefaultConfig())
+	require.NoError(t, err)
+	comp, err := CreateGraphIngest(configJSON, component.Dependencies{NATSClient: natsClient})
+	require.NoError(t, err)
+	c := comp.(*Component)
+	c.entityBucket = natsClient.NewKVStore(mockBucket)
+	return c, mockBucket
+}
+
+func countPredicate(es *graph.EntityState, predicate string) int {
+	n := 0
+	for _, tr := range es.Triples {
+		if tr.Predicate == predicate {
+			n++
+		}
+	}
+	return n
+}
+
+var routeMT = message.Type{Domain: "test", Category: "fixture", Version: "v1"}
+
+const routeEdgePred = "child.isHostedBy"
+
+func routeEdge() message.Triple {
+	return message.Triple{Subject: flChildID, Predicate: routeEdgePred, Object: flParentID}
+}
+
+// EdgeNoBirthStub + absent target: the seam materialises the envelope-bearing
+// referential stub (the only thing that ever births a sensorml-style child) and
+// then routes the edge onto it EXACTLY ONCE — not duplicated by stub+append.
+func TestRouteForeignEdges_NoBirthStub_AbsentTarget_StubAndAppendOnce(t *testing.T) {
+	comp, _ := routeTestComp(t)
+	comp.claimReader = &fakeClassifier{modes: map[string]ownership.EdgeMode{routeEdgePred: ownership.EdgeNoBirthStub}}
+
+	comp.routeForeignEdges(context.Background(), flParentID, routeMT, []message.Triple{routeEdge()})
+
+	child := storedEntity(t, comp, flChildID)
+	assert.True(t, hasPredicate(child, predStubMarker), "no-birth-stub target must be materialised as an envelope-bearing stub")
+	assert.Equal(t, 1, countPredicate(child, routeEdgePred), "the routed edge must appear EXACTLY ONCE (stub-materialise must not double-append)")
+}
+
+// EdgeStrict + absent target: the edge is DROPPED (target must pre-exist by
+// causal ordering) — no stub, no edge — and metered on foreign_edge_dropped_total
+// with reason=strict_absent_target, distinct from the unclaimed hatch counter.
+func TestRouteForeignEdges_Strict_AbsentTarget_DroppedWithMetric(t *testing.T) {
+	comp, _ := routeTestComp(t)
+	comp.claimReader = &fakeClassifier{modes: map[string]ownership.EdgeMode{routeEdgePred: ownership.EdgeStrict}}
+
+	label := routeMT.Key()
+	beforeDropped := testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent))
+	beforeUnclaimed := testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues(label, routeEdgePred))
+
+	comp.routeForeignEdges(context.Background(), flParentID, routeMT, []message.Triple{routeEdge()})
+
+	_, err := comp.entityBucket.Get(context.Background(), flChildID)
+	assert.True(t, natsclient.IsKVNotFoundError(err), "a Strict drop must NOT vivify or stub the absent target")
+	assert.InDelta(t, beforeDropped+1, testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent)), 0.0001,
+		"a Strict drop must increment foreign_edge_dropped_total{reason=strict_absent_target}")
+	assert.InDelta(t, beforeUnclaimed, testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues(label, routeEdgePred)), 0.0001,
+		"a Strict drop must NOT touch the flip-gate hatch counter (foreign_edge_unclaimed_total)")
+}
+
+// A present target appends regardless of mode — even EdgeStrict, which would
+// drop an ABSENT target, routes onto a target that already exists.
+func TestRouteForeignEdges_PresentTarget_AppendsRegardlessOfMode(t *testing.T) {
+	comp, _ := routeTestComp(t)
+	comp.claimReader = &fakeClassifier{modes: map[string]ownership.EdgeMode{routeEdgePred: ownership.EdgeStrict}}
+
+	// Pre-seed the target so it exists before routing.
+	seed, _ := json.Marshal(&graph.EntityState{ID: flChildID, Version: 1})
+	_, err := comp.entityBucket.Put(context.Background(), flChildID, seed)
+	require.NoError(t, err)
+
+	label := routeMT.Key()
+	beforeDropped := testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent))
+
+	comp.routeForeignEdges(context.Background(), flParentID, routeMT, []message.Triple{routeEdge()})
+
+	child := storedEntity(t, comp, flChildID)
+	assert.True(t, hasPredicate(child, routeEdgePred), "an edge onto a PRESENT target must be appended regardless of mode")
+	assert.InDelta(t, beforeDropped, testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent)), 0.0001,
+		"a present-target append must NOT increment the drop counter")
+}
+
+// UNCLAIMED + absent target: the deprecated-on-arrival hatch — the edge stays
+// routed (so the flip-gate hatch counter can still drain to zero) and is NOT
+// metered on the drop counter (it is the unclaimed lane, metered upstream).
+func TestRouteForeignEdges_Unclaimed_AbsentTarget_RouteWithWarn(t *testing.T) {
+	comp, _ := routeTestComp(t)
+	comp.claimReader = &fakeClassifier{} // no modes configured → ForeignEdgeMode reports unclaimed
+
+	label := routeMT.Key()
+	beforeDropped := testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent))
+
+	comp.routeForeignEdges(context.Background(), flParentID, routeMT, []message.Triple{routeEdge()})
+
+	child := storedEntity(t, comp, flChildID)
+	assert.True(t, hasPredicate(child, routeEdgePred), "an unclaimed foreign edge must stay routed (deprecated-on-arrival hatch)")
+	assert.InDelta(t, beforeDropped, testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent)), 0.0001,
+		"the unclaimed hatch must NOT increment the drop counter")
+}
+
+// A mode-lookup read error inside routeForeignEdges fails OPEN: the edge is
+// routed-with-warn (never blocked, never Strict-dropped on a transient read
+// blip) — the route-time mirror of the foreignTargetExists fail-open.
+func TestRouteForeignEdges_ModeLookupError_FailsOpen(t *testing.T) {
+	comp, _ := routeTestComp(t)
+	comp.claimReader = &fakeClassifier{err: assertErr} // ForeignEdgeMode returns an error
+
+	label := routeMT.Key()
+	beforeDropped := testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent))
+
+	comp.routeForeignEdges(context.Background(), flParentID, routeMT, []message.Triple{routeEdge()})
+
+	child := storedEntity(t, comp, flChildID)
+	assert.True(t, hasPredicate(child, routeEdgePred), "a mode-lookup read error must fail open — the edge is still routed")
+	assert.InDelta(t, beforeDropped, testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent)), 0.0001,
+		"a fail-open route must NOT increment the drop counter")
+}
+
+// An UNKNOWN/future EdgeMode + absent target takes the forward-compat default:
+// route-with-warn (hatch), NEVER a silent drop. Locks the contract that adding a
+// new EdgeMode cannot silently start dropping edges before the seam handles it.
+func TestRouteForeignEdges_UnknownMode_AbsentTarget_RouteWithWarn(t *testing.T) {
+	comp, _ := routeTestComp(t)
+	comp.claimReader = &fakeClassifier{modes: map[string]ownership.EdgeMode{routeEdgePred: ownership.EdgeMode("future-unhandled")}}
+
+	label := routeMT.Key()
+	beforeDropped := testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent))
+
+	comp.routeForeignEdges(context.Background(), flParentID, routeMT, []message.Triple{routeEdge()})
+
+	child := storedEntity(t, comp, flChildID)
+	assert.True(t, hasPredicate(child, routeEdgePred), "an unknown EdgeMode must route-with-warn (hatch), never silent-drop")
+	assert.InDelta(t, beforeDropped, testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent)), 0.0001,
+		"an unknown-mode route must NOT increment the drop counter")
+}
+
+// foreignTargetExists fails toward the LESS destructive outcome on a transient
+// read error: it reports "exists" so the edge is APPENDED, never Strict-dropped
+// on a read blip (which would lose a legitimately-present edge).
+func TestForeignTargetExists_ReadBlip_FailsTowardExists(t *testing.T) {
+	comp, mock := routeTestComp(t)
+	ctx := context.Background()
+
+	// notfound → false
+	assert.False(t, comp.foreignTargetExists(ctx, flChildID), "absent target reports not-exists")
+
+	// present → true
+	seed, _ := json.Marshal(&graph.EntityState{ID: flChildID, Version: 1})
+	_, err := comp.entityBucket.Put(ctx, flChildID, seed)
+	require.NoError(t, err)
+	assert.True(t, comp.foreignTargetExists(ctx, flChildID), "present target reports exists")
+
+	// transient (non-notfound) read error → true (fail-less-destructive)
+	mock.getFunc = func(_ context.Context, _ string) (jetstream.KeyValueEntry, error) {
+		return nil, errors.New("transient read blip")
+	}
+	assert.True(t, comp.foreignTargetExists(ctx, flChildID), "a transient read error must fail toward exists (append), not drop")
+}

--- a/processor/graph-ingest/foreign_edge_seam_test.go
+++ b/processor/graph-ingest/foreign_edge_seam_test.go
@@ -11,13 +11,18 @@ import (
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/ownership"
 )
 
 // fakeClassifier is an injected foreignEdgeClassifier for unit-testing the
-// observe-only T2-seam (ADR-056 Decision 4) without NATS. It records what the
-// seam asked and returns a configured unclaimed set.
+// T2-seam (ADR-056 Decision 4) without NATS. It records what the seam asked and
+// returns a configured unclaimed set + per-predicate EdgeMode. A predicate
+// absent from `modes` is reported UNCLAIMED by ForeignEdgeMode (ok=false), so
+// the observe-only seam tests (which configure only `unclaimed`) keep routing
+// unchanged.
 type fakeClassifier struct {
-	unclaimed   map[string]bool // predicate -> reported unclaimed
+	unclaimed   map[string]bool               // predicate -> reported unclaimed (UnclaimedForeignEdges)
+	modes       map[string]ownership.EdgeMode // predicate -> covering mode (ForeignEdgeMode; absent = unclaimed)
 	err         error
 	gotProducer string
 	gotPreds    []string
@@ -36,6 +41,15 @@ func (f *fakeClassifier) UnclaimedForeignEdges(_ context.Context, producer strin
 		}
 	}
 	return out, nil
+}
+
+func (f *fakeClassifier) ForeignEdgeMode(_ context.Context, producer, predicate string) (ownership.EdgeMode, bool, error) {
+	f.gotProducer = producer
+	if f.err != nil {
+		return "", false, f.err
+	}
+	m, ok := f.modes[predicate]
+	return m, ok, nil
 }
 
 // The seam meters an unclaimed foreign edge, leaves a claimed one quiet, never

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -452,7 +452,7 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 
 	// Primary committed — route foreign edges onto their own subjects (after the
 	// commit so a failed create never orphans a routed edge).
-	c.routeForeignEdges(ctx, req.Entity.ID, foreign)
+	c.routeForeignEdges(ctx, req.Entity.ID, req.Entity.MessageType, foreign)
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
@@ -666,7 +666,7 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		// primary that never landed. Gate on the decoded Success; the unmarshal is
 		// skipped on the no-foreign-edge happy path (every current caller).
 		if err == nil && len(foreign) > 0 && casUpdateCommitted(resp) {
-			c.routeForeignEdges(ctx, req.Entity.ID, foreign)
+			c.routeForeignEdges(ctx, req.Entity.ID, req.Entity.MessageType, foreign)
 		}
 		return resp, err
 	}
@@ -748,7 +748,7 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	}
 
 	// Primary update committed — route foreign edges onto their own subjects.
-	c.routeForeignEdges(ctx, req.Entity.ID, foreign)
+	c.routeForeignEdges(ctx, req.Entity.ID, req.Entity.MessageType, foreign)
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {


### PR DESCRIPTION
## Summary

ADR-056 increment **4c-pre-2** — the first step of the 4c arc toward the BREAKING must-exist flip. **Additive / observe-leaning; this is NOT the flip.**

`routeForeignEdges` moves from a bare `AddTriples` append to a per-edge **must-exist policy**. After the primary commit, for each foreign-subject edge it does its own existence check (`foreignTargetExists`) and, for an absent target, branches on the covering `ForeignEdgeClaim`'s `EdgeMode`:

| Case | Behavior |
|------|----------|
| target present (any mode) | append |
| `EdgeNoBirthStub` + absent | materialize the 4b envelope-bearing stub, then append (exactly once) |
| `EdgeStrict` + absent | loud-drop + `foreign_edge_dropped_total{…,reason=strict_absent_target}` |
| `EdgeConditional`/`EdgeBackfill` | **deferred** → route-with-warn + `reason=conditional_deferred` |
| unclaimed + absent | route-with-warn (deprecated-on-arrival hatch stays drainable) |
| `claimReader==nil` / read blip | graceful-skip / fail-open (never block, never drop on transient error) |

The own existence check is what makes routing correct **both before and after** the eventual flip removes `AddTriples`' auto-vivify else-branch.

## Key design points

- **New `foreign_edge_dropped_total{message_type,predicate,reason}`** is kept **distinct** from `foreign_edge_unclaimed_total` so a Strict drop cannot corrupt the flip-gate's hatch-empty signal.
- **New `ClaimReader.ForeignEdgeMode`** reuses `epoch.foreignEdgeClaimFor` (one epoch read; zero production foreign-edge volume today).
- **Scope**: Conditional/Backfill + the `PENDING_EDGES` buffer + crash-recovery test **defer** to a later increment — the only live producer (sensorml `isHostedBy`) is `EdgeNoBirthStub`, and the buffer carries its own BLOCKING-grade gate.
- **Lane-asymmetry fix**: the upstream `ensureRelationshipTargetsExist` stub runs only on the fact-arrival and `create_with_triples` lanes; `update_with_triples` does **not** call it, so `routeForeignEdges`' own `ensureReferencedEntityExists` call for `EdgeNoBirthStub` is **load-bearing** there, not redundant.
- ADR-056 Decision-4 gains a "W0 4c-pre-2 landed" status note + the lane-asymmetry correction.

## Does NOT enable the flip

The ADR-055 must-exist flip remains gated on: the `PENDING_EDGES` increment (if any Conditional producer ever ships), the bare-triple-lane precondition (Fix part 6), the hatch-empty bake, and the e2e fourth-path fixture.

## Review & gates

- **architect** design pass (scope boundary + mode-branch + interface deltas, code-grounded)
- **go-reviewer**: **APPROVE-WITH-NITS**, no BLOCKING/HIGH. Both flagged LOW gaps (route-level fail-open-on-mode-error; unknown-mode `default` branch) **now have tests**.
- ✅ build, `task lint` (revive/vet/fmt clean), schema no-drift, contract tests
- ✅ `go test -race` graph-ingest + ownership; `-tags=integration` graph-ingest
- Full `-tags=integration ./...` sweep: one unrelated testcontainers startup-timeout flake (`TestRuntimeMetricsIntegration`, `port 8222/tcp`), passes on isolated re-run.

## Test coverage (new `foreign_edge_route_test.go`, 7 tests)

NoBirthStub absent→stub+exactly-once-append · Strict absent→drop+distinct-metric+not-appended · present→append-regardless-of-mode · unclaimed absent→route-with-warn · mode-lookup-error→fail-open · unknown-mode→route-with-warn (never silent-drop) · `foreignTargetExists` read-blip→fail-toward-exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)