### PR TITLE
feat(graph-ingest): ADR-056 OwnerToken write-lease PR-5 — gated owner-lease reject

### DIFF
--- a/graph/mutation_responses.go
+++ b/graph/mutation_responses.go
@@ -99,9 +99,11 @@ const (
 	// match the live owner recorded in the owner registry for the contested
 	// (entity, predicate) cell — the writer is either a different process or
 	// a revived-stale incarnation of the same owner id. Callers should NOT
-	// retry without resolving the ownership conflict. No handler emits this
-	// code yet (ADR-056 PR-1 is additive plumbing only); the reject logic
-	// arrives in a later increment.
+	// retry without resolving the ownership conflict. Emitted by graph-ingest's
+	// create_with_triples / update_with_triples handlers ONLY when the
+	// enforce_owner_lease config is set (ADR-056 PR-5). The default observe-only
+	// posture (PR-3) meters owner_lease_mismatch_total + Warn-logs the mismatch
+	// and commits the write instead.
 	ErrorCodeOwnerLeaseStale = "owner_lease_stale"
 )
 

--- a/pkg/ownership/doc.go
+++ b/pkg/ownership/doc.go
@@ -49,6 +49,25 @@
 //     graph-ingest seam wiring + the foreign_edge_unclaimed_total metric live in
 //     processor/graph-ingest.
 //
+// W0 OwnerToken write-lease landed (Decision 2 write seam — the full PR-1..PR-5 arc):
+//
+//   - PR-1 wire field + incarnation fence; PR-2 ClaimReader.OwnerOf lease reader;
+//     PR-3 observe-only lease check at the graph-ingest create_with_triples /
+//     update_with_triples handlers (meter owner_lease_mismatch_total + Warn,
+//     write commits); PR-3.5 typed opaque OwnerToken; PR-4 post-registration
+//     Watch-revival quiesce (WatchRevival quiesces the lifecycle Manager producer
+//     — quiesce-not-HALT, availability over strict).
+//   - PR-5 (the reject flip) is the closing move: a write whose OwnerToken does
+//     not match the live owner of a contested predicate is REJECTED with
+//     ErrorCodeOwnerLeaseStale — but ONLY when graph-ingest's enforce_owner_lease
+//     config is set. Default false keeps the observe-only bake posture; operators
+//     flip it on per-deploy once owner_lease_mismatch_total reads zero. The reject
+//     protects the rule-pack replace_owned producer that PR-4's Manager quiesce
+//     does not cover (a superseded pack holds a cached token, so its stale
+//     incarnation fails the lease check at the write seam). All fail-open cases
+//     (empty token, no claim reader, legacy/pre-fence owner, reader blip) stay
+//     fail-open even under enforcement.
+//
 // What is deliberately NOT here yet (later W0 increments, each with its own
 // review):
 //
@@ -59,16 +78,6 @@
 //     boot re-drain + the fourth-path (ensureReferencedEntityExists) fold + the
 //     counting crash-recovery flip-gate test (Decision 4 / 4b). EnsureBuckets
 //     does NOT create PENDING_EDGES yet (no consumer).
-//   - The handler lease check returning ErrorCodeOwnerLeaseStale (Decision 2
-//     write seam, the reject flip) is the remaining write-gating step (PR-5).
-//     The OwnerToken wire field (PR-1) + observe-only lease check (PR-3) and the
-//     post-registration Watch-revival quiesce (PR-4: WatchRevival quiesces the
-//     lifecycle Manager producer — quiesce-not-HALT, availability over strict)
-//     have landed. NOTE: PR-4 quiesces the lifecycle Manager only; the rule-pack
-//     replace_owned producer's protection is PR-5's write-seam reject (it holds a
-//     cached token, so a superseded pack's stale incarnation simply fails the
-//     lease check there). Until PR-5, a superseded rule pack's writes are
-//     mismatch-logged (PR-3) but still commit.
 //   - The hard-fail-on-overlap flip + observability metric for the Manager embed
 //     (gated behind explicit enforcement, alongside the write-lease above).
 //   - The projection-contract auto-derivation wiring into graph-ingest boot

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -217,6 +217,14 @@ type Config struct {
 	Ports              *component.PortConfig `json:"ports" schema:"type:ports,description:Port configuration,category:basic"`
 	EnableHierarchy    bool                  `json:"enable_hierarchy" schema:"type:bool,description:Enable hierarchy inference,default:false,category:advanced"`
 	EnableTypeSiblings *bool                 `json:"enable_type_siblings" schema:"type:bool,description:Enable sibling edges between same-type entities (default true when hierarchy enabled),category:advanced"`
+	// EnforceOwnerLease flips the ADR-056 owner-lease check from observe-only
+	// (PR-3: meter owner_lease_mismatch_total + Warn, write commits) to a hard
+	// reject (PR-5): a write whose OwnerToken does not match the live owner of a
+	// contested predicate is refused with ErrorCodeOwnerLeaseStale. Default false
+	// preserves the observe-only bake posture; operators flip it on per-deploy
+	// once the mismatch metric reads zero. All fail-open cases (empty token,
+	// no claim reader, legacy/pre-fence owner, reader blip) stay fail-open.
+	EnforceOwnerLease bool `json:"enforce_owner_lease" schema:"type:bool,description:Reject writes whose OwnerToken does not match the live owner lease (ADR-056 PR-5); default false keeps observe-only metering,default:false,category:advanced"`
 }
 
 // Validate implements component.Validatable interface
@@ -1312,49 +1320,79 @@ func (c *Component) classifyForeignEdges(ctx context.Context, mt message.Type, f
 	}
 }
 
-// checkOwnerLease is the ADR-056 PR-3 observe-only lease check. It inspects
-// each owned predicate being written against the live OwnerClaim in the registry
-// and emits owner_lease_mismatch_total + a Warn when the request's OwnerToken
-// does not match the live "<owner>#<incarnation>". The write ALWAYS COMMITS —
-// this is strictly observe-only; the reject flip is PR-5.
+// leaseViolation is the first confirmed owner-lease mismatch found in a
+// request's owned-predicate set. checkOwnerLease returns a non-nil
+// *leaseViolation ONLY when enforcement (Config.EnforceOwnerLease) is on AND a
+// mismatch is confirmed; the handler then rejects the write with
+// ErrorCodeOwnerLeaseStale. In the default observe-only posture it is always nil
+// (the mismatch is still metered + Warn-logged).
+type leaseViolation struct {
+	predicate     string // the contested owned predicate
+	expectedOwner string // live owner id (no incarnation nonce — safe for the caller-facing error)
+	got           string // the request's presented OwnerToken
+}
+
+// detail renders the caller-facing reject message. It names the live owner that
+// holds the lease and the contested predicate, but deliberately omits the live
+// incarnation nonce (a liveness fence surfaced only in the operator Warn log).
+func (v *leaseViolation) detail() string {
+	return fmt.Sprintf("owner lease stale: predicate %q is held by live owner %q; the request's OwnerToken does not match",
+		v.predicate, v.expectedOwner)
+}
+
+// checkOwnerLease is the ADR-056 owner-lease check at the graph-ingest write
+// seam. It inspects each owned predicate being written against the live
+// OwnerClaim in the registry. On a mismatch (the request's OwnerToken != the
+// live "<owner>#<incarnation>") it ALWAYS meters owner_lease_mismatch_total + a
+// Warn. Whether it BLOCKS depends on Config.EnforceOwnerLease:
+//
+//   - PR-3 default (EnforceOwnerLease=false): observe-only — returns nil, the
+//     write always commits. This is the bake posture.
+//   - PR-5 enforce (EnforceOwnerLease=true): a confirmed mismatch returns a
+//     non-nil *leaseViolation; the handler rejects the write before it commits
+//     with ErrorCodeOwnerLeaseStale.
 //
 // ownedPredicates is the deduped set of owned-write predicates for this request
 // (own/addOwn predicates + RemoveTriples predicates on the update lanes).
 // messageType is the bounded metric label (registry key or "_invalid").
 //
-// Two-state contract:
-//   - ownerToken == ""  → skip (legacy/unowned writer; the single agreed skip signal).
-//   - claimReader == nil → skip (resourceless/unmigrated deploy graceful-skip).
+// Two-state skip (return nil — never reject):
+//   - ownerToken == ""  → legacy/unowned writer (the single agreed skip signal).
+//   - claimReader == nil → resourceless/unmigrated deploy graceful-skip.
 //
-// Per-predicate:
-//   - err != nil  → Warn + return (fail-open, never block on a reader blip).
+// Per-predicate (fail-open paths return nil even under enforcement):
+//   - err != nil  → Warn + stop (fail-open; honor a mismatch already confirmed
+//     on an earlier predicate, but never block on a reader blip alone).
 //   - ok == false → continue (unclaimed/append-evidence — not lease-governed).
 //   - ok == true && incarnation == "" → fail-open (legacy/pre-fence owner; lease
-//     not enforceable — do NOT emit metric, do NOT Warn, do NOT reject).
+//     not enforceable — no metric, no Warn, no reject).
 //   - ok == true && incarnation != "" → compare ownerToken vs "<owner>#<incarnation>";
-//     mismatch → increment metric + Warn, then continue (OBSERVE-ONLY).
-func (c *Component) checkOwnerLease(ctx context.Context, entityID, messageType, ownerToken string, ownedPredicates []string) {
+//     mismatch → meter + Warn, capture the first violation, continue.
+func (c *Component) checkOwnerLease(ctx context.Context, entityID, messageType, ownerToken string, ownedPredicates []string) *leaseViolation {
 	// Two-state skip.
 	if ownerToken == "" {
-		return
+		return nil
 	}
 	if c.claimReader == nil {
-		return
+		return nil
 	}
 	if len(ownedPredicates) == 0 {
-		return
+		return nil
 	}
 
+	var violation *leaseViolation
 	for _, pred := range ownedPredicates {
 		owner, incarnation, ok, err := c.claimReader.OwnerOf(ctx, entityID, pred)
 		if err != nil {
-			// Fail-open: a transient reader blip must never block a write.
-			c.logger.Warn("graph-ingest: owner-lease read failed — skipping lease check for this predicate (observe-only fail-open)",
+			// Fail-open: a transient reader blip must never block a write. Stop
+			// checking here (PR-3 behavior), but still honor a mismatch already
+			// confirmed on an earlier predicate when enforcing.
+			c.logger.Warn("graph-ingest: owner-lease read failed — skipping lease check for this predicate (fail-open)",
 				slog.String("entity_id", entityID),
 				slog.String("predicate", pred),
 				slog.String("message_type", messageType),
 				slog.Any("error", err))
-			return
+			return c.leaseVerdict(violation)
 		}
 		if !ok {
 			// Unclaimed / append-evidence — not lease-governed.
@@ -1371,14 +1409,38 @@ func (c *Component) checkOwnerLease(ctx context.Context, entityID, messageType, 
 		expected := ownership.ExpectedOwnerToken(owner, incarnation).Wire()
 		if ownerToken != expected {
 			c.ownerLeaseMismatch.WithLabelValues(messageType, pred).Inc()
-			c.logger.Warn("graph-ingest: OwnerToken mismatch — write proceeds (observe-only; reject is PR-5)",
-				slog.String("entity_id", entityID),
-				slog.String("predicate", pred),
-				slog.String("message_type", messageType),
-				slog.String("owner_token", ownerToken),
-				slog.String("expected_token", expected))
+			if c.config.EnforceOwnerLease {
+				c.logger.Warn("graph-ingest: OwnerToken mismatch — write REJECTED (owner_lease_stale; enforce_owner_lease on)",
+					slog.String("entity_id", entityID),
+					slog.String("predicate", pred),
+					slog.String("message_type", messageType),
+					slog.String("owner_token", ownerToken),
+					slog.String("expected_token", expected))
+			} else {
+				c.logger.Warn("graph-ingest: OwnerToken mismatch — write proceeds (observe-only; set enforce_owner_lease to reject)",
+					slog.String("entity_id", entityID),
+					slog.String("predicate", pred),
+					slog.String("message_type", messageType),
+					slog.String("owner_token", ownerToken),
+					slog.String("expected_token", expected))
+			}
+			if violation == nil {
+				violation = &leaseViolation{predicate: pred, expectedOwner: owner, got: ownerToken}
+			}
 		}
 	}
+	return c.leaseVerdict(violation)
+}
+
+// leaseVerdict gates the reject on the enforcement toggle: it surfaces a
+// confirmed violation ONLY when Config.EnforceOwnerLease is set, so the default
+// observe-only path never blocks a write even after a mismatch has been
+// metered + Warn-logged.
+func (c *Component) leaseVerdict(v *leaseViolation) *leaseViolation {
+	if v != nil && c.config.EnforceOwnerLease {
+		return v
+	}
+	return nil
 }
 
 // extractEntityFromMessage extracts an EntityState from a BaseMessage

--- a/processor/graph-ingest/component_test.go
+++ b/processor/graph-ingest/component_test.go
@@ -357,6 +357,48 @@ func TestDefaultConfig_ReturnsValidConfig(t *testing.T) {
 	assert.NotEmpty(t, config.Ports.Inputs)
 	assert.NotEmpty(t, config.Ports.Outputs)
 	assert.False(t, config.EnableHierarchy)
+	// ADR-056 PR-5: the lease-enforcement toggle defaults to the observe-only
+	// bake posture (off) so existing deploys are unaffected.
+	assert.False(t, config.EnforceOwnerLease, "EnforceOwnerLease must default to false (observe-only)")
+}
+
+// TestConfig_EnforceOwnerLease_JSONRoundTrip locks the operator-reachable
+// enforce_owner_lease toggle against the JSON wire: absent → false (the
+// observe-only default), explicit true survives a marshal/unmarshal round-trip,
+// and the factory honors it. Per the operator-configurable-surface discipline
+// (every operator-reachable field needs a JSON round-trip test).
+func TestConfig_EnforceOwnerLease_JSONRoundTrip(t *testing.T) {
+	// Absent in JSON → false.
+	{
+		var cfg Config
+		require.NoError(t, json.Unmarshal([]byte(`{"ports":{}}`), &cfg))
+		assert.False(t, cfg.EnforceOwnerLease, "absent enforce_owner_lease must decode to false")
+	}
+	// Explicit true round-trips.
+	{
+		in := DefaultConfig()
+		in.EnforceOwnerLease = true
+		raw, err := json.Marshal(in)
+		require.NoError(t, err)
+		assert.Contains(t, string(raw), `"enforce_owner_lease":true`, "field must marshal under its json tag")
+
+		var out Config
+		require.NoError(t, json.Unmarshal(raw, &out))
+		assert.True(t, out.EnforceOwnerLease, "explicit true must survive the round-trip")
+	}
+	// The factory threads the toggle onto the live component.
+	{
+		cfg := DefaultConfig()
+		cfg.EnforceOwnerLease = true
+		raw, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		natsClient, err := natsclient.NewClient("nats://localhost:4222")
+		require.NoError(t, err)
+		comp, err := CreateGraphIngest(raw, component.Dependencies{NATSClient: natsClient})
+		require.NoError(t, err)
+		assert.True(t, comp.(*Component).config.EnforceOwnerLease,
+			"CreateGraphIngest must honor enforce_owner_lease from config JSON")
+	}
 }
 
 // ====================================================================================

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -437,11 +437,17 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 	own, foreign := c.normalizeProjection(ctx, req.Entity.ID, req.Entity.MessageType, req.Entity.Triples)
 	req.Entity.Triples = own
 
-	// ADR-056 PR-3: observe-only owner-lease check. The owned-predicate set is
-	// the own-subject triples after normalizeProjection (the non-foreign portion
-	// committed to the primary). Write ALWAYS commits — never blocks here.
-	c.checkOwnerLease(ctx, req.Entity.ID, labelForMessageType(req.Entity.MessageType), req.OwnerToken,
-		predicatesOf(own))
+	// ADR-056 owner-lease check. Observe-only by default (PR-3: meter + Warn,
+	// write commits); when enforce_owner_lease is set (PR-5) a confirmed mismatch
+	// on an owned predicate rejects the write BEFORE CreateEntityStrict commits,
+	// with ErrorCodeOwnerLeaseStale. The owned-predicate set is the own-subject
+	// triples after normalizeProjection (the non-foreign portion committed to the
+	// primary).
+	if v := c.checkOwnerLease(ctx, req.Entity.ID, labelForMessageType(req.Entity.MessageType), req.OwnerToken,
+		predicatesOf(own)); v != nil {
+		return marshalCreateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID,
+			graph.ErrorCodeOwnerLeaseStale, v.detail())
+	}
 
 	// ADR-054 channel (b): stamp an explicitly declared indexing profile from
 	// the mutation envelope (highest precedence). Empty/invalid is ignored and
@@ -657,14 +663,21 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	addOwn, foreign := c.normalizeProjection(ctx, req.Entity.ID, req.Entity.MessageType, req.AddTriples)
 	req.AddTriples = addOwn
 
-	// ADR-056 PR-3: observe-only owner-lease check. The owned-predicate set is
-	// the union of own add-triples predicates (the replace-merge set) and
-	// remove-triples predicates (a predicate named only in RemoveTriples is the
-	// owned cell being cleared — the write targets that owned predicate even
-	// though no new triple is added for it). Deduped by checkOwnerLease's loop.
-	// Write ALWAYS commits — never blocks here.
-	c.checkOwnerLease(ctx, req.Entity.ID, labelForMessageType(req.Entity.MessageType), req.OwnerToken,
-		dedupePredicates(predicatesOf(addOwn), req.RemoveTriples))
+	// ADR-056 owner-lease check (observe-only by default; rejects with
+	// ErrorCodeOwnerLeaseStale when enforce_owner_lease is set — PR-5). This runs
+	// BEFORE the ExpectedRevision CAS dispatch below, so a SINGLE check covers
+	// BOTH the CAS and the UpdateWithRetry sub-paths (the lifecycle-transition CAS
+	// lane included) — reject once, no double-count, and no orphaned foreign edge
+	// (we return before routeForeignEdges). The owned-predicate set is the union
+	// of own add-triples predicates (the replace-merge set) and remove-triples
+	// predicates (a predicate named only in RemoveTriples is the owned cell being
+	// cleared — the write targets that owned predicate even though no new triple
+	// is added for it). Deduped by checkOwnerLease's loop.
+	if v := c.checkOwnerLease(ctx, req.Entity.ID, labelForMessageType(req.Entity.MessageType), req.OwnerToken,
+		dedupePredicates(predicatesOf(addOwn), req.RemoveTriples)); v != nil {
+		return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID,
+			graph.ErrorCodeOwnerLeaseStale, v.detail())
+	}
 
 	// ADR-049: CAS-on-condition path. Non-zero ExpectedRevision means
 	// the caller requires the entity's current KV revision to match

--- a/processor/graph-ingest/owner_lease_check_integration_test.go
+++ b/processor/graph-ingest/owner_lease_check_integration_test.go
@@ -40,6 +40,15 @@ func bootIngestWithOwnerClaim(
 	t *testing.T, ownerID, entityPattern, pred string,
 ) (*Component, *ownership.Registry, context.Context) {
 	t.Helper()
+	return bootIngestWithOwnerClaimCfg(t, ownerID, entityPattern, pred, DefaultConfig())
+}
+
+// bootIngestWithOwnerClaimCfg is bootIngestWithOwnerClaim with an explicit
+// Config so PR-5 tests can boot with EnforceOwnerLease=true.
+func bootIngestWithOwnerClaimCfg(
+	t *testing.T, ownerID, entityPattern, pred string, cfg Config,
+) (*Component, *ownership.Registry, context.Context) {
+	t.Helper()
 	ctx := context.Background()
 	streams := []natsclient.TestStreamConfig{{Name: "ENTITY", Subjects: []string{"entity.>"}}}
 	tc := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
@@ -63,7 +72,7 @@ func bootIngestWithOwnerClaim(
 	}))
 
 	// Boot graph-ingest; Start() self-wires the real ClaimReader.
-	configJSON, err := json.Marshal(DefaultConfig())
+	configJSON, err := json.Marshal(cfg)
 	require.NoError(t, err)
 	comp, err := CreateGraphIngest(configJSON, component.Dependencies{NATSClient: tc.Client})
 	require.NoError(t, err)
@@ -241,4 +250,163 @@ func TestIntegration_OwnerLease_UpdateWithTriples_StaleToken(t *testing.T) {
 	}
 	assert.Equal(t, "updated", updatedValue,
 		"entity predicate must reflect the written value after observe-only stale-token update")
+}
+
+// ─── PR-5 enforce-mode reject (EnforceOwnerLease=true) ────────────────────────
+//
+// These drive the SAME production wire with enforce_owner_lease on and prove the
+// reject is durable: the write never lands. A matching token still commits.
+
+func enforceCfg() Config {
+	cfg := DefaultConfig()
+	cfg.EnforceOwnerLease = true
+	return cfg
+}
+
+// TestIntegration_OwnerLease_Enforce_CreateWithTriples_StaleRejected proves the
+// create lane rejects a stale token AND the entity is never created.
+func TestIntegration_OwnerLease_Enforce_CreateWithTriples_StaleRejected(t *testing.T) {
+	c, _, ctx := bootIngestWithOwnerClaimCfg(t, intOwnerID, intEntityPat, intPred, enforceCfg())
+	label := labelForMessageType(intMT)
+	stale := ownerToken(intOwnerID, "deadbeef-stale-enf0")
+
+	eid := "c360.platform.test.sys.w.enfcrt"
+	before := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: eid, MessageType: intMT},
+		Triples: []message.Triple{
+			{Subject: eid, Predicate: intPred, Object: "active", Timestamp: time.Now(), Confidence: 1},
+		},
+		OwnerToken: stale,
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := c.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, handlerErr, "reject is encoded in the body, never a transport error")
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.False(t, resp.Success, "enforce on: create with a stale token must be rejected")
+	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+
+	// Metric still fires.
+	after := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
+	assert.InDelta(t, before+1, after, 0.0001, "enforce on still meters the mismatch")
+
+	// The entity must NOT exist — the reject returned before CreateEntityStrict.
+	_, _, readErr := c.fetchEntityState(ctx, eid)
+	require.Error(t, readErr, "rejected create must NOT have committed the entity")
+}
+
+// TestIntegration_OwnerLease_Enforce_UpdateWithTriples_StaleRejected proves the
+// update lane rejects a stale token AND the prior state is unchanged.
+func TestIntegration_OwnerLease_Enforce_UpdateWithTriples_StaleRejected(t *testing.T) {
+	c, _, ctx := bootIngestWithOwnerClaimCfg(t, intOwnerID, intEntityPat, intPred, enforceCfg())
+	stale := ownerToken(intOwnerID, "deadbeef-stale-enfu")
+
+	eid := "c360.platform.test.sys.w.enfupd"
+	require.NoError(t, c.CreateEntity(ctx, &graph.EntityState{
+		ID: eid, MessageType: intMT, Version: 1, UpdatedAt: time.Now(),
+		Triples: []message.Triple{{Subject: eid, Predicate: intPred, Object: "init", Timestamp: time.Now(), Confidence: 1}},
+	}))
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:     &graph.EntityState{ID: eid, MessageType: intMT},
+		AddTriples: []message.Triple{{Subject: eid, Predicate: intPred, Object: "updated", Timestamp: time.Now(), Confidence: 1}},
+		OwnerToken: stale,
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := c.handleEntityUpdateWithTriples(ctx, data)
+	require.NoError(t, handlerErr)
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.False(t, resp.Success, "enforce on: update with a stale token must be rejected")
+	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+
+	// Prior state unchanged.
+	stored, _, readErr := c.fetchEntityState(ctx, eid)
+	require.NoError(t, readErr)
+	var got string
+	for _, tr := range stored.Triples {
+		if tr.Predicate == intPred {
+			got = tr.Object.(string)
+		}
+	}
+	assert.Equal(t, "init", got, "rejected update must NOT have applied the delta")
+}
+
+// TestIntegration_OwnerLease_Enforce_UpdateWithTriplesCAS_StaleRejected proves
+// the CAS lane (ExpectedRevision > 0 — the lifecycle Manager's production write
+// path) rejects a stale token through the real wire AND the prior state and
+// revision are untouched (the CAS write never ran).
+func TestIntegration_OwnerLease_Enforce_UpdateWithTriplesCAS_StaleRejected(t *testing.T) {
+	c, _, ctx := bootIngestWithOwnerClaimCfg(t, intOwnerID, intEntityPat, intPred, enforceCfg())
+	stale := ownerToken(intOwnerID, "deadbeef-stale-enfc")
+
+	eid := "c360.platform.test.sys.w.enfcas"
+	require.NoError(t, c.CreateEntity(ctx, &graph.EntityState{
+		ID: eid, MessageType: intMT, Version: 1, UpdatedAt: time.Now(),
+		Triples: []message.Triple{{Subject: eid, Predicate: intPred, Object: "init", Timestamp: time.Now(), Confidence: 1}},
+	}))
+	_, revBefore, err := c.fetchEntityState(ctx, eid)
+	require.NoError(t, err)
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:           &graph.EntityState{ID: eid, MessageType: intMT},
+		AddTriples:       []message.Triple{{Subject: eid, Predicate: intPred, Object: "active", Timestamp: time.Now(), Confidence: 1}},
+		ExpectedRevision: revBefore,
+		OwnerToken:       stale,
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := c.handleEntityUpdateWithTriples(ctx, data)
+	require.NoError(t, handlerErr)
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.False(t, resp.Success, "enforce on: CAS update with a stale token must be rejected")
+	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+
+	// Prior state AND revision unchanged — the CAS write never ran.
+	stored, revAfter, readErr := c.fetchEntityState(ctx, eid)
+	require.NoError(t, readErr)
+	assert.Equal(t, revBefore, revAfter, "rejected CAS update must NOT have advanced the revision")
+	var got string
+	for _, tr := range stored.Triples {
+		if tr.Predicate == intPred {
+			got = tr.Object.(string)
+		}
+	}
+	assert.Equal(t, "init", got, "rejected CAS update must NOT have applied the delta")
+}
+
+// TestIntegration_OwnerLease_Enforce_MatchingToken_Commits proves enforcement
+// does not block the legitimate live owner: a matching token still commits.
+func TestIntegration_OwnerLease_Enforce_MatchingToken_Commits(t *testing.T) {
+	c, reg, ctx := bootIngestWithOwnerClaimCfg(t, intOwnerID, intEntityPat, intPred, enforceCfg())
+	token := ownerToken(intOwnerID, reg.Incarnation())
+
+	eid := "c360.platform.test.sys.w.enfok"
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: eid, MessageType: intMT},
+		Triples: []message.Triple{
+			{Subject: eid, Predicate: intPred, Object: "planning", Timestamp: time.Now(), Confidence: 1},
+		},
+		OwnerToken: token,
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := c.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, handlerErr)
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.True(t, resp.Success, "enforce on: the live owner's matching token must still commit: %s", resp.Error)
+
+	stored, _, readErr := c.fetchEntityState(ctx, eid)
+	require.NoError(t, readErr, "committed entity must be readable")
+	assert.True(t, hasPredicate(stored, intPred))
 }

--- a/processor/graph-ingest/owner_lease_check_test.go
+++ b/processor/graph-ingest/owner_lease_check_test.go
@@ -14,12 +14,15 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Unit tests for checkOwnerLease (ADR-056 PR-3, observe-only)
+// Unit tests for checkOwnerLease (ADR-056 PR-3 observe-only + PR-5 gated reject)
 // ---------------------------------------------------------------------------
 //
 // All tests use a fakeClassifier (defined in foreign_edge_seam_test.go) as the
-// injected ownershipClaimReader so no NATS is needed. checkOwnerLease is a
-// void method; writes always commit. Tests assert metric delta only.
+// injected ownershipClaimReader so no NATS is needed. checkOwnerLease returns a
+// *leaseViolation: nil in the default observe-only posture (writes always commit,
+// tests assert metric delta only); non-nil ONLY when Config.EnforceOwnerLease is
+// set AND a mismatch is confirmed (PR-5 reject). The fail-open cases stay nil
+// even under enforcement.
 
 const (
 	leaseEntityID    = "c360.platform.test.sys.widget.001"
@@ -320,4 +323,266 @@ func TestOwnerLease_EmptyToken_AllLanes_NoMetric(t *testing.T) {
 		after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, pred))
 		assert.InDelta(t, before, after, 0.0001, "update_with_triples: empty OwnerToken → no mismatch metric")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// PR-5 enforce-mode unit tests for checkOwnerLease (the gated reject).
+// ---------------------------------------------------------------------------
+//
+// The enforce toggle (Config.EnforceOwnerLease) ONLY changes the verdict on a
+// CONFIRMED mismatch (ok=true, incarnation!="", token!=expected). It must NEVER
+// turn a fail-open path (empty token, nil reader, legacy incarnation, reader
+// blip) into a reject — those stay nil even under enforcement.
+
+// TestCheckOwnerLease_EnforceOff_StaleToken_NoViolation proves the default
+// posture: a stale token meters the mismatch but returns nil (write commits).
+func TestCheckOwnerLease_EnforceOff_StaleToken_NoViolation(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = false // explicit: the default
+	comp.claimReader = leaseFake(leasePred, leaseOwner, leaseIncarnation)
+	label := "test.rule.v1"
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+	v := comp.checkOwnerLease(context.Background(), leaseEntityID, label, staleToken(), []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+
+	assert.Nil(t, v, "observe-only (enforce off): a stale token must NOT yield a reject verdict")
+	assert.InDelta(t, before+1, after, 0.0001, "observe-only still meters the mismatch")
+}
+
+// TestCheckOwnerLease_EnforceOn_StaleToken_Violation proves the reject verdict
+// carries the contested predicate, the live owner id (not the nonce), and the
+// presented token — and still meters the mismatch.
+func TestCheckOwnerLease_EnforceOn_StaleToken_Violation(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = true
+	comp.claimReader = leaseFake(leasePred, leaseOwner, leaseIncarnation)
+	label := "test.rule.v1"
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+	v := comp.checkOwnerLease(context.Background(), leaseEntityID, label, staleToken(), []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues(label, leasePred))
+
+	require.NotNil(t, v, "enforce on: a stale token must yield a reject verdict")
+	assert.Equal(t, leasePred, v.predicate)
+	assert.Equal(t, leaseOwner, v.expectedOwner, "expectedOwner is the owner id only — no incarnation nonce")
+	assert.NotContains(t, v.expectedOwner, "#", "the caller-facing owner must not leak the live incarnation nonce")
+	assert.Equal(t, staleToken(), v.got)
+	assert.InDelta(t, before+1, after, 0.0001, "enforce on still meters the mismatch")
+}
+
+// TestCheckOwnerLease_EnforceOn_MatchingToken_NoViolation proves a matching
+// token never rejects, even with enforcement on.
+func TestCheckOwnerLease_EnforceOn_MatchingToken_NoViolation(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = true
+	comp.claimReader = leaseFake(leasePred, leaseOwner, leaseIncarnation)
+
+	v := comp.checkOwnerLease(context.Background(), leaseEntityID, "test.rule.v1", liveToken(), []string{leasePred})
+	assert.Nil(t, v, "enforce on: a matching token must NOT reject")
+}
+
+// TestCheckOwnerLease_EnforceOn_LegacyIncarnation_FailOpen is the critical
+// invariant: a legacy/pre-fence owner (ok=true, incarnation="") must fail-open
+// even under enforcement — a naive compare against a fenced token would always
+// mismatch and brick every legacy owner's writes.
+func TestCheckOwnerLease_EnforceOn_LegacyIncarnation_FailOpen(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = true
+	comp.claimReader = leaseFake(leasePred, leaseOwner, "") // legacy owner
+
+	before := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues("test.rule.v1", leasePred))
+	v := comp.checkOwnerLease(context.Background(), leaseEntityID, "test.rule.v1", liveToken(), []string{leasePred})
+	after := testutil.ToFloat64(comp.ownerLeaseMismatch.WithLabelValues("test.rule.v1", leasePred))
+
+	assert.Nil(t, v, "enforce on: a legacy/pre-fence owner must fail-open (no reject)")
+	assert.InDelta(t, before, after, 0.0001, "legacy owner: no metric even under enforcement")
+}
+
+// TestCheckOwnerLease_EnforceOn_ReaderError_FailOpen proves a transient reader
+// blip never blocks, even under enforcement.
+func TestCheckOwnerLease_EnforceOn_ReaderError_FailOpen(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = true
+	comp.claimReader = &fakeClassifier{owners: map[string]fakeOwnerEntry{leasePred: {err: assertErr}}}
+
+	v := comp.checkOwnerLease(context.Background(), leaseEntityID, "test.rule.v1", staleToken(), []string{leasePred})
+	assert.Nil(t, v, "enforce on: a reader error must fail-open (no reject)")
+}
+
+// TestCheckOwnerLease_EnforceOn_EmptyTokenAndNilReader_NoViolation proves the
+// two-state skips never reject under enforcement.
+func TestCheckOwnerLease_EnforceOn_EmptyTokenAndNilReader_NoViolation(t *testing.T) {
+	// empty token
+	{
+		comp := createTestComponentWithMockKV(t)
+		comp.config.EnforceOwnerLease = true
+		comp.claimReader = leaseFake(leasePred, leaseOwner, leaseIncarnation)
+		v := comp.checkOwnerLease(context.Background(), leaseEntityID, "test.rule.v1", "", []string{leasePred})
+		assert.Nil(t, v, "enforce on: empty OwnerToken (legacy writer) must NOT reject")
+	}
+	// nil reader
+	{
+		comp := createTestComponentWithMockKV(t)
+		comp.config.EnforceOwnerLease = true
+		comp.claimReader = nil
+		v := comp.checkOwnerLease(context.Background(), leaseEntityID, "test.rule.v1", liveToken(), []string{leasePred})
+		assert.Nil(t, v, "enforce on: nil claimReader must graceful-skip (no reject)")
+	}
+}
+
+// TestCheckOwnerLease_EnforceOn_MismatchThenReaderError_HonorsEarlierMismatch
+// proves the err-path return still surfaces a mismatch confirmed on an EARLIER
+// predicate (the reader blip on a later predicate must not erase a real reject).
+func TestCheckOwnerLease_EnforceOn_MismatchThenReaderError_HonorsEarlierMismatch(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = true
+	const predA, predB = "a.pred", "b.pred"
+	comp.claimReader = &fakeClassifier{owners: map[string]fakeOwnerEntry{
+		predA: {owner: leaseOwner, incarnation: leaseIncarnation}, // confirmed mismatch vs stale token
+		predB: {err: assertErr},                                   // reader blip on the next predicate
+	}}
+
+	v := comp.checkOwnerLease(context.Background(), leaseEntityID, "test.rule.v1", staleToken(), []string{predA, predB})
+	require.NotNil(t, v, "a mismatch on predA must reject even though predB hit a reader error")
+	assert.Equal(t, predA, v.predicate)
+}
+
+// ---------------------------------------------------------------------------
+// PR-5 lane-wiring reject tests: enforce on → handler returns the coded reject
+// and (for update lanes) the prior state is unchanged.
+// ---------------------------------------------------------------------------
+
+// TestOwnerLease_CreateWithTriples_EnforceOn_Rejects proves the create lane
+// returns Success=false + ErrorCodeOwnerLeaseStale on a stale token.
+func TestOwnerLease_CreateWithTriples_EnforceOn_Rejects(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = true
+	mt := message.Type{Domain: "test", Category: "lease", Version: "v1"}
+	pred := "mission.phase"
+	eid := "c360.test.lease.sys.w.crtrej"
+	comp.claimReader = leaseFake(pred, leaseOwner, leaseIncarnation)
+
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity:     &graph.EntityState{ID: eid, MessageType: mt},
+		Triples:    []message.Triple{{Subject: eid, Predicate: pred, Object: "planning"}},
+		OwnerToken: staleToken(),
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := comp.handleEntityCreateWithTriples(context.Background(), data)
+	require.NoError(t, handlerErr, "handler encodes the reject in the body, never a transport error")
+
+	var resp graph.CreateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	assert.False(t, resp.Success, "enforce on: create with a stale token must be rejected")
+	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+}
+
+// TestOwnerLease_UpdateWithTriples_EnforceOn_Rejects proves the update lane
+// rejects AND leaves the prior state untouched (the delta never applied).
+func TestOwnerLease_UpdateWithTriples_EnforceOn_Rejects(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = true
+	mt := message.Type{Domain: "test", Category: "lease", Version: "v1"}
+	pred := "mission.phase"
+	eid := "c360.test.lease.sys.w.updrej"
+	comp.claimReader = leaseFake(pred, leaseOwner, leaseIncarnation)
+
+	require.NoError(t, comp.CreateEntity(context.Background(), &graph.EntityState{
+		ID: eid, MessageType: mt, Version: 1,
+		Triples: []message.Triple{{Subject: eid, Predicate: pred, Object: "init"}},
+	}))
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:     &graph.EntityState{ID: eid, MessageType: mt},
+		AddTriples: []message.Triple{{Subject: eid, Predicate: pred, Object: "planning"}},
+		OwnerToken: staleToken(),
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := comp.handleEntityUpdateWithTriples(context.Background(), data)
+	require.NoError(t, handlerErr)
+
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	assert.False(t, resp.Success, "enforce on: update with a stale token must be rejected")
+	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+
+	// The prior value must be untouched — the reject returns before UpdateWithRetry.
+	stored, _, readErr := comp.fetchEntityState(context.Background(), eid)
+	require.NoError(t, readErr)
+	var got string
+	for _, tr := range stored.Triples {
+		if tr.Predicate == pred {
+			got, _ = tr.Object.(string)
+		}
+	}
+	assert.Equal(t, "init", got, "rejected update must NOT have applied the delta")
+}
+
+// TestOwnerLease_UpdateWithTriplesCAS_EnforceOn_Rejects proves the CAS lane is
+// covered by the single pre-dispatch check (reject before the CAS write).
+func TestOwnerLease_UpdateWithTriplesCAS_EnforceOn_Rejects(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = true
+	mt := message.Type{Domain: "test", Category: "lease", Version: "v1"}
+	pred := "mission.phase"
+	eid := "c360.test.lease.sys.w.casrej"
+	comp.claimReader = leaseFake(pred, leaseOwner, leaseIncarnation)
+
+	require.NoError(t, comp.CreateEntity(context.Background(), &graph.EntityState{
+		ID: eid, MessageType: mt, Version: 1,
+		Triples: []message.Triple{{Subject: eid, Predicate: pred, Object: "init"}},
+	}))
+	_, rev, err := comp.fetchEntityState(context.Background(), eid)
+	require.NoError(t, err)
+
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:           &graph.EntityState{ID: eid, MessageType: mt},
+		AddTriples:       []message.Triple{{Subject: eid, Predicate: pred, Object: "active"}},
+		ExpectedRevision: rev,
+		OwnerToken:       staleToken(),
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, handlerErr := comp.handleEntityUpdateWithTriples(context.Background(), data)
+	require.NoError(t, handlerErr)
+
+	var resp graph.UpdateEntityWithTriplesResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	assert.False(t, resp.Success, "enforce on: CAS update with a stale token must be rejected")
+	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+}
+
+// TestOwnerLease_EnforceOn_MeteredMutation_RecordsRejection proves the reject
+// flows through meteredMutation as mutation_rejections_total{reason=owner_lease_stale}
+// — the operator-facing rejection metric, for free via the wrapper.
+func TestOwnerLease_EnforceOn_MeteredMutation_RecordsRejection(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	comp.config.EnforceOwnerLease = true
+	mt := message.Type{Domain: "test", Category: "lease", Version: "v1"}
+	pred := "mission.phase"
+	eid := "c360.test.lease.sys.w.metrej"
+	comp.claimReader = leaseFake(pred, leaseOwner, leaseIncarnation)
+
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity:     &graph.EntityState{ID: eid, MessageType: mt},
+		Triples:    []message.Triple{{Subject: eid, Predicate: pred, Object: "planning"}},
+		OwnerToken: staleToken(),
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	before := testutil.ToFloat64(comp.mutationRejections.WithLabelValues(SubjectEntityCreateWithTriples, graph.ErrorCodeOwnerLeaseStale))
+	handler := comp.meteredMutation(SubjectEntityCreateWithTriples, comp.handleEntityCreateWithTriples)
+	_, handlerErr := handler(context.Background(), data)
+	require.NoError(t, handlerErr)
+	after := testutil.ToFloat64(comp.mutationRejections.WithLabelValues(SubjectEntityCreateWithTriples, graph.ErrorCodeOwnerLeaseStale))
+
+	assert.InDelta(t, before+1, after, 0.0001,
+		"meteredMutation must record mutation_rejections_total{reason=owner_lease_stale} on the gated reject")
 }

--- a/schemas/graph-ingest.v1.json
+++ b/schemas/graph-ingest.v1.json
@@ -16,6 +16,12 @@
       "description": "Enable sibling edges between same-type entities (default true when hierarchy enabled)",
       "category": "advanced"
     },
+    "enforce_owner_lease": {
+      "type": "boolean",
+      "description": "Reject writes whose OwnerToken does not match the live owner lease (ADR-056 PR-5); default false keeps observe-only metering",
+      "default": false,
+      "category": "advanced"
+    },
     "ports": {
       "type": "string",
       "description": "Port configuration",


### PR DESCRIPTION
## ADR-056 OwnerToken write-lease — PR-5 (the closing move)

Flips PR-3's **observe-only** owner-lease check to a **config-gated reject**. This completes the OwnerToken write-lease arc (PR-1 wire field → PR-2 lease reader → PR-3 observe-only check → PR-3.5 typed token → PR-4 Watch-revival quiesce → **PR-5 reject**).

### What changes
- **New `Config.EnforceOwnerLease`** (`enforce_owner_lease`, **default `false`**). Default-off preserves the observe-only bake posture; operators flip it on per-deploy once `owner_lease_mismatch_total` reads zero for the message types they own.
- **`checkOwnerLease` now returns `*leaseViolation`.** It still meters `owner_lease_mismatch_total` + Warns on **every** mismatch (identical in both modes); it surfaces a reject **only when** `EnforceOwnerLease` is on **and** a mismatch is confirmed. A `leaseVerdict` helper applies the toggle uniformly at both return points.
- **Both owned-write call sites reject before the write commits** (`create_with_triples`, `update_with_triples`) with `graph.ErrorCodeOwnerLeaseStale`. The update-lane check runs **before** the `ExpectedRevision` CAS dispatch, so one check covers **both** the CAS and `UpdateWithRetry` sub-paths and never orphans a foreign edge.
- **`mutation_rejections_total{reason=owner_lease_stale}`** is recorded for free via `meteredMutation`. The caller-facing error names the owner id but **not** the live incarnation nonce (operator Warn log only).

### Fail-open is preserved even under enforcement
Empty token, nil claim reader, empty owned-predicate set, legacy/pre-fence owner (`incarnation==""`), and reader errors **never reject** — even with `EnforceOwnerLease=true`. The enforce toggle ONLY changes the verdict on a *confirmed* mismatch. (A bug here would brick every legacy owner's writes — explicitly tested.)

### Safety
Non-breaking: with the default toggle, behavior is byte-identical to PR-3 observe-only. The reject is the only behavior change and it is entirely gated.

### Tests
- Enforce on/off unit matrix incl. the fail-open-under-enforce invariants + earlier-mismatch-then-reader-error.
- Lane-wiring rejects (create / update / CAS) asserting the coded response.
- **Durability via real-NATS integration**: entity absent on rejected create; prior state + revision unchanged on rejected update/CAS; live owner's matching token still commits.
- Config JSON round-trip (absent→false, explicit-true survival, factory threading).

### Gates (all green locally)
`task lint` (revive clean) · `go fmt` (no changes) · full `go test -race ./...` · full `go test -race -tags=integration ./processor/graph-ingest/...` (incl. new enforce integration tests) · contract tests · Linux cross-compile · `task schema:generate` (the `enforce_owner_lease` schema diff is committed).

go-reviewer: **ACCEPT-WITH-NITS** — all 8 adversarial invariants verified against the production code; the one LOW (integration-level CAS enforce test) folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)