### PR TITLE
fix(agentic-dispatch)!: bare /activity loop_id + loop_completed event type (BREAKING) (#226)

### DIFF
--- a/processor/agentic-dispatch/http.go
+++ b/processor/agentic-dispatch/http.go
@@ -511,8 +511,11 @@ type ApprovalAcceptResponse struct {
 //   - "loop_updated"   — live loop updated (non-COMPLETE_ key, revision > 1)
 //   - "loop_deleted"   — KV entry deleted
 //   - "loop_completed" — terminal event (COMPLETE_<id> key); LoopID is the bare
-//     loop ID (prefix stripped) so it equals data.loop_id. Terminal-ness is
-//     also derivable from data.state ("complete", "failed", "cancelled").
+//     loop ID (prefix stripped) so it equals data.loop_id. The primary signal for
+//     terminal-ness is event.type == "loop_completed". When present, data.outcome
+//     carries the verdict: "success", "failed", or "cancelled". Note: data.state
+//     is NOT populated on terminal events — production terminal payloads
+//     (LoopCompletedEvent, LoopFailedEvent, LoopCancelledEvent) have no state field.
 type ActivityEvent struct {
 	Type      string    `json:"type"` // loop_created, loop_updated, loop_deleted, loop_completed
 	LoopID    string    `json:"loop_id"`
@@ -974,31 +977,13 @@ func (c *Component) handleActivityStream(w http.ResponseWriter, r *http.Request)
 			// COMPLETE_<loopID> keys carry terminal event payloads; all other
 			// keys carry agentic.LoopEntity live state.
 			//
-			// Derive the bare loop ID and event type before building the
-			// ActivityEvent so the envelope LoopID always matches
-			// data.loop_id. For terminal (COMPLETE_) keys the prefix is
-			// internal KV bookkeeping; callers correlate on bare IDs and
-			// determine terminal-ness via event.Type == "loop_completed"
-			// (or event.Data.State being a terminal value).
+			// activityEventTypeAndID is the single decision point for deriving
+			// the wire event type and bare loop ID so the envelope LoopID always
+			// matches data.loop_id. Terminal-ness is wire-observable from
+			// event.Type == "loop_completed" without inspecting data fields.
 			rawKey := entry.Key()
-			isCompletion := strings.HasPrefix(rawKey, "COMPLETE_")
-
-			// Bare ID: strip the COMPLETE_ prefix for terminal keys so the
-			// envelope loop_id matches data.loop_id.
-			bareLoopID := rawKey
-			if isCompletion {
-				bareLoopID = strings.TrimPrefix(rawKey, "COMPLETE_")
-			}
-
-			// Event type: COMPLETE_ keys always emit "loop_completed",
-			// regardless of KV revision, so terminal-ness is wire-observable
-			// from event.Type without inspecting data.state.
-			var eventType string
-			if isCompletion {
-				eventType = "loop_completed"
-			} else {
-				eventType = c.mapKVOperation(entry.Operation(), entry.Revision())
-			}
+			eventType, bareLoopID := activityEventTypeAndID(rawKey, entry.Operation(), entry.Revision())
+			isCompletion := eventType == "loop_completed"
 
 			// Build activity event
 			event := ActivityEvent{
@@ -1066,6 +1051,32 @@ func (c *Component) mapKVOperation(op jetstream.KeyValueOp, revision uint64) str
 		return "loop_deleted"
 	default:
 		return "unknown"
+	}
+}
+
+// activityEventTypeAndID derives the wire event type and bare loop ID from a
+// raw AGENT_LOOPS KV key, operation, and revision. It is the single source of
+// truth for the isCompletion / bareLoopID / eventType decision that
+// handleActivityStream emits onto the /activity SSE wire.
+//
+// For COMPLETE_<id> keys the prefix is stripped so the returned loopID matches
+// data.loop_id; eventType is always "loop_completed" for those keys.
+// For non-terminal keys, eventType is derived from op/revision via the same
+// mapping as mapKVOperation.
+func activityEventTypeAndID(key string, op jetstream.KeyValueOp, revision uint64) (eventType, loopID string) {
+	if strings.HasPrefix(key, "COMPLETE_") {
+		return "loop_completed", strings.TrimPrefix(key, "COMPLETE_")
+	}
+	switch op {
+	case jetstream.KeyValuePut:
+		if revision == 1 {
+			return "loop_created", key
+		}
+		return "loop_updated", key
+	case jetstream.KeyValueDelete:
+		return "loop_deleted", key
+	default:
+		return "unknown", key
 	}
 }
 
@@ -1321,7 +1332,7 @@ func agenticDispatchOpenAPISpec() *service.OpenAPISpec {
 			"/activity": {
 				GET: &service.OperationSpec{
 					Summary:     "Real-time activity events (SSE)",
-					Description: "Server-Sent Events stream of loop activity. Event types: loop_created, loop_updated, loop_deleted, loop_completed. loop_completed fires when a COMPLETE_<id> KV key is written; the envelope loop_id is the bare id (prefix stripped) matching data.loop_id — use event.type==\"loop_completed\" or data.state to detect terminal entries. Each event's data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.",
+					Description: "Server-Sent Events stream of loop activity. Event types: loop_created, loop_updated, loop_deleted, loop_completed. loop_completed fires when a COMPLETE_<id> KV key is written; the envelope loop_id is the bare id (prefix stripped) matching data.loop_id — use event.type==\"loop_completed\" to detect terminal entries. When type is loop_completed, data.outcome carries the verdict (\"success\", \"failed\", or \"cancelled\"); data.state is NOT populated on terminal events. Each event's data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.",
 					Tags:        []string{"AgenticDispatch"},
 					Responses: map[string]service.ResponseSpec{
 						"200": {

--- a/processor/agentic-dispatch/http.go
+++ b/processor/agentic-dispatch/http.go
@@ -505,8 +505,16 @@ type ApprovalAcceptResponse struct {
 // for the full field set; fields absent from a given source stay empty.
 // (OpenAPI 3.0 cannot express per-event SSE JSON schema — see the Loop and
 // ActivityEvent component schemas for the documented shapes.)
+//
+// Type values:
+//   - "loop_created"   — new live loop entry (non-COMPLETE_ key, revision 1)
+//   - "loop_updated"   — live loop updated (non-COMPLETE_ key, revision > 1)
+//   - "loop_deleted"   — KV entry deleted
+//   - "loop_completed" — terminal event (COMPLETE_<id> key); LoopID is the bare
+//     loop ID (prefix stripped) so it equals data.loop_id. Terminal-ness is
+//     also derivable from data.state ("complete", "failed", "cancelled").
 type ActivityEvent struct {
-	Type      string    `json:"type"` // loop_created, loop_updated, loop_deleted
+	Type      string    `json:"type"` // loop_created, loop_updated, loop_deleted, loop_completed
 	LoopID    string    `json:"loop_id"`
 	Timestamp time.Time `json:"timestamp"`
 	Data      *Loop     `json:"data,omitempty"`
@@ -963,32 +971,56 @@ func (c *Component) handleActivityStream(w http.ResponseWriter, r *http.Request)
 				continue
 			}
 
-			// Determine event type from KV operation
-			eventType := c.mapKVOperation(entry.Operation(), entry.Revision())
+			// COMPLETE_<loopID> keys carry terminal event payloads; all other
+			// keys carry agentic.LoopEntity live state.
+			//
+			// Derive the bare loop ID and event type before building the
+			// ActivityEvent so the envelope LoopID always matches
+			// data.loop_id. For terminal (COMPLETE_) keys the prefix is
+			// internal KV bookkeeping; callers correlate on bare IDs and
+			// determine terminal-ness via event.Type == "loop_completed"
+			// (or event.Data.State being a terminal value).
+			rawKey := entry.Key()
+			isCompletion := strings.HasPrefix(rawKey, "COMPLETE_")
+
+			// Bare ID: strip the COMPLETE_ prefix for terminal keys so the
+			// envelope loop_id matches data.loop_id.
+			bareLoopID := rawKey
+			if isCompletion {
+				bareLoopID = strings.TrimPrefix(rawKey, "COMPLETE_")
+			}
+
+			// Event type: COMPLETE_ keys always emit "loop_completed",
+			// regardless of KV revision, so terminal-ness is wire-observable
+			// from event.Type without inspecting data.state.
+			var eventType string
+			if isCompletion {
+				eventType = "loop_completed"
+			} else {
+				eventType = c.mapKVOperation(entry.Operation(), entry.Revision())
+			}
 
 			// Build activity event
 			event := ActivityEvent{
 				Type:      eventType,
-				LoopID:    entry.Key(),
+				LoopID:    bareLoopID,
 				Timestamp: entry.Created(),
 			}
 
 			// Project non-delete entries onto the canonical Loop wire type.
-			// COMPLETE_<loopID> keys carry terminal event payloads; all other
-			// keys carry agentic.LoopEntity live state.
 			if entry.Operation() != jetstream.KeyValueDelete {
 				var loop Loop
 				var ok bool
-				if strings.HasPrefix(entry.Key(), "COMPLETE_") {
+				if isCompletion {
 					if loop, ok = loopFromCompletion(entry.Value()); !ok {
 						c.logger.DebugContext(ctx, "activity stream: dropping undecodable completion payload",
-							slog.String("key", entry.Key()))
+							slog.String("key", rawKey))
 					}
 				} else {
 					var e agentic.LoopEntity
 					if err := json.Unmarshal(entry.Value(), &e); err != nil {
 						c.logger.DebugContext(ctx, "activity stream: dropping undecodable loop entity",
-							slog.String("key", entry.Key()),
+							slog.String("key", rawKey),
 							slog.String("error", err.Error()))
 					} else {
 						loop, ok = loopFromEntity(&e, c.deps.Platform.Org, c.deps.Platform.Platform), true
@@ -1004,7 +1036,7 @@ func (c *Component) handleActivityStream(w http.ResponseWriter, r *http.Request)
 			if err != nil {
 				c.logger.ErrorContext(ctx, "failed to marshal activity event",
 					slog.String("client_id", clientID),
-					slog.String("loop_id", entry.Key()),
+					slog.String("loop_id", bareLoopID),
 					slog.String("error", err.Error()))
 				c.metrics.recordSSEError("marshal_event")
 				continue
@@ -1016,7 +1048,7 @@ func (c *Component) handleActivityStream(w http.ResponseWriter, r *http.Request)
 
 			c.logger.DebugContext(ctx, "sent activity event",
 				slog.String("client_id", clientID),
-				slog.String("loop_id", entry.Key()),
+				slog.String("loop_id", bareLoopID),
 				slog.String("event_type", eventType))
 		}
 	}
@@ -1289,7 +1321,7 @@ func agenticDispatchOpenAPISpec() *service.OpenAPISpec {
 			"/activity": {
 				GET: &service.OperationSpec{
 					Summary:     "Real-time activity events (SSE)",
-					Description: "Server-Sent Events stream of loop activity. Events include loop_created, loop_updated, loop_deleted. Each event's data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.",
+					Description: "Server-Sent Events stream of loop activity. Event types: loop_created, loop_updated, loop_deleted, loop_completed. loop_completed fires when a COMPLETE_<id> KV key is written; the envelope loop_id is the bare id (prefix stripped) matching data.loop_id — use event.type==\"loop_completed\" or data.state to detect terminal entries. Each event's data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.",
 					Tags:        []string{"AgenticDispatch"},
 					Responses: map[string]service.ResponseSpec{
 						"200": {

--- a/processor/agentic-dispatch/http_loops_test.go
+++ b/processor/agentic-dispatch/http_loops_test.go
@@ -352,6 +352,130 @@ func TestActivityEventSerialization(t *testing.T) {
 	assert.Equal(t, "pending", decoded.Data.State)
 }
 
+// TestActivityEventLoopIDCorrelation verifies that for a COMPLETE_<id>-keyed
+// terminal entry the ActivityEvent envelope loop_id equals data.loop_id (no
+// COMPLETE_ prefix leak), and that terminal-ness is signalled by event.Type
+// rather than requiring callers to inspect the raw KV key or data.state.
+//
+// This is a regression test for gh#226: previously LoopID was set from
+// entry.Key() so terminal events carried "COMPLETE_<id>" in the envelope
+// while data.loop_id held the bare "<id>".
+func TestActivityEventLoopIDCorrelation(t *testing.T) {
+	const bareID = "loop_abc123"
+
+	// Simulate the COMPLETE_<loopID> payload written by agentic-loop on
+	// terminal outcomes.  loopFromCompletion unmarshals via completionWire
+	// which reads the "loop_id" JSON field — this is the bare ID already.
+	completionPayload := []byte(`{
+		"loop_id":"` + bareID + `",
+		"task_id":"task-1",
+		"role":"researcher",
+		"state":"complete",
+		"outcome":"success",
+		"result":"42",
+		"iterations":3,
+		"tokens_in":100,
+		"tokens_out":200
+	}`)
+
+	t.Run("loopFromCompletion returns bare loop_id", func(t *testing.T) {
+		loop, ok := loopFromCompletion(completionPayload)
+		require.True(t, ok, "expected loopFromCompletion to succeed")
+		// data.loop_id must be the bare ID, not COMPLETE_<id>
+		assert.Equal(t, bareID, loop.LoopID)
+		assert.Equal(t, "complete", loop.State)
+		assert.Equal(t, "success", loop.Outcome)
+	})
+
+	t.Run("ActivityEvent envelope loop_id matches data.loop_id for COMPLETE_ key", func(t *testing.T) {
+		// Replicate the exact logic in handleActivityStream so we lock the
+		// fix and catch any future regression without requiring a live NATS
+		// client.
+		rawKey := "COMPLETE_" + bareID
+		isCompletion := strings.HasPrefix(rawKey, "COMPLETE_")
+		require.True(t, isCompletion)
+
+		bareLoopID := rawKey
+		if isCompletion {
+			bareLoopID = strings.TrimPrefix(rawKey, "COMPLETE_")
+		}
+
+		var eventType string
+		if isCompletion {
+			eventType = "loop_completed"
+		} else {
+			comp := newTestComponent(t)
+			eventType = comp.mapKVOperation(jetstream.KeyValuePut, 1)
+		}
+
+		loop, ok := loopFromCompletion(completionPayload)
+		require.True(t, ok)
+
+		event := ActivityEvent{
+			Type:      eventType,
+			LoopID:    bareLoopID,
+			Timestamp: time.Now(),
+			Data:      &loop,
+		}
+
+		// Core assertion: envelope loop_id == data.loop_id (no COMPLETE_ prefix).
+		assert.Equal(t, event.Data.LoopID, event.LoopID,
+			"envelope loop_id must equal data.loop_id so consumers can correlate")
+		assert.Equal(t, bareID, event.LoopID,
+			"envelope loop_id must be the bare ID without COMPLETE_ prefix")
+
+		// Terminal-ness is signalled by event.Type, not the raw KV key.
+		assert.Equal(t, "loop_completed", event.Type,
+			"COMPLETE_ key must emit loop_completed so terminal-ness is wire-observable from event.Type")
+
+		// data.state also independently confirms terminal-ness.
+		assert.Equal(t, "complete", event.Data.State,
+			"data.state must reflect the terminal outcome from the completion payload")
+	})
+
+	t.Run("non-terminal key preserves existing type mapping", func(t *testing.T) {
+		rawKey := bareID // no COMPLETE_ prefix
+		isCompletion := strings.HasPrefix(rawKey, "COMPLETE_")
+		require.False(t, isCompletion)
+
+		bareLoopID := rawKey
+		comp := newTestComponent(t)
+
+		assert.Equal(t, bareID, bareLoopID, "bare ID is unchanged for non-terminal keys")
+		assert.Equal(t, "loop_created", comp.mapKVOperation(jetstream.KeyValuePut, 1),
+			"revision 1 maps to loop_created for non-terminal keys")
+		assert.Equal(t, "loop_updated", comp.mapKVOperation(jetstream.KeyValuePut, 5),
+			"revision > 1 maps to loop_updated for non-terminal keys")
+	})
+
+	t.Run("ActivityEvent round-trips through JSON with bare loop_id", func(t *testing.T) {
+		loop, ok := loopFromCompletion(completionPayload)
+		require.True(t, ok)
+
+		event := ActivityEvent{
+			Type:      "loop_completed",
+			LoopID:    bareID,
+			Timestamp: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+			Data:      &loop,
+		}
+
+		data, err := json.Marshal(event)
+		require.NoError(t, err)
+
+		var decoded ActivityEvent
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+
+		assert.Equal(t, "loop_completed", decoded.Type)
+		assert.Equal(t, bareID, decoded.LoopID)
+		require.NotNil(t, decoded.Data)
+		assert.Equal(t, bareID, decoded.Data.LoopID,
+			"data.loop_id must survive JSON round-trip as bare ID")
+		assert.Equal(t, decoded.LoopID, decoded.Data.LoopID,
+			"envelope loop_id must equal data.loop_id after JSON round-trip")
+	})
+}
+
 func TestSignalResponseSerialization(t *testing.T) {
 	resp := SignalResponse{
 		LoopID:    "loop-123",

--- a/processor/agentic-dispatch/http_loops_test.go
+++ b/processor/agentic-dispatch/http_loops_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/c360studio/semstreams/agentic"
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -352,110 +353,211 @@ func TestActivityEventSerialization(t *testing.T) {
 	assert.Equal(t, "pending", decoded.Data.State)
 }
 
+// TestActivityEventTypeAndID table-tests the activityEventTypeAndID pure
+// function — the single decision point for the isCompletion / bareLoopID /
+// eventType triple that handleActivityStream emits onto the /activity wire.
+// Locking the function prevents handler refactors from silently regressing
+// the correlation without a failing test.
+func TestActivityEventTypeAndID(t *testing.T) {
+	const bare = "loop_abc123"
+
+	cases := []struct {
+		name       string
+		key        string
+		op         jetstream.KeyValueOp
+		revision   uint64
+		wantType   string
+		wantLoopID string
+	}{
+		{
+			name:       "COMPLETE_ key always emits loop_completed with bare id",
+			key:        "COMPLETE_" + bare,
+			op:         jetstream.KeyValuePut,
+			revision:   1,
+			wantType:   "loop_completed",
+			wantLoopID: bare,
+		},
+		{
+			name:       "COMPLETE_ key revision > 1 still emits loop_completed",
+			key:        "COMPLETE_" + bare,
+			op:         jetstream.KeyValuePut,
+			revision:   5,
+			wantType:   "loop_completed",
+			wantLoopID: bare,
+		},
+		{
+			name:       "non-terminal put revision 1 emits loop_created",
+			key:        bare,
+			op:         jetstream.KeyValuePut,
+			revision:   1,
+			wantType:   "loop_created",
+			wantLoopID: bare,
+		},
+		{
+			name:       "non-terminal put revision > 1 emits loop_updated",
+			key:        bare,
+			op:         jetstream.KeyValuePut,
+			revision:   7,
+			wantType:   "loop_updated",
+			wantLoopID: bare,
+		},
+		{
+			name:       "non-terminal delete emits loop_deleted",
+			key:        bare,
+			op:         jetstream.KeyValueDelete,
+			revision:   3,
+			wantType:   "loop_deleted",
+			wantLoopID: bare,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotType, gotLoopID := activityEventTypeAndID(tc.key, tc.op, tc.revision)
+			assert.Equal(t, tc.wantType, gotType, "event type")
+			assert.Equal(t, tc.wantLoopID, gotLoopID, "bare loop ID")
+		})
+	}
+}
+
 // TestActivityEventLoopIDCorrelation verifies that for a COMPLETE_<id>-keyed
 // terminal entry the ActivityEvent envelope loop_id equals data.loop_id (no
-// COMPLETE_ prefix leak), and that terminal-ness is signalled by event.Type
-// rather than requiring callers to inspect the raw KV key or data.state.
+// COMPLETE_ prefix leak), and that terminal-ness is signalled by event.Type.
+// Tests drive the PRODUCTION decoder (loopFromCompletion) against real
+// agentic event types — not synthetic JSON shapes — to lock the wire contract.
 //
 // This is a regression test for gh#226: previously LoopID was set from
 // entry.Key() so terminal events carried "COMPLETE_<id>" in the envelope
 // while data.loop_id held the bare "<id>".
 func TestActivityEventLoopIDCorrelation(t *testing.T) {
 	const bareID = "loop_abc123"
+	const taskID = "task-1"
+	ts := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
 
-	// Simulate the COMPLETE_<loopID> payload written by agentic-loop on
-	// terminal outcomes.  loopFromCompletion unmarshals via completionWire
-	// which reads the "loop_id" JSON field — this is the bare ID already.
-	completionPayload := []byte(`{
-		"loop_id":"` + bareID + `",
-		"task_id":"task-1",
-		"role":"researcher",
-		"state":"complete",
-		"outcome":"success",
-		"result":"42",
-		"iterations":3,
-		"tokens_in":100,
-		"tokens_out":200
-	}`)
+	// marshalEvent marshals a real agentic terminal event via its own
+	// MarshalJSON method — this is the payload agentic-loop actually writes
+	// to the COMPLETE_<id> KV key.
+	marshalCompleted := func(t *testing.T) []byte {
+		t.Helper()
+		ev := &agentic.LoopCompletedEvent{
+			LoopID:      bareID,
+			TaskID:      taskID,
+			Role:        "researcher",
+			Outcome:     agentic.OutcomeSuccess,
+			Result:      "42",
+			Iterations:  3,
+			TokensIn:    100,
+			TokensOut:   200,
+			CompletedAt: ts,
+		}
+		b, err := json.Marshal(ev)
+		require.NoError(t, err)
+		return b
+	}
 
-	t.Run("loopFromCompletion returns bare loop_id", func(t *testing.T) {
-		loop, ok := loopFromCompletion(completionPayload)
-		require.True(t, ok, "expected loopFromCompletion to succeed")
-		// data.loop_id must be the bare ID, not COMPLETE_<id>
+	marshalFailed := func(t *testing.T) []byte {
+		t.Helper()
+		ev := &agentic.LoopFailedEvent{
+			LoopID:     bareID,
+			TaskID:     taskID,
+			Role:       "researcher",
+			Outcome:    agentic.OutcomeFailed,
+			Reason:     "tool_error",
+			Error:      "dial timeout",
+			Iterations: 2,
+			FailedAt:   ts,
+		}
+		b, err := json.Marshal(ev)
+		require.NoError(t, err)
+		return b
+	}
+
+	marshalCancelled := func(t *testing.T) []byte {
+		t.Helper()
+		ev := &agentic.LoopCancelledEvent{
+			LoopID:      bareID,
+			TaskID:      taskID,
+			Outcome:     agentic.OutcomeCancelled,
+			CancelledBy: "user",
+			CancelledAt: ts,
+		}
+		b, err := json.Marshal(ev)
+		require.NoError(t, err)
+		return b
+	}
+
+	t.Run("LoopCompletedEvent: loopFromCompletion decodes outcome, no state", func(t *testing.T) {
+		payload := marshalCompleted(t)
+		loop, ok := loopFromCompletion(payload)
+		require.True(t, ok, "loopFromCompletion must succeed on a real LoopCompletedEvent")
 		assert.Equal(t, bareID, loop.LoopID)
-		assert.Equal(t, "complete", loop.State)
-		assert.Equal(t, "success", loop.Outcome)
+		// outcome must carry the verdict
+		assert.Equal(t, agentic.OutcomeSuccess, loop.Outcome)
+		// state is NOT populated by production terminal events — the field is absent
+		// from LoopCompletedEvent/LoopFailedEvent/LoopCancelledEvent.
+		assert.Empty(t, loop.State,
+			"data.state must be empty for production terminal events (no state field on the event type)")
 	})
 
-	t.Run("ActivityEvent envelope loop_id matches data.loop_id for COMPLETE_ key", func(t *testing.T) {
-		// Replicate the exact logic in handleActivityStream so we lock the
-		// fix and catch any future regression without requiring a live NATS
-		// client.
+	t.Run("LoopFailedEvent: loopFromCompletion decodes outcome, no state", func(t *testing.T) {
+		payload := marshalFailed(t)
+		loop, ok := loopFromCompletion(payload)
+		require.True(t, ok)
+		assert.Equal(t, bareID, loop.LoopID)
+		assert.Equal(t, agentic.OutcomeFailed, loop.Outcome)
+		assert.Empty(t, loop.State)
+	})
+
+	t.Run("LoopCancelledEvent: loopFromCompletion decodes outcome, no state", func(t *testing.T) {
+		payload := marshalCancelled(t)
+		loop, ok := loopFromCompletion(payload)
+		require.True(t, ok)
+		assert.Equal(t, bareID, loop.LoopID)
+		assert.Equal(t, agentic.OutcomeCancelled, loop.Outcome)
+		assert.Empty(t, loop.State)
+	})
+
+	t.Run("COMPLETE_ key: envelope loop_id == data.loop_id, type == loop_completed", func(t *testing.T) {
+		payload := marshalCompleted(t)
 		rawKey := "COMPLETE_" + bareID
-		isCompletion := strings.HasPrefix(rawKey, "COMPLETE_")
-		require.True(t, isCompletion)
 
-		bareLoopID := rawKey
-		if isCompletion {
-			bareLoopID = strings.TrimPrefix(rawKey, "COMPLETE_")
-		}
+		// Drive through the production function, not a reimplementation.
+		eventType, bareLoopID := activityEventTypeAndID(rawKey, jetstream.KeyValuePut, 1)
+		assert.Equal(t, "loop_completed", eventType)
+		assert.Equal(t, bareID, bareLoopID)
 
-		var eventType string
-		if isCompletion {
-			eventType = "loop_completed"
-		} else {
-			comp := newTestComponent(t)
-			eventType = comp.mapKVOperation(jetstream.KeyValuePut, 1)
-		}
-
-		loop, ok := loopFromCompletion(completionPayload)
+		loop, ok := loopFromCompletion(payload)
 		require.True(t, ok)
 
 		event := ActivityEvent{
 			Type:      eventType,
 			LoopID:    bareLoopID,
-			Timestamp: time.Now(),
+			Timestamp: ts,
 			Data:      &loop,
 		}
 
-		// Core assertion: envelope loop_id == data.loop_id (no COMPLETE_ prefix).
 		assert.Equal(t, event.Data.LoopID, event.LoopID,
 			"envelope loop_id must equal data.loop_id so consumers can correlate")
 		assert.Equal(t, bareID, event.LoopID,
 			"envelope loop_id must be the bare ID without COMPLETE_ prefix")
-
-		// Terminal-ness is signalled by event.Type, not the raw KV key.
 		assert.Equal(t, "loop_completed", event.Type,
 			"COMPLETE_ key must emit loop_completed so terminal-ness is wire-observable from event.Type")
-
-		// data.state also independently confirms terminal-ness.
-		assert.Equal(t, "complete", event.Data.State,
-			"data.state must reflect the terminal outcome from the completion payload")
+		// data.outcome carries the verdict; data.state is absent on real terminal events.
+		assert.Equal(t, agentic.OutcomeSuccess, event.Data.Outcome,
+			"data.outcome must carry the terminal verdict")
+		assert.Empty(t, event.Data.State,
+			"data.state must be empty — production terminal events have no state field")
 	})
 
-	t.Run("non-terminal key preserves existing type mapping", func(t *testing.T) {
-		rawKey := bareID // no COMPLETE_ prefix
-		isCompletion := strings.HasPrefix(rawKey, "COMPLETE_")
-		require.False(t, isCompletion)
-
-		bareLoopID := rawKey
-		comp := newTestComponent(t)
-
-		assert.Equal(t, bareID, bareLoopID, "bare ID is unchanged for non-terminal keys")
-		assert.Equal(t, "loop_created", comp.mapKVOperation(jetstream.KeyValuePut, 1),
-			"revision 1 maps to loop_created for non-terminal keys")
-		assert.Equal(t, "loop_updated", comp.mapKVOperation(jetstream.KeyValuePut, 5),
-			"revision > 1 maps to loop_updated for non-terminal keys")
-	})
-
-	t.Run("ActivityEvent round-trips through JSON with bare loop_id", func(t *testing.T) {
-		loop, ok := loopFromCompletion(completionPayload)
+	t.Run("ActivityEvent round-trips through JSON with bare loop_id and outcome", func(t *testing.T) {
+		payload := marshalCompleted(t)
+		loop, ok := loopFromCompletion(payload)
 		require.True(t, ok)
 
 		event := ActivityEvent{
 			Type:      "loop_completed",
 			LoopID:    bareID,
-			Timestamp: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+			Timestamp: ts,
 			Data:      &loop,
 		}
 
@@ -473,6 +575,10 @@ func TestActivityEventLoopIDCorrelation(t *testing.T) {
 			"data.loop_id must survive JSON round-trip as bare ID")
 		assert.Equal(t, decoded.LoopID, decoded.Data.LoopID,
 			"envelope loop_id must equal data.loop_id after JSON round-trip")
+		assert.Equal(t, agentic.OutcomeSuccess, decoded.Data.Outcome,
+			"data.outcome must survive JSON round-trip")
+		assert.Empty(t, decoded.Data.State,
+			"data.state must remain empty after JSON round-trip")
 	})
 }
 

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -16,7 +16,7 @@ paths:
     /activity:
         get:
             summary: Real-time activity events (SSE)
-            description: 'Server-Sent Events stream of loop activity. Events include loop_created, loop_updated, loop_deleted. Each event''s data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.'
+            description: 'Server-Sent Events stream of loop activity. Event types: loop_created, loop_updated, loop_deleted, loop_completed. loop_completed fires when a COMPLETE_<id> KV key is written; the envelope loop_id is the bare id (prefix stripped) matching data.loop_id — use event.type=="loop_completed" or data.state to detect terminal entries. Each event''s data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.'
             tags:
                 - AgenticDispatch
             responses:

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -16,7 +16,7 @@ paths:
     /activity:
         get:
             summary: Real-time activity events (SSE)
-            description: 'Server-Sent Events stream of loop activity. Event types: loop_created, loop_updated, loop_deleted, loop_completed. loop_completed fires when a COMPLETE_<id> KV key is written; the envelope loop_id is the bare id (prefix stripped) matching data.loop_id — use event.type=="loop_completed" or data.state to detect terminal entries. Each event''s data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.'
+            description: 'Server-Sent Events stream of loop activity. Event types: loop_created, loop_updated, loop_deleted, loop_completed. loop_completed fires when a COMPLETE_<id> KV key is written; the envelope loop_id is the bare id (prefix stripped) matching data.loop_id — use event.type=="loop_completed" to detect terminal entries. When type is loop_completed, data.outcome carries the verdict ("success", "failed", or "cancelled"); data.state is NOT populated on terminal events. Each event''s data field is an ActivityEvent whose data field is a Loop (see #/components/schemas/Loop and #/components/schemas/ActivityEvent). Connect with EventSource or curl -N. Note: OpenAPI 3.0 cannot express per-event SSE JSON schema; consult the ActivityEvent and Loop component schemas.'
             tags:
                 - AgenticDispatch
             responses:


### PR DESCRIPTION
## What

Fixes the `/activity` SSE event stream so the envelope `loop_id` correlates with `data.loop_id`. Previously, terminal entries arrived with envelope `loop_id = "COMPLETE_<id>"` while `data.loop_id` was bare — observers couldn't correlate them.

## ⚠️ BREAKING — `/activity` wire-contract change

- **Envelope `loop_id` is now bare** (the `COMPLETE_` prefix is stripped) so it matches `data.loop_id`.
- **New event type `loop_completed`** is emitted for terminal entries (terminal-ness was previously NOT observable via `.Type` — `mapKVOperation` returned `loop_created`/`loop_updated` even for terminal keys, so the prefix was the only signal).
- **Terminal verdict is in `data.outcome`** (`success`/`failed`/`cancelled`), NOT `data.state` (which is empty on terminal events — the prior doc/spec guidance was wrong and is corrected here).

### Affected consumers (coordination required)

- **semteams** (confirmed): `ui/src/lib/types/agent.ts` — `normalizeWireLoop` (`:127`) drops `COMPLETE_` envelopes and `extractCompletionPatch` (`:162-163`) slices the prefix. Both must retarget to `event.type == "loop_completed"`; the generated API types (`api.generated.ts`) need regeneration to include `loop_completed`. A coordination issue is filed in semteams.
- **semconnect / cs-api**: verified NOT affected (grep clean — no `/activity` consumption).

Per the greenfield/cross-product policy (pre-1.0, we own every consumer): taking the break now with a coordinated flip, no compat shim.

## Review & gates

- go-reviewer: **APPROVE-MERGE** (re-review confirmed all 3 prior BLOCKING items fixed — `data.outcome` guidance, real `LoopCompletedEvent`/`LoopFailedEvent`/`LoopCancelledEvent` round-trip test through the production decoder, extracted pure `activityEventTypeAndID` the handler calls).
- **`task e2e:agentic` green** (BREAKING hard-rule gate): scenario completed successfully, `loops_completed:2`, all `verify-*` steps clean.
- Zero OpenAPI schema drift; `-race` tests green; rebased on current main.

## Follow-up

- #323 — `mapKVOperation` is now dead-in-production + duplicated by `activityEventTypeAndID` (DRY cleanup, non-blocking).

Closes #226.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
