### PR TITLE
fix(agentic-loop): warn on loop_id reuse under divergent task_id (#276)

### DIFF
--- a/processor/agentic-loop/export_test.go
+++ b/processor/agentic-loop/export_test.go
@@ -43,6 +43,12 @@ func (g *GraphWriterForTest) SetContentStore(store *objectstore.Store) {
 	g.w.contentStore = store
 }
 
+// SetLogger replaces the graphWriter's logger for integration tests that need
+// to capture log output (e.g. verifying divergent task_id warnings).
+func (g *GraphWriterForTest) SetLogger(logger *slog.Logger) {
+	g.w.logger = logger
+}
+
 func (g *GraphWriterForTest) WriteModelEndpoints(ctx context.Context) { g.w.WriteModelEndpoints(ctx) }
 func (g *GraphWriterForTest) WriteLoopCompletion(ctx context.Context, e *agentic.LoopCompletedEvent) {
 	g.w.WriteLoopCompletion(ctx, e)

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -198,7 +198,18 @@ func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtype
 		// envelope) or a foreign entity into a "born" loop origin, defeating the
 		// typed-origin contract (ADR-056). Read + verify before treating it as born.
 		if resp.ErrorCode == gtypes.ErrorCodeEntityExists {
-			return w.verifyExistingLoopOrigin(ctx, entity.ID, entity.MessageType)
+			// Extract the incoming task_id from the spawn triples so
+			// verifyExistingLoopOrigin can detect divergent-task_id reuse (gh#276).
+			var incomingTaskID string
+			for _, t := range triples {
+				if t.Predicate == agvocab.LoopTask {
+					if s, ok := t.Object.(string); ok {
+						incomingTaskID = s
+					}
+					break
+				}
+			}
+			return w.verifyExistingLoopOrigin(ctx, entity.ID, entity.MessageType, incomingTaskID)
 		}
 		return fmt.Errorf("create_with_triples failed (code=%s): %s", resp.ErrorCode, resp.Error)
 	}
@@ -214,17 +225,20 @@ func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtype
 // birth FAILURE the caller halts on — never a silent "born." Reuses the
 // same-package graph.ingest.query.entity read surface (see todos.go).
 //
-// Canonicality note (gh#276): a same-MessageType match treats the
-// FIRST spawn's identity triples as canonical — a divergent re-spawn that reuses
-// the same loop_id under a DIFFERENT task_id is accepted as idempotent and its
-// new identity triples are NOT written (create_with_triples returns before any
-// merge on EntityExists). This is intentional: refusing a same-MessageType match
-// would break genuine retry/redelivery, and the normal redelivery path is already
-// short-circuited upstream by the task_id dedup before birth is reached. The only
-// trigger is a producer contract violation (loop_id reuse), and this is strictly
-// safer than the pre-4c-pre-1 triple.add_batch path, which would have APPENDED
-// conflicting role/parent values onto the existing entity.
-func (w *graphWriter) verifyExistingLoopOrigin(ctx context.Context, entityID string, want message.Type) error {
+// loop_id immutability contract (gh#276): a loop_id is bound to a single task_id
+// at birth. A same-MessageType match is idempotent success — the first spawn's
+// identity triples (role, task, prompt, parent) remain canonical and the new
+// spawn's identity triples are NOT written (create_with_triples returns
+// EntityExists before any merge). When incomingTaskID is non-empty and differs
+// from the existing entity's agent.loop.task triple, this function emits a
+// structured WARNING so operators can detect loop_id reuse across tasks. The
+// identity is NOT rewritten: refusing a same-MessageType match would break
+// genuine retry/redelivery, and a hard reject or identity-rewrite could silently
+// break idempotency-reliant callers. The only safe action is to make the
+// violation observable. This is strictly safer than the pre-4c-pre-1
+// triple.add_batch path, which would have APPENDED conflicting role/parent
+// values onto the existing entity.
+func (w *graphWriter) verifyExistingLoopOrigin(ctx context.Context, entityID string, want message.Type, incomingTaskID string) error {
 	reqData, err := json.Marshal(struct {
 		ID string `json:"id"`
 	}{ID: entityID})
@@ -240,11 +254,45 @@ func (w *graphWriter) verifyExistingLoopOrigin(ctx context.Context, entityID str
 	if err := json.Unmarshal(respData, &existing); err != nil {
 		return fmt.Errorf("create_with_triples entity_exists: unmarshal existing entity %s: %w", entityID, err)
 	}
-	if existing.MessageType == want {
-		return nil // same typed origin — idempotent re-birth, safe to treat as born
+	if existing.MessageType != want {
+		return fmt.Errorf("create_with_triples: %s already exists but is NOT a %s typed origin (existing message_type=%q) — refusing to bless a non-origin shell as born",
+			entityID, want.Key(), existing.MessageType.Key())
 	}
-	return fmt.Errorf("create_with_triples: %s already exists but is NOT a %s typed origin (existing message_type=%q) — refusing to bless a non-origin shell as born",
-		entityID, want.Key(), existing.MessageType.Key())
+
+	// Same typed origin — idempotent re-birth. Now check for divergent task_id
+	// (gh#276): if the caller supplied an incoming task_id and the existing entity
+	// was born under a different task_id, the loop_id is being reused across tasks.
+	// This is a producer contract violation. We keep the first spawn's identity
+	// (loop_id is immutable per task) and emit a WARNING so operators can detect it.
+	if existingTaskID, divergent := divergentTaskID(&existing, incomingTaskID); divergent {
+		w.logger.Warn("graph_writer: loop_id reuse under divergent task_id; keeping original spawn identity (loop_id is immutable per task)",
+			"loop_id", entityID,
+			"existing_task_id", existingTaskID,
+			"incoming_task_id", incomingTaskID,
+		)
+	}
+
+	return nil // same typed origin — idempotent re-birth, safe to treat as born
+}
+
+// divergentTaskID reports whether the existing entity carries a different task_id
+// than incomingTaskID. Returns the existing task_id and true when a divergence is
+// detected — both values are empty / false when incomingTaskID is empty, the existing
+// entity has no agent.loop.task triple, or the two task_ids match.
+// Pure function; no NATS or clock side-effects.
+func divergentTaskID(existing *gtypes.EntityState, incomingTaskID string) (existingTaskID string, divergent bool) {
+	if incomingTaskID == "" {
+		return "", false
+	}
+	triple := existing.GetTriple(agvocab.LoopTask)
+	if triple == nil {
+		return "", false
+	}
+	s, ok := triple.Object.(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, s != incomingTaskID
 }
 
 // WriteSyntheticDecide stamps the synthetic decide triples (#133) onto

--- a/processor/agentic-loop/graph_writer_divergent_task_test.go
+++ b/processor/agentic-loop/graph_writer_divergent_task_test.go
@@ -1,0 +1,264 @@
+package agenticloop
+
+// gh#276: tests for loop_id reuse under divergent task_id detection.
+//
+// Unit tests exercise the pure divergentTaskID helper directly (no NATS
+// required). The full warning-emission path through verifyExistingLoopOrigin
+// is covered by TestWriteSpawnIdentity_DivergentTaskID_Warns_Integration in
+// graph_writer_integration_test.go.
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
+)
+
+// --- divergentTaskID unit tests (pure, no NATS) ---
+
+func TestDivergentTaskID_DifferentTaskIDs_ReturnsDivergent(t *testing.T) {
+	t.Parallel()
+	existing := entityStateWithTask("task-original")
+	existingID, divergent := divergentTaskID(existing, "task-new")
+	if !divergent {
+		t.Error("expected divergent=true for different task IDs, got false")
+	}
+	if existingID != "task-original" {
+		t.Errorf("expected existingTaskID=%q, got %q", "task-original", existingID)
+	}
+}
+
+func TestDivergentTaskID_SameTaskID_NotDivergent(t *testing.T) {
+	t.Parallel()
+	existing := entityStateWithTask("task-same")
+	existingID, divergent := divergentTaskID(existing, "task-same")
+	if divergent {
+		t.Errorf("expected divergent=false for same task ID, got true (existingID=%q)", existingID)
+	}
+}
+
+func TestDivergentTaskID_EmptyIncomingTaskID_NotDivergent(t *testing.T) {
+	t.Parallel()
+	// When the incoming task_id is empty (caller didn't supply one), never flag.
+	existing := entityStateWithTask("task-original")
+	_, divergent := divergentTaskID(existing, "")
+	if divergent {
+		t.Error("expected divergent=false when incomingTaskID is empty")
+	}
+}
+
+func TestDivergentTaskID_NoLoopTaskTriple_NotDivergent(t *testing.T) {
+	t.Parallel()
+	// Existing entity has no agent.loop.task triple — can't compare, so no divergence.
+	existing := &gtypes.EntityState{
+		ID: "acme.ops.agent.agentic-loop.execution.loop-001",
+	}
+	_, divergent := divergentTaskID(existing, "task-new")
+	if divergent {
+		t.Error("expected divergent=false when existing entity has no loop.task triple")
+	}
+}
+
+func TestDivergentTaskID_NonStringTaskIDObject_NotDivergent(t *testing.T) {
+	t.Parallel()
+	// Object is not a string — guard against unexpected triple shapes.
+	existing := &gtypes.EntityState{
+		ID: "acme.ops.agent.agentic-loop.execution.loop-001",
+		Triples: []message.Triple{
+			{Predicate: agvocab.LoopTask, Object: 42},
+		},
+	}
+	_, divergent := divergentTaskID(existing, "task-new")
+	if divergent {
+		t.Error("expected divergent=false for non-string triple Object")
+	}
+}
+
+func TestDivergentTaskID_EmptyExistingTaskID_NotDivergent(t *testing.T) {
+	t.Parallel()
+	// Existing triple has an empty string — treat as absent.
+	existing := &gtypes.EntityState{
+		ID: "acme.ops.agent.agentic-loop.execution.loop-001",
+		Triples: []message.Triple{
+			{Predicate: agvocab.LoopTask, Object: ""},
+		},
+	}
+	_, divergent := divergentTaskID(existing, "task-new")
+	if divergent {
+		t.Error("expected divergent=false when existing task ID triple is empty string")
+	}
+}
+
+// --- warning emission unit test via verifyExistingLoopOriginWithLogger ---
+//
+// We cannot call verifyExistingLoopOrigin without a real NATS connection, but
+// we CAN test the warning logic in isolation by constructing a graphWriter with
+// a recording logger and exercising divergentTaskID via a table-driven suite
+// that verifies the exact log shape expected by operators.
+
+// divergentTaskWarnCase drives the table in TestDivergentTaskID_LoggingShape.
+type divergentTaskWarnCase struct {
+	name           string
+	existing       *gtypes.EntityState
+	incomingTaskID string
+	wantWarn       bool
+}
+
+// captureHandler is a minimal slog.Handler that records Warn-level records.
+// NOT calling slog.SetDefault — safe for t.Parallel().
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *captureHandler) warnMessages() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out []string
+	for _, r := range h.records {
+		if r.Level == slog.LevelWarn {
+			out = append(out, r.Message)
+		}
+	}
+	return out
+}
+
+// TestVerifyExistingLoopOrigin_DivergentTaskID_WarnShape tests that the graphWriter
+// produces the correct Warn log message when divergentTaskID detects a mismatch.
+// This wires the logger capture directly to a graphWriter and calls
+// divergentTaskID, validating (a) warning is emitted on divergence and (b) not
+// emitted for same-task-id or missing-task-id cases.
+//
+// Does NOT call verifyExistingLoopOrigin (which requires NATS). The full end-to-end
+// path is covered by TestWriteSpawnIdentity_DivergentTaskID_Warns_Integration.
+func TestVerifyExistingLoopOrigin_DivergentTaskID_WarnShape(t *testing.T) {
+	t.Parallel()
+
+	cases := []divergentTaskWarnCase{
+		{
+			name:           "divergent task_id emits warning",
+			existing:       entityStateWithTask("task-original"),
+			incomingTaskID: "task-new",
+			wantWarn:       true,
+		},
+		{
+			name:           "same task_id suppresses warning",
+			existing:       entityStateWithTask("task-same"),
+			incomingTaskID: "task-same",
+			wantWarn:       false,
+		},
+		{
+			name:           "empty incoming task_id suppresses warning",
+			existing:       entityStateWithTask("task-original"),
+			incomingTaskID: "",
+			wantWarn:       false,
+		},
+		{
+			name:           "no loop.task triple suppresses warning",
+			existing:       &gtypes.EntityState{ID: "acme.ops.agent.agentic-loop.execution.loop-001"},
+			incomingTaskID: "task-new",
+			wantWarn:       false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := &captureHandler{}
+			logger := slog.New(h)
+			w := &graphWriter{logger: logger}
+
+			// Directly exercise the divergentTaskID check + logging path that
+			// lives inside verifyExistingLoopOrigin.
+			if existingTaskID, divergent := divergentTaskID(tc.existing, tc.incomingTaskID); divergent {
+				w.logger.Warn("graph_writer: loop_id reuse under divergent task_id; keeping original spawn identity (loop_id is immutable per task)",
+					"loop_id", tc.existing.ID,
+					"existing_task_id", existingTaskID,
+					"incoming_task_id", tc.incomingTaskID,
+				)
+			}
+
+			warns := h.warnMessages()
+			if tc.wantWarn {
+				if len(warns) == 0 {
+					t.Errorf("expected a Warn log entry for divergent task_id, got none")
+				} else {
+					warnMsg := warns[0]
+					if warnMsg != "graph_writer: loop_id reuse under divergent task_id; keeping original spawn identity (loop_id is immutable per task)" {
+						t.Errorf("unexpected warn message: %q", warnMsg)
+					}
+				}
+			} else {
+				if len(warns) > 0 {
+					t.Errorf("expected no Warn log entry, got: %v", warns)
+				}
+			}
+		})
+	}
+}
+
+// TestDivergentTaskID_IdentityTriples_FirstSpawnWins verifies that the FIRST
+// spawn's identity (task_id) is preserved by divergentTaskID — it does not mutate
+// the existing entity or return any error. This is the "behavior unchanged" pin
+// for gh#276 scope: keep-first, just make it observable.
+func TestDivergentTaskID_IdentityTriples_FirstSpawnWins(t *testing.T) {
+	t.Parallel()
+
+	// Simulate first spawn's entity as canonically stored.
+	firstTaskID := "task-first"
+	existing := entityStateWithTask(firstTaskID)
+
+	// Second spawn reuses the same loop_id with a new task.
+	secondTaskID := "task-second"
+	existingID, divergent := divergentTaskID(existing, secondTaskID)
+
+	// Must detect divergence.
+	if !divergent {
+		t.Fatal("expected divergent=true")
+	}
+
+	// The returned existing task_id must be the FIRST spawn's, not the second's.
+	if existingID != firstTaskID {
+		t.Errorf("existingTaskID = %q, want %q (first spawn must remain canonical)", existingID, firstTaskID)
+	}
+
+	// The existing entity must be UNCHANGED — divergentTaskID is a read-only check.
+	triple := existing.GetTriple(agvocab.LoopTask)
+	if triple == nil {
+		t.Fatal("loop.task triple unexpectedly removed from existing entity")
+	}
+	if got, _ := triple.Object.(string); got != firstTaskID {
+		t.Errorf("existing entity's task_id was mutated: got %q, want %q", got, firstTaskID)
+	}
+}
+
+// entityStateWithTask is a test helper that builds a minimal gtypes.EntityState
+// with a single agent.loop.task triple carrying the given taskID.
+func entityStateWithTask(taskID string) *gtypes.EntityState {
+	return &gtypes.EntityState{
+		ID: "acme.ops.agent.agentic-loop.execution.loop-001",
+		Triples: []message.Triple{
+			{
+				Subject:   "acme.ops.agent.agentic-loop.execution.loop-001",
+				Predicate: agvocab.LoopTask,
+				Object:    taskID,
+			},
+		},
+	}
+}

--- a/processor/agentic-loop/graph_writer_integration_test.go
+++ b/processor/agentic-loop/graph_writer_integration_test.go
@@ -5,6 +5,7 @@ package agenticloop_test
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -978,4 +979,124 @@ func TestWriteMutationFailure_Integration(t *testing.T) {
 
 	// Should log warnings but not panic.
 	w.WriteModelEndpoints(ctx)
+}
+
+// integrationCaptureHandler is a minimal slog.Handler for capturing log records
+// in integration tests. NOT using slog.SetDefault — safe for t.Parallel().
+type integrationCaptureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *integrationCaptureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *integrationCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+func (h *integrationCaptureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *integrationCaptureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *integrationCaptureHandler) warnMessages() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out []string
+	for _, r := range h.records {
+		if r.Level == slog.LevelWarn {
+			out = append(out, r.Message)
+		}
+	}
+	return out
+}
+
+// TestWriteSpawnIdentity_DivergentTaskID_Warns_Integration verifies the full
+// wire-level path for gh#276:
+//
+//   - When loop_id is reused under a DIFFERENT task_id (EntityExists + same typed
+//     origin + mismatched agent.loop.task triple), WriteSpawnIdentity returns nil
+//     (keep-first-identity — behavior unchanged) AND emits a structured Warn log.
+//
+//   - When loop_id is reused under the SAME task_id (genuine retry/redelivery),
+//     WriteSpawnIdentity returns nil with NO warning emitted.
+func TestWriteSpawnIdentity_DivergentTaskID_Warns_Integration(t *testing.T) {
+	t.Run("divergent task_id warns and succeeds", func(t *testing.T) {
+		tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
+		ctx := context.Background()
+
+		// create_with_triples returns EntityExists — the loop is already born.
+		responder := &createWithTriplesResponder{alreadyExists: true}
+		responder.subscribe(t, ctx, tc.Client)
+
+		// The read-back returns a same-typed-origin entity but with the FIRST
+		// spawn's task_id ("task-first"), not the incoming "task-second".
+		q := &queryEntityResponder{entity: gtypes.EntityState{
+			ID:          "acme.ops.agent.agentic-loop.execution.loop-reuse",
+			MessageType: agentic.LoopExecutionMessageType(),
+			Triples: []message.Triple{
+				{
+					Subject:   "acme.ops.agent.agentic-loop.execution.loop-reuse",
+					Predicate: agvocab.LoopTask,
+					Object:    "task-first",
+				},
+			},
+		}}
+		q.subscribe(t, ctx, tc.Client)
+
+		h := &integrationCaptureHandler{}
+		logger := slog.New(h)
+
+		w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
+		w.SetLogger(logger)
+
+		// Second spawn: same loop_id, different task_id.
+		task := &agentic.TaskMessage{TaskID: "task-second", Role: "researcher"}
+		if err := w.WriteSpawnIdentity(ctx, "loop-reuse", task); err != nil {
+			t.Errorf("WriteSpawnIdentity must return nil (keep-first-identity), got error: %v", err)
+		}
+
+		warns := h.warnMessages()
+		if len(warns) == 0 {
+			t.Error("expected a Warn log for divergent task_id reuse, got none")
+		} else if warns[0] != "graph_writer: loop_id reuse under divergent task_id; keeping original spawn identity (loop_id is immutable per task)" {
+			t.Errorf("unexpected Warn message: %q", warns[0])
+		}
+	})
+
+	t.Run("same task_id no warning", func(t *testing.T) {
+		tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
+		ctx := context.Background()
+
+		responder := &createWithTriplesResponder{alreadyExists: true}
+		responder.subscribe(t, ctx, tc.Client)
+
+		// Read-back returns the SAME task_id as the incoming spawn.
+		q := &queryEntityResponder{entity: gtypes.EntityState{
+			ID:          "acme.ops.agent.agentic-loop.execution.loop-retry",
+			MessageType: agentic.LoopExecutionMessageType(),
+			Triples: []message.Triple{
+				{
+					Subject:   "acme.ops.agent.agentic-loop.execution.loop-retry",
+					Predicate: agvocab.LoopTask,
+					Object:    "task-same",
+				},
+			},
+		}}
+		q.subscribe(t, ctx, tc.Client)
+
+		h := &integrationCaptureHandler{}
+		logger := slog.New(h)
+
+		w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
+		w.SetLogger(logger)
+
+		task := &agentic.TaskMessage{TaskID: "task-same", Role: "researcher"}
+		if err := w.WriteSpawnIdentity(ctx, "loop-retry", task); err != nil {
+			t.Errorf("WriteSpawnIdentity must return nil on same-task retry, got error: %v", err)
+		}
+
+		if warns := h.warnMessages(); len(warns) > 0 {
+			t.Errorf("expected no Warn log for same task_id retry, got: %v", warns)
+		}
+	})
 }


### PR DESCRIPTION
## What

Re-spawning a loop that reuses an existing `loop_id` under a **different** `task_id` silently kept the first spawn's identity triples. This makes the condition **observable** (a structured warning) and documents the contract — with **no behavior change**.

## Why observe-only (not reject / not identity-rewrite)

`HasActiveLoopForTask` dedupes incoming tasks by `task_id`, so genuine retries/redelivery (same task_id) never reach this path a second time. The only way to arrive here with an existing entity is a producer reusing a `loop_id` it previously assigned to a *different* task — a producer-side contract violation, not a legitimate workflow. So `loop_id` is immutable per task; keep-first-identity is correct. The fix removes the *silence*, not the behavior.

## How

- `graph_writer.go`: `verifyExistingLoopOrigin` gains `incomingTaskID`; after the idempotency match it calls a new pure `divergentTaskID(existing, incomingTaskID)` helper and emits a structured Warn on a real mismatch (both task_ids + loop_id). Identity is **not** rewritten. Godoc rewritten to state the loop_id-immutability contract explicitly.
- Warn is suppressed for same/empty/absent/non-string task_id — no false positives on legit retries.

## Review (pre-merge go-reviewer gate)

**APPROVE-MERGE — no blocking.** Confirmed observe-only (identical terminal outcomes, side-effect-free Warn added between them); warn fires only on genuine mismatch; incoming task_id read from the correct `agent.loop.task` predicate; tests `t.Parallel()` with per-logger capture handlers (no `slog.SetDefault`); integration test drives the real wire path; `-race` + `vet` (±integration) + revive clean.

Closes #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
