### PR TITLE
fix(agentic-loop): publish agent.approval_response on approval-timeout sweep (#266)

### DIFF
--- a/processor/agentic-loop/approval_integration_test.go
+++ b/processor/agentic-loop/approval_integration_test.go
@@ -249,3 +249,168 @@ func TestIntegration_ApprovalFlow_Approve(t *testing.T) {
 		t.Errorf("re-dispatch lost original arguments: %v", approved.Arguments)
 	}
 }
+
+// TestIntegration_ApprovalTimeoutSweeper_PublishesWireResponse verifies that
+// when a loop's approval timeout elapses the sweeper publishes an
+// ApprovalResponse to agent.approval_response.<loopID> on the wire, so that
+// external observers (dashboards, audit consumers, sister repos) see timeout
+// auto-rejects symmetrically with human approvals.
+//
+// The test drives the loop to LoopStateAwaitingApproval with a very short
+// approval timeout (500 ms), then subscribes to agent.approval_response.*
+// and waits for the sweeper to fire and publish. Explicit channel
+// synchronisation — no time.Sleep blocking on the critical assert path.
+func TestIntegration_ApprovalTimeoutSweeper_PublishesWireResponse(t *testing.T) {
+	natsClient := getSharedNATSClient(t)
+
+	const loopID = "loop_approval_timeout_wire"
+	const callID = "call_approval_timeout_wire"
+
+	// Very short approval timeout so the sweeper fires quickly.
+	const approvalTimeout = "500ms"
+
+	config := agenticloop.Config{
+		Ports: &component.PortConfig{
+			Inputs: []component.PortDefinition{
+				{Name: "agent.task", Type: "jetstream", Subject: "agent.task.*", StreamName: "AGENT", Required: true},
+				{Name: "agent.response", Type: "jetstream", Subject: "agent.response.>", StreamName: "AGENT"},
+				{Name: "tool.result", Type: "jetstream", Subject: "tool.result.>", StreamName: "AGENT"},
+				{Name: "agent.approval_response", Type: "jetstream", Subject: "agent.approval_response.*", StreamName: "AGENT"},
+			},
+			Outputs: []component.PortDefinition{
+				{Name: "agent.request", Type: "jetstream", Subject: "agent.request.*", StreamName: "AGENT"},
+				{Name: "tool.execute", Type: "jetstream", Subject: "tool.execute.*", StreamName: "AGENT"},
+				{Name: "agent.approval_pending", Type: "jetstream", Subject: "agent.approval_pending.*", StreamName: "AGENT"},
+				{Name: "agent.complete", Type: "jetstream", Subject: "agent.complete.*", StreamName: "AGENT"},
+				{Name: "agent.failed", Type: "jetstream", Subject: "agent.failed.*", StreamName: "AGENT"},
+			},
+		},
+		MaxIterations:      10,
+		Timeout:            "60s",
+		ApprovalTimeoutStr: approvalTimeout,
+		StreamName:         "AGENT",
+		ConsumerNameSuffix: "approval-timeout-wire-test",
+		LoopsBucket:        "AGENT_LOOPS",
+	}
+
+	rawConfig, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	deps := component.Dependencies{
+		NATSClient:      natsClient,
+		PayloadRegistry: payloadbuiltins.NewTestRegistry(t),
+	}
+
+	comp, err := agenticloop.NewComponent(rawConfig, deps)
+	require.NoError(t, err)
+
+	lc := comp.(component.LifecycleComponent)
+	require.NoError(t, lc.Initialize())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	require.NoError(t, lc.Start(ctx))
+	defer lc.Stop(5 * time.Second)
+
+	time.Sleep(200 * time.Millisecond)
+
+	dec := payloadbuiltins.NewTestDecoder(t)
+
+	// Subscribe to model requests so we can feed a response.
+	var firstRequestID string
+	var requestMu sync.Mutex
+	_, err = natsClient.Subscribe(ctx, "agent.request.>", func(_ context.Context, msg *nats.Msg) {
+		baseMsg, decErr := dec.Decode(msg.Data)
+		if decErr != nil {
+			return
+		}
+		req, ok := baseMsg.Payload().(*agentic.AgentRequest)
+		if !ok {
+			return
+		}
+		requestMu.Lock()
+		if firstRequestID == "" {
+			firstRequestID = req.RequestID
+		}
+		requestMu.Unlock()
+	})
+	require.NoError(t, err)
+
+	// Subscribe to agent.approval_response.* to capture wire publishes.
+	approvalRespCh := make(chan *agentic.ApprovalResponse, 4)
+	_, err = natsClient.Subscribe(ctx, "agent.approval_response.>", func(_ context.Context, msg *nats.Msg) {
+		baseMsg, decErr := dec.Decode(msg.Data)
+		if decErr != nil {
+			return
+		}
+		resp, ok := baseMsg.Payload().(*agentic.ApprovalResponse)
+		if !ok {
+			return
+		}
+		// Filter to only the loop under test.
+		if resp.LoopID != loopID {
+			return
+		}
+		approvalRespCh <- resp
+	})
+	require.NoError(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Step 1: publish task.
+	task := &agentic.TaskMessage{
+		LoopID: loopID,
+		TaskID: "task-approval-timeout-wire",
+		Role:   "general",
+		Model:  "test-model",
+		Prompt: "Delete a rule",
+	}
+	publishTaskMessage(t, natsClient, "agent.task.approval-timeout", task)
+
+	require.Eventually(t, func() bool {
+		requestMu.Lock()
+		defer requestMu.Unlock()
+		return firstRequestID != ""
+	}, 5*time.Second, 50*time.Millisecond, "loop should publish first agent.request")
+
+	requestMu.Lock()
+	reqID := firstRequestID
+	requestMu.Unlock()
+
+	// Step 2: model response with tool_call.
+	resp := &agentic.AgentResponse{
+		RequestID: reqID,
+		Status:    "tool_call",
+		Message: agentic.ChatMessage{
+			Role: "assistant",
+			ToolCalls: []agentic.ToolCall{
+				{ID: callID, Name: "delete_rule", Arguments: map[string]any{"rule_id": "rule-42"}},
+			},
+		},
+	}
+	publishResponseMessage(t, natsClient, "agent.response."+reqID, resp)
+
+	// Step 3: simulate agentic-tools approval filter rejecting the call.
+	gateResult := &agentic.ToolResult{
+		CallID:    callID,
+		Name:      "delete_rule",
+		ErrorKind: agentic.ToolErrorPermission,
+		Error:     agentic.ApprovalRequiredPrefix + "Tool 'delete_rule' requires human approval",
+	}
+	publishToolResultMessage(t, natsClient, "tool.result."+callID, gateResult)
+
+	// Step 4: the sweeper fires after the approval timeout (~500ms) and publishes
+	// the ApprovalResponse to agent.approval_response.<loopID>. Wait up to 15s
+	// to give the sweeper (5s interval) plus timeout (500ms) plus startup margin.
+	select {
+	case wireResp := <-approvalRespCh:
+		assert.Equal(t, loopID, wireResp.LoopID, "wire response must carry correct loop_id")
+		assert.Equal(t, callID, wireResp.CallID, "wire response must carry correct call_id")
+		assert.Equal(t, agentic.ApprovalDecisionReject, wireResp.Decision, "timeout auto-reject must use reject decision")
+		assert.Contains(t, wireResp.Reason, "timed out", "wire response reason must mention timeout")
+		assert.Equal(t, "system:approval-timeout", wireResp.ApprovedBy, "wire response must carry timeout sentinel in approved_by")
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for sweeper to publish agent.approval_response wire message")
+	}
+}

--- a/processor/agentic-loop/approval_sweeper.go
+++ b/processor/agentic-loop/approval_sweeper.go
@@ -2,11 +2,14 @@ package agenticloop
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/message"
 )
 
 // approvalSweepInterval is the cadence at which the component scans
@@ -90,10 +93,61 @@ func (c *Component) sweepExpiredApprovals(ctx context.Context) {
 		}
 		c.publishResults(ctx, result)
 		c.persistLoopState(ctx, cand.LoopID)
+		// Publish the ApprovalResponse onto agent.approval_response.<loopID> so
+		// wire observers (sister-repo dashboards, audit consumers) see timeout
+		// auto-rejects the same way they see human responses. The component's
+		// own consumer receives this and drops it as a stale response (the
+		// approval is already resolved by HandleApprovalResponse above), so
+		// there is no double-processing risk.
+		c.publishApprovalResponseToWire(ctx, response)
 		c.logger.Info("approval timed out; auto-rejected",
 			slog.String("loop_id", cand.LoopID),
 			slog.String("call_id", cand.CallID),
 			slog.String("tool_name", cand.ToolName),
 			slog.Duration("timeout", cand.Timeout))
+	}
+}
+
+// publishApprovalResponseToWire publishes an ApprovalResponse to the
+// agent.approval_response.<loopID> JetStream subject so wire observers
+// (dashboards, audit consumers, sister repos) see timeout auto-rejects
+// symmetrically with human approvals.
+//
+// Subject is resolved from the input-port configuration (the same subject
+// external UIs publish to). The component's own consumer safely drops the
+// message as a stale-response idempotent no-op because the approval is
+// already resolved before this publish fires.
+//
+// Guards against nil natsClient (unit tests, Stop race) and logs but does
+// not fail on marshal/publish errors — the in-process state transition via
+// HandleApprovalResponse is already committed.
+func (c *Component) publishApprovalResponseToWire(ctx context.Context, response agentic.ApprovalResponse) {
+	envelope := message.NewBaseMessage(response.Schema(), &response, "agentic-loop")
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		c.logger.Error("failed to marshal approval response for wire publish",
+			slog.String("loop_id", response.LoopID),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	var inputs []component.PortDefinition
+	if c.config.Ports != nil {
+		inputs = c.config.Ports.Inputs
+	}
+	subject := component.ResolveSubject(inputs, "agent.approval_response", response.LoopID)
+
+	if c.testPublishHook != nil {
+		c.testPublishHook(subject, data)
+		return
+	}
+	if c.natsClient == nil {
+		return
+	}
+	if err := c.natsClient.PublishToStream(ctx, subject, data); err != nil {
+		c.logger.Error("failed to publish approval response to wire",
+			slog.String("loop_id", response.LoopID),
+			slog.String("subject", subject),
+			slog.String("error", err.Error()))
 	}
 }

--- a/processor/agentic-loop/approval_sweeper_test.go
+++ b/processor/agentic-loop/approval_sweeper_test.go
@@ -2,6 +2,7 @@ package agenticloop
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"strings"
 	"testing"
@@ -280,4 +281,107 @@ func TestRunApprovalTimeoutSweeper_ExitsOnContextCancel(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("sweeper did not exit within 2s after ctx cancel")
 	}
+}
+
+// TestSweepExpiredApprovals_PublishesApprovalResponseToWire verifies that
+// sweepExpiredApprovals publishes the synthesised ApprovalResponse to the
+// agent.approval_response.<loopID> subject so wire observers (dashboards,
+// audit consumers, sister repos) see timeout auto-rejects symmetrically
+// with human approvals.
+//
+// Uses the testPublishHook seam (set via SetTestPublishHook / export_test.go)
+// to capture wire-level publishes without a real NATS connection. Explicit
+// channel synchronisation — no time.Sleep.
+func TestSweepExpiredApprovals_PublishesApprovalResponseToWire(t *testing.T) {
+	t.Parallel()
+
+	// Build a Component with an expired awaiting-approval loop.
+	cfg := DefaultConfig()
+	c := &Component{
+		config:  cfg,
+		handler: NewMessageHandler(cfg),
+		logger:  slog.Default(),
+	}
+
+	loopID := setUpAwaitingLoop(t, c.handler, 1*time.Minute, 90*time.Second)
+
+	// Wire the testPublishHook to capture all wire-level publishes.
+	type wireMsg struct {
+		subject string
+		data    []byte
+	}
+	published := make(chan wireMsg, 8) // buffered: sweep is synchronous
+	c.SetTestPublishHook(func(subject string, data []byte) {
+		published <- wireMsg{subject: subject, data: data}
+	})
+
+	c.sweepExpiredApprovals(context.Background())
+
+	// The hook must have received at least one message whose subject
+	// matches agent.approval_response.<loopID>.
+	expectedSubject := "agent.approval_response." + loopID
+	select {
+	case msg := <-published:
+		if msg.subject != expectedSubject {
+			t.Errorf("wire publish subject = %q, want %q", msg.subject, expectedSubject)
+		}
+		// Verify it is a valid BaseMessage envelope carrying an ApprovalResponse.
+		var envelope struct {
+			Type struct {
+				Domain   string `json:"domain"`
+				Category string `json:"category"`
+			} `json:"type"`
+			Payload struct {
+				LoopID   string `json:"loop_id"`
+				Decision string `json:"decision"`
+				Reason   string `json:"reason"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal(msg.data, &envelope); err != nil {
+			t.Fatalf("decode wire envelope: %v", err)
+		}
+		if envelope.Type.Category != agentic.CategoryApprovalResponse {
+			t.Errorf("envelope type.category = %q, want %q",
+				envelope.Type.Category, agentic.CategoryApprovalResponse)
+		}
+		if envelope.Payload.LoopID != loopID {
+			t.Errorf("envelope payload.loop_id = %q, want %q", envelope.Payload.LoopID, loopID)
+		}
+		if envelope.Payload.Decision != agentic.ApprovalDecisionReject {
+			t.Errorf("envelope payload.decision = %q, want %q",
+				envelope.Payload.Decision, agentic.ApprovalDecisionReject)
+		}
+		if !strings.Contains(envelope.Payload.Reason, "timed out") {
+			t.Errorf("envelope payload.reason = %q, want it to mention 'timed out'", envelope.Payload.Reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sweepExpiredApprovals did not publish to agent.approval_response wire within 2s")
+	}
+}
+
+// TestPublishApprovalResponseToWire_NilNATSClientIsNoop verifies that
+// publishApprovalResponseToWire does not panic when natsClient is nil
+// (pure unit tests, Stop race). Guards against a nil-deref regression.
+func TestPublishApprovalResponseToWire_NilNATSClientIsNoop(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	c := &Component{
+		config:  cfg,
+		handler: NewMessageHandler(cfg),
+		logger:  slog.Default(),
+		// natsClient intentionally nil
+	}
+
+	response := agentic.ApprovalResponse{
+		LoopID:     "loop-noop",
+		CallID:     "call-noop",
+		Decision:   agentic.ApprovalDecisionReject,
+		Reason:     "approval timed out after 1m",
+		ApprovedBy: approvalTimeoutSystemApprover,
+		DecidedAt:  time.Now().UTC(),
+	}
+
+	// Must not panic.
+	c.publishApprovalResponseToWire(context.Background(), response)
 }

--- a/processor/agentic-loop/component.go
+++ b/processor/agentic-loop/component.go
@@ -74,6 +74,12 @@ type Component struct {
 
 	// Graph writer for model endpoint and loop execution entities
 	graphWriter *graphWriter
+
+	// testPublishHook, if non-nil, is called by publishApprovalResponseToWire
+	// in place of the real NATS publish. Used in unit tests to capture
+	// wire-level approval-response messages without a NATS connection.
+	// Always nil in production.
+	testPublishHook func(subject string, data []byte)
 }
 
 // consumerInfo tracks JetStream consumer details for cleanup

--- a/processor/agentic-loop/export_test.go
+++ b/processor/agentic-loop/export_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/c360studio/semstreams/types"
 )
 
+// SetTestPublishHook wires a capturing function onto c.testPublishHook so
+// unit tests can observe wire-level publishes from publishApprovalResponseToWire
+// without a real NATS connection. The hook is only ever set from test code;
+// production components always have a nil hook.
+func (c *Component) SetTestPublishHook(fn func(subject string, data []byte)) {
+	c.testPublishHook = fn
+}
+
 // GraphWriterForTest exposes graphWriter for integration testing.
 // This type wraps the unexported graphWriter so that the _test package
 // can exercise the full NATS round-trip without duplicating construction logic.


### PR DESCRIPTION
## What

The approval-timeout sweeper (`sweepExpiredApprovals`) resolved timeouts in-process — `HandleApprovalResponse` + `publishResults` + `persistLoopState` — but never published to `agent.approval_response.<loopID>`. Wire observers (dashboards, audit consumers, semconnect/semteams) saw human approvals but **silently missed sweeper-driven timeout auto-rejects**, leaving them wedged.

This makes the sweeper publish a wire message **symmetric with the HTTP approval path**.

## How

- `approval_sweeper.go`: new `publishApprovalResponseToWire` called after `publishResults` + `persistLoopState`. Subject via `component.ResolveSubject(...Inputs, "agent.approval_response", loopID)`; envelope via `message.NewBaseMessage(response.Schema(), &response, "agentic-loop")`.
- Unit test (fast, no NATS) + integration test (subscribes to the real subject and asserts the timeout-reject wire message).

## Review (pre-merge go-reviewer gate)

**APPROVE-MERGE — no blocking issues.** Verified independently: package suite green under `-race`, `go vet` clean (±integration tag), cross-package `go build ./...` clean.

**Symmetry proven:** identical wire subject (`agent.approval_response.<loopID>`, both via `ResolveSubject`), identical payload discriminator (`Schema()` → `{Domain, "approval_response", SchemaVersion}`), identical reject field set. The one divergence — `meta.source` `agentic-loop` (sweeper) vs `agentic-dispatch` (human) — is **correct** (different originating components); observers filter on `type.category`, which matches. Re-entrancy safe: the self-consumed message hits the `ResolveApprovalIfPending` `ok=false` stale-drop (loop already transitioned out of `awaiting_approval` before publish) — no republish loop.

**Non-blocking follow-ups** (filed separately): harden/remove the `testPublishHook` test seam, and meter wire-publish failures across both approval-response publish paths (best-effort publish currently only logs on failure).

Closes #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
