### PR TITLE
test(graph-ingest): ADR-056 residual claimed foreign-edge coverage (Strict / update-lane / Producer-empty)

### DIFF
--- a/processor/graph-ingest/foreign_edge_claimed_integration_test.go
+++ b/processor/graph-ingest/foreign_edge_claimed_integration_test.go
@@ -20,6 +20,32 @@ import (
 	"github.com/c360studio/semstreams/pkg/projection"
 )
 
+// bindClaimAndBootIngest spins up a real NATS, creates OWNER_CLAIMS, binds the
+// given foreign-edge contract under ownerID, then boots a graph-ingest component
+// whose Start() SELF-WIRES the real ClaimReader against the bound claim — the
+// production wire under test, not a hand-set field. Returns the component + ctx.
+func bindClaimAndBootIngest(t *testing.T, ownerID string, contract projection.Contract) (*Component, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	streams := []natsclient.TestStreamConfig{{Name: "ENTITY", Subjects: []string{"entity.>"}}}
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+
+	reg, err := ownership.EnsureBuckets(ctx, testClient.Client, nil, nil)
+	require.NoError(t, err, "EnsureBuckets (OWNER_CLAIMS)")
+	require.NoError(t, projection.Bind(ctx, reg, ownerID, contract), "Bind foreign-edge contract")
+
+	configJSON, err := json.Marshal(DefaultConfig())
+	require.NoError(t, err)
+	comp, err := CreateGraphIngest(configJSON, component.Dependencies{NATSClient: testClient.Client})
+	require.NoError(t, err)
+	c := comp.(*Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Stop(5 * time.Second) })
+	require.NotNil(t, c.claimReader, "Start must self-wire the claim reader once OWNER_CLAIMS exists")
+	return c, ctx
+}
+
 // TestIntegration_SharedSeam_ClaimedForeignEdge_RoutesNoBirthStub proves the full
 // ADR-056 Decision-4 CLAIMED foreign-edge chain end-to-end through the production
 // wire: a projection.Contract declaring a NoBirthStub ForeignEdge is derived to a
@@ -36,58 +62,31 @@ import (
 // — the cs-api SensorML-hierarchy path, before the must-exist flip makes it
 // load-bearing. The contract here is the REFERENCE SHAPE cs-api adopts (it
 // currently stamps an empty MessageType in ingestTriples, so its real adoption is
-// either a Producer-empty claim or stamping a System type — a semconnect detail).
+// either a Producer-empty claim or stamping a System type — see the Producer-empty
+// test below).
 func TestIntegration_SharedSeam_ClaimedForeignEdge_RoutesNoBirthStub(t *testing.T) {
-	ctx := context.Background()
-	streams := []natsclient.TestStreamConfig{{Name: "ENTITY", Subjects: []string{"entity.>"}}}
-	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
-
-	// The producer + foreign-edge predicate the contract claims. isHostedBy is the
-	// genuine sensorml child→system foreign edge; NoBirthStub because the child is
-	// never independently published (the parent's Graphable emits it).
 	const (
-		producerType  = "c360.csapi.system.v1"
-		isHostedBy    = "sensorml.component.isHostedBy"
-		systemID      = "c360.csapi.facility.gateway.system.001"
-		componentID   = "c360.csapi.facility.gateway.component.001"
-		bindOwnerID   = "cs-api-systems"
-		entityPattern = "*.*.*.*.system.*"
+		producerType = "c360.csapi.system.v1"
+		isHostedBy   = "sensorml.component.isHostedBy"
+		systemID     = "c360.csapi.facility.gateway.system.001"
+		componentID  = "c360.csapi.facility.gateway.component.001"
 	)
 	producerMT := message.Type{Domain: "c360", Category: "csapi.system", Version: "v1"}
 	require.Equal(t, producerType, producerMT.Key(), "producer Key() must match the contract MessageType")
 
-	// 1. Eagerly create OWNER_CLAIMS + bind the reference contract BEFORE the
-	//    component boots, so Start()'s NewClaimReader sees the bound claim.
-	reg, err := ownership.EnsureBuckets(ctx, testClient.Client, nil, nil)
-	require.NoError(t, err, "EnsureBuckets (OWNER_CLAIMS)")
-
-	contract := projection.Contract{
+	c, ctx := bindClaimAndBootIngest(t, "cs-api-systems", projection.Contract{
 		Name:          "csapi.system.hierarchy",
 		MessageType:   producerType, // stamped as the ForeignEdgeClaim Producer
-		EntityPattern: entityPattern,
-		ForeignEdges: []projection.ForeignEdge{
-			{Predicate: isHostedBy, Mode: ownership.EdgeNoBirthStub},
-		},
-	}
-	require.NoError(t, projection.Bind(ctx, reg, bindOwnerID, contract), "Bind reference foreign-edge contract")
-
-	// 2. Boot graph-ingest — Start() self-wires the real ClaimReader (production wire).
-	configJSON, err := json.Marshal(DefaultConfig())
-	require.NoError(t, err)
-	comp, err := CreateGraphIngest(configJSON, component.Dependencies{NATSClient: testClient.Client})
-	require.NoError(t, err)
-	c := comp.(*Component)
-	require.NoError(t, c.Initialize())
-	require.NoError(t, c.Start(ctx))
-	defer func() { _ = c.Stop(5 * time.Second) }()
-	require.NotNil(t, c.claimReader, "Start must self-wire the claim reader once OWNER_CLAIMS exists")
+		EntityPattern: "*.*.*.*.system.*",
+		ForeignEdges:  []projection.ForeignEdge{{Predicate: isHostedBy, Mode: ownership.EdgeNoBirthStub}},
+	})
 
 	unclaimedBefore := testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(producerType, isHostedBy))
 	droppedStrictBefore := testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, isHostedBy, dropReasonStrictAbsent))
 	droppedDeferredBefore := testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, isHostedBy, dropReasonConditionalDeferred))
 
-	// 3. Drive create_with_triples: a System (the contract's producer type) whose
-	//    triples include the foreign-subject isHostedBy edge onto an absent child.
+	// Drive create_with_triples: a System (the contract's producer type) whose
+	// triples include the foreign-subject isHostedBy edge onto an absent child.
 	req := graph.CreateEntityWithTriplesRequest{
 		Entity: &graph.EntityState{ID: systemID, MessageType: producerMT},
 		Triples: []message.Triple{
@@ -103,23 +102,169 @@ func TestIntegration_SharedSeam_ClaimedForeignEdge_RoutesNoBirthStub(t *testing.
 	require.NoError(t, json.Unmarshal(respData, &resp))
 	require.True(t, resp.Success, "create_with_triples should succeed: %s", resp.Error)
 
-	// 4a. The foreign edge was CLAIMED → NOT metered on the unclaimed-hatch counter.
+	// The foreign edge was CLAIMED → NOT metered on the unclaimed-hatch counter.
 	assert.InDelta(t, unclaimedBefore, testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(producerType, isHostedBy)), 0.0001,
 		"a CLAIMED foreign edge must NOT increment foreign_edge_unclaimed_total (the hatch-empty flip-gate signal)")
 
-	// 4b. NoBirthStub routing materialised the child as an envelope-bearing stub
-	//     AND appended the edge — distinct from the unclaimed auto-vivify (which
-	//     would create the child with the edge but NO stub marker).
-	entry, getErr := c.entityBucket.Get(ctx, componentID)
-	require.NoError(t, getErr, "NoBirthStub must materialise the foreign-edge target")
-	var child graph.EntityState
-	require.NoError(t, json.Unmarshal(entry.Value, &child))
-	assert.True(t, hasPredicate(&child, predStubMarker), "NoBirthStub target must carry the core.identity.stub marker")
-	assert.True(t, hasPredicate(&child, isHostedBy), "the routed foreign edge must land on the child")
+	// NoBirthStub routing materialised the child as an envelope-bearing stub AND
+	// appended the edge — distinct from the unclaimed auto-vivify (child + edge,
+	// but NO stub marker).
+	child := storedEntity(t, c, componentID)
+	assert.True(t, hasPredicate(child, predStubMarker), "NoBirthStub target must carry the core.identity.stub marker")
+	assert.True(t, hasPredicate(child, isHostedBy), "the routed foreign edge must land on the child")
 
-	// 4c. A claimed NoBirthStub edge is never dropped — under EITHER drop reason.
+	// A claimed NoBirthStub edge is never dropped — under EITHER drop reason.
 	assert.InDelta(t, droppedStrictBefore, testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, isHostedBy, dropReasonStrictAbsent)), 0.0001,
 		"a claimed NoBirthStub edge must NOT increment foreign_edge_dropped_total{reason=strict_absent_target}")
 	assert.InDelta(t, droppedDeferredBefore, testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, isHostedBy, dropReasonConditionalDeferred)), 0.0001,
 		"a claimed NoBirthStub edge must NOT increment foreign_edge_dropped_total{reason=conditional_deferred}")
+}
+
+// TestIntegration_SharedSeam_ClaimedForeignEdge_StrictDropsAbsentTarget proves the
+// CLAIMED EdgeStrict lane through the real wire: a Strict foreign edge whose target
+// is absent is LOUD-DROPPED — metered on foreign_edge_dropped_total, NOT routed,
+// the target NOT materialised — distinct from NoBirthStub (which materialises a
+// stub). Strict is for edges whose target must pre-exist by causal ordering.
+func TestIntegration_SharedSeam_ClaimedForeignEdge_StrictDropsAbsentTarget(t *testing.T) {
+	const (
+		producerType = "c360.csapi.strict.v1"
+		strictEdge   = "test.strict.hosted_by"
+		systemID     = "c360.csapi.strict.gateway.system.001"
+		componentID  = "c360.csapi.strict.gateway.component.001"
+	)
+	producerMT := message.Type{Domain: "c360", Category: "csapi.strict", Version: "v1"}
+
+	c, ctx := bindClaimAndBootIngest(t, "cs-api-strict", projection.Contract{
+		Name:          "csapi.strict",
+		MessageType:   producerType,
+		EntityPattern: "*.*.*.*.system.*",
+		ForeignEdges:  []projection.ForeignEdge{{Predicate: strictEdge, Mode: ownership.EdgeStrict}},
+	})
+
+	unclaimedBefore := testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(producerType, strictEdge))
+	droppedBefore := testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, strictEdge, dropReasonStrictAbsent))
+
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: systemID, MessageType: producerMT},
+		Triples: []message.Triple{
+			{Subject: systemID, Predicate: "system.label", Object: "Gateway", Timestamp: time.Now(), Confidence: 1}, // own
+			{Subject: componentID, Predicate: strictEdge, Object: systemID, Timestamp: time.Now(), Confidence: 1},   // foreign, Strict, absent target
+		},
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	respData, err := c.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, err)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "primary create must succeed even when the foreign edge is dropped: %s", resp.Error)
+
+	// Claimed Strict + absent target → LOUD DROP: metered, NOT routed, NOT materialised.
+	assert.InDelta(t, droppedBefore+1, testutil.ToFloat64(c.foreignEdgeDropped.WithLabelValues(producerType, strictEdge, dropReasonStrictAbsent)), 0.0001,
+		"a claimed EdgeStrict edge to an absent target must increment foreign_edge_dropped_total{reason=strict_absent_target}")
+	assert.InDelta(t, unclaimedBefore, testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(producerType, strictEdge)), 0.0001,
+		"a claimed Strict drop must NOT touch the unclaimed-hatch counter")
+	_, getErr := c.entityBucket.Get(ctx, componentID)
+	assert.True(t, natsclient.IsKVNotFoundError(getErr), "EdgeStrict must NOT materialise or vivify the absent target")
+}
+
+// TestIntegration_SharedSeam_ClaimedForeignEdge_UpdateLaneMaterialisesStub proves
+// NoBirthStub routing on the update_with_triples lane — where it is MOST
+// load-bearing. Unlike create_with_triples / fact-arrival, update_with_triples does
+// NOT run the upstream ensureRelationshipTargetsExist stub walk, so routeForeignEdges'
+// own NoBirthStub materialisation is the ONLY thing that births the foreign-edge
+// target. Post-flip (auto-vivify removed) this claimed routing is what keeps the
+// update-lane foreign edge from being dropped.
+func TestIntegration_SharedSeam_ClaimedForeignEdge_UpdateLaneMaterialisesStub(t *testing.T) {
+	const (
+		producerType = "c360.csapi.updatelane.v1"
+		isHostedBy   = "sensorml.component.isHostedBy"
+		systemID     = "c360.csapi.updatelane.gateway.system.001"
+		componentID  = "c360.csapi.updatelane.gateway.component.001"
+	)
+	producerMT := message.Type{Domain: "c360", Category: "csapi.updatelane", Version: "v1"}
+
+	c, ctx := bindClaimAndBootIngest(t, "cs-api-updatelane", projection.Contract{
+		Name:          "csapi.updatelane",
+		MessageType:   producerType,
+		EntityPattern: "*.*.*.*.system.*",
+		ForeignEdges:  []projection.ForeignEdge{{Predicate: isHostedBy, Mode: ownership.EdgeNoBirthStub}},
+	})
+
+	// Pre-create the parent so update_with_triples has an existing entity (must-exist on the primary).
+	require.NoError(t, c.CreateEntity(ctx, &graph.EntityState{
+		ID: systemID, MessageType: producerMT, Version: 1, UpdatedAt: time.Now(),
+		Triples: []message.Triple{{Subject: systemID, Predicate: "system.label", Object: "Gateway", Timestamp: time.Now(), Confidence: 1}},
+	}))
+
+	unclaimedBefore := testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(producerType, isHostedBy))
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: systemID, MessageType: producerMT},
+		AddTriples: []message.Triple{
+			{Subject: systemID, Predicate: "system.note", Object: "n", Timestamp: time.Now(), Confidence: 1},      // own
+			{Subject: componentID, Predicate: isHostedBy, Object: systemID, Timestamp: time.Now(), Confidence: 1}, // foreign
+		},
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	respData, err := c.handleEntityUpdateWithTriples(ctx, data)
+	require.NoError(t, err)
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "update_with_triples must succeed: %s", resp.Error)
+
+	assert.InDelta(t, unclaimedBefore, testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(producerType, isHostedBy)), 0.0001,
+		"a CLAIMED foreign edge on the update lane must NOT increment the unclaimed counter")
+	// On the update lane the NoBirthStub routing is the ONLY materialiser — the stub
+	// marker proves routeForeignEdges (not an upstream walk) births the target.
+	child := storedEntity(t, c, componentID)
+	assert.True(t, hasPredicate(child, predStubMarker), "update-lane NoBirthStub target must carry the core.identity.stub marker")
+	assert.True(t, hasPredicate(child, isHostedBy), "the routed foreign edge must land on the child")
+}
+
+// TestIntegration_SharedSeam_ProducerEmptyClaim_RoutesAnyProducer proves the
+// Producer-empty ("any producer") claim path at the seam — the shape cs-api uses
+// TODAY, because its ingestTriples stamps an EMPTY MessageType. An empty-MessageType
+// producer's foreign edge (lookup key "..", metric label "_invalid") is matched by
+// a Producer-empty ForeignEdgeClaim and routed via NoBirthStub, NOT metered unclaimed.
+func TestIntegration_SharedSeam_ProducerEmptyClaim_RoutesAnyProducer(t *testing.T) {
+	const (
+		anyEdge      = "test.anyproducer.hosted_by"
+		systemID     = "c360.csapi.anyprod.gateway.system.001"
+		componentID  = "c360.csapi.anyprod.gateway.component.001"
+		invalidLabel = "_invalid" // the bounded metric label for an invalid/zero MessageType
+	)
+
+	c, ctx := bindClaimAndBootIngest(t, "cs-api-anyproducer", projection.Contract{
+		Name:          "csapi.anyproducer",
+		MessageType:   "", // Producer-empty → matches any producer at the seam (transitional shape)
+		EntityPattern: "*.*.*.*.system.*",
+		ForeignEdges:  []projection.ForeignEdge{{Predicate: anyEdge, Mode: ownership.EdgeNoBirthStub}},
+	})
+
+	unclaimedBefore := testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(invalidLabel, anyEdge))
+
+	// The producer stamps an EMPTY MessageType (cs-api's real shape today).
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: systemID}, // empty MessageType, like cs-api ingestTriples
+		Triples: []message.Triple{
+			{Subject: systemID, Predicate: "system.label", Object: "Gateway", Timestamp: time.Now(), Confidence: 1}, // own
+			{Subject: componentID, Predicate: anyEdge, Object: systemID, Timestamp: time.Now(), Confidence: 1},      // foreign
+		},
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	respData, err := c.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, err)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "create must succeed: %s", resp.Error)
+
+	// The any-producer claim matched at the seam → NOT metered unclaimed (under the _invalid label).
+	assert.InDelta(t, unclaimedBefore, testutil.ToFloat64(c.foreignEdgeUnclaimed.WithLabelValues(invalidLabel, anyEdge)), 0.0001,
+		"a Producer-empty claim must match an empty-MessageType producer at the seam (NOT metered unclaimed)")
+	child := storedEntity(t, c, componentID)
+	assert.True(t, hasPredicate(child, predStubMarker), "Producer-empty NoBirthStub target must carry the stub marker")
+	assert.True(t, hasPredicate(child, anyEdge), "the routed foreign edge must land on the child")
 }


### PR DESCRIPTION
## Summary

Closes the **three claimed-path gaps** #287 named, before the ADR-055 must-exist flip makes the claimed foreign-edge path load-bearing. **Test-only**, all through the real `Contract → Bind → OWNER_CLAIMS → ClaimReader → routeForeignEdges` production wire (testcontainers, `-race`).

| Test | Proves |
|------|--------|
| `...StrictDropsAbsentTarget` | CLAIMED `EdgeStrict` + absent target → **loud drop** (`foreign_edge_dropped_total{reason=strict_absent_target}` +1, NOT routed, target NOT materialised, unclaimed counter untouched) |
| `...UpdateLaneMaterialisesStub` | NoBirthStub via `update_with_triples` — **the lane where it's most load-bearing**: that lane skips the upstream `ensureRelationshipTargetsExist` walk, so `routeForeignEdges`' own materialisation is the only thing that births the child (asserted via the `core.identity.stub` marker) |
| `...ProducerEmptyClaim_RoutesAnyProducer` | Producer-empty claim matched by an **empty-MessageType** producer — **cs-api's real `ingestTriples` shape today** (lookup key `..`, label `_invalid`): the any-producer claim matches at the seam, routes NoBirthStub, not metered unclaimed |

Refactor: the repeated NATS + `EnsureBuckets` + `Bind` + boot is extracted into `bindClaimAndBootIngest` (Start self-wires the real ClaimReader); the merged #287 test now uses it + the existing `storedEntity` helper (assertions preserved).

## Coverage statement (honest — per go-reviewer)

**Now proven through the production wire:** claimed NoBirthStub (create + update lanes) + Strict-drop + Producer-empty/any-producer matching.

**Still open (correctly deferred — do not over-claim at the flip):**
- Conditional/Backfill claimed routing → the `PENDING_EDGES` increment (no live producer; route-with-warn today)
- The fact-arrival lane shares the **identical** `routeForeignEdges` body; the lane difference is confined to upstream triple-splitting, which `normalizeProjection` makes lane-independent.

## Review & gates

- **go-reviewer: APPROVE-WITH-NITS** — no BLOCKING/HIGH/MEDIUM. Assertions non-vacuous (each fails if its branch breaks), metric tuples collision-free across the package, `t.Cleanup` Stop-before-NATS-teardown ordering correct, contracts bind through the real validators with no over-permissiveness.
- ✅ all 4 tests `-race`; full `-tags=integration` graph-ingest suite green (44s); lint clean.

This is the last framework-side claimed-path hardening before the flip; the remaining foreign-edge gate is the operational `foreign_edge_unclaimed_total`-zero bake with cs-api's live traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)