### PR TITLE
feat(ownership): ADR-056 OwnerToken write-lease — PR-2 (ClaimReader.OwnerOf lease reader)

### DIFF
--- a/pkg/ownership/claim_reader.go
+++ b/pkg/ownership/claim_reader.go
@@ -108,6 +108,49 @@ func (cr *ClaimReader) ForeignEdgeMode(ctx context.Context, producer, predicate 
 	return claim.Mode, true, nil
 }
 
+// OwnerOf returns the owner id and the per-process incarnation nonce recorded
+// at RegisterOwner time for the OwnerClaim that, in an OWNING mode, governs
+// (entityID, predicate) — the read half of the ADR-056 write-time lease check.
+// ok=true means an owning claim was found; the caller (PR-3) compares the
+// returned (owner, incarnation) pair against the request's OwnerToken
+// "<owner>#<incarnation>" to detect a revived-stale writer.
+//
+// ok=false is returned (not an error) in three normal cases:
+//   - the predicate is unclaimed (no owning OwnerClaim covers it);
+//   - the entity does not match any registered pattern;
+//   - the registry is empty / absent (no RegisterOwner has run yet).
+//
+// The structure mirrors ForeignEdgeMode exactly: one epoch read per call,
+// ErrKVKeyNotFound treated as empty-registry (not an error), any other Get
+// error wrapped and returned.
+//
+// NOTE for PR-3: a returned incarnation MAY be "" even when ok=true — an owning
+// claim registered by a legacy / pre-fence owner carries no incarnation
+// (OwnerClaim.Incarnation is omitempty). The lease check must handle this
+// deliberately: a naive "<owner>#<incarnation>" string compare would never match
+// a fenced request token against an unfenced live owner. The consistent reading
+// is the two-state contract's fail-open — an empty live incarnation means the
+// lease is not enforceable for that owner, so SKIP the reject; do NOT fail-closed
+// and reject every legitimate write against a legacy owner.
+func (cr *ClaimReader) OwnerOf(ctx context.Context, entityID, predicate string) (owner, incarnation string, ok bool, err error) {
+	entry, err := cr.claims.Get(ctx, registryKey)
+	if err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return "", "", false, nil // empty registry: nothing claimed yet
+		}
+		return "", "", false, fmt.Errorf("ownership: read epoch for OwnerOf: %w", err)
+	}
+	ep, err := decodeEpoch(entry.Value)
+	if err != nil {
+		return "", "", false, err
+	}
+	o, inc, found := ep.ownerWithIncarnationOf(entityID, predicate)
+	if !found {
+		return "", "", false, nil
+	}
+	return o, inc, true, nil
+}
+
 // dedupeStrings returns the sorted, de-duplicated set of non-empty strings.
 func dedupeStrings(in []string) []string {
 	if len(in) == 0 {

--- a/pkg/ownership/claim_reader_owner_of_integration_test.go
+++ b/pkg/ownership/claim_reader_owner_of_integration_test.go
@@ -1,0 +1,116 @@
+//go:build integration
+
+package ownership
+
+import (
+	"context"
+	"testing"
+
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// TestIntegration_ClaimReader_OwnerOf proves the ADR-056 PR-2 lease-reader
+// seam: ClaimReader.OwnerOf resolves the LIVE owning claim's owner id and
+// per-process incarnation nonce from OWNER_CLAIMS, returning (owner,
+// incarnation, true, nil) for a covered (entityID, predicate) pair and
+// ("", "", false, nil) for unclaimed / pattern-miss / empty-registry cases.
+//
+// The test drives through the real NATS KV (testcontainer) and the production
+// RegisterOwner → ClaimReader.OwnerOf wire, so a deletion of the stamp loop
+// in RegisterOwner or the epoch read in OwnerOf would cause failures here.
+func TestIntegration_ClaimReader_OwnerOf(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	ctx := context.Background()
+
+	reg, err := EnsureBuckets(ctx, tc.Client, nil, nil)
+	if err != nil {
+		t.Fatalf("EnsureBuckets: %v", err)
+	}
+
+	cr, err := NewClaimReader(ctx, tc.Client, nil)
+	if err != nil {
+		t.Fatalf("NewClaimReader: %v", err)
+	}
+
+	// --- Case 1: empty / absent registry → ok=false, nil err (NOT an error). ---
+	owner, inc, ok, err := cr.OwnerOf(ctx, "c360.semconnect.systems.csapi.system.drone-001", "sensorml.process.label")
+	if err != nil {
+		t.Fatalf("OwnerOf on empty registry must not error: %v", err)
+	}
+	if ok || owner != "" || inc != "" {
+		t.Fatalf("OwnerOf on empty registry: got (%q,%q,%v), want (\"\",\"\",false)", owner, inc, ok)
+	}
+
+	// Register cs-api as the owning owner of sensorml.process.label on sysPat
+	// entities. The registry stamps its per-process incarnation onto the stored
+	// claim so OwnerOf can return it.
+	if err := reg.RegisterOwner(ctx, reg_("cs-api", sysPat, "sensorml.process.label")); err != nil {
+		t.Fatalf("RegisterOwner: %v", err)
+	}
+	wantIncarnation := reg.Incarnation()
+
+	// --- Case 2: matching entity + registered predicate → ok=true with owner + incarnation. ---
+	const inPatternEntity = "c360.semconnect.systems.csapi.system.drone-001"
+	owner, inc, ok, err = cr.OwnerOf(ctx, inPatternEntity, "sensorml.process.label")
+	if err != nil {
+		t.Fatalf("OwnerOf(claimed): unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("OwnerOf(claimed): ok=false, want true (registered owning claim should be found)")
+	}
+	if owner != "cs-api" {
+		t.Errorf("OwnerOf(claimed): owner = %q, want %q", owner, "cs-api")
+	}
+	if inc != wantIncarnation {
+		t.Errorf("OwnerOf(claimed): incarnation = %q, want the registry's per-process nonce %q", inc, wantIncarnation)
+	}
+
+	// --- Case 3: predicate NOT in the claim → ok=false (unclaimed). ---
+	owner, inc, ok, err = cr.OwnerOf(ctx, inPatternEntity, "other.predicate")
+	if err != nil {
+		t.Fatalf("OwnerOf(unclaimed predicate): unexpected error: %v", err)
+	}
+	if ok || owner != "" || inc != "" {
+		t.Fatalf("OwnerOf(unclaimed predicate): got (%q,%q,%v), want (\"\",\"\",false)", owner, inc, ok)
+	}
+
+	// --- Case 4: entity NOT matching the pattern → ok=false. ---
+	// sysPat = "c360.semconnect.systems.csapi.system.*" so a deployment entity
+	// does not match.
+	const outOfPatternEntity = "c360.semconnect.systems.csapi.deployment.deploy-001"
+	owner, inc, ok, err = cr.OwnerOf(ctx, outOfPatternEntity, "sensorml.process.label")
+	if err != nil {
+		t.Fatalf("OwnerOf(pattern miss): unexpected error: %v", err)
+	}
+	if ok || owner != "" || inc != "" {
+		t.Fatalf("OwnerOf(pattern miss): got (%q,%q,%v), want (\"\",\"\",false)", owner, inc, ok)
+	}
+
+	// --- Case 5: append-evidence mode claim → ok=false (non-owning; no lease). ---
+	// Register a second owner with an APPEND-EVIDENCE claim on the same entity
+	// space and a different predicate, confirming the non-owning mode is
+	// transparent to OwnerOf.
+	if err := reg.RegisterOwner(ctx, Registration{
+		Owner: "evidence-writer",
+		Claims: []OwnerClaim{
+			oc("evidence-writer", sysPat, ModeAppendEvidence, "web.backlink"),
+		},
+	}); err != nil {
+		t.Fatalf("RegisterOwner(append-evidence): %v", err)
+	}
+	owner, inc, ok, err = cr.OwnerOf(ctx, inPatternEntity, "web.backlink")
+	if err != nil {
+		t.Fatalf("OwnerOf(append-evidence): unexpected error: %v", err)
+	}
+	if ok || owner != "" || inc != "" {
+		t.Fatalf("OwnerOf(append-evidence): got (%q,%q,%v), want (\"\",\"\",false) — append-evidence has no owner", owner, inc, ok)
+	}
+}
+
+// reg_ is a local alias for the reg() helper (defined in
+// registry_integration_test.go) to avoid the name collision with the *Registry
+// variable named reg in the same test function. Both compile in the same
+// package under the integration build tag.
+func reg_(owner, pattern string, preds ...string) Registration {
+	return reg(owner, pattern, preds...)
+}

--- a/pkg/ownership/epoch.go
+++ b/pkg/ownership/epoch.go
@@ -163,8 +163,23 @@ func (e *epoch) foreignEdgeClaimFor(messageType, predicate string) (ForeignEdgeC
 // one owning owner per cell, so the order is immaterial for a well-formed
 // epoch.
 func (e *epoch) ownerOf(entityID, predicate string) (owner string, ok bool) {
-	for ownerID, entry := range e.Owners {
-		for _, c := range entry.Claims {
+	o, _, found := e.ownerWithIncarnationOf(entityID, predicate)
+	return o, found
+}
+
+// ownerWithIncarnationOf is the full-detail sibling of ownerOf: it returns the
+// owner id AND the Incarnation nonce recorded at RegisterOwner time for the
+// matching OwnerClaim. The incarnation is the "<owner>#<incarnation>" token
+// half that a later PR's write-time lease check compares against the incoming
+// request's OwnerToken (ADR-056 PR-2). ok is false when no owning claim covers
+// (entityID, predicate) — an un-claimed predicate or append-evidence cell.
+// Owners are iterated in SORTED order (matching foreignEdgeClaimFor) so the
+// result is deterministic — defense-in-depth for a lease lookup that feeds a
+// reject decision, should a malformed epoch ever carry two owning owners for a
+// cell; the overlap check guarantees at most one in a well-formed epoch.
+func (e *epoch) ownerWithIncarnationOf(entityID, predicate string) (owner, incarnation string, ok bool) {
+	for _, ownerID := range sortedOwners(e.Owners) {
+		for _, c := range e.Owners[ownerID].Claims {
 			if !c.Mode.isOwning() {
 				continue
 			}
@@ -173,10 +188,10 @@ func (e *epoch) ownerOf(entityID, predicate string) (owner string, ok bool) {
 			}
 			for _, p := range c.Predicates {
 				if p == predicate {
-					return ownerID, true
+					return ownerID, c.Incarnation, true
 				}
 			}
 		}
 	}
-	return "", false
+	return "", "", false
 }


### PR DESCRIPTION
## What

PR-2 of the ADR-056 **OwnerToken write-lease**. Small, **read-only** addition — nothing calls the new method yet except its integration test (no runtime behavior change). Gives graph-ingest the read half of the deferred lease check: resolve the LIVE owner + incarnation of an owned predicate cell, so PR-3 can compare it against the request's `OwnerToken` (`<owner>#<incarnation>`, PR-1).

- `ClaimReader.OwnerOf(ctx, entityID, predicate) (owner, incarnation string, ok bool, err error)` — mirrors the existing `ForeignEdgeMode` (one epoch read, `ErrKVKeyNotFound`→ok=false-not-error, owning-mode claims only; append-evidence never resolves).
- `epoch.ownerWithIncarnationOf` carries the matching logic; existing `epoch.ownerOf` now delegates to it (DRY, signature unchanged for existing callers). Iterates owners in **sorted** order (deterministic — defense-in-depth for a lease lookup feeding a reject decision).
- Integration test (real `RegisterOwner` → epoch → `OwnerOf`, 5 cases incl. exact-incarnation-equality and a genuine non-owning append-evidence claim).

**No graph-ingest change** — it already holds this `ClaimReader` (self-wired for `ForeignEdgeMode`).

## Carried forward to PR-3 (from go-reviewer)

- **Interface widening**: graph-ingest holds the reader behind a narrow `foreignEdgeClassifier` interface (`component.go:292`) that doesn't declare `OwnerOf`. PR-3 widens + renames it (keeps the seam mockable; better than a type-assert).
- **Empty-incarnation legacy owners**: `OwnerOf` may return `(owner, "", true, nil)` for a pre-fence owner. PR-3's lease check **fails open** on empty live incarnation (lease not enforceable → skip reject), never fail-closed. Documented on the method.

## Review

go-reviewer: **APPROVE-WITH-NITS** (no BLOCKING/HIGH). NIT-A (deterministic iteration) + NIT-B (empty-incarnation doc) applied in the amended commit.

## Gates

`task lint`, unit `-race`, `go vet -tags=integration`, integration `-race` (real NATS) — all green. No schema drift.

**Stacked on #289 (PR-1).** Step 2 of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)