### PR TITLE
feat(graph-ingest,lifecycle): classify mutation seam + empty lint allowlist (ADR-060 PR-C)

### DIFF
--- a/agentic/agentrun/nats_reader.go
+++ b/agentic/agentrun/nats_reader.go
@@ -65,12 +65,11 @@ func (p *NATSTriplePublisher) AddTriple(ctx context.Context, _ string, triple me
 	if err != nil {
 		return 0, fmt.Errorf("agentrun: NATSTriplePublisher: NATS request: %w", err)
 	}
+	// ADR-060: a handler failure arrives as the classified err above; decode the
+	// success body only for the KV revision.
 	var resp graph.AddTripleResponse
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return 0, fmt.Errorf("agentrun: NATSTriplePublisher: unmarshal response: %w", err)
-	}
-	if !resp.Success {
-		return 0, fmt.Errorf("agentrun: NATSTriplePublisher: mutation failed: %s", resp.Error)
 	}
 	return resp.KVRevision, nil
 }

--- a/examples/github-pr-workflow/component.go
+++ b/examples/github-pr-workflow/component.go
@@ -468,21 +468,13 @@ func (c *PRWorkflowComponent) writeTriple(ctx context.Context, entityID, predica
 		return fmt.Errorf("marshal AddTripleRequest: %w", err)
 	}
 
-	// RequestWithRetry handles transient "no responders" errors when
-	// graph-gateway is restarting or its subscription hasn't yet
-	// propagated. Triple mutations are idempotent on the responder
-	// side (same triple twice = same state), so retry is safe.
-	respData, err := c.natsClient.RequestWithRetry(ctx, "graph.mutation.triple.add", reqData, 5*time.Second, natsclient.DefaultRetryConfig())
-	if err != nil {
+	// RequestWithRetryClassified handles transient "no responders" errors when
+	// graph-gateway is restarting or its subscription hasn't yet propagated.
+	// Triple mutations are idempotent on the responder side (same triple twice =
+	// same state), so retry is safe. ADR-060: handler failures arrive as a
+	// classified error via err, not an in-body Success=false.
+	if _, err := c.natsClient.RequestWithRetryClassified(ctx, "graph.mutation.triple.add", reqData, 5*time.Second, natsclient.DefaultRetryConfig()); err != nil {
 		return fmt.Errorf("NATS request failed: %w", err)
-	}
-
-	var resp gtypes.AddTripleResponse
-	if err := json.Unmarshal(respData, &resp); err != nil {
-		return fmt.Errorf("unmarshal AddTripleResponse: %w", err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("graph mutation failed: %s", resp.Error)
 	}
 
 	return nil

--- a/graph/inference/applier.go
+++ b/graph/inference/applier.go
@@ -4,7 +4,6 @@ package inference
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -269,21 +268,13 @@ func (a *MutationRelationshipApplier) ApplyRelationship(
 	// retry is safe and avoids silently dropping inferred edges.
 	// gh#93 Phase 2: Classified variant surfaces handler errors via err
 	// rather than silently mis-decoding legacy "error: " body as success JSON.
-	resp, err := a.natsClient.RequestWithRetryClassified(ctx, "graph.mutation.triple.add", data, 5*time.Second, natsclient.DefaultRetryConfig())
-	if err != nil {
+	// ADR-060: a handler failure arrives as the classified err below (no in-body
+	// Success=false), so no response decode is needed — the success body carries
+	// nothing this caller uses.
+	if _, err := a.natsClient.RequestWithRetryClassified(ctx, "graph.mutation.triple.add", data, 5*time.Second, natsclient.DefaultRetryConfig()); err != nil {
 		return errs.WrapTransient(err, "MutationRelationshipApplier", "ApplyRelationship",
 			fmt.Sprintf("mutation request failed: %s -> %s -> %s",
 				suggestion.FromEntity, suggestion.Predicate, suggestion.ToEntity))
-	}
-
-	var result graph.AddTripleResponse
-	if err := json.Unmarshal(resp, &result); err != nil {
-		return errs.WrapInvalid(err, "MutationRelationshipApplier", "ApplyRelationship",
-			"failed to parse response")
-	}
-
-	if !result.Success {
-		return errors.New(result.Error)
 	}
 
 	a.logger.Debug("Applied inferred relationship via mutation API",

--- a/graph/llm/nats_content_fetcher.go
+++ b/graph/llm/nats_content_fetcher.go
@@ -164,8 +164,12 @@ func (f *NATSContentFetcher) fetchSingleEntity(
 		return nil, err
 	}
 
-	// NATS request/reply with timeout
-	respData, err := f.natsClient.Request(ctx, f.subject, reqData, f.timeout)
+	// NATS request/reply with timeout. RequestClassified surfaces a
+	// transport/handler failure via err (ADR-060) instead of an "error: <msg>"
+	// body that would mis-decode as a zero objectstore.Response. The Success
+	// field below is the ObjectStore envelope's own contract, distinct from the
+	// graph mutation lane — kept.
+	respData, err := f.natsClient.RequestClassified(ctx, f.subject, reqData, f.timeout)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lifecycle/graph_emit.go
+++ b/pkg/lifecycle/graph_emit.go
@@ -33,6 +33,7 @@ import (
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 )
 
 // graphEmitter is the abstraction Manager uses to push entity +
@@ -42,10 +43,10 @@ import (
 // without NATS.
 type graphEmitter interface {
 	// update sends an UpdateEntityWithTriplesRequest to graph-ingest
-	// and waits for the response. Returns errEmitRevisionMismatch
-	// when the handler signals CAS failed (Manager.Transition retry
-	// loop). Returns ErrEntityNotFound when the handler reports the
-	// entity doesn't exist.
+	// and waits for the response. Returns an error matching
+	// errs.ErrRevisionMismatch (errors.Is) when the handler signals CAS
+	// failed (Manager.Transition retry loop). Returns ErrEntityNotFound
+	// when the handler reports the entity doesn't exist.
 	update(ctx context.Context, req *graph.UpdateEntityWithTriplesRequest) (*graph.UpdateEntityWithTriplesResponse, error)
 
 	// create sends a CreateEntityWithTriplesRequest to graph-ingest.
@@ -78,11 +79,6 @@ const (
 	graphSubjectCreateWithTriples = "graph.mutation.entity.create_with_triples"
 )
 
-// errEmitRevisionMismatch is the package-internal sentinel Manager
-// branches on for CAS retry. Translated from the handler's
-// ErrorCodeRevisionMismatch response.
-var errEmitRevisionMismatch = errors.New("lifecycle: emit revision mismatch (CAS conflict)")
-
 // lifecycleEmitRetryConfig is the retry budget for Manager emit
 // requests. natsclient.DefaultRetryConfig (~700ms total) is tuned for
 // subscription propagation latency, but the lifecycle Manager faces a
@@ -102,14 +98,25 @@ var lifecycleEmitRetryConfig = natsclient.RetryConfig{
 }
 
 // update marshals an UpdateEntityWithTriplesRequest, fires it as a
-// NATS request/reply, and classifies the response by ErrorCode.
+// NATS request/reply, and classifies the response via the ADR-060 typed
+// error contract.
 //
-// Uses RequestWithRetry with lifecycleEmitRetryConfig to survive the
-// graph-ingest cold-start race (gh#170). Retry is safe here:
+// Uses RequestWithRetryClassified with lifecycleEmitRetryConfig to
+// survive the graph-ingest cold-start race (gh#170). Retry is safe here:
 // graph-ingest's update_with_triples handler enforces CAS via
 // ExpectedRevision, so a duplicate-delivery after a lost response
-// surfaces as ErrorCodeRevisionMismatch, which Manager.Transition's
-// outer CAS loop re-reads and re-validates.
+// surfaces as revision_mismatch, which Manager.Transition's outer CAS
+// loop re-reads and re-validates. A handler error-reply is a successful
+// round-trip (not a transport failure), so it is NOT retried — only
+// cold-start "no responders" consumes the retry budget.
+//
+// ADR-060: a hard failure arrives as a non-nil *errs.ClassifiedError
+// reconstructed from the wire headers (X-Error-Class + X-Error-Code), not
+// an in-body Success=false. A revision_mismatch is the control-flow
+// sentinel — propagated so Manager's errors.Is(err, errs.ErrRevisionMismatch)
+// CAS loop fires; entity_not_found becomes ErrEntityNotFound; anything else
+// is ErrEmitFailed. The per-consumer body-unmarshal + ErrorCode switch is
+// gone (it collapses into the framework's ClassifyReply).
 //
 // No outer context.WithTimeout: the retry budget (~13s) controls
 // total duration; each retry attempt is bounded internally by
@@ -121,24 +128,22 @@ func (g *graphEmitterNATS) update(ctx context.Context, req *graph.UpdateEntityWi
 		return nil, fmt.Errorf("%w: marshal request: %w", ErrEmitFailed, err)
 	}
 
-	respBody, err := g.client.RequestWithRetry(ctx, graphSubjectUpdateWithTriples, body, g.timeout, lifecycleEmitRetryConfig)
+	respBody, err := g.client.RequestWithRetryClassified(ctx, graphSubjectUpdateWithTriples, body, g.timeout, lifecycleEmitRetryConfig)
 	if err != nil {
+		// Control-flow sentinel: propagate so Manager's CAS loop re-reads.
+		if errors.Is(err, errs.ErrRevisionMismatch) {
+			return nil, err
+		}
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) && ce.Code == graph.ErrorCodeEntityNotFound {
+			return nil, fmt.Errorf("%w: %s", ErrEntityNotFound, err.Error())
+		}
 		return nil, fmt.Errorf("%w: NATS request to %s: %w", ErrEmitFailed, graphSubjectUpdateWithTriples, err)
 	}
 
 	var resp graph.UpdateEntityWithTriplesResponse
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return nil, fmt.Errorf("%w: unmarshal response: %w", ErrEmitFailed, err)
-	}
-	if !resp.Success {
-		switch resp.ErrorCode {
-		case graph.ErrorCodeRevisionMismatch:
-			return &resp, errEmitRevisionMismatch
-		case graph.ErrorCodeEntityNotFound:
-			return &resp, fmt.Errorf("%w: %s", ErrEntityNotFound, resp.Error)
-		}
-		return &resp, fmt.Errorf("%w: graph-ingest rejected request (code=%q): %s",
-			ErrEmitFailed, resp.ErrorCode, resp.Error)
 	}
 	return &resp, nil
 }
@@ -165,21 +170,20 @@ func (g *graphEmitterNATS) create(ctx context.Context, req *graph.CreateEntityWi
 		return nil, fmt.Errorf("%w: marshal request: %w", ErrEmitFailed, err)
 	}
 
-	respBody, err := g.client.RequestWithRetry(ctx, graphSubjectCreateWithTriples, body, g.timeout, lifecycleEmitRetryConfig)
+	respBody, err := g.client.RequestWithRetryClassified(ctx, graphSubjectCreateWithTriples, body, g.timeout, lifecycleEmitRetryConfig)
 	if err != nil {
+		// ADR-060: entity_already_exists arrives as a classified error
+		// (Code on the wire header), not an in-body Success=false.
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) && ce.Code == graph.ErrorCodeEntityExists {
+			return nil, fmt.Errorf("%w: %s", ErrAlreadyExists, err.Error())
+		}
 		return nil, fmt.Errorf("%w: NATS request to %s: %w", ErrEmitFailed, graphSubjectCreateWithTriples, err)
 	}
 
 	var resp graph.CreateEntityWithTriplesResponse
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return nil, fmt.Errorf("%w: unmarshal response: %w", ErrEmitFailed, err)
-	}
-	if !resp.Success {
-		if resp.ErrorCode == graph.ErrorCodeEntityExists {
-			return &resp, fmt.Errorf("%w: %s", ErrAlreadyExists, resp.Error)
-		}
-		return &resp, fmt.Errorf("%w: graph-ingest rejected create (code=%q): %s",
-			ErrEmitFailed, resp.ErrorCode, resp.Error)
 	}
 	return &resp, nil
 }

--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/pkg/ownership"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -521,7 +522,7 @@ func (m *Manager) Create(ctx context.Context, initial Participant) error {
 		OwnerToken:       ownerTok,
 	}
 	if _, err := m.emitter.update(ctx, updateReq); err != nil {
-		if errors.Is(err, errEmitRevisionMismatch) {
+		if errors.Is(err, errs.ErrRevisionMismatch) {
 			// Concurrent attach from a sibling — surface as
 			// ErrAlreadyExists since the most likely cause is
 			// a parallel lifecycle attach.
@@ -687,7 +688,7 @@ func (m *Manager) TransitionWith(ctx context.Context, workflow, entityID, newPha
 			)
 			return nil
 		}
-		if errors.Is(err, errEmitRevisionMismatch) {
+		if errors.Is(err, errs.ErrRevisionMismatch) {
 			lastErr = err
 			continue
 		}
@@ -810,7 +811,7 @@ func (m *Manager) UpdateFromOperator(ctx context.Context, workflow, entityID str
 		if err == nil {
 			return nil
 		}
-		if errors.Is(err, errEmitRevisionMismatch) {
+		if errors.Is(err, errs.ErrRevisionMismatch) {
 			lastErr = err
 			continue
 		}

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -37,22 +38,13 @@ func (f *fakeEmitter) update(_ context.Context, req *graph.UpdateEntityWithTripl
 	f.requests = append(f.requests, req)
 	currentRev := f.bucket.revOf(req.Entity.ID)
 	if !f.bucket.exists(req.Entity.ID) {
-		return &graph.UpdateEntityWithTriplesResponse{
-			MutationResponse: graph.MutationResponse{
-				Success:   false,
-				ErrorCode: graph.ErrorCodeEntityNotFound,
-				Error:     "entity not found: " + req.Entity.ID,
-			},
-		}, fmt.Errorf("%w: entity not found", ErrEntityNotFound)
+		// ADR-060: production update() returns (nil, <error wrapping ErrEntityNotFound>).
+		return nil, fmt.Errorf("%w: entity not found", ErrEntityNotFound)
 	}
 	if req.ExpectedRevision > 0 && req.ExpectedRevision != currentRev {
-		return &graph.UpdateEntityWithTriplesResponse{
-			MutationResponse: graph.MutationResponse{
-				Success:   false,
-				ErrorCode: graph.ErrorCodeRevisionMismatch,
-				Error:     "revision mismatch",
-			},
-		}, errEmitRevisionMismatch
+		// ADR-060: production update() now returns (nil, <classified error>)
+		// matching errs.ErrRevisionMismatch on the CAS-conflict path.
+		return nil, errs.ErrRevisionMismatch
 	}
 	current := f.bucket.get(req.Entity.ID)
 	merged := current.Triples
@@ -92,13 +84,8 @@ func (f *fakeEmitter) create(_ context.Context, req *graph.CreateEntityWithTripl
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.bucket.exists(req.Entity.ID) {
-		return &graph.CreateEntityWithTriplesResponse{
-			MutationResponse: graph.MutationResponse{
-				Success:   false,
-				ErrorCode: graph.ErrorCodeEntityExists,
-				Error:     "entity already exists: " + req.Entity.ID,
-			},
-		}, fmt.Errorf("%w: entity already exists", ErrAlreadyExists)
+		// ADR-060: production create() returns (nil, <error wrapping ErrAlreadyExists>).
+		return nil, fmt.Errorf("%w: entity already exists", ErrAlreadyExists)
 	}
 	state := *req.Entity
 	state.Triples = req.Triples

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -3,6 +3,7 @@ package agenticloop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/model"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/storage/objectstore"
 	"github.com/c360studio/semstreams/types"
 	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
@@ -111,13 +113,11 @@ func (w *graphWriter) writeTriple(ctx context.Context, triple message.Triple) er
 		return fmt.Errorf("NATS request failed: %w", err)
 	}
 
+	// ADR-060: a handler failure arrives as the classified err above; the
+	// legacy !resp.Success second check is gone. Decode only to confirm shape.
 	var resp gtypes.AddTripleResponse
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return fmt.Errorf("unmarshal response: %w", err)
-	}
-
-	if !resp.Success {
-		return fmt.Errorf("mutation failed: %s", resp.Error)
 	}
 
 	return nil
@@ -149,8 +149,12 @@ func (w *graphWriter) writeBatch(ctx context.Context, triples []message.Triple) 
 		return fmt.Errorf("unmarshal batch response: %w", err)
 	}
 
+	// ADR-060: a whole-batch failure now arrives as the classified err above.
+	// A PARTIAL batch (some subjects committed) still returns a success body
+	// with Success=false + FailedSubjects — that path is handled here.
 	if !resp.Success {
-		return fmt.Errorf("batch mutation failed: %s", resp.Error)
+		return fmt.Errorf("batch mutation failed (written=%d, failed=%v): %s",
+			resp.WrittenCount, resp.FailedSubjects, resp.Error)
 	}
 
 	return nil
@@ -182,25 +186,18 @@ func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtype
 		return fmt.Errorf("marshal create_with_triples request: %w", err)
 	}
 
-	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
-	respData, err := w.natsClient.RequestWithRetryClassified(ctx, graphMutationCreateWithTriplesSubj, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig())
-	if err != nil {
-		return fmt.Errorf("NATS create_with_triples request failed: %w", err)
-	}
-
-	var resp gtypes.CreateEntityWithTriplesResponse
-	if err := json.Unmarshal(respData, &resp); err != nil {
-		return fmt.Errorf("unmarshal create_with_triples response: %w", err)
-	}
-
-	if !resp.Success {
+	// ADR-060: handler failures arrive as a classified error carrying the
+	// stable Code (no in-body Success=false). The success body has no fields
+	// this caller needs, so no response decode is required.
+	if _, err := w.natsClient.RequestWithRetryClassified(ctx, graphMutationCreateWithTriplesSubj, reqData, graphWriterTimeout, natsclient.DefaultRetryConfig()); err != nil {
 		// EntityExists is idempotent-success ONLY if the existing entity is
 		// already this typed origin (same MessageType) — a genuine retry /
 		// redelivery / re-spawn of OUR origin. Blessing any EntityExists blindly
 		// would launder a pre-existing auto-vivified shell (Version-0 / no
 		// envelope) or a foreign entity into a "born" loop origin, defeating the
 		// typed-origin contract (ADR-056). Read + verify before treating it as born.
-		if resp.ErrorCode == gtypes.ErrorCodeEntityExists {
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) && ce.Code == gtypes.ErrorCodeEntityExists {
 			// Extract the incoming task_id from the spawn triples so
 			// verifyExistingLoopOrigin can detect divergent-task_id reuse (gh#276).
 			var incomingTaskID string
@@ -214,7 +211,7 @@ func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtype
 			}
 			return w.verifyExistingLoopOrigin(ctx, entity.ID, entity.MessageType, incomingTaskID)
 		}
-		return fmt.Errorf("create_with_triples failed (code=%s): %s", resp.ErrorCode, resp.Error)
+		return fmt.Errorf("NATS create_with_triples request failed: %w", err)
 	}
 
 	return nil

--- a/processor/agentic-loop/graph_writer_integration_test.go
+++ b/processor/agentic-loop/graph_writer_integration_test.go
@@ -5,6 +5,7 @@ package agenticloop_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"sync"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/model"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 	agenticloop "github.com/c360studio/semstreams/processor/agentic-loop"
 	"github.com/c360studio/semstreams/storage/objectstore"
 	"github.com/c360studio/semstreams/types"
@@ -136,30 +138,24 @@ func (r *createWithTriplesResponder) handler(_ context.Context, data []byte) ([]
 	r.received = append(r.received, req)
 	r.mu.Unlock()
 
-	resp := gtypes.CreateEntityWithTriplesResponse{}
+	// ADR-060: mirror the production handler — a hard failure returns
+	// (nil, *errs.ClassifiedError), which SubscribeForRequests turns into a
+	// header-classified reply (the contract createEntityWithTriples now reads).
 	switch {
 	case r.alreadyExists:
-		resp.MutationResponse = gtypes.MutationResponse{
-			Success:   false,
-			Error:     "entity already exists",
-			ErrorCode: gtypes.ErrorCodeEntityExists,
-			Timestamp: time.Now().UnixNano(),
-		}
+		return nil, errs.ClassifiedCode(errs.ErrorInvalid, gtypes.ErrorCodeEntityExists, errors.New("entity already exists"))
 	case r.failWith != "":
-		resp.MutationResponse = gtypes.MutationResponse{
-			Success:   false,
-			Error:     r.failWith,
-			ErrorCode: gtypes.ErrorCodeInternal,
-			Timestamp: time.Now().UnixNano(),
-		}
+		return nil, errs.ClassifiedCode(errs.ErrorTransient, gtypes.ErrorCodeInternal, errors.New(r.failWith))
 	default:
-		resp.MutationResponse = gtypes.MutationResponse{
-			Success:   true,
-			Timestamp: time.Now().UnixNano(),
+		resp := gtypes.CreateEntityWithTriplesResponse{
+			MutationResponse: gtypes.MutationResponse{
+				Success:   true,
+				Timestamp: time.Now().UnixNano(),
+			},
+			TriplesAdded: len(req.Triples),
 		}
-		resp.TriplesAdded = len(req.Triples)
+		return json.Marshal(resp)
 	}
-	return json.Marshal(resp)
 }
 
 func (r *createWithTriplesResponder) subscribe(t *testing.T, ctx context.Context, client *natsclient.Client) {
@@ -954,16 +950,11 @@ func TestWriteMutationFailure_Integration(t *testing.T) {
 	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
 	ctx := context.Background()
 
-	// Respond with failure to verify graceful handling.
+	// Respond with failure to verify graceful handling. ADR-060: a hard failure
+	// is a classified error, mirroring the production handler.
 	_, err := tc.Client.SubscribeForRequests(ctx, "graph.mutation.triple.add",
 		func(_ context.Context, _ []byte) ([]byte, error) {
-			resp := gtypes.AddTripleResponse{
-				MutationResponse: gtypes.MutationResponse{
-					Success: false,
-					Error:   "test error",
-				},
-			}
-			return json.Marshal(resp)
+			return nil, errs.ClassifiedCode(errs.ErrorTransient, gtypes.ErrorCodeInternal, errors.New("test error"))
 		})
 	if err != nil {
 		t.Fatalf("subscribe: %v", err)

--- a/processor/agentic-tools/decide.go
+++ b/processor/agentic-tools/decide.go
@@ -699,12 +699,10 @@ func (p *natsTriplePublisher) AddTriple(ctx context.Context, triple message.Trip
 	if err != nil {
 		return fmt.Errorf("request %s: %w", decideMutationSubject, err)
 	}
+	// ADR-060: handler failures arrive as the classified err above.
 	var resp graph.AddTripleResponse
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return fmt.Errorf("unmarshal response: %w", err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("graph-ingest rejected triple: %s", resp.Error)
 	}
 	return nil
 }
@@ -735,6 +733,9 @@ func (p *natsTriplePublisher) AddTriplesBatch(ctx context.Context, triples []mes
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return fmt.Errorf("unmarshal batch response: %w", err)
 	}
+	// ADR-060: a whole-batch failure arrives as the classified err above. A
+	// PARTIAL batch (some subjects committed) still returns a success body with
+	// Success=false + FailedSubjects, handled here.
 	if !resp.Success {
 		return fmt.Errorf("graph-ingest rejected batch (written=%d, failed=%v): %s",
 			resp.WrittenCount, resp.FailedSubjects, resp.Error)

--- a/processor/agentic-tools/write_todos.go
+++ b/processor/agentic-tools/write_todos.go
@@ -422,17 +422,13 @@ func (w *natsTodoWriter) RemoveByPredicate(ctx context.Context, subject, predica
 	if err != nil {
 		return fmt.Errorf("request %s: %w", writeTodosRemoveSubject, err)
 	}
+	// ADR-060: handler failures arrive as the classified err above. Removing
+	// from a missing entity is an idempotent no-op success on the handler side
+	// (RemoveTriple returns nil), so "entity not found" never reaches here as a
+	// failure — the first write_todos call on a fresh loop has nothing to clear.
 	var resp graph.RemoveTripleResponse
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return fmt.Errorf("unmarshal remove response: %w", err)
-	}
-	if !resp.Success {
-		// "entity not found" is not an error for our use case — first
-		// write_todos call on a fresh loop has nothing to clear. The
-		// graph-ingest handler returns Success=true for missing
-		// entities (RemoveTriple returns nil); other failures
-		// (network, marshal) surface the error string.
-		return fmt.Errorf("graph-ingest rejected remove: %s", resp.Error)
 	}
 	return nil
 }
@@ -452,6 +448,9 @@ func (w *natsTodoWriter) AddTriplesBatch(ctx context.Context, triples []message.
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return fmt.Errorf("unmarshal batch response: %w", err)
 	}
+	// ADR-060: a whole-batch failure arrives as the classified err above. A
+	// PARTIAL batch (some subjects committed) still returns a success body with
+	// Success=false + FailedSubjects, handled here.
 	if !resp.Success {
 		return fmt.Errorf("graph-ingest rejected batch (written=%d, failed=%v): %s",
 			resp.WrittenCount, resp.FailedSubjects, resp.Error)

--- a/processor/graph-ingest/batch_integration_test.go
+++ b/processor/graph-ingest/batch_integration_test.go
@@ -285,12 +285,8 @@ func TestIntegration_HandleTripleAddBatch_InvalidJSON(t *testing.T) {
 	ctx, c := startBatchTestComponent(t)
 
 	respBytes, err := c.handleTripleAddBatch(ctx, []byte("not json"))
-	require.NoError(t, err)
-
-	var resp graph.AddTriplesBatchResponse
-	require.NoError(t, json.Unmarshal(respBytes, &resp))
-	assert.False(t, resp.Success)
-	assert.Contains(t, resp.Error, "invalid request")
+	// ADR-060: a malformed envelope is a typed invalid_request reject (no body).
+	requireClassifiedReject(t, respBytes, err, graph.ErrorCodeInvalidRequest, "invalid request")
 }
 
 // TestIntegration_HandleTripleAdd_AbsentEntityRejects verifies ADR-055
@@ -313,14 +309,9 @@ func TestIntegration_HandleTripleAdd_AbsentEntityRejects(t *testing.T) {
 	require.NoError(t, err)
 
 	respBytes, handlerErr := c.handleTripleAdd(ctx, reqBytes)
-	require.NoError(t, handlerErr, "handler must not return a Go error; rejections are in the response body")
-
-	var resp graph.AddTripleResponse
-	require.NoError(t, json.Unmarshal(respBytes, &resp))
-	assert.False(t, resp.Success, "absent entity must produce Success=false")
-	assert.Equal(t, graph.ErrorCodeEntityNotFound, resp.ErrorCode,
-		"absent entity must produce ErrorCode=entity_not_found (not empty/unclassified)")
-	assert.NotEmpty(t, resp.Error, "rejection must carry a human-readable error message")
+	// ADR-060: a single must-exist add on an absent entity is a typed
+	// entity_not_found reject (invalid class), no longer an in-body Success=false.
+	requireClassifiedReject(t, respBytes, handlerErr, graph.ErrorCodeEntityNotFound, "")
 
 	// State must be unchanged: entity must still not exist.
 	_, getErr := c.entityBucket.Get(ctx, subject)

--- a/processor/graph-ingest/cas_integration_test.go
+++ b/processor/graph-ingest/cas_integration_test.go
@@ -386,10 +386,8 @@ func TestIntegration_SharedSeam_CASFailureDoesNotRouteForeign(t *testing.T) {
 		}
 		data, _ := json.Marshal(req)
 		respData, err := c.handleEntityUpdateWithTriples(ctx, data)
-		require.NoError(t, err)
-		var resp graph.UpdateEntityWithTriplesResponse
-		require.NoError(t, json.Unmarshal(respData, &resp))
-		require.False(t, resp.Success, "stale-revision CAS must fail")
+		// ADR-060: a stale CAS is the revision_mismatch sentinel reject (no body).
+		requireClassifiedReject(t, respData, err, graph.ErrorCodeRevisionMismatch, "revision mismatch")
 
 		// The failed primary write must NOT have routed the foreign edge — the
 		// child was never created.

--- a/processor/graph-ingest/entity_mutation_integration_test.go
+++ b/processor/graph-ingest/entity_mutation_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -92,14 +93,11 @@ func TestIntegration_HandleEntityCreate_Conflict(t *testing.T) {
 	require.NoError(t, err)
 
 	respBytes, err := c.handleEntityCreate(ctx, reqBytes)
-	require.NoError(t, err)
-
-	var resp graph.CreateEntityResponse
-	require.NoError(t, json.Unmarshal(respBytes, &resp))
-	assert.False(t, resp.Success, "duplicate create should not succeed")
-	assert.Contains(t, resp.Error, "already exists",
-		"error body should signal conflict so semconnect can map to HTTP 409")
-	assert.Equal(t, "req-create-conflict", resp.RequestID)
+	// ADR-060: a duplicate create is a typed entity_already_exists reject
+	// (invalid class), no longer an in-body Success=false. RequestID is no
+	// longer echoed on the failure path (failures carry no body).
+	requireClassifiedReject(t, respBytes, err, graph.ErrorCodeEntityExists, "already exists")
+	assert.True(t, errs.IsInvalid(err), "conflict classifies invalid so semconnect can map to HTTP 409")
 }
 
 func TestIntegration_HandleEntityCreateWithTriples_PreservesProvenance(t *testing.T) {
@@ -173,13 +171,10 @@ func TestIntegration_HandleEntityUpdate_NotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	respBytes, err := c.handleEntityUpdate(ctx, reqBytes)
-	require.NoError(t, err)
-
-	var resp graph.UpdateEntityResponse
-	require.NoError(t, json.Unmarshal(respBytes, &resp))
-	assert.False(t, resp.Success, "update on absent entity should not succeed")
-	assert.Contains(t, resp.Error, "not found",
-		"error body should signal absence so semconnect can map to HTTP 404")
+	// ADR-060: must-exist update on an absent entity is a typed entity_not_found
+	// reject (invalid class), so semconnect can map to HTTP 404.
+	requireClassifiedReject(t, respBytes, err, graph.ErrorCodeEntityNotFound, "not found")
+	assert.True(t, errs.IsInvalid(err))
 }
 
 func TestIntegration_HandleEntityUpdate_Success(t *testing.T) {
@@ -457,13 +452,10 @@ func TestIntegration_HandleEntityUpdate_DeleteBeforeUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	respBytes, err := c.handleEntityUpdate(ctx, reqBytes)
-	require.NoError(t, err)
-
-	var resp graph.UpdateEntityResponse
-	require.NoError(t, json.Unmarshal(respBytes, &resp))
-	assert.False(t, resp.Success, "update on deleted entity must NOT silently resurrect")
-	assert.Contains(t, resp.Error, "not found",
-		"error body should signal absence so semconnect can map to HTTP 404")
+	// ADR-060: a concurrent delete surfaces as a typed entity_not_found reject
+	// (invalid class) rather than silently resurrecting the entity.
+	requireClassifiedReject(t, respBytes, err, graph.ErrorCodeEntityNotFound, "not found")
+	assert.True(t, errs.IsInvalid(err))
 
 	exists, err := c.entityExists(ctx, entityID)
 	require.NoError(t, err)
@@ -564,15 +556,8 @@ func TestIntegration_HandleEntity_NilEntity(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			respBytes, err := tc.handler(mustJSON(t, tc.payload))
-			require.NoError(t, err)
-
-			var base struct {
-				Success bool   `json:"success"`
-				Error   string `json:"error"`
-			}
-			require.NoError(t, json.Unmarshal(respBytes, &base))
-			assert.False(t, base.Success)
-			assert.Contains(t, base.Error, "entity cannot be nil")
+			// ADR-060: the nil-body guard rejects with a typed invalid_request error.
+			requireClassifiedReject(t, respBytes, err, graph.ErrorCodeInvalidRequest, "entity cannot be nil")
 		})
 	}
 }
@@ -587,12 +572,8 @@ func TestIntegration_HandleEntityDelete_EmptyID(t *testing.T) {
 
 	req := graph.DeleteEntityRequest{EntityID: "", RequestID: "req-delete-empty"}
 	respBytes, err := c.handleEntityDelete(ctx, mustJSON(t, req))
-	require.NoError(t, err)
-
-	var resp graph.DeleteEntityResponse
-	require.NoError(t, json.Unmarshal(respBytes, &resp))
-	assert.False(t, resp.Success)
-	assert.Contains(t, resp.Error, "entity_id cannot be empty")
+	// ADR-060: the empty-EntityID guard rejects with a typed invalid_request error.
+	requireClassifiedReject(t, respBytes, err, graph.ErrorCodeInvalidRequest, "entity_id cannot be empty")
 }
 
 // TestIntegration_HandleEntityUpdateWithTriples_UnknownRemovePredicate
@@ -629,6 +610,23 @@ func mustJSON(t *testing.T, v any) []byte {
 	return b
 }
 
+// requireClassifiedReject asserts the ADR-060 typed-error reject contract: a
+// hard mutation failure returns (nil body, *errs.ClassifiedError) carrying the
+// expected stable Code, with the handler's message preserved in err.Error().
+// Replaces the pre-ADR-060 "no Go error, Success=false + ErrorCode in the body"
+// assertions across the graph-ingest mutation integration tests.
+func requireClassifiedReject(t *testing.T, respBytes []byte, err error, wantCode, wantMsgSubstr string) {
+	t.Helper()
+	require.Error(t, err)
+	require.Nil(t, respBytes, "ADR-060: a hard failure returns no body")
+	var ce *errs.ClassifiedError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, wantCode, ce.Code, "classified error Code")
+	if wantMsgSubstr != "" {
+		assert.Contains(t, err.Error(), wantMsgSubstr)
+	}
+}
+
 func TestIntegration_HandleEntity_InvalidJSON(t *testing.T) {
 	ctx, c := startBatchTestComponent(t)
 
@@ -646,17 +644,9 @@ func TestIntegration_HandleEntity_InvalidJSON(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			respBytes, err := tc.handler([]byte("not json"))
-			require.NoError(t, err, "handler should never return a non-nil err — error lives in the response body per feedback_natsclient_error_payload_convention")
-
-			// Each shape has a MutationResponse embedded; we can unmarshal
-			// to the base type just to read the Success/Error flags.
-			var base struct {
-				Success bool   `json:"success"`
-				Error   string `json:"error"`
-			}
-			require.NoError(t, json.Unmarshal(respBytes, &base))
-			assert.False(t, base.Success)
-			assert.Contains(t, base.Error, "invalid request")
+			// ADR-060: malformed JSON rejects with a typed invalid_request error
+			// (handler returns (nil, *errs.ClassifiedError), not an in-body flag).
+			requireClassifiedReject(t, respBytes, err, graph.ErrorCodeInvalidRequest, "invalid request")
 		})
 	}
 }
@@ -915,13 +905,10 @@ func TestIntegration_UpdateEntityWithTriples_ExpectedRevisionMismatchAtRead(t *t
 		RequestID:        "req-update-wt-cas-stale",
 	}
 	respBytes, err := c.handleEntityUpdateWithTriples(ctx, mustJSON(t, req))
-	require.NoError(t, err)
-
-	var resp graph.UpdateEntityWithTriplesResponse
-	require.NoError(t, json.Unmarshal(respBytes, &resp))
-	assert.False(t, resp.Success, "stale ExpectedRevision must fail")
-	assert.Contains(t, resp.Error, "revision mismatch",
-		"error should signal revision mismatch so callers can re-read + re-validate")
+	// ADR-060: a stale CAS is the revision_mismatch control-flow sentinel, so a
+	// caller can errors.Is(err, errs.ErrRevisionMismatch) and re-read + re-validate.
+	requireClassifiedReject(t, respBytes, err, graph.ErrorCodeRevisionMismatch, "revision mismatch")
+	assert.True(t, errors.Is(err, errs.ErrRevisionMismatch), "stale CAS surfaces the revision-mismatch sentinel")
 
 	// Verify the stale delta did NOT land.
 	_, currentRev, err := c.fetchEntityState(ctx, entityID)
@@ -975,13 +962,10 @@ func TestIntegration_UpdateEntityWithTriples_ExpectedRevisionAbsentEntity(t *tes
 		RequestID:        "req-update-wt-cas-absent",
 	}
 	respBytes, err := c.handleEntityUpdateWithTriples(ctx, mustJSON(t, req))
-	require.NoError(t, err)
-
-	var resp graph.UpdateEntityWithTriplesResponse
-	require.NoError(t, json.Unmarshal(respBytes, &resp))
-	assert.False(t, resp.Success, "CAS-on-condition against absent entity must fail")
-	assert.Contains(t, resp.Error, "entity not found",
-		"absent-entity error message must allow callers to disambiguate from CAS mismatch")
+	// ADR-060: CAS against an absent entity is entity_not_found (not
+	// revision_mismatch), so callers can disambiguate from a CAS conflict.
+	requireClassifiedReject(t, respBytes, err, graph.ErrorCodeEntityNotFound, "entity not found")
+	assert.False(t, errors.Is(err, errs.ErrRevisionMismatch), "absent entity is not the revision-mismatch sentinel")
 }
 
 func TestIntegration_UpdateEntityWithTriples_ExpectedRevisionRaceAtWrite(t *testing.T) {
@@ -1019,6 +1003,13 @@ func TestIntegration_UpdateEntityWithTriples_ExpectedRevisionRaceAtWrite(t *test
 			}
 			respBytes, err := c.handleEntityUpdateWithTriples(ctx, mustJSON(t, req))
 			if err != nil {
+				// ADR-060: a CAS loser now surfaces as the revision_mismatch
+				// sentinel error (no in-body Success=false).
+				if errors.Is(err, errs.ErrRevisionMismatch) {
+					mu.Lock()
+					mismatchErrs++
+					mu.Unlock()
+				}
 				return
 			}
 			var resp graph.UpdateEntityWithTriplesResponse
@@ -1029,8 +1020,6 @@ func TestIntegration_UpdateEntityWithTriples_ExpectedRevisionRaceAtWrite(t *test
 			defer mu.Unlock()
 			if resp.Success {
 				successCount++
-			} else if errors.Is(errors.New(resp.Error), errors.New("revision mismatch")) || (resp.Error != "" && (containsAny(resp.Error, "revision mismatch", "concurrent modification"))) {
-				mismatchErrs++
 			}
 		}(i)
 	}
@@ -1038,17 +1027,4 @@ func TestIntegration_UpdateEntityWithTriples_ExpectedRevisionRaceAtWrite(t *test
 
 	assert.Equal(t, 1, successCount, "exactly one CAS race winner expected from %d racers", N)
 	assert.Equal(t, N-1, mismatchErrs, "all other racers must observe revision-mismatch errors")
-}
-
-// containsAny is a small test helper — true if s contains any of the
-// substrings. Avoids importing strings just for this assertion.
-func containsAny(s string, subs ...string) bool {
-	for _, sub := range subs {
-		for i := 0; i+len(sub) <= len(s); i++ {
-			if s[i:i+len(sub)] == sub {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/processor/graph-ingest/indexing_profile_test.go
+++ b/processor/graph-ingest/indexing_profile_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/vocabulary"
 )
 
@@ -177,11 +178,15 @@ func TestIndexingProfile_UpdateOverride_InvalidRejected(t *testing.T) {
 		IndexingProfile: "bogus",
 	}
 	updateData, _ := json.Marshal(updateReq)
+	// ADR-060: an invalid explicit override is rejected as a typed error
+	// (invalid_request), not an in-body Success=false.
 	respData, err := comp.handleEntityUpdateWithTriples(ctx, updateData)
-	require.NoError(t, err)
-	var resp graph.MutationResponse
-	require.NoError(t, json.Unmarshal(respData, &resp))
-	assert.False(t, resp.Success, "an invalid explicit override must be rejected (not silently dropped)")
+	require.Error(t, err, "an invalid explicit override must be rejected (not silently dropped)")
+	assert.Nil(t, respData, "a hard failure returns no body")
+	var ce *errs.ClassifiedError
+	require.ErrorAs(t, err, &ce)
+	assert.Equal(t, graph.ErrorCodeInvalidRequest, ce.Code)
+	assert.True(t, errs.IsInvalid(err))
 }
 
 // --- Graphable arrival (channel a) via MergeEntity ---

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -13,6 +13,7 @@ import (
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/pkg/retry"
 	"github.com/c360studio/semstreams/vocabulary"
 )
@@ -135,24 +136,34 @@ func (c *Component) setupMutationHandlers(ctx context.Context) error {
 type mutationHandler = func(ctx context.Context, data []byte) ([]byte, error)
 
 // meteredMutation wraps a mutation request handler to meter rejections
-// (ADR-055 §3 observability). A mutation handler encodes a rejection as a
-// MutationResponse with success=false (and a bounded ErrorCode); on that, this
-// increments mutation_rejections_total{subject, reason} and logs the reason at
-// Warn. The handler's (response, error) is passed through UNCHANGED — metering
-// never alters the verdict. The success path costs only one substring scan, no
-// unmarshal. A handler that returns a non-nil error (rare; handlers normally
-// encode failure in the body) is metered as reason="internal".
+// (ADR-055 §3 observability). It increments mutation_rejections_total{subject,
+// reason} and logs the reason at Warn. The handler's (response, error) is passed
+// through UNCHANGED — metering never alters the verdict.
+//
+// ADR-060: a hard mutation failure now arrives as a non-nil
+// (*errs.ClassifiedError) carrying the stable Code, NOT an in-body
+// success=false. The reason label is read from ce.Code (pre-ADR-060 this branch
+// hardcoded "internal", which would now collapse EVERY rejection reason to
+// internal). The only remaining (body, nil) success=false shape is a PARTIAL
+// batch (handleTripleAddBatch with FailedSubjects); the cheap substring gate
+// below still meters it for metric continuity. Full + degraded success marshal
+// success=true and skip the unmarshal.
 func (c *Component) meteredMutation(subject string, h mutationHandler) mutationHandler {
 	return func(ctx context.Context, data []byte) ([]byte, error) {
 		resp, err := h(ctx, data)
 		if err != nil {
-			c.recordMutationRejection(subject, graph.ErrorCodeInternal, err.Error())
+			reason := graph.ErrorCodeInternal
+			var ce *errs.ClassifiedError
+			if errors.As(err, &ce) && ce.Code != "" {
+				reason = ce.Code
+			}
+			c.recordMutationRejection(subject, reason, err.Error())
 			return resp, err
 		}
-		// A rejection always marshals `"success":false` (the field has no
-		// omitempty), so this cheap gate skips the unmarshal on the success path.
-		// The explicit !Success check below rejects a false-positive substring
-		// that happened to appear inside entity data.
+		// Only a partial batch still encodes success=false in the body (the
+		// field has no omitempty), so this cheap gate skips the unmarshal on the
+		// success path. The explicit !Success check below rejects a false-positive
+		// substring that happened to appear inside entity data.
 		if bytes.Contains(resp, []byte(`"success":false`)) {
 			var r struct {
 				Success   bool   `json:"success"`
@@ -191,29 +202,18 @@ func (c *Component) recordMutationRejection(subject, reason, detail string) {
 func (c *Component) handleTripleAdd(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.AddTripleRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return json.Marshal(graph.AddTripleResponse{
-			MutationResponse: graph.MutationResponse{
-				Success:   false,
-				Error:     fmt.Sprintf("invalid request: %v", err),
-				Timestamp: time.Now().UnixNano(),
-			},
-		})
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, fmt.Errorf("invalid request: %w", err))
 	}
 
 	// AddTriple uses triple.Subject as entity ID
-	err := c.AddTriple(ctx, req.Triple)
-	if err != nil {
-		resp := graph.AddTripleResponse{
-			MutationResponse: graph.MutationResponse{
-				Success:   false,
-				Error:     err.Error(),
-				Timestamp: time.Now().UnixNano(),
-			},
-		}
+	if err := c.AddTriple(ctx, req.Triple); err != nil {
 		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
-			resp.ErrorCode = graph.ErrorCodeEntityNotFound
+			return nil, rejectInvalidDetail(graph.ErrorCodeEntityNotFound,
+				map[string]any{"entity": req.Triple.Subject}, err)
 		}
-		return json.Marshal(resp)
+		// A malformed triple is WrapInvalid (do-not-retry); a KV blip is
+		// transient. Classify by the error so the wire class is honest.
+		return nil, rejectFromError(err)
 	}
 
 	// Get revision after successful mutation for feedback loop prevention
@@ -242,13 +242,7 @@ func (c *Component) handleTripleAdd(ctx context.Context, data []byte) ([]byte, e
 func (c *Component) handleTripleAddBatch(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.AddTriplesBatchRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return json.Marshal(graph.AddTriplesBatchResponse{
-			MutationResponse: graph.MutationResponse{
-				Success:   false,
-				Error:     fmt.Sprintf("invalid request: %v", err),
-				Timestamp: time.Now().UnixNano(),
-			},
-		})
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, fmt.Errorf("invalid request: %w", err))
 	}
 
 	if len(req.Triples) == 0 {
@@ -263,15 +257,17 @@ func (c *Component) handleTripleAddBatch(ctx context.Context, data []byte) ([]by
 
 	written, failed, err := c.AddTriples(ctx, req.Triples)
 	if err != nil && len(failed) == 0 {
-		// Pre-CAS validation failure (e.g. empty subject/predicate).
-		// Whole batch rejected.
-		return json.Marshal(graph.AddTriplesBatchResponse{
-			MutationResponse: graph.MutationResponse{
-				Success:   false,
-				Error:     err.Error(),
-				Timestamp: time.Now().UnixNano(),
-			},
-		})
+		// Whole-batch failure: nothing committed. ADR-060: hard failure →
+		// typed error. Classify by the error's nature — pre-CAS validation
+		// (empty subject/predicate, WrapInvalid) is invalid_request; a context
+		// cancellation/deadline is transient. A PARTIAL batch (some subjects
+		// committed) is handled below as a success-with-FailedSubjects body, NOT
+		// an error. (ErrKVKeyNotFound always lands in failedSubjects → the
+		// partial path, so it cannot reach here; mapped defensively.)
+		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
+			return nil, rejectInvalidDetail(graph.ErrorCodeEntityNotFound, nil, err)
+		}
+		return nil, rejectFromError(err)
 	}
 
 	resp := graph.AddTriplesBatchResponse{
@@ -295,25 +291,14 @@ func (c *Component) handleTripleAddBatch(ctx context.Context, data []byte) ([]by
 func (c *Component) handleTripleRemove(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.RemoveTripleRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return json.Marshal(graph.RemoveTripleResponse{
-			MutationResponse: graph.MutationResponse{
-				Success:   false,
-				Error:     fmt.Sprintf("invalid request: %v", err),
-				Timestamp: time.Now().UnixNano(),
-			},
-		})
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, fmt.Errorf("invalid request: %w", err))
 	}
 
-	// RemoveTriple takes subject (entity ID) and predicate
-	err := c.RemoveTriple(ctx, req.Subject, req.Predicate)
-	if err != nil {
-		return json.Marshal(graph.RemoveTripleResponse{
-			MutationResponse: graph.MutationResponse{
-				Success:   false,
-				Error:     err.Error(),
-				Timestamp: time.Now().UnixNano(),
-			},
-		})
+	// RemoveTriple takes subject (entity ID) and predicate. Removing from a
+	// missing entity is an idempotent no-op success on the handler side, so a
+	// non-nil error here is a genuine internal failure (transient).
+	if err := c.RemoveTriple(ctx, req.Subject, req.Predicate); err != nil {
+		return nil, rejectInternal(err)
 	}
 
 	// Get revision after successful mutation for feedback loop prevention
@@ -370,19 +355,19 @@ func (c *Component) entityExists(ctx context.Context, entityID string) (bool, er
 func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.CreateEntityRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return marshalCreateEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("invalid request: %v", err))
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, fmt.Errorf("invalid request: %w", err))
 	}
 	if req.Entity == nil {
-		return marshalCreateEntityError(req.TraceID, req.RequestID, "entity cannot be nil")
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, errors.New("entity cannot be nil"))
 	}
 
 	if err := c.CreateEntityStrict(ctx, req.Entity); err != nil {
 		if errors.Is(err, natsclient.ErrKVKeyExists) {
-			return marshalCreateEntityError(req.TraceID, req.RequestID,
-				fmt.Sprintf("entity already exists: %s", req.Entity.ID))
+			return nil, rejectInvalidDetail(graph.ErrorCodeEntityExists,
+				map[string]any{"entity": req.Entity.ID},
+				fmt.Errorf("entity already exists: %s", req.Entity.ID))
 		}
-		return marshalCreateEntityError(req.TraceID, req.RequestID, err.Error())
+		return nil, rejectInternal(err)
 	}
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
@@ -423,12 +408,10 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.CreateEntityWithTriplesRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return marshalCreateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeInvalidRequest,
-			fmt.Sprintf("invalid request: %v", err))
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, fmt.Errorf("invalid request: %w", err))
 	}
 	if req.Entity == nil {
-		return marshalCreateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeInvalidRequest,
-			"entity cannot be nil")
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, errors.New("entity cannot be nil"))
 	}
 
 	if len(req.Triples) > 0 {
@@ -452,8 +435,8 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 	// primary).
 	if v := c.checkOwnerLease(ctx, req.Entity.ID, labelForMessageType(req.Entity.MessageType), req.OwnerToken,
 		predicatesOf(own)); v != nil {
-		return marshalCreateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID,
-			graph.ErrorCodeOwnerLeaseStale, v.detail())
+		return nil, rejectInvalidDetail(graph.ErrorCodeOwnerLeaseStale,
+			map[string]any{"entity": req.Entity.ID}, errors.New(v.detail()))
 	}
 
 	// ADR-054 channel (b): stamp an explicitly declared indexing profile from
@@ -463,10 +446,11 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 
 	if err := c.CreateEntityStrict(ctx, req.Entity); err != nil {
 		if errors.Is(err, natsclient.ErrKVKeyExists) {
-			return marshalCreateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeEntityExists,
-				fmt.Sprintf("entity already exists: %s", req.Entity.ID))
+			return nil, rejectInvalidDetail(graph.ErrorCodeEntityExists,
+				map[string]any{"entity": req.Entity.ID},
+				fmt.Errorf("entity already exists: %s", req.Entity.ID))
 		}
-		return marshalCreateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
+		return nil, rejectInternal(err)
 	}
 
 	// Primary committed — route foreign edges onto their own subjects (after the
@@ -507,29 +491,33 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 func (c *Component) handleEntityUpdate(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.UpdateEntityRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return marshalUpdateEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("invalid request: %v", err))
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, fmt.Errorf("invalid request: %w", err))
 	}
 	if req.Entity == nil {
-		return marshalUpdateEntityError(req.TraceID, req.RequestID, "entity cannot be nil")
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, errors.New("entity cannot be nil"))
 	}
 
 	_, currentRev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
 		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
-			return marshalUpdateEntityError(req.TraceID, req.RequestID,
-				fmt.Sprintf("entity not found: %s", req.Entity.ID))
+			return nil, rejectInvalidDetail(graph.ErrorCodeEntityNotFound,
+				map[string]any{"entity": req.Entity.ID},
+				fmt.Errorf("entity not found: %s", req.Entity.ID))
 		}
-		return marshalUpdateEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("fetch current entity failed: %v", err))
+		return nil, rejectInternal(fmt.Errorf("fetch current entity failed: %w", err))
 	}
 
 	if err := c.updateEntityAtRevision(ctx, req.Entity, currentRev); err != nil {
 		if errors.Is(err, natsclient.ErrKVRevisionMismatch) {
-			return marshalUpdateEntityError(req.TraceID, req.RequestID,
-				fmt.Sprintf("entity not found: %s (concurrent modification or delete)", req.Entity.ID))
+			// A concurrent delete/modify between read and write on this
+			// must-exist (non-CAS) update surfaces as "entity not found" — the
+			// 404 contract semconnect maps. This is NOT the revision_mismatch
+			// CAS-retry sentinel (that is the ExpectedRevision path below).
+			return nil, rejectInvalidDetail(graph.ErrorCodeEntityNotFound,
+				map[string]any{"entity": req.Entity.ID},
+				fmt.Errorf("entity not found: %s (concurrent modification or delete)", req.Entity.ID))
 		}
-		return marshalUpdateEntityError(req.TraceID, req.RequestID, err.Error())
+		return nil, rejectInternal(err)
 	}
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
@@ -631,12 +619,10 @@ func preserveStoredEntityMetadata(newEntity, stored *graph.EntityState) {
 func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.UpdateEntityWithTriplesRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeInvalidRequest,
-			fmt.Sprintf("invalid request: %v", err))
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, fmt.Errorf("invalid request: %w", err))
 	}
 	if req.Entity == nil {
-		return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeInvalidRequest,
-			"entity cannot be nil")
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, errors.New("entity cannot be nil"))
 	}
 
 	// ADR-054 §5: the indexing profile is immutable after creation EXCEPT via
@@ -647,8 +633,8 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	// different writer must NOT change the profile — only this envelope does.
 	if req.IndexingProfile != "" {
 		if !vocabulary.IsValidIndexingProfile(req.IndexingProfile) {
-			return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeInvalidRequest,
-				fmt.Sprintf("invalid indexing_profile %q (want content|control|signal|trace)", req.IndexingProfile))
+			return nil, rejectInvalid(graph.ErrorCodeInvalidRequest,
+				fmt.Errorf("invalid indexing_profile %q (want content|control|signal|trace)", req.IndexingProfile))
 		}
 		req.RemoveTriples = append(req.RemoveTriples, vocabulary.EntityIndexingProfile)
 		req.AddTriples = append(req.AddTriples, message.Triple{
@@ -682,8 +668,8 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	// is added for it). Deduped by checkOwnerLease's loop.
 	if v := c.checkOwnerLease(ctx, req.Entity.ID, labelForMessageType(req.Entity.MessageType), req.OwnerToken,
 		dedupePredicates(predicatesOf(addOwn), req.RemoveTriples)); v != nil {
-		return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID,
-			graph.ErrorCodeOwnerLeaseStale, v.detail())
+		return nil, rejectInvalidDetail(graph.ErrorCodeOwnerLeaseStale,
+			map[string]any{"entity": req.Entity.ID}, errors.New(v.detail()))
 	}
 
 	// ADR-049: CAS-on-condition path. Non-zero ExpectedRevision means
@@ -696,11 +682,12 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	if req.ExpectedRevision > 0 {
 		resp, err := c.handleEntityUpdateWithTriplesCAS(ctx, &req)
 		// Route foreign edges ONLY when the CAS primary write actually COMMITTED.
-		// A logical CAS failure (revision mismatch) returns (Success=false, nil
-		// err), so gating on err==nil alone would orphan a foreign edge onto a
-		// primary that never landed. Gate on the decoded Success; the unmarshal is
-		// skipped on the no-foreign-edge happy path (every current caller).
-		if err == nil && len(foreign) > 0 && casUpdateCommitted(resp) {
+		// ADR-060: a logical CAS failure (revision mismatch) now returns
+		// (nil, *errs.ClassifiedError), so err != nil captures every non-commit
+		// outcome; an err==nil reply is always a committed (full or degraded)
+		// success. The decoded-Success gate this used to need is gone with the
+		// in-body Success flag.
+		if err == nil && len(foreign) > 0 {
 			c.routeForeignEdges(ctx, req.Entity.ID, req.Entity.MessageType, foreign)
 		}
 		return resp, err
@@ -776,10 +763,11 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	})
 	if err != nil {
 		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
-			return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeEntityNotFound,
-				fmt.Sprintf("entity not found: %s", req.Entity.ID))
+			return nil, rejectInvalidDetail(graph.ErrorCodeEntityNotFound,
+				map[string]any{"entity": req.Entity.ID},
+				fmt.Errorf("entity not found: %s", req.Entity.ID))
 		}
-		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
+		return nil, rejectInternal(err)
 	}
 
 	// Primary update committed — route foreign edges onto their own subjects.
@@ -806,17 +794,6 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 	})
 }
 
-// casUpdateCommitted reports whether a handleEntityUpdateWithTriplesCAS response
-// represents an actually-committed primary write. The CAS handler returns
-// (Success=false, nil err) on a logical revision mismatch, so the shared-seam
-// foreign-edge routing must gate on this decoded Success — not on err==nil — or a
-// stale-CAS request carrying a foreign edge would orphan it onto a primary that
-// never landed (ADR-056 Decision 4).
-func casUpdateCommitted(resp []byte) bool {
-	var r graph.UpdateEntityWithTriplesResponse
-	return json.Unmarshal(resp, &r) == nil && r.Success
-}
-
 // handleEntityUpdateWithTriplesCAS is the CAS-on-condition branch of
 // handleEntityUpdateWithTriples (ADR-049). Reads the entity's current
 // state + revision, rejects if the revision doesn't match the caller's
@@ -840,17 +817,21 @@ func (c *Component) handleEntityUpdateWithTriplesCAS(ctx context.Context, req *g
 	current, currentRev, err := c.fetchEntityState(ctx, req.Entity.ID)
 	if err != nil {
 		if errors.Is(err, natsclient.ErrKVKeyNotFound) {
-			return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeEntityNotFound,
-				fmt.Sprintf("entity not found: %s", req.Entity.ID))
+			return nil, rejectInvalidDetail(graph.ErrorCodeEntityNotFound,
+				map[string]any{"entity": req.Entity.ID},
+				fmt.Errorf("entity not found: %s", req.Entity.ID))
 		}
-		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID,
-			fmt.Sprintf("fetch current entity failed: %v", err))
+		return nil, rejectInternal(fmt.Errorf("fetch current entity failed: %w", err))
 	}
 
 	// CAS-on-condition: caller's expected rev must match what we just read.
+	// ADR-060: a revision mismatch is the ONE control-flow sentinel — it carries
+	// Code revision_mismatch so the caller's errors.Is(err, errs.ErrRevisionMismatch)
+	// CAS-retry loop fires (Manager.Transition). NOT a hard failure.
 	if currentRev != req.ExpectedRevision {
-		return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeRevisionMismatch,
-			fmt.Sprintf("revision mismatch: expected %d, current %d", req.ExpectedRevision, currentRev))
+		return nil, rejectRevisionMismatch(
+			map[string]any{"entity": req.Entity.ID, "expected_revision": req.ExpectedRevision, "current_revision": currentRev},
+			fmt.Errorf("revision mismatch: expected %d, current %d", req.ExpectedRevision, currentRev))
 	}
 
 	// Apply delta against current state. Same merge logic as the
@@ -891,11 +872,12 @@ func (c *Component) handleEntityUpdateWithTriplesCAS(ctx context.Context, req *g
 	// check passed.
 	if err := c.updateEntityAtRevision(ctx, &newEntity, req.ExpectedRevision); err != nil {
 		if errors.Is(err, natsclient.ErrKVRevisionMismatch) {
-			return marshalUpdateEntityWithTriplesErrorCoded(req.TraceID, req.RequestID, graph.ErrorCodeRevisionMismatch,
-				fmt.Sprintf("revision mismatch: concurrent modification of %s (expected revision %d)",
+			return nil, rejectRevisionMismatch(
+				map[string]any{"entity": req.Entity.ID, "expected_revision": req.ExpectedRevision},
+				fmt.Errorf("revision mismatch: concurrent modification of %s (expected revision %d)",
 					req.Entity.ID, req.ExpectedRevision))
 		}
-		return marshalUpdateEntityWithTriplesError(req.TraceID, req.RequestID, err.Error())
+		return nil, rejectInternal(err)
 	}
 
 	// Read back for response. Degraded path handles read-back failure
@@ -929,21 +911,19 @@ func (c *Component) handleEntityUpdateWithTriplesCAS(ctx context.Context, req *g
 func (c *Component) handleEntityDelete(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.DeleteEntityRequest
 	if err := json.Unmarshal(data, &req); err != nil {
-		return marshalDeleteEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("invalid request: %v", err))
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, fmt.Errorf("invalid request: %w", err))
 	}
 	if req.EntityID == "" {
-		return marshalDeleteEntityError(req.TraceID, req.RequestID, "entity_id cannot be empty")
+		return nil, rejectInvalid(graph.ErrorCodeInvalidRequest, errors.New("entity_id cannot be empty"))
 	}
 
 	existed, err := c.entityExists(ctx, req.EntityID)
 	if err != nil {
-		return marshalDeleteEntityError(req.TraceID, req.RequestID,
-			fmt.Sprintf("existence check failed: %v", err))
+		return nil, rejectInternal(fmt.Errorf("existence check failed: %w", err))
 	}
 
 	if err := c.DeleteEntity(ctx, req.EntityID); err != nil {
-		return marshalDeleteEntityError(req.TraceID, req.RequestID, err.Error())
+		return nil, rejectInternal(err)
 	}
 
 	return json.Marshal(graph.DeleteEntityResponse{
@@ -1036,67 +1016,58 @@ func labelForMessageType(mt message.Type) string {
 	return invalidMessageTypeLabel
 }
 
-// Per-response-shape error marshalers. The body-prefix error
-// convention (feedback_natsclient_error_payload_convention) lives in
-// these helpers — they each emit a Success=false response with the
-// caller's TraceID/RequestID preserved.
+// ADR-060 producer helpers — a hard graph-ingest mutation failure travels as
+// (nil, *errs.ClassifiedError), which the SubscribeForRequests wrapper turns
+// into a header-classified reply (X-Error-Class + X-Error-Code) via
+// natsclient.RespondError. This replaces the per-response-shape Success=false
+// body marshalers: a failure carries no success body, so the response-shape
+// specificity (and the TraceID/RequestID echo) no longer applies on the failure
+// path — the reply inbox already correlates the response, and in-tree callers
+// branch on err, not a body field.
+//
+// Code is the stable graph.ErrorCode* discriminator; Detail carries structured
+// context (entity id, revisions). Detail is carried on the error value now and
+// serialized into the standard error body by the PR-D breaking change — until
+// then it does not cross the wire (callers see Code via the header).
 
-func marshalCreateEntityError(traceID, requestID, msg string) ([]byte, error) {
-	return json.Marshal(graph.CreateEntityResponse{
-		MutationResponse: graph.MutationResponse{
-			Success:   false,
-			Error:     msg,
-			Timestamp: time.Now().UnixNano(),
-			TraceID:   traceID,
-			RequestID: requestID,
-		},
-	})
+// rejectInvalid builds an invalid-class (400-like) classified failure with the
+// given stable Code. err's text is preserved verbatim as the wire message.
+func rejectInvalid(code string, err error) error {
+	return errs.ClassifiedCode(errs.ErrorInvalid, code, err)
 }
 
-func marshalCreateEntityWithTriplesError(traceID, requestID, msg string) ([]byte, error) {
-	return marshalCreateEntityWithTriplesErrorCoded(traceID, requestID, graph.ErrorCodeInternal, msg)
+// rejectInvalidDetail is rejectInvalid plus structured Detail (entity id, ...).
+func rejectInvalidDetail(code string, detail map[string]any, err error) error {
+	return errs.ClassifiedCodeDetail(errs.ErrorInvalid, code, detail, err)
 }
 
-func marshalCreateEntityWithTriplesErrorCoded(traceID, requestID, code, msg string) ([]byte, error) {
-	return json.Marshal(graph.CreateEntityWithTriplesResponse{
-		MutationResponse: graph.MutationResponse{
-			Success:   false,
-			Error:     msg,
-			ErrorCode: code,
-			Timestamp: time.Now().UnixNano(),
-			TraceID:   traceID,
-			RequestID: requestID,
-		},
-	})
+// rejectInternal builds a transient-class (retryable, 5xx-like) internal
+// failure. Matches the query handlers' choice that "internal" is transient.
+func rejectInternal(err error) error {
+	return errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, err)
 }
 
-func marshalUpdateEntityError(traceID, requestID, msg string) ([]byte, error) {
-	return json.Marshal(graph.UpdateEntityResponse{
-		MutationResponse: graph.MutationResponse{
-			Success:   false,
-			Error:     msg,
-			Timestamp: time.Now().UnixNano(),
-			TraceID:   traceID,
-			RequestID: requestID,
-		},
-	})
+// rejectFromError classifies a GENERIC handler-internal error by the error's own
+// nature, for the fallback paths where the failure could be either a do-not-retry
+// validation error or a retryable transient one. An already-invalid error (e.g.
+// AddTriple/AddTriples' WrapInvalid on a malformed triple) becomes
+// invalid_request; everything else (KV blips, context cancel/deadline) becomes
+// internal/transient (retryable). Without this, a fixed per-call-site class would
+// advertise a malformed-triple as retryable, or a context cancellation as a hard
+// 400 — wrong now that the class rides the wire (ADR-060).
+func rejectFromError(err error) error {
+	if errs.IsInvalid(err) {
+		return rejectInvalid(graph.ErrorCodeInvalidRequest, err)
+	}
+	return rejectInternal(err)
 }
 
-func marshalUpdateEntityWithTriplesError(traceID, requestID, msg string) ([]byte, error) {
-	return marshalUpdateEntityWithTriplesErrorCoded(traceID, requestID, graph.ErrorCodeInternal, msg)
-}
-
-func marshalUpdateEntityWithTriplesErrorCoded(traceID, requestID, code, msg string) ([]byte, error) {
-	return json.Marshal(graph.UpdateEntityWithTriplesResponse{
-		MutationResponse: graph.MutationResponse{
-			Success:   false,
-			Error:     msg,
-			ErrorCode: code,
-			Timestamp: time.Now().UnixNano(),
-			TraceID:   traceID,
-			RequestID: requestID,
-		},
-	})
+// rejectRevisionMismatch builds the ONE control-flow sentinel — a CAS
+// revision_mismatch. It is invalid-class but carries Code revision_mismatch so a
+// CAS-retry caller resolves errors.Is(err, errs.ErrRevisionMismatch) and loops
+// (Manager.Transition), rather than treating it as a hard 400.
+func rejectRevisionMismatch(detail map[string]any, err error) error {
+	return errs.ClassifiedCodeDetail(errs.ErrorInvalid, graph.ErrorCodeRevisionMismatch, detail, err)
 }
 
 // Per-response-shape "degraded success" marshalers (#120). Emitted
@@ -1162,18 +1133,6 @@ func marshalUpdateEntityWithTriplesDegraded(traceID, requestID, readbackErr stri
 			Success:   true,
 			Degraded:  true,
 			Error:     degradedReadbackErrPrefix + readbackErr,
-			Timestamp: time.Now().UnixNano(),
-			TraceID:   traceID,
-			RequestID: requestID,
-		},
-	})
-}
-
-func marshalDeleteEntityError(traceID, requestID, msg string) ([]byte, error) {
-	return json.Marshal(graph.DeleteEntityResponse{
-		MutationResponse: graph.MutationResponse{
-			Success:   false,
-			Error:     msg,
 			Timestamp: time.Now().UnixNano(),
 			TraceID:   traceID,
 			RequestID: requestID,

--- a/processor/graph-ingest/owner_lease_check_integration_test.go
+++ b/processor/graph-ingest/owner_lease_check_integration_test.go
@@ -284,11 +284,8 @@ func TestIntegration_OwnerLease_Enforce_CreateWithTriples_StaleRejected(t *testi
 	require.NoError(t, err)
 
 	respData, handlerErr := c.handleEntityCreateWithTriples(ctx, data)
-	require.NoError(t, handlerErr, "reject is encoded in the body, never a transport error")
-	var resp graph.CreateEntityWithTriplesResponse
-	require.NoError(t, json.Unmarshal(respData, &resp))
-	require.False(t, resp.Success, "enforce on: create with a stale token must be rejected")
-	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+	// ADR-060: a stale lease is a typed owner_lease_stale reject (no body).
+	requireClassifiedReject(t, respData, handlerErr, graph.ErrorCodeOwnerLeaseStale, "")
 
 	// Metric still fires.
 	after := testutil.ToFloat64(c.ownerLeaseMismatch.WithLabelValues(label, intPred))
@@ -320,11 +317,8 @@ func TestIntegration_OwnerLease_Enforce_UpdateWithTriples_StaleRejected(t *testi
 	require.NoError(t, err)
 
 	respData, handlerErr := c.handleEntityUpdateWithTriples(ctx, data)
-	require.NoError(t, handlerErr)
-	var resp graph.UpdateEntityWithTriplesResponse
-	require.NoError(t, json.Unmarshal(respData, &resp))
-	require.False(t, resp.Success, "enforce on: update with a stale token must be rejected")
-	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+	// ADR-060: a stale lease is a typed owner_lease_stale reject (no body).
+	requireClassifiedReject(t, respData, handlerErr, graph.ErrorCodeOwnerLeaseStale, "")
 
 	// Prior state unchanged.
 	stored, _, readErr := c.fetchEntityState(ctx, eid)
@@ -364,11 +358,8 @@ func TestIntegration_OwnerLease_Enforce_UpdateWithTriplesCAS_StaleRejected(t *te
 	require.NoError(t, err)
 
 	respData, handlerErr := c.handleEntityUpdateWithTriples(ctx, data)
-	require.NoError(t, handlerErr)
-	var resp graph.UpdateEntityWithTriplesResponse
-	require.NoError(t, json.Unmarshal(respData, &resp))
-	require.False(t, resp.Success, "enforce on: CAS update with a stale token must be rejected")
-	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+	// ADR-060: a stale lease is a typed owner_lease_stale reject (no body).
+	requireClassifiedReject(t, respData, handlerErr, graph.ErrorCodeOwnerLeaseStale, "")
 
 	// Prior state AND revision unchanged — the CAS write never ran.
 	stored, revAfter, readErr := c.fetchEntityState(ctx, eid)

--- a/processor/graph-ingest/owner_lease_check_test.go
+++ b/processor/graph-ingest/owner_lease_check_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
 )
 
 // ---------------------------------------------------------------------------
@@ -471,13 +472,15 @@ func TestOwnerLease_CreateWithTriples_EnforceOn_Rejects(t *testing.T) {
 	data, err := json.Marshal(req)
 	require.NoError(t, err)
 
+	// ADR-060: the reject is a typed error (owner_lease_stale / invalid class),
+	// not an in-body Success=false.
 	respData, handlerErr := comp.handleEntityCreateWithTriples(context.Background(), data)
-	require.NoError(t, handlerErr, "handler encodes the reject in the body, never a transport error")
-
-	var resp graph.CreateEntityWithTriplesResponse
-	require.NoError(t, json.Unmarshal(respData, &resp))
-	assert.False(t, resp.Success, "enforce on: create with a stale token must be rejected")
-	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+	require.Error(t, handlerErr, "enforce on: create with a stale token must be rejected")
+	assert.Nil(t, respData, "a hard failure returns no body")
+	var ce *errs.ClassifiedError
+	require.ErrorAs(t, handlerErr, &ce)
+	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, ce.Code)
+	assert.True(t, errs.IsInvalid(handlerErr))
 }
 
 // TestOwnerLease_UpdateWithTriples_EnforceOn_Rejects proves the update lane
@@ -504,12 +507,12 @@ func TestOwnerLease_UpdateWithTriples_EnforceOn_Rejects(t *testing.T) {
 	require.NoError(t, err)
 
 	respData, handlerErr := comp.handleEntityUpdateWithTriples(context.Background(), data)
-	require.NoError(t, handlerErr)
-
-	var resp graph.UpdateEntityWithTriplesResponse
-	require.NoError(t, json.Unmarshal(respData, &resp))
-	assert.False(t, resp.Success, "enforce on: update with a stale token must be rejected")
-	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+	require.Error(t, handlerErr, "enforce on: update with a stale token must be rejected")
+	assert.Nil(t, respData, "a hard failure returns no body")
+	var ce *errs.ClassifiedError
+	require.ErrorAs(t, handlerErr, &ce)
+	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, ce.Code)
+	assert.True(t, errs.IsInvalid(handlerErr))
 
 	// The prior value must be untouched — the reject returns before UpdateWithRetry.
 	stored, _, readErr := comp.fetchEntityState(context.Background(), eid)
@@ -550,12 +553,12 @@ func TestOwnerLease_UpdateWithTriplesCAS_EnforceOn_Rejects(t *testing.T) {
 	require.NoError(t, err)
 
 	respData, handlerErr := comp.handleEntityUpdateWithTriples(context.Background(), data)
-	require.NoError(t, handlerErr)
-
-	var resp graph.UpdateEntityWithTriplesResponse
-	require.NoError(t, json.Unmarshal(respData, &resp))
-	assert.False(t, resp.Success, "enforce on: CAS update with a stale token must be rejected")
-	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, resp.ErrorCode)
+	require.Error(t, handlerErr, "enforce on: CAS update with a stale token must be rejected")
+	assert.Nil(t, respData, "a hard failure returns no body")
+	var ce *errs.ClassifiedError
+	require.ErrorAs(t, handlerErr, &ce)
+	assert.Equal(t, graph.ErrorCodeOwnerLeaseStale, ce.Code)
+	assert.True(t, errs.IsInvalid(handlerErr))
 }
 
 // TestOwnerLease_EnforceOn_MeteredMutation_RecordsRejection proves the reject
@@ -580,7 +583,9 @@ func TestOwnerLease_EnforceOn_MeteredMutation_RecordsRejection(t *testing.T) {
 	before := testutil.ToFloat64(comp.mutationRejections.WithLabelValues(SubjectEntityCreateWithTriples, graph.ErrorCodeOwnerLeaseStale))
 	handler := comp.meteredMutation(SubjectEntityCreateWithTriples, comp.handleEntityCreateWithTriples)
 	_, handlerErr := handler(context.Background(), data)
-	require.NoError(t, handlerErr)
+	// ADR-060: the reject now flows through meteredMutation's error path, which
+	// reads the rejection reason from ce.Code (owner_lease_stale).
+	require.Error(t, handlerErr)
 	after := testutil.ToFloat64(comp.mutationRejections.WithLabelValues(SubjectEntityCreateWithTriples, graph.ErrorCodeOwnerLeaseStale))
 
 	assert.InDelta(t, before+1, after, 0.0001,

--- a/processor/graph-query/entity_resolver.go
+++ b/processor/graph-query/entity_resolver.go
@@ -96,7 +96,10 @@ func (c *Component) resolveViaSuffix(ctx context.Context, suffix string) string 
 	queryCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	respData, err := c.natsClient.Request(queryCtx, "graph.ingest.query.suffix", reqData, 2*time.Second)
+	// ADR-060: RequestClassified surfaces a handler failure via err instead of
+	// an "error: <msg>" body that would mis-decode as an empty {id} (a silent
+	// "no match"). On any error the resolver returns "" (no match) as before.
+	respData, err := c.natsClient.RequestClassified(queryCtx, "graph.ingest.query.suffix", reqData, 2*time.Second)
 	if err != nil {
 		return ""
 	}

--- a/processor/graph-query/graphrag.go
+++ b/processor/graph-query/graphrag.go
@@ -1206,7 +1206,9 @@ func (c *Component) loadEntities(ctx context.Context, entityIDs []string) ([]*gt
 	if subject == "" {
 		return nil, errs.WrapTransient(errors.New("entityBatch query routing not available"), "GraphQuery", "loadEntities", "route query")
 	}
-	respData, err := c.natsClient.Request(ctx, subject, reqData, c.config.QueryTimeout)
+	// ADR-060: RequestClassified surfaces a handler failure via err instead of
+	// an "error: <msg>" body that would mis-decode as an empty entity batch.
+	respData, err := c.natsClient.RequestClassified(ctx, subject, reqData, c.config.QueryTimeout)
 	if err != nil {
 		return nil, errs.WrapTransient(err, "GraphQuery", "loadEntities", "request entities")
 	}
@@ -1676,7 +1678,9 @@ func (c *Component) fetchEntityCommunityFromStorage(ctx context.Context, entityI
 	}
 
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	resp, err := c.natsClient.Request(queryCtx, "graph.clustering.query.entity", data, 5*time.Second)
+	// ADR-060: RequestClassified surfaces a handler failure via err instead of
+	// an "error: <msg>" body that would mis-decode as a nil community.
+	resp, err := c.natsClient.RequestClassified(queryCtx, "graph.clustering.query.entity", data, 5*time.Second)
 	cancel()
 
 	if err != nil {

--- a/processor/research-graph-llmwrap/triplepub.go
+++ b/processor/research-graph-llmwrap/triplepub.go
@@ -83,12 +83,10 @@ func (p *natsTriplePublisher) AddTriple(ctx context.Context, triple message.Trip
 	if err != nil {
 		return fmt.Errorf("request %s: %w", graphMutationAddSubject, err)
 	}
+	// ADR-060: handler failures arrive as the classified err above.
 	var resp graph.AddTripleResponse
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return fmt.Errorf("unmarshal response: %w", err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("graph-ingest rejected triple: %s", resp.Error)
 	}
 	return nil
 }
@@ -111,6 +109,9 @@ func (p *natsTriplePublisher) AddTriplesBatch(ctx context.Context, triples []mes
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return fmt.Errorf("unmarshal batch response: %w", err)
 	}
+	// ADR-060: a whole-batch failure arrives as the classified err above. A
+	// PARTIAL batch (some subjects committed) still returns a success body with
+	// Success=false + FailedSubjects, handled here.
 	if !resp.Success {
 		return fmt.Errorf("graph-ingest rejected batch: %s", resp.Error)
 	}

--- a/processor/rule/triple_mutator.go
+++ b/processor/rule/triple_mutator.go
@@ -4,12 +4,14 @@ package rule
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	gtypes "github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 )
 
 // NATS subjects for graph mutations (must match processor/graph-ingest/mutations.go)
@@ -75,14 +77,12 @@ func (m *tripleMutator) AddTriple(ctx context.Context, ruleID string, triple mes
 		return 0, fmt.Errorf("NATS request failed: %w", err)
 	}
 
-	// Parse response
+	// Parse the success response for the KV revision. ADR-060: a handler
+	// failure now arrives as the classified err above, so the legacy
+	// !resp.Success second check is gone.
 	var resp gtypes.AddTripleResponse
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return 0, fmt.Errorf("unmarshal response: %w", err)
-	}
-
-	if !resp.Success {
-		return 0, fmt.Errorf("mutation failed: %s", resp.Error)
 	}
 
 	// Track the revision to prevent this rule from re-triggering on its own write.
@@ -119,14 +119,11 @@ func (m *tripleMutator) RemoveTriple(ctx context.Context, ruleID, subject, predi
 		return 0, fmt.Errorf("NATS request failed: %w", err)
 	}
 
-	// Parse response
+	// Parse the success response for the KV revision. ADR-060: handler
+	// failures arrive as the classified err above.
 	var resp gtypes.RemoveTripleResponse
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return 0, fmt.Errorf("unmarshal response: %w", err)
-	}
-
-	if !resp.Success {
-		return 0, fmt.Errorf("mutation failed: %s", resp.Error)
 	}
 
 	if m.revisionTracker != nil && resp.KVRevision > 0 && ruleID != "" {
@@ -152,10 +149,11 @@ func (m *tripleMutator) RemoveTriple(ctx context.Context, ruleID, subject, predi
 // onto the request's OwnerToken field for the lease check (a later increment).
 // Token composition is the caller's responsibility (ActionExecutor.executeReplaceOwned).
 //
-// Unlike AddTriple/RemoveTriple, this checks resp.Success (NOT the body-prefix
-// convention) and surfaces the handler's ErrorCode on failure. On a
-// non-existent entity the handler returns ErrorCodeEntityNotFound; that is
-// returned verbatim as an error (no auto-vivify).
+// ADR-060: handler failures arrive as a classified error (entity_not_found,
+// owner_lease_stale, internal); this surfaces the stable Code in the returned
+// error so callers/operators can distinguish must-exist failures from transport.
+// On a non-existent entity the handler returns entity_not_found — returned as an
+// error (no auto-vivify).
 func (m *tripleMutator) ReplaceOwned(ctx context.Context, ruleID, ownerToken, entityID, predicate string, objects []message.Triple) (uint64, error) {
 	if m.natsClient == nil {
 		return 0, fmt.Errorf("NATS client not available")
@@ -182,22 +180,21 @@ func (m *tripleMutator) ReplaceOwned(ctx context.Context, ruleID, ownerToken, en
 	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
 	respData, err := m.natsClient.RequestWithRetryClassified(ctx, SubjectEntityUpdateWithTriples, reqData, MutationTimeout, natsclient.DefaultRetryConfig())
 	if err != nil {
-		return 0, fmt.Errorf("NATS request failed: %w", err)
+		// ADR-060: handler failures (entity_not_found, owner_lease_stale,
+		// internal) arrive classified here, not as an in-body Success=false.
+		// Surface the stable Code so callers and operators can distinguish
+		// must-exist failures from transport without substring-matching.
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) && ce.Code != "" {
+			return 0, fmt.Errorf("replace_owned mutation failed [%s]: %w", ce.Code, err)
+		}
+		return 0, fmt.Errorf("replace_owned mutation failed: %w", err)
 	}
 
+	// Parse the success response for the KV revision.
 	var resp gtypes.UpdateEntityWithTriplesResponse
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return 0, fmt.Errorf("unmarshal response: %w", err)
-	}
-
-	if !resp.Success {
-		// Surface the machine-readable error code so callers (and operators)
-		// can distinguish must-exist failures (entity_not_found) from
-		// transport/internal errors without substring-matching.
-		if resp.ErrorCode != "" {
-			return 0, fmt.Errorf("replace_owned mutation failed [%s]: %s", resp.ErrorCode, resp.Error)
-		}
-		return 0, fmt.Errorf("replace_owned mutation failed: %s", resp.Error)
 	}
 
 	if m.revisionTracker != nil && resp.KVRevision > 0 && ruleID != "" {

--- a/test/e2e/client/nats.go
+++ b/test/e2e/client/nats.go
@@ -172,10 +172,8 @@ func (c *NATSValidationClient) Publish(ctx context.Context, subject string, data
 }
 
 // Request sends a NATS request/reply and returns the raw response payload.
-// Used by validation steps that drive a request/reply API directly — notably
-// the graph mutation lane (graph.mutation.entity.create_with_triples), which
-// replies with a structured MutationResponse rather than the natsclient
-// "error: <msg>" payload convention, so callers parse and check Success.
+// Prefer RequestClassified for handlers on the ADR-060 typed-error contract
+// (the graph mutation lane); Request remains for raw-body request/reply.
 func (c *NATSValidationClient) Request(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error) {
 	c.mu.Lock()
 	if c.closed {
@@ -185,6 +183,21 @@ func (c *NATSValidationClient) Request(ctx context.Context, subject string, data
 	c.mu.Unlock()
 
 	return c.client.Request(ctx, subject, data, timeout)
+}
+
+// RequestClassified sends a NATS request/reply and surfaces handler failures as
+// a classified error (ADR-060) rather than an "error: <msg>" body that a caller
+// would silently mis-decode. Used by the graph mutation lane, whose handlers
+// return (nil, *errs.ClassifiedError) on failure.
+func (c *NATSValidationClient) RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("client is closed")
+	}
+	c.mu.Unlock()
+
+	return c.client.RequestClassified(ctx, subject, data, timeout)
 }
 
 // CountEntities counts the number of entities in the ENTITY_STATES bucket
@@ -239,7 +252,9 @@ func (c *NATSValidationClient) GetTrajectory(ctx context.Context, loopID string)
 		return nil, fmt.Errorf("failed to marshal trajectory request: %w", err)
 	}
 
-	resp, err := c.client.Request(ctx, "agentic.query.trajectory", req, 5*time.Second)
+	// ADR-060: RequestClassified surfaces handler errors via err instead of an
+	// "error: <msg>" body that would mis-decode as an empty Trajectory.
+	resp, err := c.client.RequestClassified(ctx, "agentic.query.trajectory", req, 5*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("trajectory query failed for loop %s: %w", loopID, err)
 	}

--- a/test/e2e/scenarios/tiered_structural.go
+++ b/test/e2e/scenarios/tiered_structural.go
@@ -286,16 +286,10 @@ func (s *TieredScenario) executeValidateReferentialStub(ctx context.Context, res
 		return fmt.Errorf("marshal create_with_triples request: %w", err)
 	}
 
-	respData, err := s.natsClient.Request(ctx, createSubject, reqData, 10*time.Second)
-	if err != nil {
+	// ADR-060: RequestClassified surfaces handler failures via err; a hard
+	// failure no longer returns an in-body Success=false.
+	if _, err := s.natsClient.RequestClassified(ctx, createSubject, reqData, 10*time.Second); err != nil {
 		return fmt.Errorf("create_with_triples request failed: %w", err)
-	}
-	var resp graph.CreateEntityWithTriplesResponse
-	if err := json.Unmarshal(respData, &resp); err != nil {
-		return fmt.Errorf("parse create_with_triples response (%q): %w", string(respData), err)
-	}
-	if !resp.Success {
-		return fmt.Errorf("create_with_triples failed: %s", resp.Error)
 	}
 
 	// 2. Poll for the referential stub on the dangling target. ensureRelationshipTargetsExist

--- a/test/natsclient/request_guard_test.go
+++ b/test/natsclient/request_guard_test.go
@@ -77,44 +77,13 @@ import (
 // Entries here are tracked violations, NOT silent exclusions.
 // Dead entries (keys that match no live violation) are rejected by
 // TestRequestGuardAllowlistNoDeadEntries — keep this list exact.
-var requestGuardAllowlist = map[string]string{
-	// gh#326 — graphrag global-search batch: loadEntities passes NATS
-	// respData directly to json.Unmarshal without a bytes.HasPrefix guard.
-	"processor/graph-query/graphrag.go:loadEntities": "deferred to gh#326: migrate to RequestClassified",
-
-	// gh#326 — fetchEntityCommunityFromStorage in graphrag.go: clustering
-	// community lookup uses .Request + json.Unmarshal without a guard.
-	"processor/graph-query/graphrag.go:fetchEntityCommunityFromStorage": "deferred to gh#326: same graphrag batch as loadEntities",
-
-	// gh#334 — entity_resolver.resolveViaSuffix: hits graph.ingest.query.suffix
-	// (NOT a graph.index.query.* subject), so it is out of ADR-060 PR-B's
-	// graph-index seam. Remains a .Request + json.Unmarshal caller until the
-	// graph-ingest seam migrates (PR-C burn-down). resolveViaAlias migrated in PR-B.
-	"processor/graph-query/entity_resolver.go:resolveViaSuffix": "deferred to gh#334: graph.ingest.query.suffix seam (PR-C), not graph-index PR-B",
-
-	// gh#334 — graph/llm/nats_content_fetcher.go: fetchSingleEntity uses .Request
-	// then json.Unmarshal without a guard.
-	"graph/llm/nats_content_fetcher.go:fetchSingleEntity": "deferred to gh#334: migrate to RequestClassified",
-
-	// gh#334 — pkg/lifecycle/graph_emit.go: update() and create() use
-	// RequestWithRetry + json.Unmarshal without a bytes.HasPrefix guard.
-	// Migration to RequestWithRetryClassified tracked under gh#334.
-	"pkg/lifecycle/graph_emit.go:update": "deferred to gh#334: migrate to RequestWithRetryClassified",
-	"pkg/lifecycle/graph_emit.go:create": "deferred to gh#334: migrate to RequestWithRetryClassified",
-
-	// gh#334 — examples/github-pr-workflow: example component uses .Request
-	// + json.Unmarshal without a guard. NOT graphrag (gh#326 is the global-search
-	// batch only); this is a generic caller-to-migrate tracked in the gh#334
-	// burn-down. Example code, low priority — but linted so the example doesn't
-	// teach the footgun.
-	"examples/github-pr-workflow/component.go:writeTriple": "deferred to gh#334: example code, migrate to RequestWithRetryClassified",
-
-	// gh#334 — E2E test infrastructure: these are regular (non-_test.go) Go
-	// files that the walker scans. They predate gh#93 and are low-priority;
-	// migration is tracked under gh#334.
-	"test/e2e/scenarios/tiered_structural.go:executeValidateReferentialStub": "deferred to gh#334: e2e test infrastructure, low priority migration",
-	"test/e2e/client/nats.go:GetTrajectory":                                  "deferred to gh#334: e2e test client, low priority migration",
-}
+// ADR-060 PR-C emptied this allowlist: every remaining Request+Unmarshal
+// caller was migrated to RequestClassified / RequestWithRetryClassified (the
+// gh#334 caller burn-down plus the gh#326 graphrag entries). The lint stays
+// armed to prevent regressions; PR-D deletes the guard once the breaking wire
+// change lands. Keep this EMPTY — a new entry is a tracked regression that must
+// carry a gh# reference, not a quiet exemption.
+var requestGuardAllowlist = map[string]string{}
 
 // requestMethodNames is the set of method names (selector suffixes)
 // that constitute the unclassified legacy call forms. RequestClassified


### PR DESCRIPTION
## ADR-060 PR-C — graph-ingest mutation seam → one typed error channel

Third PR of the [ADR-060](docs/adr/060-unified-rpc-error-contract.md) program (PR-A #336, PR-B #338 merged). Retires the **dual error channel** for the graph-ingest **mutation** seam. **Non-breaking** (semstreams-internal): response structs keep their fields and the legacy `error:` body stays until PR-D.

### What changes
- **Producers** (`mutations.go`): every `marshal*Error*` / inline `Success:false` return → `(nil, *errs.ClassifiedError)` with a wire class + stable `Code` (+ `Detail`). `rejectFromError` classifies the generic-error fallback by the error's own nature (malformed triple → `invalid_request`; ctx-cancel/KV blip → transient) so the wire class is honest now that it's wire-meaningful.
- **`revision_mismatch`** is the one control-flow sentinel (`errs.ErrRevisionMismatch`); everything else is a `ce.Code` discriminator.
- **Partial batch stays a success body** (`Success=false` + `FailedSubjects`); only **whole-batch** failure flips to a typed error. Batch callers keep their `!resp.Success` block (now the partial path); non-batch callers drop the dead check.
- **`meteredMutation`** reads the rejection reason from `ce.Code` (no longer hardcodes `internal`).
- **Lifecycle** (`graph_emit.go`/`manager.go`): `update`/`create` → `RequestWithRetryClassified`; both per-consumer body→sentinel translations collapse into `ClassifyReply`; Manager CAS loops branch on `errs.ErrRevisionMismatch` (`errEmitRevisionMismatch` deleted).
- **`createEntityWithTriples`** keeps the EntityExists idempotency-after-verify path via `ce.Code`.
- **Caller burn-down — empties the gh#334 lint allowlist**: graph_emit, examples writeTriple, e2e tiered_structural + GetTrajectory, entity_resolver suffix, nats_content_fetcher, graphrag loadEntities + fetchEntityCommunityFromStorage (the gh#326 leftover), applier, nats_reader → classified variants. The gh#162 lint stays armed (deleted in PR-D once the wire breaks).

### Gates (all green locally)
- `go build ./...`, `task lint` (allowlist empty), `go test -race ./...`
- **`go test -race -tags=integration ./...`** — full sweep, 0 failures (framework-change discipline)
- schema:generate clean, contract tests pass, gofmt clean
- go-reviewer pre-merge pass — M1/M2 (class correctness) + L1 (dead-code) folded in

### Not in scope
PR-D (BREAKING): drop the `Success`/`Error`/`ErrorCode` fields + legacy `error:` body, switch to the `{message, detail}` envelope, delete the lint, lockstep sister-repo bump. Needs explicit authorization + e2e negative-path gate.

Closes #334. Refs ADR-060, #161 (PR-D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)