### PR TITLE
feat(graph-query): typed prefix-discovery contract + client helper (#302)

### DIFF
--- a/graph/query/interface.go
+++ b/graph/query/interface.go
@@ -43,6 +43,16 @@ type Client interface {
 	GetPredicateStats(ctx context.Context, predicate string, sampleLimit int) (*gtypes.PredicateStatsData, error)
 	QueryCompoundPredicates(ctx context.Context, query gtypes.CompoundPredicateQuery) ([]string, error)
 
+	// Prefix queries
+	// QueryPrefix fetches one page of entities whose IDs share the given prefix.
+	// Pass the NextCursor from the previous PrefixQueryResponse to page forward;
+	// leave Cursor empty for the first page. Calls graph.query.prefix via
+	// RequestClassified, so errors surface as a non-nil error (never a silent
+	// empty result). Note: the public-subject passthrough coerces handler errors
+	// to Invalid class — see QueryPrefix's doc comment for the class-fidelity
+	// caveat.
+	QueryPrefix(ctx context.Context, req gtypes.PrefixQueryRequest) (gtypes.PrefixQueryResponse, error)
+
 	// Cache and metrics
 	GetCacheStats() CacheStats
 	Clear() error

--- a/graph/query/prefix.go
+++ b/graph/query/prefix.go
@@ -1,0 +1,51 @@
+package query
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+)
+
+const prefixQueryTimeout = 30 * time.Second
+const prefixQuerySubject = "graph.query.prefix"
+
+// QueryPrefix fetches one page of entities whose IDs share the given prefix.
+// Pass graph.PrefixQueryRequest.Cursor from the previous response to page
+// forward; leave it empty for the first page.
+//
+// Error handling: transport errors and handler failures surface as a non-nil
+// error (never a silently-empty result decoded from an "error: " body). Use
+// errs.IsInvalid / IsTransient to branch on error class.
+//
+// Class-fidelity caveat: this helper calls the PUBLIC graph.query.prefix
+// subject, whose graph-query passthrough re-responds the graph-ingest body with
+// plain Request (no X-Error-Class propagation). So a graph-ingest error reaches
+// here only via the legacy "error: " body prefix, which ClassifyReply always
+// coerces to Invalid — a transient graph-ingest failure is reported as Invalid,
+// not Transient. The error is still surfaced (the contract that matters for
+// SemOps); only the class can be imprecise. Call graph.ingest.query.prefix
+// directly for full class fidelity. Propagating the class through the
+// passthrough is a tracked follow-up.
+//
+// A future QueryPrefixAll convenience helper (auto-paging accumulator) may be
+// added, but is deliberately omitted here to avoid re-introducing unbounded
+// accumulation at the call site.
+func (qc *natsClient) QueryPrefix(ctx context.Context, req graph.PrefixQueryRequest) (graph.PrefixQueryResponse, error) {
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return graph.PrefixQueryResponse{}, err
+	}
+
+	resp, err := qc.natsClient.RequestClassified(ctx, prefixQuerySubject, reqData, prefixQueryTimeout)
+	if err != nil {
+		return graph.PrefixQueryResponse{}, err
+	}
+
+	var result graph.PrefixQueryResponse
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return graph.PrefixQueryResponse{}, err
+	}
+	return result, nil
+}

--- a/graph/query_prefix_types.go
+++ b/graph/query_prefix_types.go
@@ -1,0 +1,97 @@
+// Package graph defines the types and primitives for the SemStreams knowledge
+// graph engine.
+package graph
+
+import "encoding/base64"
+
+// DefaultPrefixQueryLimit is the default number of entities returned per page
+// when the caller does not specify a limit. Matches the server-side default
+// that existed before typed pagination was introduced.
+const DefaultPrefixQueryLimit = 1000
+
+// MaxPrefixQueryLimit is the maximum number of entities returned per page.
+// The NATS max_payload ceiling (~1 MB) is the binding constraint: a typical
+// EntityState with a handful of triples serialises to a few KB; at 1000
+// entities that is already several MB. We therefore cap count at
+// DefaultPrefixQueryLimit and rely on the byte-budget guard
+// (maxPrefixResponseBytes in graph-ingest) as the hard ceiling. Callers
+// requesting more than this value are silently clamped.
+const MaxPrefixQueryLimit = DefaultPrefixQueryLimit
+
+// PrefixQueryRequest is the typed request envelope for graph.query.prefix.
+//
+// Cursor contract (OPAQUE):
+//   - First page: leave Cursor empty.
+//   - Subsequent pages: pass back the NextCursor value VERBATIM from the
+//     previous PrefixQueryResponse. Consumers MUST NOT parse, construct, or
+//     modify cursor values — the encoding may change between server versions.
+//   - Empty NextCursor in the response means the result set is exhausted.
+//
+// Limit semantics:
+//   - <=0 → server applies DefaultPrefixQueryLimit.
+//   - Values above MaxPrefixQueryLimit are clamped to MaxPrefixQueryLimit.
+//   - Even within the limit, the server may return fewer entities when the
+//     accumulated response size would approach the NATS max_payload ceiling.
+//     In that case NextCursor is set so the caller can fetch the remainder.
+//
+// V1 pagination caveat (keyset semantics):
+//   - The server sorts matching keys lexicographically and uses the last
+//     returned key as the page boundary. Entities whose IDs sort before the
+//     cursor position and that are inserted between page fetches will not
+//     appear on later pages — standard keyset behaviour.
+//
+// Backend note (informational, subject to change):
+//   - NATS KV has no ranged scan; the server fetches ALL keys matching the
+//     prefix, sorts them, then slices the requested page. Large namespaces
+//     therefore incur a full key scan on every request.
+type PrefixQueryRequest struct {
+	// Prefix is a dot-delimited entity-ID prefix (e.g. "acme.ops.robotics").
+	// Empty string matches all entities. Do NOT include a trailing dot —
+	// the server appends it automatically when filtering.
+	Prefix string `json:"prefix"`
+
+	// Limit is the maximum number of entities to return on this page.
+	// <=0 means "use server default". Clamped to MaxPrefixQueryLimit.
+	Limit int `json:"limit,omitempty"`
+
+	// Cursor is the opaque page-continuation token from a previous response.
+	// Leave empty to request the first page.
+	Cursor string `json:"cursor,omitempty"`
+}
+
+// PrefixQueryResponse is the typed response envelope for graph.query.prefix.
+//
+// Entities contains the full EntityState values for this page, triples
+// included. SemOps depends on full values being present so that downstream
+// consumers do not need additional N+1 fetches.
+//
+// NextCursor is the opaque token to pass as PrefixQueryRequest.Cursor on the
+// next call. An empty NextCursor means the result set is exhausted. The field
+// is omitted from the JSON output when empty, preserving wire-compatibility
+// with old consumers that expect {"entities":[…]}.
+type PrefixQueryResponse struct {
+	// Entities is the full EntityState slice for this page.
+	Entities []EntityState `json:"entities"`
+
+	// NextCursor is the opaque continuation token; empty = exhausted.
+	// Old consumers that do not know about pagination safely ignore this field.
+	NextCursor string `json:"next_cursor,omitempty"`
+}
+
+// EncodeCursor encodes a raw key as an opaque, URL-safe cursor token.
+func EncodeCursor(key string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(key))
+}
+
+// DecodeCursor decodes a cursor token back to its raw key.
+// Returns empty string and no error for the empty-cursor (first-page) case.
+func DecodeCursor(cursor string) (string, error) {
+	if cursor == "" {
+		return "", nil
+	}
+	b, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/graph/query_prefix_types_test.go
+++ b/graph/query_prefix_types_test.go
@@ -1,0 +1,125 @@
+package graph
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCursorRoundTrip verifies that EncodeCursor/DecodeCursor are inverses
+// for a representative set of entity ID values.
+func TestCursorRoundTrip(t *testing.T) {
+	cases := []string{
+		"acme.ops.logistics.warehouse.robot.robot-001",
+		"c360.platform.robotics.mav1.drone.001",
+		"z",
+		"a.b.c.d.e.f",
+		// Characters that are special in standard Base64 but safe in URL-safe:
+		"org.sys-hyphen.dom_underscore.sub.type.inst",
+	}
+	for _, key := range cases {
+		t.Run(key, func(t *testing.T) {
+			encoded := EncodeCursor(key)
+			decoded, err := DecodeCursor(encoded)
+			require.NoError(t, err)
+			assert.Equal(t, key, decoded, "round-trip must be identity")
+		})
+	}
+}
+
+// TestDecodeCursorEmpty verifies the first-page sentinel: empty cursor decodes
+// to empty string without error.
+func TestDecodeCursorEmpty(t *testing.T) {
+	key, err := DecodeCursor("")
+	require.NoError(t, err)
+	assert.Equal(t, "", key)
+}
+
+// TestDecodeCursorInvalid verifies that a malformed cursor returns an error
+// rather than silently producing garbage.
+func TestDecodeCursorInvalid(t *testing.T) {
+	_, err := DecodeCursor("!!!not-base64!!!")
+	require.Error(t, err, "malformed cursor must return error")
+}
+
+// TestPrefixQueryResponseWireSuperset verifies that the old wire shape
+// {"entities":[]} decodes cleanly into PrefixQueryResponse with an empty
+// Entities slice and no NextCursor — old consumers are unaffected.
+func TestPrefixQueryResponseWireSuperset(t *testing.T) {
+	oldWire := []byte(`{"entities":[]}`)
+	var resp PrefixQueryResponse
+	require.NoError(t, json.Unmarshal(oldWire, &resp))
+	assert.Empty(t, resp.Entities)
+	assert.Empty(t, resp.NextCursor, "old wire shape must leave NextCursor empty")
+}
+
+// TestPrefixQueryResponseOmitsNextCursorWhenEmpty verifies that marshalling a
+// PrefixQueryResponse with an empty NextCursor does NOT include the field —
+// preserving wire-compatibility with consumers that expect {"entities":[…]}.
+func TestPrefixQueryResponseOmitsNextCursorWhenEmpty(t *testing.T) {
+	resp := PrefixQueryResponse{
+		Entities: []EntityState{},
+	}
+	b, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &raw))
+	_, hasNextCursor := raw["next_cursor"]
+	assert.False(t, hasNextCursor, "next_cursor must be absent when empty (omitempty)")
+}
+
+// TestPrefixQueryRequestOldShapeUnmarshal verifies that the old wire shape
+// {"prefix":"foo","limit":10} unmarshals cleanly into PrefixQueryRequest.
+func TestPrefixQueryRequestOldShapeUnmarshal(t *testing.T) {
+	oldWire := []byte(`{"prefix":"foo","limit":10}`)
+	var req PrefixQueryRequest
+	require.NoError(t, json.Unmarshal(oldWire, &req))
+	assert.Equal(t, "foo", req.Prefix)
+	assert.Equal(t, 10, req.Limit)
+	assert.Empty(t, req.Cursor, "old wire shape must leave Cursor empty")
+}
+
+// TestPrefixQueryRequestMarshalOmitsCursorWhenEmpty verifies that a
+// PrefixQueryRequest with no Cursor omits the "cursor" key from JSON
+// output — keeping the wire shape identical to old consumers' expectations.
+func TestPrefixQueryRequestMarshalOmitsCursorWhenEmpty(t *testing.T) {
+	req := PrefixQueryRequest{Prefix: "acme", Limit: 5}
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &raw))
+	_, hasCursor := raw["cursor"]
+	assert.False(t, hasCursor, "cursor must be absent when empty (omitempty)")
+}
+
+// TestPrefixQueryResponseWithNextCursor verifies the happy-path pagination shape:
+// a populated NextCursor survives a JSON round-trip.
+func TestPrefixQueryResponseWithNextCursor(t *testing.T) {
+	entityID := "acme.ops.logistics.warehouse.robot.robot-001"
+	cursor := EncodeCursor(entityID)
+	resp := PrefixQueryResponse{
+		Entities:   []EntityState{{ID: entityID}},
+		NextCursor: cursor,
+	}
+	b, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var decoded PrefixQueryResponse
+	require.NoError(t, json.Unmarshal(b, &decoded))
+	assert.Equal(t, cursor, decoded.NextCursor)
+	require.Len(t, decoded.Entities, 1)
+	assert.Equal(t, entityID, decoded.Entities[0].ID)
+}
+
+// TestPrefixQueryLimitConstants verifies the published constant values so
+// downstream consumers that hard-code comparisons against them detect
+// accidental changes.
+func TestPrefixQueryLimitConstants(t *testing.T) {
+	assert.Equal(t, 1000, DefaultPrefixQueryLimit)
+	assert.Equal(t, DefaultPrefixQueryLimit, MaxPrefixQueryLimit,
+		"MaxPrefixQueryLimit must equal DefaultPrefixQueryLimit until byte-budget refinement")
+}

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -367,6 +367,14 @@ type Component struct {
 	claimReader           ownershipClaimReader
 	foreignEdgeWarnedKeys sync.Map
 
+	// maxPrefixResponseBytesOverride, when > 0, replaces the package-level
+	// maxPrefixResponseBytes byte budget in handleQueryPrefixNATS. It exists
+	// solely so unit tests can exercise the byte-trim cursor path without
+	// constructing 800KB of fixtures. Production never sets it (stays 0 →
+	// the const default applies). Set once before the handler runs in tests;
+	// the handler only reads it, so no synchronisation is required.
+	maxPrefixResponseBytesOverride int
+
 	// Inference components
 	hierarchyInference *inference.HierarchyInference
 

--- a/processor/graph-ingest/query.go
+++ b/processor/graph-ingest/query.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -125,59 +126,182 @@ func (c *Component) handleQueryBatchNATS(ctx context.Context, data []byte) ([]by
 	})
 }
 
-// handleQueryPrefixNATS handles prefix-based entity listing for hierarchy queries
+// maxPrefixResponseBytes is the soft ceiling for the marshalled response body.
+// Conservative count cap (MaxPrefixQueryLimit = 1000) is the primary guard;
+// this byte budget is a secondary safety net for pathologically large entities.
+// NATS has a hard max_payload of ~1 MB; we stop well below it so that the
+// JSON envelope overhead and any per-entity growth cannot push us over.
+//
+// NOTE: The current implementation uses the conservative count cap approach
+// (MaxPrefixQueryLimit) as the primary page-size guard. Incremental byte
+// budgeting within a page is deferred — see gh follow-up for byte-budget
+// refinement when entity sizes grow beyond a few KB each.
+const maxPrefixResponseBytes = 800 * 1024
+
+// handleQueryPrefixNATS handles prefix-based entity listing for hierarchy queries.
+//
+// Wire contract (additive, non-breaking):
+//   - Accepts both old {"prefix":"…","limit":N} and new PrefixQueryRequest
+//     (which adds "cursor") — both unmarshal cleanly into PrefixQueryRequest.
+//   - Returns graph.PrefixQueryResponse {"entities":[…],"next_cursor":"…"}.
+//     Old consumers reading only "entities" are unaffected; "next_cursor" is
+//     omitempty so it doesn't appear on the final page or single-page results.
+//   - Keys are sorted lexicographically before cursor application. This is a
+//     behaviour change from pre-pagination (where order was KV-scan order,
+//     i.e. non-deterministic) but is required for cursor correctness and is
+//     safe because callers have always treated the result as a set.
 func (c *Component) handleQueryPrefixNATS(ctx context.Context, data []byte) ([]byte, error) {
 	// Create context with timeout for KV operation
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	// Parse request
-	var req struct {
-		Prefix string `json:"prefix"`
-		Limit  int    `json:"limit"`
-	}
+	// Parse request — PrefixQueryRequest is a superset of the old anonymous
+	// struct so old {"prefix","limit"} payloads unmarshal cleanly.
+	var req graph.PrefixQueryRequest
 	if err := json.Unmarshal(data, &req); err != nil {
 		return nil, errs.Classified(errs.ErrorInvalid, fmt.Errorf("invalid request: %w", err))
 	}
 
-	// Build prefix for server-side filtering
+	// Clamp limit.
+	limit := req.Limit
+	if limit <= 0 {
+		limit = graph.DefaultPrefixQueryLimit
+	}
+	if limit > graph.MaxPrefixQueryLimit {
+		limit = graph.MaxPrefixQueryLimit
+	}
+
+	// Build prefix for server-side filtering.
 	prefixDot := req.Prefix
 	if req.Prefix != "" {
 		prefixDot = req.Prefix + "."
 	}
 
-	// Use server-side prefix filtering instead of loading all keys
+	// Use server-side prefix filtering instead of loading all keys.
 	keys, err := c.entityBucket.KeysByPrefix(ctx, prefixDot)
 	if err != nil {
 		return nil, errs.Classified(errs.ErrorTransient, fmt.Errorf("failed to get keys: %w", err))
 	}
 
 	// Also check exact match for full entity ID queries (6-part IDs
-	// where KeysByPrefix("org.plat.dom.sys.type.inst.") finds nothing)
+	// where KeysByPrefix("org.plat.dom.sys.type.inst.") finds nothing).
 	if req.Prefix != "" && len(keys) == 0 {
 		if _, getErr := c.entityBucket.Get(ctx, req.Prefix); getErr == nil {
 			keys = []string{req.Prefix}
 		}
 	}
 
-	limit := req.Limit
-	if limit <= 0 {
-		limit = 1000 // Default limit
+	// MANDATORY: sort before cursor application — cursor is meaningless
+	// without a deterministic key order.
+	sort.Strings(keys)
+
+	// Apply cursor: advance past keys up to and including lastKey.
+	if req.Cursor != "" {
+		lastKey, decodeErr := graph.DecodeCursor(req.Cursor)
+		if decodeErr != nil {
+			return nil, errs.Classified(errs.ErrorInvalid, fmt.Errorf("invalid cursor: %w", decodeErr))
+		}
+		// SearchStrings finds first index where keys[i] >= lastKey.
+		idx := sort.SearchStrings(keys, lastKey)
+		// Advance past any key equal to lastKey (inclusive skip).
+		for idx < len(keys) && keys[idx] == lastKey {
+			idx++
+		}
+		keys = keys[idx:]
 	}
 
-	// Apply limit
-	matched := keys
-	if len(matched) > limit {
-		matched = matched[:limit]
+	// Slice the page — we'll potentially trim further by byte budget below.
+	pageKeys := keys
+	if len(pageKeys) > limit {
+		pageKeys = pageKeys[:limit]
 	}
 
-	// Fetch full entities with bounded concurrency and cache
-	entities := c.fetchEntitiesConcurrent(ctx, matched, defaultMaxConcurrent)
+	// Fetch full entities with bounded concurrency and cache.
+	entities := c.fetchEntitiesConcurrent(ctx, pageKeys, defaultMaxConcurrent)
 
-	// Return entities wrapped in envelope for consistency with batch query
-	return json.Marshal(map[string]any{
-		"entities": entities,
-	})
+	// fetchEntitiesConcurrent returns cache-hits-then-misses order, NOT sorted.
+	// Re-sort by ID so the page is a deterministic sorted prefix of pageKeys and
+	// the byte-trim cursor below (derived from the last RETURNED entity) is the
+	// true lexicographic max. Without this, a byte-trimmed page would set a
+	// cursor on an arbitrary key and skip entities on the next page.
+	sort.Slice(entities, func(i, j int) bool { return entities[i].ID < entities[j].ID })
+
+	// Byte-budget guard: if the marshalled response would exceed
+	// maxPrefixResponseBytes, trim the entity slice until it fits and set
+	// a cursor so the caller can fetch the remainder.
+	//
+	// This is a secondary safety net; the primary guard is the count cap
+	// above. applyPrefixByteLimit marshals each entity once to sum sizes
+	// (O(N) in the page's entities) — acceptable since the page is already
+	// count-capped at MaxPrefixQueryLimit.
+	byteBudget := maxPrefixResponseBytes
+	if c.maxPrefixResponseBytesOverride > 0 {
+		byteBudget = c.maxPrefixResponseBytesOverride // test-only hook; 0 in production
+	}
+	trimmedEntities, byteLimited := applyPrefixByteLimit(entities, byteBudget)
+
+	// Determine next cursor. A cursor is needed when:
+	//   (a) there are remaining keys beyond this page (len(keys) > len(pageKeys)), OR
+	//   (b) the byte budget trimmed the entity set within the page.
+	var nextCursor string
+	if byteLimited && len(trimmedEntities) > 0 {
+		// Cursor points to the last entity we actually returned.
+		nextCursor = graph.EncodeCursor(trimmedEntities[len(trimmedEntities)-1].ID)
+	} else if len(keys) > len(pageKeys) {
+		// More pages exist beyond this one.
+		if len(pageKeys) > 0 {
+			nextCursor = graph.EncodeCursor(pageKeys[len(pageKeys)-1])
+		}
+	}
+
+	resp := graph.PrefixQueryResponse{
+		Entities:   trimmedEntities,
+		NextCursor: nextCursor,
+	}
+
+	return json.Marshal(resp)
+}
+
+// applyPrefixByteLimit trims an entity slice to fit within byteLimit bytes
+// when marshalled. Returns the (possibly trimmed) slice and a boolean
+// indicating whether trimming occurred.
+//
+// The byte estimate is computed incrementally using json.Marshal on each
+// entity. This is correct but O(N) in entities. At MaxPrefixQueryLimit=1000
+// it runs in well under 1 ms for typical entity sizes.
+func applyPrefixByteLimit(entities []graph.EntityState, byteLimit int) ([]graph.EntityState, bool) {
+	if len(entities) == 0 {
+		return entities, false
+	}
+
+	// Overhead: {"entities":[ ... ],"next_cursor":"..."} — we reserve a
+	// conservative 256 bytes for the envelope so we don't have to track it
+	// precisely.
+	const envelopeOverhead = 256
+	budget := byteLimit - envelopeOverhead
+	accumulated := 0
+
+	for i, e := range entities {
+		b, err := json.Marshal(e)
+		if err != nil {
+			// Marshal failure on an individual entity: skip the rest to be safe.
+			return entities[:i], i > 0
+		}
+		accumulated += len(b) + 1 // +1 for comma separator
+		if accumulated > budget {
+			if i == 0 {
+				// Even the first entity exceeds budget — return it anyway
+				// rather than an empty page. Report byteLimited=true so the
+				// caller sets a cursor on THIS entity's key: the next page
+				// resumes strictly after it (no infinite loop, and no skip of
+				// the rest of the page that a count-boundary cursor would cause).
+				return entities[:1], true
+			}
+			return entities[:i], true
+		}
+	}
+
+	return entities, false
 }
 
 // handleQuerySuffixNATS handles suffix-based entity ID resolution.

--- a/processor/graph-ingest/query_prefix_integration_test.go
+++ b/processor/graph-ingest/query_prefix_integration_test.go
@@ -1,0 +1,197 @@
+//go:build integration
+
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// startPrefixTestComponent boots a graph-ingest component against a real
+// testcontainer NATS instance and returns it. The caller is responsible for
+// stopping it.
+func startPrefixTestComponent(t *testing.T) (*Component, *natsclient.Client) {
+	t.Helper()
+	ctx := context.Background()
+
+	streams := []natsclient.TestStreamConfig{
+		{Name: "ENTITY", Subjects: []string{"entity.>"}},
+	}
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+	nc := testClient.Client
+
+	config := DefaultConfig()
+	deps := component.Dependencies{NATSClient: nc}
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := CreateGraphIngest(configJSON, deps)
+	require.NoError(t, err)
+
+	c := comp.(*Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Stop(5 * time.Second) })
+
+	// Allow subscriptions to stabilise.
+	time.Sleep(100 * time.Millisecond)
+	return c, nc
+}
+
+// seedPrefixEntity writes a minimal entity to the KV bucket via the mutation
+// handler so it shows up in prefix queries.
+func seedPrefixEntity(t *testing.T, ctx context.Context, c *Component, id string) {
+	t.Helper()
+	entity := &graph.EntityState{
+		ID: id,
+		Triples: []message.Triple{
+			{Subject: id, Predicate: "test.attr", Object: "val", Timestamp: time.Now()},
+		},
+		Version:   1,
+		UpdatedAt: time.Now(),
+	}
+	require.NoError(t, c.CreateEntity(ctx, entity))
+}
+
+// TestIntegration_PrefixQuery_PaginationCoverage drives the registered
+// graph.ingest.query.prefix handler end-to-end via NATS request/reply and
+// asserts:
+//   - Multiple pages with a cursor return sorted, disjoint results.
+//   - The union of all pages covers the full seeded set.
+//   - A single no-cursor page has the "entities" key (old-shape compatibility).
+//   - No "next_cursor" key on the final page (wire-compatible omitempty).
+func TestIntegration_PrefixQuery_PaginationCoverage(t *testing.T) {
+	ctx := context.Background()
+	c, nc := startPrefixTestComponent(t)
+
+	// Seed 5 entities with a sortable ID suffix.
+	const count = 5
+	const prefix = "pagtest.ops.dom.sys.type"
+	for i := 1; i <= count; i++ {
+		seedPrefixEntity(t, ctx, c, fmt.Sprintf("%s.entity-%03d", prefix, i))
+	}
+
+	// Collect pages with limit=2 until exhausted.
+	var allEntities []graph.EntityState
+	var cursor string
+	var pageCount int
+	var lastPageHasCursor bool
+
+	for {
+		req := graph.PrefixQueryRequest{
+			Prefix: "pagtest",
+			Limit:  2,
+			Cursor: cursor,
+		}
+		reqData, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		respData, err := nc.RequestClassified(ctx, "graph.ingest.query.prefix", reqData, 5*time.Second)
+		require.NoError(t, err, "transport must succeed")
+
+		var resp graph.PrefixQueryResponse
+		require.NoError(t, json.Unmarshal(respData, &resp))
+		require.NotEmpty(t, resp.Entities, "each page must return at least one entity")
+
+		allEntities = append(allEntities, resp.Entities...)
+		pageCount++
+		cursor = resp.NextCursor
+		lastPageHasCursor = cursor != ""
+
+		if cursor == "" {
+			break
+		}
+		if pageCount > count {
+			t.Fatal("pagination loop did not terminate after expected pages")
+		}
+	}
+
+	assert.False(t, lastPageHasCursor, "last page must have empty next_cursor")
+	assert.Equal(t, count, len(allEntities), "union of pages must cover all seeded entities")
+
+	// Verify sorted order across all pages.
+	for i := 1; i < len(allEntities); i++ {
+		assert.LessOrEqual(t, allEntities[i-1].ID, allEntities[i].ID,
+			"entities must be in lexicographic order across pages")
+	}
+
+	// Verify disjointness.
+	seen := map[string]bool{}
+	for _, e := range allEntities {
+		assert.False(t, seen[e.ID], "duplicate entity across pages: %s", e.ID)
+		seen[e.ID] = true
+	}
+}
+
+// TestIntegration_PrefixQuery_ErrorClassification verifies that an invalid
+// cursor produces a classified error via RequestClassified, not a silent empty
+// response. This closes the "errors travel as body payloads" failure class for
+// the prefix handler.
+func TestIntegration_PrefixQuery_ErrorClassification(t *testing.T) {
+	ctx := context.Background()
+	_, nc := startPrefixTestComponent(t)
+
+	req := graph.PrefixQueryRequest{
+		Prefix: "acme",
+		Limit:  10,
+		Cursor: "!!!this-is-not-valid-base64!!!",
+	}
+	reqData, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	_, classifiedErr := nc.RequestClassified(ctx, "graph.ingest.query.prefix", reqData, 5*time.Second)
+	require.Error(t, classifiedErr, "invalid cursor must produce a classified error")
+	assert.True(t, errs.IsInvalid(classifiedErr),
+		"invalid cursor must be classified as invalid, not transient; got: %v", classifiedErr)
+}
+
+// TestIntegration_PrefixQuery_SinglePageWireCompat verifies that a single-page
+// response (no pagination needed) has the "entities" key and no "next_cursor"
+// key — preserving backward-compatibility for old consumers that expect only
+// {"entities":[…]}.
+func TestIntegration_PrefixQuery_SinglePageWireCompat(t *testing.T) {
+	ctx := context.Background()
+	c, nc := startPrefixTestComponent(t)
+
+	const id = "wirecompat.ops.dom.sys.type.entity-001"
+	seedPrefixEntity(t, ctx, c, id)
+
+	// Old-style request (no cursor key, no typed struct) — raw map as old consumers send.
+	oldReq := map[string]any{"prefix": "wirecompat", "limit": 100}
+	reqData, err := json.Marshal(oldReq)
+	require.NoError(t, err)
+
+	respData, err := nc.RequestClassified(ctx, "graph.ingest.query.prefix", reqData, 5*time.Second)
+	require.NoError(t, err)
+
+	// 1. Must decode into old-shape: {"entities":[…]}.
+	var oldShapeResp struct {
+		Entities []map[string]any `json:"entities"`
+	}
+	require.NoError(t, json.Unmarshal(respData, &oldShapeResp), "must parse as old-shape envelope")
+	require.Len(t, oldShapeResp.Entities, 1, "must return the seeded entity")
+
+	// 2. Must NOT include "next_cursor" on the last/only page.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(respData, &raw))
+	_, hasCursor := raw["next_cursor"]
+	assert.False(t, hasCursor, "next_cursor must be absent on a single-page response (old consumers)")
+
+	// 3. Must decode into typed PrefixQueryResponse.
+	var typedResp graph.PrefixQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &typedResp))
+	require.Len(t, typedResp.Entities, 1)
+	assert.Equal(t, id, typedResp.Entities[0].ID)
+}

--- a/processor/graph-ingest/query_prefix_regression_test.go
+++ b/processor/graph-ingest/query_prefix_regression_test.go
@@ -1,0 +1,276 @@
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/pkg/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createTestComponentWithCache is like createTestComponentWithMockKV but also
+// installs a real in-memory entityCache so a test can pre-warm cache HITS and
+// thereby drive fetchEntitiesConcurrent's "cached-first, misses-second" return
+// ordering — the exact condition under which the byte-trim cursor would be
+// derived from an UNSORTED slice. createTestComponentWithMockKV leaves
+// entityCache nil, which masks the sort bug (all-misses come back already in
+// sorted pageKeys order). That nil-cache blind spot is precisely why the
+// pre-existing TestHandleQueryPrefix_SortDeterminism did not fail without the
+// sort fix.
+func createTestComponentWithCache(t *testing.T) *Component {
+	t.Helper()
+	comp := createTestComponentWithMockKV(t)
+	c, err := cache.NewSimple[graph.EntityState]()
+	require.NoError(t, err)
+	comp.entityCache = c
+	t.Cleanup(func() { _ = c.Close() })
+	return comp
+}
+
+// prewarmCacheEntity writes id to KV (so KeysByPrefix sees the key) AND seeds
+// the entityCache with the SAME entity the KV write produced, so the entity is
+// returned as a cache HIT — and therefore FIRST — by fetchEntitiesConcurrent.
+// It reads the stored entity back out of KV rather than reconstructing it so
+// the cached value is byte-identical to the fetched one (CreateEntity stamps an
+// indexing-profile triple per ADR-054).
+func prewarmCacheEntity(t *testing.T, comp *Component, id string) {
+	t.Helper()
+	storePrefixEntity(t, comp, id)
+	entry, err := comp.entityBucket.Get(context.Background(), id)
+	require.NoError(t, err)
+	var entity graph.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value, &entity))
+	_, err = comp.entityCache.Set(id, entity)
+	require.NoError(t, err)
+}
+
+func idsSorted(entities []graph.EntityState) bool {
+	return sort.SliceIsSorted(entities, func(i, j int) bool {
+		return entities[i].ID < entities[j].ID
+	})
+}
+
+func idIDs(entities []graph.EntityState) []string {
+	out := make([]string, len(entities))
+	for i, e := range entities {
+		out[i] = e.ID
+	}
+	return out
+}
+
+func entityMarshalLen(t *testing.T, comp *Component, id string) int {
+	t.Helper()
+	storePrefixEntity(t, comp, id)
+	entry, err := comp.entityBucket.Get(context.Background(), id)
+	require.NoError(t, err)
+	return len(entry.Value)
+}
+
+// TestRegression_ByteTrimCursor_ScrambledFetchOrder is the handler-level
+// regression for the fetch-order sort fix (orchestrator fix #1 — the
+// sort.Slice(entities, byID) added right after fetchEntitiesConcurrent).
+//
+// Setup: 5 entities k01..k05. The two LATE-sorting IDs (k04,k05) are pre-warmed
+// into the cache, so fetchEntitiesConcurrent returns them FIRST
+// ([k04,k05,k01,k02,k03]). A small byte budget then trims the page to 2.
+//
+//   - WITHOUT sort.Slice(entities): the trimmed page is [k04,k05] and the
+//     cursor is set on k05 — the lexicographic MAX of the whole prefix. Page 2
+//     resumes after k05 -> empty. k01,k02,k03 are SILENTLY SKIPPED.
+//   - WITH the fix: entities are re-sorted to [k01..k05], the trimmed page is
+//     [k01,k02], cursor on k02, page 2 resumes at k03 -> full, sorted, disjoint
+//     coverage.
+//
+// Verified to FAIL when the sort.Slice line is reverted (see review notes):
+// without it the union is {k01,k02,k04,k05} (k03 skipped) and the page-0 cursor
+// decodes to k05, not k02.
+func TestRegression_ByteTrimCursor_ScrambledFetchOrder(t *testing.T) {
+	comp := createTestComponentWithCache(t)
+
+	const n = 5
+	ids := make([]string, 0, n)
+	for i := 1; i <= n; i++ {
+		ids = append(ids, fmt.Sprintf("acme.ops.dom.sys.type.k%02d", i))
+	}
+	// k01,k02,k03 -> KV-only (cache MISS). k04,k05 -> cache HIT (returned first
+	// by fetchEntitiesConcurrent, scrambling order before the sort fix).
+	for _, id := range ids[:3] {
+		storePrefixEntity(t, comp, id)
+	}
+	for _, id := range ids[3:] {
+		prewarmCacheEntity(t, comp, id)
+	}
+
+	// Budget that fits ~2 entities, then trims (each entity marshals to ~515B;
+	// see TestRegression_FixtureMarshalSizes for the arithmetic guard).
+	comp.maxPrefixResponseBytesOverride = 1500
+
+	var collected []graph.EntityState
+	seen := map[string]bool{}
+	cursor := ""
+	sawTrim := false
+	for page := 0; page < n+2; page++ {
+		resp := callPrefixHandler(t, comp, graph.PrefixQueryRequest{
+			Prefix: "acme",
+			Limit:  n, // count cap is NOT the binding constraint; byte budget is
+			Cursor: cursor,
+		})
+
+		// INVARIANT 1: every page is sorted by ID.
+		assert.True(t, idsSorted(resp.Entities),
+			"page %d must be sorted by ID; got %v", page, idIDs(resp.Entities))
+
+		// INVARIANT 2: when a cursor is set, it is the sorted MAX of the page
+		// (the last returned entity). This is the exact property the sort fix
+		// guarantees and the bug violated by setting it on an arbitrary key.
+		if resp.NextCursor != "" {
+			decoded, err := graph.DecodeCursor(resp.NextCursor)
+			require.NoError(t, err)
+			require.NotEmpty(t, resp.Entities, "a cursor with an empty page would loop")
+			maxID := resp.Entities[len(resp.Entities)-1].ID
+			assert.Equal(t, maxID, decoded,
+				"page %d cursor must be the sorted MAX of the returned page", page)
+		}
+
+		if len(resp.Entities) > 0 && len(resp.Entities) < n {
+			sawTrim = true
+		}
+		for _, e := range resp.Entities {
+			assert.False(t, seen[e.ID], "duplicate entity across pages: %s", e.ID)
+			seen[e.ID] = true
+		}
+		collected = append(collected, resp.Entities...)
+		cursor = resp.NextCursor
+		if cursor == "" {
+			break
+		}
+	}
+
+	// The byte budget must actually have trimmed at least one page, else the
+	// test isn't exercising the byte-trim cursor path it claims to.
+	require.True(t, sawTrim, "byte budget must have produced at least one trimmed page")
+
+	// INVARIANT 3: complete coverage, no skips, globally sorted.
+	require.Len(t, seen, n, "all %d entities must appear across pages (no skip); got %v", n, idIDs(collected))
+	for _, id := range ids {
+		assert.True(t, seen[id], "entity %s was skipped", id)
+	}
+	assert.True(t, idsSorted(collected), "global page sequence must be sorted; got %v", idIDs(collected))
+}
+
+// TestRegression_FirstEntityOversized_NoSkip is the handler-level regression
+// for the first-entity-oversized fix (orchestrator fix #2 — applyPrefixByteLimit
+// returning (entities[:1], true) instead of (entities[:1], false) when the
+// first entity alone exceeds the budget).
+//
+// Setup: 3 entities. The byte budget is set SO small that even the first entity
+// alone exceeds it.
+//
+//   - WITHOUT the fix ((entities[:1], false)): byteLimited=false, so the
+//     handler falls to the COUNT branch. With limit>=3 the count branch sets NO
+//     cursor (len(keys)==len(pageKeys)), so the response is [e1] with an EMPTY
+//     cursor -> e2,e3 SILENTLY SKIPPED and pagination terminates after page 0.
+//   - WITH the fix ((entities[:1], true)): byteLimited=true, cursor set on e1.
+//     Page 1 resumes strictly after e1 -> [e2] -> page 2 -> [e3] -> a final
+//     empty trailing page (cursor was set on e3). Full coverage, exactly one
+//     entity per non-trailing page, monotonic advance (no infinite loop).
+//
+// Verified to FAIL when the (entities[:1], true) line is reverted to
+// (entities[:1], false): coverage drops to {aaa} (bbb,ccc skipped) and the loop
+// terminates after a single page.
+func TestRegression_FirstEntityOversized_NoSkip(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+
+	ids := []string{
+		"acme.ops.dom.sys.type.aaa",
+		"acme.ops.dom.sys.type.bbb",
+		"acme.ops.dom.sys.type.ccc",
+	}
+	for _, id := range ids {
+		storePrefixEntity(t, comp, id)
+	}
+
+	// Budget below even a single ~515B entity (300 - 256 envelope = 44 byte
+	// content budget) -> first-entity-oversized fires on every page.
+	comp.maxPrefixResponseBytesOverride = 300
+
+	var collected []graph.EntityState
+	seen := map[string]bool{}
+	cursor := ""
+	const maxPages = 16 // generous bound; an infinite loop trips this
+	pages := 0
+	var lastReturned string
+	for ; pages < maxPages; pages++ {
+		resp := callPrefixHandler(t, comp, graph.PrefixQueryRequest{
+			Prefix: "acme",
+			Limit:  len(ids), // count is NOT the binding constraint
+			Cursor: cursor,
+		})
+
+		// Non-trailing pages return exactly one entity (first-oversized). The
+		// final page may be empty (the cursor was set on the last entity), which
+		// is correct termination — assert <=1, and that any returned entity is
+		// new (no infinite loop) and strictly advances.
+		require.LessOrEqual(t, len(resp.Entities), 1,
+			"first-entity-oversized must return at most one entity per page")
+
+		for _, e := range resp.Entities {
+			assert.False(t, seen[e.ID], "entity repeated across pages (infinite loop): %s", e.ID)
+			assert.Greater(t, e.ID, lastReturned, "entities must strictly advance")
+			lastReturned = e.ID
+			seen[e.ID] = true
+			collected = append(collected, e)
+
+			// The cursor must point at the entity just returned so the next
+			// page resumes strictly after it.
+			require.NotEmpty(t, resp.NextCursor, "a returned-but-oversized entity must carry a resume cursor")
+			decoded, err := graph.DecodeCursor(resp.NextCursor)
+			require.NoError(t, err)
+			assert.Equal(t, e.ID, decoded, "cursor must be the just-returned entity's ID")
+		}
+
+		cursor = resp.NextCursor
+		if cursor == "" {
+			break
+		}
+	}
+
+	require.Less(t, pages, maxPages, "pagination must terminate (no infinite loop)")
+	require.Len(t, seen, len(ids), "every entity must be returned (no skip); got %v", idIDs(collected))
+	for _, id := range ids {
+		assert.True(t, seen[id], "entity %s was skipped", id)
+	}
+	assert.True(t, idsSorted(collected), "single-entity pages must arrive sorted; got %v", idIDs(collected))
+}
+
+// TestRegression_FixtureMarshalSizes documents the byte arithmetic the two
+// regression tests rely on. A future change to EntityState's JSON shape (or to
+// CreateEntity's stamped triples) that invalidates the budgets fails HERE with
+// a clear message rather than as a confusing coverage regression elsewhere.
+func TestRegression_FixtureMarshalSizes(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	size := entityMarshalLen(t, comp, "acme.ops.dom.sys.type.k01")
+
+	// Scrambled-order test: budget 1500, envelope overhead 256 -> 1244 content
+	// budget. Two entities must fit, three must not, so the trim fires at 2.
+	const envelopeOverhead = 256
+	scrambledBudget := 1500 - envelopeOverhead
+	assert.Greater(t, scrambledBudget, 2*size,
+		"two entities must fit the scrambled-order content budget (trim at page boundary)")
+	assert.Less(t, scrambledBudget, 3*size,
+		"three entities must exceed the scrambled-order content budget so a trim occurs")
+
+	// First-entity-oversized test: budget 300 -> 44 content budget, below one
+	// entity, so the first entity alone trips the over-budget branch.
+	firstOversizedBudget := 300 - envelopeOverhead
+	assert.Less(t, firstOversizedBudget, size,
+		"a single entity must exceed the first-entity-oversized content budget")
+
+	_ = time.Now
+}

--- a/processor/graph-ingest/query_prefix_unit_test.go
+++ b/processor/graph-ingest/query_prefix_unit_test.go
@@ -1,0 +1,240 @@
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// storePrefixEntity is a helper that stores an entity with a single triple.
+func storePrefixEntity(t *testing.T, comp *Component, id string) {
+	t.Helper()
+	ctx := context.Background()
+	entity := &graph.EntityState{
+		ID: id,
+		Triples: []message.Triple{
+			{
+				Subject:   id,
+				Predicate: "test.attr",
+				Object:    "val",
+				Timestamp: time.Now(),
+			},
+		},
+		Version:   1,
+		UpdatedAt: time.Now(),
+	}
+	require.NoError(t, comp.CreateEntity(ctx, entity))
+}
+
+// callPrefixHandler is a helper that marshals the request and calls
+// handleQueryPrefixNATS, returning a decoded PrefixQueryResponse.
+func callPrefixHandler(t *testing.T, comp *Component, req graph.PrefixQueryRequest) graph.PrefixQueryResponse {
+	t.Helper()
+	reqData, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	respData, err := comp.handleQueryPrefixNATS(context.Background(), reqData)
+	require.NoError(t, err)
+
+	var resp graph.PrefixQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	return resp
+}
+
+// TestHandleQueryPrefix_SortDeterminism verifies that the same set of keys is
+// always returned in sorted lexicographic order regardless of insertion order.
+func TestHandleQueryPrefix_SortDeterminism(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+
+	// Store entities in reverse lexicographic order to confirm sorting happens.
+	ids := []string{
+		"acme.ops.robotics.gcs.drone.zzz",
+		"acme.ops.robotics.gcs.drone.aaa",
+		"acme.ops.robotics.gcs.drone.mmm",
+	}
+	for _, id := range ids {
+		storePrefixEntity(t, comp, id)
+	}
+
+	resp := callPrefixHandler(t, comp, graph.PrefixQueryRequest{Prefix: "acme"})
+	require.Len(t, resp.Entities, 3)
+
+	// Verify lexicographic order.
+	assert.Equal(t, "acme.ops.robotics.gcs.drone.aaa", resp.Entities[0].ID)
+	assert.Equal(t, "acme.ops.robotics.gcs.drone.mmm", resp.Entities[1].ID)
+	assert.Equal(t, "acme.ops.robotics.gcs.drone.zzz", resp.Entities[2].ID)
+}
+
+// TestHandleQueryPrefix_CursorPagination verifies that paginating with a cursor
+// returns sorted, disjoint pages that together cover the full result set.
+func TestHandleQueryPrefix_CursorPagination(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+
+	// Store 5 entities.
+	for i := 1; i <= 5; i++ {
+		storePrefixEntity(t, comp, fmt.Sprintf("org.ops.dom.sys.type.entity-%03d", i))
+	}
+
+	// Page 1: limit=2.
+	page1 := callPrefixHandler(t, comp, graph.PrefixQueryRequest{
+		Prefix: "org",
+		Limit:  2,
+	})
+	require.Len(t, page1.Entities, 2)
+	assert.NotEmpty(t, page1.NextCursor, "page1 must carry a cursor because there are more results")
+	assert.Equal(t, "org.ops.dom.sys.type.entity-001", page1.Entities[0].ID)
+	assert.Equal(t, "org.ops.dom.sys.type.entity-002", page1.Entities[1].ID)
+
+	// Page 2: limit=2, cursor from page 1.
+	page2 := callPrefixHandler(t, comp, graph.PrefixQueryRequest{
+		Prefix: "org",
+		Limit:  2,
+		Cursor: page1.NextCursor,
+	})
+	require.Len(t, page2.Entities, 2)
+	assert.NotEmpty(t, page2.NextCursor, "page2 must carry a cursor because there are more results")
+	assert.Equal(t, "org.ops.dom.sys.type.entity-003", page2.Entities[0].ID)
+	assert.Equal(t, "org.ops.dom.sys.type.entity-004", page2.Entities[1].ID)
+
+	// Page 3: cursor from page 2 — should return the last entity with no cursor.
+	page3 := callPrefixHandler(t, comp, graph.PrefixQueryRequest{
+		Prefix: "org",
+		Limit:  2,
+		Cursor: page2.NextCursor,
+	})
+	require.Len(t, page3.Entities, 1)
+	assert.Empty(t, page3.NextCursor, "page3 is the last page: no cursor expected")
+	assert.Equal(t, "org.ops.dom.sys.type.entity-005", page3.Entities[0].ID)
+
+	// Disjointness: collect all IDs across pages and verify no duplicates.
+	seen := map[string]bool{}
+	for _, p := range []graph.PrefixQueryResponse{page1, page2, page3} {
+		for _, e := range p.Entities {
+			assert.False(t, seen[e.ID], "duplicate entity ID across pages: %s", e.ID)
+			seen[e.ID] = true
+		}
+	}
+	assert.Len(t, seen, 5, "all 5 entities must appear across the pages")
+}
+
+// TestHandleQueryPrefix_LimitClampZero verifies that limit<=0 is clamped to
+// DefaultPrefixQueryLimit rather than returning zero or an error.
+func TestHandleQueryPrefix_LimitClampZero(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	storePrefixEntity(t, comp, "acme.ops.dom.sys.type.entity-001")
+	storePrefixEntity(t, comp, "acme.ops.dom.sys.type.entity-002")
+
+	// limit=0 should default to DefaultPrefixQueryLimit (both entities returned).
+	resp := callPrefixHandler(t, comp, graph.PrefixQueryRequest{Prefix: "acme", Limit: 0})
+	assert.Len(t, resp.Entities, 2, "limit=0 must default to DefaultPrefixQueryLimit")
+
+	// limit=-1 should also default.
+	resp2 := callPrefixHandler(t, comp, graph.PrefixQueryRequest{Prefix: "acme", Limit: -1})
+	assert.Len(t, resp2.Entities, 2, "limit=-1 must default to DefaultPrefixQueryLimit")
+}
+
+// TestHandleQueryPrefix_LimitClampAboveMax verifies that limit > MaxPrefixQueryLimit
+// is silently clamped — the handler returns at most MaxPrefixQueryLimit entities.
+func TestHandleQueryPrefix_LimitClampAboveMax(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	// Store 3 entities — well below the cap but enough to verify clamping doesn't error.
+	for i := 1; i <= 3; i++ {
+		storePrefixEntity(t, comp, fmt.Sprintf("org.ops.dom.sys.type.entity-%03d", i))
+	}
+
+	// Request limit of 999999 (above MaxPrefixQueryLimit=1000).
+	resp := callPrefixHandler(t, comp, graph.PrefixQueryRequest{Prefix: "org", Limit: 999999})
+	// All 3 entities must be returned (clamping doesn't truncate the actual result
+	// when total entities < MaxPrefixQueryLimit).
+	assert.Len(t, resp.Entities, 3, "clamped limit must not reduce below actual result count")
+	assert.Empty(t, resp.NextCursor, "no cursor when all entities fit in one page")
+}
+
+// TestHandleQueryPrefix_ByteBudgetSetsNextCursor verifies that when the
+// applyPrefixByteLimit helper trims the entity slice, a NextCursor is set.
+// We drive this by calling the helper directly with a tiny budget.
+func TestHandleQueryPrefix_ByteBudgetSetsNextCursor(t *testing.T) {
+	entities := []graph.EntityState{
+		{ID: "a.b.c.d.e.one"},
+		{ID: "a.b.c.d.e.two"},
+		{ID: "a.b.c.d.e.three"},
+	}
+
+	// Use a budget that fits only the first entity (~50 bytes per marshal +
+	// 256 envelope overhead = we need budget < 2 entity budgets to trigger trim).
+	// Marshal size of first entity is ≈ 80 bytes; set budget to 400 to fit 1.
+	trimmed, limited := applyPrefixByteLimit(entities, 400)
+	assert.True(t, limited, "byte budget must have triggered trimming")
+	assert.Less(t, len(trimmed), len(entities), "trimmed slice must be smaller")
+	require.NotEmpty(t, trimmed, "at least one entity must survive trimming")
+}
+
+// TestHandleQueryPrefix_InvalidCursor verifies that a malformed cursor returns
+// a classified error rather than panicking or silently returning wrong data.
+func TestHandleQueryPrefix_InvalidCursor(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	storePrefixEntity(t, comp, "acme.ops.dom.sys.type.entity-001")
+
+	reqData, err := json.Marshal(graph.PrefixQueryRequest{
+		Prefix: "acme",
+		Limit:  10,
+		Cursor: "!!!invalid-base64!!!",
+	})
+	require.NoError(t, err)
+
+	_, err = comp.handleQueryPrefixNATS(context.Background(), reqData)
+	require.Error(t, err, "invalid cursor must return an error")
+}
+
+// TestHandleQueryPrefix_SinglePageNoNextCursor verifies the wire-compatibility
+// guarantee: when all entities fit in one page, no NextCursor field appears.
+func TestHandleQueryPrefix_SinglePageNoNextCursor(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	storePrefixEntity(t, comp, "acme.ops.dom.sys.type.entity-001")
+	storePrefixEntity(t, comp, "acme.ops.dom.sys.type.entity-002")
+
+	reqData, err := json.Marshal(graph.PrefixQueryRequest{Prefix: "acme", Limit: 100})
+	require.NoError(t, err)
+
+	respData, err := comp.handleQueryPrefixNATS(context.Background(), reqData)
+	require.NoError(t, err)
+
+	// Decode as raw map to check field absence.
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(respData, &raw))
+	_, hasCursor := raw["next_cursor"]
+	assert.False(t, hasCursor, "next_cursor must be absent when all results fit in one page")
+
+	// Also verify entities key is present.
+	_, hasEntities := raw["entities"]
+	assert.True(t, hasEntities, "entities key must always be present")
+}
+
+// TestHandleQueryPrefix_OldRequestShape verifies backward compatibility:
+// old-style {"prefix":"…","limit":N} requests (no "cursor" key) are handled
+// correctly, proving the typed PrefixQueryRequest is a superset.
+func TestHandleQueryPrefix_OldRequestShape(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	storePrefixEntity(t, comp, "c360.platform.robotics.mav1.drone.001")
+
+	// Old-style request as anonymous map (no "cursor" field).
+	oldReq := map[string]any{"prefix": "c360", "limit": 10}
+	reqData, err := json.Marshal(oldReq)
+	require.NoError(t, err)
+
+	respData, err := comp.handleQueryPrefixNATS(context.Background(), reqData)
+	require.NoError(t, err)
+
+	// Must decode into PrefixQueryResponse successfully.
+	var resp graph.PrefixQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	require.Len(t, resp.Entities, 1)
+	assert.Equal(t, "c360.platform.robotics.mav1.drone.001", resp.Entities[0].ID)
+}

--- a/processor/graph-query/query.go
+++ b/processor/graph-query/query.go
@@ -356,8 +356,11 @@ func (c *Component) handleQueryHierarchyStats(ctx context.Context, data []byte) 
 		return nil, errs.WrapInvalid(err, "GraphQuery", "handleQueryHierarchyStats", "parse request")
 	}
 
-	// Get all entity IDs with prefix from graph-ingest
-	prefixReq, err := json.Marshal(map[string]any{"prefix": req.Prefix, "limit": 10000})
+	// Get all entity IDs with prefix from graph-ingest.
+	// Use typed PrefixQueryRequest to participate in the pagination contract;
+	// 10000 is intentionally above MaxPrefixQueryLimit so the server clamps
+	// it — hierarchy stats is a best-effort scan and accepts the clamped page.
+	prefixReq, err := json.Marshal(graph.PrefixQueryRequest{Prefix: req.Prefix, Limit: 10000})
 	if err != nil {
 		return nil, errs.Wrap(err, "GraphQuery", "handleQueryHierarchyStats", "marshal prefix request")
 	}

--- a/processor/graph-query/summary.go
+++ b/processor/graph-query/summary.go
@@ -65,10 +65,11 @@ func (c *Component) handleQueryGraphSummary(ctx context.Context, data []byte) ([
 	// Entity-type aggregation via the prefix-query orchestration the
 	// hierarchyStats handler already uses. Empty prefix scans all
 	// entities up to the limit; downstream is responsible for the
-	// envelope shape.
-	prefixPayload, err := json.Marshal(map[string]any{
-		"prefix": "",
-		"limit":  req.EntitySampleLimit,
+	// envelope shape. Use typed PrefixQueryRequest to participate in
+	// the pagination contract.
+	prefixPayload, err := json.Marshal(graph.PrefixQueryRequest{
+		Prefix: "",
+		Limit:  req.EntitySampleLimit,
 	})
 	if err != nil {
 		return nil, errs.Wrap(err, "GraphQuery", "handleQueryGraphSummary", "marshal prefix request")


### PR DESCRIPTION
## Typed prefix-discovery contract + client helper (closes #302)

Lifts the implicit `graph.query.prefix` contract into shared Go types and a safe client helper, with opaque cursor pagination designed into the contract from the start. **Non-breaking / additive** — existing `{prefix,limit}`→`{entities}` consumers are unaffected (new fields are `omitempty`; a no-cursor response is byte-identical to today).

### What's new
- **`graph.PrefixQueryRequest{Prefix, Limit, Cursor}` + `graph.PrefixQueryResponse{Entities, NextCursor}`** — shared types replacing the inline `map[string]any` / anon-struct shapes. Full `EntityState` values are returned (SemOps relies on no N+1 hydration).
- **Opaque cursor pagination** — `EncodeCursor`/`DecodeCursor` (base64 of the last entity ID). Consumers pass `NextCursor` back verbatim; empty = exhausted. Opaque so the backend can evolve (sort-and-slice now → ranged-scan later) without contract churn.
- **`graph/query.QueryPrefix` client helper** — uses `RequestClassified` (not a hand-rolled `error:` body match), so handler errors surface as a typed error instead of silently decoding as empty (the "legacy error handling" #302 called out).
- **Byte-budget reply bound** — the genuine ceiling vs NATS `~1MB max_payload`. Honest docs: v1 still scans all keys per page (NATS KV has no ranged scan); the count cap is decorative once entities exceed ~800B.

### Honesty notes / follow-ups (non-blocking)
- The public-subject passthrough (`graph-query handleQueryPrefix`) re-responds with plain `Request`, so a *transient* graph-ingest error is coerced to *Invalid* class via the legacy `error:` body. The error is still surfaced (the contract that matters); only the class can be imprecise. Documented on the helper; passthrough class-fidelity is a tracked follow-up.
- `QueryPrefixAll` auto-pager deliberately omitted (would re-introduce unbounded accumulation).

### Review & correctness
Two bugs caught in adversarial review and fixed, both locked by regression tests proven to fail without the fix:
1. `fetchEntitiesConcurrent` returns cache-hits-then-misses order (not sorted) → the byte-trim cursor would skip entities across pages. Fixed by sorting entities by ID before trim/cursor.
2. First-entity-oversized returned `byteLimited=false` → cursor skipped the rest of the page. Fixed to advance past the entity.

Cadence: architect scope → adversarial over-eng review → go-developer → go-reviewer **ACCEPT-WITH-NITS** (doc + comment nits folded).

### Gates
lint (revive 0), `go vet` ×{default,integration,live_llm}, full unit `-race`, integration `-race` (graph-ingest + graph/...), zero schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
