### PR TITLE
fix(e2e): add graph-ingest to crud-tools flow so the agent loop can birth (gh#342)

### DIFF
--- a/configs/flows/crud-tools-test.json
+++ b/configs/flows/crud-tools-test.json
@@ -160,6 +160,22 @@
         }
       }
     },
+    "graph-ingest": {
+      "type": "processor",
+      "name": "graph-ingest",
+      "enabled": true,
+      "config": {
+        "enable_hierarchy": true,
+        "ports": {
+          "inputs": [
+            {"name": "graph_mutations", "subject": "graph.mutation.>", "type": "nats"}
+          ],
+          "outputs": [
+            {"name": "entity_states", "subject": "ENTITY_STATES", "type": "kv-write"}
+          ]
+        }
+      }
+    },
     "rule-processor": {
       "type": "processor",
       "name": "rule-processor",


### PR DESCRIPTION
## Fixes #342 — crud-tools broken on main since 2026-06-14

crud-tools was a deliberately **graph-less** minimal flow (dispatch + loop + model + tools + rule-processor) testing `create_rule → RuleExecutor → ConfigManager → KV` — a path that never touches the graph. ADR-056 4c-pre-1 (`c75d01d4`) then made the agentic **loop** birth its loop-execution entity via `create_with_triples` and **hard-halt on failure**. With no graph-ingest responder, birth got "no responders" and the loop halted before any tool ran. Silent because e2e tiers aren't in default CI.

**Accepted invariant:** *any flow running the agent loop needs graph-ingest.* So the minimal flow can't represent a real deployment — the fix makes the tier realistic by adding the `graph-ingest` processor (same block `ops-agent-test` / `deep-research-test` use). Config-only; no Go changed.

**Verified:** `task e2e:crud-tools` green — `tool_executions:4`, `verify-rule-in-kv` + `validate-rule-content` pass.

Found while running the e2e gate for ADR-060 PR-D (#341); not caused by it. Independent, non-breaking — safe to merge to main on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)