### PR TITLE
feat(component): HTTPClientPort declarative descriptor (#310)

### DIFF
--- a/component/flowgraph/doc.go
+++ b/component/flowgraph/doc.go
@@ -4,7 +4,7 @@
 //
 // The flowgraph package builds a directed graph representation of component port
 // connections, enabling static analysis to detect configuration issues before runtime.
-// It supports four interaction patterns (stream, request, watch, network) and provides:
+// It supports five interaction patterns (stream, request, watch, network, http-client) and provides:
 //
 //   - Pattern-based connection matching (NATS wildcard subject matching)
 //   - Connected component analysis (DFS-based clustering)
@@ -24,6 +24,7 @@
 //	│  - OutputPorts            - To (portref)       - request (req/reply)    │
 //	│  - Component ref          - Pattern            - watch (KV)             │
 //	│                           - ConnectionID       - network (external)     │
+//	│                                                - http-client (outbound) │
 //	└─────────────────────────────────────────────────────────────────────────┘
 //	                                 ↓
 //	┌─────────────────────────────────────────────────────────────────────────┐
@@ -86,10 +87,16 @@
 //   - Multiple writers to same bucket generates warning
 //   - Watchers receive change notifications
 //
-// PatternNetwork (external):
-//   - External boundary ports (HTTP, UDP, etc.)
+// PatternNetwork (external listener):
+//   - External boundary ports (HTTP server, UDP listener, etc.)
 //   - Exclusive binding: multiple binds to same port is an error
 //   - Not connected in graph (external endpoints)
+//
+// PatternHTTPClient (outbound HTTP-client/polling):
+//   - Component initiates connections to an external HTTP resource
+//   - Non-exclusive: multiple components may poll the same URL
+//   - Not connected in graph; treated like PatternNetwork for orphan detection
+//   - Declared via HTTPClientPort; cadence is owned by a sibling TimerPort
 //
 // # Connection Matching
 //

--- a/component/flowgraph/flowgraph.go
+++ b/component/flowgraph/flowgraph.go
@@ -59,8 +59,14 @@ const (
 	PatternRequest InteractionPattern = "request"
 	// PatternWatch represents KVWatchPort (observation) interactions
 	PatternWatch InteractionPattern = "watch"
-	// PatternNetwork represents NetworkPort (external) interactions
+	// PatternNetwork represents NetworkPort (external listener) interactions
 	PatternNetwork InteractionPattern = "network"
+	// PatternHTTPClient represents HTTPClientPort (outbound HTTP-client/polling) interactions.
+	// Like PatternNetwork, an HTTPClientPort is an external boundary port: the component
+	// initiates the connection outward, so there is no internal publisher to match against.
+	// findOrphanedPorts skips PatternHTTPClient inputs for the same reason it skips
+	// PatternNetwork inputs — a legitimately unconnected external input is not orphaned.
+	PatternHTTPClient InteractionPattern = "http-client"
 )
 
 // Issue type constants for orphaned port classification
@@ -183,6 +189,8 @@ func (g *FlowGraph) extractInterfaceContract(portConfig component.Portable) *com
 	case component.FilePort:
 		// FilePort has no interface contract
 		return nil
+	case component.HTTPClientPort:
+		return config.Interface
 	default:
 		return nil
 	}
@@ -205,6 +213,8 @@ func (g *FlowGraph) classifyInteractionPattern(portConfig component.Portable) In
 		return PatternNetwork
 	case component.FilePort:
 		return PatternNetwork // File I/O is external like network
+	case component.HTTPClientPort:
+		return PatternHTTPClient
 	default:
 		return PatternStream // Safe default
 	}
@@ -259,6 +269,11 @@ func (g *FlowGraph) extractConnectionID(portConfig component.Portable) string {
 			return config.Path
 		}
 		return "file_unknown"
+	case component.HTTPClientPort:
+		if config.URLPattern == "" {
+			return "http_client_missing_url"
+		}
+		return config.URLPattern
 	default:
 		return fmt.Sprintf("unknown_type_%T", config)
 	}
@@ -783,8 +798,11 @@ func (g *FlowGraph) findOrphanedPorts() []OrphanedPort {
 		// Check input ports
 		for _, port := range node.InputPorts {
 			if connectedPorts[componentName] == nil || !connectedPorts[componentName][port.Name] {
-				// Skip network boundary inputs - they ARE the external source
-				if port.Pattern == PatternNetwork {
+				// Skip external boundary inputs — they ARE the external source.
+				// PatternNetwork binds a local listener; PatternHTTPClient initiates
+				// an outbound connection. Both are legitimately unmatched in the
+				// internal graph because their "publisher" is outside the system.
+				if port.Pattern == PatternNetwork || port.Pattern == PatternHTTPClient {
 					continue // Not orphaned, it's an external input
 				}
 
@@ -812,8 +830,10 @@ func (g *FlowGraph) findOrphanedPorts() []OrphanedPort {
 		// Check output ports
 		for _, port := range node.OutputPorts {
 			if connectedPorts[componentName] == nil || !connectedPorts[componentName][port.Name] {
-				// Skip network boundary outputs - they ARE the external sink
-				if port.Pattern == PatternNetwork {
+				// Skip external boundary outputs — they ARE the external sink.
+				// PatternHTTPClient is also skipped: the component owns the
+				// outbound connection so no internal subscriber is expected.
+				if port.Pattern == PatternNetwork || port.Pattern == PatternHTTPClient {
 					continue // Not orphaned, it's an external output
 				}
 

--- a/component/flowgraph/flowgraph_test.go
+++ b/component/flowgraph/flowgraph_test.go
@@ -298,6 +298,72 @@ func TestFlowGraphAnalysis(t *testing.T) {
 	})
 }
 
+// TestHTTPClientPortFlowGraph verifies the three flowgraph behaviours required
+// by the HTTPClientPort contract:
+//  1. classifyInteractionPattern returns PatternHTTPClient.
+//  2. extractConnectionID returns the URL (or the missing-URL sentinel).
+//  3. findOrphanedPorts does NOT flag an HTTPClientPort input as orphaned —
+//     outbound client connections have no internal publisher by design.
+func TestHTTPClientPortFlowGraph(t *testing.T) {
+	g := &FlowGraph{nodes: make(map[string]*ComponentNode), edges: []FlowEdge{}}
+
+	t.Run("classifyInteractionPattern returns PatternHTTPClient", func(t *testing.T) {
+		port := component.HTTPClientPort{
+			Method:     "GET",
+			URLPattern: "https://api.weather.gov/alerts/active",
+		}
+		got := g.classifyInteractionPattern(port)
+		assert.Equal(t, PatternHTTPClient, got, "HTTPClientPort must classify as PatternHTTPClient")
+	})
+
+	t.Run("extractConnectionID returns URL", func(t *testing.T) {
+		port := component.HTTPClientPort{URLPattern: "https://api.weather.gov/alerts/active"}
+		got := g.extractConnectionID(port)
+		assert.Equal(t, "https://api.weather.gov/alerts/active", got)
+	})
+
+	t.Run("extractConnectionID returns sentinel on empty URL", func(t *testing.T) {
+		port := component.HTTPClientPort{}
+		got := g.extractConnectionID(port)
+		assert.Equal(t, "http_client_missing_url", got, "missing URL must return the sentinel (mirrors nats_missing_subject)")
+	})
+
+	t.Run("HTTPClientPort input is NOT reported as orphaned", func(t *testing.T) {
+		// A component with only an HTTPClientPort input and a NATS output is a
+		// valid CAP-poller-style input component. Its HTTPClientPort has no
+		// internal publisher, but that is correct — the external HTTP resource
+		// IS the publisher. findOrphanedPorts must NOT flag it.
+		comp := createMockComponentWithPorts("cap_poller", "input",
+			[]component.Port{{
+				Name:      "cap_feed",
+				Direction: component.DirectionInput,
+				Required:  true,
+				Config: component.HTTPClientPort{
+					Method:     "GET",
+					URLPattern: "https://api.weather.gov/alerts/active",
+				},
+			}},
+			[]component.Port{{
+				Name:      "alerts_out",
+				Direction: component.DirectionOutput,
+				Config:    component.NATSPort{Subject: "alerts.cap.>"},
+			}},
+		)
+		graph := NewFlowGraph()
+		require.NoError(t, graph.AddComponentNode("cap_poller", comp))
+
+		orphans := graph.findOrphanedPorts()
+
+		for _, o := range orphans {
+			if o.PortName == "cap_feed" {
+				t.Errorf("HTTPClientPort input %q incorrectly reported as orphaned (issue=%s); "+
+					"outbound HTTP inputs have no internal publisher by design",
+					o.PortName, o.Issue)
+			}
+		}
+	})
+}
+
 // Test helper functions
 func createMockComponent(name, componentType string) component.Discoverable {
 	return createMockComponentWithPorts(name, componentType, nil, nil)

--- a/component/port.go
+++ b/component/port.go
@@ -163,6 +163,12 @@ func (p *Port) UnmarshalJSON(data []byte) error {
 				return errs.Wrap(err, "Port", "UnmarshalJSON", "kvwrite config unmarshaling")
 			}
 			p.Config = kvConfig
+		case "http-client":
+			var hcConfig HTTPClientPort
+			if err := json.Unmarshal(configWrapper.Data, &hcConfig); err != nil {
+				return errs.Wrap(err, "Port", "UnmarshalJSON", "http-client config unmarshaling")
+			}
+			p.Config = hcConfig
 		default:
 			return errs.WrapInvalid(
 				fmt.Errorf("unknown config type: %s", configWrapper.Type),

--- a/component/port_httpclient.go
+++ b/component/port_httpclient.go
@@ -1,0 +1,44 @@
+package component
+
+import "fmt"
+
+// HTTPClientPort describes an outbound HTTP-client / polling input dependency:
+// a relationship where the component initiates connections to an external HTTP
+// resource (REST API, alert feed, snapshot endpoint) rather than binding a
+// listener (NetworkPort) or consuming a NATS subject (NATSPort).
+//
+// It is a DESCRIPTOR, not a runtime — like TimerPort it declares the dependency
+// shape so lifecycle/config/health/flowgraph/ownership/telemetry tooling can SEE
+// it; the polling/HTTP execution stays in the component. Cadence is NOT owned
+// here: when polling is timer-driven the component also declares a TimerPort and
+// this port references it by name via TriggerPort (single source of truth for
+// the interval).
+//
+// Secrets never appear in this descriptor. AuthRef carries a credential
+// REFERENCE (a key name resolved at runtime from the component's secret source),
+// never a value. No field holds a secret.
+type HTTPClientPort struct {
+	Method        string             `json:"method,omitempty"`         // HTTP method; defaults to GET when empty
+	URLPattern    string             `json:"url_pattern"`              // target endpoint/resource pattern; NO inline creds, NO query-string secrets
+	TriggerPort   string             `json:"trigger_port,omitempty"`   // NAME of a sibling TimerPort driving cadence (empty = event-driven/internal)
+	AuthRef       string             `json:"auth_ref,omitempty"`       // credential key name resolved at runtime; NEVER a secret value; empty = unauthenticated
+	ContactPolicy string             `json:"contact_policy,omitempty"` // public User-Agent/contact identity (feeds often require it); not a secret
+	Interface     *InterfaceContract `json:"interface,omitempty"`      // message-interface contract this port produces
+}
+
+// ResourceID returns a unique identifier for the HTTP client dependency.
+// Two ports with the same method and URL pattern identify the same external resource.
+func (h HTTPClientPort) ResourceID() string {
+	method := h.Method
+	if method == "" {
+		method = "GET"
+	}
+	return fmt.Sprintf("http-client:%s:%s", method, h.URLPattern)
+}
+
+// IsExclusive returns false: an outbound client relationship is shareable
+// (multiple components may poll the same endpoint), unlike a NetworkPort listener.
+func (h HTTPClientPort) IsExclusive() bool { return false }
+
+// Type returns the port type identifier.
+func (h HTTPClientPort) Type() string { return "http-client" }

--- a/component/port_test.go
+++ b/component/port_test.go
@@ -3,6 +3,7 @@ package component
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 )
@@ -288,6 +289,7 @@ func TestPortableInterface(_ *testing.T) {
 	var _ Portable = JetStreamPort{}
 	var _ Portable = KVWatchPort{}
 	var _ Portable = KVWritePort{}
+	var _ Portable = HTTPClientPort{}
 }
 
 func TestPortJSONSerialization(t *testing.T) {
@@ -1529,6 +1531,44 @@ func TestPort_UnmarshalJSON_RoundTripsToTypedConfig(t *testing.T) {
 				}
 			},
 		},
+		{
+			// Envelope round-trip for HTTPClientPort catches drift in
+			// Port.UnmarshalJSON's http-client case (same class as
+			// TestPort_UnmarshalJSON_RoundTripsToTypedConfig motivation).
+			name: "HTTPClient",
+			original: Port{
+				Name:        "cap_feed",
+				Direction:   DirectionInput,
+				Required:    false,
+				Description: "CAP alert feed input",
+				Config: HTTPClientPort{
+					Method:        "GET",
+					URLPattern:    "https://api.weather.gov/alerts/active",
+					TriggerPort:   "cap_timer",
+					AuthRef:       "opensky_basic",
+					ContactPolicy: "SemStreams/1.0 (contact@example.com)",
+					Interface:     &InterfaceContract{Type: "alert.CAP", Version: "v1"},
+				},
+			},
+			assert: func(t *testing.T, decoded Port) {
+				hc, ok := decoded.Config.(HTTPClientPort)
+				if !ok {
+					t.Fatalf("Config = %T, want HTTPClientPort (drift in Port.UnmarshalJSON http-client case)", decoded.Config)
+				}
+				if hc.URLPattern != "https://api.weather.gov/alerts/active" {
+					t.Errorf("URLPattern = %q, want https://api.weather.gov/alerts/active", hc.URLPattern)
+				}
+				if hc.TriggerPort != "cap_timer" {
+					t.Errorf("TriggerPort = %q, want cap_timer", hc.TriggerPort)
+				}
+				if hc.AuthRef != "opensky_basic" {
+					t.Errorf("AuthRef = %q, want opensky_basic", hc.AuthRef)
+				}
+				if hc.Method != "GET" {
+					t.Errorf("Method = %q, want GET", hc.Method)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1631,4 +1671,322 @@ func TestPort_UnmarshalJSON_KVDashedAliases(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHTTPClientPort exercises ResourceID, IsExclusive, and Type.
+// ResourceID must prefix with "http-client:", default an empty Method to GET,
+// and incorporate the URL pattern. IsExclusive must be false (outbound client
+// relationships are shareable). Type must be "http-client".
+func TestHTTPClientPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		port        HTTPClientPort
+		resourceID  string
+		isExclusive bool
+		portType    string
+	}{
+		{
+			name:        "GET with full URL",
+			port:        HTTPClientPort{Method: "GET", URLPattern: "https://api.weather.gov/alerts/active"},
+			resourceID:  "http-client:GET:https://api.weather.gov/alerts/active",
+			isExclusive: false,
+			portType:    "http-client",
+		},
+		{
+			name:        "empty method defaults to GET",
+			port:        HTTPClientPort{URLPattern: "https://api.opensky-network.org/api/states/all"},
+			resourceID:  "http-client:GET:https://api.opensky-network.org/api/states/all",
+			isExclusive: false,
+			portType:    "http-client",
+		},
+		{
+			name:        "POST variant",
+			port:        HTTPClientPort{Method: "POST", URLPattern: "https://api.example.com/data"},
+			resourceID:  "http-client:POST:https://api.example.com/data",
+			isExclusive: false,
+			portType:    "http-client",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.port.ResourceID() != tt.resourceID {
+				t.Errorf("ResourceID = %q, want %q", tt.port.ResourceID(), tt.resourceID)
+			}
+			if tt.port.IsExclusive() != tt.isExclusive {
+				t.Errorf("IsExclusive = %v, want %v", tt.port.IsExclusive(), tt.isExclusive)
+			}
+			if tt.port.Type() != tt.portType {
+				t.Errorf("Type = %q, want %q", tt.port.Type(), tt.portType)
+			}
+		})
+	}
+}
+
+// TestHTTPClientPortJSONSerialization verifies struct-level marshal → unmarshal
+// round-trip preserving all six fields. Mirrors TestNetworkPortJSONSerialization.
+func TestHTTPClientPortJSONSerialization(t *testing.T) {
+	original := HTTPClientPort{
+		Method:        "GET",
+		URLPattern:    "https://api.weather.gov/alerts/active",
+		TriggerPort:   "cap_timer",
+		AuthRef:       "opensky_basic",
+		ContactPolicy: "SemStreams/1.0 (contact@example.com)",
+		Interface:     &InterfaceContract{Type: "alert.CAP", Version: "v1"},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var restored HTTPClientPort
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if restored.Method != original.Method {
+		t.Errorf("Method = %q, want %q", restored.Method, original.Method)
+	}
+	if restored.URLPattern != original.URLPattern {
+		t.Errorf("URLPattern = %q, want %q", restored.URLPattern, original.URLPattern)
+	}
+	if restored.TriggerPort != original.TriggerPort {
+		t.Errorf("TriggerPort = %q, want %q", restored.TriggerPort, original.TriggerPort)
+	}
+	if restored.AuthRef != original.AuthRef {
+		t.Errorf("AuthRef = %q, want %q", restored.AuthRef, original.AuthRef)
+	}
+	if restored.ContactPolicy != original.ContactPolicy {
+		t.Errorf("ContactPolicy = %q, want %q", restored.ContactPolicy, original.ContactPolicy)
+	}
+	if restored.Interface == nil {
+		t.Fatal("Interface = nil, want non-nil")
+	}
+	if restored.Interface.Type != original.Interface.Type {
+		t.Errorf("Interface.Type = %q, want %q", restored.Interface.Type, original.Interface.Type)
+	}
+	if restored.Interface.Version != original.Interface.Version {
+		t.Errorf("Interface.Version = %q, want %q", restored.Interface.Version, original.Interface.Version)
+	}
+}
+
+// TestHTTPClientPort_SecretsNotInSerializedOutput verifies that:
+//  1. AuthRef (a credential key reference, NOT a value) is present in the
+//     serialized JSON — the reference must survive the round-trip so the
+//     runtime resolver can find it.
+//  2. The set of JSON keys emitted for a fully-populated HTTPClientPort is
+//     exactly {method, url_pattern, trigger_port, auth_ref, contact_policy,
+//     interface} — no extra keys leak into the wire format.
+//  3. A sparse port (only URLPattern set) omits all omitempty optional fields,
+//     confirming they do not pollute the wire format when unused.
+func TestHTTPClientPort_SecretsNotInSerializedOutput(t *testing.T) {
+	t.Run("fully populated — AuthRef survives and key set is exact", func(t *testing.T) {
+		port := HTTPClientPort{
+			Method:        "GET",
+			URLPattern:    "https://api.weather.gov/alerts/active",
+			TriggerPort:   "cap_timer",
+			AuthRef:       "opensky_basic",
+			ContactPolicy: "SemStreams/1.0 (contact@example.com)",
+			Interface:     &InterfaceContract{Type: "alert.CAP", Version: "v1"},
+		}
+
+		data, err := json.Marshal(port)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		// (a) AuthRef reference value must survive in the output.
+		if !strings.Contains(string(data), "opensky_basic") {
+			t.Errorf("AuthRef key reference %q not found in JSON; reference was lost during serialization", "opensky_basic")
+		}
+
+		// (b) Key set must be exactly the declared fields — no extras leak in.
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal to map: %v", err)
+		}
+		expected := map[string]bool{
+			"method":         true,
+			"url_pattern":    true,
+			"trigger_port":   true,
+			"auth_ref":       true,
+			"contact_policy": true,
+			"interface":      true,
+		}
+		for k := range m {
+			if !expected[k] {
+				t.Errorf("unexpected JSON key %q in serialized HTTPClientPort; struct has undeclared field", k)
+			}
+		}
+		// Only url_pattern is non-omitempty, so verify it is present.
+		if _, ok := m["url_pattern"]; !ok {
+			t.Errorf("expected JSON key %q missing from serialized HTTPClientPort", "url_pattern")
+		}
+	})
+
+	t.Run("sparse port — omitempty fields absent when zero", func(t *testing.T) {
+		// Only URLPattern set; all other fields are zero/nil.
+		sparse := HTTPClientPort{
+			URLPattern: "https://api.weather.gov/alerts/active",
+		}
+
+		data, err := json.Marshal(sparse)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			t.Fatalf("unmarshal to map: %v", err)
+		}
+
+		// url_pattern must be present (it is not omitempty).
+		if _, ok := m["url_pattern"]; !ok {
+			t.Errorf("url_pattern missing from sparse HTTPClientPort JSON")
+		}
+
+		// All other optional fields must be absent (they are omitempty).
+		omitemptyFields := []string{"method", "trigger_port", "auth_ref", "contact_policy", "interface"}
+		for _, k := range omitemptyFields {
+			if _, ok := m[k]; ok {
+				t.Errorf("omitempty field %q should not appear in sparse HTTPClientPort JSON", k)
+			}
+		}
+	})
+}
+
+// TestPortDefinition_UnmarshalJSON_HTTPClientConfig is the load-bearing
+// regression test for PortDefinition.UnmarshalJSON's http-client case.
+// Mirrors TestPortDefinition_UnmarshalJSON_JetStreamConfig: a JSON-loaded
+// PortDefinition with type "http-client" must place an HTTPClientPort struct
+// into Config (not a map[string]any), otherwise every type assertion in
+// BuildPortFromDefinition silently fails.
+func TestPortDefinition_UnmarshalJSON_HTTPClientConfig(t *testing.T) {
+	raw := []byte(`{
+		"name": "cap_feed",
+		"type": "http-client",
+		"subject": "https://api.weather.gov/alerts/active",
+		"config": {
+			"method": "GET",
+			"auth_ref": "opensky_basic",
+			"trigger_port": "cap_timer"
+		}
+	}`)
+
+	var pd PortDefinition
+	if err := json.Unmarshal(raw, &pd); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if pd.Name != "cap_feed" || pd.Type != "http-client" {
+		t.Errorf("top-level fields lost: %+v", pd)
+	}
+
+	hc, ok := pd.Config.(HTTPClientPort)
+	if !ok {
+		t.Fatalf("Config = %T, want HTTPClientPort (http-client case in PortDefinition.UnmarshalJSON missing)", pd.Config)
+	}
+	if hc.Method != "GET" {
+		t.Errorf("Method = %q, want GET", hc.Method)
+	}
+	if hc.AuthRef != "opensky_basic" {
+		t.Errorf("AuthRef = %q, want opensky_basic", hc.AuthRef)
+	}
+	if hc.TriggerPort != "cap_timer" {
+		t.Errorf("TriggerPort = %q, want cap_timer", hc.TriggerPort)
+	}
+}
+
+// TestBuildPortFromDefinition_HTTPClient exercises BuildPortFromDefinition's
+// http-client case:
+//   - def.Subject is used as the default URLPattern when no typed Config is present.
+//   - A typed def.Config.(HTTPClientPort) overrides non-empty fields including
+//     URLPattern (typed Config wins over def.Subject).
+func TestBuildPortFromDefinition_HTTPClient(t *testing.T) {
+	t.Run("subject is default URLPattern", func(t *testing.T) {
+		def := PortDefinition{
+			Name:    "cap_feed",
+			Type:    "http-client",
+			Subject: "https://api.weather.gov/alerts/active",
+		}
+		port := BuildPortFromDefinition(def, DirectionInput)
+		hc, ok := port.Config.(HTTPClientPort)
+		if !ok {
+			t.Fatalf("Config = %T, want HTTPClientPort", port.Config)
+		}
+		if hc.URLPattern != "https://api.weather.gov/alerts/active" {
+			t.Errorf("URLPattern = %q, want def.Subject value", hc.URLPattern)
+		}
+	})
+
+	t.Run("typed Config overrides subject for URLPattern", func(t *testing.T) {
+		def := PortDefinition{
+			Name:    "cap_feed",
+			Type:    "http-client",
+			Subject: "https://api.weather.gov/alerts/active", // scalar default
+			Config: HTTPClientPort{
+				URLPattern:  "https://api.weather.gov/alerts/active?area=US", // typed Config wins
+				Method:      "GET",
+				TriggerPort: "cap_timer",
+				AuthRef:     "opensky_basic",
+			},
+		}
+		port := BuildPortFromDefinition(def, DirectionInput)
+		hc, ok := port.Config.(HTTPClientPort)
+		if !ok {
+			t.Fatalf("Config = %T, want HTTPClientPort", port.Config)
+		}
+		if hc.URLPattern != "https://api.weather.gov/alerts/active?area=US" {
+			t.Errorf("URLPattern = %q, want typed Config value (Config wins over Subject)", hc.URLPattern)
+		}
+		if hc.Method != "GET" {
+			t.Errorf("Method = %q, want GET", hc.Method)
+		}
+		if hc.TriggerPort != "cap_timer" {
+			t.Errorf("TriggerPort = %q, want cap_timer", hc.TriggerPort)
+		}
+		if hc.AuthRef != "opensky_basic" {
+			t.Errorf("AuthRef = %q, want opensky_basic", hc.AuthRef)
+		}
+	})
+
+	t.Run("flat interface field is honored when no Config block", func(t *testing.T) {
+		// Regression (go-reviewer C3-2): a config-less declaration that sets
+		// only the flat `interface:` scalar must not silently lose its contract.
+		def := PortDefinition{
+			Name:      "cap_feed",
+			Type:      "http-client",
+			Subject:   "https://api.weather.gov/alerts/active",
+			Interface: "alert.CAP",
+		}
+		port := BuildPortFromDefinition(def, DirectionInput)
+		hc, ok := port.Config.(HTTPClientPort)
+		if !ok {
+			t.Fatalf("Config = %T, want HTTPClientPort", port.Config)
+		}
+		if hc.Interface == nil {
+			t.Fatal("Interface = nil, want flat def.Interface to seed the contract")
+		}
+		if hc.Interface.Type != "alert.CAP" {
+			t.Errorf("Interface.Type = %q, want alert.CAP", hc.Interface.Type)
+		}
+	})
+
+	t.Run("typed Config.Interface wins over flat interface field", func(t *testing.T) {
+		def := PortDefinition{
+			Name:      "cap_feed",
+			Type:      "http-client",
+			Subject:   "https://api.weather.gov/alerts/active",
+			Interface: "alert.CAP", // flat seed
+			Config: HTTPClientPort{
+				Interface: &InterfaceContract{Type: "alert.CAP.v2", Version: "v2"}, // typed wins
+			},
+		}
+		port := BuildPortFromDefinition(def, DirectionInput)
+		hc := port.Config.(HTTPClientPort)
+		if hc.Interface == nil || hc.Interface.Type != "alert.CAP.v2" {
+			t.Errorf("Interface = %+v, want typed Config.Interface (alert.CAP.v2) to win", hc.Interface)
+		}
+	})
 }

--- a/component/ports.go
+++ b/component/ports.go
@@ -132,6 +132,12 @@ func (p *PortDefinition) UnmarshalJSON(data []byte) error {
 			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "file config")
 		}
 		p.Config = f
+	case "http-client":
+		var hc HTTPClientPort
+		if err := json.Unmarshal(aux.Config, &hc); err != nil {
+			return errs.Wrap(err, "PortDefinition", "UnmarshalJSON", "http-client config")
+		}
+		p.Config = hc
 	default:
 		// Unknown port type — preserve pre-fix behaviour by decoding the
 		// raw config into a generic map. Forward-compat for custom port
@@ -290,6 +296,42 @@ func BuildPortFromDefinition(def PortDefinition, direction Direction) Port {
 			Bucket:    bucket,
 			Interface: iface,
 		}
+	case "http-client":
+		// Outbound HTTP-client / polling input dependency.
+		// Precedence: typed Config wins over def.Subject for URLPattern.
+		// def.Subject is the default URL pattern (scalar field); a typed
+		// def.Config.(HTTPClientPort) overrides each non-empty field so
+		// an operator JSON config block takes effect over the scalar.
+		hcPort := HTTPClientPort{
+			URLPattern: def.Subject, // scalar default
+		}
+		// Seed Interface from the flat scalar field (like the timer/kv/nats
+		// cases) so a config-less declaration that only sets `interface:` does
+		// not silently lose its contract; a typed Config.Interface still wins below.
+		if def.Interface != "" {
+			hcPort.Interface = &InterfaceContract{Type: def.Interface, Version: "v1"}
+		}
+		if configPort, ok := def.Config.(HTTPClientPort); ok {
+			if configPort.Method != "" {
+				hcPort.Method = configPort.Method
+			}
+			if configPort.URLPattern != "" {
+				hcPort.URLPattern = configPort.URLPattern // typed Config wins
+			}
+			if configPort.TriggerPort != "" {
+				hcPort.TriggerPort = configPort.TriggerPort
+			}
+			if configPort.AuthRef != "" {
+				hcPort.AuthRef = configPort.AuthRef
+			}
+			if configPort.ContactPolicy != "" {
+				hcPort.ContactPolicy = configPort.ContactPolicy
+			}
+			if configPort.Interface != nil {
+				hcPort.Interface = configPort.Interface
+			}
+		}
+		port.Config = hcPort
 	case "http", "grpc", "websocket-server":
 		// HTTP/gRPC/WebSocket server ports are network boundary ports
 		port.Config = NetworkPort{

--- a/service/component_manager.go
+++ b/service/component_manager.go
@@ -1957,9 +1957,12 @@ func (cm *ComponentManager) isInputComponent(componentName string, node *flowgra
 		}
 	}
 
-	// Check if component has network ports (external input)
+	// Check if component has external input ports (network listener or outbound
+	// HTTP-client). Both patterns indicate the component is the data source for
+	// the internal graph: PatternNetwork binds a local listener, PatternHTTPClient
+	// initiates an outbound poll. Either makes the component an input origin.
 	for _, port := range node.InputPorts {
-		if port.Pattern == flowgraph.PatternNetwork {
+		if port.Pattern == flowgraph.PatternNetwork || port.Pattern == flowgraph.PatternHTTPClient {
 			return true
 		}
 	}


### PR DESCRIPTION
## HTTPClientPort — declarative outbound HTTP-client/polling port (closes #310)

A first-class declarative port descriptor for **outbound HTTP-client / polling input dependencies** (SemOps: CAP/NWS alerts, OpenSky ADS-B, SAPIENT REST), so lifecycle/config/health/**flowgraph**/resource-ownership/telemetry can SEE the external dependency instead of it hiding in component-specific config. **Non-breaking / additive.**

### Descriptor, not a runtime
Like `TimerPort`, this declares the dependency shape; the polling/HTTP execution stays in the component. Cadence is **referenced** from a separate `TimerPort` (`TriggerPort` name ref — single source of truth for the interval). This matches SemOps's interim plan (keep TimerPort + config for the runtime; ship the representation now).

### The gap it fills
Today `"http"` parses to `NetworkPort` — an inbound **listener**. There was no representation for an outbound HTTP **client**. `HTTPClientPort` (`Type()=="http-client"`) is a **distinct** type, `IsExclusive()==false` (a shared outbound endpoint is not a bind conflict).

### Six flat fields — disciplined
`Method, URLPattern, TriggerPort, AuthRef, ContactPolicy, Interface`. Deliberately **excluded** (runtime config the component owns, not topology): timeout/retry/backoff/rate-limit/cache → stay in `ConfigSchema`; last-success/last-error/freshness → component-emitted telemetry, never stored on a static descriptor.

### Secrets-as-refs
`AuthRef` is a credential **key name**, never a value — secrets stay out of serialized topology. A key-set test (`TestHTTPClientPort_SecretsNotInSerializedOutput`) structurally locks "no secret-value field" against future drift (verified non-vacuous: it catches an added 7th field).

### Wiring
Port/PortDefinition unmarshal + `BuildPortFromDefinition` (typed Config wins over `def.Subject`; flat `def.Interface` seeded); flowgraph `PatternHTTPClient` + classify/extractConnectionID/extractInterface + `findOrphanedPorts` skip (an outbound input has no internal publisher → not an orphan); `isInputComponent` recognizes it. **Zero OpenAPI schema impact** (ports don't feed generation — verified clean).

### Review
architect scope → adversarial over-eng review (cut the kitchen-sink fields) → go-developer → go-reviewer **ACCEPT-WITH-NITS**. The one Medium (C3-2: flat `interface:` dropped for config-less ports) was **confirmed by execution** and **fixed + regression-tested**; nits declined.

### Gates
lint (revive 0), `go vet` ×{default,integration,live_llm}, full unit `-race`, zero schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
