### PR TITLE
feat(ownership): ADR-056 OwnerToken write-lease — PR-1 (wire field + incarnation fence)

### DIFF
--- a/docs/adr/056-authoritative-semantic-state.md
+++ b/docs/adr/056-authoritative-semantic-state.md
@@ -752,6 +752,21 @@ silently vanish between deploys):
   deployment), well under the 1MB `MaxValueSize` (`natsclient/kv.go:39`); if a deployment ever
   outgrew that, the staleness compaction (below) bounds it and a sharded-epoch-by-pattern-prefix
   variant is the deferred optimization (OQ).
+
+  > **Implementation note (PR-1, 2026-06-17) — the shipped lease-token format supersedes the
+  > `owner_token` + `process_instance_id` sketch above.** The OwnerToken write-lease (workstream #2)
+  > shipped its wire field as a single string `"<owner>#<incarnation>"`, NOT the `RuleToken(owner_id)`
+  > FNV hash plus a separate `process_instance_id`. Rationale: (1) the shipped substrate already keys
+  > and compares owners by their **raw canonical identity** (`Registry.OwnerOf` returns the exact
+  > `owner_id` — "no hash"; `pkg/ownership/registry.go`), so a hash handle would be a lossy second
+  > encoding of an id the code already treats as exact; (2) the per-process incarnation is a
+  > `crypto/rand` boot nonce stored on each `OwnerClaim` at `RegisterOwner` time and folded into the
+  > token itself (`<owner>#<incarnation>`) rather than carried as a sibling `process_instance_id`
+  > field — one wire value, one comparison. The two-state wire contract is: **empty token = unowned /
+  > legacy writer, the lease check skips it; `"<owner>#<incarnation>"` = compare against the live
+  > owner+incarnation** (the comparison/reject is a later increment). This note governs the lease
+  > TOKEN only; the presence-key naming (`heartbeat.<...>`) and the key-safety question for free-form
+  > owner ids are a SEPARATE, pre-existing concern, unchanged by PR-1.
 - **Bucket `OWNER_PRESENCE` (bucket-level TTL):** the per-owner liveness keys, SEPARATE from the
   epoch precisely so the TTL applies to presence WITHOUT endangering the durable epoch. Each owner
   bumps a valid, dot-segmented presence key `heartbeat.<owner_token>` on an interval (a plain `Put`,

--- a/graph/mutation_requests.go
+++ b/graph/mutation_requests.go
@@ -50,8 +50,17 @@ type CreateEntityWithTriplesRequest struct {
 	// place a profile is set (see also UpdateEntityWithTriplesRequest for the
 	// explicit-override exception).
 	IndexingProfile string `json:"indexing_profile,omitempty"`
-	TraceID         string `json:"trace_id,omitempty"`
-	RequestID       string `json:"request_id,omitempty"`
+	// OwnerToken is the writer's owner-identity lease token in the format
+	// "<owner>#<incarnation>", where <owner> is the canonical owner id
+	// (e.g. "rule-pack.my-pack", "mission-planner") and <incarnation> is a
+	// per-process boot nonce (crypto/rand hex) that fences revived-stale
+	// writers even when the owner id is unchanged. Empty = unowned or
+	// legacy writer; graph-ingest skips the lease check when empty.
+	// Compared at graph-ingest by a later increment (ADR-056); PR-1 stamps
+	// it here for observe-only transit.
+	OwnerToken string `json:"owner_token,omitempty"`
+	TraceID    string `json:"trace_id,omitempty"`
+	RequestID  string `json:"request_id,omitempty"`
 }
 
 // UpdateEntityWithTriplesRequest updates entity and modifies triples atomically.
@@ -104,8 +113,17 @@ type UpdateEntityWithTriplesRequest struct {
 	// profile untouched. This is the only post-creation way to re-profile an
 	// entity — a later triple.add by a different writer must NOT change it.
 	IndexingProfile string `json:"indexing_profile,omitempty"`
-	TraceID         string `json:"trace_id,omitempty"`
-	RequestID       string `json:"request_id,omitempty"`
+	// OwnerToken is the writer's owner-identity lease token in the format
+	// "<owner>#<incarnation>", where <owner> is the canonical owner id
+	// (e.g. "rule-pack.my-pack", "mission-planner") and <incarnation> is a
+	// per-process boot nonce (crypto/rand hex) that fences revived-stale
+	// writers even when the owner id is unchanged. Empty = unowned or
+	// legacy writer; graph-ingest skips the lease check when empty.
+	// Compared at graph-ingest by a later increment (ADR-056); PR-1 stamps
+	// it here for observe-only transit.
+	OwnerToken string `json:"owner_token,omitempty"`
+	TraceID    string `json:"trace_id,omitempty"`
+	RequestID  string `json:"request_id,omitempty"`
 }
 
 // AddTripleRequest adds a triple to an existing entity

--- a/graph/mutation_requests_owner_token_test.go
+++ b/graph/mutation_requests_owner_token_test.go
@@ -1,0 +1,121 @@
+// Package graph — JSON round-trip tests for the ADR-056 PR-1 OwnerToken wire
+// field added to CreateEntityWithTriplesRequest and UpdateEntityWithTriplesRequest.
+//
+// Tests verify:
+//   - OwnerToken round-trips through JSON marshal→unmarshal.
+//   - Empty OwnerToken is OMITTED from the marshaled JSON (omitempty).
+//   - No other fields are disturbed by the addition of OwnerToken.
+package graph
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// TestCreateEntityWithTriplesRequest_OwnerToken_RoundTrip proves the wire field
+// survives a marshal→unmarshal cycle and that omitempty suppresses it when empty.
+func TestCreateEntityWithTriplesRequest_OwnerToken_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		req := CreateEntityWithTriplesRequest{
+			Entity:     &EntityState{ID: "acme.ops.robotics.gcs.drone.001"},
+			Triples:    []message.Triple{{Subject: "acme.ops.robotics.gcs.drone.001", Predicate: "status.phase", Object: "ready"}},
+			OwnerToken: "mission-planner#deadbeef01234567",
+			TraceID:    "trace-1",
+		}
+		data, err := json.Marshal(req)
+		require.NoError(t, err, "marshal must succeed")
+
+		var got CreateEntityWithTriplesRequest
+		require.NoError(t, json.Unmarshal(data, &got), "unmarshal must succeed")
+
+		assert.Equal(t, req.OwnerToken, got.OwnerToken, "OwnerToken must round-trip through JSON")
+		assert.Equal(t, req.Entity.ID, got.Entity.ID, "Entity.ID must be preserved")
+		assert.Equal(t, req.TraceID, got.TraceID, "TraceID must be preserved")
+	})
+
+	t.Run("empty_omitted", func(t *testing.T) {
+		t.Parallel()
+		req := CreateEntityWithTriplesRequest{
+			Entity:     &EntityState{ID: "acme.ops.robotics.gcs.drone.001"},
+			OwnerToken: "", // empty → must not appear in JSON (omitempty)
+		}
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		// The JSON must not contain the "owner_token" key when empty.
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &raw))
+		_, present := raw["owner_token"]
+		assert.False(t, present, "empty OwnerToken must be omitted from JSON (omitempty)")
+	})
+}
+
+// TestUpdateEntityWithTriplesRequest_OwnerToken_RoundTrip proves the wire field
+// on the update request type survives a marshal→unmarshal cycle and omits when
+// empty.
+func TestUpdateEntityWithTriplesRequest_OwnerToken_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("present", func(t *testing.T) {
+		t.Parallel()
+		req := UpdateEntityWithTriplesRequest{
+			Entity:           &EntityState{ID: "acme.ops.robotics.gcs.drone.001"},
+			AddTriples:       []message.Triple{{Subject: "acme.ops.robotics.gcs.drone.001", Predicate: "status.phase", Object: "running"}},
+			RemoveTriples:    []string{"status.old"},
+			ExpectedRevision: 42,
+			OwnerToken:       "rule-pack.my-pack#cafebabe12345678",
+			TraceID:          "trace-2",
+			RequestID:        "req-2",
+		}
+		data, err := json.Marshal(req)
+		require.NoError(t, err, "marshal must succeed")
+
+		var got UpdateEntityWithTriplesRequest
+		require.NoError(t, json.Unmarshal(data, &got), "unmarshal must succeed")
+
+		assert.Equal(t, req.OwnerToken, got.OwnerToken, "OwnerToken must round-trip through JSON")
+		assert.Equal(t, req.Entity.ID, got.Entity.ID, "Entity.ID must be preserved")
+		assert.Equal(t, req.ExpectedRevision, got.ExpectedRevision, "ExpectedRevision must be preserved")
+		assert.Equal(t, req.RemoveTriples, got.RemoveTriples, "RemoveTriples must be preserved")
+		assert.Equal(t, req.TraceID, got.TraceID, "TraceID must be preserved")
+		assert.Equal(t, req.RequestID, got.RequestID, "RequestID must be preserved")
+	})
+
+	t.Run("empty_omitted", func(t *testing.T) {
+		t.Parallel()
+		req := UpdateEntityWithTriplesRequest{
+			Entity:     &EntityState{ID: "acme.ops.robotics.gcs.drone.001"},
+			OwnerToken: "", // empty → must not appear in JSON (omitempty)
+		}
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(data, &raw))
+		_, present := raw["owner_token"]
+		assert.False(t, present, "empty OwnerToken must be omitted from JSON (omitempty)")
+	})
+
+	t.Run("token_format", func(t *testing.T) {
+		t.Parallel()
+		// Verify the canonical "<owner>#<incarnation>" token shape survives round-trip.
+		token := "rule-pack.sensor-pack#a1b2c3d4e5f60718"
+		req := UpdateEntityWithTriplesRequest{
+			Entity:     &EntityState{ID: "acme.ops.robotics.gcs.drone.001"},
+			OwnerToken: token,
+		}
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+		var got UpdateEntityWithTriplesRequest
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, token, got.OwnerToken, "token format <owner>#<incarnation> must survive round-trip unmodified")
+	})
+}

--- a/graph/mutation_responses.go
+++ b/graph/mutation_responses.go
@@ -94,6 +94,15 @@ const (
 	// failures (KV transport errors, unmarshal failures on stored
 	// state, etc.). Callers may retry as appropriate.
 	ErrorCodeInternal = "internal"
+
+	// ErrorCodeOwnerLeaseStale indicates the request's OwnerToken does not
+	// match the live owner recorded in the owner registry for the contested
+	// (entity, predicate) cell — the writer is either a different process or
+	// a revived-stale incarnation of the same owner id. Callers should NOT
+	// retry without resolving the ownership conflict. No handler emits this
+	// code yet (ADR-056 PR-1 is additive plumbing only); the reject logic
+	// arrives in a later increment.
+	ErrorCodeOwnerLeaseStale = "owner_lease_stale"
 )
 
 // CreateEntityResponse response for entity creation

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -256,6 +256,25 @@ func (m *Manager) lookupByWorkflow(workflow string) (*registration, error) {
 	return reg, nil
 }
 
+// ownerToken composes the OwnerToken for a lifecycle write (ADR-056 PR-1):
+// "<workflowName>#<incarnation>". When no Registry is attached (nil, test
+// paths, unmigrated deploys) the token is left empty — graph-ingest skips
+// the lease check on an empty token, so the Manager's behaviour is unchanged
+// for those paths.
+func (m *Manager) ownerToken(workflowName string) string {
+	m.mu.RLock()
+	reg := m.ownerRegistry
+	m.mu.RUnlock()
+	if reg == nil {
+		return ""
+	}
+	inc := reg.Incarnation()
+	if inc == "" {
+		return ""
+	}
+	return workflowName + "#" + inc
+}
+
 // ensureBucket lazy-initializes the ENTITY_STATES bucket handle.
 // graph-ingest owns the bucket's lifecycle; the Manager just opens
 // an existing handle.
@@ -414,6 +433,10 @@ func (m *Manager) Create(ctx context.Context, initial Participant) error {
 	// Per ADR-049 reviewer B2 this split closes the silent concurrent-
 	// create race that ExpectedRevision=0 had on the prior code.
 	now := time.Now()
+	// ownerTok is the OwnerToken for all writes in this Create call (ADR-056
+	// PR-1). Empty when the Registry is not wired — graph-ingest skips the
+	// lease check for empty tokens.
+	ownerTok := m.ownerToken(reg.workflow.Name)
 	state, rev, err := m.getEntity(ctx, entityID)
 	switch {
 	case errors.Is(err, ErrEntityNotFound):
@@ -425,7 +448,8 @@ func (m *Manager) Create(ctx context.Context, initial Participant) error {
 				UpdatedAt:   now,
 				MessageType: lifecycleMessageType,
 			},
-			Triples: delta,
+			Triples:    delta,
+			OwnerToken: ownerTok,
 		}
 		if _, err := m.emitter.create(ctx, createReq); err != nil {
 			if errors.Is(err, ErrAlreadyExists) {
@@ -453,6 +477,7 @@ func (m *Manager) Create(ctx context.Context, initial Participant) error {
 		},
 		AddTriples:       delta,
 		ExpectedRevision: rev,
+		OwnerToken:       ownerTok,
 	}
 	if _, err := m.emitter.update(ctx, updateReq); err != nil {
 		if errors.Is(err, errEmitRevisionMismatch) {
@@ -603,6 +628,7 @@ func (m *Manager) TransitionWith(ctx context.Context, workflow, entityID, newPha
 			AddTriples:       delta,
 			RemoveTriples:    removePreds,
 			ExpectedRevision: currentRev,
+			OwnerToken:       m.ownerToken(reg.workflow.Name),
 		}
 		_, err = m.emitter.update(ctx, emitReq)
 		if err == nil {
@@ -729,6 +755,7 @@ func (m *Manager) UpdateFromOperator(ctx context.Context, workflow, entityID str
 			AddTriples:       adds,
 			RemoveTriples:    removes,
 			ExpectedRevision: currentRev,
+			OwnerToken:       m.ownerToken(reg.workflow.Name),
 		}
 		_, err = m.emitter.update(ctx, emitReq)
 		if err == nil {

--- a/pkg/lifecycle/owner_token_test.go
+++ b/pkg/lifecycle/owner_token_test.go
@@ -1,0 +1,134 @@
+// Package lifecycle — unit tests for ADR-056 PR-1 OwnerToken stamping on
+// lifecycle-driven mutation requests.
+//
+// Tests coverage:
+//   - When ownerRegistry is wired, Manager.Transition stamps
+//     UpdateEntityWithTriplesRequest.OwnerToken = "<workflowName>#<incarnation>".
+//   - When ownerRegistry is nil (default, test paths), OwnerToken is empty
+//     (lease check skipped at graph-ingest — backward-compatible).
+//   - Manager.Create stamps OwnerToken on the create request.
+package lifecycle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/pkg/ownership"
+)
+
+// tokenRecorder wraps fakeEmitter and records the OwnerTokens seen on
+// update and create requests — the production wire shape we're asserting.
+type tokenRecorder struct {
+	*fakeEmitter
+	updateTokens []string
+	createTokens []string
+}
+
+func newTokenRecorder(bucket *fakeBucket) *tokenRecorder {
+	fe := &fakeEmitter{bucket: bucket}
+	return &tokenRecorder{fakeEmitter: fe}
+}
+
+func (r *tokenRecorder) update(ctx context.Context, req *graph.UpdateEntityWithTriplesRequest) (*graph.UpdateEntityWithTriplesResponse, error) {
+	r.updateTokens = append(r.updateTokens, req.OwnerToken)
+	return r.fakeEmitter.update(ctx, req)
+}
+
+func (r *tokenRecorder) create(ctx context.Context, req *graph.CreateEntityWithTriplesRequest) (*graph.CreateEntityWithTriplesResponse, error) {
+	r.createTokens = append(r.createTokens, req.OwnerToken)
+	return r.fakeEmitter.create(ctx, req)
+}
+
+const fixtureEntityID = "c360.platform1.lifecycle.gcs.mission.owntok"
+
+// newRecordingTestManager builds a Manager with a tokenRecorder emitter.
+func newRecordingTestManager(t *testing.T) (*Manager, *tokenRecorder) {
+	t.Helper()
+	bucket := newFakeBucket()
+	rec := newTokenRecorder(bucket)
+	mgr := newManagerForTest(nil, rec, bucket)
+	wf := lifecycle{}.fixtureWorkflow()
+	require.NoError(t, mgr.Register(wf), "Register fixture workflow")
+	return mgr, rec
+}
+
+// TestManager_Transition_StampsOwnerToken proves that when AttachOwnership is
+// called with a non-nil Registry, Transition stamps the outgoing
+// UpdateEntityWithTriplesRequest with the "<workflowName>#<incarnation>" token.
+func TestManager_Transition_StampsOwnerToken(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mgr, rec := newRecordingTestManager(t)
+
+	// Seed the entity in the initial phase.
+	err := mgr.Create(ctx, &fixtureMission{ID: fixtureEntityID, PhaseF: "planning"})
+	require.NoError(t, err)
+
+	// Attach a real Registry (nil KV — only the Incarnation field matters here).
+	reg := ownership.NewRegistry(nil, nil, nil)
+	mgr.mu.Lock()
+	mgr.ownerRegistry = reg
+	mgr.mu.Unlock()
+
+	err = mgr.Transition(ctx, "fixture", fixtureEntityID, "flying", TransitionSourceOperator, "taking off")
+	require.NoError(t, err)
+
+	// The last update request (the Transition write) must carry the token.
+	require.NotEmpty(t, rec.updateTokens, "Transition must have issued at least one update request")
+	lastToken := rec.updateTokens[len(rec.updateTokens)-1]
+	wantToken := "fixture" + "#" + reg.Incarnation()
+	assert.Equal(t, wantToken, lastToken,
+		"Transition update request must carry OwnerToken = <workflowName>#<incarnation>")
+}
+
+// TestManager_Transition_NoRegistryEmptyToken proves that without AttachOwnership
+// the OwnerToken is empty — graph-ingest skips the lease check, so behaviour is
+// unchanged for unmigrated deploys and test paths.
+func TestManager_Transition_NoRegistryEmptyToken(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mgr, rec := newRecordingTestManager(t)
+	// ownerRegistry stays nil (the default from newManagerForTest).
+
+	id := "c360.platform1.lifecycle.gcs.mission.noregistry"
+	err := mgr.Create(ctx, &fixtureMission{ID: id, PhaseF: "planning"})
+	require.NoError(t, err)
+
+	err = mgr.Transition(ctx, "fixture", id, "flying", TransitionSourceOperator, "")
+	require.NoError(t, err)
+
+	require.NotEmpty(t, rec.updateTokens)
+	lastToken := rec.updateTokens[len(rec.updateTokens)-1]
+	assert.Empty(t, lastToken,
+		"without an attached Registry the OwnerToken must be empty (backward-compatible)")
+}
+
+// TestManager_Create_StampsOwnerToken proves that Manager.Create stamps the
+// OwnerToken on the create request (the entity-absent path).
+func TestManager_Create_StampsOwnerToken(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mgr, rec := newRecordingTestManager(t)
+
+	reg := ownership.NewRegistry(nil, nil, nil)
+	mgr.mu.Lock()
+	mgr.ownerRegistry = reg
+	mgr.mu.Unlock()
+
+	id := "c360.platform1.lifecycle.gcs.mission.createtok"
+	err := mgr.Create(ctx, &fixtureMission{ID: id, PhaseF: "planning"})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, rec.createTokens, "Create must have issued a create request")
+	token := rec.createTokens[0]
+	wantToken := "fixture" + "#" + reg.Incarnation()
+	assert.Equal(t, wantToken, token,
+		"Create request must carry OwnerToken = <workflowName>#<incarnation>")
+}

--- a/pkg/ownership/claim.go
+++ b/pkg/ownership/claim.go
@@ -89,6 +89,16 @@ type OwnerClaim struct {
 	Pattern    string    `json:"pattern"`    // 6-part entity-ID glob
 	Predicates []string  `json:"predicates"` // EXACT strings (no prefix/glob on predicates)
 	Mode       WriteMode `json:"mode"`
+	// Incarnation is the per-process boot nonce (8 bytes crypto/rand hex)
+	// recorded at RegisterOwner time from Registry.Incarnation(). It is the
+	// incarnation half of the OwnerToken "<owner>#<incarnation>" that
+	// producers stamp on mutation requests (ADR-056 PR-1). A later
+	// increment's graph-ingest lease check reads this field via OwnerOf to
+	// compare against the incoming request's token, rejecting a revived-stale
+	// writer whose incarnation no longer matches the live claim.
+	// Empty on claims registered before the incarnation fence was shipped
+	// (legacy / test paths that use NewRegistry with empty claims stores).
+	Incarnation string `json:"incarnation,omitempty"`
 }
 
 // Validate checks the claim is well-formed: a 6-part glob pattern, a non-empty

--- a/pkg/ownership/owner_token_test.go
+++ b/pkg/ownership/owner_token_test.go
@@ -4,8 +4,10 @@
 //   - Registry.Incarnation is non-empty, stable across calls within a process,
 //     and DIFFERENT across two NewRegistry constructions (proves per-process
 //     uniqueness).
-//   - OwnerClaim.Incarnation is set at RegisterOwner time (epoch storage round-
-//     trip via the internal decodeEpoch helper).
+//   - The copy-stamp that RegisterOwner applies preserves a claim's sibling
+//     fields (unit-level field-preservation only). The GENUINE register-time
+//     storage assertion (real RegisterOwner → epoch read-back) lives in
+//     registry_integration_test.go (TestRegistry_RegisterStampsIncarnationOnStoredClaim).
 //   - OwnerToken composition: "<owner>#<incarnation>" shape verified in isolation
 //     (Registry.Incarnation is the raw nonce without the owner prefix).
 package ownership
@@ -64,16 +66,17 @@ func TestRegistry_Incarnation_HexFormat(t *testing.T) {
 	}
 }
 
-// TestOwnerClaim_IncarnationStoredAtRegister proves that after RegisterOwner
-// the epoch stores the registry's incarnation on each OwnerClaim. This is the
-// storage side of the incarnation fence: a later PR's read path retrieves this
-// value via OwnerOf/ClaimFor for the write-time comparison.
+// TestOwnerClaim_StampPreservesSiblingFields verifies, in isolation, the
+// copy-stamp semantics RegisterOwner uses: stamping Incarnation onto a claim
+// copy carries the registry nonce WITHOUT mutating the claim's other fields.
 //
-// This test is a UNIT test — it uses a no-op Registry (nil KV clients) with
-// an overridden in-memory claims store so no NATS container is needed. For the
-// full integration path (real NATS, CAS, compaction), see
-// registry_integration_test.go.
-func TestOwnerClaim_IncarnationStoredAtRegister(t *testing.T) {
+// This is deliberately a narrow UNIT test of the copy logic — it does NOT drive
+// RegisterOwner (which needs NATS) and therefore does NOT prove the epoch
+// actually persists the incarnation. That genuine register-time storage
+// assertion (real RegisterOwner → epoch read-back, would fail if the stamp loop
+// were deleted) lives in registry_integration_test.go
+// (TestRegistry_RegisterStampsIncarnationOnStoredClaim).
+func TestOwnerClaim_StampPreservesSiblingFields(t *testing.T) {
 	t.Parallel()
 	reg := newNoopRegistry(t)
 	inc := reg.Incarnation()

--- a/pkg/ownership/owner_token_test.go
+++ b/pkg/ownership/owner_token_test.go
@@ -1,0 +1,117 @@
+// Package ownership — unit tests for the ADR-056 PR-1 incarnation fence.
+//
+// Tests coverage:
+//   - Registry.Incarnation is non-empty, stable across calls within a process,
+//     and DIFFERENT across two NewRegistry constructions (proves per-process
+//     uniqueness).
+//   - OwnerClaim.Incarnation is set at RegisterOwner time (epoch storage round-
+//     trip via the internal decodeEpoch helper).
+//   - OwnerToken composition: "<owner>#<incarnation>" shape verified in isolation
+//     (Registry.Incarnation is the raw nonce without the owner prefix).
+package ownership
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRegistry_Incarnation_NonEmpty proves the boot nonce is not an empty
+// string — a zero incarnation would make every OwnerToken identical across
+// processes, defeating the fence entirely.
+func TestRegistry_Incarnation_NonEmpty(t *testing.T) {
+	t.Parallel()
+	reg := newNoopRegistry(t)
+	assert.NotEmpty(t, reg.Incarnation(), "incarnation must be non-empty immediately after NewRegistry")
+}
+
+// TestRegistry_Incarnation_StableWithinProcess proves the incarnation returned
+// by consecutive Incarnation() calls is the same value (it is generated once at
+// construction and never changes).
+func TestRegistry_Incarnation_StableWithinProcess(t *testing.T) {
+	t.Parallel()
+	reg := newNoopRegistry(t)
+	first := reg.Incarnation()
+	second := reg.Incarnation()
+	third := reg.Incarnation()
+	assert.Equal(t, first, second, "incarnation must be stable across calls")
+	assert.Equal(t, first, third, "incarnation must be stable across calls")
+}
+
+// TestRegistry_Incarnation_UniqueAcrossConstructions proves two independent
+// NewRegistry calls produce different incarnations. This is the key property
+// that makes the fence useful: a revived writer that re-registers the same
+// owner id in a new process will have a DIFFERENT incarnation, so the
+// graph-ingest lease check (a later PR) can reject the stale writer.
+func TestRegistry_Incarnation_UniqueAcrossConstructions(t *testing.T) {
+	t.Parallel()
+	r1 := newNoopRegistry(t)
+	r2 := newNoopRegistry(t)
+	assert.NotEqual(t, r1.Incarnation(), r2.Incarnation(),
+		"two distinct NewRegistry constructions must produce different incarnations (per-process uniqueness)")
+}
+
+// TestRegistry_Incarnation_HexFormat proves the incarnation is a valid
+// lowercase hex string of exactly 16 characters (8 bytes).
+func TestRegistry_Incarnation_HexFormat(t *testing.T) {
+	t.Parallel()
+	reg := newNoopRegistry(t)
+	inc := reg.Incarnation()
+	assert.Len(t, inc, 16, "incarnation must be exactly 16 hex chars (8 bytes)")
+	for _, c := range inc {
+		assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+			"incarnation must be lowercase hex, got char %q", c)
+	}
+}
+
+// TestOwnerClaim_IncarnationStoredAtRegister proves that after RegisterOwner
+// the epoch stores the registry's incarnation on each OwnerClaim. This is the
+// storage side of the incarnation fence: a later PR's read path retrieves this
+// value via OwnerOf/ClaimFor for the write-time comparison.
+//
+// This test is a UNIT test — it uses a no-op Registry (nil KV clients) with
+// an overridden in-memory claims store so no NATS container is needed. For the
+// full integration path (real NATS, CAS, compaction), see
+// registry_integration_test.go.
+func TestOwnerClaim_IncarnationStoredAtRegister(t *testing.T) {
+	t.Parallel()
+	reg := newNoopRegistry(t)
+	inc := reg.Incarnation()
+
+	// Register an owner. We call the internal stampedClaims logic directly
+	// by asserting on the Registration the struct would build — we don't
+	// drive through RegisterOwner (which needs NATS) but test the stamp
+	// logic by constructing what RegisterOwner builds.
+	//
+	// The stamp logic: reg.RegisterOwner copies r.Claims and sets
+	// c.Incarnation = reg.incarnation on each copy before writing to the
+	// epoch. We verify that logic by replicating the copy here.
+	original := OwnerClaim{
+		Owner:      "rule-pack.test",
+		Pattern:    "acme.ops.*.*.*.* ",
+		Predicates: []string{"status.phase"},
+		Mode:       ModeReplaceOwned,
+	}
+	// Fix the pattern — must be a valid 6-part glob.
+	original.Pattern = "acme.ops.robotics.gcs.drone.*"
+
+	// Replicate what RegisterOwner does: copy + stamp.
+	stamped := original
+	stamped.Incarnation = reg.incarnation
+
+	assert.Equal(t, inc, stamped.Incarnation,
+		"stamped claim must carry the registry's incarnation nonce")
+	assert.Equal(t, original.Owner, stamped.Owner,
+		"stamp must not mutate other fields")
+	assert.Equal(t, original.Pattern, stamped.Pattern,
+		"stamp must not mutate other fields")
+	assert.Equal(t, original.Predicates, stamped.Predicates,
+		"stamp must not mutate other fields")
+}
+
+// newNoopRegistry builds a Registry with nil KV stores for unit tests that
+// only exercise the incarnation field and don't issue any NATS I/O.
+func newNoopRegistry(t *testing.T) *Registry {
+	t.Helper()
+	return NewRegistry(nil, nil, nil)
+}

--- a/pkg/ownership/registry.go
+++ b/pkg/ownership/registry.go
@@ -2,6 +2,8 @@ package ownership
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -28,6 +30,16 @@ type Registry struct {
 	presence *natsclient.KVStore // OWNER_PRESENCE — heartbeat.<owner> keys (TTL = grace window)
 	logger   *slog.Logger
 
+	// incarnation is the per-process boot nonce (8 bytes crypto/rand hex). It
+	// is generated once at NewRegistry time and is stable for the lifetime of
+	// the process. Combined with the owner id it forms the OwnerToken
+	// "<owner>#<incarnation>" written on every update_with_triples /
+	// create_with_triples request (ADR-056 PR-1). The graph-ingest lease check
+	// (a later increment) compares this token against the live claim's
+	// incarnation to reject a revived-stale writer that re-registered the same
+	// owner id in a new process without the token changing.
+	incarnation string
+
 	// inverseResolver, when non-nil, enforces the Decision-4 inverse-gate over
 	// every registered ForeignEdgeClaim (a Conditional/Backfill edge predicate
 	// must have a registered inverse). Injected so pkg/ownership stays free of
@@ -45,11 +57,40 @@ type Registry struct {
 // ttl_hint ≥ 3×max(boot_time, gc_pause_budget) so a single missed heartbeat
 // never evicts a live owner (compactStale treats presence-key absence as
 // "silent beyond grace"; the TTL is what makes absence mean that).
+//
+// A per-process incarnation nonce (8 bytes, crypto/rand hex) is generated here
+// and stored for the lifetime of the Registry. It forms the incarnation half of
+// every OwnerToken ("<owner>#<incarnation>") stamped on outgoing mutation
+// requests (ADR-056 PR-1). Callers access it via Registry.Incarnation().
 func NewRegistry(claims, presence *natsclient.KVStore, logger *slog.Logger) *Registry {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Registry{claims: claims, presence: presence, logger: logger}
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failure is extremely rare and almost always indicates a
+		// broken OS RNG. Panic rather than silently stamping a zero-token that
+		// would make every token identical across processes — defeating the
+		// incarnation fence entirely.
+		panic(fmt.Sprintf("ownership: generate incarnation nonce: %v", err))
+	}
+	return &Registry{
+		claims:      claims,
+		presence:    presence,
+		logger:      logger,
+		incarnation: hex.EncodeToString(b),
+	}
+}
+
+// Incarnation returns the per-process boot nonce generated at NewRegistry time.
+// It is stable for the lifetime of this Registry instance. Together with the
+// canonical owner id it forms the OwnerToken "<owner>#<incarnation>" stamped by
+// producers on every update_with_triples / create_with_triples request
+// (ADR-056 PR-1). The graph-ingest lease-check increment (PR-2+) uses this to
+// reject revived-stale writers that re-registered the same owner id in a new
+// process without presenting the live incarnation.
+func (reg *Registry) Incarnation() string {
+	return reg.incarnation
 }
 
 // Registration is one owner's full set of claims, registered atomically against
@@ -217,10 +258,21 @@ func (reg *Registry) RegisterOwner(ctx context.Context, r Registration) error {
 		return fmt.Errorf("ownership: heartbeat before register %q: %w", r.Owner, err)
 	}
 
+	// Stamp the per-process incarnation onto each claim before writing to the
+	// epoch so a later PR's OwnerOf can return the live owner's incarnation
+	// for the lease-check comparison (ADR-056 PR-1). We copy the slice
+	// rather than mutating the caller's input to preserve Registration
+	// immutability at the call site.
+	stampedClaims := make([]OwnerClaim, len(r.Claims))
+	for i, c := range r.Claims {
+		c.Incarnation = reg.incarnation
+		stampedClaims[i] = c
+	}
+
 	var (
 		overlapErr error
 		preExisted bool
-		cand       = ownerEntry{Claims: r.Claims, ForeignEdges: r.ForeignEdges}
+		cand       = ownerEntry{Claims: stampedClaims, ForeignEdges: r.ForeignEdges}
 	)
 	err := reg.claims.UpdateWithRetry(ctx, registryKey, func(current []byte) ([]byte, error) {
 		ep, err := decodeEpoch(current)

--- a/pkg/ownership/registry_integration_test.go
+++ b/pkg/ownership/registry_integration_test.go
@@ -109,6 +109,39 @@ func TestRegistry_Idempotent(t *testing.T) {
 	}
 }
 
+// TestRegistry_RegisterStampsIncarnationOnStoredClaim drives the REAL
+// RegisterOwner through live NATS KV and reads the stored epoch back, asserting
+// every persisted OwnerClaim carries the registry's per-process incarnation
+// nonce (the storage side of the ADR-056 PR-1 fence — a later PR's read path
+// returns this for the write-time lease comparison). Unlike the unit test that
+// replicates the copy-stamp in isolation, this would FAIL if RegisterOwner's
+// stamp loop were deleted.
+func TestRegistry_RegisterStampsIncarnationOnStoredClaim(t *testing.T) {
+	r, claims, ctx := newTestRegistry(t)
+
+	if err := r.RegisterOwner(ctx, reg("cs-api", sysPat, "sensorml.process.label")); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	ep := readEpoch(t, claims, ctx)
+	entry, ok := ep.Owners["cs-api"]
+	if !ok {
+		t.Fatal("cs-api should be present in the stored epoch")
+	}
+	if len(entry.Claims) == 0 {
+		t.Fatal("cs-api entry should carry its registered claim")
+	}
+	for _, c := range entry.Claims {
+		if c.Incarnation == "" {
+			t.Error("stored claim must carry a non-empty incarnation (the fence)")
+		}
+		if c.Incarnation != r.Incarnation() {
+			t.Errorf("stored claim Incarnation = %q, want the registry's per-process nonce %q",
+				c.Incarnation, r.Incarnation())
+		}
+	}
+}
+
 func TestRegistry_OwnerOf(t *testing.T) {
 	r, _, ctx := newTestRegistry(t)
 	entity := "c360.semconnect.systems.csapi.system.drone-001"

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -1093,11 +1093,15 @@ func (e *ActionExecutor) executeReplaceOwned(ctx context.Context, action Action,
 		return nil
 	}
 
-	// Compose the OwnerToken: "<owner>#<incarnation>" (ADR-056 PR-1). When
-	// the incarnation is empty (test paths, unowned packs, Registry not wired)
-	// the token degrades to just the owner — still a valid identity for the
-	// deferred graph-ingest lease check (which skips an empty token).
-	ownerToken := e.ownerID
+	// Compose the OwnerToken: "<owner>#<incarnation>" (ADR-056 PR-1). The owner
+	// is guaranteed non-empty here (validated above). When the incarnation is
+	// NOT wired (resourceless deploy / Registry absent / test path) the token
+	// degrades to the EMPTY string — NOT a bare "<owner>". This matches the
+	// lifecycle producer's two-state wire contract (manager.go ownerToken()), so
+	// the deferred graph-ingest lease check has a single rule: empty = skip,
+	// "<owner>#<incarnation>" = compare. A bare unfenced "<owner>" would be an
+	// uninterpretable third state for that comparison.
+	ownerToken := ""
 	if e.incarnation != "" {
 		ownerToken = e.ownerID + "#" + e.incarnation
 	}

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -413,13 +413,14 @@ type TripleMutator interface {
 	// mutation (ADR-056 Decision 3): the predicate is named in RemoveTriples
 	// and the new value(s) carried in objects (AddTriples). An empty objects
 	// slice clears the predicate. ExpectedRevision is ALWAYS zero — this is
-	// owned-current-state reconciliation, never a CAS transition. The owner
-	// identity ("rule-pack.<packID>") is threaded for audit/diagnostics; it
-	// is NOT placed on the request envelope (the owner wire field is deferred
-	// to a later increment). On a non-existent entity the underlying handler
-	// surfaces ErrorCodeEntityNotFound, which is returned as an error (no
-	// auto-vivify). Returns the post-write KV revision.
-	ReplaceOwned(ctx context.Context, ruleID, owner, entityID, predicate string, objects []message.Triple) (uint64, error)
+	// owned-current-state reconciliation, never a CAS transition. The
+	// ownerToken is the pre-composed lease token "<owner>#<incarnation>"
+	// (or just "<owner>" when the Registry incarnation is unavailable) stamped
+	// onto UpdateEntityWithTriplesRequest.OwnerToken for the graph-ingest
+	// lease check (ADR-056 PR-1). On a non-existent entity the underlying
+	// handler surfaces ErrorCodeEntityNotFound, which is returned as an error
+	// (no auto-vivify). Returns the post-write KV revision.
+	ReplaceOwned(ctx context.Context, ruleID, ownerToken, entityID, predicate string, objects []message.Triple) (uint64, error)
 }
 
 // Publisher handles publishing messages to NATS subjects.
@@ -498,6 +499,13 @@ type ActionExecutor struct {
 	// owned predicate group). Set by the processor after construction via
 	// SetProjectionOwner.
 	ownerID string
+	// incarnation is the per-process boot nonce from the ownership Registry
+	// (ADR-056 PR-1). Set via SetProjectionIncarnation after construction.
+	// Together with ownerID it forms the OwnerToken "<ownerID>#<incarnation>"
+	// stamped on every replace_owned mutation request. Empty when the Registry
+	// is not wired (test paths, unowned packs) — ReplaceOwned stamps only the
+	// owner in that case (no fence, which is fine for the deferred comparison).
+	incarnation string
 }
 
 // SetToolRegistry installs the shared tool registry used by
@@ -536,6 +544,17 @@ func (e *ActionExecutor) SetVerdictAuditor(a VerdictAuditor) {
 // declares a PackID. Mirrors SetToolRegistry / SetLifecycleManager.
 func (e *ActionExecutor) SetProjectionOwner(owner string) {
 	e.ownerID = owner
+}
+
+// SetProjectionIncarnation installs the per-process boot nonce from the
+// ownership Registry (ADR-056 PR-1). Together with the owner id it forms the
+// OwnerToken "<owner>#<incarnation>" stamped on every replace_owned request.
+// Set by the processor after initializeStateTracker reads it from
+// Processor.projectionIncarnation (which BindRulePackContracts writes). An
+// empty incarnation is silently tolerated — the token is then just "<owner>"
+// for test / unowned-pack paths where the Registry is not wired.
+func (e *ActionExecutor) SetProjectionIncarnation(incarnation string) {
+	e.incarnation = incarnation
 }
 
 // NewActionExecutor creates a new ActionExecutor with the given logger.
@@ -1074,7 +1093,16 @@ func (e *ActionExecutor) executeReplaceOwned(ctx context.Context, action Action,
 		return nil
 	}
 
-	revision, err := e.tripleMutator.ReplaceOwned(ctx, ec.RuleID(), e.ownerID, entityID, action.Predicate, objects)
+	// Compose the OwnerToken: "<owner>#<incarnation>" (ADR-056 PR-1). When
+	// the incarnation is empty (test paths, unowned packs, Registry not wired)
+	// the token degrades to just the owner — still a valid identity for the
+	// deferred graph-ingest lease check (which skips an empty token).
+	ownerToken := e.ownerID
+	if e.incarnation != "" {
+		ownerToken = e.ownerID + "#" + e.incarnation
+	}
+
+	revision, err := e.tripleMutator.ReplaceOwned(ctx, ec.RuleID(), ownerToken, entityID, action.Predicate, objects)
 	if err != nil {
 		return fmt.Errorf("replace owned predicate %q on %s: %w", action.Predicate, entityID, err)
 	}
@@ -1082,6 +1110,7 @@ func (e *ActionExecutor) executeReplaceOwned(ctx context.Context, action Action,
 		e.logger.Debug("Owned predicate replaced",
 			"entity_id", entityID,
 			"predicate", action.Predicate,
+			"owner_token", ownerToken,
 			"kv_revision", revision)
 	}
 	return nil

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -414,8 +414,9 @@ type TripleMutator interface {
 	// and the new value(s) carried in objects (AddTriples). An empty objects
 	// slice clears the predicate. ExpectedRevision is ALWAYS zero — this is
 	// owned-current-state reconciliation, never a CAS transition. The
-	// ownerToken is the pre-composed lease token "<owner>#<incarnation>"
-	// (or just "<owner>" when the Registry incarnation is unavailable) stamped
+	// ownerToken is the pre-composed lease token "<owner>#<incarnation>",
+	// or EMPTY when the Registry incarnation is unavailable (two-state
+	// contract: empty = lease check SKIPs; never a bare "<owner>"), stamped
 	// onto UpdateEntityWithTriplesRequest.OwnerToken for the graph-ingest
 	// lease check (ADR-056 PR-1). On a non-existent entity the underlying
 	// handler surfaces ErrorCodeEntityNotFound, which is returned as an error
@@ -551,8 +552,10 @@ func (e *ActionExecutor) SetProjectionOwner(owner string) {
 // OwnerToken "<owner>#<incarnation>" stamped on every replace_owned request.
 // Set by the processor after initializeStateTracker reads it from
 // Processor.projectionIncarnation (which BindRulePackContracts writes). An
-// empty incarnation is silently tolerated — the token is then just "<owner>"
-// for test / unowned-pack paths where the Registry is not wired.
+// empty incarnation is tolerated — the token is then the EMPTY string (the
+// two-state contract; the lease check skips an empty token), for test /
+// unowned-pack / resourceless-deploy paths where the Registry is not wired.
+// It is never a bare "<owner>".
 func (e *ActionExecutor) SetProjectionIncarnation(incarnation string) {
 	e.incarnation = incarnation
 }

--- a/processor/rule/actions_replace_owned_integration_test.go
+++ b/processor/rule/actions_replace_owned_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -167,6 +168,57 @@ func TestIntegration_ReplaceOwned_MustExist(t *testing.T) {
 	require.Error(t, err, "replace_owned on a non-existent entity must error (no auto-vivify)")
 	assert.Contains(t, err.Error(), gtypes.ErrorCodeEntityNotFound,
 		"the handler's entity_not_found code must surface to the caller")
+}
+
+// --- The production tripleMutator stamps OwnerToken onto the wire (M2) ---
+
+// TestIntegration_ReplaceOwned_StampsOwnerTokenOnWire drives the REAL
+// tripleMutator.ReplaceOwned and captures the marshalled
+// UpdateEntityWithTriplesRequest off the wire via a fake responder, asserting the
+// OwnerToken field is actually placed on the request (the literal
+// `req.OwnerToken = ownerToken` line PR-1 adds at triple_mutator.go). A unit test
+// cannot cover this seam — tripleMutator holds a concrete *natsclient.Client, not
+// an interface — so the production marshal path is only reachable through live
+// NATS. The fake responder stands in for graph-ingest so the assertion is purely
+// on the bytes the production mutator emits.
+// (feedback_integration_tests_must_drive_production_wire)
+func TestIntegration_ReplaceOwned_StampsOwnerTokenOnWire(t *testing.T) {
+	ctx := context.Background()
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	natsClient := tc.Client
+
+	captured := make(chan gtypes.UpdateEntityWithTriplesRequest, 1)
+	_, err := natsClient.Subscribe(ctx, SubjectEntityUpdateWithTriples, func(_ context.Context, msg *nats.Msg) {
+		var req gtypes.UpdateEntityWithTriplesRequest
+		if err := json.Unmarshal(msg.Data, &req); err == nil {
+			select {
+			case captured <- req:
+			default:
+			}
+		}
+		resp, _ := json.Marshal(gtypes.UpdateEntityWithTriplesResponse{
+			MutationResponse: gtypes.MutationResponse{Success: true, KVRevision: 1},
+		})
+		_ = msg.Respond(resp)
+	})
+	require.NoError(t, err)
+	// Let the subscription propagate before the request fires.
+	time.Sleep(100 * time.Millisecond)
+
+	const entityID = "acme.ops.robotics.gcs.drone.001"
+	const wantToken = "rule-pack.test#deadbeef01234567"
+	mutator := newTripleMutator(natsClient, nil)
+	_, err = mutator.ReplaceOwned(ctx, "rule-1", wantToken, entityID, "status.phase",
+		[]message.Triple{{Subject: entityID, Predicate: "status.phase", Object: "running", Confidence: 1.0, Timestamp: time.Now()}})
+	require.NoError(t, err, "fake responder replies success; the call must round-trip")
+
+	select {
+	case req := <-captured:
+		assert.Equal(t, wantToken, req.OwnerToken,
+			"production tripleMutator.ReplaceOwned must stamp the ownerToken argument onto req.OwnerToken")
+	case <-time.After(2 * time.Second):
+		t.Fatal("no update_with_triples request captured on the wire")
+	}
 }
 
 // --- Processor owner-wiring (requires NATS for initializeStateTracker) ---

--- a/processor/rule/actions_replace_owned_test.go
+++ b/processor/rule/actions_replace_owned_test.go
@@ -406,14 +406,18 @@ func TestReplaceOwned_OwnerIdentityThreaded(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	mutator := &mockTripleMutator{}
-	executor := executorWithOwner(mutator, testReplaceOwnedOwner)
+	// The owner identity reaches the mutator embedded in the fenced token. Under
+	// the two-state contract the owner is observable on the wire only when an
+	// incarnation is wired (without one the token is empty — see
+	// TestReplaceOwned_OwnerToken_WithoutIncarnation).
+	executor := executorWithOwnerAndIncarnation(mutator, testReplaceOwnedOwner, testIncarnation)
 
 	action := Action{Type: ActionTypeReplaceOwned, Predicate: ownedPredicate, Object: "running"}
 	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "acme.ops.robotics.gcs.drone.001"}))
 
 	require.Len(t, mutator.replaceOwnedCalls, 1)
-	assert.Equal(t, testReplaceOwnedOwner, mutator.replaceOwnedCalls[0].owner,
-		"mutator must receive owner == rule-pack.<PackID>")
+	assert.Equal(t, testReplaceOwnedOwner+"#"+testIncarnation, mutator.replaceOwnedCalls[0].owner,
+		"mutator must receive owner == rule-pack.<PackID> threaded into the fenced token")
 }
 
 func TestReplaceOwned_EmptyOwner_Errors(t *testing.T) {

--- a/processor/rule/owner_token_test.go
+++ b/processor/rule/owner_token_test.go
@@ -4,8 +4,10 @@
 // Tests coverage:
 //   - With incarnation set, ReplaceOwned request carries "<owner>#<incarnation>"
 //     as the ownerToken argument to the mutator.
-//   - Without incarnation (legacy / test path), the ownerToken is just the owner
-//     string (no "#" suffix) — backward-compatible.
+//   - Without incarnation (resourceless deploy / Registry not wired / test path)
+//     the ownerToken degrades to the EMPTY string — matching the lifecycle
+//     producer's two-state wire contract (empty = the deferred lease check skips
+//     it); it is NEVER a bare unfenced "<owner>".
 //   - The UpdateEntityWithTriplesRequest.OwnerToken field is wired correctly in
 //     the production tripleMutator.ReplaceOwned implementation (via round-trip on
 //     the capturing mock).
@@ -59,9 +61,10 @@ func TestReplaceOwned_OwnerToken_WithIncarnation(t *testing.T) {
 }
 
 // TestReplaceOwned_OwnerToken_WithoutIncarnation proves that when no incarnation
-// is set (test path, unowned pack, Registry not wired) the executor falls back to
-// passing just the owner string — no "#" suffix — preserving backward compatibility
-// for legacy callers.
+// is set (resourceless deploy, Registry not wired, test path) the executor emits
+// an EMPTY ownerToken — NOT a bare "<owner>". This matches the lifecycle
+// producer's two-state contract so the deferred lease check has a single rule:
+// empty = skip. An unfenced "<owner>" would be an uninterpretable third state.
 func TestReplaceOwned_OwnerToken_WithoutIncarnation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -75,9 +78,8 @@ func TestReplaceOwned_OwnerToken_WithoutIncarnation(t *testing.T) {
 	require.Len(t, mutator.replaceOwnedCalls, 1)
 	call := mutator.replaceOwnedCalls[0]
 
-	// Without incarnation the owner is passed through unchanged (no "#").
-	assert.Equal(t, testReplaceOwnedOwner, call.owner,
-		"without incarnation the mutator receives just the owner id (backward-compatible)")
-	assert.NotContains(t, call.owner, "#",
-		"without incarnation the token must not contain '#'")
+	// Without incarnation the token is EMPTY (two-state contract with lifecycle);
+	// the deferred graph-ingest lease check skips an empty token.
+	assert.Empty(t, call.owner,
+		"without incarnation the mutator must receive an EMPTY token, never a bare '<owner>'")
 }

--- a/processor/rule/owner_token_test.go
+++ b/processor/rule/owner_token_test.go
@@ -1,0 +1,83 @@
+// Package rule — unit tests for ADR-056 PR-1 OwnerToken stamping on
+// replace_owned mutation requests.
+//
+// Tests coverage:
+//   - With incarnation set, ReplaceOwned request carries "<owner>#<incarnation>"
+//     as the ownerToken argument to the mutator.
+//   - Without incarnation (legacy / test path), the ownerToken is just the owner
+//     string (no "#" suffix) — backward-compatible.
+//   - The UpdateEntityWithTriplesRequest.OwnerToken field is wired correctly in
+//     the production tripleMutator.ReplaceOwned implementation (via round-trip on
+//     the capturing mock).
+package rule
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testIncarnation = "deadbeef01234567"
+
+// executorWithOwnerAndIncarnation builds a fully-wired executor carrying both
+// the owner and the per-process incarnation, matching the production path where
+// BindRulePackContracts calls SetProjectionIncarnation before Start.
+func executorWithOwnerAndIncarnation(mutator TripleMutator, owner, incarnation string) *ActionExecutor {
+	e := NewActionExecutorFull(nil, mutator, nil)
+	e.SetProjectionOwner(owner)
+	e.SetProjectionIncarnation(incarnation)
+	return e
+}
+
+// TestReplaceOwned_OwnerToken_WithIncarnation proves the executor composes the
+// full "<owner>#<incarnation>" token when an incarnation is wired, and passes it
+// as the ownerToken argument to TripleMutator.ReplaceOwned.
+func TestReplaceOwned_OwnerToken_WithIncarnation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mutator := &mockTripleMutator{}
+	executor := executorWithOwnerAndIncarnation(mutator, testReplaceOwnedOwner, testIncarnation)
+
+	action := Action{Type: ActionTypeReplaceOwned, Predicate: ownedPredicate, Object: "running"}
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "acme.ops.robotics.gcs.drone.001"}))
+
+	require.Len(t, mutator.replaceOwnedCalls, 1)
+	call := mutator.replaceOwnedCalls[0]
+
+	// The ownerToken passed to the mutator must be "<owner>#<incarnation>".
+	wantToken := testReplaceOwnedOwner + "#" + testIncarnation
+	assert.Equal(t, wantToken, call.owner,
+		"mutator must receive full OwnerToken = <owner>#<incarnation>")
+	// Sanity: the token contains exactly one "#" separator.
+	parts := strings.SplitN(call.owner, "#", 2)
+	require.Len(t, parts, 2, "token must have exactly one '#' separator")
+	assert.Equal(t, testReplaceOwnedOwner, parts[0], "token prefix must be the owner id")
+	assert.Equal(t, testIncarnation, parts[1], "token suffix must be the incarnation")
+}
+
+// TestReplaceOwned_OwnerToken_WithoutIncarnation proves that when no incarnation
+// is set (test path, unowned pack, Registry not wired) the executor falls back to
+// passing just the owner string — no "#" suffix — preserving backward compatibility
+// for legacy callers.
+func TestReplaceOwned_OwnerToken_WithoutIncarnation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mutator := &mockTripleMutator{}
+	// No SetProjectionIncarnation — incarnation field stays "".
+	executor := executorWithOwner(mutator, testReplaceOwnedOwner)
+
+	action := Action{Type: ActionTypeReplaceOwned, Predicate: ownedPredicate, Object: "running"}
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "acme.ops.robotics.gcs.drone.001"}))
+
+	require.Len(t, mutator.replaceOwnedCalls, 1)
+	call := mutator.replaceOwnedCalls[0]
+
+	// Without incarnation the owner is passed through unchanged (no "#").
+	assert.Equal(t, testReplaceOwnedOwner, call.owner,
+		"without incarnation the mutator receives just the owner id (backward-compatible)")
+	assert.NotContains(t, call.owner, "#",
+		"without incarnation the token must not contain '#'")
+}

--- a/processor/rule/processor.go
+++ b/processor/rule/processor.go
@@ -206,6 +206,14 @@ type Processor struct {
 	// See also: cmd/semstreams/main.go buildRuleManager — a second ConfigManager
 	// instance (processor=nil) for agent CRUD tools. Both share the same KV bucket.
 	kvConfigManager *ConfigManager
+
+	// projectionIncarnation is the per-process boot nonce from the ownership
+	// Registry (ADR-056 PR-1). Set via SetProjectionIncarnation by
+	// service.BindRulePackContracts (which holds the Registry) BEFORE
+	// initializeStateTracker. The executor reads it at initializeStateTracker
+	// time and stamps it on every replace_owned request as the incarnation half
+	// of the OwnerToken "<owner>#<incarnation>".
+	projectionIncarnation string
 }
 
 // NewProcessor creates a new rule processor
@@ -350,6 +358,15 @@ func (rp *Processor) ConfigSchema() component.ConfigSchema {
 // touches the ownership registry. All binding happens main-side.
 func (rp *Processor) ProjectionBindings() (packID string, contracts []projection.Contract) {
 	return rp.config.PackID, rp.config.ProjectionContracts
+}
+
+// SetProjectionIncarnation stores the per-process boot nonce from the ownership
+// Registry so initializeStateTracker can forward it to the ActionExecutor. Must
+// be called by service.BindRulePackContracts BEFORE Start (which calls
+// initializeStateTracker). Mirrors SetProjectionOwner's timing contract.
+// A nil/empty incarnation is a no-op — test paths and unowned packs skip it.
+func (rp *Processor) SetProjectionIncarnation(incarnation string) {
+	rp.projectionIncarnation = incarnation
 }
 
 // Health returns current health status
@@ -612,6 +629,19 @@ func (rp *Processor) initializeStateTracker(ctx context.Context) error {
 			SetProjectionOwner(string)
 		}); ok {
 			setter.SetProjectionOwner("rule-pack." + rp.config.PackID)
+		}
+		// ADR-056 PR-1: forward the per-process incarnation nonce so the
+		// executor can stamp the full "<owner>#<incarnation>" OwnerToken on
+		// every replace_owned request. The incarnation is set by
+		// service.BindRulePackContracts (which holds the Registry) BEFORE
+		// Start is called. Empty when the Registry is not wired — the executor
+		// falls back to owner-only, which is correct for test / unowned paths.
+		if rp.projectionIncarnation != "" {
+			if setter, ok := actionExecutor.(interface {
+				SetProjectionIncarnation(string)
+			}); ok {
+				setter.SetProjectionIncarnation(rp.projectionIncarnation)
+			}
 		}
 	}
 

--- a/processor/rule/triple_mutator.go
+++ b/processor/rule/triple_mutator.go
@@ -143,20 +143,17 @@ func (m *tripleMutator) RemoveTriple(ctx context.Context, ruleID, subject, predi
 // the two operations.
 //
 // ExpectedRevision is left zero: this is owned-current-state reconciliation,
-// NOT a CAS transition. The owner parameter is threaded for audit/diagnostics
-// only — it is NOT placed on the request envelope (the owner wire field is
-// deferred to a later increment per ADR-056).
+// NOT a CAS transition. The ownerToken parameter carries the pre-composed
+// lease token ("<owner>#<incarnation>" or just "<owner>" when the incarnation
+// is not available); it is stamped directly onto the request's OwnerToken field
+// for the graph-ingest lease check (a later increment). Token composition is
+// the caller's responsibility (ActionExecutor.executeReplaceOwned).
 //
 // Unlike AddTriple/RemoveTriple, this checks resp.Success (NOT the body-prefix
 // convention) and surfaces the handler's ErrorCode on failure. On a
 // non-existent entity the handler returns ErrorCodeEntityNotFound; that is
 // returned verbatim as an error (no auto-vivify).
-//
-// The owner parameter (interface position 3) is intentionally unused here: it
-// is threaded to the boundary so the audit/diagnostics shape is in place, but
-// the request envelope deliberately carries NO owner field (deferred per
-// ADR-056). Named `_` to keep that explicit and revive-clean.
-func (m *tripleMutator) ReplaceOwned(ctx context.Context, ruleID, _, entityID, predicate string, objects []message.Triple) (uint64, error) {
+func (m *tripleMutator) ReplaceOwned(ctx context.Context, ruleID, ownerToken, entityID, predicate string, objects []message.Triple) (uint64, error) {
 	if m.natsClient == nil {
 		return 0, fmt.Errorf("NATS client not available")
 	}
@@ -164,12 +161,12 @@ func (m *tripleMutator) ReplaceOwned(ctx context.Context, ruleID, _, entityID, p
 	// Build the atomic update: RemoveTriples drops the prior value of the
 	// predicate (it runs before the AddTriples merge on the handler side),
 	// AddTriples carries the new value(s). ExpectedRevision stays zero —
-	// replace_owned is NEVER a CAS write (ADR-056 Decision 3). The owner is
-	// not placed on the request (wire field deferred); it is logged below.
+	// replace_owned is NEVER a CAS write (ADR-056 Decision 3).
 	req := gtypes.UpdateEntityWithTriplesRequest{
 		Entity:        &gtypes.EntityState{ID: entityID},
 		RemoveTriples: []string{predicate},
 		AddTriples:    objects,
+		OwnerToken:    ownerToken,
 	}
 	reqData, err := json.Marshal(req)
 	if err != nil {

--- a/processor/rule/triple_mutator.go
+++ b/processor/rule/triple_mutator.go
@@ -144,10 +144,11 @@ func (m *tripleMutator) RemoveTriple(ctx context.Context, ruleID, subject, predi
 //
 // ExpectedRevision is left zero: this is owned-current-state reconciliation,
 // NOT a CAS transition. The ownerToken parameter carries the pre-composed
-// lease token ("<owner>#<incarnation>" or just "<owner>" when the incarnation
-// is not available); it is stamped directly onto the request's OwnerToken field
-// for the graph-ingest lease check (a later increment). Token composition is
-// the caller's responsibility (ActionExecutor.executeReplaceOwned).
+// lease token "<owner>#<incarnation>", or the EMPTY string when the incarnation
+// is unavailable (the two-state contract — an empty token tells the graph-ingest
+// lease check to SKIP; it is never a bare "<owner>"). It is stamped directly
+// onto the request's OwnerToken field for the lease check (a later increment).
+// Token composition is the caller's responsibility (ActionExecutor.executeReplaceOwned).
 //
 // Unlike AddTriple/RemoveTriple, this checks resp.Success (NOT the body-prefix
 // convention) and surfaces the handler's ErrorCode on failure. On a

--- a/service/rule_pack_bind.go
+++ b/service/rule_pack_bind.go
@@ -62,6 +62,12 @@ func (m *Manager) ProjectionBinders() []ProjectionBinder {
 // per-pack bind error is logged and skipped — it never aborts boot. An owner id
 // is "rule-pack.<pack_id>"; the pack_id is validated subject-safe at config
 // time (rule.Config.Validate), so RegisterOwner cannot reject it on charset.
+//
+// ADR-056 PR-1: also calls SetProjectionIncarnation (if the binder implements
+// it) with ownerReg.Incarnation() so the pack's ActionExecutor can stamp the
+// full "<owner>#<incarnation>" OwnerToken on replace_owned mutation requests.
+// This is the only point where the process-local Registry incarnation is
+// reachable alongside the binders.
 func BindRulePackContracts(ctx context.Context, manager *Manager, ownerReg *ownership.Registry, hb *ownership.Heartbeater, logger *slog.Logger) {
 	if ownerReg == nil {
 		return
@@ -82,6 +88,13 @@ func BindRulePackContracts(ctx context.Context, manager *Manager, ownerReg *owne
 			continue
 		}
 		bound[packID] = struct{}{}
+
+		// ADR-056 PR-1: stamp the incarnation fence onto the binder BEFORE
+		// Start so initializeStateTracker forwards it to the ActionExecutor.
+		// Duck-typed to keep service→processor/rule free of a direct import.
+		if setter, ok := b.(interface{ SetProjectionIncarnation(string) }); ok {
+			setter.SetProjectionIncarnation(ownerReg.Incarnation())
+		}
 
 		if len(contracts) == 0 {
 			// A pack_id with no contracts declares ownership identity but emits


### PR DESCRIPTION
## What

PR-1 of the ADR-056 **OwnerToken write-lease** (deferred workstream #2). Pure, additive plumbing — **no runtime behavior change**. Adds the write-time owner-lease *token* to the wire so a later increment can compare/enforce it; this PR only stamps it.

- `OwnerToken` field (`omitempty`) on `UpdateEntityWithTriplesRequest` + `CreateEntityWithTriplesRequest`.
- `ErrorCodeOwnerLeaseStale` constant (defined-but-unused pending the reject increment).
- Per-process **incarnation fence**: a `crypto/rand` boot nonce on `Registry` (`Registry.Incarnation()`), stored on each `OwnerClaim` at `RegisterOwner`.
- Both owned-write producers stamp the token `"<owner>#<incarnation>"`:
  - rule `replace_owned` (threaded `rule_pack_bind → Processor → ActionExecutor → executeReplaceOwned`)
  - lifecycle `Manager` owned writes (`ownerToken()` helper under RLock)

## Token contract (two-state)

- **empty** = unowned / legacy writer → the deferred lease check **skips** it.
- **`"<owner>#<incarnation>"`** = compare against the live owner+incarnation (comparison/reject is a later PR).

The incarnation fence (Coby's call) catches a *same-owner-id, different-process* revived-stale writer at the write seam — a plain owner-id token would miss it.

## Note: token format supersedes the ADR sketch

The shipped lease handle is the **raw owner identity** + a crypto nonce (`<owner>#<incarnation>`), **not** `governance.RuleToken(owner_id)` (FNV) + a separate `process_instance_id`. The substrate already compares owners by exact id. ADR-056 amended with an implementation note (N3) so PR-2's comparison author works against the right spec.

## Review

go-reviewer: **APPROVE-WITH-NITS** (no BLOCKING/HIGH). Addressed in the second commit:
- **M1** rule path collapsed to the two-state contract (no bare `<owner>`).
- **M2** live-NATS integration test proving the production `tripleMutator` stamps `req.OwnerToken` (concrete `*natsclient.Client` can't be unit-mocked).
- **N1** genuine register-stamp integration test (real `RegisterOwner` → epoch read-back); tautological unit test downgraded to honest copy-semantics.
- **N3** ADR implementation note (above).

## Gates

`task lint`, full unit `-race`, `go vet -tags=integration`, `go vet -tags=live_llm`, and full integration `-race` on `processor/rule` + `pkg/ownership` — all green. Both new integration tests proven against real NATS.

Unrelated pre-existing substrate flake noted: `TestProcessor_DebounceZero_ImmediateProcessing` (testcontainer port-4222 mapping race under parallel load; passes in isolation; zero refs to touched code). Tracking-issue candidate, not in scope here.

## Sequence

This is step 1 of 5 (additive wire field → lease reader → observe-only check → Watch-revival quiesce → gated reject). PR-2 (graph-ingest `ClaimReader.OwnerOf`) stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)