### PR TITLE
refactor(boot): ADR-058 step 2 — factor lifecycle heartbeater cancel+join into a shared helper

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -161,12 +161,13 @@ func run() error {
 	// boot, best-effort — never a boot gate).
 	//
 	// The Manager-internal heartbeater (spawned by AttachOwnership inside
-	// WireOwnership) runs on hbCtx; WaitOwnership joins it on shutdown.
-	// hbCtx/hbCancel STAY in run() scope until the lifecycle Manager is
-	// itself a Phase-B Service (ADR-058 rollout step 2).
-	defer svcDeps.LifecycleManager.WaitOwnership() // join (runs second — LIFO)
-	hbCtx, hbCancel := context.WithCancel(ctx)
-	defer hbCancel() // signal (runs first — LIFO)
+	// WireOwnership) runs on hbCtx. ADR-058 rollout step 2: the Manager is
+	// deliberately NOT wrapped as a Service (it fails the Is-it-a-Service test —
+	// WaitOwnership already provides the join). Its shutdown cancel+join is
+	// factored into one shared helper so the two mains cannot drift; the deferred
+	// cleanup runs (cancel→join) before the earlier-registered NATS Close defer.
+	hbCtx, ownershipShutdown := service.WireOwnershipShutdown(ctx, svcDeps.LifecycleManager)
+	defer ownershipShutdown()
 
 	ownerReg, staticOwnerHB := service.WireOwnership(hbCtx, natsClient, svcDeps.LifecycleManager, logger,
 		loopExecutionProjectionContract())

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -194,12 +194,13 @@ func run() error {
 	// (ownership disabled this boot, best-effort — never a boot gate).
 	//
 	// The Manager-internal heartbeater (spawned by AttachOwnership inside
-	// WireOwnership) runs on hbCtx; WaitOwnership joins it on shutdown.
-	// hbCtx/hbCancel STAY in run() scope until the lifecycle Manager is
-	// itself a Phase-B Service (ADR-058 rollout step 2).
-	defer svcDeps.LifecycleManager.WaitOwnership() // join (runs second — LIFO)
-	hbCtx, hbCancel := context.WithCancel(ctx)
-	defer hbCancel() // signal (runs first — LIFO)
+	// WireOwnership) runs on hbCtx. ADR-058 rollout step 2: the Manager is
+	// deliberately NOT wrapped as a Service (it fails the Is-it-a-Service test —
+	// WaitOwnership already provides the join). Its shutdown cancel+join is
+	// factored into one shared helper so the two mains cannot drift; the deferred
+	// cleanup runs (cancel→join) before the earlier-registered NATS Close defer.
+	hbCtx, ownershipShutdown := service.WireOwnershipShutdown(ctx, svcDeps.LifecycleManager)
+	defer ownershipShutdown()
 
 	ownerReg, staticOwnerHB := service.WireOwnership(hbCtx, natsClient, svcDeps.LifecycleManager, logger,
 		loopExecutionProjectionContract())

--- a/docs/adr/058-boot-lifecycle-phases.md
+++ b/docs/adr/058-boot-lifecycle-phases.md
@@ -101,7 +101,7 @@ helper-function call, not a Service.
 | ownership static heartbeater goroutine | B | `go`+WG+`defer` | `OwnershipService` |
 | ownership `WatchRevival` goroutine | B | `go`+WG+`defer` (PR-4) | `OwnershipService` |
 | lifecycle `Manager` construct + workflow `Register` | A | inline / helper | shared helper |
-| lifecycle Manager-internal heartbeater (`AttachOwnership` spawns it) | B | already joined via `WaitOwnership` | leave alone — already lifecycle-managed |
+| lifecycle Manager-internal heartbeater (`AttachOwnership` spawns it) | B | already joined via `WaitOwnership` | NOT a Service — cancel+join factored into shared `WireOwnershipShutdown` helper (step 2) |
 | milestone subscriber (`Start()`→stop-func) | B | hand-managed stop-func | wrap as Service |
 | pprof server | B | hand-started HTTP | wrap as Service |
 
@@ -284,13 +284,14 @@ one shared Phase-A call + one Phase-B registration + the existing
 post-construction bind:
 
 ```go
-// Manager-internal heartbeater (spawned by AttachOwnership) needs a
-// shutdown-cancellable ctx + a join — these STAY until the lifecycle Manager is
-// itself a Service (rollout step 2). Registered so LIFO runs hbCancel (signal)
-// then WaitOwnership (join), both before the NATS Close defer from earlier.
-defer svcDeps.LifecycleManager.WaitOwnership() // join (runs second)
-hbCtx, hbCancel := context.WithCancel(ctx)
-defer hbCancel()                               // signal (runs first)
+// Manager-internal heartbeater (spawned eagerly by AttachOwnership in Phase A)
+// needs a shutdown-cancellable ctx + a join. The Manager is deliberately NOT a
+// Service (rollout step 2 — it fails the Is-it-a-Service test; WaitOwnership
+// already provides the join). The cancel+join is factored into one shared helper
+// so the two mains cannot drift; the deferred cleanup runs cancel→join, both
+// before the earlier-registered NATS Close defer (gh#279).
+hbCtx, ownershipShutdown := service.WireOwnershipShutdown(ctx, svcDeps.LifecycleManager)
+defer ownershipShutdown()
 
 ownerReg, staticHB := service.WireOwnership(hbCtx, natsClient, svcDeps.LifecycleManager, logger) // Phase A
 manager.RegisterInstance("ownership", service.NewOwnershipService(ownerReg, staticHB, metricsRegistry, logger)) // Phase B
@@ -306,18 +307,21 @@ move into `OwnershipService`, which `StopAll` cancels-then-joins in reverse
 registration order before `run()` returns to the NATS `Close` defer.
 
 What STAYS (corrected — do not over-claim the cleanup): the Manager-internal
-heartbeater is **not** a Service in this phase (rollout step 2 leaves it), so its
-`hbCtx`/`hbCancel` and the `WaitOwnership()` join — the gh#279 fix from ADR-056
-PR-4 — must remain in the mains until that heartbeater also becomes
-framework-managed. Deleting them here would silently regress that join.
+heartbeater is **not** a Service, and is **never** wrapped as one (see rollout
+step 2 below). It stays **Phase-A-spawned** by `AttachOwnership` so its boot-time
+spawn behavior is preserved. Its `hbCtx`/cancel and the `WaitOwnership()` join —
+the gh#279 fix from ADR-056 PR-4 — are factored into the shared
+`service.WireOwnershipShutdown` helper rather than left hand-rolled per binary.
+PR-1 (ownership) left them hand-rolled identically in both mains; rollout step 2
+folds them into the helper.
 
-**Half-migration guard:** the two mains differ in shutdown shape today —
-`cmd/semstreams` uses three separate defers (`ownershipWG.Wait` / `WaitOwnership`
-/ `hbCancel`) while `cmd/e2e-semstreams` bundles all three into a single deferred
-closure (`cmd/e2e-semstreams/main.go:173-179`). PR-1 must edit BOTH: drop only the
-`ownershipWG` half on each, KEEP `hbCancel` + `WaitOwnership`. Pattern-matching one
-main's shape onto the other is exactly the beta.18 half-migration this ADR exists
-to prevent — verify the e2e closure is split, not copied.
+**Half-migration guard:** PR-1 already converged the two mains to the identical
+three-line `hbCtx`/`hbCancel`/`WaitOwnership` pattern (`cmd/semstreams/main.go`
+and `cmd/e2e-semstreams/main.go`). The drift risk is therefore *prospective* — a
+future editor diverging one main's three lines from the other's. Rollout step 2
+eliminates that class structurally by replacing the three lines with one shared
+`WireOwnershipShutdown(ctx, mgr)` call both mains make identically. Edit BOTH
+mains in the same PR and verify the call sites are shape-identical.
 
 ## Consequences
 
@@ -345,9 +349,13 @@ to prevent — verify the e2e closure is split, not copied.
   boot gate. Mitigation: state it in the Service's doc comment and cover it
   with a test that asserts `Start` returns `nil` on the disabled path. It is a
   review checklist item, not a new mechanism.
-- Phase 1 does NOT fully clean the mains: the lifecycle Manager-internal
-  heartbeater's cancel + `WaitOwnership` join stay until rollout step 2. The
-  win is real but partial until lifecycle is also a Service.
+- Phase 1 (PR-1, ownership) does NOT fully clean the mains: the lifecycle
+  Manager-internal heartbeater's cancel + `WaitOwnership` join stay hand-rolled
+  in both mains. Rollout step 2 resolves this — NOT by making lifecycle a Service
+  (it isn't one; `WaitOwnership` already joins), but by factoring the cancel+join
+  into the shared `service.WireOwnershipShutdown` helper. The heartbeater stays
+  permanently Phase-A-spawned by design; there is no further "until lifecycle is a
+  Service" step.
 
 **Neutral**
 
@@ -363,9 +371,15 @@ to prevent — verify the e2e closure is split, not copied.
    `OwnershipService`, delete the inline blocks and `wireLifecycleManager`'s
    ownership half. Behavior-preserving: same goroutines, same shutdown order,
    same observe-only posture.
-2. **Lifecycle Manager**: `construct + workflow Register` stays Phase A; the
-   Manager-internal heartbeater is already lifecycle-joined via
-   `WaitOwnership` — confirm it needs no Service wrapper, leave it.
+2. **Lifecycle Manager** (DONE): `construct + workflow Register` stays Phase A.
+   The Manager is deliberately NOT wrapped as a Service — it fails the
+   Is-it-a-Service test (criterion 3's clean Stop/join is already provided by
+   `WaitOwnership`), and a wrapper would be import-cycle-forced ceremony that
+   either moves the heartbeater spawn from Phase A to `StartAll` (a behavior
+   change) or has a no-op `Start`. Instead, the hand-rolled
+   `hbCtx`/`hbCancel`/`WaitOwnership` is factored into the shared
+   `service.WireOwnershipShutdown(ctx, mgr)` helper so the two mains cannot drift.
+   Behavior-preserving: the heartbeater spawn point is unchanged.
 3. **Milestone subscriber** (`cmd/semstreams/main.go:283-297`): already
    `Start()`-returns-a-stop-func — Service-shaped, wrap it.
 4. **pprof server** (`cmd/semstreams/main.go:867`): background HTTP, wrap it.

--- a/service/ownership_service.go
+++ b/service/ownership_service.go
@@ -155,3 +155,33 @@ func WireOwnership(
 	}
 	return reg, staticHB
 }
+
+// WireOwnershipShutdown is the ADR-058 rollout-step-2 drift-killer. It returns
+// the shutdown-cancellable context that governs the lifecycle Manager-internal
+// ownership heartbeater (spawned eagerly in Phase A by AttachOwnership inside
+// WireOwnership — see manager.go) and a single cleanup func that, on shutdown,
+// SIGNALS (cancel) then JOINS (WaitOwnership) it, in that order.
+//
+// Why a shared helper and not a Service: per ADR-058 the lifecycle Manager is
+// deliberately NOT wrapped as a service.Service — the heartbeater stays
+// Phase-A-spawned (preserving boot-time spawn behavior; an import cycle would
+// force a ceremony wrapper anyway). But the cancel+join was hand-rolled
+// identically in both mains, which is the beta.18 half-migration drift class
+// ADR-058 exists to prevent. Folding it into one call both mains make
+// identically removes that prospective drift structurally.
+//
+// The caller MUST pass the returned ctx to WireOwnership (so AttachOwnership's
+// heartbeater binds to it) and `defer` the returned func at the same point the
+// hand-rolled hbCancel/WaitOwnership defers lived, so LIFO still runs cancel+join
+// BEFORE the earlier-registered NATS Close defer (the gh#279 join, ADR-056 PR-4).
+//
+// With no registry attached (resourceless/unmigrated deploy, or a nil-client
+// Manager), WaitOwnership is a no-op (manager.go) so the cleanup returns
+// immediately — R3 symmetric independence.
+func WireOwnershipShutdown(ctx context.Context, lcm *lifecycle.Manager) (context.Context, func()) {
+	hbCtx, hbCancel := context.WithCancel(ctx)
+	return hbCtx, func() {
+		hbCancel()          // signal the Manager-internal ownership heartbeater
+		lcm.WaitOwnership() // join it before NATS Close (gh#279)
+	}
+}

--- a/service/ownership_service_test.go
+++ b/service/ownership_service_test.go
@@ -2,8 +2,11 @@ package service
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 	"time"
+
+	"github.com/c360studio/semstreams/pkg/lifecycle"
 )
 
 // TestOwnershipService_NilRegistry_DisabledPath verifies the R1 infallible-Start
@@ -43,5 +46,53 @@ func TestOwnershipService_ReentrancyGuard(t *testing.T) {
 	err := svc.Start(context.Background())
 	if err == nil {
 		t.Fatal("double-Start must return an error (re-entrancy guard)")
+	}
+}
+
+// TestWireOwnershipShutdown_CancelsCtxAndJoinsCleanly proves the ADR-058 step-2
+// drift-killer: the returned cleanup cancels the heartbeat ctx AND returns
+// promptly when no registry is attached (WaitOwnership is a no-op — R3 symmetric
+// independence). A hang would mean the join blocked on a goroutine never spawned.
+func TestWireOwnershipShutdown_CancelsCtxAndJoinsCleanly(t *testing.T) {
+	t.Parallel()
+	mgr := lifecycle.NewManager(nil, slog.Default()) // no AttachOwnership → WaitOwnership no-op
+
+	hbCtx, shutdown := WireOwnershipShutdown(context.Background(), mgr)
+	if hbCtx.Err() != nil {
+		t.Fatalf("hbCtx must be live before shutdown, got: %v", hbCtx.Err())
+	}
+
+	done := make(chan struct{})
+	go func() { shutdown(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown hung — WaitOwnership must be a no-op when no registry is attached (R3)")
+	}
+
+	if hbCtx.Err() == nil {
+		t.Error("shutdown must cancel the heartbeat ctx (signal the Manager-internal heartbeater)")
+	}
+}
+
+// TestWireOwnershipShutdown_ParentCancelPropagates proves the heartbeat ctx is
+// derived from the caller's ctx — so the heartbeater stops on parent cancel too,
+// not only via the returned cleanup (preserves the pre-refactor WithCancel(ctx)).
+func TestWireOwnershipShutdown_ParentCancelPropagates(t *testing.T) {
+	t.Parallel()
+	mgr := lifecycle.NewManager(nil, slog.Default())
+	parent, cancelParent := context.WithCancel(context.Background())
+
+	hbCtx, shutdown := WireOwnershipShutdown(parent, mgr)
+	defer shutdown()
+
+	if hbCtx.Err() != nil {
+		t.Fatalf("hbCtx must be live before parent cancel, got: %v", hbCtx.Err())
+	}
+	cancelParent()
+	select {
+	case <-hbCtx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("hbCtx must cancel when its parent cancels (derived context)")
 	}
 }


### PR DESCRIPTION
## ADR-058 rollout step 2 (lifecycle Manager)

After an architect scoping pass that surfaced and resolved an **internal contradiction in ADR-058** about what step 2 is, the decision: the lifecycle Manager is **deliberately NOT wrapped as a `service.Service`**.

### Why not a Service
- It **fails the Is-it-a-Service test** — criterion 3 (clean Stop/join) is *already* provided by `Manager.WaitOwnership()`.
- An **import cycle** (`package service` imports `pkg/lifecycle`) forces any wrapper into `package service` as a pointer-holding shell — ceremony, not encapsulation.
- A spawning `Start()` would move the heartbeater from **Phase-A-eager to `StartAll`-time** — a behavior change the ADR's own behavior-preservation invariant forbids; a no-op `Start()` is the "Service for ceremony" the ADR's anti-over-engineering section rejects.

### What this PR does instead
The hand-rolled `hbCtx/hbCancel + defer WaitOwnership` block — duplicated **identically** in both mains since PR-A — is the exact beta.18 half-migration drift class ADR-058 exists to kill. Factor it into one shared helper both mains call identically:

- **`service.WireOwnershipShutdown(ctx, lcm) (context.Context, func())`** — returns the shutdown-cancellable `hbCtx` governing the Manager-internal ownership heartbeater (still spawned eagerly by `AttachOwnership` in Phase A — **spawn timing unchanged**) and a single cleanup closure that **cancels THEN joins**, in that order.
- Both `cmd/semstreams/main.go` and `cmd/e2e-semstreams/main.go` replace the 3-line block with the helper + one `defer`, **edited identically**.
- **ADR-058 corrected** throughout (inventory table, worked example, Consequences, rollout step 2) so step 2 is unambiguous; the stale "divergent shutdown shapes" guard (retired by PR-A's convergence) is rewritten as a *prospective*-drift guard.
- Helper unit tests: cancel-on-cleanup, no-hang join with no registry attached (R3), parent-ctx derivation.

### Behavior preservation (the whole claim)
- Heartbeater still spawned in `AttachOwnership` (Phase A) — nothing moved to a `Start()`.
- **Ordering byte-equivalent:** the prior code achieved cancel→join via *reversed defer registration* (`defer WaitOwnership` then `defer hbCancel` → LIFO runs hbCancel→WaitOwnership); the closure does the same inline. Still runs **before** the earlier-registered `natsClient.Close` defer (the gh#279 join).
- R1/R2/R3 intact: no identity constructed in the helper (R2); no-op when no registry attached (R3).
- No config/schema change.

### Gates (all green locally)
`task lint` · full `go test -race ./...` · `go vet -tags=integration`+`-tags=live_llm` (service/cmd/lifecycle) · both binaries build · Linux cross-compile · no schema drift.

**go-reviewer: ACCEPT** — no BLOCKING/HIGH/MEDIUM; ordering equivalence verified byte-for-byte, both mains byte-identical. The one NIT (nil-`lcm` guard) declined: matches existing `WireOwnership` convention, unreachable, and a nil Manager at boot should fail loudly rather than be silently guarded.

The real next substantive PR is **rollout step 3 (milestone subscriber)** — genuinely Service-shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)