### PR TITLE
feat(ownership): ADR-056 PR-4 — Watch-revival quiesce (on OwnershipService)

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -172,7 +172,7 @@ func run() error {
 		loopExecutionProjectionContract())
 	// ADR-058 Phase B — static heartbeater goroutine under the ServiceManager's
 	// ordered shutdown.
-	manager.RegisterInstance("ownership", service.NewOwnershipService(ownerReg, staticOwnerHB, logger))
+	manager.RegisterInstance("ownership", service.NewOwnershipService(ownerReg, staticOwnerHB, metricsRegistry, logger))
 
 	// Register workflows (must come after Manager is constructed).
 	if err := svcDeps.LifecycleManager.Register(mission.WorkflowDeclaration()); err != nil {

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -205,7 +205,7 @@ func run() error {
 		loopExecutionProjectionContract())
 	// ADR-058 Phase B — static heartbeater goroutine under the ServiceManager's
 	// ordered shutdown.
-	manager.RegisterInstance("ownership", service.NewOwnershipService(ownerReg, staticOwnerHB, logger))
+	manager.RegisterInstance("ownership", service.NewOwnershipService(ownerReg, staticOwnerHB, metricsRegistry, logger))
 
 	// 10c. Register the agent-run workflow (ADR-053 D2). Must come after
 	// the Manager is constructed so lifecycle_* actions that reference

--- a/pkg/lifecycle/errors.go
+++ b/pkg/lifecycle/errors.go
@@ -107,4 +107,13 @@ var (
 	// underlying transport / handler error so callers can branch
 	// on transient-vs-permanent.
 	ErrEmitFailed = errors.New("lifecycle: emit to graph-ingest failed")
+
+	// ErrOwnerQuiesced is returned by Manager.Create / TransitionWith /
+	// UpdateFromOperator when the attached ownership Registry has QUIESCED this
+	// workflow's owner — WatchRevival detected another process re-registered the
+	// same owner id with a different incarnation, so this process is the stale
+	// writer and must not clobber the live owner's authoritative state (ADR-056
+	// PR-4, quiesce-not-HALT). The refusal is loud and surfaces to the caller
+	// (rule action / operator API) rather than silently dropping the write.
+	ErrOwnerQuiesced = errors.New("lifecycle: owner quiesced (superseded by another process; this writer must not clobber the live owner)")
 )

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -295,6 +295,22 @@ func (m *Manager) ownerToken(workflowName string) string {
 	return reg.OwnerToken(workflowName).Wire()
 }
 
+// checkQuiesced returns ErrOwnerQuiesced when the attached ownership Registry has
+// QUIESCED workflowName (ADR-056 PR-4): WatchRevival detected another process
+// re-registered the same owner id with a different incarnation, so this process
+// is the stale writer and must not clobber the live owner's authoritative state.
+// A nil Registry (ownership disabled this boot) or an un-quiesced owner returns
+// nil — the common case, a single field read on the hot path.
+func (m *Manager) checkQuiesced(workflowName string) error {
+	m.mu.RLock()
+	reg := m.ownerRegistry
+	m.mu.RUnlock()
+	if reg != nil && reg.IsQuiesced(workflowName) {
+		return fmt.Errorf("%w: workflow=%q", ErrOwnerQuiesced, workflowName)
+	}
+	return nil
+}
+
 // ensureBucket lazy-initializes the ENTITY_STATES bucket handle.
 // graph-ingest owns the bucket's lifecycle; the Manager just opens
 // an existing handle.
@@ -428,6 +444,11 @@ func (m *Manager) Create(ctx context.Context, initial Participant) error {
 	}
 	reg, err := m.lookupByWorkflow(initial.Workflow())
 	if err != nil {
+		return err
+	}
+	// ADR-056 PR-4: refuse the write if this owner was superseded by another
+	// process (WatchRevival quiesce) — we are the stale writer, do not clobber.
+	if err := m.checkQuiesced(reg.workflow.Name); err != nil {
 		return err
 	}
 	entityID := initial.EntityID()
@@ -565,6 +586,10 @@ func (m *Manager) Transition(ctx context.Context, workflow, entityID, newPhase s
 func (m *Manager) TransitionWith(ctx context.Context, workflow, entityID, newPhase string, source TransitionSource, note string, mutator func(Participant) error) error {
 	reg, err := m.lookupByWorkflow(workflow)
 	if err != nil {
+		return err
+	}
+	// ADR-056 PR-4: refuse the transition if this owner was superseded (quiesce).
+	if err := m.checkQuiesced(reg.workflow.Name); err != nil {
 		return err
 	}
 	if _, declared := reg.workflow.Transitions[newPhase]; !declared {
@@ -744,6 +769,10 @@ func (m *Manager) UpdateFromOperator(ctx context.Context, workflow, entityID str
 	}
 	reg, err := m.lookupByWorkflow(workflow)
 	if err != nil {
+		return err
+	}
+	// ADR-056 PR-4: refuse the operator patch if this owner was superseded (quiesce).
+	if err := m.checkQuiesced(reg.workflow.Name); err != nil {
 		return err
 	}
 

--- a/pkg/ownership/doc.go
+++ b/pkg/ownership/doc.go
@@ -59,12 +59,16 @@
 //     boot re-drain + the fourth-path (ensureReferencedEntityExists) fold + the
 //     counting crash-recovery flip-gate test (Decision 4 / 4b). EnsureBuckets
 //     does NOT create PENDING_EDGES yet (no consumer).
-//   - The OwnerToken wire field on the graph mutation requests + the handler
-//     lease check returning ErrorCodeOwnerLeaseStale (Decision 2 write seam),
-//     and the post-registration Watch-revival fatal-halt. These two are the
-//     write-gating half of the story; until they land, an evicted-then-revived
-//     owner only churns the epoch (no dropped writes), which is why the embed
-//     ships observe-only rather than hard-fail.
+//   - The handler lease check returning ErrorCodeOwnerLeaseStale (Decision 2
+//     write seam, the reject flip) is the remaining write-gating step (PR-5).
+//     The OwnerToken wire field (PR-1) + observe-only lease check (PR-3) and the
+//     post-registration Watch-revival quiesce (PR-4: WatchRevival quiesces the
+//     lifecycle Manager producer — quiesce-not-HALT, availability over strict)
+//     have landed. NOTE: PR-4 quiesces the lifecycle Manager only; the rule-pack
+//     replace_owned producer's protection is PR-5's write-seam reject (it holds a
+//     cached token, so a superseded pack's stale incarnation simply fails the
+//     lease check there). Until PR-5, a superseded rule pack's writes are
+//     mismatch-logged (PR-3) but still commit.
 //   - The hard-fail-on-overlap flip + observability metric for the Manager embed
 //     (gated behind explicit enforcement, alongside the write-lease above).
 //   - The projection-contract auto-derivation wiring into graph-ingest boot

--- a/pkg/ownership/epoch.go
+++ b/pkg/ownership/epoch.go
@@ -177,6 +177,25 @@ func (e *epoch) ownerOf(entityID, predicate string) (owner string, ok bool) {
 // result is deterministic — defense-in-depth for a lease lookup that feeds a
 // reject decision, should a malformed epoch ever carry two owning owners for a
 // cell; the overlap check guarantees at most one in a well-formed epoch.
+// incarnationOfOwner returns the incarnation recorded on the FIRST owning
+// OwnerClaim of `owner` in this epoch (ADR-056 PR-4 revival detection).
+// present=false means the owner has no OWNING claim in the live epoch — it was
+// compacted with no successor, or it holds only foreign-edge / append-evidence
+// claims (neither carries a write-fence incarnation). A well-formed epoch stamps
+// the SAME incarnation on every one of an owner's claims (RegisterOwner stamps
+// reg.incarnation across the whole set), so the first owning claim's incarnation
+// is the owner's incarnation. The returned incarnation may be "" for a
+// legacy/pre-fence claim — the caller treats "" as not-superseding (no rival
+// incarnation to compare).
+func (e *epoch) incarnationOfOwner(owner string) (incarnation string, present bool) {
+	for _, c := range e.Owners[owner].Claims {
+		if c.Mode.isOwning() {
+			return c.Incarnation, true
+		}
+	}
+	return "", false
+}
+
 func (e *epoch) ownerWithIncarnationOf(entityID, predicate string) (owner, incarnation string, ok bool) {
 	for _, ownerID := range sortedOwners(e.Owners) {
 		for _, c := range e.Owners[ownerID].Claims {

--- a/pkg/ownership/registry.go
+++ b/pkg/ownership/registry.go
@@ -48,6 +48,36 @@ type Registry struct {
 	// only / test default.
 	inverseResolver    InverseResolver
 	noResolverWarnOnce sync.Once
+
+	// registeredMu guards registered. registered is the set of owner ids THIS
+	// process successfully registered via RegisterOwner — the owners
+	// WatchRevival monitors for eviction-then-supersession (ADR-056 PR-4).
+	// Populated on each successful RegisterOwner; never pruned (an owner this
+	// process claims, it owns for its lifetime — losing the claim is exactly the
+	// revival condition WatchRevival exists to catch).
+	registeredMu sync.Mutex
+	registered   map[string]struct{}
+
+	// quiescedMu guards quiesced. quiesced is the set of owner ids this process
+	// has QUIESCED after WatchRevival detected they were superseded by a
+	// different incarnation (ADR-056 PR-4). Latching and terminal per owner: once
+	// a rival incarnation holds our owner, this process must never resume
+	// authoritative writes for it. Producers consult IsQuiesced before writing.
+	quiescedMu sync.RWMutex
+	quiesced   map[string]struct{}
+
+	// absentWarnedMu guards absentWarned — owners WatchRevival has already
+	// WARNed about being absent from the live epoch (compacted with no
+	// successor). De-dupes the warn to once per owner so a persistently-absent
+	// owner does not re-log on every epoch update (ADR-056 PR-4).
+	absentWarnedMu sync.Mutex
+	absentWarned   map[string]struct{}
+
+	// revivalUpdates, when non-nil, receives a signal after WatchRevival fully
+	// processes each epoch update. Test-only synchronization seam (set via
+	// setRevivalUpdates) so integration tests await detection deterministically
+	// rather than sleeping; nil in production. Non-blocking buffered send.
+	revivalUpdates chan<- struct{}
 }
 
 // NewRegistry constructs a Registry over the two pre-opened KV stores. The
@@ -75,10 +105,13 @@ func NewRegistry(claims, presence *natsclient.KVStore, logger *slog.Logger) *Reg
 		panic(fmt.Sprintf("ownership: generate incarnation nonce: %v", err))
 	}
 	return &Registry{
-		claims:      claims,
-		presence:    presence,
-		logger:      logger,
-		incarnation: hex.EncodeToString(b),
+		claims:       claims,
+		presence:     presence,
+		logger:       logger,
+		incarnation:  hex.EncodeToString(b),
+		registered:   make(map[string]struct{}),
+		quiesced:     make(map[string]struct{}),
+		absentWarned: make(map[string]struct{}),
 	}
 }
 
@@ -315,7 +348,50 @@ func (reg *Registry) RegisterOwner(ctx context.Context, r Registration) error {
 		reg.rollbackPresence(ctx, r.Owner, preExisted)
 		return fmt.Errorf("ownership: register %q: %w", r.Owner, err)
 	}
+
+	// Record this owner as one of ours so WatchRevival monitors it for
+	// eviction-then-supersession (ADR-056 PR-4). Only on a clean commit — a
+	// rejected/overlapping registration holds no claim to revive against.
+	reg.registeredMu.Lock()
+	reg.registered[r.Owner] = struct{}{}
+	reg.registeredMu.Unlock()
 	return nil
+}
+
+// registeredOwners returns a snapshot copy of the owner ids this process
+// registered — the set WatchRevival iterates each epoch update.
+func (reg *Registry) registeredOwners() map[string]struct{} {
+	reg.registeredMu.Lock()
+	defer reg.registeredMu.Unlock()
+	out := make(map[string]struct{}, len(reg.registered))
+	for o := range reg.registered {
+		out[o] = struct{}{}
+	}
+	return out
+}
+
+// IsQuiesced reports whether this process has quiesced authoritative writes for
+// owner after WatchRevival detected it was superseded by a different incarnation
+// (ADR-056 PR-4). Producers (the lifecycle Manager) consult this before an owned
+// write; a quiesced owner must not write — a live rival owns it now.
+func (reg *Registry) IsQuiesced(owner string) bool {
+	reg.quiescedMu.RLock()
+	defer reg.quiescedMu.RUnlock()
+	_, ok := reg.quiesced[owner]
+	return ok
+}
+
+// markQuiesced latches owner as quiesced. Returns true on the 0→1 transition so
+// the caller emits the CRITICAL log + metric exactly once; false if already
+// quiesced. Latching — an owner never un-quiesces within this process.
+func (reg *Registry) markQuiesced(owner string) bool {
+	reg.quiescedMu.Lock()
+	defer reg.quiescedMu.Unlock()
+	if _, already := reg.quiesced[owner]; already {
+		return false
+	}
+	reg.quiesced[owner] = struct{}{}
+	return true
 }
 
 // checkInverseGate runs the Decision-4 inverse-gate over the registration's

--- a/pkg/ownership/revival.go
+++ b/pkg/ownership/revival.go
@@ -1,0 +1,239 @@
+package ownership
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/c360studio/semstreams/metric"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// watchRearmBackoff is how long WatchRevival waits before re-arming the epoch
+// watcher after an arm failure or a closed watcher channel. Short enough that a
+// genuine supersession is caught promptly, long enough not to hot-loop against a
+// flapping connection. The detection is best-effort (the write-seam lease check
+// is the real guarantee), so a few seconds of re-arm latency is acceptable.
+const watchRearmBackoff = 2 * time.Second
+
+// revivalDecision classifies what WatchRevival should do for one of this
+// process's owners given a live epoch observation.
+type revivalDecision int
+
+const (
+	// revivalNone — the owner's live claim still carries our incarnation (or a
+	// legacy/pre-fence empty incarnation): no rival, nothing to do.
+	revivalNone revivalDecision = iota
+	// revivalQuiesce — the owner's live claim carries a DIFFERENT incarnation: a
+	// rival process owns it now, so quiesce our authoritative writes.
+	revivalQuiesce
+	// revivalAbsentWarn — the owner has no owning claim in the live epoch
+	// (compacted with no successor): warn-once, do NOT quiesce (no rival to
+	// clobber; the repair is re-registration, a later increment).
+	revivalAbsentWarn
+)
+
+// decideRevival classifies an epoch observation for one of our owners (ADR-056
+// PR-4). myInc is this process's incarnation; liveInc/present describe the
+// owner's live OWNING claim in the epoch (from epoch.incarnationOfOwner).
+//
+// Decision (Coby 2026-06-18, quiesce-only-on-supersession):
+//   - absent → warn-only (no rival is clobbering; self-silencing a still-live
+//     owner whose presence key merely lapsed under GC pressure would be worse
+//     than the benign drift).
+//   - present with a DIFFERENT non-empty incarnation → quiesce (clear
+//     supersession; we are the stale writer).
+//   - present with OUR incarnation → none (our claim, the common case on every
+//     benign epoch bump by an unrelated owner).
+//   - present with an EMPTY incarnation → none (a legacy/pre-fence owner; there
+//     is no rival incarnation to compare, so the lease is not enforceable —
+//     mirrors the graph-ingest fail-open on empty incarnation).
+func decideRevival(myInc, liveInc string, present bool) revivalDecision {
+	if !present {
+		return revivalAbsentWarn
+	}
+	if liveInc == "" || liveInc == myInc {
+		return revivalNone
+	}
+	return revivalQuiesce
+}
+
+// WatchRevival watches the OWNER_CLAIMS epoch and quiesces any of this process's
+// registered owners that the live epoch shows superseded by a different
+// incarnation (ADR-056 PR-4 — the post-registration Watch the epoch.Version
+// counter was added for). It is the producer-side courtesy that stops a
+// revived-stale writer from clobbering between its revival and the next write;
+// the write-seam lease check (PR-3 observe / PR-5 reject) is the real data-safety
+// guarantee. Posture is QUIESCE-not-HALT: a superseded owner stops writing, the
+// process keeps running (availability over strict; Coby).
+//
+// Blocks until ctx is cancelled — run it in a goroutine over a SHUTDOWN-CANCELLED
+// context (never context.Background), and join it before the NATS client closes
+// (see the cmd wiring). Best-effort and fail-open: a decode error skips one
+// update, a closed/failed watcher re-arms after a short backoff, and nothing here
+// ever blocks a write or exits the process. metrics may be nil (tests).
+func (reg *Registry) WatchRevival(ctx context.Context, metrics *metric.MetricsRegistry) error {
+	counter := getOwnerRevivalQuiesceMetric(metrics)
+	for ctx.Err() == nil {
+		watcher, err := reg.claims.Watch(ctx, registryKey)
+		if err != nil {
+			if ctx.Err() != nil {
+				break // shutting down — the arm error is just the cancelled ctx, not a fault.
+			}
+			reg.logger.Warn("ownership: WatchRevival could not arm epoch watch — retrying",
+				slog.Any("error", err))
+			if !sleepCtx(ctx, watchRearmBackoff) {
+				break
+			}
+			continue
+		}
+		// runRevivalWatch returns on ctx cancellation OR a closed watcher channel;
+		// the outer loop re-arms in the latter case.
+		reg.runRevivalWatch(ctx, watcher, counter)
+		_ = watcher.Stop()
+		if ctx.Err() == nil {
+			// Channel closed without cancellation — back off before re-arming.
+			if !sleepCtx(ctx, watchRearmBackoff) {
+				break
+			}
+		}
+	}
+	return ctx.Err()
+}
+
+// runRevivalWatch consumes one watcher's update stream until ctx is cancelled or
+// the channel closes. A nil entry is the end-of-initial-replay sentinel.
+func (reg *Registry) runRevivalWatch(ctx context.Context, watcher jetstream.KeyWatcher, counter *prometheus.CounterVec) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case entry, ok := <-watcher.Updates():
+			if !ok {
+				return // watcher channel closed → caller re-arms
+			}
+			if entry == nil {
+				continue // end-of-initial-replay sentinel (no value)
+			}
+			reg.processEpochUpdate(entry.Value(), counter)
+		}
+	}
+}
+
+// processEpochUpdate evaluates one epoch value against this process's registered
+// owners, quiescing any that a different incarnation now owns. Fail-open on a
+// decode error (skip this update). Fires the test-only revivalUpdates signal
+// after fully processing the update so integration tests can await detection.
+func (reg *Registry) processEpochUpdate(value []byte, counter *prometheus.CounterVec) {
+	defer reg.signalRevivalUpdate()
+
+	ep, err := decodeEpoch(value)
+	if err != nil {
+		reg.logger.Warn("ownership: WatchRevival could not decode epoch — skipping update (fail-open)",
+			slog.Any("error", err))
+		return
+	}
+
+	for owner := range reg.registeredOwners() {
+		if reg.IsQuiesced(owner) {
+			continue // already latched — no further action
+		}
+		liveInc, present := ep.incarnationOfOwner(owner)
+		switch decideRevival(reg.incarnation, liveInc, present) {
+		case revivalQuiesce:
+			if reg.markQuiesced(owner) {
+				counter.WithLabelValues(owner).Inc()
+				reg.logger.Error("ownership: REVIVAL QUIESCE — owner superseded by another process; quiescing this process's authoritative writes for it",
+					slog.String("owner", owner),
+					slog.String("my_incarnation", reg.incarnation),
+					slog.String("live_incarnation", liveInc),
+					slog.Uint64("epoch_version", ep.Version))
+			}
+		case revivalAbsentWarn:
+			reg.warnAbsentOnce(owner, ep.Version)
+		case revivalNone:
+			// Our claim with our incarnation (or a legacy empty one) — nothing to do.
+		}
+	}
+}
+
+// warnAbsentOnce logs (at WARN) that one of our registered owners is absent from
+// the live epoch, exactly once per owner. Absence is benign (no rival to
+// clobber), so it is not a quiesce — but it is an anomaly worth surfacing.
+func (reg *Registry) warnAbsentOnce(owner string, epochVersion uint64) {
+	reg.absentWarnedMu.Lock()
+	_, already := reg.absentWarned[owner]
+	if !already {
+		reg.absentWarned[owner] = struct{}{}
+	}
+	reg.absentWarnedMu.Unlock()
+	if already {
+		return
+	}
+	reg.logger.Warn("ownership: registered owner absent from live epoch (compacted with no successor; not quiescing — re-registration repair is a later increment)",
+		slog.String("owner", owner),
+		slog.Uint64("epoch_version", epochVersion))
+}
+
+// signalRevivalUpdate fires the test-only synchronization channel, if set, after
+// an epoch update has been fully processed. Non-blocking so a full buffer never
+// wedges the watch loop; nil (the production default) is a no-op.
+func (reg *Registry) signalRevivalUpdate() {
+	if reg.revivalUpdates == nil {
+		return
+	}
+	select {
+	case reg.revivalUpdates <- struct{}{}:
+	default:
+	}
+}
+
+// setRevivalUpdates installs the test-only post-update signal channel. Used by
+// integration tests to await detection deterministically instead of sleeping;
+// never set in production.
+func (reg *Registry) setRevivalUpdates(ch chan<- struct{}) {
+	reg.revivalUpdates = ch
+}
+
+// sleepCtx waits for d or ctx cancellation, returning true if d elapsed and
+// false if ctx was cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+var (
+	ownerRevivalQuiesceOnce sync.Once
+	ownerRevivalQuiesceVec  *prometheus.CounterVec
+)
+
+// getOwnerRevivalQuiesceMetric returns the process-wide counter for ADR-056 PR-4
+// revival quiesces — owners this process stopped writing after detecting a
+// different incarnation took them over. Registered into the app's MetricsRegistry
+// (the /metrics-scraped registry) when one is provided; falls back to the default
+// Prometheus registerer for nil (test paths). Label: owner (bounded — one of this
+// process's own registered owners). Mirrors graph-ingest's lazy metric pattern.
+func getOwnerRevivalQuiesceMetric(registry *metric.MetricsRegistry) *prometheus.CounterVec {
+	ownerRevivalQuiesceOnce.Do(func() {
+		ownerRevivalQuiesceVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "ownership",
+			Name:      "owner_revival_quiesce_total",
+			Help:      "Count of owners this process quiesced after WatchRevival detected eviction-then-supersession by a different incarnation (ADR-056 PR-4; quiesce-not-HALT). Label: owner.",
+		}, []string{"owner"})
+		if registry != nil {
+			_ = registry.RegisterCounterVec("ownership", "owner_revival_quiesce_total", ownerRevivalQuiesceVec)
+		} else {
+			_ = prometheus.DefaultRegisterer.Register(ownerRevivalQuiesceVec)
+		}
+	})
+	return ownerRevivalQuiesceVec
+}

--- a/pkg/ownership/revival_integration_test.go
+++ b/pkg/ownership/revival_integration_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package ownership
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// TestIntegration_WatchRevival_QuiescesOnSupersession proves the ADR-056 PR-4
+// Watch-revival quiesce end-to-end through the real NATS KV epoch (testcontainer):
+// when a SECOND process (a distinct Registry with a different incarnation)
+// re-registers the SAME owner id, the first process's WatchRevival goroutine sees
+// the live epoch's incarnation change and QUIESCES that owner.
+//
+// Supersession is driven deterministically (two RegisterOwner calls, both awaited)
+// and detection is awaited via the test-only revivalUpdates signal channel — no
+// sleeps gate the assertion (only a bounded safety deadline).
+func TestIntegration_WatchRevival_QuiescesOnSupersession(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	ctx := context.Background()
+	const owner = "watch-revival-owner"
+
+	// regA = "this process". Wire the test signal channel BEFORE starting the watch.
+	regA, err := EnsureBuckets(ctx, tc.Client, nil, nil)
+	if err != nil {
+		t.Fatalf("EnsureBuckets A: %v", err)
+	}
+	updates := make(chan struct{}, 32)
+	regA.setRevivalUpdates(updates)
+
+	if err := regA.RegisterOwner(ctx, reg_(owner, sysPat, "sensorml.process.label")); err != nil {
+		t.Fatalf("regA RegisterOwner: %v", err)
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = regA.WatchRevival(watchCtx, nil) }()
+
+	// regB = "a revived second process". A distinct Registry over the SAME buckets
+	// has a distinct incarnation; re-registering the SAME owner id overwrites the
+	// epoch entry with regB's incarnation — the evicted-then-superseded condition.
+	regB, err := EnsureBuckets(ctx, tc.Client, nil, nil)
+	if err != nil {
+		t.Fatalf("EnsureBuckets B: %v", err)
+	}
+	if regA.Incarnation() == regB.Incarnation() {
+		t.Fatal("regA and regB must have distinct incarnations for the test to be meaningful")
+	}
+	if err := regB.RegisterOwner(ctx, reg_(owner, sysPat, "sensorml.process.label")); err != nil {
+		t.Fatalf("regB RegisterOwner: %v", err)
+	}
+
+	// Await WatchRevival processing the supersession via the signal channel, bounded
+	// by a safety deadline. Each receive = one processed epoch update; re-check the
+	// latch (which is set BEFORE the signal fires) after each.
+	deadline := time.After(15 * time.Second)
+	for !regA.IsQuiesced(owner) {
+		select {
+		case <-updates:
+		case <-deadline:
+			t.Fatal("timed out waiting for WatchRevival to quiesce regA after supersession by regB")
+		}
+	}
+
+	if !regA.IsQuiesced(owner) {
+		t.Error("regA must be quiesced after regB's incarnation superseded it in the epoch")
+	}
+	// regB is the rightful live owner; nothing quiesced it (its own watch isn't running).
+	if regB.IsQuiesced(owner) {
+		t.Error("regB (the rightful owner) must NOT be quiesced")
+	}
+}
+
+// TestIntegration_WatchRevival_NoQuiesceOnBenignBump proves the negative: an epoch
+// bump that does NOT touch our owner (a different owner registering) must NOT
+// quiesce us. Locks decideRevival's "present with our own incarnation / unrelated
+// owner → none" branch through the real watch.
+func TestIntegration_WatchRevival_NoQuiesceOnBenignBump(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithKV())
+	ctx := context.Background()
+	const mine = "benign-bump-mine"
+
+	regA, err := EnsureBuckets(ctx, tc.Client, nil, nil)
+	if err != nil {
+		t.Fatalf("EnsureBuckets A: %v", err)
+	}
+	updates := make(chan struct{}, 32)
+	regA.setRevivalUpdates(updates)
+	if err := regA.RegisterOwner(ctx, reg_(mine, sysPat, "sensorml.process.label")); err != nil {
+		t.Fatalf("regA RegisterOwner: %v", err)
+	}
+
+	// Register the unrelated owner (disjoint pattern, no overlap) BEFORE starting
+	// regA's watcher. This is what makes the test deterministic: the watcher's
+	// initial replay then delivers an epoch that PROVABLY already contains
+	// "benign-bump-other", so the single signal we await below cannot be a
+	// regA-only initial state — it necessarily reflects the benign bump.
+	regB, err := EnsureBuckets(ctx, tc.Client, nil, nil)
+	if err != nil {
+		t.Fatalf("EnsureBuckets B: %v", err)
+	}
+	if err := regB.RegisterOwner(ctx, reg_("benign-bump-other", "c360.other.*.*.*.*", "other.predicate")); err != nil {
+		t.Fatalf("regB RegisterOwner: %v", err)
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = regA.WatchRevival(watchCtx, nil) }()
+
+	// Await the watcher processing its initial replay (which contains BOTH owners),
+	// then assert regA is STILL not quiesced — a benign bump by an unrelated owner
+	// must not quiesce us.
+	select {
+	case <-updates:
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out waiting for WatchRevival to process the initial epoch (with both owners)")
+	}
+	if regA.IsQuiesced(mine) {
+		t.Error("a benign epoch bump by an unrelated owner must NOT quiesce regA")
+	}
+}

--- a/pkg/ownership/revival_test.go
+++ b/pkg/ownership/revival_test.go
@@ -1,0 +1,147 @@
+// Package ownership — unit tests for the ADR-056 PR-4 Watch-revival quiesce
+// detection logic. These exercise the pure decision + the in-memory
+// detect-and-latch path (decideRevival, epoch.incarnationOfOwner,
+// markQuiesced/IsQuiesced, processEpochUpdate) WITHOUT NATS — the full
+// WatchRevival goroutine over a real epoch watcher is covered in
+// revival_integration_test.go.
+package ownership
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecideRevival(t *testing.T) {
+	t.Parallel()
+	const mine = "aaaa111122223333"
+	tests := []struct {
+		name    string
+		liveInc string
+		present bool
+		want    revivalDecision
+	}{
+		{"absent → warn-only", "", false, revivalAbsentWarn},
+		{"present, same incarnation → none", mine, true, revivalNone},
+		{"present, different incarnation → quiesce", "bbbb444455556666", true, revivalQuiesce},
+		{"present, empty (legacy/pre-fence) incarnation → none", "", true, revivalNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, decideRevival(mine, tt.liveInc, tt.present))
+		})
+	}
+}
+
+func TestEpoch_IncarnationOfOwner(t *testing.T) {
+	t.Parallel()
+	ep := newEpoch()
+	ep.Owners["owns"] = ownerEntry{Claims: []OwnerClaim{{
+		Owner: "owns", Pattern: "a.b.c.d.e.*", Predicates: []string{"p"},
+		Mode: ModeReplaceOwned, Incarnation: "inc-owns",
+	}}}
+	ep.Owners["appends"] = ownerEntry{Claims: []OwnerClaim{{
+		Owner: "appends", Pattern: "a.b.c.d.e.*", Predicates: []string{"p"},
+		Mode: ModeAppendEvidence, Incarnation: "inc-appends",
+	}}}
+	ep.Owners["fe-only"] = ownerEntry{ForeignEdges: []ForeignEdgeClaim{{
+		Owner: "fe-only", Predicate: "rel", Mode: EdgeStrict,
+	}}}
+
+	t.Run("owning claim returns incarnation, present", func(t *testing.T) {
+		inc, present := ep.incarnationOfOwner("owns")
+		assert.True(t, present)
+		assert.Equal(t, "inc-owns", inc)
+	})
+	t.Run("append-evidence-only owner is not present (no write-fence)", func(t *testing.T) {
+		_, present := ep.incarnationOfOwner("appends")
+		assert.False(t, present)
+	})
+	t.Run("foreign-edge-only owner is not present", func(t *testing.T) {
+		_, present := ep.incarnationOfOwner("fe-only")
+		assert.False(t, present)
+	})
+	t.Run("unknown owner is not present", func(t *testing.T) {
+		_, present := ep.incarnationOfOwner("nope")
+		assert.False(t, present)
+	})
+}
+
+func TestRegistry_MarkQuiesced_LatchesAndIsIdempotent(t *testing.T) {
+	t.Parallel()
+	reg := newNoopRegistry(t)
+	assert.False(t, reg.IsQuiesced("o"), "owner is not quiesced initially")
+	assert.True(t, reg.markQuiesced("o"), "first markQuiesced is the 0→1 transition")
+	assert.True(t, reg.IsQuiesced("o"), "owner is quiesced after markQuiesced")
+	assert.False(t, reg.markQuiesced("o"), "second markQuiesced is a no-op (already latched)")
+	assert.True(t, reg.IsQuiesced("o"), "owner stays quiesced (latching)")
+}
+
+// TestRegistry_ProcessEpochUpdate drives the in-memory detection path: build an
+// epoch value, register our owner, and assert processEpochUpdate quiesces only
+// on supersession by a different incarnation — never on our own incarnation, a
+// benign bump, or absence.
+func TestRegistry_ProcessEpochUpdate(t *testing.T) {
+	t.Parallel()
+	counter := getOwnerRevivalQuiesceMetric(nil)
+
+	encodeEpochWith := func(t *testing.T, owner, incarnation string) []byte {
+		t.Helper()
+		ep := newEpoch()
+		ep.Version = 7
+		ep.Owners[owner] = ownerEntry{Claims: []OwnerClaim{{
+			Owner: owner, Pattern: "a.b.c.d.e.*", Predicates: []string{"p"},
+			Mode: ModeReplaceOwned, Incarnation: incarnation,
+		}}}
+		b, err := ep.encode()
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("supersession by different incarnation → quiesce", func(t *testing.T) {
+		t.Parallel()
+		reg := newNoopRegistry(t)
+		reg.registered["mine"] = struct{}{}
+		reg.processEpochUpdate(encodeEpochWith(t, "mine", "RIVAL-incarnation"), counter)
+		assert.True(t, reg.IsQuiesced("mine"), "a different live incarnation must quiesce our owner")
+	})
+
+	t.Run("our own incarnation → not quiesced", func(t *testing.T) {
+		t.Parallel()
+		reg := newNoopRegistry(t)
+		reg.registered["mine"] = struct{}{}
+		reg.processEpochUpdate(encodeEpochWith(t, "mine", reg.incarnation), counter)
+		assert.False(t, reg.IsQuiesced("mine"), "our own incarnation must never quiesce")
+	})
+
+	t.Run("benign bump of an unrelated owner → not quiesced", func(t *testing.T) {
+		t.Parallel()
+		reg := newNoopRegistry(t)
+		reg.registered["mine"] = struct{}{}
+		reg.processEpochUpdate(encodeEpochWith(t, "someone-else", "their-incarnation"), counter)
+		assert.False(t, reg.IsQuiesced("mine"), "an epoch bump that does not touch our owner must not quiesce")
+	})
+
+	t.Run("our owner absent → not quiesced (warn-only)", func(t *testing.T) {
+		t.Parallel()
+		reg := newNoopRegistry(t)
+		reg.registered["mine"] = struct{}{}
+		reg.processEpochUpdate(encodeEpochWith(t, "other", "other-inc"), counter)
+		assert.False(t, reg.IsQuiesced("mine"), "absence (no rival) must not quiesce — warn-only")
+	})
+
+	t.Run("post-update signal fires for tests", func(t *testing.T) {
+		t.Parallel()
+		reg := newNoopRegistry(t)
+		updates := make(chan struct{}, 1)
+		reg.setRevivalUpdates(updates)
+		reg.processEpochUpdate(encodeEpochWith(t, "x", "y"), counter)
+		select {
+		case <-updates:
+		default:
+			t.Fatal("processEpochUpdate must fire the revivalUpdates signal")
+		}
+	})
+}

--- a/service/ownership_service.go
+++ b/service/ownership_service.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/c360studio/semstreams/metric"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
 	"github.com/c360studio/semstreams/pkg/ownership"
@@ -15,8 +16,10 @@ import (
 )
 
 // OwnershipService is the Phase-B service wrapper for the ownership subsystem
-// (ADR-058). It holds the static heartbeater goroutine that keeps the
-// process-local owner presence key alive in OWNER_PRESENCE.
+// (ADR-058). It runs the two process-lifetime ownership goroutines: the static
+// heartbeater (keeps the owner presence key alive in OWNER_PRESENCE) and the
+// WatchRevival quiesce watcher (ADR-056 PR-4 — quiesces this process's owners
+// if a different incarnation takes them over).
 //
 // The ownership Registry (the Phase-A identity) is owned by the composition
 // root and passed in — this Service NEVER constructs it (ADR-058 R2: identity
@@ -30,7 +33,8 @@ type OwnershipService struct {
 	logger   *slog.Logger        // own logger (mirrors HeartbeatService); set by ctor.
 	reg      *ownership.Registry // R2: owned by Phase A, borrowed here.
 	staticHB *ownership.Heartbeater
-	mu       sync.Mutex // serializes Start/Stop so the re-entrancy guard + launch are atomic
+	metrics  *metric.MetricsRegistry // for WatchRevival's owner_revival_quiesce_total counter (ADR-056 PR-4)
+	mu       sync.Mutex              // serializes Start/Stop so the re-entrancy guard + launch are atomic
 	cancel   context.CancelFunc
 	wg       sync.WaitGroup
 }
@@ -38,7 +42,7 @@ type OwnershipService struct {
 // NewOwnershipService builds the OwnershipService. reg and staticHB may both be
 // nil (the "ownership disabled this boot" path); Start detects nil reg and runs
 // idle with no goroutines.
-func NewOwnershipService(reg *ownership.Registry, staticHB *ownership.Heartbeater, logger *slog.Logger) *OwnershipService {
+func NewOwnershipService(reg *ownership.Registry, staticHB *ownership.Heartbeater, metrics *metric.MetricsRegistry, logger *slog.Logger) *OwnershipService {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -49,6 +53,7 @@ func NewOwnershipService(reg *ownership.Registry, staticHB *ownership.Heartbeate
 		logger:   logger,
 		reg:      reg,
 		staticHB: staticHB,
+		metrics:  metrics,
 	}
 }
 
@@ -79,8 +84,11 @@ func (s *OwnershipService) Start(ctx context.Context) error {
 	}
 	runCtx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel
-	s.wg.Add(1)
+	s.wg.Add(2)
 	go func() { defer s.wg.Done(); s.staticHB.Run(runCtx) }()
+	// ADR-056 PR-4: watch the OWNER_CLAIMS epoch and quiesce any of this process's
+	// owners a different incarnation takes over. Joined via s.wg on Stop.
+	go func() { defer s.wg.Done(); _ = s.reg.WatchRevival(runCtx, s.metrics) }()
 	return nil
 }
 

--- a/service/ownership_service_test.go
+++ b/service/ownership_service_test.go
@@ -12,7 +12,7 @@ import (
 // not crashed). Stop must also be clean.
 func TestOwnershipService_NilRegistry_DisabledPath(t *testing.T) {
 	t.Parallel()
-	svc := NewOwnershipService(nil, nil, nil)
+	svc := NewOwnershipService(nil, nil, nil, nil)
 
 	if err := svc.Start(context.Background()); err != nil {
 		t.Fatalf("Start with nil registry must return nil (R1 infallible), got: %v", err)
@@ -32,7 +32,7 @@ func TestOwnershipService_NilRegistry_DisabledPath(t *testing.T) {
 // an R1 soft failure.
 func TestOwnershipService_ReentrancyGuard(t *testing.T) {
 	t.Parallel()
-	svc := NewOwnershipService(nil, nil, nil)
+	svc := NewOwnershipService(nil, nil, nil, nil)
 
 	if err := svc.Start(context.Background()); err != nil {
 		t.Fatalf("first Start must succeed: %v", err)


### PR DESCRIPTION
## ADR-056 OwnerToken write-lease — PR-4 (Watch-revival quiesce)

The deferred ADR-056 PR-4, built on ADR-058's `OwnershipService` (#294). A new `Registry.WatchRevival` epoch-Watch goroutine detects when one of this process's registered owners is **superseded by a different incarnation** (another process re-registered the same owner id) and **quiesces** that owner's authoritative writes.

**Posture: quiesce-not-HALT** — availability over strict. The write-seam lease check (PR-3 observe / PR-5 reject) is the real data-safety guarantee; the quiesce is a producer-side courtesy so a revived-stale process stops clobbering.

### What
- `pkg/ownership/revival.go` — `WatchRevival` (arm→consume→re-arm, fail-open) + `decideRevival` (quiesce **only** on present-with-different-incarnation; absent → warn-only; same/legacy incarnation → none) + `owner_revival_quiesce_total` metric. Quiesce substrate (`IsQuiesced`/`markQuiesced`/`registeredOwners`) + `epoch.incarnationOfOwner`.
- `pkg/lifecycle` — `ErrOwnerQuiesced` + `Manager.checkQuiesced` guard on `Create`/`TransitionWith`/`UpdateFromOperator` (`Transition`/`Complete`/`Fail` inherit it). A real refusal that surfaces to the caller, not a silent drop.
- `service/ownership_service.go` — `WatchRevival` runs as `OwnershipService`'s **second goroutine** (one place, not the mains — the ADR-058 payoff). `metrics` threaded for the quiesce counter.
- Tests: `revival_test.go` (decision logic, no NATS) + `revival_integration_test.go` (real-NATS two-registry supersession → quiesce + benign-bump negative; deterministic via a test-only signal, no sleeps).

### Scope
Observe-only stays observe-only: PR-4 quiesces the **lifecycle Manager** producer; the rule-pack `replace_owned` producer's protection is **PR-5's write-seam reject** (its stale cached token simply fails the lease check there). Non-BREAKING. gh#279 + the boot extraction landed in PR-A (#294).

### Review & gates
- **go-reviewer: ACCEPT-WITH-NITS** — all high-value checks passed (goroutine correct, decideRevival semantics, two-goroutine Stop joins both, manager.go merge clean with no duplicate `WaitOwnership`, all 6 lifecycle write entrypoints guarded). Findings fixed: negative-integration-test determinism + spurious shutdown WARN.
- build · vet ×{default,integration,live_llm} · lint · unit `-race` (ownership/lifecycle/service/cmd) — green. Integration on CI.

Completes the OwnerToken observe-then-enforce arc PR-1→PR-4; **PR-5 (gated reject)** is the remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)