### PR TITLE
feat(errs,natsclient): ClassifiedError Code/Detail + ErrRevisionMismatch sentinel (ADR-060 PR-A)

### DIFF
--- a/docs/adr/060-unified-rpc-error-contract.md
+++ b/docs/adr/060-unified-rpc-error-contract.md
@@ -2,17 +2,38 @@
 
 ## Status
 
-**Proposed (scope/decision) — 2026-06-22.** This ADR **names a responsibility and decides a
-target shape**; it does **not** design the migration mechanism beyond reusing what already
-exists. It reuses the gh#93 header-classification seam (`X-Status` / `X-Error-Class`),
+**Accepted (scope/decision) — amended 2026-06-23.** This ADR **names a responsibility, decides a
+target shape, AND decides its migration as ONE idiomatic breaking change.** Pre-1.0, and we own
+every consumer (semconnect, semteams), so per the "take the break now, no compat shim" discipline
+this ADR does **not** stage an Option-B transition: it collapses the prior draft's steps 1–4 into
+a single coordinated break, landed in lockstep across the three repos under one tag.
+
+It reuses the gh#93 header-classification seam (`X-Status` / `X-Error-Class`),
 `pkg/errs.ClassifiedError` and its three-value `ErrorClass` set {transient, invalid, fatal}, the
 `graph.ErrorCode*` constants, and the `RequestClassified` / `RequestWithRetryClassified` /
-`ClassifyReply` / `RespondError` caller surface. It invents **no new taxonomy, transport,
-registry, or error class** — one small `RPCError` type and one standard error body, both built
-from primitives already on main. Every current-behavior claim below is grounded in `file:line`
-and was read against main on 2026-06-22. Pre-1.0, we own every consumer, so this ADR **takes the
-break** (gh#161) and lands the idiomatic Go/gRPC pattern as the end state; the dual-channel body
-is demoted to the **transition mechanism**, retired at gh#161.
+`ClassifyReply` / `RespondError` surface. It invents **no new error class, transport, or
+registry.**
+
+**Type decision (amended 2026-06-23).** The target is **NOT a new `RPCError` type.** Every live
+consumer already branches on `*errs.ClassifiedError` via `errs.IsInvalid`/`IsTransient`
+(semconnect `gateway/cs-api/systems.go:832,835,880,882`; semteams
+`chainpause/decision_handler.go:421`, `chain/entity_reader.go:112`,
+`tools/addsource/executor.go:194`). `IsInvalid`/`IsTransient`/`IsFatal` dispatch via
+`errors.As(err, &ce *ClassifiedError)` (`pkg/errs/errs.go:113-114,157-158,200-201`), which matches
+by concrete type and is indifferent to added fields/methods. A *new* type would force every one of
+those sites to migrate a working `IsInvalid` check to a new `errors.As(&re)` check for **no
+behavioral gain**. Instead this ADR **extends `ClassifiedError`** with `Code string` +
+`Detail map[string]any` + an `Is` method for sentinel matching. Consumers' existing class branches
+stay untouched and gain `Code` for free; the per-consumer hand-rolled discriminators (semconnect's
+`"not found:"` string-sniff at `systems.go:878`, its `mutationFailure` `ErrorCode` switch at
+`systems_post.go:440-448`) are retired by reading `ce.Code`. This is the **bigger** break (the
+legacy body still dies) with **less** consumer churn — the idiomatic-for-us type is the one the
+wire already reconstructs.
+
+Every current-behavior claim below is grounded in `file:line` and was read against main on
+2026-06-22, with the consumer-side and migration claims adversarially re-verified across all three
+repos on 2026-06-23 (extend-vs-new-type, one-sentinel, compile-enforced field deletion, and the
+`Is` empty-Code hazard were each checked by reading the code).
 
 ## Context: the same semantic, represented two ways, only one classified
 
@@ -89,74 +110,94 @@ distinguishable outcomes, not two:
 | Outcome | Wire | Caller sees |
 |---------|------|-------------|
 | Full success | success body, no error header | typed body, `nil` err |
-| **Partial (degraded) success** | success body, no error header | typed body, `nil` err — `Degraded` / `FailedSubjects` populated |
-| Hard failure | small error body + `X-Error-Class` | `nil` body, `*RPCError` |
+| **Partial (degraded) success** | success body, no error header | typed body, `nil` err — `Degraded` / `DegradedReason` / `FailedSubjects` populated |
+| Hard failure | small error body + `X-Error-Class` | `nil` body, `*errs.ClassifiedError` |
 
 The middle row is load-bearing: `Degraded` (`graph/mutation_responses.go:44-63`) and
 `FailedSubjects` (`:171-175`) are **success-with-detail**, NOT errors. A degraded write
 *committed* (`mutation_responses.go:24-30` is explicit: "the write is COMMITTED, not pending");
 a batch with `FailedSubjects` committed the subjects not listed. **Do not turn partial success
 into a Go error** — that would make a committed write look retryable and break the
-do-not-retry contract. Only the bottom row becomes `*RPCError`.
+do-not-retry contract. Only the bottom row becomes `*errs.ClassifiedError`. (The degraded
+read-back *reason* moves from the retired `Error` field to a new `DegradedReason string` on the
+success body — see "What the implementing PR decides".)
 
-## The target: one typed, wrappable RPC error
+## The target: extend `ClassifiedError` — one typed, wrappable error on the type the wire already speaks
 
-The end state is the gRPC `status` / standard-Go-typed-error pattern — one channel, one value:
+The end state is the standard-Go-typed-error pattern on the type `ClassifyReply` already
+reconstructs — `*errs.ClassifiedError`, extended:
 
 ```go
-type RPCError struct {
-    Class  errs.ErrorClass   // transient | invalid | fatal  (REUSE; no new class)
-    Code   string            // REUSE graph.ErrorCode* constants (entity_not_found, ...)
-    Detail map[string]any    // entity, revision, failed_subjects (typed-vs-map: impl-PR call)
+type ClassifiedError struct {
+    Class     ErrorClass     // transient | invalid | fatal (REUSE; no new class)
+    Err       error          // wrapped cause (unchanged; Unwrap returns it)
+    Message   string         // verbatim wire text (unchanged)
+    Component, Operation string
+    Code      string         // NEW: REUSE graph.ErrorCode* values (entity_not_found, ...); "" = uncoded
+    Detail    map[string]any // NEW: entity, revision, failed_subjects; nil = none
 }
-func (e *RPCError) Error() string
-func (e *RPCError) Is(target error) bool   // enables errors.Is(err, ErrRevisionMismatch)
+
+// Is matches a sentinel by Code. REQUIRED guards (locked by test, see below):
+//   1. target must be a *ClassifiedError (else false — protects errors.Is(err, context.Canceled))
+//   2. Code must be NON-EMPTY (else "" == "" false-matches every uncoded error)
+func (ce *ClassifiedError) Is(target error) bool {
+    var t *ClassifiedError
+    if !errors.As(target, &t) {
+        return false
+    }
+    return t.Code != "" && t.Err == nil && ce.Code == t.Code
+}
 ```
 
-- **Failure** → `(nil, *RPCError)`. ONE return value, the full idiomatic toolkit:
+- **Failure** → `(nil, *errs.ClassifiedError)`. ONE return value, the full idiomatic toolkit:
   `errs.IsInvalid(err)` / `errs.IsTransient(err)` for the coarse retry/branch decision (works
-  today via `errors.As` against the embedded `Class`); `var re *RPCError; errors.As(err, &re)`
-  to reach `Code` / `Detail`; `fmt.Errorf("transition %s: %w", id, err)` to **wrap for context**
-  with class and code surviving the wrap. No "both-non-nil / go look in the body" contract.
+  today, unchanged); `errors.As(err, &ce)` to reach `Code` / `Detail`;
+  `errors.Is(err, errs.ErrRevisionMismatch)` for the one control-flow sentinel;
+  `fmt.Errorf("transition %s: %w", id, err)` to **wrap for context** with class, code, and detail
+  surviving the wrap. No "both-non-nil / go look in the body" contract.
 - **Success / partial success** → typed success body + `nil` err. The success type goes back to
   describing only success.
 
 `Detail` **preserves** everything the typed body carried (`entity`, `revision`,
 `failed_subjects` on the hard-failure path) — `errors.As` reaches it. Nothing is lost; the
-structured detail moves from a `Success:false` struct into the error value where it belongs.
+structured detail moves from a `Success:false` struct into the error value where it belongs. New
+coded constructors `errs.ClassifiedCode(class, code, err)` and
+`errs.ClassifiedCodeDetail(class, code, detail, err)` produce these; the existing
+`errs.Classified(class, err)` is unchanged (empty `Code`, the graph-ingest query exemplar keeps
+compiling).
 
 ## The options
 
-### Option A (RECOMMENDED, "done right") — one typed, wrappable error channel
+### Option A (ACCEPTED, as extend-`ClassifiedError`) — one typed, wrappable error channel
 
-Hard failures become `(nil, *RPCError)`. The `{Success:false, ErrorCode, Error}` signaling is
-removed from the response types entirely; the typed detail it carried lives in `RPCError.Detail`,
-reachable via `errors.As`. **This is Option A done right** — the earlier rejection ("Option A
-throws away the structured detail") was a strawman that equated Option A with a *bare classified
-error string*. A typed error is ONE channel with the detail **preserved inside the error**: a
-caller does `errs.IsInvalid(err)` for the coarse branch, `errors.As(err, &re)` for `Code` /
-`Detail`, and `errors.Is(err, ErrRevisionMismatch)` for control-flow codes (next section).
-Gateways that need 404-vs-400 disambiguation read `re.Code` directly instead of substring-sniffing
-a body. **This is the end state.**
+Hard failures become `(nil, *errs.ClassifiedError)`. The `{Success:false, ErrorCode, Error}`
+signaling is removed from the response types entirely; the typed detail it carried lives in
+`ClassifiedError.Detail`, reachable via `errors.As`. **This is Option A done right** — the earlier
+rejection ("Option A throws away the structured detail") was a strawman that equated Option A with
+a *bare classified error string*. A typed error is ONE channel with the detail **preserved inside
+the error**: a caller does `errs.IsInvalid(err)` for the coarse branch, `errors.As(err, &ce)` for
+`Code` / `Detail`, and `errors.Is(err, errs.ErrRevisionMismatch)` for control-flow codes (next
+section). Gateways that need 404-vs-400 disambiguation read `ce.Code` directly instead of
+substring-sniffing a body. **This is the end state.** (The 2026-06-23 amendment fixes the *type*:
+extend `ClassifiedError`, do not mint a parallel `RPCError` — see Status.)
 
-### Option B — classify on the wire AND keep the typed body (the TRANSITION step, not the end)
+### Option B — classify on the wire AND keep the typed body — **REJECTED as a stage**
 
-During migration, group-a handlers keep returning their `(MutationResponse{Success:false,
-ErrorCode}, ...)` / `QueryResponse[T]{Error}` body **and additionally** stamp the `X-Status` /
-`X-Error-Class` header, so old body-sniffing callers keep working while new callers branch on the
-classified `err`. This is the gh#93-style additive step — it removes the footgun *before* the
-breaking body change, exactly as gh#93 Phase 1 was additive. **It is the migration mechanism, not
-the recommendation.** Keeping it forever would enshrine the dual channel; it is retired at gh#161
-(step 4) when the legacy body is dropped and only the standard error body + header remain.
+The earlier draft kept this as the additive transition: handlers stamp the class header *and*
+keep returning their `{Success:false, ErrorCode}` / `QueryResponse[T]{Error}` body so old
+body-sniffing callers keep working. **Per the 2026-06-23 amendment the break is taken directly;
+Option B's additive dual-stamp is NOT landed as an intermediate state.** Keeping it would enshrine
+the dual channel; pre-1.0 and owning every consumer, we flip in lockstep instead (see "The
+migration").
 
 ### Option C — status quo + permanent lint
 
 Leave the dual channel; rely on the gh#162 AST-walker lint to catch new `Request`+`Unmarshal`
-callers forever. **Rejected as the end state** (kept as the transition guard — step 0 of the
-migration). The lint guards against *re-introducing* the footgun; it does not remove it for
-existing callers, does not give failures a class, and leaves "same semantic, two shapes"
-permanently. A permanent lint is the tax you pay for not fixing the contract — acceptable as
-scaffolding, not as the answer.
+callers forever. **Rejected as the end state** (kept as the **transition guard** — armed through
+PR-A..C, deleted in PR-D once the allowlist is empty). The lint guards against *re-introducing* the
+footgun; it does not remove it for existing callers, does not give failures a class, and leaves
+"same semantic, two shapes" permanently. A permanent lint is the tax you pay for not fixing the
+contract — acceptable as scaffolding, not as the answer.
 
 ## CRITICAL NUANCE: control flow is error *identity*, not a separate channel
 
@@ -176,99 +217,171 @@ the canonical way to carry control-flow-as-error. So:
   for class) decide what to do. This is **simpler** than the dual channel, not more complex — one
   return value, one set of error tools, no "is this row a failure or a body?" fork.
 
-Provide sentinels **only** for the control-flow codes consumers actually loop on — primarily
-`revision_mismatch` (and `owner_lease_stale` only if a live consumer treats it as
-reconcile-and-retry, `graph/mutation_responses.go:98-107`). Do **not** mint a sentinel per
-`ErrorCode`; `RPCError.Code` is the general discriminator. Reflexively converting every code into
-a named sentinel is the over-engineering trap the guardrails forbid.
+Provide sentinels **only** for the control-flow codes consumers actually loop on. Adversarial
+verification (2026-06-23, all three repos) found **exactly one**: `revision_mismatch`
+(`pkg/lifecycle/graph_emit.go:135` → `manager.go:524,690,813` CAS `continue`). `owner_lease_stale`
+has **zero** branching consumers anywhere (only emit sites `mutations.go:456,686`); semconnect
+flat-maps it to 400 (`systems_post.go:453`). `entity_not_found` has no *looping* consumer either —
+it is a `ce.Code` discriminator (see the lifecycle note below for its `graph_emit.go:138`
+translation, which collapses to `ce.Code == "entity_not_found"` but needs no framework sentinel).
+Do **not** mint a sentinel per `ErrorCode`; `ce.Code` is the general discriminator. The net
+sentinel set is **one**.
 
 ## Decision
 
 1. **Name the responsibility.** There is **one RPC error contract** for semstreams
    request/reply: a reply either succeeds (full or degraded), or it is **one typed error value**
-   — `(nil, *RPCError)` — carrying a wire `Class` (`X-Error-Class` ∈ {transient, invalid, fatal})
-   and a `Code`. A `RequestClassified` / `RequestWithRetryClassified` caller branches with a
-   single `err` check and the standard `errors.Is`/`errors.As` toolkit. This contract already
-   holds for the Go-error channel (gh#93) and for graph-ingest query handlers; this ADR extends
-   it to the seams that still cram errors into the success body.
+   — `(nil, *errs.ClassifiedError)` — carrying a wire `Class` (`X-Error-Class` ∈ {transient,
+   invalid, fatal}) and a `Code`. A `RequestClassified` / `RequestWithRetryClassified` caller
+   branches with a single `err` check and the standard `errors.Is`/`errors.As` toolkit. This
+   contract already holds for the Go-error channel (gh#93) and for graph-ingest query handlers;
+   this ADR extends it to the seams that still cram errors into the success body.
 
-2. **Adopt the typed `RPCError` end state (Option A done right).** Hard domain failures
-   (`entity_not_found`, `entity_already_exists`, `invalid_request`, `internal`) become
-   `(nil, *RPCError)` with detail preserved in `RPCError.Detail`. The `Success`/`Error`/
-   `ErrorCode` *error-signaling* fields are retired from the response types at the end state.
+2. **Extend `ClassifiedError`; do NOT mint `RPCError`.** Add `Code` + `Detail` + an `Is` method
+   (with the two required guards) and the `ClassifiedCode`/`ClassifiedCodeDetail` constructors.
+   Hard domain failures (`entity_not_found`, `entity_already_exists`, `invalid_request`,
+   `internal`) become `(nil, *errs.ClassifiedError)` with detail preserved in `.Detail`. The
+   `Success`/`Error`/`ErrorCode` *error-signaling* fields are retired from the response types.
 
-3. **Control flow is a sentinel, not a channel.** `revision_mismatch` (and `owner_lease_stale`
-   where a live consumer reconcile-retries) is delivered as a sentinel error checked with
-   `errors.Is(err, errs.ErrRevisionMismatch)`. `pkg/lifecycle.Manager.Transition`'s CAS loop
-   (`manager.go:690`) already branches on a sentinel (`errEmitRevisionMismatch`) — it keeps
-   working, minus the manual body-unmarshal translation it does today (see below).
+3. **Control flow is a sentinel, not a channel.** `revision_mismatch` is delivered as
+   `errs.ErrRevisionMismatch`, checked with `errors.Is(err, errs.ErrRevisionMismatch)`.
+   `pkg/lifecycle.Manager.Transition`'s CAS loop (`manager.go:690`) already branches on a
+   package-private sentinel (`errEmitRevisionMismatch`) — it swaps to the framework sentinel, minus
+   the manual body-unmarshal translation it does today (see below). **One sentinel only**;
+   everything else is `ce.Code`.
 
 4. **Separate success from failure.** Success types describe only success; `Degraded` /
-   `FailedSubjects` stay on the success body with `nil` err (partial success is NOT an error).
-   The failure envelope is a small standard error body, reconstructed caller-side into `*RPCError`.
+   `DegradedReason` / `FailedSubjects` stay on the success body with `nil` err (partial success is
+   NOT an error). The failure envelope is a small standard error body, reconstructed caller-side
+   into `*errs.ClassifiedError`.
 
-5. **Reframe the in-flight issues as one migration, not separate patches** (next section), with
-   Option B as the additive transition and gh#161 as the break that lands the end state.
+5. **One break, in lockstep — not a staged transition.** Pre-1.0, we own every consumer, so the
+   four-PR plan below lands the end state directly; the sister repos flip with it under one tag.
+   Option B (additive dual-stamp) is not landed as an intermediate state.
 
-6. **Bound the blast radius** to the four enumerated seams below. This ADR brings the *existing*
-   divergent seams onto the contract; it does not speculate about hypothetical future RPCs.
+6. **Bound the blast radius** to the four enumerated seams below (graph-ingest mutations,
+   graph-index `*NATS` queries, the in-tree callers, the legacy body). The graph-ingest *query*
+   handlers are already on the contract. The semconnect **spatial** seam (`spatial.go:310`,
+   `graph-index-spatial`) is a known **out-of-scope fifth seam** — it consumes a non-conforming
+   `error: <text>` body, treats any failure as 500 (no class branching to break), and is **not**
+   migrated here; it is filed separately so "unified contract" is honestly bounded.
 
-## The wire: a small standard error body + the existing class header
+## The wire: class + code headers, and a small standard error body for detail
 
-The recommended wire shape is a **standard error envelope** — the header carries the class
-(`X-Error-Class`, already exists) and a small body `{code, message, detail}` that `ClassifyReply`
-parses **generically** into `*RPCError`, independent of any success type:
+The class and the code ride **headers**; the detail rides a small body. This split is what lets
+PR-A be **purely additive**: a NATS reply has one body, and legacy consumers on the un-bumped
+sister tags still sniff the `error: <msg>` body prefix — so the body cannot change in the additive
+window. The new `Code` therefore travels as a **header**, leaving the body untouched until the
+breaking PR:
 
-```json
-{ "code": "entity_not_found", "message": "not found: acme.ops...drone.001", "detail": { "entity": "..." } }
-```
+- `X-Status: error` + `X-Error-Class: <class>` — exist (gh#93); unchanged.
+- `X-Error-Code: <code>` — **NEW, additive (PR-A), and the permanent code channel.** Carries the
+  stable machine code (`entity_not_found`, `revision_mismatch`, ...). Stamped only when the handler
+  error carries a non-empty `Code`, so uncoded errors are byte-for-byte unchanged on the wire. It
+  is small (a short token), header-appropriate, and present from PR-A onward so the sentinel and
+  `ce.Code` discrimination work *during* the transition (PR-B/PR-C need it).
+- **Body.** Through PR-C the body stays the legacy `error: <msg>` text (additive). PR-D (breaking)
+  switches it to a small standard envelope carrying the **message and detail** —
+  `{ "message": "not found: acme.ops...drone.001", "detail": { "entity": "..." } }` — and drops the
+  `error:` prefix. `Detail` (entity, revisions) lands here, not in a header (it is structured and
+  potentially multi-field; the body is the right home).
+
+`ClassifyReply` reconstructs a `*errs.ClassifiedError` **generically** — one decode path for every
+seam, independent of any success type: it reads the class + code headers, sets `ce.Code`, and the
+`(*ClassifiedError).Is` method matches `errs.ErrRevisionMismatch` by code so
+`errors.Is(err, errs.ErrRevisionMismatch)` round-trips. This supersedes the deferred
+`X-Error-Sentinel`-header idea (`natsclient/errors.go:73-77`) — the code header *is* that
+mechanism, generalized.
+
+**Producer ergonomics.** No new `RespondRPCError` helper is needed. Because `SubscribeForRequests`
+(`request.go:208`) already calls `RespondError` **only** on a non-nil Go-error return, the entire
+producer migration is "return `(nil, errs.ClassifiedCode(...))` instead of `(marshaledBody, nil)`"
+— the convention the graph-ingest *query* handlers already use. `RespondError` / `ReplyError`
+(`errors.go:142-158,165`) learn to marshal the `{code,message,detail}` body from the
+`*ClassifiedError`; that is the only producer change.
 
 **Trade-off (the one that matters).** The alternative is header-only — put `Code` in a new header
 and leave `Detail` inside the typed success body. Rejected: it keeps detail coupled to each
 success type (so `ClassifyReply` would need to know every body shape to extract it), and it
 leaves a partially-populated success body on the *failure* path — the exact "is this a body or an
-error?" ambiguity we are retiring. The standard envelope is **generically parseable** (one decode
-path for every seam) and **decoupled from each success type** (the success type goes back to pure
-success). The cost is one small body shape to define and one `ClassifyReply` branch to add — both
-inside the gh#93 seam, no new transport. We do **not** invent five new headers; the class header
-already exists and the rest rides in the body.
+error?" ambiguity we are retiring. The standard envelope is **generically parseable** and
+**decoupled from each success type**.
 
-## The migration (reuse gh#93 mechanics; the issues are the steps)
+## The migration — ONE break, four stacked PRs, lockstep tag
 
-This is **one** migration with the already-filed issues as ordered steps. Only the **end-state
-target** changed from the prior draft (typed `RPCError`, not a permanent dual return); the steps
-are unchanged.
+The prior staged table (Option B steps 1–4) is **superseded**. This is a single coordinated break;
+the in-tree PRs are non-breaking until the final PR, which lands in lockstep with the sister repos.
+The gh#162 lint stays armed PR-A→PR-C and is deleted in PR-D.
 
-| Step | Issue | Role in the unified migration |
-|------|-------|-------------------------------|
-| 0 | gh#162 | **Transition guard.** AST-walker lint failing CI on any new `Request`+`Unmarshal` without a `RequestClassified` migration or `error:` prefix check. Lands first so no new violator rides in; **deleted at the very end** once no reply carries an unclassified in-body error. |
-| 1 | gh#164(b) | **Migrate the graph-index `*NATS` handlers** (`processor/graph-index/query.go`) to the transition shape (Option B): emit the `QueryResponse[T]` body AND stamp `X-Error-Class` (invalid for "invalid request", transient/fatal for "internal error"), retiring the third divergent shape. Same step retires the never-registered msg-style dead code gh#164 part 2 enumerates. |
-| 2 | (this ADR) | **Migrate the graph-ingest mutation handlers** (`mutations.go` group-a sites) to the transition shape; `revision_mismatch` / control-flow `owner_lease_stale` stay in-band during the window, sentinel-reconstructed at the end. |
-| 3 | (this ADR) | **Migrate in-tree callers** to `RequestClassified` / `RequestWithRetryClassified` and the single `err`-branch (`triple_mutator.go`, `graph_writer.go`, `write_todos.go`, `decide.go`, `triplepub.go`). Mutation callers that retry use `RequestWithRetryClassified` (`natsclient/request.go:275`). |
-| 4 | gh#161 | **BREAKING — lands the end state.** Drop the legacy `error: <msg>` body and the in-body `Success`/`Error`/`ErrorCode` *error* fields; the standard error envelope + `X-Error-Class` become the sole failure signal, reconstructed caller-side as `*RPCError`. Carries the e2e gate + lockstep sister-project (semconnect cs-api `classifyEntityQueryError`) migration the issue scopes. **Last step**; after it, the gh#162 lint guard is retired. |
+| PR | Scope | Breaks wire? | Clears |
+|----|-------|--------------|--------|
+| A | **Framework types.** `pkg/errs`: add `Code`/`Detail` fields, the guarded `Is` method, `ClassifiedCode`/`ClassifiedCodeDetail` ctors, the `ErrRevisionMismatch` sentinel (literal `"revision_mismatch"` + graph assertion test). `natsclient/errors.go`: add the `X-Error-Code` header — `RespondError`/`ReplyError` stamp it when the error carries a non-empty `Code` (**body unchanged**, legacy `error:` text retained); `ClassifyReply` reads it onto `ce.Code` so the sentinel + `ce.Code` round-trip. `Detail` is carried on the error value but not yet serialized (lands in PR-D's body). | No (additive — header only, body untouched) | — |
+| B | **Producers.** graph-ingest mutation handlers (`mutations.go:1057,1086` helpers) + graph-index 7 `*NATS` handlers (`graph-index/query.go:91,95,105,110`) return `(nil, errs.ClassifiedCodeDetail(...))`; delete `NewQueryError`. Response structs **keep** `Success`/`Error`/`ErrorCode` fields (unwritten on failure) until PR-D so un-bumped sister repos still compile. | No (header now flows; old fields still present) | gh#164 part 2 |
+| C | **Callers.** The 7 half-migrated `RequestWithRetryClassified` sites drop the `!resp.Success` second check; `pkg/lifecycle/graph_emit.go` deletes **both** body→sentinel translations (`:130-141`, `:84`) — revision_mismatch → `errs.ErrRevisionMismatch`, entity_not_found → `ce.Code == "entity_not_found"`; `manager.go:524,690,813` use `errs.ErrRevisionMismatch`; the gh#334/#326 read-path callers move to `RequestClassified`. | No | gh#326, gh#334 (empties allowlist) |
+| D | **BREAKING.** Switch the failure body from the legacy `error: <msg>` text to the standard `{message, detail}` envelope (class + code stay in headers); `ClassifyReply` parses it for `Detail` + drops the `error:` fallback + `legacyErrorBodyPrefix`. Delete `Success`/`Error`/`ErrorCode` from `MutationResponse` (add `DegradedReason string`), `Error` from `QueryResponse[T]`; assert the lint allowlist is empty, then delete the gh#162 guard. Add the `Detail` `float64` round-trip test (it now crosses the wire). Lands with the sister-repo PRs under one tag; e2e gate (incl. the new negative-path assertion) green first. | **Yes** | gh#161, gh#162 |
 
-gh#163 (CLOSED) and gh#304 (CLOSED, graph-query prefix passthrough now uses `RequestClassified`,
-`processor/graph-query/query.go:384`) are prior steps of this same arc already landed. gh#326
-(OPEN) is a sibling silent-corruption site the gh#162 lint (step 0) will flag — it folds into the
-step-0 burn-down rather than a standalone fix.
+**Issue mapping:** #164 → PR-B; #334 → PR-A (framework support) + PR-C (burn-down); #326 → PR-C;
+#161 → PR-D; #330 (predicate value-filter coverage) is enabled by PR-B and files as its own
+non-breaking follow-up, not a blocker. gh#163 / gh#304 are prior steps of this arc already landed.
 
-## How `revision_mismatch`-as-sentinel changes `Manager.Transition`
+### Lockstep rollout + e2e gate
 
-Today `pkg/lifecycle/graph_emit.go:130-141` manually re-implements the wire→sentinel translation:
-it `json.Unmarshal`s the body, checks `if !resp.Success`, `switch`es on
-`resp.ErrorCode == graph.ErrorCodeRevisionMismatch`, and returns a *package-private* sentinel
-`errEmitRevisionMismatch` (`graph_emit.go:84`). `Manager.Transition`'s CAS loop then branches
+Both sister repos pin a **published tag** (no `replace`), so nothing breaks until they bump. Order:
+
+1. Land semstreams PR-A → PR-B → PR-C on `main` (all non-breaking; sister repos on beta.113/114
+   keep working — PR-B/C keep the response fields present and the legacy `error:` fallback intact).
+2. Run the e2e gate on `main` (PR-A..C).
+3. Prepare semconnect + semteams branches against a `replace`/RC of semstreams `main`-with-PR-D;
+   make the consumer changes; go green locally. **semconnect** (heavier): `systems_post.go:392` /
+   `systems_crd.go:163,193` drop the `!resp.Success` check; `mutationFailure` (`systems_post.go:440-448`)
+   switches on `ce.Code` not `resp.ErrorCode`; `classifyEntityQueryFailure` (`systems.go:874-887`)
+   replaces the `"not found:"` sniff with `ce.Code == "entity_not_found"`; the degraded-reason logs
+   (`systems_post.go:394`, `systems_crd.go:165`) read `resp.DegradedReason` not `resp.Error`;
+   `listEntitiesByType` (`systems.go:918,939`) → `RequestClassified`. **semteams** (one site):
+   `tools/emitdevviatestplan/remover.go:75` → `RequestWithRetryClassified` + `err` branch (the
+   other three sites are already safe).
+4. Land semstreams PR-D on `main`.
+5. **Re-run the e2e gate** on `main` post-PR-D (BREAKING-rule gate — green BEFORE the tag).
+6. Tag semstreams (BREAKING in changelog).
+7. Bump + merge semconnect and semteams (drop the `replace`); each repo's CI is its merge gate.
+
+The window where `main` has PR-D but sister repos haven't bumped is **safe**: there is no shared
+running module; each repo fetches the breaking tag only when *it* bumps, and a stale consumer that
+bumps *without* the code change fails to **compile** (the read of the deleted `resp.Success` field
+won't build — verified there is no anonymous-struct json-decode shape that would silently see a
+zero value). The compiler is the safety net.
+
+**E2E tiers (BREAKING rule):** `e2e:lifecycle` (CAS / `revision_mismatch` sentinel via
+`Manager.Transition`), `e2e:crud-tools` + `e2e:agentic` (mutation callers), `e2e:structural`
+(graph-index queries). **Coverage gap (filed):** no tier today asserts the wire error *class* —
+they all assert the happy path. PR-D's gate MUST add a negative-path assertion (e.g. update on a
+missing entity → assert `ce.Code == "entity_not_found"` / invalid class) in `crud-tools`, per the
+"breaking change needs e2e on the touched path" hard rule. The sufficient gate is the PR-A
+production-decoder round-trip **plus** this new e2e stage — green e2e on the happy path alone is
+necessary but not sufficient.
+
+## How the sentinel collapses `Manager.Transition` (and the second `entity_not_found` translation)
+
+Today `pkg/lifecycle/graph_emit.go:130-141` manually re-implements **two** wire→sentinel
+translations: it `json.Unmarshal`s the body, checks `if !resp.Success`, and `switch`es on
+`resp.ErrorCode` — returning the *package-private* `errEmitRevisionMismatch` (`graph_emit.go:84`)
+for `revision_mismatch` **and** a package-local `ErrEntityNotFound` for `entity_not_found`
+(`graph_emit.go:138`). `Manager.Transition`'s CAS loop branches
 `if errors.Is(err, errEmitRevisionMismatch) { continue }` (`manager.go:690`; same at `:524,:813`).
 
-That translation layer exists **only because the wire doesn't carry a sentinel today.** Under the
-target, `ClassifyReply` reconstructs `errs.ErrRevisionMismatch` directly from `Code ==
-"revision_mismatch"`, so:
+Both translations exist **only because the wire doesn't carry a sentinel/code today.** Under the
+target:
 
-- `graph_emit.go`'s body-unmarshal + `Success`-check + `ErrorCode` `switch` collapses into the
-  return of whatever `RequestWithRetryClassified` already produced.
-- `Manager.Transition` branches `if errors.Is(err, errs.ErrRevisionMismatch) { re-read; retry }`
-  — the consumer **already wants this idiom** (it hand-rolled it). The framework sentinel replaces
-  the package-private one; the loop body is otherwise unchanged.
+- The `revision_mismatch` translation collapses: `ClassifyReply` reconstructs
+  `errs.ErrRevisionMismatch` directly, so `graph_emit.go`'s body-unmarshal + `Success`-check +
+  `ErrorCode` `switch` becomes the return of whatever `RequestWithRetryClassified` produced.
+- The `entity_not_found` translation collapses to `ce.Code == "entity_not_found"` (no framework
+  sentinel — no looping consumer). PR-C must address **both** so `graph_emit.go` is not left
+  half-migrated (revision via sentinel, not-found still hand-unmarshaled).
+- `Manager.Transition` branches `if errors.Is(err, errs.ErrRevisionMismatch) { re-read; retry }`.
+  **Check the sentinel BEFORE `errs.IsInvalid`** — the sentinel's class is `ErrorInvalid`, so a
+  consumer that checked `IsInvalid` first would treat a CAS-retry signal as a hard 400. `manager.go`
+  already checks only the sentinel; document the ordering in the sentinel's doc comment.
 
 Net: the consumer gets *simpler*, and the "unmarshal body, switch on `ErrorCode` string" footgun
 disappears from every CAS-retry consumer instead of being re-coded per consumer.
@@ -277,90 +390,123 @@ disappears from every CAS-retry consumer instead of being re-coded per consumer.
 
 - **No new error class.** The set stays {transient, invalid, fatal} (`pkg/errs/errs.go:19-26`).
   No "not_found" wire class, no HTTP-status leakage into the wire layer (404/400 disambiguation
-  stays at the gateway, `natsclient/errors.go:34-37`).
+  stays at the gateway via `ce.Code`, `natsclient/errors.go:34-37`). semconnect keeps its *local*
+  `errEntityNotFound` (404 is a gateway concern) but populates it from `ce.Code`, not a body sniff.
 - **No new transport or registry.** Reuses `X-Status` / `X-Error-Class`
   (`natsclient/errors.go:97-102`), `RespondError` / `ReplyError` / `ClassifyReply`,
-  `RequestClassified` / `RequestWithRetryClassified`. The only additions are one `RPCError` type
-  and one standard error body shape, both built from existing primitives.
+  `RequestClassified` / `RequestWithRetryClassified`. The only additions are **two fields + an `Is`
+  method on `ClassifiedError`** and one standard error body shape — no new type.
 - **No new `ErrorCode*` constant.** The closed set in `graph/mutation_responses.go:69-108` is
-  unchanged; the constants become `RPCError.Code` *values*. (Implementer note: the literal is
-  `entity_already_exists`, not `entity_exists`; `graph/mutation_responses.go:86`.)
+  unchanged; the constants become `ce.Code` *values*. (Implementer note: the literal is
+  `entity_already_exists`, not `entity_exists`; `graph/mutation_responses.go:86`. The
+  `revision_mismatch` literal is at `:75`.)
 - **The success DATA fields survive.** `Entity`, `KVRevision`, `Version`, `TriplesAdded`,
   `Degraded` (`graph/mutation_responses.go:44-63`), `FailedSubjects` (`:171-175`), and
-  `QueryResponse[T].Data` all stay on the success body. **Partial (degraded) success stays a
-  success** with `nil` err.
-- **What IS retired at the end state:** the in-body error *signaling* — `Success bool`, and
-  `Error`/`ErrorCode` *used as the error channel*. They are the dual channel; the typed `RPCError`
-  replaces them. (They persist through steps 1–3 as the additive transition body and are dropped
-  at gh#161.)
+  `QueryResponse[T].Data` all stay. **One additive success field:** `DegradedReason string` (the
+  degraded read-back reason that the retired `Error` field used to carry, read by semconnect
+  `systems_post.go:394` / `systems_crd.go:165`). **Partial (degraded) success stays a success**
+  with `nil` err.
+- **What IS retired:** the in-body error *signaling* — `Success bool`, and `Error`/`ErrorCode`
+  *used as the error channel* (and `QueryResponse[T].Error`). They are the dual channel; the typed
+  `*errs.ClassifiedError` replaces them. Dropped in PR-D.
 - **`revision_mismatch` is NOT a hard error.** It is a control-flow sentinel
-  (`errs.ErrRevisionMismatch`), `errors.Is`-checkable — the `io.EOF` idiom, not a `Success:false`
-  body and not a fatal classification.
+  (`errs.ErrRevisionMismatch`), `errors.Is`-checkable — the `io.EOF` idiom.
 - **`pkg/errs` semantics** (`Classified` vs `WrapInvalid/Transient/Fatal`, the dual-encoding-window
-  rationale at `errs.go:247-270`) are unchanged; `RPCError` composes them, it does not replace
-  them.
+  rationale at `errs.go:247-270`) are unchanged; the new fields/method extend `ClassifiedError`,
+  they do not alter class detection or wrapping. `Error()`/`Unwrap()` are unchanged.
 - **The graph-ingest *query* handlers** (`processor/graph-ingest/query.go`) are already on the
   contract (`errs.Classified` returns); no change.
 
 ## What the implementing PR decides
 
-- `RPCError.Detail` typed (a small struct per code) vs `map[string]any` — value-equality and
-  round-trip tests govern; `map[string]any` is the low-friction default.
-- The exact producer helper for "reply with the standard error body + `X-Error-Class`" (a new
-  `RespondRPCError(msg, *RPCError)` vs reusing `ReplyWithHeaders` + a marshalled body vs a
-  handler-return convention). `ClassifyReply`'s detection order (`natsclient/errors.go:199-221`)
-  is fixed; only producer-side ergonomics are open.
-- The precise sentinel set beyond `revision_mismatch`: whether `owner_lease_stale` gets a
-  sentinel, governed by its single live consumer's actual handling (the
-  `graph/mutation_responses.go:98-107` docstring frames it as "resolve the ownership conflict" —
-  reconcile-and-retry — but the consumer's code, not the docstring, decides).
-- The class for `internal` (`graph/mutation_responses.go:93-96`): transient (retryable) vs fatal,
-  per emit site, matching the query handlers' existing choice (`query.go:95` uses `ErrorTransient`
-  for "internal error").
+- **The `Is` two-guard contract is a REQUIRED, named test invariant — not implementer
+  discretion.** Adding `Is` changes `errors.Is` semantics for *all* `ClassifiedError`s. An
+  unguarded `Code`-equality `Is` returns **true for any two empty-`Code` errors** (`"" == ""`),
+  and today every `classifiedFromHeader` reconstruction (`natsclient/errors.go:319-333`) is
+  empty-`Code` — so an unguarded `Is` would silently false-match across unrelated errors, breaking
+  the very `errors.Is` checks this ADR adds. Lock both guards with named tests:
+  (1) target must type-assert to `*ClassifiedError` (so `errors.Is(err, context.Canceled)` /
+  `sql.ErrNoRows` / the non-classified `errEntityNotFound` stay false); (2) `Code` must be
+  non-empty. Adversarially verified 2026-06-23: the guarded form returns the correct verdict on
+  every real semconnect collision site; the unguarded form does not.
+- **`Detail` typed struct vs `map[string]any`** — `map[string]any` is the low-friction default and
+  is safe today (no consumer reads structured detail out of the error path; revision numbers are
+  currently baked into free text at `mutations.go:852,894`). The round-trip test **must assert the
+  `float64` reality** of JSON-decoded numerics so no future consumer writes
+  `.Detail["expected_revision"].(uint64)` and panics.
+- **Where the degraded read-back reason lives** — `DegradedReason string` on the success body
+  (mirroring the `Degraded`+`DegradedReason` pattern already used in graph-query / research
+  outputs), populated where `Error` is populated on the degraded path today.
+- **The class for `internal`** (`graph/mutation_responses.go:93-96`): **transient** (retryable),
+  matching the query handlers' existing choice (`query.go:95` uses `ErrorTransient`) and the
+  marshal-helper emit (`mutations.go:1057,1086`).
+- **The negative-path e2e stage** placement (`crud-tools`) and exact assertion shape.
 
 ## Consequences
 
 - **Positive.** One contract, one return value: a `RequestClassified` caller's `err` check is
-  authoritative for *every* request/reply seam, with the full idiomatic toolkit (`Is`/`As`/wrap).
-  The silent-corruption class dies structurally, not just by lint. CAS-retry consumers get
-  *simpler* (the per-consumer body→sentinel translation collapses into the framework). The typed
-  detail and the control-flow signal both survive — the detail inside `RPCError`, the signal as a
-  sentinel.
-- **Negative / risk.** Step 4 (gh#161) is a BREAKING wire change requiring the e2e gate and
-  lockstep semconnect migration; until it lands, the dual body persists (acceptable — Option B is
-  additive, same posture as gh#93 Phase 1). Mis-modeling partial success as an error would break
-  the do-not-retry contract (`mutation_responses.go:24-30`); the success/failure split is explicit
-  precisely to prevent that.
-- **Neutral.** No code is committed by this ADR; the steps are the already-filed issues with the
-  end-state target updated from dual-return to typed `RPCError`.
+  authoritative for *every* request/reply seam, with the full idiomatic toolkit (`Is`/`As`/wrap),
+  on the type consumers already speak. The silent-corruption class dies structurally, not just by
+  lint. CAS-retry consumers get *simpler* (the per-consumer body→sentinel translation collapses
+  into the framework). semconnect's hand-rolled `"not found:"` sniff and `ErrorCode` switch are
+  retired into `ce.Code`. The typed detail and the control-flow signal both survive.
+- **Negative / risk.** PR-D is a BREAKING wire change requiring the e2e gate (incl. the new
+  negative-path assertion) and a lockstep semconnect + semteams tag bump. The break is
+  compile-enforced in both sister repos (no silent zero-value shape), which bounds the risk. The
+  `Is` empty-`Code` hazard is real and is mitigated by the required guard tests. Mis-modeling
+  partial success as an error would break the do-not-retry contract
+  (`mutation_responses.go:24-30`); the success/failure split is explicit to prevent that.
+- **Neutral.** No code is committed by this ADR. The `pkg/errs` → `graph` import cycle blocks
+  putting `graph.ErrorCodeRevisionMismatch` in the sentinel literal directly (`graph` imports
+  `errs`, not vice versa); the sentinel uses the literal `"revision_mismatch"` in `pkg/errs`, with
+  an assertion test **in the `graph` package** locking
+  `errs.ErrRevisionMismatch.Code == graph.ErrorCodeRevisionMismatch` so the two never drift.
 
 ## References
 
 - `natsclient/request.go:187,208-226` — handler signature; the two-channel split at the
-  `SubscribeForRequests` wrapper.
+  `SubscribeForRequests` wrapper (stamps the class only on a non-nil Go-error return).
 - `natsclient/errors.go` — `X-Status`/`X-Error-Class` (`:97-102`), `RespondError` (`:142-158`),
-  `ClassifyReply` (`:194-222`), `RequestClassified`/`RequestWithRetryClassified` (`:242,275`),
-  the not-found-maps-to-invalid note (`:34-37`), the silent-corruption footgun warning (`:39-57`),
-  the deferred `X-Error-Sentinel` idea (`:73-77`) which this ADR's sentinel reconstruction supersedes.
-- `pkg/errs/errs.go:19-26,84-104,247-270` — the {transient, invalid, fatal} set, `ClassifiedError`
-  (which `RPCError` composes), and the `Classified` bare constructor.
-- `processor/graph-ingest/mutations.go:426,466,699,779,843,852,894,1060,1089` — domain errors
-  emitted via channel 2 today (the step-2 targets).
+  `ReplyError` (`:165`), `ClassifyReply` (`:194-222`), `classifiedFromHeader` (`:319-333`),
+  `RequestClassified`/`RequestWithRetryClassified` (`:242,275`), the not-found-maps-to-invalid note
+  (`:34-37`), the silent-corruption footgun warning (`:39-57`), the deferred `X-Error-Sentinel`
+  idea (`:73-77`) which the body-`code` sentinel reconstruction supersedes.
+- `pkg/errs/errs.go:19-26,84-104,113-114,157-158,200-201,247-270` — the {transient, invalid,
+  fatal} set, `ClassifiedError` (extended here), `IsInvalid`/`IsTransient`/`IsFatal` via
+  `errors.As`, and the `Classified` bare constructor.
+- `processor/graph-ingest/mutations.go:426,456,466,686,699,779,843,852,894,1057,1060,1086,1089` —
+  domain errors emitted via channel 2 today (PR-B producer targets).
 - `processor/graph-ingest/query.go:73-95` — the *query* exemplar already on the contract
   (`errs.Classified` returns).
 - `processor/graph-index/query.go:91,95,105,110` — the third divergent `NewQueryError[T]` shape
-  (gh#164b target).
-- `graph/mutation_responses.go:24-30,44-63,69-108,171-175` — the three-state (full/degraded/fail)
-  contract, `MutationResponse`, the closed `ErrorCode*` set, `owner_lease_stale`, `FailedSubjects`.
-- `graph/query_contracts.go:10-31` — `QueryResponse[T]` (free-text `Error`, no `ErrorCode`/class).
-- `pkg/lifecycle/graph_emit.go:81-84,130-141` — the per-consumer body→sentinel translation the
-  target collapses; `pkg/lifecycle/manager.go:524,690,813` — `Manager.Transition`'s CAS loop
-  already branching on a sentinel via `errors.Is`.
+  (PR-B target).
+- `graph/mutation_responses.go:24-30,44-63,69-108,75,86,171-175` — the three-state
+  (full/degraded/fail) contract, `MutationResponse`, the closed `ErrorCode*` set (incl. the
+  `revision_mismatch` literal at `:75`), `owner_lease_stale`, `FailedSubjects`.
+- `graph/query_contracts.go:10-31` — `QueryResponse[T]` (free-text `Error`, no `ErrorCode`/class);
+  `NewQueryError` deleted in PR-B.
+- `pkg/lifecycle/graph_emit.go:81-84,130-141` — the per-consumer body→sentinel translations the
+  target collapses (**both** revision_mismatch and entity_not_found); `pkg/lifecycle/manager.go:524,690,813`
+  — `Manager.Transition`'s CAS loop branching on the sentinel via `errors.Is`.
 - `processor/rule/triple_mutator.go:78-84,122-126,185-190`,
-  `processor/agentic-loop/graph_writer.go:113-119` — in-tree channel-2 callers (step-3 targets).
-- gh#93 (the seam), gh#161 (BREAKING — drop legacy body, land end state — step 4), gh#162
-  (AST-walker lint — step 0), gh#164 (graph-index header migration — step 1), gh#163 (CLOSED),
-  gh#304 (CLOSED, prefix passthrough RequestClassified), gh#326 (OPEN, folds into step 0).
+  `processor/agentic-loop/graph_writer.go:113-119,150,193`,
+  `processor/agentic-tools/write_todos.go:428,453`, `processor/agentic-tools/decide.go:705,736`,
+  `processor/research-graph-llmwrap/triplepub.go:89,112` — in-tree channel-2 callers (PR-C targets).
+- `test/natsclient/request_guard_test.go` — the gh#162 AST-walker lint + allowlist (gh#326/#334
+  entries); deleted in PR-D once the allowlist is empty.
+- `test/e2e/scenarios/` (lifecycle, crud-tools, agentic, structural) — e2e gate; **no tier asserts
+  the wire error class today** (the filed coverage gap PR-D must close).
+- **semconnect** `gateway/cs-api/systems.go:787,830,832,835,857,874-887,918,939` (ClassifyReply
+  consumer, the `"not found:"` sniff at `:878`, the local `errEntityNotFound` at `:857`),
+  `systems_post.go:388-458` (`Success` check `:392`, `mutationFailure` `:440-448`, degraded-reason
+  log `:394`), `systems_crd.go:159-197` (`Success` `:163,193`, degraded-reason `:165`),
+  `spatial.go:300-328` (the out-of-scope fifth seam) — lockstep consumer targets.
+- **semteams** `cmd/semteams/tools/emitdevviatestplan/remover.go:75,83-84` (the one vulnerable
+  site); `chainpause/decision_handler.go:421`, `chain/entity_reader.go:112`,
+  `tools/addsource/executor.go:194` (already on the contract — no change).
+- gh#93 (the seam), gh#161 (BREAKING — PR-D), gh#162 (AST-walker lint — PR-A..C guard, deleted
+  PR-D), gh#164 (graph-index header migration — PR-B), gh#326 / gh#334 (caller burn-down — PR-C),
+  gh#163 / gh#304 (prior steps, CLOSED), gh#330 (predicate value-filter coverage, enabled by PR-B).
 - [ADR-055](055-graph-write-intent-taxonomy.md), [ADR-056](056-authoritative-semantic-state.md) —
   the write-intent/ownership taxonomy whose mutation handlers emit these error codes; this ADR is
   orthogonal (how those handlers *report failure*, not what they authorize).

--- a/graph/errcode_sentinel_test.go
+++ b/graph/errcode_sentinel_test.go
@@ -1,0 +1,22 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// TestErrRevisionMismatchCodeMatchesConstant locks the ADR-060 sentinel's
+// Code literal to graph.ErrorCodeRevisionMismatch. pkg/errs cannot import
+// graph (graph imports errs — an import cycle), so the sentinel's Code is
+// the bare string "revision_mismatch". This test lives in the graph
+// package (which CAN see both) and fails if the two ever drift, e.g. if
+// the graph constant is renamed/revalued without updating the errs literal.
+func TestErrRevisionMismatchCodeMatchesConstant(t *testing.T) {
+	t.Parallel()
+	if errs.ErrRevisionMismatch.Code != ErrorCodeRevisionMismatch {
+		t.Fatalf("errs.ErrRevisionMismatch.Code = %q, want graph.ErrorCodeRevisionMismatch = %q — "+
+			"the literal in pkg/errs drifted from the graph constant (pkg/errs cannot import graph; keep them in sync)",
+			errs.ErrRevisionMismatch.Code, ErrorCodeRevisionMismatch)
+	}
+}

--- a/natsclient/errors.go
+++ b/natsclient/errors.go
@@ -70,11 +70,14 @@
 // taxonomy (invalid / transient / fatal) is the ONLY structured
 // signal that round-trips today.
 //
-// If a future consumer needs sentinel-Is parity across the wire,
-// the path is adding an X-Error-Sentinel header with a small
-// allowlist of framework-recognized sentinel IDs; classifiedFromHeader
-// would graft the real sentinel back into the wrap chain. Filed as
-// follow-up to gh#93 (out of Phase 1 scope).
+// ADR-060 delivers sentinel-Is parity for the one control-flow code
+// that needs it: the X-Error-Code header carries the stable machine
+// Code, classifiedFromHeader sets it on the reconstructed
+// *errs.ClassifiedError, and (*ClassifiedError).Is matches it by Code —
+// so errors.Is(err, errs.ErrRevisionMismatch) round-trips the wire. The
+// general discriminator is ce.Code (via errors.As); only revision_mismatch
+// gets a named sentinel (no other code has a looping consumer). This
+// supersedes the earlier deferred X-Error-Sentinel-header idea.
 package natsclient
 
 import (
@@ -100,6 +103,18 @@ const (
 	// lowercase string: "transient", "invalid", or "fatal". Set
 	// only when HeaderStatus == HeaderStatusError.
 	HeaderErrorClass = "X-Error-Class"
+
+	// HeaderErrorCode carries the ADR-060 stable machine Code for the
+	// failure (the graph.ErrorCode* values: "entity_not_found",
+	// "revision_mismatch", ...). Additive over the gh#93 header set:
+	// legacy callers ignore it; ClassifyReply reads it into
+	// (*errs.ClassifiedError).Code so errors.Is(err, ErrRevisionMismatch)
+	// and ce.Code discrimination work across the wire. Set ONLY when the
+	// handler error carries a non-empty Code, so existing uncoded handler
+	// errors are byte-for-byte unchanged on the wire (the reply body is
+	// also unchanged — Code rides the header; the standard error body for
+	// Detail lands with the breaking PR).
+	HeaderErrorCode = "X-Error-Code"
 )
 
 // Values used in HeaderStatus / HeaderErrorClass.
@@ -151,6 +166,9 @@ func RespondError(msg *nats.Msg, err error) error {
 	reply.Header = make(nats.Header)
 	reply.Header.Set(HeaderStatus, HeaderStatusError)
 	reply.Header.Set(HeaderErrorClass, classForHeader(err))
+	if code := codeForHeader(err); code != "" {
+		reply.Header.Set(HeaderErrorCode, code)
+	}
 	reply.Data = []byte(legacyErrorBodyPrefix)
 	reply.Data = append(reply.Data, err.Error()...)
 
@@ -171,6 +189,9 @@ func (c *Client) ReplyError(ctx context.Context, replyTo string, err error) erro
 	headers := map[string]string{
 		HeaderStatus:     HeaderStatusError,
 		HeaderErrorClass: classForHeader(err),
+	}
+	if code := codeForHeader(err); code != "" {
+		headers[HeaderErrorCode] = code
 	}
 	return c.ReplyWithHeaders(ctx, replyTo, body, headers)
 }
@@ -206,16 +227,21 @@ func ClassifyReply(msg *nats.Msg) ([]byte, error) {
 		if bytes.HasPrefix(body, legacyErrorBodyPrefix) {
 			body = bytes.TrimPrefix(body, legacyErrorBodyPrefix)
 		}
-		return nil, classifiedFromHeader(msg.Header.Get(HeaderErrorClass), string(body))
+		return nil, classifiedFromHeader(
+			msg.Header.Get(HeaderErrorClass),
+			msg.Header.Get(HeaderErrorCode),
+			string(body),
+		)
 	}
 
 	if bytes.HasPrefix(msg.Data, legacyErrorBodyPrefix) {
 		// Pre-#93 handler — no header signal. Conservative default:
 		// classify as invalid so callers don't loop-retry on an
 		// unknown shape. Gateways doing finer-grained mapping can
-		// substring-check the unwrapped message.
+		// substring-check the unwrapped message. No code on the legacy
+		// path (pre-ADR-060 handlers don't carry one).
 		body := bytes.TrimPrefix(msg.Data, legacyErrorBodyPrefix)
-		return nil, classifiedFromHeader(ErrorClassInvalid, string(body))
+		return nil, classifiedFromHeader(ErrorClassInvalid, "", string(body))
 	}
 
 	return msg.Data, nil
@@ -301,34 +327,55 @@ func classForHeader(err error) string {
 	}
 }
 
+// codeForHeader extracts the ADR-060 stable machine Code from err when
+// it carries (or wraps) a *errs.ClassifiedError with a non-empty Code;
+// "" otherwise. Returning "" means RespondError / ReplyError stamp no
+// X-Error-Code header, so uncoded handler errors are unchanged on the wire.
+func codeForHeader(err error) string {
+	var ce *errs.ClassifiedError
+	if errors.As(err, &ce) {
+		return ce.Code
+	}
+	return ""
+}
+
 // classifiedFromHeader reconstructs a *errs.ClassifiedError from the
-// X-Error-Class header value + the unwrapped body message. Uses
-// errs.Classified (the bare constructor) rather than the Wrap*
-// family so the inner message survives verbatim — external surfaces
-// (GraphQL responses, agent tool results) get the handler's clean
-// text via err.Error() instead of a leaky framework-attribution
-// prefix.
+// X-Error-Class header value, the X-Error-Code header value (ADR-060),
+// and the unwrapped body message. Uses errs.Classified / ClassifiedCode
+// (the bare constructors) rather than the Wrap* family so the inner
+// message survives verbatim — external surfaces (GraphQL responses, agent
+// tool results) get the handler's clean text via err.Error() instead of a
+// leaky framework-attribution prefix.
 //
-// The resulting error round-trips through errs.IsInvalid /
-// IsTransient / IsFatal correctly because errs.Classified preserves
-// the class tag on the ClassifiedError struct.
+// When code is non-empty the reconstructed error carries it, so
+// errors.Is(err, errs.ErrRevisionMismatch) and ce.Code discrimination
+// work caller-side (the (*ClassifiedError).Is method matches by Code).
+// When code is empty the result is exactly as before ADR-060 — uncoded.
 //
-// Unknown class strings fall back to invalid (the conservative
-// choice — a caller seeing IsInvalid won't retry on a class they
-// don't recognize, vs IsTransient which would loop).
-func classifiedFromHeader(class, message string) error {
+// The resulting error round-trips through errs.IsInvalid / IsTransient /
+// IsFatal correctly because the bare constructors preserve the class tag.
+//
+// Unknown class strings fall back to invalid (the conservative choice — a
+// caller seeing IsInvalid won't retry on a class they don't recognize, vs
+// IsTransient which would loop).
+func classifiedFromHeader(class, code, message string) error {
 	if message == "" {
 		message = "handler error"
 	}
 	inner := errors.New(message)
+	var ec errs.ErrorClass
 	switch class {
-	case ErrorClassInvalid:
-		return errs.Classified(errs.ErrorInvalid, inner)
 	case ErrorClassFatal:
-		return errs.Classified(errs.ErrorFatal, inner)
+		ec = errs.ErrorFatal
 	case ErrorClassTransient:
-		return errs.Classified(errs.ErrorTransient, inner)
+		ec = errs.ErrorTransient
+	case ErrorClassInvalid:
+		ec = errs.ErrorInvalid
 	default:
-		return errs.Classified(errs.ErrorInvalid, inner)
+		ec = errs.ErrorInvalid
 	}
+	if code != "" {
+		return errs.ClassifiedCode(ec, code, inner)
+	}
+	return errs.Classified(ec, inner)
 }

--- a/natsclient/errors_code_roundtrip_test.go
+++ b/natsclient/errors_code_roundtrip_test.go
@@ -1,0 +1,151 @@
+package natsclient
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// ADR-060: the X-Error-Code header round-trips the stable machine Code
+// through ClassifyReply onto the reconstructed *errs.ClassifiedError, so
+// errors.Is(err, ErrRevisionMismatch) and ce.Code discrimination work
+// caller-side. These tests build the reply msg directly (no connection),
+// mirroring TestClassifyReply_HeaderClassifiedError.
+
+func TestClassifyReply_CodeHeader_RevisionMismatchSentinel(t *testing.T) {
+	t.Parallel()
+	msg := &nats.Msg{
+		Header: nats.Header{
+			HeaderStatus:     []string{HeaderStatusError},
+			HeaderErrorClass: []string{ErrorClassInvalid},
+			HeaderErrorCode:  []string{"revision_mismatch"},
+		},
+		Data: []byte("error: revision mismatch: expected 5, current 7"),
+	}
+	data, err := ClassifyReply(msg)
+	if data != nil {
+		t.Fatalf("data = %q, want nil on error reply", data)
+	}
+	if !errs.IsInvalid(err) {
+		t.Errorf("IsInvalid = false, want true (err=%v)", err)
+	}
+	if !errors.Is(err, errs.ErrRevisionMismatch) {
+		t.Errorf("errors.Is(err, ErrRevisionMismatch) = false, want true — the sentinel must round-trip the wire")
+	}
+	// The inner handler text must survive verbatim (no framework prefix).
+	if errStr := err.Error(); errStr != "revision mismatch: expected 5, current 7" {
+		t.Errorf("err.Error() = %q, want the verbatim handler text", errStr)
+	}
+}
+
+func TestClassifyReply_CodeHeader_EntityNotFoundDiscriminator(t *testing.T) {
+	t.Parallel()
+	msg := &nats.Msg{
+		Header: nats.Header{
+			HeaderStatus:     []string{HeaderStatusError},
+			HeaderErrorClass: []string{ErrorClassInvalid},
+			HeaderErrorCode:  []string{"entity_not_found"},
+		},
+		Data: []byte("error: not found: acme.ops.robotics.gcs.drone.001"),
+	}
+	_, err := ClassifyReply(msg)
+	if !errs.IsInvalid(err) {
+		t.Errorf("IsInvalid = false, want true (err=%v)", err)
+	}
+	// entity_not_found is a ce.Code discriminator, NOT the sentinel.
+	if errors.Is(err, errs.ErrRevisionMismatch) {
+		t.Error("errors.Is(entity_not_found, ErrRevisionMismatch) = true, want false")
+	}
+	var ce *errs.ClassifiedError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err is not *errs.ClassifiedError: %v", err)
+	}
+	if ce.Code != "entity_not_found" {
+		t.Errorf("ce.Code = %q, want entity_not_found", ce.Code)
+	}
+}
+
+// No X-Error-Code header → reconstructed error is uncoded, exactly as
+// before ADR-060. This pins the additive guarantee: uncoded handler errors
+// (e.g. the existing graph-ingest query exemplar) are unchanged.
+func TestClassifyReply_NoCodeHeader_UncodedUnchanged(t *testing.T) {
+	t.Parallel()
+	msg := &nats.Msg{
+		Header: nats.Header{
+			HeaderStatus:     []string{HeaderStatusError},
+			HeaderErrorClass: []string{ErrorClassInvalid},
+		},
+		Data: []byte("error: bad input"),
+	}
+	_, err := ClassifyReply(msg)
+	if !errs.IsInvalid(err) {
+		t.Errorf("IsInvalid = false, want true (err=%v)", err)
+	}
+	var ce *errs.ClassifiedError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err is not *errs.ClassifiedError: %v", err)
+	}
+	if ce.Code != "" {
+		t.Errorf("ce.Code = %q, want empty (no code header)", ce.Code)
+	}
+	if errors.Is(err, errs.ErrRevisionMismatch) {
+		t.Error("errors.Is(uncoded, ErrRevisionMismatch) = true, want false")
+	}
+}
+
+// The legacy body-prefix path (no headers at all) carries no code.
+func TestClassifyReply_LegacyBody_NoCode(t *testing.T) {
+	t.Parallel()
+	msg := &nats.Msg{
+		Header: nats.Header{},
+		Data:   []byte("error: ancient handler failure"),
+	}
+	_, err := ClassifyReply(msg)
+	var ce *errs.ClassifiedError
+	if !errors.As(err, &ce) {
+		t.Fatalf("err is not *errs.ClassifiedError: %v", err)
+	}
+	if ce.Code != "" {
+		t.Errorf("ce.Code = %q, want empty on the legacy body path", ce.Code)
+	}
+}
+
+// codeForHeader extracts the Code only when err carries a *ClassifiedError
+// with a non-empty Code, so RespondError/ReplyError stamp X-Error-Code
+// only then (uncoded errors stay byte-for-byte unchanged on the wire).
+func TestCodeForHeader(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"coded", errs.ClassifiedCode(errs.ErrorInvalid, "entity_not_found", errors.New("x")), "entity_not_found"},
+		{"uncoded_classified", errs.Classified(errs.ErrorInvalid, errors.New("x")), ""},
+		{"plain", errors.New("x"), ""},
+		{"wrapped_coded", errors.New("x"), ""}, // overwritten below
+	}
+	cases[3].err = errWrap(errs.ClassifiedCode(errs.ErrorInvalid, "revision_mismatch", errors.New("x")))
+	cases[3].want = "revision_mismatch"
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := codeForHeader(tc.err); got != tc.want {
+				t.Errorf("codeForHeader(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func errWrap(err error) error {
+	return &wrapErr{err}
+}
+
+type wrapErr struct{ inner error }
+
+func (w *wrapErr) Error() string { return "wrapped: " + w.inner.Error() }
+func (w *wrapErr) Unwrap() error { return w.inner }

--- a/natsclient/errors_test.go
+++ b/natsclient/errors_test.go
@@ -57,22 +57,27 @@ func TestClassifiedFromHeader_RoundTrips(t *testing.T) {
 	cases := []struct {
 		name        string
 		class       string
+		code        string
 		msg         string
 		isInvalid   bool
 		isTransient bool
 		isFatal     bool
+		wantCode    string
 	}{
 		{name: "invalid", class: ErrorClassInvalid, msg: "bad input", isInvalid: true},
 		{name: "fatal", class: ErrorClassFatal, msg: "kv gone", isFatal: true},
 		{name: "transient", class: ErrorClassTransient, msg: "timeout", isTransient: true},
 		{name: "unknown_class_falls_back_invalid", class: "weird", msg: "x", isInvalid: true},
 		{name: "empty_message_synthesized", class: ErrorClassInvalid, msg: "", isInvalid: true},
+		// ADR-060: a coded header sets ce.Code on the reconstructed error.
+		{name: "coded_not_found", class: ErrorClassInvalid, code: "entity_not_found", msg: "not found: x", isInvalid: true, wantCode: "entity_not_found"},
+		{name: "coded_revision_mismatch", class: ErrorClassInvalid, code: "revision_mismatch", msg: "revision mismatch", isInvalid: true, wantCode: "revision_mismatch"},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			err := classifiedFromHeader(tc.class, tc.msg)
+			err := classifiedFromHeader(tc.class, tc.code, tc.msg)
 			if err == nil {
 				t.Fatal("expected non-nil error")
 			}
@@ -84,6 +89,13 @@ func TestClassifiedFromHeader_RoundTrips(t *testing.T) {
 			}
 			if errs.IsFatal(err) != tc.isFatal {
 				t.Errorf("IsFatal = %v, want %v (err=%v)", errs.IsFatal(err), tc.isFatal, err)
+			}
+			var ce *errs.ClassifiedError
+			if !errors.As(err, &ce) {
+				t.Fatalf("err is not a *errs.ClassifiedError: %v", err)
+			}
+			if ce.Code != tc.wantCode {
+				t.Errorf("ce.Code = %q, want %q", ce.Code, tc.wantCode)
 			}
 		})
 	}

--- a/pkg/errs/classified_is_test.go
+++ b/pkg/errs/classified_is_test.go
@@ -1,0 +1,139 @@
+package errs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// These tests lock the two LOAD-BEARING guards in (*ClassifiedError).Is
+// (ADR-060). Removing either guard re-opens the silent-corruption class
+// the unified RPC error contract closes:
+//
+//  1. target must resolve to a *ClassifiedError (else any non-classified
+//     sentinel — context.Canceled, a gateway's plain errEntityNotFound —
+//     would be mishandled here instead of falling through to Unwrap).
+//  2. the target sentinel's Code must be NON-EMPTY (else "" == "" makes
+//     every uncoded ClassifiedError false-match — and every
+//     wire-reconstructed error was uncoded before ADR-060).
+//
+// If a future refactor drops a guard, the corresponding test below fails.
+
+func TestClassifiedError_Is_SentinelMatch(t *testing.T) {
+	t.Parallel()
+	reconstructed := ClassifiedCode(ErrorInvalid, "revision_mismatch", errors.New("revision mismatch: expected 5, current 7"))
+	if !errors.Is(reconstructed, ErrRevisionMismatch) {
+		t.Fatal("errors.Is(reconstructed revision_mismatch, ErrRevisionMismatch) = false, want true")
+	}
+}
+
+func TestClassifiedError_Is_DifferentCodeNoMatch(t *testing.T) {
+	t.Parallel()
+	notFound := ClassifiedCode(ErrorInvalid, "entity_not_found", errors.New("not found: x"))
+	if errors.Is(notFound, ErrRevisionMismatch) {
+		t.Fatal("errors.Is(entity_not_found, ErrRevisionMismatch) = true, want false (different code)")
+	}
+}
+
+// Guard 2: the non-empty-Code guard. Without it, every uncoded
+// ClassifiedError would match an empty-Code sentinel-shaped target.
+func TestClassifiedError_Is_EmptyCodeNoFalseMatch(t *testing.T) {
+	t.Parallel()
+	emptySentinel := &ClassifiedError{Class: ErrorInvalid} // Code "", Err nil — the dangerous shape
+	uncoded := Classified(ErrorInvalid, errors.New("some handler error"))
+	if errors.Is(uncoded, emptySentinel) {
+		t.Fatal("errors.Is(uncoded, emptyCodeSentinel) = true, want false — the empty-Code guard is gone")
+	}
+	// Two coded errors with the SAME code but a real (non-nil Err) target
+	// must not match either — only a sentinel (Err==nil) is a valid target.
+	realTargetSameCode := ClassifiedCode(ErrorInvalid, "revision_mismatch", errors.New("other"))
+	reconstructed := ClassifiedCode(ErrorInvalid, "revision_mismatch", errors.New("x"))
+	if errors.Is(reconstructed, realTargetSameCode) {
+		t.Fatal("errors.Is(coded, non-sentinel-coded) = true, want false — the Err==nil guard is gone")
+	}
+}
+
+// Guard 1: the type-assert guard. errors.Is against a non-ClassifiedError
+// target must return false from Is and fall through to the Unwrap walk.
+func TestClassifiedError_Is_NonClassifiedTarget(t *testing.T) {
+	t.Parallel()
+	coded := ClassifiedCode(ErrorInvalid, "revision_mismatch", errors.New("x"))
+	if errors.Is(coded, context.Canceled) {
+		t.Fatal("errors.Is(coded, context.Canceled) = true, want false")
+	}
+	if errors.Is(coded, errors.New("unrelated plain error")) {
+		t.Fatal("errors.Is(coded, plainError) = true, want false")
+	}
+}
+
+func TestClassifiedError_Is_WrappedSentinel(t *testing.T) {
+	t.Parallel()
+	reconstructed := ClassifiedCode(ErrorInvalid, "revision_mismatch", errors.New("x"))
+	wrapped := fmt.Errorf("transition acme.x: %w", reconstructed)
+	if !errors.Is(wrapped, ErrRevisionMismatch) {
+		t.Fatal("errors.Is(fmt.Errorf(%%w), ErrRevisionMismatch) = false, want true — class/code must survive the wrap")
+	}
+}
+
+// The new Is method must NOT break the pre-existing Unwrap-based matching:
+// a ClassifiedError wrapping a plain sentinel still matches that sentinel.
+func TestClassifiedError_Is_UnwrapStillWorks(t *testing.T) {
+	t.Parallel()
+	wrapping := ClassifiedCode(ErrorTransient, "internal", ErrKeyNotFound)
+	if !errors.Is(wrapping, ErrKeyNotFound) {
+		t.Fatal("errors.Is(ClassifiedCode(.., ErrKeyNotFound), ErrKeyNotFound) = false, want true (Unwrap)")
+	}
+}
+
+// Error() must be nil-safe: the sentinel carries no wrapped Err.
+func TestClassifiedError_Error_SentinelNoPanic(t *testing.T) {
+	t.Parallel()
+	if got := ErrRevisionMismatch.Error(); got != "revision_mismatch" {
+		t.Fatalf("ErrRevisionMismatch.Error() = %q, want %q", got, "revision_mismatch")
+	}
+	// A bare classified error with neither Message nor Err nor Code.
+	if got := (&ClassifiedError{}).Error(); got != "classified error" {
+		t.Fatalf("empty ClassifiedError.Error() = %q, want %q", got, "classified error")
+	}
+}
+
+// Consumers' existing IsInvalid/IsTransient branches keep working on the
+// coded constructors (the whole point of extending ClassifiedError rather
+// than minting a new type).
+func TestClassifiedCode_ClassDetectionUnchanged(t *testing.T) {
+	t.Parallel()
+	if !IsInvalid(ClassifiedCode(ErrorInvalid, "entity_not_found", errors.New("x"))) {
+		t.Error("IsInvalid(ClassifiedCode(ErrorInvalid, ...)) = false, want true")
+	}
+	if !IsTransient(ClassifiedCode(ErrorTransient, "internal", errors.New("x"))) {
+		t.Error("IsTransient(ClassifiedCode(ErrorTransient, ...)) = false, want true")
+	}
+}
+
+func TestClassifiedCode_NilErrReturnsNil(t *testing.T) {
+	t.Parallel()
+	if ClassifiedCode(ErrorInvalid, "x", nil) != nil {
+		t.Error("ClassifiedCode(.., nil) != nil, want nil")
+	}
+	if ClassifiedCodeDetail(ErrorInvalid, "x", map[string]any{"a": 1}, nil) != nil {
+		t.Error("ClassifiedCodeDetail(.., nil) != nil, want nil")
+	}
+}
+
+func TestClassifiedCodeDetail_CodeAndDetailReachable(t *testing.T) {
+	t.Parallel()
+	err := ClassifiedCodeDetail(ErrorInvalid, "entity_not_found",
+		map[string]any{"entity": "acme.ops.robotics.gcs.drone.001"},
+		errors.New("not found"))
+	var ce *ClassifiedError
+	if !errors.As(err, &ce) {
+		t.Fatal("errors.As failed")
+	}
+	if ce.Code != "entity_not_found" {
+		t.Errorf("ce.Code = %q, want entity_not_found", ce.Code)
+	}
+	if got, _ := ce.Detail["entity"].(string); got != "acme.ops.robotics.gcs.drone.001" {
+		t.Errorf("ce.Detail[entity] = %v, want the drone id", ce.Detail["entity"])
+	}
+}

--- a/pkg/errs/errs.go
+++ b/pkg/errs/errs.go
@@ -81,26 +81,74 @@ var (
 	ErrRetryTimeout       = errors.New("retry timeout exceeded")
 )
 
-// ClassifiedError wraps an error with its classification
+// ClassifiedError wraps an error with its classification.
+//
+// Code and Detail (added by ADR-060, the unified RPC error contract)
+// carry the machine-readable failure shape across the natsclient wire:
+// Code is a stable discriminator (the graph.ErrorCode* values —
+// "entity_not_found", "revision_mismatch", ...); Detail carries
+// structured context (entity id, revisions). Both are zero (empty / nil)
+// for errors that predate or don't participate in the contract — every
+// existing construction path leaves them empty, which is exactly what
+// keeps the Is method below collision-free.
 type ClassifiedError struct {
 	Class     ErrorClass
 	Err       error
 	Message   string
 	Component string
 	Operation string
+	Code      string         // ADR-060: stable machine code; "" = uncoded.
+	Detail    map[string]any // ADR-060: structured detail; nil = none.
 }
 
-// Error implements the error interface
+// Error implements the error interface.
+//
+// Nil-safe on Err: control-flow sentinels (ErrRevisionMismatch) carry a
+// Message but no wrapped Err, so Error() must not deref a nil Err.
 func (ce *ClassifiedError) Error() string {
 	if ce.Message != "" {
 		return ce.Message
 	}
-	return ce.Err.Error()
+	if ce.Err != nil {
+		return ce.Err.Error()
+	}
+	if ce.Code != "" {
+		return ce.Code
+	}
+	return "classified error"
 }
 
 // Unwrap returns the underlying error
 func (ce *ClassifiedError) Unwrap() error {
 	return ce.Err
+}
+
+// Is reports whether ce matches target as a sentinel, BY CODE. Added for
+// ADR-060 so control-flow sentinels (ErrRevisionMismatch) round-trip the
+// natsclient wire: ClassifyReply sets Code on the reconstructed error,
+// and errors.Is(err, ErrRevisionMismatch) resolves here.
+//
+// Two guards are LOAD-BEARING and locked by the TestClassifiedError_Is_*
+// tests — do not remove them:
+//
+//  1. target must resolve to a *ClassifiedError (errors.As). Otherwise
+//     errors.Is(err, context.Canceled), sql.ErrNoRows, and any plain
+//     sentinel (e.g. a gateway's local errEntityNotFound) correctly
+//     return false here and fall through to the normal Unwrap walk.
+//  2. the target's Code must be NON-EMPTY. Without this, two uncoded
+//     ClassifiedErrors ("" == "") would false-match — and every
+//     wire-reconstructed error was uncoded before ADR-060, so an
+//     unguarded Is would silently collide across unrelated errors.
+//
+// A sentinel is shaped {Code: non-empty, Err: nil}; matching is Code
+// equality. Real (non-sentinel) errors carry a non-nil Err, so two real
+// same-code errors never match each other as sentinels.
+func (ce *ClassifiedError) Is(target error) bool {
+	var t *ClassifiedError
+	if !errors.As(target, &t) {
+		return false
+	}
+	return t.Code != "" && t.Err == nil && ce.Code == t.Code
 }
 
 // IsTransient checks if an error is transient and should be retried
@@ -267,6 +315,64 @@ func Classified(class ErrorClass, err error) *ClassifiedError {
 		return nil
 	}
 	return newClassified(class, err, "", "", err.Error())
+}
+
+// ClassifiedCode is Classified plus a stable machine Code (ADR-060 — the
+// graph.ErrorCode* values). Like Classified it preserves err's verbatim
+// text (no attribution prefix) so the message survives the wire clean.
+// Returns nil when err is nil.
+func ClassifiedCode(class ErrorClass, code string, err error) *ClassifiedError {
+	if err == nil {
+		return nil
+	}
+	ce := newClassified(class, err, "", "", err.Error())
+	ce.Code = code
+	return ce
+}
+
+// ClassifiedCodeDetail is ClassifiedCode plus structured Detail (entity
+// id, revisions, ...). graph-ingest mutation handlers attach
+// entity/revision context here; the detail rides the wire in the ADR-060
+// standard error body (landed with the breaking PR — until then Detail is
+// carried on the error value but not serialized). Returns nil when err is
+// nil.
+//
+// Detail is stored by reference, not copied — pass a map you do not mutate
+// after construction (handlers build a fresh literal per error).
+func ClassifiedCodeDetail(class ErrorClass, code string, detail map[string]any, err error) *ClassifiedError {
+	if err == nil {
+		return nil
+	}
+	ce := newClassified(class, err, "", "", err.Error())
+	ce.Code = code
+	ce.Detail = detail
+	return ce
+}
+
+// ErrRevisionMismatch is the ADR-060 optimistic-concurrency (CAS)
+// control-flow sentinel — the ONLY sentinel in the unified RPC error
+// contract (every other code is a plain ce.Code discriminator, reached
+// via errors.As).
+//
+// natsclient.ClassifyReply reconstructs a *ClassifiedError carrying
+// Code == "revision_mismatch" from the wire; errors.Is(err,
+// ErrRevisionMismatch) matches it via (*ClassifiedError).Is. CAS-retry
+// consumers write:
+//
+//	if errors.Is(err, errs.ErrRevisionMismatch) { re-read; retry }
+//
+// ORDERING: check this sentinel BEFORE IsInvalid(err). Its class is
+// ErrorInvalid (a revision mismatch is a bad-precondition write), so an
+// IsInvalid-first branch would mis-handle a retry signal as a hard 400.
+//
+// The Code literal is the string "revision_mismatch" rather than
+// graph.ErrorCodeRevisionMismatch because pkg/errs cannot import graph
+// (import cycle: graph imports errs). The graph package locks the two
+// equal with a compile-time assertion test (graph/errcode_sentinel_test.go).
+var ErrRevisionMismatch = &ClassifiedError{
+	Class:   ErrorInvalid,
+	Code:    "revision_mismatch",
+	Message: "revision_mismatch",
 }
 
 // Wrap creates a standardized error with context following the pattern:


### PR DESCRIPTION
## ADR-060 PR-A — the additive framework foundation

First of four stacked PRs landing the **unified RPC error contract** ([ADR-060](docs/adr/060-unified-rpc-error-contract.md)). Pre-1.0 and we own every consumer, so the program takes the break in one lockstep tag (PRs A→B→C→**D breaking**); A–C are non-breaking. This PR is **purely additive** — no behavior change for existing paths, **no reply-body change**.

### What lands

- **`pkg/errs`** — `ClassifiedError` gains `Code string` + `Detail map[string]any`; a guarded `Is` method (sentinel match **by Code**); `ClassifiedCode`/`ClassifiedCodeDetail` constructors; the `ErrRevisionMismatch` sentinel. `Error()` is now nil-safe (the sentinel carries no wrapped `Err`).
- **`natsclient`** — new additive **`X-Error-Code` header**. `RespondError`/`ReplyError` stamp it **only** when the error carries a non-empty `Code` (reply **body byte-for-byte unchanged** — legacy `error: <msg>` retained); `ClassifyReply`/`classifiedFromHeader` read it onto `ce.Code` so `errors.Is(err, ErrRevisionMismatch)` and `ce.Code` discrimination round-trip the wire.
- **`graph`** — assertion test locks `errs.ErrRevisionMismatch.Code == graph.ErrorCodeRevisionMismatch` (pkg/errs can't import graph — cycle).

### Why extend `ClassifiedError` (not a new `RPCError`)

Every live consumer (semstreams + semconnect + semteams) already branches on `*errs.ClassifiedError` via `errs.IsInvalid`. A new type would force all of them to migrate a working check for no gain; extending the type they already speak is the bigger break with less churn. See the amended ADR for the full rationale.

### The `Is` guards (the load-bearing bit)

`Is` matches sentinels **by Code** with two guards that are **required, independently regression-locked** test invariants:
1. target must resolve to a `*ClassifiedError` (else `errors.Is(err, context.Canceled)` / plain sentinels stay false);
2. the sentinel's `Code` must be **non-empty** (else `"" == ""` would false-match every uncoded error — and every wire-reconstructed error is uncoded today).

This was the HIGH finding from the adversarial design review; the tests fail if either guard is removed.

### Gates

- `go build ./...`, `gofmt`, `go vet` — clean
- `task lint` (revive) — exit 0
- AST request-guard lint — pass (no new violations)
- `go test -race ./...` — exit 0, 0 FAIL
- integration-tagged sweep (errs/natsclient/graph) — green
- **go-reviewer: ACCEPT-WITH-NITS** (guards verified correct + regression-locked; additive wire claim holds; NIT applied)

### Scope notes

- `Detail` is carried on the error value but **not yet serialized** — it lands in PR-D's standard error body (along with the `float64` round-trip test).
- Framework support for the gh#334 caller burn-down; producers migrate in PR-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)