### PR TITLE
feat(graph-ingest): ADR-056 OwnerToken write-lease — PR-3 (observe-only lease check)

### DIFF
--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -51,6 +51,9 @@ var (
 
 	foreignEdgeDroppedOnce sync.Once
 	foreignEdgeDroppedVec  *prometheus.CounterVec
+
+	ownerLeaseMismatchOnce sync.Once
+	ownerLeaseMismatchVec  *prometheus.CounterVec
 )
 
 // entityIDRegex validates entity ID format: org.platform.domain.system.type.instance
@@ -185,6 +188,30 @@ func getForeignEdgeDroppedMetric(registry *metric.MetricsRegistry) *prometheus.C
 	return foreignEdgeDroppedVec
 }
 
+// getOwnerLeaseMismatchMetric returns the process-wide counter for the
+// ADR-056 PR-3 observe-only lease check: an owned write whose OwnerToken does
+// not match the live owner claim's "<owner>#<incarnation>" at the graph-ingest
+// write seam. OBSERVE-ONLY — the write always commits in PR-3; the reject flip
+// is a later PR. Labels: message_type (dotted registry key; '_invalid' for
+// unregistered/zero) and predicate (the specific owned predicate whose live
+// incarnation differed). Mirrors getForeignEdgeUnclaimedMetric in structure.
+func getOwnerLeaseMismatchMetric(registry *metric.MetricsRegistry) *prometheus.CounterVec {
+	ownerLeaseMismatchOnce.Do(func() {
+		ownerLeaseMismatchVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "graph_ingest",
+			Name:      "owner_lease_mismatch_total",
+			Help:      "Observe-only count of owned writes whose OwnerToken did not match the live owner lease (ADR-056 PR-3; reject is a later PR — write always commits here). Labels: message_type, predicate.",
+		}, []string{"message_type", "predicate"})
+		if registry != nil {
+			_ = registry.RegisterCounterVec("graph-ingest", "owner_lease_mismatch_total", ownerLeaseMismatchVec)
+		} else {
+			_ = prometheus.DefaultRegisterer.Register(ownerLeaseMismatchVec)
+		}
+	})
+	return ownerLeaseMismatchVec
+}
+
 // Config holds configuration for graph-ingest component
 type Config struct {
 	Ports              *component.PortConfig `json:"ports" schema:"type:ports,description:Port configuration,category:basic"`
@@ -281,17 +308,28 @@ func (a *tripleAdderAdapter) AddTriple(ctx context.Context, triple message.Tripl
 	return a.component.AddTriple(ctx, triple)
 }
 
-// foreignEdgeClassifier classifies a producer's foreign-edge predicates against
-// the registered ForeignEdgeClaims (ADR-056 Decision 4). UnclaimedForeignEdges
-// returns the subset with no covering claim (the observe-only seam metric);
+// ownershipClaimReader classifies a producer's foreign-edge predicates and
+// resolves the live owner+incarnation for the ADR-056 write-time lease check.
+//
+// UnclaimedForeignEdges returns the subset of predicates with no covering
+// ForeignEdgeClaim (the observe-only seam metric, Decision 4).
+//
 // ForeignEdgeMode returns one predicate's covering EdgeMode so the routing seam
 // can branch (NoBirthStub→stub, Strict→drop, Conditional/Backfill→deferred).
-// *ownership.ClaimReader is the production implementation (one epoch read per
-// call); tests inject a fake. Kept as an interface so the seam is unit-testable
-// without NATS.
-type foreignEdgeClassifier interface {
+//
+// OwnerOf returns the live (owner, incarnation) recorded at RegisterOwner time
+// for the OwnerClaim that governs (entityID, predicate) in an owning mode
+// (Decision 2). ok=false means the predicate is unclaimed or append-evidence —
+// the lease check skips it. incarnation may be "" even when ok=true for a
+// legacy/pre-fence claim; the PR-3 check MUST fail-open in that case (do NOT
+// reject — the lease is not enforceable against a legacy owner).
+//
+// *ownership.ClaimReader is the production implementation; tests inject a fake.
+// Kept as an interface so all seams are unit-testable without NATS.
+type ownershipClaimReader interface {
 	UnclaimedForeignEdges(ctx context.Context, producer string, predicates []string) ([]string, error)
 	ForeignEdgeMode(ctx context.Context, producer, predicate string) (ownership.EdgeMode, bool, error)
+	OwnerOf(ctx context.Context, entityID, predicate string) (owner, incarnation string, ok bool, err error)
 }
 
 // Component implements the graph-ingest processor
@@ -311,13 +349,13 @@ type Component struct {
 	suffixBucket *natsclient.KVStore            // KV suffix index: suffix → fullID
 	suffixCache  cache.Cache[string]            // TTL cache for suffix resolution
 
-	// ADR-056 Decision-4 T2-seam: read-only view of registered ForeignEdgeClaims.
-	// nil when OWNER_CLAIMS is absent (resourceless/unmigrated deploy) — the seam
-	// then skips classification (observe-only graceful-skip). An interface so the
-	// seam is unit-testable with a fake; *ownership.ClaimReader is production.
-	// foreignEdgeWarnedKeys dedupes the one-time WARN per (message_type|predicate)
-	// so an unclaimed producer logs once, not per message.
-	claimReader           foreignEdgeClassifier
+	// ADR-056 Decision-4 T2-seam + PR-3 owner-lease check: read-only view of
+	// registered ForeignEdgeClaims and owning OwnerClaims. nil when OWNER_CLAIMS
+	// is absent (resourceless/unmigrated deploy) — both seams graceful-skip.
+	// An interface so seams are unit-testable with a fake; *ownership.ClaimReader
+	// is production. foreignEdgeWarnedKeys dedupes the one-time WARN per
+	// (message_type|predicate) so an unclaimed producer logs once, not per message.
+	claimReader           ownershipClaimReader
 	foreignEdgeWarnedKeys sync.Map
 
 	// Inference components
@@ -343,6 +381,7 @@ type Component struct {
 	mutationRejections     *prometheus.CounterVec
 	foreignEdgeUnclaimed   *prometheus.CounterVec
 	foreignEdgeDropped     *prometheus.CounterVec
+	ownerLeaseMismatch     *prometheus.CounterVec // ADR-056 PR-3 observe-only lease-mismatch counter
 	metricsRegistry        *metric.MetricsRegistry
 
 	// Lifecycle reporting
@@ -391,6 +430,7 @@ func CreateGraphIngest(rawConfig json.RawMessage, deps component.Dependencies) (
 		mutationRejections:     getMutationRejectionsMetric(deps.MetricsRegistry),
 		foreignEdgeUnclaimed:   getForeignEdgeUnclaimedMetric(deps.MetricsRegistry),
 		foreignEdgeDropped:     getForeignEdgeDroppedMetric(deps.MetricsRegistry),
+		ownerLeaseMismatch:     getOwnerLeaseMismatchMetric(deps.MetricsRegistry),
 		metricsRegistry:        deps.MetricsRegistry,
 	}
 
@@ -1268,6 +1308,73 @@ func (c *Component) classifyForeignEdges(ctx context.Context, mt message.Type, f
 			c.logger.Warn("graph-ingest: foreign-subject edge has no registered ForeignEdgeClaim — routed deprecated-on-arrival (ADR-056 Decision 4; register a claim before the must-exist flip)",
 				slog.String("message_type", label),
 				slog.String("predicate", p))
+		}
+	}
+}
+
+// checkOwnerLease is the ADR-056 PR-3 observe-only lease check. It inspects
+// each owned predicate being written against the live OwnerClaim in the registry
+// and emits owner_lease_mismatch_total + a Warn when the request's OwnerToken
+// does not match the live "<owner>#<incarnation>". The write ALWAYS COMMITS —
+// this is strictly observe-only; the reject flip is PR-5.
+//
+// ownedPredicates is the deduped set of owned-write predicates for this request
+// (own/addOwn predicates + RemoveTriples predicates on the update lanes).
+// messageType is the bounded metric label (registry key or "_invalid").
+//
+// Two-state contract:
+//   - ownerToken == ""  → skip (legacy/unowned writer; the single agreed skip signal).
+//   - claimReader == nil → skip (resourceless/unmigrated deploy graceful-skip).
+//
+// Per-predicate:
+//   - err != nil  → Warn + return (fail-open, never block on a reader blip).
+//   - ok == false → continue (unclaimed/append-evidence — not lease-governed).
+//   - ok == true && incarnation == "" → fail-open (legacy/pre-fence owner; lease
+//     not enforceable — do NOT emit metric, do NOT Warn, do NOT reject).
+//   - ok == true && incarnation != "" → compare ownerToken vs "<owner>#<incarnation>";
+//     mismatch → increment metric + Warn, then continue (OBSERVE-ONLY).
+func (c *Component) checkOwnerLease(ctx context.Context, entityID, messageType, ownerToken string, ownedPredicates []string) {
+	// Two-state skip.
+	if ownerToken == "" {
+		return
+	}
+	if c.claimReader == nil {
+		return
+	}
+	if len(ownedPredicates) == 0 {
+		return
+	}
+
+	for _, pred := range ownedPredicates {
+		owner, incarnation, ok, err := c.claimReader.OwnerOf(ctx, entityID, pred)
+		if err != nil {
+			// Fail-open: a transient reader blip must never block a write.
+			c.logger.Warn("graph-ingest: owner-lease read failed — skipping lease check for this predicate (observe-only fail-open)",
+				slog.String("entity_id", entityID),
+				slog.String("predicate", pred),
+				slog.String("message_type", messageType),
+				slog.Any("error", err))
+			return
+		}
+		if !ok {
+			// Unclaimed / append-evidence — not lease-governed.
+			continue
+		}
+		if incarnation == "" {
+			// Legacy/pre-fence owning claim: the lease is not enforceable.
+			// Fail-open — no metric, no Warn, no reject.
+			continue
+		}
+		// Compare the request token against the live "<owner>#<incarnation>".
+		expected := owner + "#" + incarnation
+		if ownerToken != expected {
+			c.ownerLeaseMismatch.WithLabelValues(messageType, pred).Inc()
+			c.logger.Warn("graph-ingest: OwnerToken mismatch — write proceeds (observe-only; reject is PR-5)",
+				slog.String("entity_id", entityID),
+				slog.String("predicate", pred),
+				slog.String("message_type", messageType),
+				slog.String("owner_token", ownerToken),
+				slog.String("expected_token", expected))
 		}
 	}
 }

--- a/processor/graph-ingest/foreign_edge_seam_test.go
+++ b/processor/graph-ingest/foreign_edge_seam_test.go
@@ -14,18 +14,27 @@ import (
 	"github.com/c360studio/semstreams/pkg/ownership"
 )
 
-// fakeClassifier is an injected foreignEdgeClassifier for unit-testing the
-// T2-seam (ADR-056 Decision 4) without NATS. It records what the seam asked and
-// returns a configured unclaimed set + per-predicate EdgeMode. A predicate
-// absent from `modes` is reported UNCLAIMED by ForeignEdgeMode (ok=false), so
-// the observe-only seam tests (which configure only `unclaimed`) keep routing
-// unchanged.
+// fakeClassifier is an injected ownershipClaimReader for unit-testing the
+// T2-seam (ADR-056 Decision 4) and the PR-3 owner-lease check without NATS. It
+// records what the seam asked and returns a configured unclaimed set, per-predicate
+// EdgeMode, and per-predicate OwnerOf results. A predicate absent from `modes` is
+// reported UNCLAIMED by ForeignEdgeMode (ok=false), and absent from `owners` is
+// reported unclaimed by OwnerOf (ok=false), so the observe-only seam tests (which
+// configure only `unclaimed`) keep routing unchanged.
 type fakeClassifier struct {
 	unclaimed   map[string]bool               // predicate -> reported unclaimed (UnclaimedForeignEdges)
 	modes       map[string]ownership.EdgeMode // predicate -> covering mode (ForeignEdgeMode; absent = unclaimed)
+	owners      map[string]fakeOwnerEntry     // predicate -> OwnerOf result (absent = ok=false)
 	err         error
 	gotProducer string
 	gotPreds    []string
+}
+
+// fakeOwnerEntry is the result fakeClassifier.OwnerOf returns for a predicate.
+type fakeOwnerEntry struct {
+	owner       string
+	incarnation string
+	err         error
 }
 
 func (f *fakeClassifier) UnclaimedForeignEdges(_ context.Context, producer string, preds []string) ([]string, error) {
@@ -50,6 +59,16 @@ func (f *fakeClassifier) ForeignEdgeMode(_ context.Context, producer, predicate 
 	}
 	m, ok := f.modes[predicate]
 	return m, ok, nil
+}
+
+func (f *fakeClassifier) OwnerOf(_ context.Context, _, predicate string) (owner, incarnation string, ok bool, err error) {
+	if entry, found := f.owners[predicate]; found {
+		if entry.err != nil {
+			return "", "", false, entry.err
+		}
+		return entry.owner, entry.incarnation, true, nil
+	}
+	return "", "", false, nil
 }
 
 // The seam meters an unclaimed foreign edge, leaves a claimed one quiet, never

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -437,6 +437,12 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 	own, foreign := c.normalizeProjection(ctx, req.Entity.ID, req.Entity.MessageType, req.Entity.Triples)
 	req.Entity.Triples = own
 
+	// ADR-056 PR-3: observe-only owner-lease check. The owned-predicate set is
+	// the own-subject triples after normalizeProjection (the non-foreign portion
+	// committed to the primary). Write ALWAYS commits — never blocks here.
+	c.checkOwnerLease(ctx, req.Entity.ID, labelForMessageType(req.Entity.MessageType), req.OwnerToken,
+		predicatesOf(own))
+
 	// ADR-054 channel (b): stamp an explicitly declared indexing profile from
 	// the mutation envelope (highest precedence). Empty/invalid is ignored and
 	// the createEntity seam applies the fallback floor instead.
@@ -650,6 +656,15 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	// deltas are single-subject; cs-api's singleSubject guard blocks multi-subject).
 	addOwn, foreign := c.normalizeProjection(ctx, req.Entity.ID, req.Entity.MessageType, req.AddTriples)
 	req.AddTriples = addOwn
+
+	// ADR-056 PR-3: observe-only owner-lease check. The owned-predicate set is
+	// the union of own add-triples predicates (the replace-merge set) and
+	// remove-triples predicates (a predicate named only in RemoveTriples is the
+	// owned cell being cleared — the write targets that owned predicate even
+	// though no new triple is added for it). Deduped by checkOwnerLease's loop.
+	// Write ALWAYS commits — never blocks here.
+	c.checkOwnerLease(ctx, req.Entity.ID, labelForMessageType(req.Entity.MessageType), req.OwnerToken,
+		dedupePredicates(predicatesOf(addOwn), req.RemoveTriples))
 
 	// ADR-049: CAS-on-condition path. Non-zero ExpectedRevision means
 	// the caller requires the entity's current KV revision to match
@@ -943,6 +958,62 @@ func (c *Component) fetchEntityState(ctx context.Context, entityID string) (*gra
 		return nil, 0, fmt.Errorf("unmarshal entity state: %w", err)
 	}
 	return &state, entry.Revision, nil
+}
+
+// predicatesOf extracts the Predicate strings from a triple slice, for use in
+// the owner-lease check's owned-predicate set computation.
+func predicatesOf(triples []message.Triple) []string {
+	if len(triples) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(triples))
+	for _, t := range triples {
+		if t.Predicate != "" {
+			out = append(out, t.Predicate)
+		}
+	}
+	return out
+}
+
+// dedupePredicates merges two predicate slices and returns a deduped result,
+// preserving the first appearance of each predicate. Used by checkOwnerLease to
+// build the union of add-triples and remove-triples predicate sets.
+func dedupePredicates(a, b []string) []string {
+	total := len(a) + len(b)
+	if total == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, total)
+	out := make([]string, 0, total)
+	for _, s := range a {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; !dup {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	for _, s := range b {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; !dup {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// labelForMessageType returns a metric-safe label for the given MessageType:
+// the dotted Key() when valid, or "_invalid" when zero/unregistered (cardinality
+// guard matching the existing foreign-edge metric convention).
+func labelForMessageType(mt message.Type) string {
+	if mt.IsValid() {
+		return mt.Key()
+	}
+	return invalidMessageTypeLabel
 }
 
 // Per-response-shape error marshalers. The body-prefix error

--- a/processor/graph-ingest/owner_lease_check_integration_test.go
+++ b/processor/graph-ingest/owner_lease_check_integration_test.go
@@ -1,0 +1,244 @@
+//go:build integration
+
+package graphingest
+
+// Integration tests for ADR-056 PR-3: observe-only owner-lease check at the
+// graph-ingest write seam. These drive the production wire end-to-end:
+//
+//  1. ownership.EnsureBuckets → real OWNER_CLAIMS bucket
+//  2. registry.RegisterOwner → OWNING OwnerClaim stamped with live incarnation
+//  3. graph-ingest Start() self-wires a real ClaimReader against the bucket
+//  4. The three owned-write lanes are driven directly (handleEntityCreate...
+//     / handleEntityUpdate...) so we can assert metric deltas + committed state.
+//
+// The observe-only invariant: in EVERY case the write commits (Success=true
+// and the entity reads back updated). The metric fires ONLY on a stale token;
+// matching and empty tokens are silent.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/ownership"
+)
+
+// bootIngestWithOwnerClaim creates a real NATS + OWNER_CLAIMS, registers an
+// OWNING OwnerClaim (ModeReplaceOwned) for (ownerID, entityPattern, pred),
+// then boots a graph-ingest Component that self-wires the real ClaimReader.
+// Returns the component, the registry (so callers can read Incarnation()), and ctx.
+func bootIngestWithOwnerClaim(
+	t *testing.T, ownerID, entityPattern, pred string,
+) (*Component, *ownership.Registry, context.Context) {
+	t.Helper()
+	ctx := context.Background()
+	streams := []natsclient.TestStreamConfig{{Name: "ENTITY", Subjects: []string{"entity.>"}}}
+	tc := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+
+	// EnsureBuckets creates OWNER_CLAIMS + OWNER_PRESENCE; returns a registry
+	// with a per-process incarnation nonce.
+	reg, err := ownership.EnsureBuckets(ctx, tc.Client, nil, nil)
+	require.NoError(t, err, "EnsureBuckets (OWNER_CLAIMS + OWNER_PRESENCE)")
+
+	// Register an OWNING claim for (ownerID, entityPattern, pred).
+	require.NoError(t, reg.RegisterOwner(ctx, ownership.Registration{
+		Owner: ownerID,
+		Claims: []ownership.OwnerClaim{
+			{
+				Owner:      ownerID,
+				Pattern:    entityPattern,
+				Predicates: []string{pred},
+				Mode:       ownership.ModeReplaceOwned,
+			},
+		},
+	}))
+
+	// Boot graph-ingest; Start() self-wires the real ClaimReader.
+	configJSON, err := json.Marshal(DefaultConfig())
+	require.NoError(t, err)
+	comp, err := CreateGraphIngest(configJSON, component.Dependencies{NATSClient: tc.Client})
+	require.NoError(t, err)
+	c := comp.(*Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Stop(5 * time.Second) })
+
+	require.NotNil(t, c.claimReader,
+		"Start must self-wire the claim reader once OWNER_CLAIMS exists (PR-3 boot check)")
+	return c, reg, ctx
+}
+
+// ownerToken builds the fenced token "<owner>#<incarnation>".
+func ownerToken(ownerID, incarnation string) string { return ownerID + "#" + incarnation }
+
+const (
+	intOwnerID   = "mission-planner"
+	intEntityPat = "*.*.test.sys.w.*"
+	intPred      = "mission.phase"
+)
+
+var intMT = message.Type{Domain: "test", Category: "integration", Version: "v1"}
+
+// ─── create_with_triples ──────────────────────────────────────────────────────
+
+// TestIntegration_OwnerLease_CreateWithTriples_MatchingToken proves that a
+// matching OwnerToken on create_with_triples produces no metric increment AND
+// the write commits (Success=true, entity readable).
+func TestIntegration_OwnerLease_CreateWithTriples_MatchingToken(t *testing.T) {
+	c, reg, ctx := bootIngestWithOwnerClaim(t, intOwnerID, intEntityPat, intPred)
+	label := labelForMessageType(intMT)
+	token := ownerToken(intOwnerID, reg.Incarnation())
+
+	eid := "c360.platform.test.sys.w.match"
+	before := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: eid, MessageType: intMT},
+		Triples: []message.Triple{
+			{Subject: eid, Predicate: intPred, Object: "planning", Timestamp: time.Now(), Confidence: 1},
+		},
+		OwnerToken: token,
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := c.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, handlerErr)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "matching token: write must commit: %s", resp.Error)
+
+	after := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+	assert.InDelta(t, before, after, 0.0001,
+		"matching OwnerToken on create_with_triples must NOT increment owner_lease_mismatch_total")
+}
+
+// TestIntegration_OwnerLease_CreateWithTriples_StaleToken proves that a stale
+// OwnerToken (same owner, dead incarnation) increments the metric BUT the write
+// still commits (observe-only).
+func TestIntegration_OwnerLease_CreateWithTriples_StaleToken(t *testing.T) {
+	c, _, ctx := bootIngestWithOwnerClaim(t, intOwnerID, intEntityPat, intPred)
+	label := labelForMessageType(intMT)
+	stale := ownerToken(intOwnerID, "deadbeef-stale-0000") // not the live incarnation
+
+	eid := "c360.platform.test.sys.w.stale"
+	before := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: eid, MessageType: intMT},
+		Triples: []message.Triple{
+			{Subject: eid, Predicate: intPred, Object: "active", Timestamp: time.Now(), Confidence: 1},
+		},
+		OwnerToken: stale,
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := c.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, handlerErr)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	// Observe-only: write MUST commit even with stale token.
+	require.True(t, resp.Success, "observe-only: write must commit with stale token: %s", resp.Error)
+
+	// Metric must have fired.
+	after := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+	assert.InDelta(t, before+1, after, 0.0001,
+		"stale OwnerToken on create_with_triples must increment owner_lease_mismatch_total")
+
+	// Entity must be readable with the written value.
+	stored, _, readErr := c.fetchEntityState(ctx, eid)
+	require.NoError(t, readErr, "written entity must be readable after observe-only stale-token write")
+	assert.True(t, hasPredicate(stored, intPred),
+		"entity must contain the written predicate after observe-only stale-token write")
+}
+
+// TestIntegration_OwnerLease_CreateWithTriples_EmptyToken proves the legacy-
+// writer skip: empty OwnerToken → no metric, write commits.
+func TestIntegration_OwnerLease_CreateWithTriples_EmptyToken(t *testing.T) {
+	c, _, ctx := bootIngestWithOwnerClaim(t, intOwnerID, intEntityPat, intPred)
+	label := labelForMessageType(intMT)
+
+	eid := "c360.platform.test.sys.w.empty"
+	before := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: eid, MessageType: intMT},
+		Triples: []message.Triple{
+			{Subject: eid, Predicate: intPred, Object: "legacy", Timestamp: time.Now(), Confidence: 1},
+		},
+		OwnerToken: "", // empty = legacy/unowned writer
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := c.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, handlerErr)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "empty token: write must commit: %s", resp.Error)
+
+	after := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+	assert.InDelta(t, before, after, 0.0001,
+		"empty OwnerToken (legacy writer) must NOT increment owner_lease_mismatch_total")
+}
+
+// ─── update_with_triples (non-CAS) ───────────────────────────────────────────
+
+// TestIntegration_OwnerLease_UpdateWithTriples_StaleToken proves the observe-only
+// invariant on the update_with_triples lane: stale token → metric fires, write
+// commits.
+func TestIntegration_OwnerLease_UpdateWithTriples_StaleToken(t *testing.T) {
+	c, _, ctx := bootIngestWithOwnerClaim(t, intOwnerID, intEntityPat, intPred)
+	label := labelForMessageType(intMT)
+	stale := ownerToken(intOwnerID, "deadbeef-stale-upd0")
+
+	eid := "c360.platform.test.sys.w.upd1"
+	// Pre-create.
+	require.NoError(t, c.CreateEntity(ctx, &graph.EntityState{
+		ID: eid, MessageType: intMT, Version: 1, UpdatedAt: time.Now(),
+		Triples: []message.Triple{{Subject: eid, Predicate: intPred, Object: "init", Timestamp: time.Now(), Confidence: 1}},
+	}))
+
+	before := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:     &graph.EntityState{ID: eid, MessageType: intMT},
+		AddTriples: []message.Triple{{Subject: eid, Predicate: intPred, Object: "updated", Timestamp: time.Now(), Confidence: 1}},
+		OwnerToken: stale,
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := c.handleEntityUpdateWithTriples(ctx, data)
+	require.NoError(t, handlerErr)
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	// Observe-only: write MUST commit.
+	require.True(t, resp.Success, "observe-only: update must commit with stale token: %s", resp.Error)
+
+	after := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+	assert.InDelta(t, before+1, after, 0.0001,
+		"stale OwnerToken on update_with_triples must increment owner_lease_mismatch_total")
+
+	// Read back — value must be updated.
+	stored, _, readErr := c.fetchEntityState(ctx, eid)
+	require.NoError(t, readErr)
+	var updatedValue string
+	for _, tr := range stored.Triples {
+		if tr.Predicate == intPred {
+			updatedValue = tr.Object.(string)
+		}
+	}
+	assert.Equal(t, "updated", updatedValue,
+		"entity predicate must reflect the written value after observe-only stale-token update")
+}

--- a/processor/graph-ingest/owner_lease_check_test.go
+++ b/processor/graph-ingest/owner_lease_check_test.go
@@ -1,0 +1,323 @@
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests for checkOwnerLease (ADR-056 PR-3, observe-only)
+// ---------------------------------------------------------------------------
+//
+// All tests use a fakeClassifier (defined in foreign_edge_seam_test.go) as the
+// injected ownershipClaimReader so no NATS is needed. checkOwnerLease is a
+// void method; writes always commit. Tests assert metric delta only.
+
+const (
+	leaseEntityID    = "c360.platform.test.sys.widget.001"
+	leasePred        = "mission.phase"
+	leaseOwner       = "mission-planner"
+	leaseIncarnation = "deadbeef01234567"
+)
+
+// liveToken returns the token a fenced writer would stamp.
+func liveToken() string { return leaseOwner + "#" + leaseIncarnation }
+
+// staleToken returns a token with the same owner but a different incarnation.
+func staleToken() string { return leaseOwner + "#cafebabe00000000" }
+
+// leaseFake builds a fakeClassifier whose OwnerOf for predicate `pred` returns
+// (owner, incarnation, ok=true). Other predicates return ok=false.
+func leaseFake(pred, owner, incarnation string) *fakeClassifier {
+	return &fakeClassifier{
+		owners: map[string]fakeOwnerEntry{
+			pred: {owner: owner, incarnation: incarnation},
+		},
+	}
+}
+
+// TestCheckOwnerLease_MatchingToken_NoMetric verifies that a matching
+// OwnerToken does not increment the mismatch counter.
+func TestCheckOwnerLease_MatchingToken_NoMetric(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.claimReader = leaseFake(leasePred, leaseOwner, leaseIncarnation)
+	label := "test.rule.v1"
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+	comp.checkOwnerLease(context.Background(), leaseEntityID, label, liveToken(), []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+
+	assert.InDelta(t, before, after, 0.0001, "a matching OwnerToken must NOT increment owner_lease_mismatch_total")
+}
+
+// TestCheckOwnerLease_StaleToken_MetricIncremented verifies that a stale
+// OwnerToken increments the counter. The helper is void — write always commits.
+func TestCheckOwnerLease_StaleToken_MetricIncremented(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.claimReader = leaseFake(leasePred, leaseOwner, leaseIncarnation)
+	label := "test.rule.v1"
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+	comp.checkOwnerLease(context.Background(), leaseEntityID, label, staleToken(), []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+
+	assert.InDelta(t, before+1, after, 0.0001, "a stale OwnerToken must increment owner_lease_mismatch_total{message_type,predicate}")
+}
+
+// TestCheckOwnerLease_EmptyToken_Skip verifies that an empty OwnerToken
+// (legacy/unowned writer) is skipped under the two-state contract: no metric.
+func TestCheckOwnerLease_EmptyToken_Skip(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	fake := leaseFake(leasePred, leaseOwner, leaseIncarnation)
+	comp.claimReader = fake
+	label := "test.rule.v1"
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+	comp.checkOwnerLease(context.Background(), leaseEntityID, label, "", []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+
+	// The empty-token early return is proven by the absence of a metric: had the
+	// check proceeded, this fake holds a matching owning claim, so a non-empty
+	// stale token would fire — an empty token must not.
+	assert.InDelta(t, before, after, 0.0001, "an empty OwnerToken must skip the check entirely (no metric)")
+}
+
+// TestCheckOwnerLease_NilReader_Skip verifies graceful-skip when no reader is
+// wired (resourceless/unmigrated deploy).
+func TestCheckOwnerLease_NilReader_Skip(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.claimReader = nil
+	label := "test.rule.v1"
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+	comp.checkOwnerLease(context.Background(), leaseEntityID, label, liveToken(), []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+
+	assert.InDelta(t, before, after, 0.0001, "a nil claimReader must graceful-skip (no metric, no panic)")
+}
+
+// TestCheckOwnerLease_UnclaimedPredicate_Skip verifies that a predicate with
+// no owning claim (ok=false) is not metered.
+func TestCheckOwnerLease_UnclaimedPredicate_Skip(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	// Empty owners map → OwnerOf returns ok=false for every predicate.
+	comp.claimReader = &fakeClassifier{owners: map[string]fakeOwnerEntry{}}
+	label := "test.rule.v1"
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+	comp.checkOwnerLease(context.Background(), leaseEntityID, label, staleToken(), []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+
+	assert.InDelta(t, before, after, 0.0001, "an unclaimed predicate (ok=false) must not be metered")
+}
+
+// TestCheckOwnerLease_LegacyEmptyIncarnation_FailOpen proves the critical
+// two-state contract: ok=true, incarnation="" → the live owner is legacy/
+// pre-fence, lease is not enforceable → FAIL OPEN (no metric, no Warn, no
+// reject). A naive compare would always mismatch against a fenced token.
+func TestCheckOwnerLease_LegacyEmptyIncarnation_FailOpen(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	// ok=true, incarnation="" → legacy owner, lease not enforceable.
+	comp.claimReader = leaseFake(leasePred, leaseOwner, "")
+	label := "test.rule.v1"
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+	// Provide a non-empty fenced token — a naive compare would mismatch.
+	comp.checkOwnerLease(context.Background(), leaseEntityID, label, liveToken(), []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+
+	assert.InDelta(t, before, after, 0.0001,
+		"ok=true but empty incarnation (legacy owner) must fail-open: no metric")
+}
+
+// TestCheckOwnerLease_ReaderError_FailOpen verifies that a transient OwnerOf
+// error causes fail-open: no metric, no blocking.
+func TestCheckOwnerLease_ReaderError_FailOpen(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.claimReader = &fakeClassifier{
+		owners: map[string]fakeOwnerEntry{
+			leasePred: {err: assertErr},
+		},
+	}
+	label := "test.rule.v1"
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+	comp.checkOwnerLease(context.Background(), leaseEntityID, label, staleToken(), []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+
+	assert.InDelta(t, before, after, 0.0001, "a reader error must fail-open: no metric")
+}
+
+// ---------------------------------------------------------------------------
+// Lane-wiring tests: verify checkOwnerLease is reachable from each handler.
+// ---------------------------------------------------------------------------
+
+// TestOwnerLease_CreateWithTriples_StaleToken_MetricAndCommits drives
+// handleEntityCreateWithTriples with a stale OwnerToken: verifies the
+// mismatch metric fires AND the write commits (Success=true).
+func TestOwnerLease_CreateWithTriples_StaleToken_MetricAndCommits(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	mt := message.Type{Domain: "test", Category: "lease", Version: "v1"}
+	pred := "mission.phase"
+	comp.claimReader = leaseFake(pred, leaseOwner, leaseIncarnation)
+
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: "c360.test.lease.sys.w.crt1", MessageType: mt},
+		Triples: []message.Triple{
+			{Subject: "c360.test.lease.sys.w.crt1", Predicate: pred, Object: "planning"},
+		},
+		OwnerToken: staleToken(),
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	label := mt.Key()
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+
+	respData, handlerErr := comp.handleEntityCreateWithTriples(context.Background(), data)
+	require.NoError(t, handlerErr, "handler must never return a blocking error")
+
+	// The write must commit.
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	assert.True(t, resp.Success, "observe-only: write must commit even with stale token: %s", resp.Error)
+
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+	assert.InDelta(t, before+1, after, 0.0001,
+		"create_with_triples: stale OwnerToken must increment owner_lease_mismatch_total")
+}
+
+// TestOwnerLease_UpdateWithTriples_StaleToken_MetricAndCommits drives
+// handleEntityUpdateWithTriples (non-CAS) with a stale token.
+func TestOwnerLease_UpdateWithTriples_StaleToken_MetricAndCommits(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	mt := message.Type{Domain: "test", Category: "lease", Version: "v1"}
+	pred := "mission.phase"
+	eid := "c360.test.lease.sys.w.upd1"
+	comp.claimReader = leaseFake(pred, leaseOwner, leaseIncarnation)
+
+	// Pre-create so update_with_triples finds a must-exist entity.
+	require.NoError(t, comp.CreateEntity(context.Background(), &graph.EntityState{
+		ID: eid, MessageType: mt, Version: 1,
+		Triples: []message.Triple{{Subject: eid, Predicate: pred, Object: "init"}},
+	}))
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:     &graph.EntityState{ID: eid, MessageType: mt},
+		AddTriples: []message.Triple{{Subject: eid, Predicate: pred, Object: "planning"}},
+		OwnerToken: staleToken(),
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	label := mt.Key()
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+
+	respData, handlerErr := comp.handleEntityUpdateWithTriples(context.Background(), data)
+	require.NoError(t, handlerErr, "handler must never return a blocking error")
+
+	// The write must commit.
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	assert.True(t, resp.Success, "observe-only: write must commit even with stale token: %s", resp.Error)
+
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+	assert.InDelta(t, before+1, after, 0.0001,
+		"update_with_triples: stale OwnerToken must increment owner_lease_mismatch_total")
+}
+
+// TestOwnerLease_UpdateWithTriplesCAS_StaleToken_MetricAndCommits drives the
+// CAS path (ExpectedRevision > 0) with a stale token.
+func TestOwnerLease_UpdateWithTriplesCAS_StaleToken_MetricAndCommits(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	mt := message.Type{Domain: "test", Category: "lease", Version: "v1"}
+	pred := "mission.phase"
+	eid := "c360.test.lease.sys.w.cas1"
+	comp.claimReader = leaseFake(pred, leaseOwner, leaseIncarnation)
+
+	// Pre-create and capture the revision.
+	require.NoError(t, comp.CreateEntity(context.Background(), &graph.EntityState{
+		ID: eid, MessageType: mt, Version: 1,
+		Triples: []message.Triple{{Subject: eid, Predicate: pred, Object: "init"}},
+	}))
+	_, rev, err := comp.fetchEntityState(context.Background(), eid)
+	require.NoError(t, err)
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:           &graph.EntityState{ID: eid, MessageType: mt},
+		AddTriples:       []message.Triple{{Subject: eid, Predicate: pred, Object: "active"}},
+		ExpectedRevision: rev,
+		OwnerToken:       staleToken(),
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	label := mt.Key()
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+
+	respData, handlerErr := comp.handleEntityUpdateWithTriples(context.Background(), data)
+	require.NoError(t, handlerErr, "handler must never return a blocking error")
+
+	// The write must commit.
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	assert.True(t, resp.Success, "observe-only: write must commit even with stale token on CAS lane: %s", resp.Error)
+
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+	assert.InDelta(t, before+1, after, 0.0001,
+		"update_with_triples CAS lane: stale OwnerToken must increment owner_lease_mismatch_total")
+}
+
+// TestOwnerLease_EmptyToken_AllLanes_NoMetric verifies the legacy-writer skip:
+// empty OwnerToken on all three owned-write lanes → no mismatch metric.
+func TestOwnerLease_EmptyToken_AllLanes_NoMetric(t *testing.T) {
+	mt := message.Type{Domain: "test", Category: "lease", Version: "v1"}
+	label := mt.Key()
+	pred := "mission.phase"
+
+	// create_with_triples
+	{
+		comp := createTestComponentWithMockKV(t)
+		comp.claimReader = leaseFake(pred, leaseOwner, leaseIncarnation)
+		eid := "c360.test.lease.sys.w.emp1"
+		req := graph.CreateEntityWithTriplesRequest{
+			Entity:     &graph.EntityState{ID: eid, MessageType: mt},
+			Triples:    []message.Triple{{Subject: eid, Predicate: pred, Object: "x"}},
+			OwnerToken: "",
+		}
+		data, _ := json.Marshal(req)
+		before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+		_, _ = comp.handleEntityCreateWithTriples(context.Background(), data)
+		after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+		assert.InDelta(t, before, after, 0.0001, "create_with_triples: empty OwnerToken → no mismatch metric")
+	}
+
+	// update_with_triples (non-CAS)
+	{
+		comp := createTestComponentWithMockKV(t)
+		comp.claimReader = leaseFake(pred, leaseOwner, leaseIncarnation)
+		eid := "c360.test.lease.sys.w.emp2"
+		require.NoError(t, comp.CreateEntity(context.Background(), &graph.EntityState{
+			ID: eid, MessageType: mt, Version: 1,
+			Triples: []message.Triple{{Subject: eid, Predicate: pred, Object: "init"}},
+		}))
+		req := graph.UpdateEntityWithTriplesRequest{
+			Entity:     &graph.EntityState{ID: eid, MessageType: mt},
+			AddTriples: []message.Triple{{Subject: eid, Predicate: pred, Object: "updated"}},
+			OwnerToken: "",
+		}
+		data, _ := json.Marshal(req)
+		before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+		_, _ = comp.handleEntityUpdateWithTriples(context.Background(), data)
+		after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
+		assert.InDelta(t, before, after, 0.0001, "update_with_triples: empty OwnerToken → no mismatch metric")
+	}
+}


### PR DESCRIPTION
## What

PR-3 of the ADR-056 **OwnerToken write-lease**. The **observe-only** owner-lease check at the graph-ingest owned-write seam: detect a stale `OwnerToken`, emit a metric + Warn, **but NEVER reject — the write always commits.** This is the bake-window increment; the actual reject is PR-5.

- Renamed + widened the graph-ingest claim-reader interface `foreignEdgeClassifier` → `ownershipClaimReader` (adds `OwnerOf`, shipped by PR-2 / #291).
- New `checkOwnerLease` helper (void — observe-only is guaranteed by the signature), called at all three owned-write lanes: create, non-CAS update, and CAS update (the single check in `handleEntityUpdateWithTriples` runs before the `ExpectedRevision>0` dispatch, so it covers the lifecycle-transition CAS path without double-counting).
- New metric `owner_lease_mismatch_total{message_type,predicate}` (mirrors `foreign_edge_unclaimed_total`).
- **Fail-open** on: empty token (legacy/unowned writer), nil reader (resourceless deploy), reader error, unclaimed/append-evidence cell, and — load-bearing — **empty live incarnation** (a legacy/pre-fence owner; a naive compare would false-positive every write against it).

## The owned-predicate set
- create lane: `predicatesOf(own)` (the own-subject triples after `normalizeProjection`).
- update lanes: `predicatesOf(addOwn) ∪ RemoveTriples` (the replace-clear case names the owned cell only in `RemoveTriples`). Over-inclusion is harmlessly backstopped by `OwnerOf` returning `ok=false` for non-owned predicates.

## Review

go-reviewer: **APPROVE** — no BLOCKING/HIGH/MEDIUM. Observe-only invariant proven across every path; fail-open correct on all branches; CAS coverage confirmed (no bypass, no double-count); interface rename complete; metric bounded. One optional NIT (a vacuous test assertion) fixed in this commit.

## Gates

`task lint`, unit `-race`, `go vet -tags=integration`, integration `-race` (real NATS — drives the real handler + wired `ClaimReader`, proves the observe-only invariant: stale token → metric fires AND write COMMITS), schema no-drift — all green.

Step 3 of 5. **No behavior change to writes** (observe-only). PR-4 = Watch-revival quiesce; PR-5 = the gated reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)