### PR TITLE
feat(graph-ingest)!: ADR-055 must-exist flip — retire triple.add auto-vivify (BREAKING)

### DIFF
--- a/docs/adr/055-graph-write-intent-taxonomy.md
+++ b/docs/adr/055-graph-write-intent-taxonomy.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-**Proposed** — 2026-06-11. Not yet implemented or tagged. Derived from a
+**Accepted — must-exist flip implemented 2026-06-19** (BREAKING; see
+[Implementation](#implementation--breaking-consequence-2026-06-19) below).
+Originally proposed 2026-06-11. Derived from a
 two-pass multi-agent audit + design exercise, then a five-lens adversarial
 review (architect / breaker / feasibility / code-accuracy / completeness) whose
 findings are folded in below; every load-bearing fact is verified against code.
@@ -27,6 +29,48 @@ birth envelope-less entities via `triple.add`. Builds on
 [ADR-054](054-semantic-indexing-eligibility.md) (the create envelope carries the
 `IndexingProfile`). Honors [ADR-028](028-orchestration-architecture.md) and the
 KV-twofer.
+
+## Implementation — BREAKING consequence (2026-06-19)
+
+The narrowed flip landed: the bare `triple.add` / `triple.add_batch` lane is now
+**must-exist**. A triple targeting an absent entity is **rejected** with
+`graph.ErrorCodeEntityNotFound` instead of silently auto-vivifying a
+metadata-less entity. Mechanically: the two `len(current)==0` auto-vivify
+else-branches in `Component.AddTriple` and `Component.AddTriples`
+(`processor/graph-ingest/component.go`) now return
+`retry.NonRetryable(natsclient.ErrKVKeyNotFound)`; `handleTripleAdd` /
+`handleTripleAddBatch` (`mutations.go`) map that sentinel to the stable
+`entity_not_found` error code, which `meteredMutation` auto-counts on
+`mutation_rejections_total{reason="entity_not_found"}`. The legitimate
+entity-birth seams (`MergeEntity`, `CreateEntity`, lifecycle `Create`, the
+NoBirthStub referential-integrity stub) are untouched.
+
+**The breaking consequence is wider than the bare-triple lane** — it also closes
+the foreign-edge auto-vivify hatch, because foreign-edge routing
+(`routeForeignEdges` → `appendForeignEdges`) ultimately calls `AddTriples`:
+
+- **Claimed foreign edges** (a registered `ForeignEdgeClaim` in `NoBirthStub`
+  mode — e.g. cs-api's `isHostedBy`) materialize their target stub via
+  `ensureReferencedEntityExists` *before* the append, so the target exists and
+  the edge is **not** rejected. **Safe.**
+- **Unclaimed / fail-open / unknown-mode foreign edges to an absent target** were
+  previously auto-vivified; post-flip the routing *decision* is unchanged (the
+  edge still enters `toAppend`) but `AddTriples` rejects the absent target and
+  `appendForeignEdges` only warns — so the edge is **silently dropped, not
+  birthed**. This is the intended ADR-055 end-state (an unclaimed edge to a
+  non-existent entity is exactly the metadata-less vivification being retired),
+  but it is a **live data-loss event for any producer still emitting unclaimed
+  foreign edges at tag time.**
+
+**Rollout gate.** The data-safe precondition is `foreign_edge_unclaimed_total`
+drained to **zero** across every registered producer (cs-api, semteams, semops) —
+the ADR-056 §4c hatch-drain. As of the tag this is tracked **post-tag** per the
+product owner's call (2026-06-19): all three consumers report prep complete
+(`semconnect#65` / `semteams#222` / `semops#1` held open as post-tag compliance
+trackers). The residual risk — a straggler producer's unclaimed edges dropped in
+the window before its hatch reaches zero — is accepted knowingly. Anyone reading
+this who has NOT confirmed their `foreign_edge_unclaimed_total` is zero should do
+so before relying on unclaimed foreign-edge writes landing.
 
 ## Context
 
@@ -639,9 +683,10 @@ residual. Decide before the flip.
 - Code anchors:
   - `processor/graph-ingest/component.go:857` (`extractEntityFromMessage`), `:946`
     (`MergeEntity`), `:1006` (append), `:1311` (`updateEntityAtRevision`), `:885`
-    (`MessageType` stamp), `:1411-1423` (`AddTriple` auto-vivify — deleted) and
-    `:1511-1521` (`AddTriples`/add_batch auto-vivify — deleted), `:1478-1484`
-    (`AddTriples` bySubject regroup — the T2 model)
+    (`MessageType` stamp), `AddTriple` auto-vivify else-branch (deleted 2026-06-19,
+    now `retry.NonRetryable(ErrKVKeyNotFound)`) and the `AddTriples`/add_batch
+    per-subject auto-vivify else-branch (likewise deleted), the `AddTriples`
+    bySubject regroup (the T2 model)
   - `processor/graph-ingest/mutations.go` (subjects + handlers; `:40/:53/:66` bare CS-API)
   - `processor/rule/actions.go:1390-1467` (deny/approve), `:576` (subject override)
   - `natsclient/client.go:793-799` (`PublishToStream`, the T1 gap)

--- a/processor/agentic-loop/todos_integration_test.go
+++ b/processor/agentic-loop/todos_integration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
 	agenticloop "github.com/c360studio/semstreams/processor/agentic-loop"
@@ -78,6 +79,16 @@ func TestIntegration_TodoWriteReadRoundTrip(t *testing.T) {
 			message.Triple{Subject: loopEntityID, Predicate: agvocab.TodoUpdatedAt, Object: now.Format(time.RFC3339Nano), Timestamp: now, Confidence: 1.0, Source: "agent-write-todos"},
 		)
 	}
+
+	// Born-first (ADR-055): the loop-execution entity must exist before
+	// write_todos appends triples to it. In production graphWriter creates it
+	// via create_with_triples carrying agentic.LoopExecutionMessageType()
+	// (#277) before the agent's first write_todos; post-must-exist-flip a
+	// triple.add_batch to an absent entity is rejected, not auto-vivified.
+	require.NoError(t, c.CreateEntityStrict(ctx, &graph.EntityState{
+		ID:          loopEntityID,
+		MessageType: agentic.LoopExecutionMessageType(),
+	}))
 
 	written, failed, err := c.AddTriples(ctx, triples)
 	require.NoError(t, err)

--- a/processor/graph-ingest/batch_integration_test.go
+++ b/processor/graph-ingest/batch_integration_test.go
@@ -60,6 +60,18 @@ func TestIntegration_AddTriples_SingleSubjectIsOneCAS(t *testing.T) {
 	const entityID = "c360.test.batch.single.loop.001"
 	now := time.Now()
 
+	// ADR-055: pre-create the entity before adding triples (must-exist).
+	require.NoError(t, c.MergeEntity(ctx, &graph.EntityState{ID: entityID}))
+
+	// Capture version baseline immediately after pre-create so we can assert
+	// AddTriples applies exactly one CAS increment (not one per triple).
+	preEntry, err := c.entityBucket.Get(ctx, entityID)
+	require.NoError(t, err)
+	var preEntity graph.EntityState
+	require.NoError(t, json.Unmarshal(preEntry.Value, &preEntity))
+	baseVersion := preEntity.Version
+	baseTripleCount := len(preEntity.Triples)
+
 	triples := []message.Triple{
 		{Subject: entityID, Predicate: "agent.todo.id", Object: "1", Timestamp: now, Confidence: 1.0},
 		{Subject: entityID, Predicate: "agent.todo.content", Object: "Write code", Timestamp: now, Confidence: 1.0},
@@ -73,26 +85,40 @@ func TestIntegration_AddTriples_SingleSubjectIsOneCAS(t *testing.T) {
 	require.Empty(t, failed)
 	assert.Equal(t, 5, written)
 
-	// Single CAS → entity version increments by exactly 1, not 5.
+	// Single CAS → version increments by exactly 1 (not 5 — one per triple).
 	entry, err := c.entityBucket.Get(ctx, entityID)
 	require.NoError(t, err)
 
 	var entity graph.EntityState
 	require.NoError(t, json.Unmarshal(entry.Value, &entity))
 
-	assert.Equal(t, 5, len(entity.Triples), "all 5 triples present")
-	assert.Equal(t, uint64(1), entity.Version, "single CAS commit, version=1 (not 5)")
+	assert.Equal(t, baseTripleCount+5, len(entity.Triples), "all 5 triples appended to pre-created entity")
+	assert.Equal(t, baseVersion+1, entity.Version, "single CAS commit: version incremented by exactly 1 (not 5)")
 }
 
 // TestIntegration_AddTriples_MultiSubjectGroupsByEntity verifies multi-subject
 // batches issue one CAS per entity, not one per triple. Two entities × N
-// triples each → 2 CAS round-trips, each entity reaches version=1.
+// triples each → 2 CAS round-trips (1 create + 1 batch add per entity).
 func TestIntegration_AddTriples_MultiSubjectGroupsByEntity(t *testing.T) {
 	ctx, c := startBatchTestComponent(t)
 
 	const idA = "c360.test.batch.multi.loop.a01"
 	const idB = "c360.test.batch.multi.loop.b02"
 	now := time.Now()
+
+	// ADR-055: pre-create both entities before adding triples (must-exist).
+	require.NoError(t, c.MergeEntity(ctx, &graph.EntityState{ID: idA}))
+	require.NoError(t, c.MergeEntity(ctx, &graph.EntityState{ID: idB}))
+
+	// Capture baseline versions and triple counts after pre-create.
+	preA, err := c.entityBucket.Get(ctx, idA)
+	require.NoError(t, err)
+	var preEntityA graph.EntityState
+	require.NoError(t, json.Unmarshal(preA.Value, &preEntityA))
+	preB, err := c.entityBucket.Get(ctx, idB)
+	require.NoError(t, err)
+	var preEntityB graph.EntityState
+	require.NoError(t, json.Unmarshal(preB.Value, &preEntityB))
 
 	triples := []message.Triple{
 		{Subject: idA, Predicate: "agent.todo.id", Object: "1", Timestamp: now, Confidence: 1.0},
@@ -111,15 +137,16 @@ func TestIntegration_AddTriples_MultiSubjectGroupsByEntity(t *testing.T) {
 	require.NoError(t, err)
 	var entityA graph.EntityState
 	require.NoError(t, json.Unmarshal(entryA.Value, &entityA))
-	assert.Equal(t, 3, len(entityA.Triples))
-	assert.Equal(t, uint64(1), entityA.Version)
+	assert.Equal(t, len(preEntityA.Triples)+3, len(entityA.Triples))
+	// Each entity version incremented by exactly 1 (single batched CAS per entity).
+	assert.Equal(t, preEntityA.Version+1, entityA.Version)
 
 	entryB, err := c.entityBucket.Get(ctx, idB)
 	require.NoError(t, err)
 	var entityB graph.EntityState
 	require.NoError(t, json.Unmarshal(entryB.Value, &entityB))
-	assert.Equal(t, 2, len(entityB.Triples))
-	assert.Equal(t, uint64(1), entityB.Version)
+	assert.Equal(t, len(preEntityB.Triples)+2, len(entityB.Triples))
+	assert.Equal(t, preEntityB.Version+1, entityB.Version)
 }
 
 // TestIntegration_AddTriples_ValidationRejectsWholeBatch ensures a single
@@ -167,6 +194,9 @@ func TestIntegration_HandleTripleAddBatch_RoundTrip(t *testing.T) {
 	const entityID = "c360.test.batch.handler.loop.001"
 	now := time.Now()
 
+	// ADR-055: pre-create the entity before adding triples (must-exist).
+	require.NoError(t, c.MergeEntity(ctx, &graph.EntityState{ID: entityID}))
+
 	req := graph.AddTriplesBatchRequest{
 		Triples: []message.Triple{
 			{Subject: entityID, Predicate: "agent.todo.id", Object: "1", Timestamp: now, Confidence: 1.0},
@@ -202,6 +232,9 @@ func TestIntegration_AddTriples_PreservesInputOrderWithinSubject(t *testing.T) {
 	const entityID = "c360.test.batch.order.loop.001"
 	now := time.Now()
 
+	// ADR-055: pre-create the entity before adding triples (must-exist).
+	require.NoError(t, c.MergeEntity(ctx, &graph.EntityState{ID: entityID}))
+
 	// Emit a known sequence: A, B, C, D, E across the same subject.
 	// The retrieved Triples slice must come back in this exact order.
 	want := []string{"A", "B", "C", "D", "E"}
@@ -226,16 +259,22 @@ func TestIntegration_AddTriples_PreservesInputOrderWithinSubject(t *testing.T) {
 
 	var entity graph.EntityState
 	require.NoError(t, json.Unmarshal(entry.Value, &entity))
-	require.Len(t, entity.Triples, len(want))
 
-	got := make([]string, len(entity.Triples))
-	for i, tr := range entity.Triples {
+	// Collect only the test.order.label triples in their stored order.
+	// MergeEntity may have stamped additional framework triples (e.g. indexing
+	// profile); we filter to the predicate we care about to stay robust.
+	got := make([]string, 0, len(want))
+	for _, tr := range entity.Triples {
+		if tr.Predicate != "test.order.label" {
+			continue
+		}
 		s, ok := tr.Object.(string)
 		if !ok {
-			t.Fatalf("triple[%d].Object expected string, got %T", i, tr.Object)
+			t.Fatalf("triple with predicate test.order.label: Object expected string, got %T", tr.Object)
 		}
-		got[i] = s
+		got = append(got, s)
 	}
+	require.Len(t, got, len(want), "exactly %d test.order.label triples must be present", len(want))
 	assert.Equal(t, want, got, "ADR-036 Stage 4 ReconstructTodos parses by stride; input order must be preserved")
 }
 
@@ -252,4 +291,73 @@ func TestIntegration_HandleTripleAddBatch_InvalidJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(respBytes, &resp))
 	assert.False(t, resp.Success)
 	assert.Contains(t, resp.Error, "invalid request")
+}
+
+// TestIntegration_HandleTripleAdd_AbsentEntityRejects verifies ADR-055
+// must-exist: a triple targeting a never-created entity is rejected with
+// ErrorCodeEntityNotFound. The entity bucket must remain empty (no
+// auto-vivification).
+func TestIntegration_HandleTripleAdd_AbsentEntityRejects(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const subject = "c360.test.absent.single.entity.001"
+	req := graph.AddTripleRequest{
+		Triple: message.Triple{
+			Subject:    subject,
+			Predicate:  "evidence.note",
+			Object:     "should-not-land",
+			Confidence: 1.0,
+		},
+	}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, handlerErr := c.handleTripleAdd(ctx, reqBytes)
+	require.NoError(t, handlerErr, "handler must not return a Go error; rejections are in the response body")
+
+	var resp graph.AddTripleResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	assert.False(t, resp.Success, "absent entity must produce Success=false")
+	assert.Equal(t, graph.ErrorCodeEntityNotFound, resp.ErrorCode,
+		"absent entity must produce ErrorCode=entity_not_found (not empty/unclassified)")
+	assert.NotEmpty(t, resp.Error, "rejection must carry a human-readable error message")
+
+	// State must be unchanged: entity must still not exist.
+	_, getErr := c.entityBucket.Get(ctx, subject)
+	assert.True(t, natsclient.IsKVNotFoundError(getErr),
+		"entity bucket must remain empty — no auto-vivification (ADR-055)")
+}
+
+// TestIntegration_HandleTripleAddBatch_AbsentEntityRejects verifies ADR-055
+// must-exist for the batch handler: an all-absent batch is rejected with
+// ErrorCodeEntityNotFound, FailedSubjects names the subject, WrittenCount is 0,
+// and the entity bucket remains empty.
+func TestIntegration_HandleTripleAddBatch_AbsentEntityRejects(t *testing.T) {
+	ctx, c := startBatchTestComponent(t)
+
+	const subject = "c360.test.absent.batch.entity.001"
+	req := graph.AddTriplesBatchRequest{
+		Triples: []message.Triple{
+			{Subject: subject, Predicate: "evidence.note", Object: "should-not-land", Confidence: 1.0},
+		},
+	}
+	reqBytes, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respBytes, handlerErr := c.handleTripleAddBatch(ctx, reqBytes)
+	require.NoError(t, handlerErr, "handler must not return a Go error; rejections are in the response body")
+
+	var resp graph.AddTriplesBatchResponse
+	require.NoError(t, json.Unmarshal(respBytes, &resp))
+	assert.False(t, resp.Success, "absent entity must produce Success=false")
+	assert.Equal(t, graph.ErrorCodeEntityNotFound, resp.ErrorCode,
+		"all-absent batch must produce ErrorCode=entity_not_found")
+	assert.Equal(t, 0, resp.WrittenCount, "no triples must be written for an absent entity")
+	require.Len(t, resp.FailedSubjects, 1, "FailedSubjects must name the one failing subject")
+	assert.Contains(t, resp.FailedSubjects, subject, "FailedSubjects must include the absent subject")
+
+	// State must be unchanged: entity must still not exist.
+	_, getErr := c.entityBucket.Get(ctx, subject)
+	assert.True(t, natsclient.IsKVNotFoundError(getErr),
+		"entity bucket must remain empty — no auto-vivification (ADR-055)")
 }

--- a/processor/graph-ingest/cas_integration_test.go
+++ b/processor/graph-ingest/cas_integration_test.go
@@ -401,6 +401,11 @@ func TestIntegration_SharedSeam_CASFailureDoesNotRouteForeign(t *testing.T) {
 	t.Run("correct_revision_routes_foreign", func(t *testing.T) {
 		_, rev, err := c.fetchEntityState(ctx, parentID)
 		require.NoError(t, err)
+
+		// Pre-create the child entity so the foreign edge can land (ADR-055
+		// must-exist: AddTriples rejects absent targets).
+		require.NoError(t, c.CreateEntity(ctx, &graph.EntityState{ID: childID}))
+
 		req := graph.UpdateEntityWithTriplesRequest{
 			Entity:           &graph.EntityState{ID: parentID},
 			AddTriples:       []message.Triple{foreignEdge},
@@ -413,7 +418,7 @@ func TestIntegration_SharedSeam_CASFailureDoesNotRouteForeign(t *testing.T) {
 		require.NoError(t, json.Unmarshal(respData, &resp))
 		require.True(t, resp.Success, "current-revision CAS must succeed: %s", resp.Error)
 
-		// On success the foreign edge IS routed onto the child.
+		// On success the foreign edge IS routed onto the (pre-created) child.
 		entry, getErr := c.entityBucket.Get(ctx, childID)
 		require.NoError(t, getErr, "foreign edge must be routed onto the child when the CAS primary write committed")
 		var child graph.EntityState

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -24,6 +24,7 @@ import (
 	"github.com/c360studio/semstreams/pkg/cache"
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/pkg/ownership"
+	"github.com/c360studio/semstreams/pkg/retry"
 	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/prometheus/client_golang/prometheus"
@@ -1213,7 +1214,11 @@ func (c *Component) routeForeignEdges(ctx context.Context, primaryID string, mt 
 		case !claimed:
 			// UNCLAIMED + absent: the deprecated-on-arrival hatch. Stay routed so
 			// foreign_edge_unclaimed_total (metered upstream in classifyForeignEdges)
-			// can still reach zero over the flip-gate bake window.
+			// can still reach zero over the flip-gate bake window. Post-ADR-055 the
+			// append no longer auto-vivifies the absent target — AddTriples rejects
+			// it (appendForeignEdges warn-not-fails), so an unclaimed edge to a
+			// not-yet-born target is dropped, not silently birthed. Draining this
+			// counter to zero is the rollout gate for the must-exist flip.
 			toAppend = append(toAppend, edge)
 		case mode == ownership.EdgeNoBirthStub:
 			// Backstop: materialise the envelope-bearing stub then append. Idempotent
@@ -1231,7 +1236,9 @@ func (c *Component) routeForeignEdges(ctx context.Context, primaryID string, mt 
 			// NOT appended.
 		case mode == ownership.EdgeConditional || mode == ownership.EdgeBackfill:
 			// DEFERRED to the PENDING_EDGES increment. No live producer reaches here
-			// today; route-with-warn (keeps auto-vivify) so it is observable, not silent.
+			// today; route-with-warn so it is observable, not silent. Post-ADR-055 the
+			// append no longer auto-vivifies an absent target — AddTriples rejects it
+			// (warn-not-fails), same as the unclaimed hatch above.
 			c.foreignEdgeDropped.WithLabelValues(label, edge.Predicate, dropReasonConditionalDeferred).Inc()
 			c.warnForeignEdgeDropOnce(dropReasonConditionalDeferred, label, edge)
 			toAppend = append(toAppend, edge)
@@ -2190,12 +2197,10 @@ func (c *Component) AddTriple(ctx context.Context, triple message.Triple) error 
 				return nil, err // Non-retryable
 			}
 		} else {
-			// Create new entity if doesn't exist
-			entity = graph.EntityState{
-				ID:        triple.Subject,
-				Version:   0,
-				UpdatedAt: time.Now(),
-			}
+			// Must-exist (ADR-055): a triple targeting an absent entity is
+			// rejected, not silently auto-vivified. NonRetryable stops the CAS
+			// loop and surfaces the sentinel for the handler to map.
+			return nil, retry.NonRetryable(natsclient.ErrKVKeyNotFound)
 		}
 
 		// Add triple
@@ -2266,6 +2271,12 @@ func (c *Component) AddTriples(ctx context.Context, triples []message.Triple) (w
 	sort.Strings(subjects)
 
 	failedSubjects = make(map[string]string)
+	// allAbsences tracks whether EVERY per-subject failure was an ADR-055
+	// entity-not-found rejection. When true the aggregated error wraps
+	// ErrKVKeyNotFound so the handler can set ErrorCodeEntityNotFound on the
+	// response without string-sniffing. Mixed-reason batches (allAbsences=false)
+	// stay un-sentineled → handler leaves ErrorCode empty (unclassified).
+	allAbsences := true
 	for i, subject := range subjects {
 		// Short-circuit on context cancellation: don't burn the retry
 		// budget for every remaining subject when the caller has
@@ -2277,6 +2288,8 @@ func (c *Component) AddTriples(ctx context.Context, triples []message.Triple) (w
 			for _, s := range subjects[i:] {
 				failedSubjects[s] = ctxErr.Error()
 			}
+			// A cancelled batch is NOT a pure entity-not-found batch.
+			allAbsences = false
 			atomic.AddInt64(&c.errors, 1)
 			break
 		}
@@ -2289,11 +2302,10 @@ func (c *Component) AddTriples(ctx context.Context, triples []message.Triple) (w
 					return nil, err // Non-retryable
 				}
 			} else {
-				entity = graph.EntityState{
-					ID:        subject,
-					Version:   0,
-					UpdatedAt: time.Now(),
-				}
+				// Must-exist (ADR-055): a triple targeting an absent entity is
+				// rejected, not silently auto-vivified. NonRetryable stops the CAS
+				// loop and surfaces the sentinel for the handler to map.
+				return nil, retry.NonRetryable(natsclient.ErrKVKeyNotFound)
 			}
 
 			entity.Triples = append(entity.Triples, group...)
@@ -2306,6 +2318,9 @@ func (c *Component) AddTriples(ctx context.Context, triples []message.Triple) (w
 		if casErr != nil {
 			atomic.AddInt64(&c.errors, 1)
 			failedSubjects[subject] = casErr.Error()
+			if !errors.Is(casErr, natsclient.ErrKVKeyNotFound) {
+				allAbsences = false
+			}
 			continue
 		}
 		writtenCount += len(group)
@@ -2321,9 +2336,17 @@ func (c *Component) AddTriples(ctx context.Context, triples []message.Triple) (w
 		failed = append(failed, s)
 	}
 	sort.Strings(failed)
-	return writtenCount, failedSubjects, errs.Wrap(
-		fmt.Errorf("CAS update failed for %d/%d subjects: %v", len(failedSubjects), len(subjects), failed),
-		"Component", "AddTriples", "batch CAS partial failure")
+	var innerErr error
+	if allAbsences {
+		// All failures were entity-not-found: wrap the sentinel so the handler
+		// can set ErrorCodeEntityNotFound without string-sniffing.
+		innerErr = fmt.Errorf("CAS update failed for %d/%d subjects: %v: %w",
+			len(failedSubjects), len(subjects), failed, natsclient.ErrKVKeyNotFound)
+	} else {
+		innerErr = fmt.Errorf("CAS update failed for %d/%d subjects: %v",
+			len(failedSubjects), len(subjects), failed)
+	}
+	return writtenCount, failedSubjects, errs.Wrap(innerErr, "Component", "AddTriples", "batch CAS partial failure")
 }
 
 // RemoveTriple removes a triple from an entity using CAS for concurrency safety

--- a/processor/graph-ingest/foreign_edge_route_test.go
+++ b/processor/graph-ingest/foreign_edge_route_test.go
@@ -113,6 +113,9 @@ func TestRouteForeignEdges_PresentTarget_AppendsRegardlessOfMode(t *testing.T) {
 // UNCLAIMED + absent target: the deprecated-on-arrival hatch — the edge stays
 // routed (so the flip-gate hatch counter can still drain to zero) and is NOT
 // metered on the drop counter (it is the unclaimed lane, metered upstream).
+// ADR-055: after the must-exist flip the routing decision is unchanged (edge
+// goes into toAppend), but AddTriples now rejects absent targets → entity
+// remains absent. The primary write is unaffected (warn-not-fails contract).
 func TestRouteForeignEdges_Unclaimed_AbsentTarget_RouteWithWarn(t *testing.T) {
 	comp, _ := routeTestComp(t)
 	comp.claimReader = &fakeClassifier{} // no modes configured → ForeignEdgeMode reports unclaimed
@@ -122,8 +125,11 @@ func TestRouteForeignEdges_Unclaimed_AbsentTarget_RouteWithWarn(t *testing.T) {
 
 	comp.routeForeignEdges(context.Background(), flParentID, routeMT, []message.Triple{routeEdge()})
 
-	child := storedEntity(t, comp, flChildID)
-	assert.True(t, hasPredicate(child, routeEdgePred), "an unclaimed foreign edge must stay routed (deprecated-on-arrival hatch)")
+	// ADR-055: the unclaimed routing decision still routes (not dropped), but
+	// AddTriples rejects the absent target — entity must NOT exist post-flip.
+	_, err := comp.entityBucket.Get(context.Background(), flChildID)
+	assert.True(t, natsclient.IsKVNotFoundError(err),
+		"ADR-055: unclaimed absent target must NOT be auto-vivified; AddTriples fails (warn-not-fails)")
 	assert.InDelta(t, beforeDropped, testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent)), 0.0001,
 		"the unclaimed hatch must NOT increment the drop counter")
 }
@@ -131,6 +137,9 @@ func TestRouteForeignEdges_Unclaimed_AbsentTarget_RouteWithWarn(t *testing.T) {
 // A mode-lookup read error inside routeForeignEdges fails OPEN: the edge is
 // routed-with-warn (never blocked, never Strict-dropped on a transient read
 // blip) — the route-time mirror of the foreignTargetExists fail-open.
+// ADR-055: after the must-exist flip the fail-open routing decision is unchanged
+// (edge goes into toAppend), but AddTriples rejects the absent target →
+// entity remains absent. The primary write is unaffected (warn-not-fails).
 func TestRouteForeignEdges_ModeLookupError_FailsOpen(t *testing.T) {
 	comp, _ := routeTestComp(t)
 	comp.claimReader = &fakeClassifier{err: assertErr} // ForeignEdgeMode returns an error
@@ -140,8 +149,11 @@ func TestRouteForeignEdges_ModeLookupError_FailsOpen(t *testing.T) {
 
 	comp.routeForeignEdges(context.Background(), flParentID, routeMT, []message.Triple{routeEdge()})
 
-	child := storedEntity(t, comp, flChildID)
-	assert.True(t, hasPredicate(child, routeEdgePred), "a mode-lookup read error must fail open — the edge is still routed")
+	// ADR-055: the fail-open routing decision still routes (not dropped), but
+	// AddTriples rejects the absent target — entity must NOT exist post-flip.
+	_, err := comp.entityBucket.Get(context.Background(), flChildID)
+	assert.True(t, natsclient.IsKVNotFoundError(err),
+		"ADR-055: fail-open absent target must NOT be auto-vivified; AddTriples fails (warn-not-fails)")
 	assert.InDelta(t, beforeDropped, testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent)), 0.0001,
 		"a fail-open route must NOT increment the drop counter")
 }
@@ -149,6 +161,9 @@ func TestRouteForeignEdges_ModeLookupError_FailsOpen(t *testing.T) {
 // An UNKNOWN/future EdgeMode + absent target takes the forward-compat default:
 // route-with-warn (hatch), NEVER a silent drop. Locks the contract that adding a
 // new EdgeMode cannot silently start dropping edges before the seam handles it.
+// ADR-055: after the must-exist flip the forward-compat routing decision is
+// unchanged (edge goes into toAppend), but AddTriples rejects the absent target
+// → entity remains absent. The primary write is unaffected (warn-not-fails).
 func TestRouteForeignEdges_UnknownMode_AbsentTarget_RouteWithWarn(t *testing.T) {
 	comp, _ := routeTestComp(t)
 	comp.claimReader = &fakeClassifier{modes: map[string]ownership.EdgeMode{routeEdgePred: ownership.EdgeMode("future-unhandled")}}
@@ -158,8 +173,11 @@ func TestRouteForeignEdges_UnknownMode_AbsentTarget_RouteWithWarn(t *testing.T) 
 
 	comp.routeForeignEdges(context.Background(), flParentID, routeMT, []message.Triple{routeEdge()})
 
-	child := storedEntity(t, comp, flChildID)
-	assert.True(t, hasPredicate(child, routeEdgePred), "an unknown EdgeMode must route-with-warn (hatch), never silent-drop")
+	// ADR-055: the unknown-mode routing decision still routes (not dropped), but
+	// AddTriples rejects the absent target — entity must NOT exist post-flip.
+	_, err := comp.entityBucket.Get(context.Background(), flChildID)
+	assert.True(t, natsclient.IsKVNotFoundError(err),
+		"ADR-055: unknown-mode absent target must NOT be auto-vivified; AddTriples fails (warn-not-fails)")
 	assert.InDelta(t, beforeDropped, testutil.ToFloat64(comp.foreignEdgeDropped.WithLabelValues(label, routeEdgePred, dropReasonStrictAbsent)), 0.0001,
 		"an unknown-mode route must NOT increment the drop counter")
 }

--- a/processor/graph-ingest/foreign_edge_seam_test.go
+++ b/processor/graph-ingest/foreign_edge_seam_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/ownership"
 )
 
@@ -108,7 +109,9 @@ func TestForeignEdgeSeam_MetersUnclaimedOnly(t *testing.T) {
 }
 
 // No claim reader wired (resourceless/unmigrated deploy): the seam is a pure
-// no-op — no panic, ingest proceeds, the foreign edge is still routed.
+// no-op — no panic, ingest proceeds, the foreign edge routing is attempted.
+// ADR-055: after the must-exist flip, AddTriples rejects the absent target
+// → entity stays absent, but the primary write is unaffected (warn-not-fails).
 func TestForeignEdgeSeam_GracefulSkipWhenNoReader(t *testing.T) {
 	comp := createTestComponentWithMockKV(t)
 	comp.claimReader = nil
@@ -121,9 +124,11 @@ func TestForeignEdgeSeam_GracefulSkipWhenNoReader(t *testing.T) {
 	}
 	comp.ingestEntity(context.Background(), entity) // must not panic
 
-	// The foreign edge still landed on its subject (routing unchanged).
-	child := storedEntity(t, comp, flChildID)
-	assert.True(t, hasPredicate(child, "x.edge"), "graceful-skip must not change routing — the foreign edge is still appended")
+	// ADR-055: routing is attempted (graceful-skip contract preserved) but
+	// AddTriples rejects the absent target — entity must NOT be auto-vivified.
+	_, err := comp.entityBucket.Get(context.Background(), flChildID)
+	assert.True(t, natsclient.IsKVNotFoundError(err),
+		"ADR-055: graceful-skip must attempt routing but NOT auto-vivify absent target (warn-not-fails)")
 }
 
 // A producer with an invalid/zero MessageType is metered under a bounded
@@ -151,6 +156,8 @@ func TestForeignEdgeSeam_InvalidMessageTypeLabel(t *testing.T) {
 
 // A classifier read error is fail-open: the seam logs and routes anyway (no
 // metric, no panic, ingest not blocked).
+// ADR-055: after the must-exist flip, AddTriples rejects the absent target
+// → entity stays absent, but the primary write is unaffected (warn-not-fails).
 func TestForeignEdgeSeam_ClassifierErrorFailsOpen(t *testing.T) {
 	comp := createTestComponentWithMockKV(t)
 	comp.claimReader = &fakeClassifier{err: assertErr}
@@ -163,8 +170,11 @@ func TestForeignEdgeSeam_ClassifierErrorFailsOpen(t *testing.T) {
 	}
 	comp.ingestEntity(context.Background(), entity) // must not panic
 
-	child := storedEntity(t, comp, flChildID)
-	assert.True(t, hasPredicate(child, "x.edge"), "a classifier error must not block routing (fail-open)")
+	// ADR-055: a classifier error causes fail-open routing (routing decision preserved),
+	// but AddTriples rejects the absent target — entity must NOT be auto-vivified.
+	_, err := comp.entityBucket.Get(context.Background(), flChildID)
+	assert.True(t, natsclient.IsKVNotFoundError(err),
+		"ADR-055: fail-open must NOT auto-vivify absent target; AddTriples fails (warn-not-fails)")
 }
 
 var assertErr = errForTest("classifier read blip")
@@ -211,10 +221,12 @@ func TestSharedSeam_CreateWithTriples_PartitionsClassifiesRoutesForeign(t *testi
 	assert.InDelta(t, before+1, testutil.ToFloat64(comp.foreignEdgeUnclaimed.WithLabelValues(mt.Key(), "child.isHostedBy")), 0.0001,
 		"the mutation-lane foreign edge must be classified by the shared seam")
 	assert.Equal(t, mt.Key(), fake.gotProducer)
-	// …and routed onto its own subject (the child entity).
-	child := storedEntity(t, comp, flChildID)
-	assert.True(t, hasPredicate(child, "child.isHostedBy"),
-		"foreign edge must be routed onto its own subject, not dropped")
+	// …and routing was attempted (edge goes into toAppend, not dropped).
+	// ADR-055: AddTriples now rejects absent targets — the child entity stays
+	// absent (warn-not-fails). The metric alone confirms classification happened.
+	_, childErr := comp.entityBucket.Get(context.Background(), flChildID)
+	assert.True(t, natsclient.IsKVNotFoundError(childErr),
+		"ADR-055: unclaimed absent child must NOT be auto-vivified; AddTriples fails (warn-not-fails)")
 }
 
 // A single-subject create_with_triples (every current caller) is a pure no-op for

--- a/processor/graph-ingest/indexing_profile_registry_test.go
+++ b/processor/graph-ingest/indexing_profile_registry_test.go
@@ -84,25 +84,37 @@ func TestIndexingProfileRegistry_KeysTrackDomainVersionConstants(t *testing.T) {
 	}
 }
 
-// TestIndexingProfile_AddTripleAutoVivify_DoesNotStamp locks the ADR-055
-// forward-compat decision: the triple.add auto-vivify path (which ADR-055 will
-// DELETE) is NOT a stamp seam. An entity born via triple.add carries no profile
-// triple — lenient consumers index it, and the floor metric never fires because
-// reconcileIndexingProfile is not on this path. If a future change wires
-// stamping into the auto-vivify branch (rather than removing it per ADR-055),
-// this fails.
-func TestIndexingProfile_AddTripleAutoVivify_DoesNotStamp(t *testing.T) {
+// TestIndexingProfile_AddTriple_DoesNotStamp locks the ADR-055 invariant:
+// triple.add is NOT a stamp seam. An entity updated via triple.add carries no
+// additional profile triple — reconcileIndexingProfile is not on this path.
+// The entity must be pre-created (ADR-055 deleted the auto-vivify path);
+// triple.add to a pre-existing entity must NOT re-stamp indexing metadata.
+func TestIndexingProfile_AddTriple_DoesNotStamp(t *testing.T) {
 	comp := createTestComponentWithMockKV(t)
 	ctx := context.Background()
 
-	const id = "c360.platform.test.sys.widget.autovivify1"
+	const id = "c360.platform.test.sys.widget.addtriple1"
+	// Pre-create the entity via the create seam so it exists in ENTITY_STATES.
+	req := graph.CreateEntityWithTriplesRequest{Entity: &graph.EntityState{ID: id}}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	_, err = comp.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, err)
+
+	// Record the profile triples stamped at create time so we can assert
+	// that triple.add does NOT add more.
+	esBefore := storedEntity(t, comp, id)
+	profilesBefore := profileValues(esBefore)
+
+	// Now add a user triple via the triple.add path.
 	tr := message.Triple{Subject: id, Predicate: "evidence.note", Object: "v", Confidence: 1.0}
 	require.NoError(t, comp.AddTriple(ctx, tr))
 
-	es := storedEntity(t, comp, id)
-	assert.Empty(t, profileValues(es),
-		"triple.add auto-vivify must NOT stamp an indexing profile (ADR-055 deletes that create path)")
-	assert.Equal(t, 1, nonProfileTripleCount(es), "the entity holds exactly the one added triple")
+	esAfter := storedEntity(t, comp, id)
+	assert.Equal(t, profilesBefore, profileValues(esAfter),
+		"triple.add must NOT stamp or change the indexing profile (ADR-055: only create seam stamps)")
+	assert.Equal(t, nonProfileTripleCount(esBefore)+1, nonProfileTripleCount(esAfter),
+		"the entity holds exactly one additional user triple after AddTriple")
 }
 
 // End-to-end through the production create handler: a REGISTERED type floors to

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -203,13 +203,17 @@ func (c *Component) handleTripleAdd(ctx context.Context, data []byte) ([]byte, e
 	// AddTriple uses triple.Subject as entity ID
 	err := c.AddTriple(ctx, req.Triple)
 	if err != nil {
-		return json.Marshal(graph.AddTripleResponse{
+		resp := graph.AddTripleResponse{
 			MutationResponse: graph.MutationResponse{
 				Success:   false,
 				Error:     err.Error(),
 				Timestamp: time.Now().UnixNano(),
 			},
-		})
+		}
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			resp.ErrorCode = graph.ErrorCodeEntityNotFound
+		}
+		return json.Marshal(resp)
 	}
 
 	// Get revision after successful mutation for feedback loop prevention
@@ -280,6 +284,9 @@ func (c *Component) handleTripleAddBatch(ctx context.Context, data []byte) ([]by
 	}
 	if err != nil {
 		resp.Error = err.Error()
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			resp.ErrorCode = graph.ErrorCodeEntityNotFound
+		}
 	}
 	return json.Marshal(resp)
 }


### PR DESCRIPTION
## ADR-055 must-exist flip (BREAKING) — retire `triple.add` auto-vivify

The closing move of ADR-055. The bare `triple.add` / `triple.add_batch` lane now
**rejects** a triple targeting an absent entity with `ErrorCodeEntityNotFound`
instead of silently auto-vivifying a metadata-less entity. Mirrors the
already-must-exist `update_with_triples` lane.

### Changes
- `AddTriple` / `AddTriples` (`component.go`): the `len(current)==0` auto-vivify
  else-branches now `return retry.NonRetryable(natsclient.ErrKVKeyNotFound)`.
- `AddTriples` aggregation: an `allAbsences` flag wraps the sentinel into the
  top-level error only when **every** per-subject failure was an absence, so the
  batch handler sets `ErrorCode` **without string-sniffing** (the documented
  anti-pattern). Mixed-reason batches stay `unclassified` (matches pre-flip).
- `handleTripleAdd` / `handleTripleAddBatch` (`mutations.go`): map the sentinel to
  `entity_not_found`; `meteredMutation` auto-counts
  `mutation_rejections_total{reason="entity_not_found"}`.

### BREAKING — foreign-edge consequence
Foreign-edge routing calls `AddTriples`, so this also closes the foreign-edge
auto-vivify hatch:
- **Claimed edges** (NoBirthStub, e.g. cs-api `isHostedBy`) materialize their
  target via `ensureReferencedEntityExists` before the append → **safe**.
- **Unclaimed / fail-open / unknown-mode edges to an absent target** are now
  dropped-with-warn (not auto-vivified). Intended ADR-055 end-state; a live
  data-loss risk only for a producer still emitting unclaimed foreign edges.

**Rollout gate:** `foreign_edge_unclaimed_total` drains to zero across producers
(cs-api/semteams/semops) — tracked post-tag per owner call (semconnect#65 /
semteams#222 / semops#1). See `docs/adr/055`.

### Survives (untouched)
`MergeEntity`, `CreateEntity`, lifecycle `Create`, `ensureReferencedEntityExists`
(NoBirthStub referential-integrity stub), `routeForeignEdges` routing decisions.

### Tests & gates
- New integration tests prove `entity_not_found` rejection **and state-unchanged**.
- Throughput/foreign-edge tests updated to born-first / assert-absent-stays-absent.
- Green: lint, `go vet` ×{default,integration,live_llm}, schema no-drift, unit +
  integration `-race`. e2e: **core / structural / agentic green**
  (born-first flows, zero data loss). `crud-tools` red is pre-existing
  (reproduces on clean main; tracked separately).
- Reviewed in isolation (architect scope → adversarial over-eng review →
  go-developer → go-reviewer ACCEPT-WITH-NITS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
