### PR TITLE
feat(graph-query): bounded QueryPrefixAll auto-pager (#305)

### DIFF
--- a/graph/query/interface.go
+++ b/graph/query/interface.go
@@ -53,6 +53,13 @@ type Client interface {
 	// caveat.
 	QueryPrefix(ctx context.Context, req gtypes.PrefixQueryRequest) (gtypes.PrefixQueryResponse, error)
 
+	// QueryPrefixAll pages through graph.query.prefix following the opaque cursor
+	// and returns all matching entities UP TO maxEntities (which MUST be > 0 —
+	// there is no unbounded mode). The bool result is true when the cap was hit
+	// while more results remained. req.Cursor is ignored (paging starts at the
+	// beginning). See the QueryPrefixAll doc comment for details.
+	QueryPrefixAll(ctx context.Context, req gtypes.PrefixQueryRequest, maxEntities int) ([]gtypes.EntityState, bool, error)
+
 	// Cache and metrics
 	GetCacheStats() CacheStats
 	Clear() error

--- a/graph/query/prefix.go
+++ b/graph/query/prefix.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
@@ -29,9 +30,7 @@ const prefixQuerySubject = "graph.query.prefix"
 // directly for full class fidelity. Propagating the class through the
 // passthrough is a tracked follow-up.
 //
-// A future QueryPrefixAll convenience helper (auto-paging accumulator) may be
-// added, but is deliberately omitted here to avoid re-introducing unbounded
-// accumulation at the call site.
+// For a multi-page accumulate, use QueryPrefixAll (bounded by a caller cap).
 func (qc *natsClient) QueryPrefix(ctx context.Context, req graph.PrefixQueryRequest) (graph.PrefixQueryResponse, error) {
 	reqData, err := json.Marshal(req)
 	if err != nil {
@@ -48,4 +47,75 @@ func (qc *natsClient) QueryPrefix(ctx context.Context, req graph.PrefixQueryRequ
 		return graph.PrefixQueryResponse{}, err
 	}
 	return result, nil
+}
+
+// QueryPrefixAll pages through graph.query.prefix following the opaque cursor and
+// returns all matching entities, UP TO maxEntities. It exists so callers don't
+// hand-roll the cursor loop for prefix-scoped snapshot hydration.
+//
+// Bounded by design: maxEntities MUST be > 0. There is no unbounded mode — an
+// unbounded accumulator would re-introduce the reply-size / OOM risk the
+// single-page cursor exists to bound (the caller chooses the bound explicitly).
+//
+// Returns (entities, truncated, err):
+//   - truncated is true when maxEntities was reached while the server still had
+//     more results (i.e. entities exist beyond those returned). false means the
+//     full result set was returned (it was <= maxEntities). (Edge: if a
+//     contract-violating server ever returns an empty page WITH a cursor, the
+//     helper stops defensively and reports truncated=false rather than spin.)
+//
+// req.Cursor is ignored — paging always starts at the beginning of the prefix.
+// Set req.Prefix (and optionally req.Limit as the per-page size); the helper
+// caps each page to the remaining budget so it never over-fetches past the cap.
+//
+// No streaming/never-accumulate variant exists yet (this package returns slices);
+// add one only if a consumer must process pages without holding the working set.
+func (qc *natsClient) QueryPrefixAll(ctx context.Context, req graph.PrefixQueryRequest, maxEntities int) ([]graph.EntityState, bool, error) {
+	return pagePrefixAll(ctx, req, maxEntities, qc.QueryPrefix)
+}
+
+// pagePrefixAll is the cursor-following accumulator behind QueryPrefixAll,
+// factored out so the paging / truncation / per-page-cap logic is unit-testable
+// with a scripted fetch function (no NATS).
+func pagePrefixAll(
+	ctx context.Context,
+	req graph.PrefixQueryRequest,
+	maxEntities int,
+	fetch func(context.Context, graph.PrefixQueryRequest) (graph.PrefixQueryResponse, error),
+) ([]graph.EntityState, bool, error) {
+	if maxEntities <= 0 {
+		return nil, false, fmt.Errorf("QueryPrefixAll: maxEntities must be > 0 (got %d); there is no unbounded mode", maxEntities)
+	}
+
+	req.Cursor = "" // always start from the beginning of the prefix
+	var all []graph.EntityState
+	for {
+		// Cap this page to the remaining budget so a large req.Limit (or the
+		// server default) can't over-fetch past maxEntities.
+		pageReq := req
+		remaining := maxEntities - len(all)
+		if pageReq.Limit <= 0 || pageReq.Limit > remaining {
+			pageReq.Limit = remaining
+		}
+
+		page, err := fetch(ctx, pageReq)
+		if err != nil {
+			return nil, false, err
+		}
+		all = append(all, page.Entities...)
+
+		if len(all) >= maxEntities {
+			// Hit the cap. More exist iff the server still has a cursor.
+			return all, page.NextCursor != "", nil
+		}
+		if page.NextCursor == "" {
+			return all, false, nil // result set exhausted
+		}
+		if len(page.Entities) == 0 {
+			// Defensive: a cursor with no entities should not occur (keyset
+			// exhaustion clears the cursor). Stop rather than spin.
+			return all, false, nil
+		}
+		req.Cursor = page.NextCursor
+	}
 }

--- a/graph/query/prefix_test.go
+++ b/graph/query/prefix_test.go
@@ -1,0 +1,164 @@
+package query
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scriptedPage is one page a fake fetcher hands back.
+type scriptedPage struct {
+	entities []graph.EntityState
+	cursor   string // NextCursor; "" = exhausted
+}
+
+func ents(ids ...string) []graph.EntityState {
+	out := make([]graph.EntityState, len(ids))
+	for i, id := range ids {
+		out[i] = graph.EntityState{ID: id}
+	}
+	return out
+}
+
+func idsOf(es []graph.EntityState) []string {
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.ID
+	}
+	return out
+}
+
+// scriptedFetch returns a fetch func that replays pages in order and records
+// every request it received (so tests can assert cursor threading + per-page cap).
+func scriptedFetch(pages []scriptedPage, got *[]graph.PrefixQueryRequest) func(context.Context, graph.PrefixQueryRequest) (graph.PrefixQueryResponse, error) {
+	i := 0
+	return func(_ context.Context, req graph.PrefixQueryRequest) (graph.PrefixQueryResponse, error) {
+		*got = append(*got, req)
+		if i >= len(pages) {
+			return graph.PrefixQueryResponse{}, nil // no more pages
+		}
+		p := pages[i]
+		i++
+		return graph.PrefixQueryResponse{Entities: p.entities, NextCursor: p.cursor}, nil
+	}
+}
+
+func TestPagePrefixAll_RejectsNonPositiveMax(t *testing.T) {
+	for _, max := range []int{0, -1, -100} {
+		_, _, err := pagePrefixAll(context.Background(), graph.PrefixQueryRequest{Prefix: "p"}, max, nil)
+		require.Error(t, err, "maxEntities=%d must error", max)
+		assert.Contains(t, err.Error(), "no unbounded mode")
+	}
+}
+
+func TestPagePrefixAll_SinglePageExhausted(t *testing.T) {
+	var got []graph.PrefixQueryRequest
+	fetch := scriptedFetch([]scriptedPage{{entities: ents("a", "b"), cursor: ""}}, &got)
+
+	all, truncated, err := pagePrefixAll(context.Background(), graph.PrefixQueryRequest{Prefix: "p"}, 100, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, idsOf(all))
+	assert.False(t, truncated, "exhausted set under the cap is not truncated")
+	assert.Len(t, got, 1, "one page fetched")
+}
+
+func TestPagePrefixAll_MultiPageExhausted(t *testing.T) {
+	var got []graph.PrefixQueryRequest
+	fetch := scriptedFetch([]scriptedPage{
+		{entities: ents("a", "b"), cursor: "c1"},
+		{entities: ents("c", "d"), cursor: "c2"},
+		{entities: ents("e"), cursor: ""},
+	}, &got)
+
+	all, truncated, err := pagePrefixAll(context.Background(), graph.PrefixQueryRequest{Prefix: "p"}, 100, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c", "d", "e"}, idsOf(all))
+	assert.False(t, truncated)
+	// Cursor threading: req 1 empty (start), req 2 = c1, req 3 = c2.
+	require.Len(t, got, 3)
+	assert.Equal(t, "", got[0].Cursor)
+	assert.Equal(t, "c1", got[1].Cursor)
+	assert.Equal(t, "c2", got[2].Cursor)
+}
+
+func TestPagePrefixAll_TruncatedWhenCapHitMidStream(t *testing.T) {
+	var got []graph.PrefixQueryRequest
+	fetch := scriptedFetch([]scriptedPage{
+		{entities: ents("a", "b"), cursor: "c1"},
+		{entities: ents("c"), cursor: "c2"}, // server still has more (c2)
+	}, &got)
+
+	all, truncated, err := pagePrefixAll(context.Background(), graph.PrefixQueryRequest{Prefix: "p"}, 3, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, idsOf(all))
+	assert.True(t, truncated, "cap reached while the server still had a cursor -> truncated")
+}
+
+func TestPagePrefixAll_NotTruncatedWhenCapEqualsExhaustion(t *testing.T) {
+	var got []graph.PrefixQueryRequest
+	fetch := scriptedFetch([]scriptedPage{
+		{entities: ents("a", "b"), cursor: "c1"},
+		{entities: ents("c"), cursor: ""}, // lands exactly at cap AND exhausted
+	}, &got)
+
+	all, truncated, err := pagePrefixAll(context.Background(), graph.PrefixQueryRequest{Prefix: "p"}, 3, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "c"}, idsOf(all))
+	assert.False(t, truncated, "exactly at cap but exhausted -> not truncated")
+}
+
+func TestPagePrefixAll_PerPageBudgetCapsLimit(t *testing.T) {
+	var got []graph.PrefixQueryRequest
+	fetch := scriptedFetch([]scriptedPage{
+		{entities: ents("a", "b"), cursor: "c1"},
+		{entities: ents("c"), cursor: "c2"},
+	}, &got)
+
+	// maxEntities=3, caller asks for big pages; helper must shrink the 2nd
+	// page request to the remaining budget (3-2=1) rather than over-fetch.
+	_, _, err := pagePrefixAll(context.Background(), graph.PrefixQueryRequest{Prefix: "p", Limit: 1000}, 3, fetch)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, 3, got[0].Limit, "first page capped to remaining budget (3)")
+	assert.Equal(t, 1, got[1].Limit, "second page capped to remaining budget (1)")
+}
+
+func TestPagePrefixAll_IgnoresEntryCursor(t *testing.T) {
+	var got []graph.PrefixQueryRequest
+	fetch := scriptedFetch([]scriptedPage{{entities: ents("a"), cursor: ""}}, &got)
+
+	_, _, err := pagePrefixAll(context.Background(), graph.PrefixQueryRequest{Prefix: "p", Cursor: "caller-supplied"}, 10, fetch)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "", got[0].Cursor, "QueryPrefixAll starts from the beginning; entry Cursor is ignored")
+}
+
+func TestPagePrefixAll_PropagatesFetchError(t *testing.T) {
+	sentinel := errors.New("boom")
+	fetch := func(_ context.Context, _ graph.PrefixQueryRequest) (graph.PrefixQueryResponse, error) {
+		return graph.PrefixQueryResponse{}, sentinel
+	}
+	all, truncated, err := pagePrefixAll(context.Background(), graph.PrefixQueryRequest{Prefix: "p"}, 10, fetch)
+	require.ErrorIs(t, err, sentinel)
+	assert.Nil(t, all)
+	assert.False(t, truncated)
+}
+
+func TestPagePrefixAll_DefensiveEmptyPageWithCursor(t *testing.T) {
+	var got []graph.PrefixQueryRequest
+	// Anomalous: a page with a cursor but no entities. Must stop, not spin.
+	fetch := scriptedFetch([]scriptedPage{
+		{entities: ents("a"), cursor: "c1"},
+		{entities: nil, cursor: "c2"}, // empty page WITH cursor -> defensive stop
+	}, &got)
+
+	all, truncated, err := pagePrefixAll(context.Background(), graph.PrefixQueryRequest{Prefix: "p"}, 100, fetch)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a"}, idsOf(all))
+	assert.False(t, truncated)
+	assert.Len(t, got, 2, "stopped after the empty page rather than spinning")
+}


### PR DESCRIPTION
## Bounded `QueryPrefixAll` auto-pager (closes #305)

Adds `graph/query.QueryPrefixAll(ctx, req, maxEntities) ([]EntityState, bool, error)` — pages through `graph.query.prefix` following the opaque cursor so callers don't hand-roll the loop for prefix-scoped snapshot hydration. **Non-breaking / additive** (new method on the `query.Client` interface; sole implementer `*natsClient`, no mocks).

### Bounded by design
- `maxEntities` **MUST be > 0** — there is no unbounded mode (an unbounded accumulator would re-introduce the reply-size/OOM risk the single-page cursor exists to bound; the caller picks the bound).
- Returns `(entities, truncated, err)`: `truncated=true` only when the cap was reached while the server still had more.
- Each page's `Limit` is capped to the remaining budget, so a large `req.Limit` / server default can't over-fetch past the cap.
- Slice-return matches the `graph/query` package idiom (no streaming/iterator precedent; noted as a future option only, not built).

### Testability
The cursor loop is factored into an unexported `pagePrefixAll(...fetch)`, so the paging / truncation / per-page-cap logic is unit-tested with scripted fetchers (no NATS) at **100% statement coverage** — including the truncated true/false boundaries, cursor threading, the per-page cap shrink, the `maxEntities<=0` error, fetch-error propagation, and the defensive empty-page stop.

go-reviewer **ACCEPT** — no Critical/High; infinite-loop and silent-over-cap proven impossible against the server contract; one doc nit folded.

### Gates
lint (revive 0), `go vet` ×{default,integration}, full unit `-race`, zero schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
