### PR TITLE
feat(ownership): ADR-056 OwnerToken write-lease — PR-3.5 (typed opaque OwnerToken)

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -278,7 +278,7 @@ func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ 
 		// stops on shutdown.
 		staticOwnerHB = ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
 		go staticOwnerHB.Run(ctx)
-		if err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
+		if _, err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
 			loopExecutionProjectionContract()); err != nil {
 			svcDeps.Logger.Warn("ownership: loop-execution projection contract registration failed",
 				slog.Any("error", err))

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -236,7 +236,7 @@ func run() error {
 		// the ticker stops on shutdown; the one-shot Bind itself uses ctx.
 		staticOwnerHB = ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
 		go staticOwnerHB.Run(hbCtx)
-		if err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
+		if _, err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
 			loopExecutionProjectionContract()); err != nil {
 			logger.Warn("ownership: loop-execution projection contract registration failed",
 				slog.Any("error", err))

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -256,11 +256,13 @@ func (m *Manager) lookupByWorkflow(workflow string) (*registration, error) {
 	return reg, nil
 }
 
-// ownerToken composes the OwnerToken for a lifecycle write (ADR-056 PR-1):
-// "<workflowName>#<incarnation>". When no Registry is attached (nil, test
-// paths, unmigrated deploys) the token is left empty — graph-ingest skips
-// the lease check on an empty token, so the Manager's behaviour is unchanged
-// for those paths.
+// ownerToken returns the wire form of the OwnerToken for a lifecycle write
+// (ADR-056 PR-3.5). The token is minted by the attached ownership Registry
+// (Registry.OwnerToken) — the Manager never composes the
+// "<workflowName>#<incarnation>" format itself. When no Registry is attached
+// (nil, test paths, unmigrated deploys) the token is the empty string —
+// graph-ingest skips the lease check on an empty token, so the Manager's
+// behaviour is unchanged for those paths.
 func (m *Manager) ownerToken(workflowName string) string {
 	m.mu.RLock()
 	reg := m.ownerRegistry
@@ -268,11 +270,7 @@ func (m *Manager) ownerToken(workflowName string) string {
 	if reg == nil {
 		return ""
 	}
-	inc := reg.Incarnation()
-	if inc == "" {
-		return ""
-	}
-	return workflowName + "#" + inc
+	return reg.OwnerToken(workflowName).Wire()
 }
 
 // ensureBucket lazy-initializes the ENTITY_STATES bucket handle.

--- a/pkg/ownership/owner_token.go
+++ b/pkg/ownership/owner_token.go
@@ -1,0 +1,76 @@
+package ownership
+
+// ownerTokenSep separates the owner id from the per-process incarnation nonce in
+// an OwnerToken's wire form. It is intentionally unexported — no caller outside
+// this file should know or compose the token format.
+const ownerTokenSep = "#"
+
+// OwnerToken is the write-lease credential a producer stamps on an owned graph
+// mutation request (ADR-056 OwnerToken write-lease). Its wire form is
+// "<owner>#<incarnation>", but that composition is an IMPLEMENTATION DETAIL:
+// producers obtain a token from Registry.OwnerToken (or a pkg/projection bind
+// result, which delegates here) and put OwnerToken.Wire() on the request — they
+// never hand-compose the "<owner>#<incarnation>" string. Hand-composition
+// couples every adapter, YAML config, and operator to the credential format and
+// re-opens the footgun SemOps flagged (ADR-056 PR-3.5): a governance credential
+// should be minted by the registry that owns the incarnation, not assembled by
+// its consumers.
+//
+// The zero value is the empty token: Wire() returns "" and IsZero() reports
+// true. The graph-ingest lease check treats an empty token as "skip" — the
+// two-state wire contract (empty = skip, "<owner>#<incarnation>" = compare). An
+// OwnerToken built with an empty incarnation (a legacy / pre-fence owner, or a
+// process with no ownership Registry wired) collapses to the zero token, so a
+// bare "<owner>#" can never reach the wire.
+type OwnerToken struct {
+	owner       string
+	incarnation string
+}
+
+// newOwnerToken is the single composition point for the token. An empty
+// incarnation collapses to the zero token, enforcing the two-state contract: a
+// token is either empty or a full "<owner>#<incarnation>", never a bare owner.
+func newOwnerToken(owner, incarnation string) OwnerToken {
+	if incarnation == "" {
+		return OwnerToken{}
+	}
+	return OwnerToken{owner: owner, incarnation: incarnation}
+}
+
+// ExpectedOwnerToken reconstructs the token the rightful owner of a cell would
+// stamp, from the (owner, incarnation) the lease reader (ClaimReader.OwnerOf)
+// returns for a claimed (entity, predicate) cell. The graph-ingest lease check
+// compares the incoming request's OwnerToken against ExpectedOwnerToken(...).Wire().
+// A "" incarnation (a legacy / pre-fence owner) yields the zero token, so the
+// caller fail-opens rather than rejecting every legitimate write against an
+// unfenced owner. This is also the explicit constructor tests use to forge a
+// token from known parts; producers mint via Registry.OwnerToken instead.
+func ExpectedOwnerToken(owner, incarnation string) OwnerToken {
+	return newOwnerToken(owner, incarnation)
+}
+
+// Wire returns the on-the-wire credential stamped on a mutation request's
+// OwnerToken field: "<owner>#<incarnation>", or "" for the zero token.
+func (t OwnerToken) Wire() string {
+	if t.incarnation == "" {
+		return ""
+	}
+	return t.owner + ownerTokenSep + t.incarnation
+}
+
+// IsZero reports whether this is the empty token — no incarnation, so the lease
+// is not enforceable and the graph-ingest check skips it.
+func (t OwnerToken) IsZero() bool {
+	return t.incarnation == ""
+}
+
+// OwnerToken mints the write-lease credential for `owner` from this process's
+// incarnation nonce (ADR-056 PR-3.5). This — and the pkg/projection bind result,
+// which delegates here — is the ONLY way a producer should obtain a token.
+// Producers never string-concatenate "<owner>#<incarnation>" themselves; the
+// format lives only in this file. A Registry always carries a non-empty
+// incarnation (NewRegistry generates one), so the minted token is the zero token
+// only via an explicitly empty incarnation, never in normal operation.
+func (reg *Registry) OwnerToken(owner string) OwnerToken {
+	return newOwnerToken(owner, reg.incarnation)
+}

--- a/pkg/ownership/owner_token_test.go
+++ b/pkg/ownership/owner_token_test.go
@@ -8,8 +8,10 @@
 //     fields (unit-level field-preservation only). The GENUINE register-time
 //     storage assertion (real RegisterOwner → epoch read-back) lives in
 //     registry_integration_test.go (TestRegistry_RegisterStampsIncarnationOnStoredClaim).
-//   - OwnerToken composition: "<owner>#<incarnation>" shape verified in isolation
-//     (Registry.Incarnation is the raw nonce without the owner prefix).
+//   - OwnerToken composition (ADR-056 PR-3.5): Registry.OwnerToken mints
+//     "<owner>#<incarnation>"; the producer mint and the verifier reconstruction
+//     (ExpectedOwnerToken) agree; an empty incarnation collapses to the zero
+//     token; two processes mint distinct tokens for the same owner (the fence).
 package ownership
 
 import (
@@ -110,6 +112,59 @@ func TestOwnerClaim_StampPreservesSiblingFields(t *testing.T) {
 		"stamp must not mutate other fields")
 	assert.Equal(t, original.Predicates, stamped.Predicates,
 		"stamp must not mutate other fields")
+}
+
+// TestOwnerToken_Wire_Format proves Registry.OwnerToken mints a token whose wire
+// form is exactly "<owner>#<incarnation>" — the credential producers stamp on
+// mutation requests (ADR-056 PR-3.5). The format lives only in pkg/ownership;
+// this test is the single place that asserts the literal "#" composition.
+func TestOwnerToken_Wire_Format(t *testing.T) {
+	t.Parallel()
+	reg := newNoopRegistry(t)
+	tok := reg.OwnerToken("rule-pack.demo")
+	assert.False(t, tok.IsZero(), "a token minted from a live registry is not the zero token")
+	assert.Equal(t, "rule-pack.demo#"+reg.Incarnation(), tok.Wire(),
+		"minted token Wire() must be exactly <owner>#<incarnation>")
+}
+
+// TestOwnerToken_ProducerMatchesVerifier proves the producer mint
+// (Registry.OwnerToken) and the verifier reconstruction (ExpectedOwnerToken) agree
+// for the same owner + incarnation — the core lease-check round-trip. If they
+// diverged, every legitimate write would log a false mismatch.
+func TestOwnerToken_ProducerMatchesVerifier(t *testing.T) {
+	t.Parallel()
+	reg := newNoopRegistry(t)
+	const owner = "mission-planner"
+	produced := reg.OwnerToken(owner)
+	expected := ExpectedOwnerToken(owner, reg.Incarnation())
+	assert.Equal(t, produced.Wire(), expected.Wire(),
+		"producer mint and verifier reconstruction must yield the same wire token")
+	assert.NotEmpty(t, produced.Wire(), "round-trip token must be non-empty")
+}
+
+// TestOwnerToken_EmptyIncarnation_IsZero proves the two-state contract: an empty
+// incarnation (a legacy / pre-fence owner, or no Registry wired) collapses to the
+// zero token whose Wire() is "" — never a bare "<owner>#" or "<owner>". The
+// graph-ingest lease check skips an empty token.
+func TestOwnerToken_EmptyIncarnation_IsZero(t *testing.T) {
+	t.Parallel()
+	tok := ExpectedOwnerToken("some-owner", "")
+	assert.True(t, tok.IsZero(), "empty incarnation must yield the zero token")
+	assert.Equal(t, "", tok.Wire(), "zero token Wire() must be the empty string, never a bare owner")
+	assert.True(t, OwnerToken{}.IsZero(), "the zero value is the zero token")
+	assert.Equal(t, "", OwnerToken{}.Wire(), "the zero value Wire() is empty")
+}
+
+// TestOwnerToken_DistinctAcrossIncarnations proves two processes (two NewRegistry
+// constructions) mint DIFFERENT tokens for the SAME owner — the fence that lets
+// the lease check reject a revived-stale writer that re-registered the same owner
+// id in a new process.
+func TestOwnerToken_DistinctAcrossIncarnations(t *testing.T) {
+	t.Parallel()
+	r1 := newNoopRegistry(t)
+	r2 := newNoopRegistry(t)
+	assert.NotEqual(t, r1.OwnerToken("same-owner").Wire(), r2.OwnerToken("same-owner").Wire(),
+		"two processes must mint different tokens for the same owner (the incarnation fence)")
 }
 
 // newNoopRegistry builds a Registry with nil KV stores for unit tests that

--- a/pkg/projection/bind_integration_test.go
+++ b/pkg/projection/bind_integration_test.go
@@ -31,8 +31,15 @@ func newOwnershipRegistry(t *testing.T) (*ownership.Registry, context.Context) {
 // to the write-time lease lookup.
 func TestBind_DerivesAndRegisters(t *testing.T) {
 	reg, ctx := newOwnershipRegistry(t)
-	if err := Bind(ctx, reg, "cs-api", csapiSystem()); err != nil {
+	token, err := Bind(ctx, reg, "cs-api", csapiSystem())
+	if err != nil {
 		t.Fatalf("bind cs-api System projection: %v", err)
+	}
+	// ADR-056 PR-3.5: Bind surfaces the bound owner's typed OwnerToken so the
+	// producer can stamp it without hand-composing the credential. It must equal
+	// the registry's own mint for the same owner.
+	if got, want := token.Wire(), reg.OwnerToken("cs-api").Wire(); got != want || got == "" {
+		t.Errorf("Bind returned token.Wire() = %q, want %q (non-empty)", got, want)
 	}
 	owner, ok, err := reg.OwnerOf(ctx, "c360.semconnect.systems.csapi.system.drone-001", "sensorml.process.label")
 	if err != nil || !ok || owner != "cs-api" {
@@ -47,7 +54,7 @@ func TestBind_DerivesAndRegisters(t *testing.T) {
 // one Registry, so this proves cross-OWNER rejection.)
 func TestBind_CrossOwnerOverlapRejected(t *testing.T) {
 	reg, ctx := newOwnershipRegistry(t)
-	if err := Bind(ctx, reg, "cs-api", csapiSystem()); err != nil {
+	if _, err := Bind(ctx, reg, "cs-api", csapiSystem()); err != nil {
 		t.Fatal(err)
 	}
 	poacher := Contract{
@@ -55,8 +62,14 @@ func TestBind_CrossOwnerOverlapRejected(t *testing.T) {
 		EntityPattern: sysPat,
 		Groups:        []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"sensorml.process.label"}}},
 	}
-	if err := Bind(ctx, reg, "other", poacher); !errors.Is(err, ownership.ErrOwnershipOverlap) {
+	token, err := Bind(ctx, reg, "other", poacher)
+	if !errors.Is(err, ownership.ErrOwnershipOverlap) {
 		t.Errorf("cross-owner overlap via Bind should reject with ErrOwnershipOverlap, got %v", err)
+	}
+	// ADR-056 PR-3.5: a rejected bind surfaces the zero token, never a usable
+	// credential for an owner that holds no recorded claim.
+	if !token.IsZero() {
+		t.Errorf("Bind on overlap must return the zero token, got Wire()=%q", token.Wire())
 	}
 }
 
@@ -69,7 +82,7 @@ func TestBindAndHeartbeat_EnrollsOnSuccess(t *testing.T) {
 	reg, ctx := newOwnershipRegistry(t)
 	hb := reg.NewHeartbeater(ownership.HeartbeatInterval)
 
-	if err := BindAndHeartbeat(ctx, reg, hb, "cs-api", csapiSystem()); err != nil {
+	if _, err := BindAndHeartbeat(ctx, reg, hb, "cs-api", csapiSystem()); err != nil {
 		t.Fatalf("BindAndHeartbeat: %v", err)
 	}
 	if !hb.IsEnrolled("cs-api") {
@@ -86,7 +99,7 @@ func TestBindAndHeartbeat_EnrollsOnSuccess(t *testing.T) {
 // it would heartbeat a presence key for a non-owner.
 func TestBindAndHeartbeat_SkipsEnrollOnBindFailure(t *testing.T) {
 	reg, ctx := newOwnershipRegistry(t)
-	if err := Bind(ctx, reg, "cs-api", csapiSystem()); err != nil {
+	if _, err := Bind(ctx, reg, "cs-api", csapiSystem()); err != nil {
 		t.Fatal(err)
 	}
 	hb := reg.NewHeartbeater(ownership.HeartbeatInterval)
@@ -95,7 +108,7 @@ func TestBindAndHeartbeat_SkipsEnrollOnBindFailure(t *testing.T) {
 		EntityPattern: sysPat,
 		Groups:        []PredicateGroup{{Mode: ownership.ModeReplaceOwned, Predicates: []string{"sensorml.process.label"}}},
 	}
-	if err := BindAndHeartbeat(ctx, reg, hb, "other", poacher); !errors.Is(err, ownership.ErrOwnershipOverlap) {
+	if _, err := BindAndHeartbeat(ctx, reg, hb, "other", poacher); !errors.Is(err, ownership.ErrOwnershipOverlap) {
 		t.Fatalf("overlap should reject with ErrOwnershipOverlap, got %v", err)
 	}
 	if hb.IsEnrolled("other") {

--- a/pkg/projection/contract.go
+++ b/pkg/projection/contract.go
@@ -164,21 +164,30 @@ func Derive(owner string, contracts ...Contract) (ownership.Registration, error)
 }
 
 // Bind is the component/gateway boot step: derive the owner's claims from its
-// contracts and register them with the ownership substrate. Returns
-// ownership.ErrOwnershipOverlap (wrapped) when another owner already holds a
-// derived cell.
-func Bind(ctx context.Context, ownerReg *ownership.Registry, owner string, contracts ...Contract) error {
+// contracts and register them with the ownership substrate. On success it
+// returns the owner's typed OwnerToken (ADR-056 PR-3.5) — the write-lease
+// credential the bound owner stamps on its mutation requests, surfaced on the
+// bind result so the right path is the easy path (producers never hand-compose
+// "<owner>#<incarnation>"). Returns the zero token and ownership.ErrOwnershipOverlap
+// (wrapped) when another owner already holds a derived cell, or the zero token
+// and a derive/validation error.
+func Bind(ctx context.Context, ownerReg *ownership.Registry, owner string, contracts ...Contract) (ownership.OwnerToken, error) {
 	registration, err := Derive(owner, contracts...)
 	if err != nil {
-		return err
+		return ownership.OwnerToken{}, err
 	}
-	return ownerReg.RegisterOwner(ctx, registration)
+	if err := ownerReg.RegisterOwner(ctx, registration); err != nil {
+		return ownership.OwnerToken{}, err
+	}
+	return ownerReg.OwnerToken(owner), nil
 }
 
 // BindAndHeartbeat is Bind plus liveness enrollment for a STATIC projection owner
 // — one registered once at boot for the whole process lifetime (a graph-writer, a
 // rule pack), as opposed to a lifecycle.Manager workflow owner (which the Manager
-// enrolls into its own heartbeater). A static owner that derives a real OwnerClaim
+// enrolls into its own heartbeater). It returns the bound owner's typed
+// OwnerToken on success (the same credential Bind surfaces; the zero token on
+// failure). A static owner that derives a real OwnerClaim
 // MUST heartbeat: RegisterOwner bumps its OWNER_PRESENCE key once at registration,
 // but without ongoing heartbeats that key ages out after ownership.PresenceTTL and
 // the next registrant compacts the claim out of the epoch — the FE-only compaction
@@ -190,12 +199,13 @@ func Bind(ctx context.Context, ownerReg *ownership.Registry, owner string, contr
 // — build it once at the composition root (ownerReg.NewHeartbeater), run it on a
 // shutdown-cancelled context (go hb.Run(ctx)), and pass it here for every static
 // owner it binds.
-func BindAndHeartbeat(ctx context.Context, ownerReg *ownership.Registry, hb *ownership.Heartbeater, owner string, contracts ...Contract) error {
-	if err := Bind(ctx, ownerReg, owner, contracts...); err != nil {
-		return err
+func BindAndHeartbeat(ctx context.Context, ownerReg *ownership.Registry, hb *ownership.Heartbeater, owner string, contracts ...Contract) (ownership.OwnerToken, error) {
+	token, err := Bind(ctx, ownerReg, owner, contracts...)
+	if err != nil {
+		return ownership.OwnerToken{}, err
 	}
 	if hb != nil {
 		hb.Add(owner)
 	}
-	return nil
+	return token, nil
 }

--- a/pkg/projection/doc.go
+++ b/pkg/projection/doc.go
@@ -13,7 +13,8 @@
 //	       (entity pattern · predicates × write mode · foreign-edge claims · indexing profile)
 //	component / gateway boot
 //	  └─ projection.Bind(ctx, ownerRegistry, ownerID, contracts...)
-//	       derives the ownership.OwnerClaim/ForeignEdgeClaim set and registers it
+//	       derives the ownership.OwnerClaim/ForeignEdgeClaim set, registers it, and
+//	       returns the owner's typed ownership.OwnerToken to stamp on its writes
 //	graph-ingest
 //	  └─ enforces the registered claims at the write boundary (a later increment)
 //

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -1365,8 +1365,10 @@ func (c *Component) checkOwnerLease(ctx context.Context, entityID, messageType, 
 			// Fail-open — no metric, no Warn, no reject.
 			continue
 		}
-		// Compare the request token against the live "<owner>#<incarnation>".
-		expected := owner + "#" + incarnation
+		// Compare the request token against the live owner's expected token.
+		// ExpectedOwnerToken keeps the "<owner>#<incarnation>" format in
+		// pkg/ownership — graph-ingest never composes it (ADR-056 PR-3.5).
+		expected := ownership.ExpectedOwnerToken(owner, incarnation).Wire()
 		if ownerToken != expected {
 			c.ownerLeaseMismatch.WithLabelValues(messageType, pred).Inc()
 			c.logger.Warn("graph-ingest: OwnerToken mismatch — write proceeds (observe-only; reject is PR-5)",

--- a/processor/graph-ingest/foreign_edge_claimed_integration_test.go
+++ b/processor/graph-ingest/foreign_edge_claimed_integration_test.go
@@ -32,7 +32,8 @@ func bindClaimAndBootIngest(t *testing.T, ownerID string, contract projection.Co
 
 	reg, err := ownership.EnsureBuckets(ctx, testClient.Client, nil, nil)
 	require.NoError(t, err, "EnsureBuckets (OWNER_CLAIMS)")
-	require.NoError(t, projection.Bind(ctx, reg, ownerID, contract), "Bind foreign-edge contract")
+	_, bindErr := projection.Bind(ctx, reg, ownerID, contract)
+	require.NoError(t, bindErr, "Bind foreign-edge contract")
 
 	configJSON, err := json.Marshal(DefaultConfig())
 	require.NoError(t, err)

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -18,6 +18,7 @@ import (
 	gtypes "github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
+	"github.com/c360studio/semstreams/pkg/ownership"
 	"github.com/c360studio/semstreams/processor/rule/expression"
 	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
@@ -500,13 +501,17 @@ type ActionExecutor struct {
 	// owned predicate group). Set by the processor after construction via
 	// SetProjectionOwner.
 	ownerID string
-	// incarnation is the per-process boot nonce from the ownership Registry
-	// (ADR-056 PR-1). Set via SetProjectionIncarnation after construction.
-	// Together with ownerID it forms the OwnerToken "<ownerID>#<incarnation>"
-	// stamped on every replace_owned mutation request. Empty when the Registry
-	// is not wired (test paths, unowned packs) — ReplaceOwned stamps only the
-	// owner in that case (no fence, which is fine for the deferred comparison).
-	incarnation string
+	// ownerToken is the typed write-lease credential the rule pack's
+	// replace_owned actions stamp on every mutation request (ADR-056 PR-3.5).
+	// It is minted by the ownership Registry (Registry.OwnerToken) and forwarded
+	// from the rule Processor, which the composition root
+	// (service.BindRulePackContracts) sets via SetProjectionOwnerToken BEFORE
+	// Start. The executor stamps ownerToken.Wire() verbatim — it never composes
+	// the "<owner>#<incarnation>" format itself. The zero token (Registry not
+	// wired: test paths, unowned packs, resourceless deploys) yields an empty
+	// wire string, which the graph-ingest lease check skips (the two-state
+	// contract: empty = skip, "<owner>#<incarnation>" = compare).
+	ownerToken ownership.OwnerToken
 }
 
 // SetToolRegistry installs the shared tool registry used by
@@ -547,17 +552,18 @@ func (e *ActionExecutor) SetProjectionOwner(owner string) {
 	e.ownerID = owner
 }
 
-// SetProjectionIncarnation installs the per-process boot nonce from the
-// ownership Registry (ADR-056 PR-1). Together with the owner id it forms the
-// OwnerToken "<owner>#<incarnation>" stamped on every replace_owned request.
-// Set by the processor after initializeStateTracker reads it from
-// Processor.projectionIncarnation (which BindRulePackContracts writes). An
-// empty incarnation is tolerated — the token is then the EMPTY string (the
-// two-state contract; the lease check skips an empty token), for test /
-// unowned-pack / resourceless-deploy paths where the Registry is not wired.
-// It is never a bare "<owner>".
-func (e *ActionExecutor) SetProjectionIncarnation(incarnation string) {
-	e.incarnation = incarnation
+// SetProjectionOwnerToken installs the typed write-lease credential the rule
+// pack's replace_owned actions stamp on every mutation request (ADR-056
+// PR-3.5). The token is minted by the ownership Registry (Registry.OwnerToken)
+// and forwarded by the rule Processor, which the composition root
+// (service.BindRulePackContracts) sets after initializeStateTracker reads it
+// from Processor.projectionOwnerToken. The zero token is tolerated — its Wire()
+// is the EMPTY string (the two-state contract; the lease check skips an empty
+// token) for test / unowned-pack / resourceless-deploy paths where the Registry
+// is not wired. The executor stamps token.Wire() verbatim; it never composes the
+// "<owner>#<incarnation>" format itself.
+func (e *ActionExecutor) SetProjectionOwnerToken(token ownership.OwnerToken) {
+	e.ownerToken = token
 }
 
 // NewActionExecutor creates a new ActionExecutor with the given logger.
@@ -1096,18 +1102,14 @@ func (e *ActionExecutor) executeReplaceOwned(ctx context.Context, action Action,
 		return nil
 	}
 
-	// Compose the OwnerToken: "<owner>#<incarnation>" (ADR-056 PR-1). The owner
-	// is guaranteed non-empty here (validated above). When the incarnation is
-	// NOT wired (resourceless deploy / Registry absent / test path) the token
-	// degrades to the EMPTY string — NOT a bare "<owner>". This matches the
-	// lifecycle producer's two-state wire contract (manager.go ownerToken()), so
-	// the deferred graph-ingest lease check has a single rule: empty = skip,
-	// "<owner>#<incarnation>" = compare. A bare unfenced "<owner>" would be an
-	// uninterpretable third state for that comparison.
-	ownerToken := ""
-	if e.incarnation != "" {
-		ownerToken = e.ownerID + "#" + e.incarnation
-	}
+	// Stamp the typed OwnerToken's wire form (ADR-056 PR-3.5). The credential is
+	// minted by the ownership Registry and forwarded to this executor — the
+	// "<owner>#<incarnation>" format lives only in pkg/ownership, never here.
+	// The zero token (Registry not wired: resourceless deploy / absent / test
+	// path) yields an empty string, which matches the lifecycle producer's
+	// two-state wire contract (manager.go ownerToken()): the graph-ingest lease
+	// check skips empty and compares "<owner>#<incarnation>".
+	ownerToken := e.ownerToken.Wire()
 
 	revision, err := e.tripleMutator.ReplaceOwned(ctx, ec.RuleID(), ownerToken, entityID, action.Predicate, objects)
 	if err != nil {

--- a/processor/rule/owner_token_test.go
+++ b/processor/rule/owner_token_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/c360studio/semstreams/pkg/ownership"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,12 +26,13 @@ import (
 const testIncarnation = "deadbeef01234567"
 
 // executorWithOwnerAndIncarnation builds a fully-wired executor carrying both
-// the owner and the per-process incarnation, matching the production path where
-// BindRulePackContracts calls SetProjectionIncarnation before Start.
+// the owner and a typed OwnerToken forged from the owner + per-process
+// incarnation, matching the production path where BindRulePackContracts mints the
+// token via Registry.OwnerToken and calls SetProjectionOwnerToken before Start.
 func executorWithOwnerAndIncarnation(mutator TripleMutator, owner, incarnation string) *ActionExecutor {
 	e := NewActionExecutorFull(nil, mutator, nil)
 	e.SetProjectionOwner(owner)
-	e.SetProjectionIncarnation(incarnation)
+	e.SetProjectionOwnerToken(ownership.ExpectedOwnerToken(owner, incarnation))
 	return e
 }
 
@@ -69,7 +71,7 @@ func TestReplaceOwned_OwnerToken_WithoutIncarnation(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	mutator := &mockTripleMutator{}
-	// No SetProjectionIncarnation — incarnation field stays "".
+	// No SetProjectionOwnerToken — the executor's ownerToken stays the zero token.
 	executor := executorWithOwner(mutator, testReplaceOwnedOwner)
 
 	action := Action{Type: ActionTypeReplaceOwned, Predicate: ownedPredicate, Object: "running"}

--- a/processor/rule/processor.go
+++ b/processor/rule/processor.go
@@ -207,13 +207,13 @@ type Processor struct {
 	// instance (processor=nil) for agent CRUD tools. Both share the same KV bucket.
 	kvConfigManager *ConfigManager
 
-	// projectionIncarnation is the per-process boot nonce from the ownership
-	// Registry (ADR-056 PR-1). Set via SetProjectionIncarnation by
+	// projectionOwnerToken is the typed write-lease credential minted by the
+	// ownership Registry (ADR-056 PR-3.5). Set via SetProjectionOwnerToken by
 	// service.BindRulePackContracts (which holds the Registry) BEFORE
-	// initializeStateTracker. The executor reads it at initializeStateTracker
-	// time and stamps it on every replace_owned request as the incarnation half
-	// of the OwnerToken "<owner>#<incarnation>".
-	projectionIncarnation string
+	// initializeStateTracker, which forwards it to the ActionExecutor. The
+	// executor stamps token.Wire() on every replace_owned request — the
+	// "<owner>#<incarnation>" format lives only in pkg/ownership.
+	projectionOwnerToken ownership.OwnerToken
 }
 
 // NewProcessor creates a new rule processor
@@ -360,13 +360,14 @@ func (rp *Processor) ProjectionBindings() (packID string, contracts []projection
 	return rp.config.PackID, rp.config.ProjectionContracts
 }
 
-// SetProjectionIncarnation stores the per-process boot nonce from the ownership
-// Registry so initializeStateTracker can forward it to the ActionExecutor. Must
-// be called by service.BindRulePackContracts BEFORE Start (which calls
-// initializeStateTracker). Mirrors SetProjectionOwner's timing contract.
-// A nil/empty incarnation is a no-op — test paths and unowned packs skip it.
-func (rp *Processor) SetProjectionIncarnation(incarnation string) {
-	rp.projectionIncarnation = incarnation
+// SetProjectionOwnerToken stores the typed write-lease credential minted by the
+// ownership Registry so initializeStateTracker can forward it to the
+// ActionExecutor. Must be called by service.BindRulePackContracts BEFORE Start
+// (which calls initializeStateTracker). Mirrors SetProjectionOwner's timing
+// contract. A zero token is tolerated — test paths and unowned packs stamp an
+// empty wire string, which the lease check skips.
+func (rp *Processor) SetProjectionOwnerToken(token ownership.OwnerToken) {
+	rp.projectionOwnerToken = token
 }
 
 // Health returns current health status
@@ -630,17 +631,17 @@ func (rp *Processor) initializeStateTracker(ctx context.Context) error {
 		}); ok {
 			setter.SetProjectionOwner("rule-pack." + rp.config.PackID)
 		}
-		// ADR-056 PR-1: forward the per-process incarnation nonce so the
-		// executor can stamp the full "<owner>#<incarnation>" OwnerToken on
-		// every replace_owned request. The incarnation is set by
-		// service.BindRulePackContracts (which holds the Registry) BEFORE
-		// Start is called. Empty when the Registry is not wired — the executor
-		// falls back to owner-only, which is correct for test / unowned paths.
-		if rp.projectionIncarnation != "" {
+		// ADR-056 PR-3.5: forward the typed OwnerToken so the executor can stamp
+		// its wire form on every replace_owned request. The token is minted by
+		// the ownership Registry and set by service.BindRulePackContracts (which
+		// holds the Registry) BEFORE Start is called. A zero token (Registry not
+		// wired) yields an empty wire string — correct for test / unowned paths,
+		// where the lease check skips an empty token.
+		if !rp.projectionOwnerToken.IsZero() {
 			if setter, ok := actionExecutor.(interface {
-				SetProjectionIncarnation(string)
+				SetProjectionOwnerToken(ownership.OwnerToken)
 			}); ok {
-				setter.SetProjectionIncarnation(rp.projectionIncarnation)
+				setter.SetProjectionOwnerToken(rp.projectionOwnerToken)
 			}
 		}
 	}

--- a/service/rule_pack_bind.go
+++ b/service/rule_pack_bind.go
@@ -63,11 +63,12 @@ func (m *Manager) ProjectionBinders() []ProjectionBinder {
 // is "rule-pack.<pack_id>"; the pack_id is validated subject-safe at config
 // time (rule.Config.Validate), so RegisterOwner cannot reject it on charset.
 //
-// ADR-056 PR-1: also calls SetProjectionIncarnation (if the binder implements
-// it) with ownerReg.Incarnation() so the pack's ActionExecutor can stamp the
-// full "<owner>#<incarnation>" OwnerToken on replace_owned mutation requests.
-// This is the only point where the process-local Registry incarnation is
-// reachable alongside the binders.
+// ADR-056 PR-3.5: also mints the typed OwnerToken via ownerReg.OwnerToken and
+// stamps it on the binder (if it implements SetProjectionOwnerToken) so the
+// pack's ActionExecutor can put the credential on replace_owned mutation
+// requests. This is the only point where the process-local Registry is reachable
+// alongside the binders; minting here keeps producers from hand-composing the
+// "<owner>#<incarnation>" format.
 func BindRulePackContracts(ctx context.Context, manager *Manager, ownerReg *ownership.Registry, hb *ownership.Heartbeater, logger *slog.Logger) {
 	if ownerReg == nil {
 		return
@@ -89,11 +90,21 @@ func BindRulePackContracts(ctx context.Context, manager *Manager, ownerReg *owne
 		}
 		bound[packID] = struct{}{}
 
-		// ADR-056 PR-1: stamp the incarnation fence onto the binder BEFORE
-		// Start so initializeStateTracker forwards it to the ActionExecutor.
-		// Duck-typed to keep service→processor/rule free of a direct import.
-		if setter, ok := b.(interface{ SetProjectionIncarnation(string) }); ok {
-			setter.SetProjectionIncarnation(ownerReg.Incarnation())
+		ownerID := "rule-pack." + packID
+
+		// ADR-056 PR-3.5: mint the typed OwnerToken from the Registry and stamp
+		// it on the binder BEFORE Start so initializeStateTracker forwards it to
+		// the ActionExecutor. Minting via Registry.OwnerToken keeps the
+		// "<owner>#<incarnation>" credential format inside pkg/ownership — the
+		// pack never hand-composes it. Stamped even for no-contract packs (which
+		// own nothing and never reach BindAndHeartbeat below) so a replace_owned
+		// action on an unowned predicate still presents a comparable token to the
+		// observe-only lease check. Duck-typed to keep service→processor/rule
+		// free of a direct import.
+		if setter, ok := b.(interface {
+			SetProjectionOwnerToken(ownership.OwnerToken)
+		}); ok {
+			setter.SetProjectionOwnerToken(ownerReg.OwnerToken(ownerID))
 		}
 
 		if len(contracts) == 0 {
@@ -103,8 +114,7 @@ func BindRulePackContracts(ctx context.Context, manager *Manager, ownerReg *owne
 			continue
 		}
 
-		ownerID := "rule-pack." + packID
-		if err := projection.BindAndHeartbeat(ctx, ownerReg, hb, ownerID, contracts...); err != nil {
+		if _, err := projection.BindAndHeartbeat(ctx, ownerReg, hb, ownerID, contracts...); err != nil {
 			if errors.Is(err, ownership.ErrOwnershipOverlap) {
 				logger.Warn("ownership overlap on rule pack bind — continuing (observe-only)",
 					"owner_id", ownerID, "err", err)

--- a/service/rule_pack_bind_integration_test.go
+++ b/service/rule_pack_bind_integration_test.go
@@ -188,7 +188,7 @@ func TestBindRulePackContracts_OverlapLoggedNotAborted(t *testing.T) {
 	// it, so assert against a direct derive to keep the test honest).
 	_, derr := projection.Derive("rule-pack.pack-b", overlapping)
 	require.NoError(t, derr, "derive itself is valid; the overlap is cross-owner at register time")
-	berr := projection.Bind(ctx, ownerReg, "rule-pack.pack-c", overlapping)
+	_, berr := projection.Bind(ctx, ownerReg, "rule-pack.pack-c", overlapping)
 	require.True(t, errors.Is(berr, ownership.ErrOwnershipOverlap),
 		"a fresh owner binding the same cell must hit ErrOwnershipOverlap")
 }


### PR DESCRIPTION
## ADR-056 OwnerToken write-lease — PR-3.5

Introduce a typed, opaque `OwnerToken` so producers stop hand-composing the
`<owner>#<incarnation>` lease credential. **Non-behavioral refactor** — identical
bytes on the wire; the two-state contract (`empty = skip` / `"<owner>#<incarnation>" = compare`)
is preserved exactly.

### Why
SemOps feedback (accepted): they'll build against `<owner>#<incarnation>` **only**
if the incarnation is an opaque runtime lease token minted by the registry/bind
path. The footgun was that the framework string-concatenated the credential in
3 places and exposed only `Registry.Incarnation()` (raw nonce) — nothing stopped
an adapter, YAML config, or operator from hand-building a governance credential.
Slotted **before PR-4** because it changes the integration surface products build against.

### What
The `<owner>#<incarnation>` format now lives in exactly one file
(`pkg/ownership/owner_token.go`):
- `Registry.OwnerToken(owner) OwnerToken` — the producer mint
- `ExpectedOwnerToken(owner, incarnation) OwnerToken` — the verifier (graph-ingest) reconstruction + test constructor
- `(OwnerToken).Wire()` / `(OwnerToken).IsZero()` — wire form + the two-state check
- `pkg/projection.Bind` / `BindAndHeartbeat` now return `(OwnerToken, error)` — the credential is **surfaced on the bind result** so the right path is the easy path for downstream producers (semteams / cs-api / SemOps).

The 3 former string-concat sites — `processor/rule` (replace_owned), `pkg/lifecycle` (Manager writes), `processor/graph-ingest` (the verifier) — now mint/reconstruct via the typed token.

**Out of scope (separate follow-up):** append-evidence first-class modeling (the other half of the SemOps feedback) — it is behaviorally correct already; only the type modeling is muddy.

### Review & gates
- **go-reviewer: APPROVE-WITH-NITS** (1 doc nit applied; 2 optional items noted).
- `go build ./...` ✅ · `go vet` ×{default, integration, live_llm} ✅ · `task lint` ✅
- full unit suite `-race` ✅
- integration `-race` on all touched packages (ownership, projection, lifecycle, graph-ingest, service — real NATS) ✅

> Note: a full `-tags=integration -race ./...` run had one FAIL in `processor/graph-index` — a package **untouched** by this PR, ~214s under heavy local Docker load (testcontainer-contention flake class). Deferred to CI on clean infra to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)