### PR TITLE
refactor(boot): ADR-058 step 3 — wrap agent-run milestone subscriber as a Phase-B Service

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -184,24 +184,24 @@ func run() error {
 		return fmt.Errorf("register agent-run workflow: %w", err)
 	}
 
-	// Start the agent-run milestone subscriber (ADR-053 D6). Mirrors
-	// cmd/semstreams wiring. No product handlers registered in e2e binary;
-	// D3 zombie-prevention still applies.
-	milestoneSubscriber := agentrun.NewMilestoneSubscriber(
-		svcDeps.LifecycleManager,
-		agentrun.NewNATSLoopTripleReader(natsClient),
-		agentrun.NewNATSTriplePublisher(natsClient),
-		platform.Org,
-		platform.Platform,
+	// ADR-058 Phase B — agent-run milestone subscriber (ADR-053 D6) under the
+	// ServiceManager's ordered shutdown. Mirrors cmd/semstreams wiring (identical
+	// RegisterInstance block — the half-migration guard). Registered AFTER
+	// "ownership" so StopAll stops it first; Start CAN abort boot on a genuine
+	// consumer-start failure (D3 hard dependency); stream-absent graceful-skips.
+	manager.RegisterInstance("milestone", service.NewMilestoneService(
+		agentrun.NewMilestoneSubscriber(
+			svcDeps.LifecycleManager,
+			agentrun.NewNATSLoopTripleReader(natsClient),
+			agentrun.NewNATSTriplePublisher(natsClient),
+			platform.Org,
+			platform.Platform,
+			logger,
+		),
+		natsClient,
+		agentrun.StartConfig{StreamName: agentrun.AgentStreamName},
 		logger,
-	)
-	stopMilestoneSubscriber, err := milestoneSubscriber.Start(ctx, natsClient, agentrun.StartConfig{
-		StreamName: agentrun.AgentStreamName,
-	})
-	if err != nil {
-		return fmt.Errorf("start agent-run milestone subscriber: %w", err)
-	}
-	defer stopMilestoneSubscriber()
+	))
 
 	if err := configureAndCreateServices(cfg, manager, svcDeps); err != nil {
 		return err

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -217,27 +217,27 @@ func run() error {
 		return fmt.Errorf("register agent-run workflow: %w", err)
 	}
 
-	// 10d. Start the agent-run milestone subscriber (ADR-053 D6).
-	// Subscribes to agent.complete.* and agent.failed.*, pre-resolves
-	// the run, applies zombie-prevention terminal authority (D3), and
-	// fans out to registered product handlers. No product handlers
-	// registered in the framework binary; the subscriber still enforces
-	// D3 (zombie prevention) for runs minted by run_scope=new rules.
-	milestoneSubscriber := agentrun.NewMilestoneSubscriber(
-		svcDeps.LifecycleManager,
-		agentrun.NewNATSLoopTripleReader(natsClient),
-		agentrun.NewNATSTriplePublisher(natsClient),
-		platform.Org,
-		platform.Platform,
+	// 10d. ADR-058 Phase B — agent-run milestone subscriber (ADR-053 D6) under the
+	// ServiceManager's ordered shutdown. Subscribes to agent.complete.* /
+	// agent.failed.*, pre-resolves the run, applies D3 zombie-prevention terminal
+	// authority, and fans out to registered product handlers (none in the framework
+	// binary; D3 still enforced for run_scope=new rules). Registered AFTER
+	// "ownership" so StopAll stops it first (mirrors the old defer LIFO). Its Start
+	// CAN abort boot on a genuine consumer-start failure (D3 is a hard dependency);
+	// the stream-absent case graceful-skips inside the subscriber (gh#246).
+	manager.RegisterInstance("milestone", service.NewMilestoneService(
+		agentrun.NewMilestoneSubscriber(
+			svcDeps.LifecycleManager,
+			agentrun.NewNATSLoopTripleReader(natsClient),
+			agentrun.NewNATSTriplePublisher(natsClient),
+			platform.Org,
+			platform.Platform,
+			logger,
+		),
+		natsClient,
+		agentrun.StartConfig{StreamName: agentrun.AgentStreamName},
 		logger,
-	)
-	stopMilestoneSubscriber, err := milestoneSubscriber.Start(ctx, natsClient, agentrun.StartConfig{
-		StreamName: agentrun.AgentStreamName,
-	})
-	if err != nil {
-		return fmt.Errorf("start agent-run milestone subscriber: %w", err)
-	}
-	defer stopMilestoneSubscriber()
+	))
 
 	// 11. Configure and create services
 	if err := configureAndCreateServices(cfg, manager, svcDeps); err != nil {

--- a/service/milestone_service.go
+++ b/service/milestone_service.go
@@ -1,0 +1,112 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic/agentrun"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// milestoneStarter is the subscriber seam MilestoneService drives. The production
+// implementation is *agentrun.MilestoneSubscriber; tests inject a fake so the
+// wrapper's Start/Stop lifecycle — including the error-forward + status rollback —
+// is unit-testable without a live NATS connection (every Start path otherwise
+// requires the subscriber's real durable-consumer setup).
+type milestoneStarter interface {
+	Start(ctx context.Context, client *natsclient.Client, cfg agentrun.StartConfig) (func(), error)
+}
+
+// MilestoneService is the Phase-B service wrapper for the agent-run milestone
+// subscriber (ADR-058 rollout step 3). It drives the subscriber's durable
+// JetStream consumers (agent.complete.* / agent.failed.*) under the
+// ServiceManager's ordered shutdown, replacing the hand-rolled
+// NewMilestoneSubscriber + Start + defer-stop block that was duplicated in both
+// mains.
+//
+// Unlike OwnershipService, Start CAN return an error: the milestone subscriber
+// enforces ADR-053 D3 zombie-prevention terminal authority, a HARD correctness
+// dependency — NOT the observe-only/best-effort posture ADR-058 R1's infallibility
+// targets (ownership/lifecycle "never a boot gate"). A genuine consumer-start
+// failure is therefore forwarded so StartAll aborts boot, preserving today's
+// inline-abort behavior. The stream-absent case is already a graceful no-op inside
+// the subscriber (gh#246) — it returns a no-op stop with no error — so resourceless
+// deploys (no agentic components) still boot.
+//
+// Shutdown semantics: Start receives the ServiceManager's lifecycle ctx (the
+// SIGTERM-derived signal context), which the subscriber binds its consumers to.
+// The old inline wiring passed an uncancellable context, so in-flight HandleEvent
+// calls ran to completion at shutdown; now they observe cancellation. This is safe
+// — a D3 transition interrupted at shutdown Naks and is redelivered idempotently
+// on restart (durable consumers, MaxDeliver 5) — and arguably more correct
+// (shutdown is respected). Stop() additionally cancels consumption via the
+// captured stop func, so delivery halts regardless of ctx.
+type MilestoneService struct {
+	*BaseService
+	logger     *slog.Logger // own logger (mirrors OwnershipService); set by ctor.
+	subscriber milestoneStarter
+	client     *natsclient.Client   // live NATS conn (Phase A), passed to subscriber.Start.
+	cfg        agentrun.StartConfig // StreamName: agentrun.AgentStreamName.
+	mu         sync.Mutex           // serializes Start/Stop so the re-entrancy guard is atomic.
+	stop       func()               // captured stop func from subscriber.Start; nil until started / after Stop.
+}
+
+// NewMilestoneService builds the MilestoneService over a pre-built subscriber.
+// The composition root constructs the subscriber (R2 — this wrapper never does)
+// and passes it plus the live NATS client and StartConfig.
+func NewMilestoneService(subscriber milestoneStarter, client *natsclient.Client, cfg agentrun.StartConfig, logger *slog.Logger) *MilestoneService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MilestoneService{
+		BaseService: NewBaseServiceWithOptions("milestone", nil, WithLogger(logger)),
+		logger:      logger,
+		subscriber:  subscriber,
+		client:      client,
+		cfg:         cfg,
+	}
+}
+
+// Start starts the subscriber's durable consumers. A double-Start returns an
+// error (BUG-CLASS guard, mirrors OwnershipService). A genuine consumer-start
+// failure is FORWARDED — StartAll aborts boot — because the subscriber is a hard
+// dependency (see the type doc for why this is deliberately not R1-degraded). The
+// subscriber's stream-absent graceful-skip returns a non-nil no-op stop with no
+// error, so that path stores the no-op and reports running (boot preserved).
+func (s *MilestoneService) Start(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Status() == StatusRunning {
+		return fmt.Errorf("milestone service already running")
+	}
+	if err := s.BaseService.Start(ctx); err != nil {
+		return err
+	}
+	stop, err := s.subscriber.Start(ctx, s.client, s.cfg)
+	if err != nil {
+		// Hard dependency (D3): forward the error so StartAll aborts boot. Roll
+		// back BaseService status so a failed Start does not leave us phantom-Running.
+		_ = s.BaseService.Stop(0)
+		return fmt.Errorf("milestone subscriber start: %w", err)
+	}
+	s.stop = stop
+	return nil
+}
+
+// Stop cancels the subscriber's local consumption (durable offsets persist in
+// NATS for restart recovery). The wrapper spawns no goroutine of its own, so —
+// unlike OwnershipService — there is nothing to join. Idempotent: a second Stop
+// (or a Stop before Start) is a no-op.
+func (s *MilestoneService) Stop(timeout time.Duration) error {
+	s.mu.Lock()
+	stop := s.stop
+	s.stop = nil
+	s.mu.Unlock()
+	if stop != nil {
+		stop()
+	}
+	return s.BaseService.Stop(timeout)
+}

--- a/service/milestone_service_test.go
+++ b/service/milestone_service_test.go
@@ -1,0 +1,119 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/agentic/agentrun"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// fakeStarter is a milestoneStarter test double. It records call counts and
+// returns a canned (stop, err) so the MilestoneService lifecycle can be exercised
+// without a live NATS connection.
+type fakeStarter struct {
+	startErr   error
+	startCalls int
+	stopCalls  int
+}
+
+func (f *fakeStarter) Start(_ context.Context, _ *natsclient.Client, _ agentrun.StartConfig) (func(), error) {
+	f.startCalls++
+	if f.startErr != nil {
+		return nil, f.startErr
+	}
+	return func() { f.stopCalls++ }, nil
+}
+
+func newTestMilestoneService(f *fakeStarter) *MilestoneService {
+	return NewMilestoneService(f, nil, agentrun.StartConfig{StreamName: agentrun.AgentStreamName}, nil)
+}
+
+// TestMilestoneService_Start_RunsAndStops covers the happy path AND the gh#246
+// resourceless-boot path: the subscriber returns (stop, nil) — whether a real
+// consumer or the stream-absent no-op — and the wrapper reports Running and calls
+// the captured stop on Stop. A nil-error Start is exactly what keeps StartAll from
+// aborting boot when there are no agentic components.
+func TestMilestoneService_Start_RunsAndStops(t *testing.T) {
+	t.Parallel()
+	f := &fakeStarter{}
+	svc := newTestMilestoneService(f)
+
+	require.NoError(t, svc.Start(context.Background()))
+	assert.Equal(t, StatusRunning, svc.Status())
+	assert.Equal(t, 1, f.startCalls)
+
+	require.NoError(t, svc.Stop(time.Second))
+	assert.Equal(t, 1, f.stopCalls, "Stop must call the captured stop func exactly once")
+}
+
+// TestMilestoneService_Start_ErrorForwardedAndRollsBack proves the deliberate
+// divergence from OwnershipService: a genuine consumer-start failure is forwarded
+// (so StartAll aborts boot) AND BaseService status is rolled back so a failed
+// Start does not leave the service phantom-Running.
+func TestMilestoneService_Start_ErrorForwardedAndRollsBack(t *testing.T) {
+	t.Parallel()
+	f := &fakeStarter{startErr: errors.New("consumer boom")}
+	svc := newTestMilestoneService(f)
+
+	err := svc.Start(context.Background())
+	require.Error(t, err, "a genuine consumer-start failure must be forwarded (hard dependency, not R1-degraded)")
+	assert.Contains(t, err.Error(), "milestone subscriber start")
+	assert.NotEqual(t, StatusRunning, svc.Status(), "a failed Start must roll back status — not phantom-Running")
+}
+
+// TestMilestoneService_ReentrancyGuard verifies a double-Start returns an error
+// and does NOT re-invoke the subscriber (BUG-CLASS guard, mirrors OwnershipService).
+func TestMilestoneService_ReentrancyGuard(t *testing.T) {
+	t.Parallel()
+	f := &fakeStarter{}
+	svc := newTestMilestoneService(f)
+
+	require.NoError(t, svc.Start(context.Background()))
+	defer svc.Stop(time.Second) //nolint:errcheck
+
+	require.Error(t, svc.Start(context.Background()), "double-Start must return an error")
+	assert.Equal(t, 1, f.startCalls, "double-Start must NOT re-invoke subscriber.Start")
+}
+
+// TestMilestoneService_Stop_Idempotent verifies the captured stop func is called
+// at most once across repeated Stop calls.
+func TestMilestoneService_Stop_Idempotent(t *testing.T) {
+	t.Parallel()
+	f := &fakeStarter{}
+	svc := newTestMilestoneService(f)
+
+	require.NoError(t, svc.Start(context.Background()))
+	require.NoError(t, svc.Stop(time.Second))
+	require.NoError(t, svc.Stop(time.Second), "second Stop must be a clean no-op")
+	assert.Equal(t, 1, f.stopCalls, "stop func must be called at most once")
+}
+
+// TestMilestoneService_StopBeforeStart_NoPanic verifies Stop on a never-started
+// service is a clean no-op (nil stop func guarded).
+func TestMilestoneService_StopBeforeStart_NoPanic(t *testing.T) {
+	t.Parallel()
+	f := &fakeStarter{}
+	svc := newTestMilestoneService(f)
+
+	require.NoError(t, svc.Stop(time.Second))
+	assert.Equal(t, 0, f.stopCalls)
+}
+
+// TestMilestoneService_StopAfterFailedStart_NoPanic verifies Stop is clean after
+// a forwarded Start error: no stop func was captured (subscriber.Start failed
+// before returning one), so Stop is a no-op and does not panic.
+func TestMilestoneService_StopAfterFailedStart_NoPanic(t *testing.T) {
+	t.Parallel()
+	f := &fakeStarter{startErr: errors.New("boom")}
+	svc := newTestMilestoneService(f)
+
+	require.Error(t, svc.Start(context.Background()))
+	require.NoError(t, svc.Stop(time.Second), "Stop after a failed Start must be a clean no-op")
+	assert.Equal(t, 0, f.stopCalls)
+}


### PR DESCRIPTION
## ADR-058 rollout step 3 (milestone subscriber)

Wraps the agent-run milestone subscriber as a Phase-B `service.Service` registered via `ServiceManager.RegisterInstance`, **deleting the hand-rolled `NewMilestoneSubscriber + Start + err-check + defer-stop` block duplicated identically in both mains**. Mirrors `OwnershipService` (step 1). The first genuinely Service-shaped rollout subsystem.

### Design decisions (architect-scoped, code-verified)
- **Wrapper in `package service`** (not `agentic/agentrun`) — both placements are transitively cycle-free; chosen for exemplar-consistency with `OwnershipService` and to keep `agentrun` a leaf (no `agentrun → service` edge).
- **`Start` CAN return an error** — the deliberate divergence from `OwnershipService`'s R1-infallible `Start`. The subscriber enforces ADR-053 **D3 zombie-prevention (a hard correctness dependency)**, and ADR-058 R1's infallibility is explicitly scoped to ownership/lifecycle "never a boot gate", not every service. A genuine consumer-start failure is **forwarded → `StartAll` aborts boot**, preserving today's inline-abort. The **stream-absent case already graceful-skips** inside the subscriber (gh#246 → no-op stop, nil error), so resourceless deploys still boot.
- **Status rollback on `Start` error** — `BaseService.Stop(0)` so a failed Start isn't left phantom-Running.
- **Simpler `Stop`** — just calls the captured stop func (`StopConsumer` ×2); the wrapper spawns no goroutine, so no wg/done join (unlike `OwnershipService`).
- **Registered after `"ownership"`** → `StopAll` (reverse order) stops it first, mirroring the old defer LIFO; `StopConsumer` still runs before `natsClient.Close`.
- **Tiny unexported `milestoneStarter` interface** so the wrapper is unit-testable with a fake (every `Start` path otherwise needs live durable-consumer setup); the production `*agentrun.MilestoneSubscriber` satisfies it implicitly.

### Behavior preservation
- Start-timing shift (inline → `StartAll`) is safe: durable consumers (DeliverPolicy "new", stable names) + nothing publishes `agent.complete/failed` during boot → no message drop.
- Stop-ordering shift (defer → `StopAll`) is safe: `StopConsumer` has no cross-service dependency.
- **Shutdown-semantics note (review NIT-2):** the subscriber's consumers now bind to the `StartAll` lifecycle ctx (SIGTERM signal ctx) instead of the old uncancellable inline ctx, so in-flight `HandleEvent` observes cancellation at shutdown — safe (D3 Naks + redelivers idempotently, MaxDeliver 5) and arguably more correct. Documented on the type.
- **Corrected rationale (review NIT-1):** on a `StartAll` mid-iteration abort the process `os.Exit`s **without running defers**; safety there is OS process-death reclamation, not defer cleanup.

### Both mains edited identically (half-migration guard)
The two `RegisterInstance("milestone", ...)` blocks are byte-identical (`diff`-verified).

### Gates (all green locally)
`task lint` · full `go test -race ./...` · `go vet -tags=integration`+`-tags=live_llm` (service/cmd/agentrun) · both binaries build · Linux cross-compile · no schema change.

**go-reviewer: ACCEPT-WITH-NITS** — no BLOCKING/HIGH/MEDIUM; all invariants verified against code (no import cycle, rollback correct, nothing to join, both mains byte-identical). NITs 2 (ctx-semantics doc) and 3 (Stop-after-failed-Start test) folded; NIT-1 (rationale) corrected; NIT-4 (no metrics) matches the `OwnershipService` exemplar.

Next: rollout step 4 (pprof) — the last ADR-058 subsystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)