### PR TITLE
test(e2e): ADR-056 4c-pre-3 — structural e2e coverage for the fourth path (referential stub)

### DIFF
--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -1102,6 +1102,13 @@ live sources:
   DROP is a correctness question (the graph loses a traversal edge), not a free degradation —
   and the least-observable of the two (container) has no metric at all, which strengthens the
   case that this is a correctness bug, not a degradation knob.**
+  - **4c-pre-3 update (code-traced):** the container-inverse drop now increments `edgesFailed`
+    for parity with the sibling drop (`hierarchy.go`). The trace also clarified its NATURE: the
+    container is materialised by `ensureContainerExists` *before* the inverse write, so an absent
+    target is never the cause — this drop is a CAS/storage failure, NOT a must-exist/absent-target
+    drop, and the closing-move flip does not touch this in-process `AddTriple` path. The
+    observability gap is closed; the "correctness drop" framing applies to the foreign-edge lane
+    (the `PENDING_EDGES`/Conditional story), not to this container-inverse counter.
 
 **The enforcement seam is the SHARED projection-normalization step, not claim-registration
 (BLOCKING-B fix part 1 — the core bypass) and not one lane (the lane-independence correction

--- a/graph/inference/hierarchy.go
+++ b/graph/inference/hierarchy.go
@@ -366,7 +366,14 @@ func (h *HierarchyInference) ensureContainerAndReturnEdge(ctx context.Context, e
 		}
 
 		if err := h.tripleAdder.AddTriple(ctx, inverseTriple); err != nil {
-			// Log warning but don't fail - forward edge will still be returned
+			// Log warning but don't fail - forward edge will still be returned.
+			// Count it on edgesFailed for parity with the sibling-inverse drop
+			// above — ADR-056 Decision 4 flagged this container-inverse drop as
+			// the least-observable (Warn-only, no counter). NOTE: the container
+			// is materialised by ensureContainerExists above before this write,
+			// so an absent target is not the cause here — this is a CAS/storage
+			// failure, not a must-exist drop (the flip does not touch this path).
+			h.edgesFailed.Add(1)
 			h.logger.Warn("Failed to create inverse edge",
 				"container_id", containerID,
 				"entity_id", entityID,

--- a/test/e2e/client/nats.go
+++ b/test/e2e/client/nats.go
@@ -171,6 +171,22 @@ func (c *NATSValidationClient) Publish(ctx context.Context, subject string, data
 	return c.client.PublishToStream(ctx, subject, data)
 }
 
+// Request sends a NATS request/reply and returns the raw response payload.
+// Used by validation steps that drive a request/reply API directly — notably
+// the graph mutation lane (graph.mutation.entity.create_with_triples), which
+// replies with a structured MutationResponse rather than the natsclient
+// "error: <msg>" payload convention, so callers parse and check Success.
+func (c *NATSValidationClient) Request(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("client is closed")
+	}
+	c.mu.Unlock()
+
+	return c.client.Request(ctx, subject, data, timeout)
+}
+
 // CountEntities counts the number of entities in the ENTITY_STATES bucket
 // Returns 0, nil if bucket doesn't exist (graceful degradation)
 func (c *NATSValidationClient) CountEntities(ctx context.Context) (int, error) {

--- a/test/e2e/scenarios/tiered.go
+++ b/test/e2e/scenarios/tiered.go
@@ -295,6 +295,9 @@ func (s *TieredScenario) getStagesForVariant(variant string) []stage {
 		{"validate-zero-clusters", s.executeValidateZeroClusters, []string{"structural"}},
 		{"validate-rule-transitions", s.executeValidateRuleTransitions, []string{"structural"}},
 		{"validate-entity-triples", s.executeValidateEntityTriples, []string{"structural"}},
+		// ADR-056 Decision-4 fourth path: a dangling entity-ID relationship target
+		// is materialised as an envelope-bearing referential stub (structural — no ML).
+		{"validate-referential-stub", s.executeValidateReferentialStub, []string{"structural"}},
 
 		// === Tier 1+: Statistical capabilities (statistical + semantic) ===
 		{"verify-search-quality", s.executeVerifySearchQuality, []string{"statistical", "semantic"}},

--- a/test/e2e/scenarios/tiered_structural.go
+++ b/test/e2e/scenarios/tiered_structural.go
@@ -10,6 +10,9 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
 )
 
 // Structural variant validation functions for rules-only testing
@@ -244,6 +247,118 @@ func (s *TieredScenario) executeValidateEntityTriples(ctx context.Context, resul
 		fmt.Printf("[HUMIDITY DEBUG] percent value: %v, type value: %v, conditions met: %v\n", percentValue, typeValue, conditionsMet)
 	}
 
+	return nil
+}
+
+// executeValidateReferentialStub validates ADR-056 Decision-4's fourth path: when
+// a write carries a RELATIONSHIP triple whose Object is a valid 6-part entity ID
+// that no producer independently creates, graph-ingest materialises an
+// envelope-bearing referential-integrity stub for that target so the reference
+// always resolves to a node (load-bearing for traversal, and what makes the
+// must-exist flip safe). This is the e2e coverage gap ADR-056 tracked as "gated to
+// 4c": the only relationship-emitting production processor (IoT sensor) also
+// emits its zone target, so nothing else exercises this path. Structural tier — no ML.
+//
+// The fixture drives the create_with_triples mutation lane (the cs-api lane that
+// runs ensureRelationshipTargetsExist) directly, with a target under a dedicated
+// e2e prefix that no processor emits, so the stub is the ONLY thing that can create it.
+func (s *TieredScenario) executeValidateReferentialStub(ctx context.Context, result *Result) error {
+	const (
+		referrerID    = "c360.platform.e2e.referential.referrer.001"
+		danglingID    = "c360.platform.e2e.referential.target.001"
+		relationPred  = "test.e2e.references"
+		createSubject = "graph.mutation.entity.create_with_triples"
+	)
+
+	// 1. Create the referrer carrying a relationship triple to the dangling target.
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{
+			ID:          referrerID,
+			MessageType: message.Type{Domain: "e2e", Category: "referential", Version: "v1"},
+		},
+		Triples: []message.Triple{
+			{Subject: referrerID, Predicate: relationPred, Object: danglingID, Confidence: 1.0},
+		},
+		RequestID: "e2e-referential-stub",
+	}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal create_with_triples request: %w", err)
+	}
+
+	respData, err := s.natsClient.Request(ctx, createSubject, reqData, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("create_with_triples request failed: %w", err)
+	}
+	var resp graph.CreateEntityWithTriplesResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return fmt.Errorf("parse create_with_triples response (%q): %w", string(respData), err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("create_with_triples failed: %s", resp.Error)
+	}
+
+	// 2. Poll for the referential stub on the dangling target. ensureRelationshipTargetsExist
+	//    blocks (wg.Wait) before the mutation reply, so this typically resolves on the first
+	//    read; the bounded poll absorbs any KV/cache visibility lag.
+	stub, getErr := s.natsClient.GetEntity(ctx, danglingID)
+	for attempt := 0; (getErr != nil || stub == nil) && attempt < 20; attempt++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(250 * time.Millisecond):
+		}
+		stub, getErr = s.natsClient.GetEntity(ctx, danglingID)
+	}
+	if stub == nil {
+		return fmt.Errorf("referential stub %s was not created within timeout — fourth path (ensureReferencedEntityExists) did not fire", danglingID)
+	}
+
+	// 3. Assert the envelope-bearing stub markers (ADR-056 4b): the core.identity.stub
+	//    marker and core.identity.referenced_by = the referrer that named it.
+	hasMarker, hasReferencedBy, hasStubOwner := false, false, false
+	var referencedByValue, stubOwnerValue any
+	for _, t := range stub.Triples {
+		switch t.Predicate {
+		case "core.identity.stub":
+			hasMarker = true
+		case "core.identity.referenced_by":
+			hasReferencedBy = true
+			referencedByValue = t.Object
+		case "core.identity.stub_owner":
+			hasStubOwner = true
+			stubOwnerValue = t.Object
+		}
+	}
+
+	result.Metrics["referential_stub_triples"] = len(stub.Triples)
+	result.Details["referential_stub_validation"] = map[string]any{
+		"referrer_id":         referrerID,
+		"dangling_target_id":  danglingID,
+		"stub_created":        true,
+		"has_stub_marker":     hasMarker,
+		"has_referenced_by":   hasReferencedBy,
+		"has_stub_owner":      hasStubOwner,
+		"referenced_by_value": referencedByValue,
+		"stub_owner_value":    stubOwnerValue,
+		"stub_version":        stub.Version,
+		"message":             fmt.Sprintf("Fourth path created referential stub %s (marker=%v, referenced_by=%v, owner=%v)", danglingID, hasMarker, referencedByValue, stubOwnerValue),
+	}
+
+	if !hasMarker || !hasReferencedBy || !hasStubOwner {
+		return fmt.Errorf("referential stub %s missing required markers: core.identity.stub=%v, core.identity.referenced_by=%v, core.identity.stub_owner=%v",
+			danglingID, hasMarker, hasReferencedBy, hasStubOwner)
+	}
+	if got := fmt.Sprintf("%v", referencedByValue); got != referrerID {
+		return fmt.Errorf("referential stub %s core.identity.referenced_by = %q, want %q", danglingID, got, referrerID)
+	}
+	// Envelope-bearing stub must record a non-empty owner — the ADR-055
+	// "no ownerless births" property the must-exist flip relies on.
+	if owner, ok := stubOwnerValue.(string); !ok || owner == "" {
+		return fmt.Errorf("referential stub %s core.identity.stub_owner is empty — an envelope-bearing stub must record an owner", danglingID)
+	}
+
+	result.Metrics["referential_stub_valid"] = 1
 	return nil
 }
 


### PR DESCRIPTION
## Summary

ADR-056 increment **4c-pre-3** — closes the Decision-4 e2e coverage gap tracked as *"gated to 4c"*. **Additive test + observability work; not the breaking flip.**

No e2e tier drove a production write with an entity-ID relationship target through `ensureReferencedEntityExists`' referential-stub lane (the "fourth path"). The only relationship-emitting production processor (IoT sensor) **also emits its own zone target**, so nothing dangled — which is *why* the gap existed (confirmed by reading the processor, saving a wasted fixture attempt).

## What it does

New structural-tier step `executeValidateReferentialStub` drives the `create_with_triples` mutation lane (the cs-api lane that runs `ensureRelationshipTargetsExist`) with a referrer carrying **one** relationship triple whose Object is a deliberately-dangling 6-part entity ID (`c360.platform.e2e.referential.target.001`) under a prefix **no processor emits** — so the referential stub is the only thing that can create it. It then polls `GetEntity(target)` and asserts the envelope-bearing stub:

| Assertion | Property |
|-----------|----------|
| `core.identity.stub` present | the stub marker |
| `core.identity.referenced_by` == referrer | provenance back-link |
| `core.identity.stub_owner` present + non-empty | ADR-055 *no ownerless births* |

Hard-fails (returns error) if the stub is absent or any marker is wrong — non-vacuous.

## Verified live (structural Docker tier)

`validate-referential-stub completed` · `referential_stub_valid:1` · `referential_stub_triples:3` · `Scenario completed successfully` · `validation_errors:0` · `embeddings_generated:0` (structural constraint intact).

## Ride-along (4c-pre-4, ~1 line)

The container-inverse-edge drop in `HierarchyInference` now increments `edgesFailed` for parity with the sibling-inverse drop (it was the least-observable drop, Warn-only, per ADR-056 Decision 4). A code trace recorded in the ADR clarifies its **nature**: `ensureContainerExists` materialises the container *before* the inverse write, so this is a CAS/storage failure — **not** an absent-target/must-exist drop, and the closing-move flip does not touch this in-process `AddTriple` path. (The architect found the standalone metric wasn't worth its own PR, so it rides here.)

## Supporting

New `NATSValidationClient.Request` wraps `client.Request` so a validation step can drive a request/reply mutation. The mutation API replies with a structured `MutationResponse` (Success/Error), so the step parses and checks `Success` rather than the natsclient `error: <msg>` payload convention.

## Review & gates

- **architect** scoping pass (ordering + scope: dropped the mis-labeled "free-facts quarantine", which was an ADR-055 LLM-lane concept on the wrong lane)
- **go-reviewer**: **APPROVE-WITH-NITS**, no BLOCKING/HIGH. The optional `stub_owner` assertion (NIT-2) was added and re-validated live.
- ✅ build, `task lint`, `go vet`/`gofmt`, hierarchy unit tests (`-race`)
- ✅ structural e2e tier green end-to-end

## Does NOT enable the flip

The ADR-055 must-exist flip remains gated on the `PENDING_EDGES` increment (if any Conditional producer ships), the bare-triple-lane precondition (Fix part 6), and the hatch-empty bake. This PR closes the e2e-fixture prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)