### PR TITLE
refactor(ownership): ADR-058 + PR-A — extract ownership boot into a Phase-B Service

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -41,7 +41,6 @@ import (
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/service"
 	"github.com/c360studio/semstreams/types"
-	"github.com/c360studio/semstreams/vocabulary"
 	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
 
@@ -150,23 +149,38 @@ func run() error {
 	svcDeps := createServiceDependencies(natsClient, metricsRegistry, logger, platform, configManager, componentRegistry)
 	svcDeps.ToolRegistry = toolRegistry
 	svcDeps.PayloadRegistry = payloadReg
-	// Wire the lifecycle manager but DO NOT seed yet — graph-ingest
-	// is not started until manager.StartAll runs inside
-	// runWithSignalHandling. Seeding pre-start would deadlock: the
-	// emit retry holds the goroutine that would otherwise call
-	// StartAll, so the responder we are waiting for can never come
-	// up. The seed is run as a post-start hook below. See gh#170.
-	// The heartbeat goroutine AttachOwnership spawns must stop on shutdown.
-	// `ctx` is context.Background() (the signal-cancelled context is a downstream
-	// child created in runWithSignalHandling), so derive a cancellable context
-	// here and cancel it as run() unwinds. Registered after natsClient.Close's
-	// defer, so by LIFO it fires FIRST — the heartbeat stops before the client
-	// closes. Threaded through wireLifecycleManager to AttachOwnership.
+
+	// Build the lifecycle Manager. DO NOT seed yet — graph-ingest is not
+	// started until manager.StartAll inside runWithSignalHandling; seeding
+	// pre-start would deadlock (emit retry holds the goroutine that would
+	// otherwise call StartAll). See gh#170.
+	svcDeps.LifecycleManager = lifecycle.NewManager(natsClient, logger)
+
+	// ADR-058 Phase A — wire ownership buckets, Registry, and static projection
+	// contracts. Returns nil, nil on bucket-bootstrap failure (disabled this
+	// boot, best-effort — never a boot gate).
+	//
+	// The Manager-internal heartbeater (spawned by AttachOwnership inside
+	// WireOwnership) runs on hbCtx; WaitOwnership joins it on shutdown.
+	// hbCtx/hbCancel STAY in run() scope until the lifecycle Manager is
+	// itself a Phase-B Service (ADR-058 rollout step 2).
+	defer svcDeps.LifecycleManager.WaitOwnership() // join (runs second — LIFO)
 	hbCtx, hbCancel := context.WithCancel(ctx)
-	defer hbCancel()
-	ownerReg, staticOwnerHB, err := wireLifecycleManager(hbCtx, svcDeps, natsClient, logger)
-	if err != nil {
-		return err
+	defer hbCancel() // signal (runs first — LIFO)
+
+	ownerReg, staticOwnerHB := service.WireOwnership(hbCtx, natsClient, svcDeps.LifecycleManager, logger,
+		loopExecutionProjectionContract())
+	// ADR-058 Phase B — static heartbeater goroutine under the ServiceManager's
+	// ordered shutdown.
+	manager.RegisterInstance("ownership", service.NewOwnershipService(ownerReg, staticOwnerHB, logger))
+
+	// Register workflows (must come after Manager is constructed).
+	if err := svcDeps.LifecycleManager.Register(mission.WorkflowDeclaration()); err != nil {
+		return fmt.Errorf("register mission workflow: %w", err)
+	}
+	// Register the agent-run workflow (ADR-053 D2). Mirrors cmd/semstreams wiring.
+	if err := agentrun.Register(svcDeps.LifecycleManager); err != nil {
+		return fmt.Errorf("register agent-run workflow: %w", err)
 	}
 
 	// Start the agent-run milestone subscriber (ADR-053 D6). Mirrors
@@ -232,67 +246,6 @@ func buildPayloadRegistry() (*payloadregistry.Registry, error) {
 		return nil, fmt.Errorf("register mission payloads: %w", err)
 	}
 	return reg, nil
-}
-
-// wireLifecycleManager builds the pkg/lifecycle.Manager, plumbs it
-// into svcDeps (rule processor + lifecycle-gateway both pull from
-// here), and registers the e2e-only mission workflow. Seeding the
-// initial mission instance is the caller's responsibility AFTER
-// manager.StartAll — see runWithSignalHandling's postStart hook and
-// gh#170 for the cold-start race that drove this split.
-//
-// Per ADR-049 the harness lives over ENTITY_STATES — no per-workflow
-// bucket provisioning. State changes emit through graph-ingest like
-// every other write; reads project triples into the registered
-// Schema struct.
-// It returns the owner registry and static heartbeater (nil when ownership is
-// disabled this boot) so run() can bind rule-pack projection contracts AFTER
-// the rule processors are constructed (ADR-056 #278 inc 2) using the same
-// registry/heartbeater.
-func wireLifecycleManager(ctx context.Context, svcDeps *service.Dependencies, _ *natsclient.Client, _ *slog.Logger) (*ownership.Registry, *ownership.Heartbeater, error) {
-	svcDeps.LifecycleManager = lifecycle.NewManager(svcDeps.NATSClient, svcDeps.Logger)
-
-	var ownerReg *ownership.Registry
-	var staticOwnerHB *ownership.Heartbeater
-
-	// ADR-056 Decision 5 — attach the owner registry BEFORE Register so each
-	// workflow's claim registers through the shared epoch (cross-process overlap
-	// surfaced, observe-only for the first consumer). EnsureBuckets is eager:
-	// graph-ingest (which creates the other framework buckets) boots later than
-	// this wiring, so the ownership buckets must be created here. A NATS hiccup
-	// logs + skips — ownership is best-effort observe-only, never a boot gate.
-	if reg, err := ownership.EnsureBuckets(ctx, svcDeps.NATSClient, svcDeps.Logger, vocabulary.InverseResolver); err != nil {
-		svcDeps.Logger.Warn("ownership: bucket bootstrap failed — lifecycle ownership disabled this boot", slog.Any("error", err))
-	} else {
-		ownerReg = reg
-		svcDeps.LifecycleManager.AttachOwnership(ctx, ownerReg)
-
-		// ADR-056 4c-pre-1: register the loop-execution entity projection contract.
-		// Mirrors cmd/semstreams wiring — best-effort, never a boot gate.
-		//
-		// Static projection owners (not lifecycle.Manager workflows) need their OWN
-		// heartbeater: they derive a real OwnerClaim, so without ongoing heartbeats
-		// their OWNER_PRESENCE key ages out after PresenceTTL and the next registrant
-		// compacts the claim out of the epoch (Codex review of #277). ctx here is the
-		// shutdown-cancellable context (hbCtx, threaded from run()), so the ticker
-		// stops on shutdown.
-		staticOwnerHB = ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
-		go staticOwnerHB.Run(ctx)
-		if _, err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
-			loopExecutionProjectionContract()); err != nil {
-			svcDeps.Logger.Warn("ownership: loop-execution projection contract registration failed",
-				slog.Any("error", err))
-		}
-	}
-
-	if err := svcDeps.LifecycleManager.Register(mission.WorkflowDeclaration()); err != nil {
-		return nil, nil, fmt.Errorf("register mission workflow: %w", err)
-	}
-	// Register the agent-run workflow (ADR-053 D2). Mirrors cmd/semstreams wiring.
-	if err := agentrun.Register(svcDeps.LifecycleManager); err != nil {
-		return nil, nil, fmt.Errorf("register agent-run workflow: %w", err)
-	}
-	return ownerReg, staticOwnerHB, nil
 }
 
 // seedMission Creates a mission Participant at the given entity ID

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -39,7 +39,6 @@ import (
 	rulepkg "github.com/c360studio/semstreams/processor/rule"
 	"github.com/c360studio/semstreams/service"
 	"github.com/c360studio/semstreams/types"
-	"github.com/c360studio/semstreams/vocabulary"
 	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
 
@@ -190,58 +189,23 @@ func run() error {
 	// half-migrated framework binaries silently break workflows.
 	svcDeps.LifecycleManager = lifecycle.NewManager(natsClient, logger)
 
-	// 10b. ADR-056 Decision 5 — attach the owner registry BEFORE Register so the
-	// agent-run workflow's claim registers through the shared OWNER_CLAIMS epoch
-	// (cross-process overlap surfaced, observe-only for the first consumer).
-	// EnsureBuckets is EAGER and deliberately here, not in graph-ingest:
-	// graph-ingest's initStorage runs only after services start
-	// (configureAndCreateServices below), long after this Register — so creating
-	// the ownership buckets there would make every registration a silent no-op.
-	// A NATS hiccup logs + skips; ownership is best-effort observe-only, never a
-	// boot gate ([[feedback_unconditional_resource_wiring_breaks_resourceless_deploys]]).
+	// 10b. ADR-058 Phase A — wire ownership buckets, Registry, and static
+	// projection contracts. Returns nil, nil on bucket-bootstrap failure
+	// (ownership disabled this boot, best-effort — never a boot gate).
 	//
-	// ownerReg/staticOwnerHB/hbCtx are lifted to run() scope (nil/ctx until the
-	// EnsureBuckets else-branch assigns them) so the rule-pack contract bind
-	// below — which must run AFTER configureAndCreateServices has constructed the
-	// rule processors — can reuse the same registry and heartbeater (ADR-056 #278
-	// inc 2).
-	var ownerReg *ownership.Registry
-	var staticOwnerHB *ownership.Heartbeater
-	hbCtx := ctx
-	if reg, err := ownership.EnsureBuckets(ctx, natsClient, logger, vocabulary.InverseResolver); err != nil {
-		logger.Warn("ownership: bucket bootstrap failed — lifecycle ownership disabled this boot", slog.Any("error", err))
-	} else {
-		ownerReg = reg
-		// The heartbeat goroutine must stop on shutdown. `ctx` here is
-		// context.Background() (the signal-cancelled context is a downstream
-		// CHILD created in runWithSignalHandling, and a child cancelling never
-		// cancels its parent), so derive a cancellable context and cancel it as
-		// run() unwinds. Registered after natsClient.Close's defer, so by LIFO it
-		// fires FIRST — the heartbeat stops before the client closes.
-		var hbCancel context.CancelFunc
-		hbCtx, hbCancel = context.WithCancel(ctx)
-		defer hbCancel()
-		svcDeps.LifecycleManager.AttachOwnership(hbCtx, ownerReg)
+	// The Manager-internal heartbeater (spawned by AttachOwnership inside
+	// WireOwnership) runs on hbCtx; WaitOwnership joins it on shutdown.
+	// hbCtx/hbCancel STAY in run() scope until the lifecycle Manager is
+	// itself a Phase-B Service (ADR-058 rollout step 2).
+	defer svcDeps.LifecycleManager.WaitOwnership() // join (runs second — LIFO)
+	hbCtx, hbCancel := context.WithCancel(ctx)
+	defer hbCancel() // signal (runs first — LIFO)
 
-		// ADR-056 4c-pre-1: register the loop-execution entity projection contract.
-		// This declares that "agentic-loop-graph-writer" owns the spawn-identity
-		// origin predicates on every loop-execution entity (*.*.agent.agentic-loop.execution.*)
-		// in replace-owned mode. Best-effort: a registration failure logs a warning
-		// but does not block boot — ownership is observe-only, never a boot gate.
-		//
-		// Static projection owners (not lifecycle.Manager workflows) need their OWN
-		// heartbeater: they derive a real OwnerClaim, so without ongoing heartbeats
-		// their OWNER_PRESENCE key ages out after PresenceTTL and the next registrant
-		// compacts the claim out of the epoch (Codex review of #277). Run on hbCtx so
-		// the ticker stops on shutdown; the one-shot Bind itself uses ctx.
-		staticOwnerHB = ownerReg.NewHeartbeater(ownership.HeartbeatInterval)
-		go staticOwnerHB.Run(hbCtx)
-		if _, err := projection.BindAndHeartbeat(ctx, ownerReg, staticOwnerHB, "agentic-loop-graph-writer",
-			loopExecutionProjectionContract()); err != nil {
-			logger.Warn("ownership: loop-execution projection contract registration failed",
-				slog.Any("error", err))
-		}
-	}
+	ownerReg, staticOwnerHB := service.WireOwnership(hbCtx, natsClient, svcDeps.LifecycleManager, logger,
+		loopExecutionProjectionContract())
+	// ADR-058 Phase B — static heartbeater goroutine under the ServiceManager's
+	// ordered shutdown.
+	manager.RegisterInstance("ownership", service.NewOwnershipService(ownerReg, staticOwnerHB, logger))
 
 	// 10c. Register the agent-run workflow (ADR-053 D2). Must come after
 	// the Manager is constructed so lifecycle_* actions that reference

--- a/docs/adr/058-boot-lifecycle-phases.md
+++ b/docs/adr/058-boot-lifecycle-phases.md
@@ -1,0 +1,395 @@
+# ADR-058: Boot Lifecycle — Phase-A Eager Wiring vs Phase-B Managed Services
+
+- **Status**: Draft
+- **Date**: 2026-06-18
+- **Supersedes**: none
+- **Related**: ADR-047 (Lifecycle harness), ADR-056 (authoritative semantic
+  state / ownership write-lease)
+
+## Context
+
+`cmd/semstreams/main.go run()` and `cmd/e2e-semstreams/main.go run()` hand-wire
+their process-lifetime background subsystems with raw `go X.Run()` +
+`sync.WaitGroup` + LIFO-`defer` shutdown ordering, instead of using the
+framework's existing `service.Service` lifecycle. Two concrete forcing
+functions:
+
+1. **`run()` is over the function-length limit.** ADR-056 PR-4 added a
+   `WatchRevival` goroutine to the inline ownership block; `run()` is now 82
+   statements against an 80 limit. Every new background subsystem makes this
+   worse.
+2. **The eager wiring is duplicated AND already divergent across the two
+   mains.** The identical ownership sequence — `EnsureBuckets` →
+   `AttachOwnership` → static heartbeater goroutine → `WatchRevival` goroutine
+   → `BindAndHeartbeat` — appears inline in `cmd/semstreams/main.go:209-266`
+   and wrapped in a `wireLifecycleManager` helper in
+   `cmd/e2e-semstreams/main.go:264-315`. The rule-pack contract bind
+   (`service.BindRulePackContracts`) is inline in both. This is exactly the
+   beta.18 half-migration failure mode CLAUDE.md documents: one binary gets a
+   change, the sister binary silently does not.
+
+The framework already has almost all the pieces; we are mostly not using them.
+There is **one genuine gap** — a way to register a composition-root-constructed
+Service *instance* (today the `ServiceManager` only creates services from
+config-registered constructors). We close it with one minimal primitive
+(`RegisterInstance`, below), not a new subsystem. The existing pieces:
+
+- `service.Service` interface — `Name / Start(ctx) / Stop(timeout) / Status /
+  IsHealthy / GetStatus / Health / RegisterMetrics`
+  (`service/base.go:471`). `service.BaseService` (`service/base.go:66`) embeds
+  for defaults and provides a `waitGroup` + `done` channel
+  (`service/base.go:94-95`).
+- `service.Manager` — `StartAll` (`service/service_manager.go:266-273`) starts
+  registered services (iterating a **map — random order**) and **aborts boot on
+  the first `Start()` error**; `StopAll` (`service/service_manager.go:382+`)
+  stops in **reverse registration order** and **continues on `Stop()` errors**,
+  collecting them. Services enter only via config-driven `CreateService` /
+  `ConfigureFromServices` (`service/service_manager.go:163,77`) — there is **no
+  instance-registration path today** (the gap above).
+- Exemplar to mirror: `HeartbeatService` (`service/heartbeat.go:125`) — `Start`
+  launches its loop goroutine under its own `wg`; `Stop` signals + joins with an
+  inline `done`-channel-`select` timeout. Other exemplars: `Metrics`,
+  `LogForwarder`, `MessageLogger`, `FlowService`.
+
+## Decision
+
+Classify every boot citizen into one of two phases. This is the whole ADR;
+everything else is application.
+
+### The two phases
+
+**Phase A — eager registration / construction.** Create resources and register
+identities that *other subsystems reference by name or by claim*: NATS
+connection, streams, metrics, loggers, the payload/tool/component registries,
+KV buckets, the ownership Registry, lifecycle workflow registrations,
+rule-pack projection contracts. Phase A:
+
+- must run in **deterministic, source-order** sequence,
+- must run **before** the consumers that reference those identities,
+- must run **before** `StartAll` (which is post-wiring and starts services in
+  **random map-iteration order** — `service/service_manager.go:266`),
+- lives in the **composition root**, factored into **plain shared helper
+  functions** so the two mains call the same code, never duplicated per binary.
+
+Phase A is boring on purpose: it is sequential Go in a function. No DAG, no
+phase enum, no container.
+
+**Phase B — runtime lifecycle.** Background goroutine(s) and runtime resources
+that need a clean `Start` and a join-on-`Stop`: the static-owner heartbeater,
+`WatchRevival`, the milestone subscriber, the pprof server. Phase B lives in a
+`service.Service` registered with the `ServiceManager`, which gives us
+ordered shutdown and uniform health/metrics for free.
+
+### The "Is it a Service?" test
+
+Make it a Phase-B `service.Service` if and only if **all three** hold:
+
+1. it lives for the whole process,
+2. it owns background goroutine(s) or runtime resources,
+3. it needs a clean `Stop` / join (not just process exit).
+
+If it only creates a resource or registers an identity, it is Phase A — a
+helper-function call, not a Service.
+
+### run() inventory
+
+| Boot citizen | Phase | Today | Target |
+|---|---|---|---|
+| NATS / streams / metrics / logger / payload+tool+component registries | A | eager, correct | leave alone |
+| ownership buckets + Registry + `AttachOwnership` | A | inline, divergent | shared `WireOwnership` helper |
+| ownership rule-pack contract bind (`BindRulePackContracts`) | A | inline, duplicated | shared helper, post-construction call |
+| ownership static heartbeater goroutine | B | `go`+WG+`defer` | `OwnershipService` |
+| ownership `WatchRevival` goroutine | B | `go`+WG+`defer` (PR-4) | `OwnershipService` |
+| lifecycle `Manager` construct + workflow `Register` | A | inline / helper | shared helper |
+| lifecycle Manager-internal heartbeater (`AttachOwnership` spawns it) | B | already joined via `WaitOwnership` | leave alone — already lifecycle-managed |
+| milestone subscriber (`Start()`→stop-func) | B | hand-managed stop-func | wrap as Service |
+| pprof server | B | hand-started HTTP | wrap as Service |
+
+### Robustness constraints (non-negotiable)
+
+These three rules exist because the subsystems being migrated (ownership,
+lifecycle) are **observe-only / best-effort** today and must stay that way.
+They are not future-proofing; each one prevents a concrete regression.
+
+- **R1 — A Phase-B `Start()` must be infallible for soft failures.** Because
+  `StartAll` aborts the whole boot on any `Start()` error
+  (`service/service_manager.go:268-271`), a best-effort subsystem that fails
+  to start must **degrade to disabled** (log + no-op, return `nil`), never
+  return an error. This preserves today's "ownership disabled this boot"
+  posture (`cmd/semstreams/main.go:213`) and matches graph-ingest, which
+  already graceful-skips when `OWNER_CLAIMS` is absent
+  (`processor/graph-ingest/component.go:812`). Ownership and lifecycle must
+  **never** become a boot gate. Hard dependencies (NATS itself) stay in
+  Phase A, where a failure *is* allowed to abort boot.
+
+- **R2 — Identity/state is created once in Phase A, never in `Start()`.** The
+  ownership `Registry` — including its incarnation nonce and quiesced set —
+  is constructed exactly once, in Phase A. A `service.Service` restart must
+  **not** re-mint the incarnation (a fresh nonce would self-supersede the
+  process's own prior claims → false quiesce, per ADR-056) and must not
+  dangle the references consumers already hold. The Service owns only the
+  **restartable goroutines**; it holds a pointer to the Phase-A-owned
+  Registry, it does not own its construction.
+
+- **R3 — No consumer-presence assumptions; independence is symmetric.** A
+  Phase-B Service must be a no-op with zero consumers: an empty owner set
+  means `WatchRevival` and the heartbeater do nothing. Consumers already
+  fail-open on absent ownership (`AttachOwnership` is a nil-safe no-op,
+  `pkg/lifecycle/manager.go:237`; the claim reader graceful-skips,
+  `processor/graph-ingest/component.go:806-815`) and that must be preserved.
+  Symmetrically: ownership failing or restarting must not cascade into graph
+  components, and missing graph consumers must not break ownership.
+
+## Worked example — ownership (the PR-4 forcing function)
+
+Today's inline block is mixed Phase A + Phase B. Split it cleanly.
+
+### Phase A — `service.WireOwnership` (plain function, shared by both mains)
+
+A composition-root helper that does only the eager, deterministic work and
+returns the constructed identities. No goroutines spawned here.
+
+```go
+// WireOwnership performs Phase-A ownership wiring: create buckets, construct
+// the Registry (R2 — once, here), attach it to the lifecycle Manager, and bind
+// static projection contracts. Best-effort (R1): a bucket-bootstrap failure
+// logs and returns a nil Registry; callers treat nil as "ownership disabled
+// this boot" and pass it straight to the OwnershipService (which no-ops on nil).
+//
+// Returns the Registry and its static heartbeater so the caller can (a) start
+// the Phase-B OwnershipService and (b) bind rule-pack contracts AFTER the rule
+// processors are constructed.
+func WireOwnership(
+    ctx context.Context,
+    natsClient *natsclient.Client,
+    lcm *lifecycle.Manager,
+    logger *slog.Logger,
+) (*ownership.Registry, *ownership.Heartbeater) {
+    reg, err := ownership.EnsureBuckets(ctx, natsClient, logger, vocabulary.InverseResolver)
+    if err != nil {
+        logger.Warn("ownership: bucket bootstrap failed — disabled this boot", slog.Any("error", err))
+        return nil, nil // R1: degrade, do not abort.
+    }
+    lcm.AttachOwnership(ctx, reg) // nil-safe; spawns the Manager-internal
+                                  // heartbeater, joined via lcm.WaitOwnership().
+    staticHB := reg.NewHeartbeater(ownership.HeartbeatInterval)
+    if _, err := projection.BindAndHeartbeat(ctx, reg, staticHB,
+        "agentic-loop-graph-writer", loopExecutionProjectionContract()); err != nil {
+        logger.Warn("ownership: projection contract bind failed", slog.Any("error", err))
+    }
+    return reg, staticHB
+}
+```
+
+The static heartbeater is *constructed* in Phase A (it is identity-adjacent —
+it heartbeats the static owner's presence key) but it is not *run* here. The
+goroutine that runs it moves to Phase B.
+
+### Phase B — `OwnershipService` (mirrors `HeartbeatService`)
+
+Lives in **`package service`** (alongside `WireOwnership` and
+`BindRulePackContracts`) and carries its **own `logger`** field exactly like
+`HeartbeatService` (`heartbeat.go:67`) — do not reach for `BaseService`'s
+unexported `logger`, which has no accessor.
+
+```go
+type OwnershipService struct { // in package service — no self-qualification below
+    *BaseService
+    logger   *slog.Logger             // own logger (mirrors HeartbeatService); set by ctor.
+    reg      *ownership.Registry      // R2: owned by Phase A, borrowed here.
+    staticHB *ownership.Heartbeater
+    metrics  *metric.MetricsRegistry
+    cancel   context.CancelFunc
+    wg       sync.WaitGroup
+}
+
+func (s *OwnershipService) Start(ctx context.Context) error {
+    // Re-entrancy guard (mirrors HeartbeatService:126-128). An already-running
+    // double-Start is a BUG-CLASS error, NOT an R1 soft failure — returning an
+    // error here is correct even though R1 forbids erroring on soft failures.
+    // Without it, BaseService.Start returns nil-if-already-running (base.go:220)
+    // and control falls through to a duplicate wg.Add(2) + leaked goroutines.
+    if s.Status() == StatusRunning {
+        return fmt.Errorf("ownership service already running")
+    }
+    // Mark the service running — even on the disabled path it is
+    // intentionally-disabled-but-healthy, not crashed, so Status()/Health()
+    // report correctly rather than "stopped".
+    if err := s.BaseService.Start(ctx); err != nil {
+        return err
+    }
+    if s.reg == nil { // R1 (disabled this boot) + R3 (no consumers): idle, no goroutines.
+        s.logger.Info("ownership service: no registry — running idle (disabled this boot)")
+        return nil
+    }
+    runCtx, cancel := context.WithCancel(ctx)
+    s.cancel = cancel
+    s.wg.Add(2)
+    go func() { defer s.wg.Done(); s.staticHB.Run(runCtx) }()
+    go func() { defer s.wg.Done(); _ = s.reg.WatchRevival(runCtx, s.metrics) }()
+    return nil
+}
+
+func (s *OwnershipService) Stop(timeout time.Duration) error {
+    if s.cancel != nil {
+        s.cancel() // signal (no-op on the disabled path — cancel is nil)
+    }
+    // Join with timeout — inline, mirroring HeartbeatService.Stop:142-160.
+    done := make(chan struct{})
+    go func() { s.wg.Wait(); close(done) }()
+    select {
+    case <-done:
+    case <-time.After(timeout):
+        s.logger.Warn("ownership service: stop timeout waiting for goroutines")
+    }
+    return s.BaseService.Stop(timeout)
+}
+```
+
+`Start` only ever errors if `BaseService.Start` does (exotic) — there is no
+soft-failure path that returns an error, so it cannot trip `StartAll`'s boot
+abort (R1). The Registry is never constructed here (R2). With zero enrolled
+owners both goroutines idle (R3). `s.wg` mirrors `HeartbeatService`'s own-`wg`
+precedent; cancellation is via `runCtx` because the goroutines (`staticHB.Run`,
+`WatchRevival`) already take a context.
+
+### The one new primitive — `RegisterInstance`
+
+`OwnershipService` is built by the composition root (it borrows the Phase-A
+Registry, which is not config-shaped), but the `ServiceManager` today only
+admits services via config-driven constructors (`CreateService`). We add one
+small method — the minimal honest gap-closer, not a subsystem:
+
+```go
+// RegisterInstance admits a pre-built Service to the manager (composition-root
+// wiring, as opposed to config-driven CreateService). Same map + order tracking
+// CreateService uses, so StartAll/StopAll treat it identically.
+func (m *Manager) RegisterInstance(name string, svc Service) {
+    m.mu.Lock(); defer m.mu.Unlock()
+    m.services[name] = svc
+    m.order = append(m.order, name)
+}
+```
+
+This is the *only* new mechanism in this ADR. The constructor path is rejected
+for ownership precisely because threading a non-config dependency (the Registry)
+through `Dependencies` + a no-op-config constructor is more indirection than a
+five-line instance register.
+
+### What the mains become
+
+The two divergent ownership blocks (`cmd/semstreams/main.go:209-266` and the
+`wireLifecycleManager` body in `cmd/e2e-semstreams/main.go:264-315`) collapse to
+one shared Phase-A call + one Phase-B registration + the existing
+post-construction bind:
+
+```go
+// Manager-internal heartbeater (spawned by AttachOwnership) needs a
+// shutdown-cancellable ctx + a join — these STAY until the lifecycle Manager is
+// itself a Service (rollout step 2). Registered so LIFO runs hbCancel (signal)
+// then WaitOwnership (join), both before the NATS Close defer from earlier.
+defer svcDeps.LifecycleManager.WaitOwnership() // join (runs second)
+hbCtx, hbCancel := context.WithCancel(ctx)
+defer hbCancel()                               // signal (runs first)
+
+ownerReg, staticHB := service.WireOwnership(hbCtx, natsClient, svcDeps.LifecycleManager, logger) // Phase A
+manager.RegisterInstance("ownership", service.NewOwnershipService(ownerReg, staticHB, metricsRegistry, logger)) // Phase B
+// ... configureAndCreateServices(...) constructs rule processors ...
+if ownerReg != nil {
+    service.BindRulePackContracts(hbCtx, manager, ownerReg, staticHB, logger) // Phase A, post-construction
+}
+```
+
+What deletes: the hand-rolled `ownershipWG`, the two ownership goroutine spawns
+(`go staticHB.Run` / `go WatchRevival`), and their `WaitGroup.Wait` defer — those
+move into `OwnershipService`, which `StopAll` cancels-then-joins in reverse
+registration order before `run()` returns to the NATS `Close` defer.
+
+What STAYS (corrected — do not over-claim the cleanup): the Manager-internal
+heartbeater is **not** a Service in this phase (rollout step 2 leaves it), so its
+`hbCtx`/`hbCancel` and the `WaitOwnership()` join — the gh#279 fix from ADR-056
+PR-4 — must remain in the mains until that heartbeater also becomes
+framework-managed. Deleting them here would silently regress that join.
+
+**Half-migration guard:** the two mains differ in shutdown shape today —
+`cmd/semstreams` uses three separate defers (`ownershipWG.Wait` / `WaitOwnership`
+/ `hbCancel`) while `cmd/e2e-semstreams` bundles all three into a single deferred
+closure (`cmd/e2e-semstreams/main.go:173-179`). PR-1 must edit BOTH: drop only the
+`ownershipWG` half on each, KEEP `hbCancel` + `WaitOwnership`. Pattern-matching one
+main's shape onto the other is exactly the beta.18 half-migration this ADR exists
+to prevent — verify the e2e closure is split, not copied.
+
+## Consequences
+
+**Positive**
+
+- `run()` drops back under the function-length limit; new background
+  subsystems become "write a Service + register it," not "add a goroutine +
+  WaitGroup + defer to `run()`."
+- The Phase-A sequence lives in one shared helper, so the two mains cannot
+  drift — the beta.18 half-migration class is structurally prevented for this
+  code.
+- Ownership goroutines get uniform health + metrics + ordered shutdown via the
+  framework, for free.
+
+**Negative / cost**
+
+- One new `service.Service` type per migrated subsystem (small, mechanical,
+  mirrors `HeartbeatService`).
+- One new `ServiceManager.RegisterInstance(name, Service)` method (~5 lines) —
+  the single new framework mechanism, to admit composition-root-built service
+  instances. Justified over the constructor path (which would force a non-config
+  dependency through `Dependencies`); covered by a test.
+- The R1 infallible-`Start` discipline is a footgun if forgotten: a future
+  author who returns an error from a best-effort `Start` re-introduces the
+  boot gate. Mitigation: state it in the Service's doc comment and cover it
+  with a test that asserts `Start` returns `nil` on the disabled path. It is a
+  review checklist item, not a new mechanism.
+- Phase 1 does NOT fully clean the mains: the lifecycle Manager-internal
+  heartbeater's cancel + `WaitOwnership` join stay until rollout step 2. The
+  win is real but partial until lifecycle is also a Service.
+
+**Neutral**
+
+- No config-schema change. `OwnershipService` is wired by the composition root
+  via `RegisterInstance`, not a config-registered constructor, because its
+  Phase-A dependency (the Registry) is not config-shaped. (If a later subsystem
+  *is* config-driven, use the existing `Constructor` / `CreateService` path
+  instead.)
+
+## Rollout — one behavior-preserving PR per subsystem
+
+1. **Ownership** (this ADR's forcing function): extract `WireOwnership` +
+   `OwnershipService`, delete the inline blocks and `wireLifecycleManager`'s
+   ownership half. Behavior-preserving: same goroutines, same shutdown order,
+   same observe-only posture.
+2. **Lifecycle Manager**: `construct + workflow Register` stays Phase A; the
+   Manager-internal heartbeater is already lifecycle-joined via
+   `WaitOwnership` — confirm it needs no Service wrapper, leave it.
+3. **Milestone subscriber** (`cmd/semstreams/main.go:283-297`): already
+   `Start()`-returns-a-stop-func — Service-shaped, wrap it.
+4. **pprof server** (`cmd/semstreams/main.go:867`): background HTTP, wrap it.
+
+Each PR is independently revertible and adds nothing to the public surface
+beyond a new internal Service type.
+
+## Explicitly NOT in scope (anti-over-engineering)
+
+We considered and rejected each of these because the existing
+`service.Service` + a plain helper already covers the need:
+
+- A boot-orchestration engine, dependency-DAG resolver, or DI container —
+  Phase-A ordering is source-order sequential code; a DAG would encode an
+  ordering Go already gives us for free.
+- A lifecycle-phase enum or boot state machine — "Phase A vs Phase B" is a
+  *classification for humans*, not a runtime construct. Encoding it as state
+  would be a mechanism with no reader.
+- A generalized `Subsystem` interface beyond `service.Service` — there is
+  nothing a boot subsystem needs that `service.Service` does not already
+  provide.
+- A new registry type or config-schema change — the existing `Dependencies` /
+  `Constructor` / `CreateService` path covers the config-driven case; the
+  non-config case is handled by the one new `RegisterInstance` *method* on the
+  existing `Manager` (not a new registry, not config).
+- A big-bang migration — the rollout is one subsystem per PR, each
+  behavior-preserving.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/mgechev/revive v1.15.0
 	github.com/nats-io/nats.go v1.48.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
@@ -69,6 +68,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mgechev/dots v1.0.0 // indirect
+	github.com/mgechev/revive v1.15.0 // indirect
 	github.com/miekg/dns v1.1.62 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -73,6 +73,12 @@ type Manager struct {
 	// callers polling at dashboard frequencies don't generate
 	// N×interval log lines per drifted entity.
 	driftSeen sync.Map
+
+	// ownershipWG tracks the heartbeat goroutine spawned by AttachOwnership
+	// so callers can join it via WaitOwnership (gh#279). The goroutine is
+	// started exactly once — in AttachOwnership — and runs until the ctx
+	// passed there is cancelled.
+	ownershipWG sync.WaitGroup
 }
 
 // registration holds the per-workflow-type state Manager needs at
@@ -241,7 +247,23 @@ func (m *Manager) AttachOwnership(ctx context.Context, reg *ownership.Registry) 
 
 	// One heartbeat goroutine ticks every enrolled owner's presence key until
 	// ctx is cancelled. Started here with no owners yet; Register enrolls each.
-	go hb.Run(ctx)
+	// Tracked via ownershipWG so callers can join via WaitOwnership (gh#279).
+	m.ownershipWG.Add(1)
+	go func() {
+		defer m.ownershipWG.Done()
+		hb.Run(ctx)
+	}()
+}
+
+// WaitOwnership blocks until the heartbeat goroutine spawned by AttachOwnership
+// exits. Callers should cancel the ctx passed to AttachOwnership first (to signal
+// the goroutine), then call WaitOwnership to join it. This closes the gh#279 join
+// gap — without this, the goroutine may still be running when the NATS client
+// closes, causing a benign-but-noisy "connection closed" error.
+//
+// No-op when AttachOwnership was never called or was called with a nil registry.
+func (m *Manager) WaitOwnership() {
+	m.ownershipWG.Wait()
 }
 
 // lookupByWorkflow finds the registration for the given workflow type.

--- a/pkg/lifecycle/ownership_test.go
+++ b/pkg/lifecycle/ownership_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/c360studio/semstreams/pkg/ownership"
 )
@@ -167,5 +168,54 @@ func TestOwnershipSentinelsExist(t *testing.T) {
 	t.Parallel()
 	if !errors.Is(&ownership.OverlapError{}, ownership.ErrOwnershipOverlap) {
 		t.Error("OverlapError must match ErrOwnershipOverlap via errors.Is")
+	}
+}
+
+// TestWaitOwnership_JoinsHeartbeatGoroutine verifies the gh#279 join: WaitOwnership
+// must block while a tracked goroutine runs and return promptly after ctx is
+// cancelled. No NATS required — we use the ownershipWG directly since the test
+// is in package lifecycle.
+func TestWaitOwnership_JoinsHeartbeatGoroutine(t *testing.T) {
+	t.Parallel()
+	mgr := newManagerForTest(nil, nil, nil)
+
+	// Simulate what AttachOwnership does: track a long-running goroutine.
+	ready := make(chan struct{})
+	quit := make(chan struct{})
+	mgr.ownershipWG.Add(1)
+	go func() {
+		defer mgr.ownershipWG.Done()
+		close(ready)
+		<-quit
+	}()
+
+	// Wait until the goroutine is running.
+	<-ready
+
+	// WaitOwnership must not return yet (the goroutine is still running).
+	// We verify this by attempting to call it in a goroutine and checking that
+	// it does not complete within a short window.
+	done := make(chan struct{})
+	go func() {
+		mgr.WaitOwnership()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("WaitOwnership returned before goroutine exited")
+	case <-time.After(20 * time.Millisecond):
+		// Good — still waiting.
+	}
+
+	// Signal the goroutine to exit.
+	close(quit)
+
+	// WaitOwnership must now return promptly.
+	select {
+	case <-done:
+		// Correct.
+	case <-time.After(time.Second):
+		t.Fatal("WaitOwnership did not return after goroutine exited")
 	}
 }

--- a/service/ownership_service.go
+++ b/service/ownership_service.go
@@ -1,0 +1,149 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/c360studio/semstreams/pkg/projection"
+	"github.com/c360studio/semstreams/vocabulary"
+)
+
+// OwnershipService is the Phase-B service wrapper for the ownership subsystem
+// (ADR-058). It holds the static heartbeater goroutine that keeps the
+// process-local owner presence key alive in OWNER_PRESENCE.
+//
+// The ownership Registry (the Phase-A identity) is owned by the composition
+// root and passed in — this Service NEVER constructs it (ADR-058 R2: identity
+// is created once in Phase A, never in Start).
+//
+// Start is infallible for soft failures (ADR-058 R1): a nil registry means
+// ownership is disabled this boot; Start returns nil and the service runs
+// idle rather than aborting the whole process via StartAll's first-error gate.
+type OwnershipService struct {
+	*BaseService
+	logger   *slog.Logger        // own logger (mirrors HeartbeatService); set by ctor.
+	reg      *ownership.Registry // R2: owned by Phase A, borrowed here.
+	staticHB *ownership.Heartbeater
+	mu       sync.Mutex // serializes Start/Stop so the re-entrancy guard + launch are atomic
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+}
+
+// NewOwnershipService builds the OwnershipService. reg and staticHB may both be
+// nil (the "ownership disabled this boot" path); Start detects nil reg and runs
+// idle with no goroutines.
+func NewOwnershipService(reg *ownership.Registry, staticHB *ownership.Heartbeater, logger *slog.Logger) *OwnershipService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OwnershipService{
+		BaseService: NewBaseServiceWithOptions("ownership", nil,
+			WithLogger(logger),
+		),
+		logger:   logger,
+		reg:      reg,
+		staticHB: staticHB,
+	}
+}
+
+// Start starts the ownership service. Infallible on soft failures (ADR-058 R1):
+// a nil registry logs and returns nil (idle, no goroutines). A double-Start
+// returns an error — that is a BUG-CLASS caller error, not a soft failure.
+func (s *OwnershipService) Start(ctx context.Context) error {
+	// s.mu makes the re-entrancy guard + goroutine launch ATOMIC: BaseService.Start
+	// returns nil-if-already-running (not an error), so the Status() check alone is a
+	// TOCTOU race under concurrent Start — two callers could both pass it and each
+	// launch a goroutine. The lock, not the check, is what serializes. A double-Start
+	// is a programming error, NOT an R1 soft failure, so erroring here is correct.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Status() == StatusRunning {
+		return fmt.Errorf("ownership service already running")
+	}
+	// Mark the service running — even on the disabled path it is
+	// intentionally-disabled-but-healthy, not crashed, so Status/Health report
+	// correctly rather than "stopped".
+	if err := s.BaseService.Start(ctx); err != nil {
+		return err
+	}
+	if s.reg == nil {
+		// R1 (disabled this boot) + R3 (no consumers): idle, no goroutines.
+		s.logger.Info("ownership service: no registry — running idle (disabled this boot)")
+		return nil
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wg.Add(1)
+	go func() { defer s.wg.Done(); s.staticHB.Run(runCtx) }()
+	return nil
+}
+
+// Stop cancels the running goroutine and waits for it to finish with a timeout.
+// Mirrors HeartbeatService.Stop's inline join pattern.
+func (s *OwnershipService) Stop(timeout time.Duration) error {
+	s.mu.Lock()
+	cancel := s.cancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel() // signal (nil on the disabled path); join outside the lock below
+	}
+	// Join with timeout — inline, mirroring HeartbeatService.Stop.
+	done := make(chan struct{})
+	go func() { s.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		s.logger.Warn("ownership service: stop timeout waiting for goroutines")
+	}
+	return s.BaseService.Stop(timeout)
+}
+
+// WireOwnership performs Phase-A ownership wiring (ADR-058): create buckets,
+// construct the Registry (R2 — once, here), attach it to the lifecycle Manager,
+// and bind static projection contracts. Best-effort (R1): a bucket-bootstrap
+// failure logs and returns nil, nil; callers treat nil as "ownership disabled
+// this boot" and pass it straight to NewOwnershipService (which no-ops on nil).
+//
+// Returns the Registry and its static heartbeater so the caller can (a) start
+// the Phase-B OwnershipService and (b) bind rule-pack contracts AFTER the rule
+// processors are constructed.
+//
+// contracts is the set of static projection contracts to bind at boot (e.g.,
+// the loop-execution contract from loopExecutionProjectionContract()). Passing
+// them as a variadic keeps the service package free of main-package functions.
+func WireOwnership(
+	ctx context.Context,
+	natsClient *natsclient.Client,
+	lcm *lifecycle.Manager,
+	logger *slog.Logger,
+	contracts ...projection.Contract,
+) (*ownership.Registry, *ownership.Heartbeater) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	reg, err := ownership.EnsureBuckets(ctx, natsClient, logger, vocabulary.InverseResolver)
+	if err != nil {
+		logger.Warn("ownership: bucket bootstrap failed — disabled this boot",
+			slog.Any("error", err))
+		return nil, nil // R1: degrade, do not abort.
+	}
+	// nil-safe; spawns the Manager-internal heartbeater, joined via lcm.WaitOwnership().
+	lcm.AttachOwnership(ctx, reg)
+
+	staticHB := reg.NewHeartbeater(ownership.HeartbeatInterval)
+	for _, contract := range contracts {
+		if _, err := projection.BindAndHeartbeat(ctx, reg, staticHB,
+			"agentic-loop-graph-writer", contract); err != nil {
+			logger.Warn("ownership: projection contract bind failed",
+				slog.String("contract", contract.Name),
+				slog.Any("error", err))
+		}
+	}
+	return reg, staticHB
+}

--- a/service/ownership_service_test.go
+++ b/service/ownership_service_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestOwnershipService_NilRegistry_DisabledPath verifies the R1 infallible-Start
+// discipline: when no registry is attached (ownership disabled this boot) Start
+// must return nil and the service must report StatusRunning (intentionally-idle,
+// not crashed). Stop must also be clean.
+func TestOwnershipService_NilRegistry_DisabledPath(t *testing.T) {
+	t.Parallel()
+	svc := NewOwnershipService(nil, nil, nil)
+
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("Start with nil registry must return nil (R1 infallible), got: %v", err)
+	}
+
+	if svc.Status() != StatusRunning {
+		t.Errorf("Status after Start = %v, want StatusRunning", svc.Status())
+	}
+
+	if err := svc.Stop(time.Second); err != nil {
+		t.Errorf("Stop on disabled path must be clean, got: %v", err)
+	}
+}
+
+// TestOwnershipService_ReentrancyGuard verifies that a double-Start returns an
+// error and does not launch duplicate goroutines. This is a BUG-CLASS guard, not
+// an R1 soft failure.
+func TestOwnershipService_ReentrancyGuard(t *testing.T) {
+	t.Parallel()
+	svc := NewOwnershipService(nil, nil, nil)
+
+	if err := svc.Start(context.Background()); err != nil {
+		t.Fatalf("first Start must succeed: %v", err)
+	}
+	defer svc.Stop(time.Second) //nolint:errcheck
+
+	// Second Start while already running must return an error.
+	err := svc.Start(context.Background())
+	if err == nil {
+		t.Fatal("double-Start must return an error (re-entrancy guard)")
+	}
+}

--- a/service/service_manager.go
+++ b/service/service_manager.go
@@ -186,6 +186,28 @@ func (m *Manager) CreateService(name string, rawConfig json.RawMessage, deps *De
 	return service, nil
 }
 
+// RegisterInstance admits a pre-built Service to the manager (composition-root
+// wiring, as opposed to config-driven CreateService). Same map + order tracking
+// CreateService uses, so StartAll/StopAll treat it identically.
+func (m *Manager) RegisterInstance(name string, svc Service) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.services[name]; exists {
+		// Composition-root duplicate registration is a wiring bug. Overwrite the
+		// instance but do NOT re-track order — a second m.order entry would make
+		// StopAll call Stop twice. Mirrors CreateService's duplicate rejection
+		// without the error return (RegisterInstance is void by design).
+		if m.logger != nil {
+			m.logger.Warn("service instance already registered — overwriting, not re-tracking order",
+				"service", name)
+		}
+		m.services[name] = svc
+		return
+	}
+	m.services[name] = svc
+	m.order = append(m.order, name)
+}
+
 // GetService returns a service instance by name
 func (m *Manager) GetService(name string) (Service, bool) {
 	m.mu.RLock()

--- a/service/service_manager_test.go
+++ b/service/service_manager_test.go
@@ -800,3 +800,76 @@ func TestServiceManager_RuntimeConfigurable_Interface(t *testing.T) {
 		}
 	}
 }
+
+// TestServiceManager_RegisterInstance verifies that RegisterInstance places the
+// service into the map AND the order slice so StartAll and StopAll treat it
+// identically to a config-driven CreateService registration.
+func TestServiceManager_RegisterInstance(t *testing.T) {
+	t.Parallel()
+	manager := createTestServiceManager(ManagerConfig{}, nil)
+
+	svc := &MockService{
+		name:    "instance-svc",
+		status:  StatusStopped,
+		healthy: true,
+	}
+
+	manager.RegisterInstance("instance-svc", svc)
+
+	// GetService must find it.
+	got, ok := manager.GetService("instance-svc")
+	if !ok {
+		t.Fatal("RegisterInstance: GetService returned not-found")
+	}
+	if got != svc {
+		t.Error("RegisterInstance: GetService returned wrong instance")
+	}
+
+	// order slice must include it so StopAll visits it in reverse order.
+	manager.mu.RLock()
+	found := false
+	for _, name := range manager.order {
+		if name == "instance-svc" {
+			found = true
+			break
+		}
+	}
+	manager.mu.RUnlock()
+
+	if !found {
+		t.Error("RegisterInstance: service name not found in order slice")
+	}
+}
+
+// TestServiceManager_RegisterInstance_DuplicateNoDoubleTrack verifies the C2 fix:
+// a second RegisterInstance with the same name overwrites the instance but does
+// NOT append a second order entry — otherwise StopAll would call Stop twice.
+func TestServiceManager_RegisterInstance_DuplicateNoDoubleTrack(t *testing.T) {
+	t.Parallel()
+	manager := createTestServiceManager(ManagerConfig{}, nil)
+
+	first := &MockService{name: "dup-svc", status: StatusStopped, healthy: true}
+	second := &MockService{name: "dup-svc", status: StatusStopped, healthy: true}
+
+	manager.RegisterInstance("dup-svc", first)
+	manager.RegisterInstance("dup-svc", second)
+
+	// Latest instance wins.
+	got, ok := manager.GetService("dup-svc")
+	if !ok || got != second {
+		t.Errorf("duplicate RegisterInstance: GetService = %v,%v, want the second instance", got, ok)
+	}
+
+	// order must contain exactly ONE entry for the name (no double-Stop).
+	manager.mu.RLock()
+	count := 0
+	for _, name := range manager.order {
+		if name == "dup-svc" {
+			count++
+		}
+	}
+	manager.mu.RUnlock()
+	if count != 1 {
+		t.Errorf("duplicate RegisterInstance: order has %d entries for dup-svc, want exactly 1 (double entry → double Stop)", count)
+	}
+}


### PR DESCRIPTION
## ADR-058 + PR-A — boot-lifecycle extraction (ownership)

Two commits:
1. **ADR-058** (`docs/adr/058-boot-lifecycle-phases.md`, Draft) — the boot-lifecycle pattern: **Phase A** (eager resource creation + identity registration → shared composition-root helper functions) vs **Phase B** (process-lifetime background goroutines needing clean Start+join → a `service.Service` managed by `ServiceManager`). Architect-drafted, adversarially reviewed (caught 2 fictional-API claims), go-reviewer-approved.
2. **PR-A** — the first rollout step: extract the ownership boot out of both `cmd` mains.

### Why
The ownership boot wiring was hand-rolled (`go X.Run()` + `WaitGroup` + LIFO-`defer`) and **duplicated + already divergent** across `cmd/semstreams` (inline) and `cmd/e2e-semstreams` (`wireLifecycleManager`) — the beta.18 half-migration failure mode. Adding ADR-056 PR-4's `WatchRevival` tipped `run()` past the function-length lint limit, forcing the cleanup.

### What (behavior-preserving + one gh#279 hardening)
- `service/ownership_service.go` — `WireOwnership` (Phase-A: EnsureBuckets + Registry + AttachOwnership + static-contract bind; returns nil = "disabled this boot") + `OwnershipService` (Phase-B `service.Service`, mirrors `HeartbeatService`; runs the static heartbeater — `WatchRevival` is the follow-up PR).
- `service/service_manager.go` — `RegisterInstance(name, Service)`: the one new primitive, for composition-root-built service instances (the manager only had config-driven `CreateService`).
- `pkg/lifecycle/manager.go` — **closes gh#279**: `WaitOwnership()` joins the `AttachOwnership` heartbeater goroutine on shutdown (was signalled-but-not-joined).
- both mains rewired to the **same** `WireOwnership` → `RegisterInstance` shape.

### Result
- **beta.18 risk structurally eliminated**: the two mains' ownership regions are now byte-for-byte identical (go-reviewer-confirmed).
- `run()` back under the function-length limit.
- Observe-only posture preserved (R1: `OwnershipService.Start` is infallible for soft failures — a bucket-bootstrap hiccup degrades to "disabled this boot", never aborts boot via `StartAll`'s first-error gate).
- Registry identity created once in Phase A, never in `Start` (R2: a service restart can't re-mint the incarnation).

### Review & gates
- **go-reviewer: ACCEPT-WITH-NITS** (behavior preserved, mains consistent, shutdown ordering traced correct, 3 self-found issues fixed: TOCTOU→mutex, dup-guard+test, dead `Name()` removed).
- build · vet ×{default,integration,live_llm} · lint (run() under limit) · unit `-race` (service/lifecycle/cmd) — all green. Integration on CI (behavior-preserving; not a BREAKING change).

Follow-up: PR-B rebases ADR-056 PR-4 (`WatchRevival` quiesce) onto this, wiring `WatchRevival` into `OwnershipService.Start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)