### PR TITLE
fix: classify write-path Request callers via RequestWithRetryClassified (gh#93 step 3 / ADR-060)

### DIFF
--- a/agentic/agentrun/nats_reader.go
+++ b/agentic/agentrun/nats_reader.go
@@ -58,7 +58,10 @@ func (p *NATSTriplePublisher) AddTriple(ctx context.Context, _ string, triple me
 	if err != nil {
 		return 0, fmt.Errorf("agentrun: NATSTriplePublisher: marshal: %w", err)
 	}
-	respData, err := p.client.RequestWithRetry(ctx, natsTripleAddSubject, reqData, natsTripleMutationTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: RequestWithRetryClassified surfaces handler errors
+	// (legacy "error: " body prefix) as err rather than silently
+	// mis-decoding them as success JSON. Migration from RequestWithRetry.
+	respData, err := p.client.RequestWithRetryClassified(ctx, natsTripleAddSubject, reqData, natsTripleMutationTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return 0, fmt.Errorf("agentrun: NATSTriplePublisher: NATS request: %w", err)
 	}

--- a/graph/inference/applier.go
+++ b/graph/inference/applier.go
@@ -262,12 +262,14 @@ func (a *MutationRelationshipApplier) ApplyRelationship(
 			"failed to serialize request")
 	}
 
-	// RequestWithRetry handles transient "no responders" errors when
+	// RequestWithRetryClassified handles transient "no responders" errors when
 	// graph-gateway is restarting or its subscription hasn't yet
 	// propagated. Inference-emitted triples are idempotent on the
 	// responder side (same triple twice = same graph state), so
 	// retry is safe and avoids silently dropping inferred edges.
-	resp, err := a.natsClient.RequestWithRetry(ctx, "graph.mutation.triple.add", data, 5*time.Second, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err
+	// rather than silently mis-decoding legacy "error: " body as success JSON.
+	resp, err := a.natsClient.RequestWithRetryClassified(ctx, "graph.mutation.triple.add", data, 5*time.Second, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return errs.WrapTransient(err, "MutationRelationshipApplier", "ApplyRelationship",
 			fmt.Sprintf("mutation request failed: %s -> %s -> %s",

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -97,7 +97,7 @@ func (w *graphWriter) writeTriple(ctx context.Context, triple message.Triple) er
 		return fmt.Errorf("marshal request: %w", err)
 	}
 
-	// RequestWithRetry handles transient "no responders" errors that
+	// RequestWithRetryClassified handles transient "no responders" errors that
 	// happen when graph-gateway is restarting or the subscription
 	// hasn't propagated to the NATS server yet. Without retry, a
 	// single trajectory step on the boundary of a gateway restart
@@ -105,7 +105,8 @@ func (w *graphWriter) writeTriple(ctx context.Context, triple message.Triple) er
 	// TestWriteTrajectorySteps_NoContentStore_StillWritesTriples
 	// when -race + many test containers in flight delay subscription
 	// readiness past the per-request timeout.
-	respData, err := w.natsClient.RequestWithRetry(ctx, graphMutationSubject, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := w.natsClient.RequestWithRetryClassified(ctx, graphMutationSubject, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("NATS request failed: %w", err)
 	}
@@ -137,7 +138,8 @@ func (w *graphWriter) writeBatch(ctx context.Context, triples []message.Triple) 
 		return fmt.Errorf("marshal batch request: %w", err)
 	}
 
-	respData, err := w.natsClient.RequestWithRetry(ctx, graphMutationBatchSubject, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := w.natsClient.RequestWithRetryClassified(ctx, graphMutationBatchSubject, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("NATS batch request failed: %w", err)
 	}
@@ -180,7 +182,8 @@ func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtype
 		return fmt.Errorf("marshal create_with_triples request: %w", err)
 	}
 
-	respData, err := w.natsClient.RequestWithRetry(ctx, graphMutationCreateWithTriplesSubj, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := w.natsClient.RequestWithRetryClassified(ctx, graphMutationCreateWithTriplesSubj, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("NATS create_with_triples request failed: %w", err)
 	}

--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -688,13 +688,14 @@ func (p *natsTriplePublisher) AddTriple(ctx context.Context, triple message.Trip
 	if err != nil {
 		return fmt.Errorf("marshal add-triple request: %w", err)
 	}
-	// RequestWithRetry handles transient "no responders" errors when
+	// RequestWithRetryClassified handles transient "no responders" errors when
 	// graph-gateway is restarting or its subscription hasn't yet
 	// propagated. The decide tool's terminal action is the triple
 	// downstream rules trigger on — silent failure here breaks the
 	// coordinator pattern's workflow. Idempotent (graph is a set of
 	// triples), so retry is safe.
-	respData, err := p.client.RequestWithRetry(ctx, decideMutationSubject, reqData, decideMutationTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := p.client.RequestWithRetryClassified(ctx, decideMutationSubject, reqData, decideMutationTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("request %s: %w", decideMutationSubject, err)
 	}
@@ -725,7 +726,8 @@ func (p *natsTriplePublisher) AddTriplesBatch(ctx context.Context, triples []mes
 	if err != nil {
 		return fmt.Errorf("marshal batch-add request: %w", err)
 	}
-	respData, err := p.client.RequestWithRetry(ctx, natsTriplesBatchSubject, reqData, natsTriplesBatchTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := p.client.RequestWithRetryClassified(ctx, natsTriplesBatchSubject, reqData, natsTriplesBatchTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("request %s: %w", natsTriplesBatchSubject, err)
 	}

--- a/processor/agentic-tools/write_todos.go
+++ b/processor/agentic-tools/write_todos.go
@@ -417,7 +417,8 @@ func (w *natsTodoWriter) RemoveByPredicate(ctx context.Context, subject, predica
 	if err != nil {
 		return fmt.Errorf("marshal remove-triple request: %w", err)
 	}
-	respData, err := w.client.RequestWithRetry(ctx, writeTodosRemoveSubject, reqData, writeTodosTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := w.client.RequestWithRetryClassified(ctx, writeTodosRemoveSubject, reqData, writeTodosTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("request %s: %w", writeTodosRemoveSubject, err)
 	}
@@ -442,7 +443,8 @@ func (w *natsTodoWriter) AddTriplesBatch(ctx context.Context, triples []message.
 	if err != nil {
 		return fmt.Errorf("marshal batch-add request: %w", err)
 	}
-	respData, err := w.client.RequestWithRetry(ctx, writeTodosBatchSubject, reqData, writeTodosTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := w.client.RequestWithRetryClassified(ctx, writeTodosBatchSubject, reqData, writeTodosTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("request %s: %w", writeTodosBatchSubject, err)
 	}

--- a/processor/research-graph-llmwrap/triplepub.go
+++ b/processor/research-graph-llmwrap/triplepub.go
@@ -78,7 +78,8 @@ func (p *natsTriplePublisher) AddTriple(ctx context.Context, triple message.Trip
 	if err != nil {
 		return fmt.Errorf("marshal add-triple request: %w", err)
 	}
-	respData, err := p.client.RequestWithRetry(ctx, graphMutationAddSubject, reqData, graphMutationTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := p.client.RequestWithRetryClassified(ctx, graphMutationAddSubject, reqData, graphMutationTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("request %s: %w", graphMutationAddSubject, err)
 	}
@@ -101,7 +102,8 @@ func (p *natsTriplePublisher) AddTriplesBatch(ctx context.Context, triples []mes
 	if err != nil {
 		return fmt.Errorf("marshal batch-add request: %w", err)
 	}
-	respData, err := p.client.RequestWithRetry(ctx, graphMutationAddBatchSubject, reqData, graphMutationTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := p.client.RequestWithRetryClassified(ctx, graphMutationAddBatchSubject, reqData, graphMutationTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return fmt.Errorf("request %s: %w", graphMutationAddBatchSubject, err)
 	}

--- a/processor/rule/triple_mutator.go
+++ b/processor/rule/triple_mutator.go
@@ -63,13 +63,14 @@ func (m *tripleMutator) AddTriple(ctx context.Context, ruleID string, triple mes
 		return 0, fmt.Errorf("marshal request: %w", err)
 	}
 
-	// RequestWithRetry handles transient "no responders" errors when
+	// RequestWithRetryClassified handles transient "no responders" errors when
 	// graph-gateway is restarting or its subscription hasn't yet
 	// propagated. Without retry, rule-driven add_triple actions
 	// silently fail during graph-gateway startup races. The mutation
 	// is idempotent (graph is a set of triples; same triple twice =
 	// same state), so retry is safe.
-	respData, err := m.natsClient.RequestWithRetry(ctx, SubjectTripleAdd, reqData, MutationTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := m.natsClient.RequestWithRetryClassified(ctx, SubjectTripleAdd, reqData, MutationTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return 0, fmt.Errorf("NATS request failed: %w", err)
 	}
@@ -109,10 +110,11 @@ func (m *tripleMutator) RemoveTriple(ctx context.Context, ruleID, subject, predi
 		return 0, fmt.Errorf("marshal request: %w", err)
 	}
 
-	// RequestWithRetry: same rationale as AddTriple. Removing
+	// RequestWithRetryClassified: same rationale as AddTriple. Removing
 	// already-removed is a no-op success on the responder side, so
 	// duplicate retries converge to the same state.
-	respData, err := m.natsClient.RequestWithRetry(ctx, SubjectTripleRemove, reqData, MutationTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := m.natsClient.RequestWithRetryClassified(ctx, SubjectTripleRemove, reqData, MutationTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return 0, fmt.Errorf("NATS request failed: %w", err)
 	}
@@ -174,10 +176,11 @@ func (m *tripleMutator) ReplaceOwned(ctx context.Context, ruleID, ownerToken, en
 		return 0, fmt.Errorf("marshal request: %w", err)
 	}
 
-	// RequestWithRetry: same transient-no-responders rationale as AddTriple.
+	// RequestWithRetryClassified: same transient-no-responders rationale as AddTriple.
 	// The replace is idempotent (replace-by-predicate converges to the same
 	// single-valued state on a duplicate delivery), so retry is safe.
-	respData, err := m.natsClient.RequestWithRetry(ctx, SubjectEntityUpdateWithTriples, reqData, MutationTimeout, natsclient.DefaultRetryConfig())
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	respData, err := m.natsClient.RequestWithRetryClassified(ctx, SubjectEntityUpdateWithTriples, reqData, MutationTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
 		return 0, fmt.Errorf("NATS request failed: %w", err)
 	}


### PR DESCRIPTION
## What — gh#93 step 3 (per ADR-060): classify the in-tree write-path callers

Migrates 7 in-tree `Request*` + `json.Unmarshal` + `if !resp.Success` callers to `RequestWithRetryClassified`, so a handler-*internal* failure that takes the classified channel surfaces as a classified `err` instead of being silently zero-value-decoded as a `Success:false` body (the gh#93 silent-corruption class):

- `agentic/agentrun/nats_reader.go`, `graph/inference/applier.go`,
  `processor/agentic-loop/graph_writer.go` (writeTriple/writeBatch/createEntityWithTriples),
  `processor/agentic-tools/decide.go` + `write_todos.go`,
  `processor/research-graph-llmwrap/triplepub.go`,
  `processor/rule/triple_mutator.go` (AddTriple/RemoveTriple/ReplaceOwned).

This is **step 3** of the ADR-060 migration (the typed-error end state). The handlers still emit domain errors as `Success:false` bodies *during* the transition (steps 2/4 stamp the class / drop the legacy body), so these callers' existing `!resp.Success`/`ErrorCode` branches stay correct; the migration only *adds* correct handling of the classified internal-error channel.

## Review

These were reviewed in the #162 bundle (go-reviewer verified all 11 sites behavior-preserving on the success path + correct bug-fix on the error path, and ran all 8 packages' tests). Per ADR-060 + the earlier split decision, they're split out of the lint PR into this focused `fix(` change. **`ReplaceOwned`** (ADR-056 owner-token lease) confirmed behavior-preserving: `entity_not_found` / owner-lease-stale still arrive as `Success:false` JSON handled by the existing `ErrorCode` branch; only internal Go errors now surface classified.

Re-verified on the extracted branch: `go build ./...`, unit `-race` (7 packages), and integration `-race` (rule 48s, agentic-loop 36s, agentic-tools, agentrun) all green.

Part of gh#93 / ADR-060.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
