### PR TITLE
refactor(boot): ADR-058 step 4 — factor pprof into a shared helper (not a Service)

### DIFF
--- a/cmd/e2e-semstreams/main.go
+++ b/cmd/e2e-semstreams/main.go
@@ -9,8 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" // Register pprof handlers on DefaultServeMux (served by service.MaybeStartPProf)
 	"os"
 	"os/signal"
 	"runtime"
@@ -76,9 +75,9 @@ func run() error {
 		return err
 	}
 
-	if cliCfg.Debug && cliCfg.DebugPort > 0 {
-		go startPProfServer(cliCfg.DebugPort)
-	}
+	// pprof (debug mode) — ADR-058 step 4 shared helper, NOT a Service. Kept early
+	// (before NATS) so a wedged boot stays profilable. Identical to cmd/semstreams.
+	service.MaybeStartPProf(cliCfg.Debug, cliCfg.DebugPort)
 
 	cfg, err := loadConfig(cliCfg.ConfigPath)
 	if err != nil {
@@ -761,14 +760,6 @@ func registerExampleComponents(registry *component.Registry) error {
 		return fmt.Errorf("register mission-command: %w", err)
 	}
 	return nil
-}
-
-func startPProfServer(port int) {
-	addr := fmt.Sprintf(":%d", port)
-	fmt.Printf("Starting pprof server on %s\n", addr)
-	if err := http.ListenAndServe(addr, nil); err != nil && err != http.ErrServerClosed {
-		fmt.Printf("pprof server error: %v\n", err)
-	}
 }
 
 // loopExecutionProjectionContract returns the graph projection contract for

--- a/cmd/semstreams/main.go
+++ b/cmd/semstreams/main.go
@@ -8,8 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"net/http"
-	_ "net/http/pprof" // Register pprof handlers on DefaultServeMux
+	_ "net/http/pprof" // Register pprof handlers on DefaultServeMux (served by service.MaybeStartPProf)
 	"os"
 	"os/signal"
 	"runtime"
@@ -77,10 +76,10 @@ func run() error {
 		return err
 	}
 
-	// 2.5. Start pprof server if debug mode enabled (before NATS - independent)
-	if cliCfg.Debug && cliCfg.DebugPort > 0 {
-		go startPProfServer(cliCfg.DebugPort)
-	}
+	// 2.5. Start pprof server if debug mode enabled (before NATS - independent).
+	// ADR-058 step 4: shared helper, deliberately NOT a Service (see
+	// service.MaybeStartPProf) — kept early so a wedged boot stays profilable.
+	service.MaybeStartPProf(cliCfg.Debug, cliCfg.DebugPort)
 
 	// 3. Load and validate configuration
 	cfg, err := loadConfig(cliCfg.ConfigPath)
@@ -804,17 +803,5 @@ func loopExecutionProjectionContract() projection.Contract {
 				agvocab.LoopDescription,
 			},
 		}},
-	}
-}
-
-// startPProfServer starts the pprof HTTP server for profiling.
-// The server runs on http.DefaultServeMux which has pprof handlers
-// registered via the blank import of net/http/pprof.
-func startPProfServer(port int) {
-	addr := fmt.Sprintf(":%d", port)
-	// Use a simple logger that works before slog is configured
-	fmt.Printf("Starting pprof server on %s\n", addr)
-	if err := http.ListenAndServe(addr, nil); err != nil && err != http.ErrServerClosed {
-		fmt.Printf("pprof server error: %v\n", err)
 	}
 }

--- a/docs/adr/058-boot-lifecycle-phases.md
+++ b/docs/adr/058-boot-lifecycle-phases.md
@@ -76,9 +76,11 @@ phase enum, no container.
 
 **Phase B — runtime lifecycle.** Background goroutine(s) and runtime resources
 that need a clean `Start` and a join-on-`Stop`: the static-owner heartbeater,
-`WatchRevival`, the milestone subscriber, the pprof server. Phase B lives in a
+`WatchRevival`, the milestone subscriber. Phase B lives in a
 `service.Service` registered with the `ServiceManager`, which gives us
-ordered shutdown and uniform health/metrics for free.
+ordered shutdown and uniform health/metrics for free. (The pprof server looks
+Phase-B but fails the Is-it-a-Service test — no state to flush, needs no clean
+Stop — so it stays a Phase-A fire-and-forget helper; see rollout step 4.)
 
 ### The "Is it a Service?" test
 
@@ -103,7 +105,7 @@ helper-function call, not a Service.
 | lifecycle `Manager` construct + workflow `Register` | A | inline / helper | shared helper |
 | lifecycle Manager-internal heartbeater (`AttachOwnership` spawns it) | B | already joined via `WaitOwnership` | NOT a Service — cancel+join factored into shared `WireOwnershipShutdown` helper (step 2) |
 | milestone subscriber (`Start()`→stop-func) | B | hand-managed stop-func | wrap as Service |
-| pprof server | B | hand-started HTTP | wrap as Service |
+| pprof server | A | hand-started HTTP, duplicated | shared `service.MaybeStartPProf` helper — NOT a Service (step 4) |
 
 ### Robustness constraints (non-negotiable)
 
@@ -382,7 +384,15 @@ mains in the same PR and verify the call sites are shape-identical.
    Behavior-preserving: the heartbeater spawn point is unchanged.
 3. **Milestone subscriber** (`cmd/semstreams/main.go:283-297`): already
    `Start()`-returns-a-stop-func — Service-shaped, wrap it.
-4. **pprof server** (`cmd/semstreams/main.go:867`): background HTTP, wrap it.
+4. **pprof server** (DONE): the duplicated `startPProfServer` (both mains) is
+   factored into the shared `service.MaybeStartPProf(debug, port)` helper — and
+   deliberately NOT a Service. Applying the Is-it-a-Service test (like step 2 did
+   for the lifecycle Manager): pprof fails criterion 3 — an HTTP `/debug/pprof`
+   mux has no process state to flush, so process exit cleans it with no
+   correctness loss (it is fire-and-forget today). And it is started EARLY, before
+   NATS, so a wedged/slow boot stays profilable; a StartAll-timed Service would
+   lose that window. So, mirroring step 2, the duplication is killed by a shared
+   helper, keeping the early fire-and-forget start. Behavior-preserving.
 
 Each PR is independently revertible and adds nothing to the public surface
 beyond a new internal Service type.

--- a/service/pprof.go
+++ b/service/pprof.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// MaybeStartPProf starts the pprof HTTP server in a background goroutine when
+// debug mode is enabled (debug && port > 0); otherwise it is a no-op.
+//
+// ADR-058 rollout step 4: pprof is deliberately NOT a service.Service. An HTTP
+// /debug/pprof mux has no process state to flush — every handler reads live
+// runtime state per request — so it fails the Is-it-a-Service test on criterion 3
+// (needs a clean Stop/join): process exit cleans the listener with no correctness
+// loss. Wrapping it in a StartAll-managed Service would also move the start from
+// the composition root (before NATS) to StartAll (after NATS + all wiring),
+// losing the ability to profile a wedged or slow boot — the canonical pprof use
+// case. So, mirroring step 2's "shared helper, not a Service" conclusion, this is
+// a plain helper called early and identically by both mains, killing the
+// duplicated startPProfServer that otherwise drifts (the beta.18 class).
+//
+// Fire-and-forget by design: a bind failure is a best-effort debug aid degrading,
+// never a boot gate (the R1 posture). The pprof handlers are registered on
+// http.DefaultServeMux by the CALLER's `import _ "net/http/pprof"` blank import —
+// this helper serves that mux (nil handler). The blank import stays in the mains,
+// not here, so importing package service does not silently arm pprof everywhere.
+func MaybeStartPProf(debug bool, port int) {
+	if !debug || port <= 0 {
+		return
+	}
+	go func() {
+		addr := fmt.Sprintf(":%d", port)
+		// stdout because this runs before slog is configured (pre-Phase-A).
+		fmt.Printf("Starting pprof server on %s\n", addr)
+		if err := http.ListenAndServe(addr, nil); err != nil && err != http.ErrServerClosed {
+			fmt.Printf("pprof server error: %v\n", err)
+		}
+	}()
+}

--- a/service/pprof_test.go
+++ b/service/pprof_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	_ "net/http/pprof" // populate DefaultServeMux so the happy-path test serves /debug/pprof
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// (freePort lives in service_manager_health_listener_test.go — reused here.)
+
+// TestMaybeStartPProf_DisabledOrInvalid_NoListener verifies the gate: with debug
+// off or a non-positive port, no server is started (nothing answers on the port).
+func TestMaybeStartPProf_DisabledOrInvalid_NoListener(t *testing.T) {
+	// debug off → no goroutine spawned, so nothing serves on the port.
+	port := freePort(t)
+	MaybeStartPProf(false, port)
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port)) //nolint:bodyclose // err path
+	require.Error(t, err, "debug off must not start a pprof listener")
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+
+	// port <= 0 → early return, no panic, no bind.
+	MaybeStartPProf(true, 0)
+	MaybeStartPProf(true, -1)
+}
+
+// TestMaybeStartPProf_Enabled_ServesPprof verifies the happy path: with debug on
+// and a valid port, the pprof index becomes reachable over HTTP — proving the
+// full chain (blank import → DefaultServeMux → served by the helper).
+func TestMaybeStartPProf_Enabled_ServesPprof(t *testing.T) {
+	port := freePort(t)
+	MaybeStartPProf(true, port)
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", port)
+	var resp *http.Response
+	var err error
+	for i := 0; i < 50; i++ { // listener comes up asynchronously; poll up to ~1s.
+		if resp, err = http.Get(url); err == nil { //nolint:bodyclose // closed below
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.NoError(t, err, "pprof endpoint must become reachable")
+	require.Equal(t, http.StatusOK, resp.StatusCode, "/debug/pprof/ must serve the pprof index")
+	require.NoError(t, resp.Body.Close())
+}


### PR DESCRIPTION
## ADR-058 rollout step 4 (pprof) — the LAST step

Applying the same Is-it-a-Service rigor that made **step 2** conclude "the lifecycle Manager is NOT a Service": **pprof is NOT a Service either.**

### Why not a Service
- **Fails the Is-it-a-Service test on criterion 3** — an HTTP `/debug/pprof` mux has no process state to flush; it's fire-and-forget today, and process exit cleans the listener with no correctness loss.
- **Started deliberately EARLY** (before NATS, `// before NATS - independent`) so a wedged/slow boot stays profilable — a `StartAll`-timed Service would lose that window (the canonical pprof use case).

So, mirroring step 2, the duplicated `startPProfServer` (byte-identical in both mains — the beta.18 drift target) is killed by a **shared helper**, keeping the early fire-and-forget start.

### What this does
- **`service.MaybeStartPProf(debug, port)`** (new `service/pprof.go`) — lifts the existing `startPProfServer` body + its debug gate verbatim. A bind failure degrades (printed), never a boot gate (R1 posture).
- Both mains call it **early and identically** (half-migration guard — call sites byte-identical); both `startPProfServer` copies deleted; the now-unused `net/http` import dropped from both.
- **`_ "net/http/pprof"` blank import STAYS in the mains** (not moved to `service/`) — moving it would arm `/debug/pprof` on `DefaultServeMux` for *every* importer of `service`, a latent-exposure footgun. The helper serves whatever the caller's blank import registered.
- `service/pprof_test.go`: gate test (disabled / `port<=0` → nothing serves, via `http.Get`-expects-refused) + happy path (enabled → `/debug/pprof/` 200, ephemeral `freePort`, own blank import so it proves the full chain). No fixed ports (`lint:test-ports` clean).
- **ADR-058 reconciled** (table row, Phase-B example list, rollout step 4) to "shared helper, not a Service."

### Behavior preservation
Byte-equivalent served behavior (same gate, early position, `go`, messages, error filter, `ListenAndServe(addr, nil)`). The e2e profile client (`test/e2e/client/profile.go` → `localhost:36060`) keeps working — same endpoint, same lifetime. No config/schema change.

### Gates (all green locally)
`task lint` (incl. test-ports guard) · full `go test -race ./...` · `go vet -tags=integration`+`-tags=live_llm` · both binaries build · Linux cross-compile.

**go-reviewer: ACCEPT** — all 8 invariants verified against code (behavior preservation byte-equivalent; blank-import boundary correct; even the third binary `cmd/e2e` confirmed a pprof *consumer*, not a server — out of scope). 3 cosmetic NITs, none actionable.

**This completes the ADR-058 rollout (steps 1–4).** Next: the BREAKING ADR-055 must-exist flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)