### PR TITLE
test(engine): fix TestStopFlow flake (poll for async component-disable)

### DIFF
--- a/engine/engine_integration_test.go
+++ b/engine/engine_integration_test.go
@@ -247,11 +247,16 @@ func (s *EngineIntegrationSuite) TestStopFlow() {
 	s.Require().NoError(err)
 	s.Equal(flowstore.StateDeployedStopped, stopped.RuntimeState, "Flow should be deployed_stopped")
 
-	// Verify components are disabled
-	cfg := s.configMgr.GetConfig()
-	currentConfig := cfg.Get()
-	udpConfig := currentConfig.Components["udp-stop-1"]
-	s.False(udpConfig.Enabled, "Component should be disabled after stop")
+	// Verify components are disabled. engine.Stop() returns once the flow's
+	// RuntimeState is persisted (asserted above), but disabling the component
+	// in the config manager propagates asynchronously — reading GetConfig()
+	// immediately races that propagation and flaked intermittently under CI
+	// load. Poll for the end-state instead; a real "never disabled" bug still
+	// fails (the poll times out) rather than being masked.
+	s.Eventually(func() bool {
+		currentConfig := s.configMgr.GetConfig().Get()
+		return !currentConfig.Components["udp-stop-1"].Enabled
+	}, 5*time.Second, 20*time.Millisecond, "Component should be disabled after stop")
 }
 
 // TestStopNotRunningFlow tests that stopping a non-running flow fails


### PR DESCRIPTION
TestStopFlow read the component Enabled flag immediately after engine.Stop() returned, but disabling the component in the config manager propagates asynchronously (the flow RuntimeState assertion above it is synchronous). Under CI parallel load the read raced the propagation and flaked — failed on the main push for PR #321, passed on that PR run and all prior pushes. Fix: poll for the disabled end-state via s.Eventually (5s budget, 20ms tick) instead of reading once. A never-disabled regression still fails via timeout, so this cannot mask a real bug. Verified locally: suite green x2 (-count=2), TestStopFlow 0.02s/0.01s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)