### PR TITLE
test(agentic-loop): sync tool.result after dispatch in approval timeout test (fix flake)

### DIFF
--- a/processor/agentic-loop/approval_integration_test.go
+++ b/processor/agentic-loop/approval_integration_test.go
@@ -337,6 +337,33 @@ func TestIntegration_ApprovalTimeoutSweeper_PublishesWireResponse(t *testing.T) 
 	})
 	require.NoError(t, err)
 
+	// Subscribe to tool dispatches so we can synchronise before sending
+	// the tool.result. Without this gate, tool.result arrives on its own
+	// JetStream consumer concurrently with the agent.response consumer;
+	// under CI load the result can be processed before the loop has
+	// registered the tool call (TrackToolCall), causing the component to
+	// log "No loop found for tool call" and drop the result — the loop
+	// never reaches awaiting_approval and the sweeper has nothing to fire.
+	var dispatchedCall bool
+	var dispatchMu sync.Mutex
+	_, err = natsClient.Subscribe(ctx, "tool.execute.>", func(_ context.Context, msg *nats.Msg) {
+		baseMsg, decErr := dec.Decode(msg.Data)
+		if decErr != nil {
+			return
+		}
+		call, ok := baseMsg.Payload().(*agentic.ToolCall)
+		if !ok {
+			return
+		}
+		if call.ID != callID {
+			return
+		}
+		dispatchMu.Lock()
+		dispatchedCall = true
+		dispatchMu.Unlock()
+	})
+	require.NoError(t, err)
+
 	// Subscribe to agent.approval_response.* to capture wire publishes.
 	approvalRespCh := make(chan *agentic.ApprovalResponse, 4)
 	_, err = natsClient.Subscribe(ctx, "agent.approval_response.>", func(_ context.Context, msg *nats.Msg) {
@@ -390,6 +417,19 @@ func TestIntegration_ApprovalTimeoutSweeper_PublishesWireResponse(t *testing.T) 
 		},
 	}
 	publishResponseMessage(t, natsClient, "agent.response."+reqID, resp)
+
+	// Wait for the loop to dispatch the tool call before publishing the
+	// tool result. The loop registers the call-to-loop routing table entry
+	// (TrackToolCall) before emitting tool.execute; without this gate the
+	// tool.result can arrive on a parallel JetStream consumer before
+	// registration completes, yielding "No loop found for tool call" and
+	// a dropped result that prevents the loop from ever entering
+	// awaiting_approval.
+	require.Eventually(t, func() bool {
+		dispatchMu.Lock()
+		defer dispatchMu.Unlock()
+		return dispatchedCall
+	}, 5*time.Second, 50*time.Millisecond, "loop should dispatch tool call to tool.execute before tool.result is sent")
 
 	// Step 3: simulate agentic-tools approval filter rejecting the call.
 	gateResult := &agentic.ToolResult{


### PR DESCRIPTION
## What

Fixes a setup race in `TestIntegration_ApprovalTimeoutSweeper_PublishesWireResponse` (added in #266) that timed out at 30s intermittently under CI load — it failed on PR #324's run (passed on the post-merge main run; confirmed intermittent).

## Root cause

The loop consumes `agent.response.>` and `tool.result.>` on **separate JetStream consumers** (concurrent goroutines). The test published the model response (step 2) and the `tool.result` (step 3) with **no synchronization between them**. Under load the `tool.result` was processed before the response consumer reached `dispatchToolCall` → `TrackToolCall(callID, loopID)`, so `findLoopIDForToolCall` returned empty → `WARN No loop found for tool call` → the result was dropped → the loop never reached `awaiting_approval` → the sweeper never fired → 30s timeout. (Bumping the timeout would not help: the loop never reaches the required state.)

## Fix

Subscribe to `tool.execute.>` and `require.Eventually`-wait for the dispatch of `callID` before publishing `tool.result.*`. The component publishes `tool.execute.<tool>` only *after* `TrackToolCall` completes, so observing it is a strict happens-before guarantee that the call is registered. This mirrors `TestIntegration_ApprovalFlow_Approve`, which already had this exact synchronization (and therefore passed while the sweeper test flaked).

## Verification

`go test -race -tags=integration -run TestIntegration_Approval ./processor/agentic-loop/ -count=20` → **20/20 pass**; `"No loop found for tool call"` appears **0 times** across all 20 runs.

Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
