### PR TITLE
test(adr-056): prove the CLAIMED foreign-edge wire end-to-end + governed-state docs

### DIFF
--- a/docs/concepts/12-flow-architecture.md
+++ b/docs/concepts/12-flow-architecture.md
@@ -41,6 +41,11 @@ SemStreams persists state in two NATS JetStream KV buckets:
 
 The config bucket stores the runtime configuration that the ComponentManager watches and reacts to. The flows bucket stores visual flow definitions that the UI displays and modifies.
 
+Runtime configuration can change operational behavior, but governed projection ownership is data-plane authority rather
+than ordinary component config. Changes to entity patterns, predicate ownership, write modes, producer identity, or
+foreign-edge behavior should follow the contract-migration model in
+[Governed Semantic State](28-governed-semantic-state.md).
+
 ## Static Config → Flow Bridge
 
 When you start with a static config file, SemStreams automatically creates a Flow entry in the flows bucket. This bridges the gap between headless and UI modes:

--- a/docs/concepts/28-governed-semantic-state.md
+++ b/docs/concepts/28-governed-semantic-state.md
@@ -57,6 +57,37 @@ The payload registry and ownership registry are not competing systems. The paylo
 `BaseMessage` decoding. The ownership registry is distributed arbitration for shared graph state. Projection contracts
 are the bridge between them.
 
+## Runtime Config vs Contract Migration
+
+SemStreams has runtime-configurable surfaces: rule thresholds, routes, model selection, prompts, flow shape, and
+component behavior can be changed while the system is running when the component supports it.
+
+Ownership contracts are different. They declare data-plane authority over entity patterns, predicate groups, write
+modes, producer identities, and foreign-edge behavior. Changing that authority is closer to a schema migration or
+online DDL than ordinary hot config.
+
+Runtime config may change behavior *inside* an already declared ownership contract. For example, a rule pack can
+hot-reload the threshold that decides when it emits `alert.active` if that predicate is already part of its projection
+contract. A new owned predicate, write mode, entity pattern, producer identity, or foreign-edge mode is a contract
+migration.
+
+The current model treats static projection contracts as deployment-time declarations with runtime liveness. Owners
+renew presence through `OWNER_PRESENCE`; they do not renegotiate predicate-claim shape during normal hot reload.
+
+Future online contract migration would need an explicit protocol:
+
+1. Register the proposed contract and check for overlapping claims.
+2. Quiesce or fence old writes that would conflict with the new authority.
+3. Backfill, reconcile, or validate existing graph state as needed.
+4. Flip producers to the new contract.
+5. Observe the new owner and retire the old contract when safe.
+
+The practical rule is:
+
+```text
+Hot reload changes behavior. Contract migration changes authority.
+```
+
 ## What Governance Does Not Do
 
 Keep these edges sharp:

--- a/pkg/ownership/claim_reader_integration_test.go
+++ b/pkg/ownership/claim_reader_integration_test.go
@@ -73,6 +73,26 @@ func TestIntegration_ClaimReader_Classification(t *testing.T) {
 	if len(got) != 1 || got[0] != "claimed.edge" {
 		t.Fatalf("other producer: got %v, want [claimed.edge] (shared.edge covered by any-producer claim)", got)
 	}
+
+	// ForeignEdgeMode is the routing seam's mode lookup (routeForeignEdges
+	// branches NoBirthStub/Strict/... on it) — prove it resolves the REGISTERED
+	// mode against the live epoch, not just claimed/unclaimed. Same claims as
+	// above (claimed.edge = exact-producer NoBirthStub; shared.edge = any-producer
+	// NoBirthStub).
+	if mode, ok, err := cr.ForeignEdgeMode(ctx, "test.fixture.v1", "claimed.edge"); err != nil || !ok || mode != EdgeNoBirthStub {
+		t.Fatalf("ForeignEdgeMode(exact claimed.edge) = %q,%v,%v; want %q,true,nil", mode, ok, err, EdgeNoBirthStub)
+	}
+	if mode, ok, err := cr.ForeignEdgeMode(ctx, "test.fixture.v1", "unclaimed.edge"); err != nil || ok {
+		t.Fatalf("ForeignEdgeMode(unclaimed.edge) = %q,%v,%v; want \"\",false,nil (no covering claim)", mode, ok, err)
+	}
+	// any-producer claim: a DIFFERENT producer still matches the Producer-empty claim.
+	if mode, ok, err := cr.ForeignEdgeMode(ctx, "other.type.v1", "shared.edge"); err != nil || !ok || mode != EdgeNoBirthStub {
+		t.Fatalf("ForeignEdgeMode(any-producer shared.edge) = %q,%v,%v; want %q,true,nil", mode, ok, err, EdgeNoBirthStub)
+	}
+	// exact-producer claim does NOT match a different producer.
+	if mode, ok, err := cr.ForeignEdgeMode(ctx, "other.type.v1", "claimed.edge"); err != nil || ok {
+		t.Fatalf("ForeignEdgeMode(other producer, exact claimed.edge) = %q,%v,%v; want \"\",false,nil (exact-producer miss)", mode, ok, err)
+	}
 }
 
 // NewClaimReader on a deploy that never created OWNER_CLAIMS returns an error so

--- a/processor/graph-ingest/foreign_edge_claimed_integration_test.go
+++ b/processor/graph-ingest/foreign_edge_claimed_integration_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/c360studio/semstreams/pkg/projection"
+)
+
+// TestIntegration_SharedSeam_ClaimedForeignEdge_RoutesNoBirthStub proves the full
+// ADR-056 Decision-4 CLAIMED foreign-edge chain end-to-end through the production
+// wire: a projection.Contract declaring a NoBirthStub ForeignEdge is derived to a
+// ForeignEdgeClaim and Bound into OWNER_CLAIMS; graph-ingest's Start() self-wires
+// a real ClaimReader against that bucket; a create_with_triples carrying a
+// foreign-subject edge from the contract's producer MessageType is then
+// classified as CLAIMED (not metered on foreign_edge_unclaimed_total) and routed
+// via the NoBirthStub lane (the target is materialised as an envelope-bearing
+// referential stub, then the edge is appended) — NOT dropped.
+//
+// 4c-pre-2 unit-tested routeForeignEdges' mode branch with a fake classifier;
+// 4c-pre-3 e2e-proved the UNCLAIMED referential-stub lane. This proves the
+// CLAIMED lane through the real Contract→Bind→ClaimReader→routeForeignEdges wire
+// — the cs-api SensorML-hierarchy path, before the must-exist flip makes it
+// load-bearing. The contract here is the REFERENCE SHAPE cs-api adopts (it
+// currently stamps an empty MessageType in ingestTriples, so its real adoption is
+// either a Producer-empty claim or stamping a System type — a semconnect detail).
+func TestIntegration_SharedSeam_ClaimedForeignEdge_RoutesNoBirthStub(t *testing.T) {
+	ctx := context.Background()
+	streams := []natsclient.TestStreamConfig{{Name: "ENTITY", Subjects: []string{"entity.>"}}}
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+
+	// The producer + foreign-edge predicate the contract claims. isHostedBy is the
+	// genuine sensorml child→system foreign edge; NoBirthStub because the child is
+	// never independently published (the parent's Graphable emits it).
+	const (
+		producerType  = "c360.csapi.system.v1"
+		isHostedBy    = "sensorml.component.isHostedBy"
+		systemID      = "c360.csapi.facility.gateway.system.001"
+		componentID   = "c360.csapi.facility.gateway.component.001"
+		bindOwnerID   = "cs-api-systems"
+		entityPattern = "*.*.*.*.system.*"
+	)
+	producerMT := message.Type{Domain: "c360", Category: "csapi.system", Version: "v1"}
+	require.Equal(t, producerType, producerMT.Key(), "producer Key() must match the contract MessageType")
+
+	// 1. Eagerly create OWNER_CLAIMS + bind the reference contract BEFORE the
+	//    component boots, so Start()'s NewClaimReader sees the bound claim.
+	reg, err := ownership.EnsureBuckets(ctx, testClient.Client, nil, nil)
+	require.NoError(t, err, "EnsureBuckets (OWNER_CLAIMS)")
+
+	contract := projection.Contract{
+		Name:          "csapi.system.hierarchy",
+		MessageType:   producerType, // stamped as the ForeignEdgeClaim Producer
+		EntityPattern: entityPattern,
+		ForeignEdges: []projection.ForeignEdge{
+			{Predicate: isHostedBy, Mode: ownership.EdgeNoBirthStub},
+		},
+	}
+	require.NoError(t, projection.Bind(ctx, reg, bindOwnerID, contract), "Bind reference foreign-edge contract")
+
+	// 2. Boot graph-ingest — Start() self-wires the real ClaimReader (production wire).
+	configJSON, err := json.Marshal(DefaultConfig())
+	require.NoError(t, err)
+	comp, err := CreateGraphIngest(configJSON, component.Dependencies{NATSClient: testClient.Client})
+	require.NoError(t, err)
+	c := comp.(*Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	defer func() { _ = c.Stop(5 * time.Second) }()
+	require.NotNil(t, c.claimReader, "Start must self-wire the claim reader once OWNER_CLAIMS exists")
+
+	unclaimedBefore := testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(producerType, isHostedBy))
+	droppedStrictBefore := testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, isHostedBy, dropReasonStrictAbsent))
+	droppedDeferredBefore := testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, isHostedBy, dropReasonConditionalDeferred))
+
+	// 3. Drive create_with_triples: a System (the contract's producer type) whose
+	//    triples include the foreign-subject isHostedBy edge onto an absent child.
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: systemID, MessageType: producerMT},
+		Triples: []message.Triple{
+			{Subject: systemID, Predicate: "system.label", Object: "Gateway", Timestamp: time.Now(), Confidence: 1}, // own
+			{Subject: componentID, Predicate: isHostedBy, Object: systemID, Timestamp: time.Now(), Confidence: 1},   // foreign
+		},
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	respData, err := c.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, err)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "create_with_triples should succeed: %s", resp.Error)
+
+	// 4a. The foreign edge was CLAIMED → NOT metered on the unclaimed-hatch counter.
+	assert.InDelta(t, unclaimedBefore, testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(producerType, isHostedBy)), 0.0001,
+		"a CLAIMED foreign edge must NOT increment foreign_edge_unclaimed_total (the hatch-empty flip-gate signal)")
+
+	// 4b. NoBirthStub routing materialised the child as an envelope-bearing stub
+	//     AND appended the edge — distinct from the unclaimed auto-vivify (which
+	//     would create the child with the edge but NO stub marker).
+	entry, getErr := c.entityBucket.Get(ctx, componentID)
+	require.NoError(t, getErr, "NoBirthStub must materialise the foreign-edge target")
+	var child graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &child))
+	assert.True(t, hasPredicate(&child, predStubMarker), "NoBirthStub target must carry the core.identity.stub marker")
+	assert.True(t, hasPredicate(&child, isHostedBy), "the routed foreign edge must land on the child")
+
+	// 4c. A claimed NoBirthStub edge is never dropped — under EITHER drop reason.
+	assert.InDelta(t, droppedStrictBefore, testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, isHostedBy, dropReasonStrictAbsent)), 0.0001,
+		"a claimed NoBirthStub edge must NOT increment foreign_edge_dropped_total{reason=strict_absent_target}")
+	assert.InDelta(t, droppedDeferredBefore, testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, isHostedBy, dropReasonConditionalDeferred)), 0.0001,
+		"a claimed NoBirthStub edge must NOT increment foreign_edge_dropped_total{reason=conditional_deferred}")
+}


### PR DESCRIPTION
## Summary

A **flip precondition** (ADR-056 / ADR-055): before the must-exist flip makes the *claimed* foreign-edge lane load-bearing, prove it works through the **real production wire** — not just unit tests with a fake classifier. Plus Codex's governed-semantic-state docs (separate commit).

The Decision-4 mechanism was built in 4c-pre-2 (`routeForeignEdges` branches on `ForeignEdgeClaim.EdgeMode`) and proven in pieces; 4c-pre-3 e2e-proved the *unclaimed* referential-stub lane. The **claimed NoBirthStub lane — the cs-api SensorML-hierarchy path** — had no integration coverage of the assembled `Contract → Bind → OWNER_CLAIMS → ClaimReader → routeForeignEdges` chain. This is the framework proof that makes cs-api's adoption safe.

## Commits

**1. `test(...)`: prove the claimed foreign-edge wire** (2 integration tests, testcontainers NATS, `-race`)
- `pkg/ownership/claim_reader_integration_test.go` — extends the classification test with `ClaimReader.ForeignEdgeMode` assertions (exact-producer hit, unclaimed miss, any-producer fallback, exact-producer-miss) against a real registered NoBirthStub claim. `ForeignEdgeMode` is the seam's mode lookup, previously fake-only.
- `processor/graph-ingest/foreign_edge_claimed_integration_test.go` — `EnsureBuckets` + `projection.Bind` a NoBirthStub `isHostedBy` ForeignEdge contract (producer `c360.csapi.system.v1`); `Start()` **self-wires the real ClaimReader** (`component.go:772`, the genuine wire, not a hand-set field); drive `create_with_triples` with a System carrying the foreign-subject edge onto an absent child. Asserts: (a) `foreign_edge_unclaimed_total` **not** incremented [CLAIMED — fails if `Bind` removed], (b) child materialised with the `core.identity.stub` marker + the edge [NoBirthStub routing — the airtight discriminator vs. unclaimed auto-vivify], (c) `foreign_edge_dropped_total` not incremented under either reason.

**2. `docs(adr-056)`: Runtime Config vs Contract Migration** (authored by Codex) — distinguishes hot-reloadable behavior from ownership-contract authority changes (schema-migration-like), with the contract-migration protocol sketch.

## Adoption caveat surfaced

The contract here is the **reference shape cs-api adopts**. cs-api's `ingestTriples` currently stamps an *empty* MessageType, so its real claim is either Producer-empty or it starts stamping a System type (a semconnect follow-up).

## Review & coverage honesty

- **go-reviewer: APPROVE** — wire genuine, assertions non-vacuous (fail if `Bind` removed), stub-marker discriminator airtight, deterministic, coverage honestly scoped.
- ✅ `-race` + full `-tags=integration` suite green for both packages; lint clean.
- **Residual claimed-path coverage before the flip** (tracked, not in this increment): EdgeStrict claimed routing, the `update_with_triples` lane (where NoBirthStub is most load-bearing — no upstream `ensureRelationshipTargetsExist`), and the Producer-empty seam path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)