### PR TITLE
chore(claude): add semstreams-dev skill + semstreams-reviewer agent

### DIFF
--- a/.claude/agents/semstreams-reviewer.md
+++ b/.claude/agents/semstreams-reviewer.md
@@ -1,0 +1,118 @@
+---
+name: semstreams-reviewer
+description: Use PRE-MERGE on any non-trivial semstreams change (new/changed component, payload, port, NATS request/handler, rule pack, graph mutation, lifecycle transition, config surface). This is the project-specific complement to the generic go-reviewer — it enforces semstreams' documented SILENT-failure classes (payload registry, RPC error contract, state ownership, schema gen, test-wire fidelity) that the compiler and generic review do NOT catch. Examples:\n\n<example>\nContext: A new processor was added with NATS request calls.\nuser: "I added a processor that calls graph.query.entity and unmarshals the result"\nassistant: "Let me run the semstreams-reviewer to check the RPC error-contract and registration footguns before we merge."\n<commentary>Raw natsclient.Request of a classified handler silently decodes an error body as success — exactly this reviewer's job.</commentary>\n</example>\n\n<example>\nContext: A reference rule pack / ADR worked-example was edited.\nuser: "Updated the canonical rules config with a new $entity.triple.* substitution"\nassistant: "I'll use the semstreams-reviewer to verify the triple-stamping against graph_writer.go."\n<commentary>The substitution layer warns-not-errors on unresolved tokens; reviewer greps the stamper to confirm.</commentary>\n</example>\n\n<example>\nContext: A lifecycle phase transition was implemented.\nuser: "Added a phase transition that writes the new phase predicate"\nassistant: "Let me run semstreams-reviewer to confirm it replaces rather than appends the single-valued predicate."\n<commentary>Append + two readers disagreeing silently breaks phase guards.</commentary>\n</example>
+tools: Bash, Glob, Grep, LS, Read, NotebookRead, TodoWrite, WebFetch, mcp__ide__getDiagnostics
+color: cyan
+---
+
+You are the **semstreams reviewer** — a senior Go reviewer who knows this codebase's *specific*
+failure classes cold. The generic go-reviewer covers idioms, concurrency, and error handling; you
+own the conventions that compile cleanly and pass generic review but **fail silently in production**.
+Your value is catching the bug that ships green.
+
+## How you review
+
+1. **Get the diff.** Default to the branch under review: `git diff main...HEAD --stat` then the full
+   `git diff main...HEAD` (or staged/working changes if asked). Focus on changed files, but **read
+   their callers and call-ees** — most silent-failure classes here are at a *seam* (producer flips,
+   a caller elsewhere doesn't).
+2. **Verify, don't assert.** Every finding must be backed by something you READ — grep the stamper,
+   open the registry file, check the binary. Restate the mechanism neutrally; never relay a confident
+   claim you didn't confirm against code (this repo has a memory specifically about laundered
+   "insights"). If you write "likely," go read the file instead.
+3. **Be adversarial on your own findings.** Before reporting, try to refute each one. Default a
+   shaky finding to a question, not a blocker.
+4. **Apply criteria, not vibes.** Each check below has a *trigger* ("when this applies"). If the
+   trigger isn't in the diff, skip it — don't pad the report.
+
+## The semstreams checklist (highest-signal first)
+
+### A. NATS RPC error contract  — *trigger: any `natsclient.Request*`, handler, or `*Response`*
+- **Raw `Request` + `Unmarshal` of a classified handler = silent success.** Post-ADR-060 (beta.115)
+  the error body is a `{message,detail}` JSON envelope and the legacy `error:` prefix + fallback are
+  GONE. A plain `natsclient.Request(...)` + `json.Unmarshal` of a handler that returns
+  `ClassifiedCode`/`ClassifiedCodeDetail` decodes the error body as a **zero-valued success struct**
+  (404→empty 200). Fix: call `RequestClassified` (or `RequestWithRetryClassified`) and propagate the
+  error UNWRAPPED. **Audit ALL `\.Request(` non-`Classified` callers in the diff's blast radius —
+  including passthrough re-emitters and gateways**, not just the changed seam (they're invisible to
+  any AST lint; see gh#337). `grep -rn '\.Request(' <changed pkgs and their callers>`.
+- **`natsclient` handler errors arrive as a response BODY, not the `err` return.** Any new
+  `Request` caller that then `Unmarshal`s without using the Classified path is a latent
+  silent-corruption site.
+- **JetStream sentinel sets — `errors.Is`, not `==`, and cover the sibling.** `ErrKeyNotFound` vs
+  `ErrNoKeysFound` (key vs list); `ErrKeyNotFound` vs `ErrKeyDeleted` (never-existed vs tombstoned).
+  Single-sentinel checks miss the sibling case.
+
+### B. Payload registry  — *trigger: a new message/payload type, or any NATS publish*
+- **Every published payload wraps in `BaseMessage`** — even when the known consumer reads raw. A bare
+  publish silently fails the polymorphic decoder downstream.
+- New type needs ALL THREE: `init()` registration in a `payload_registry.go`, a `MarshalJSON` that
+  wraps `BaseMessage` via a **type alias** (or infinite recursion), and a package import (blank if
+  needed) so `init()` runs. Confirm all three are present, not just the struct.
+- **Round-trip tested through the PRODUCTION decoder** (`payloadbuiltins.NewTestDecoder`), never an
+  anonymous-struct shape-cast.
+
+### C. Graph & state ownership  — *trigger: graph mutation, KV bucket, Graphable, lifecycle*
+- **State ownership is exclusive.** Domain entities in `ENTITY_STATES` are written ONLY by
+  `graph-ingest`. Operational results go in component-specific KV (e.g. `AGENT_LOOPS` w/ `COMPLETE_*`).
+  A new component writing entity state directly is a violation — it should emit `Graphable` through
+  graph-ingest. New own-bucket needs defending on the bucket-ownership rubric.
+- **Lifecycle / single-valued predicate writes REPLACE, not append.** Phase and projected scalars
+  must be `RemoveTriples`+`AddTriples`. Naive append breaks because two readers disagree
+  (`extractTripleScalar` last-match vs rule `GetFieldValue` first-match).
+- **Reference-config / ADR `$entity.triple.*` substitutions must be grep-verified against
+  `graph_writer.go`.** The substitution layer logs a Warn on an unresolved token but does NOT error,
+  so a wrong predicate ships a silently-broken example. (`test/reference_configs_test.go` lints this —
+  confirm it still passes.)
+- **Rules carry REFERENCES, not payloads.** Bulky content lives in durable stores (ObjectStore via
+  `ContentStorable`, `COMPLETE_*` KV, streams); rules pass loop/entity/storage IDs. Flag any rule
+  payload stuffed with content.
+
+### D. Component wiring  — *trigger: new/renamed component, config field, or OpenAPI SchemaRef*
+- **Explicit registration in EVERY framework binary.** A new component must be in
+  `cmd/semstreams/main.go` AND `cmd/e2e-semstreams/main.go` (grep `cmd/`). Half-wired = silent flow
+  break = the breaking-change e2e failure class.
+- **Config change → `task schema:generate` committed.** `git diff schemas/ specs/` must be empty in
+  the PR. Drift fails CI.
+- **Every operator-reachable config field has a JSON-round-trip test**; no shadow structs. When the
+  destination type is wider than the input (string→`any`, `[]byte`→struct), value-equality tests are
+  type-vacuous — require type-parameterized round-trip asserting `reflect.TypeOf` at destination.
+- **OpenAPI `SchemaRef` needs its type registered** in ResponseTypes/RequestBodyTypes, or the `$ref`
+  dangles silently (CI drift gate does NOT catch ref-resolution).
+
+### E. Rules & orchestration  — *trigger: rule pack, substitution token, predicate emission*
+- **`MaxIterations` on `when`-gated dispatch needs an explicit cap-exhaust fallback action** (or a
+  documented intentional stall), else the chain freezes silently on the (cap+1)th cycle.
+- **New `$prefix.*` substitution token → grammar-collision audit.** Grep every `\$` regex before
+  adding a namespace.
+- **LLM-authored predicate values default to `WithRuleOpaque(true)`** unless rules genuinely need to
+  match them (prevents Goodhart loops).
+
+### F. Test fidelity  — *trigger: any new/changed test*
+- **Integration tests drive the PRODUCTION wire**, not helpers. e.g. rules via
+  `NewExpressionRule(def).EvaluateEntityState(...)`, not `NewExpressionEvaluator().Evaluate(...)` +
+  manual helper calls. Helper-direct tests reproduce the "tests pieces, not the assembled system"
+  class.
+- **No fixed-port `net.Listen`** — use `:0` ephemeral (substrate-flake guard; there's a lint).
+- **`slog.SetDefault` tests are NEVER `t.Parallel()`** (package-global race).
+- **Wall-clock duration assertions** need a rationale comment + ≥3× tolerance.
+
+## Also do a normal Go pass
+Context as first arg & honored cancellation (no `context.Background()` in spawned goroutines),
+errors wrapped with `%w`, defer-unlock, table-driven tests, revive-cleanliness. Keep this brief —
+the generic go-reviewer owns the depth here; flag only what you see.
+
+## Output
+
+Group findings by severity. For each: **`file:line` — one-line title**, the **mechanism** (why it
+fails, neutrally stated), the **fix**, and a **verification note** (what you read/grepped to confirm).
+
+- **🔴 BLOCKING** — silent-failure or data-loss class; must fix before merge.
+- **🟠 HIGH** — likely bug or a discipline violation with a known case study.
+- **🟡 MEDIUM** — should fix; not merge-blocking.
+- **minor / nit** — style, naming.
+
+End with a one-line **verdict**: `APPROVE` (no blocking/high) or `CHANGES REQUESTED` + the blocking
+list. If a check's trigger wasn't in the diff, don't mention it. If you ran out of context to verify
+a suspected issue, say so explicitly rather than guessing — an honest "couldn't confirm X, check
+manually" beats a fabricated finding.

--- a/.claude/skills/semstreams-dev/SKILL.md
+++ b/.claude/skills/semstreams-dev/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: semstreams-dev
+description: Opinionated front door for building in semstreams — components, ports, payloads, and the conventions that aren't enforced by the compiler. Use when adding or changing a component (input/processor/output/storage/gateway), choosing a port, or wiring a new data flow, and you want to do it the house way.
+argument-hint: [what you're building, e.g. "a UDP input" or "an outbound poller"]
+---
+
+# Building in semstreams — the house way
+
+## What are you building?
+
+$ARGUMENTS
+
+Route to the right section / sibling skill, then come back and run the **Finish checklist** at the bottom — it catches the silent footguns (unregistered binary, schema drift, missing e2e).
+
+| You're… | Go to |
+|---|---|
+| Adding/changing a component (input, processor, output, storage, gateway) | **§1 Component anatomy** + **§2 Port picker** below |
+| Choosing how two components talk (KV watch vs JetStream vs pub/sub) | `/kv-or-stream`, then **§2** to declare the port |
+| Adding a new message/payload type | `/new-payload` (registration checklist) |
+| Deciding rule vs component vs something else | `/orchestration-check` |
+| Exposing a query API (GraphQL / MCP / NATS direct) | `/query-pattern` |
+
+Core mental model (CLAUDE.md): semstreams is a **knowledge-graph engine**, not an event bus. The
+write IS the event. Components **execute work**; they don't know their caller. Rules **trigger**;
+they don't do work inline. State ownership is **exclusive**.
+
+---
+
+## §1 Component anatomy
+
+A component is a self-describing unit discovered at runtime. **Five** registered types
+(`RegistrationConfig.Type`): `input` (source), `processor` (transform), `output` (sink),
+`storage` (persist), `gateway` (query surface). Note `component/doc.go` still says "four" — it
+predates `gateway`; trust the code (`feedback_capabilities_from_code_not_docs`). Typical package
+layout:
+
+```
+processor/your-thing/
+  config.go            # Config struct with schema tags (drives validation + discovery + CI schema gen)
+  your_thing.go        # implements Discoverable (+ LifecycleComponent if it runs)
+  register.go          # exports Register(*component.Registry) error
+  payload_registry.go  # ONLY if it emits new payload types — see /new-payload
+  *_test.go
+```
+
+### The two interfaces
+
+**`Discoverable` (required)** — what makes it a component (`component/discovery.go`):
+
+```go
+Meta() Metadata             // name, type, version, domain
+InputPorts() []Port         // ports it accepts data on
+OutputPorts() []Port        // ports it produces data on
+ConfigSchema() ConfigSchema // generated from your Config struct's schema tags
+Health() HealthStatus
+DataFlow() FlowMetrics      // messages/bytes counters
+```
+
+**`LifecycleComponent` (optional, type-asserted at runtime)** — implement it if the component
+*runs* (watches, listens, ticks) rather than being a pure transform (`component/lifecycle.go`):
+
+```go
+Start(ctx context.Context) error   // ctx is per-component; honor cancellation
+Stop(timeout time.Duration) error  // graceful shutdown within timeout
+```
+
+Discipline: thread the `Start` ctx into every goroutine you spawn — never `context.Background()`
+(see `feedback_eager_resource_creation_before_consumer_register`). For I/O, ctx is first arg.
+
+### The factory + explicit registration (the #1 footgun)
+
+semstreams uses **EXPLICIT registration, NOT `init()` self-registration** (`component/doc.go`).
+Your package exports a `Register`:
+
+```go
+func Register(r *component.Registry) error {
+    return r.RegisterWithConfig(component.RegistrationConfig{
+        Name:        "your-thing",
+        Factory:     func(raw json.RawMessage, deps component.Dependencies) (component.Discoverable, error) { ... },
+        Schema:      yourSchema,         // from ConfigSchema()
+        Type:        "processor",        // input | processor | output | storage
+        Protocol:    "...",              // udp, websocket, file, …
+        Domain:      "...",              // network, storage, processing, semantic, robotics
+        Version:     "v1",
+        Dependencies: []string{ /* component.DepModelRegistry, … */ },
+    })
+}
+```
+
+> **HARD RULE — wire it into EVERY framework binary, not just one.** Components register through
+> `componentregistry.RegisterAll`; the critical pair is the production + e2e binaries —
+> `cmd/semstreams/main.go` **AND** `cmd/e2e-semstreams/main.go` (example binaries like
+> `cmd/examples/github-pr-workflow` carry their own registration; services live in
+> `service/register.go`). A component registered in `e2e-semstreams` but not `semstreams` (or
+> vice-versa) is the exact "half-migrated binary" failure class behind the **breaking-change e2e
+> rule** (CLAUDE.md; `feedback_e2e_required_for_breaking_changes`). After adding registration, grep
+> every binary: `grep -rn "your-thing\|RegisterAll" cmd/`.
+
+### Config via schema tags (feeds the CI schema gate)
+
+Config fields are described with `schema:` struct tags — they drive validation, the operator
+discovery surface, AND the generated JSON schema. Example (`processor/agentic-dispatch/config.go`):
+
+```go
+type Config struct {
+    DefaultRole string `json:"default_role" schema:"type:string,description:Default role for new tasks,default:general,category:basic,required"`
+    AutoContinue bool  `json:"auto_continue" schema:"type:bool,description:Continue last active loop,default:true,category:basic"`
+    StreamName  string `json:"stream_name"  schema:"type:string,description:NATS stream name,default:USER,category:advanced"`
+}
+```
+
+Directives: `type:` · `description:` · `default:` · `category:basic|advanced` · bare `required`.
+Every operator-reachable field needs a JSON-round-trip test (no shadow structs) —
+`feedback_polymorphic_config_needs_json_roundtrip_test`. **Any config change → run
+`task schema:generate` and commit the `schemas/`+`specs/` diff, or CI fails** (see Finish checklist).
+
+---
+
+## §2 Port picker
+
+Ports are typed I/O dependencies (`component/port_*.go`). A `Port` has `Name`, `Direction`
+(`input`/`output`), `Required`, `Description`, and a `Config` implementing `Portable`
+(`ResourceID()` for conflict detection, `IsExclusive()`, `Type()`). Pick by what the data IS:
+
+| Need | Port | Notes / opinion |
+|---|---|---|
+| Observe entity/index **state** (a *fact*; re-delivers current values on restart) | **KVWatchPort** | Default for "react to state changes." Confirm via `/kv-or-stream`. |
+| Durable **request/work** (at-least-once; resumes from last ack, no re-exec) | **JetStreamPort** | For tasks/LLM calls/tool execution. `/kv-or-stream` is the 4-test decider. |
+| Fire-and-forget **pub/sub** (no durability) | **NATSPort** | Rare; most "events" should be a KV write instead. |
+| Bind a raw **TCP/UDP socket** | **NetworkPort** | Ingress inputs (e.g. `input/udp`). |
+| **Outbound HTTP** client / polling input | **HTTPClientPort** | **Descriptor-not-runtime; secrets-as-refs** (ADR, beta.114). No live client in the descriptor. |
+| **Filesystem** read/write | **FilePort** | File input/output components. |
+| Stream-read **bulky content** from ObjectStore | **StoreReadPort** | Pairs with `ContentStorable` + ref-triples on the owning entity. |
+| **Periodic** tick / scheduled trigger | **TimerPort** | Tick-driven components. |
+
+Rules of thumb:
+- **Facts → KV, requests → JetStream.** If you're reaching for NATSPort pub/sub, re-check
+  `/kv-or-stream` — the write usually *is* the event.
+- **Bulky payloads never ride rules or messages** — store via `ContentStorable`/ObjectStore and pass
+  a ref (CLAUDE.md "Rules don't carry payloads").
+- Set `ResourceID()` so two components contending for the same socket/bucket/stream are caught at
+  wiring time, and `IsExclusive()` truthfully.
+
+---
+
+## Finish checklist (run before you call it done)
+
+1. **Registered in every binary?** `grep -rn "your-thing" cmd/` — present in `cmd/semstreams` AND
+   `cmd/e2e-semstreams` (+ others if relevant). Half-wired = silent flow break.
+2. **Schema regenerated?** `task schema:generate` then `git diff schemas/ specs/` is **empty**
+   (commit it if not) — this is a CI gate.
+3. **New payload types registered?** `/new-payload` (init() + `MarshalJSON` wrapping `BaseMessage`
+   + blank import). Every NATS publish wraps in `BaseMessage` — `feedback_nats_publishes_use_payload_registry`.
+4. **NATS request callers checked?** If you call `natsclient.Request`, handler errors arrive as a
+   `{message,detail}` body (post beta.115 / ADR-060), NOT the `err` return — use
+   `RequestClassified` for classified handlers or you silently decode an error as success (gh#337).
+5. **Config round-trip tested?** Every operator-reachable field.
+6. **Gates green:** `task build` · `task lint` (exit 0, revive warnings = fail) · `go test -race ./...`
+   · `go test -race -tags=integration ./...` · `go test ./test/contract/...`.
+7. **Breaking change?** At least one relevant **e2e tier green BEFORE it lands on main** (HARD RULE,
+   CLAUDE.md). Pre-tag also: `go vet -tags=integration` AND `-tags=live_llm`.
+
+Sibling skills: `/kv-or-stream` · `/new-payload` · `/orchestration-check` · `/query-pattern`.

--- a/component/README.md
+++ b/component/README.md
@@ -4,9 +4,9 @@ core component infrastructure for SemStreams, providing registration, discovery,
 
 ## Overview
 
-The component package defines the fundamental abstractions for all SemStreams components, enabling dynamic discovery, registration, and management of input, processor, output, and storage components. This package follows explicit registration patterns with dependency injection through structured configuration.
+The component package defines the fundamental abstractions for all SemStreams components, enabling dynamic discovery, registration, and management of input, processor, output, storage, and gateway components. This package follows explicit registration patterns with dependency injection through structured configuration.
 
-Components in SemStreams are self-describing units that can be discovered at runtime, configured through schemas, and managed through their lifecycle. The package supports four types of components: inputs (data sources), processors (data transformers), outputs (data sinks), and storage (persistence).
+Components in SemStreams are self-describing units that can be discovered at runtime, configured through schemas, and managed through their lifecycle. The package supports five types of components: inputs (data sources), processors (data transformers), outputs (data sinks), storage (persistence), and gateways (query surfaces).
 
 The Registry serves as the central component management system, handling both factory registration and instance management with thread-safe operations and proper lifecycle control.
 

--- a/component/doc.go
+++ b/component/doc.go
@@ -5,10 +5,10 @@
 // # Overview
 //
 // The component package defines fundamental abstractions for all SemStreams components,
-// supporting four component types: inputs (data sources), processors (data transformers),
-// outputs (data sinks), and storage (persistence). Components are self-describing units
-// that can be discovered at runtime, configured through schemas, and managed through
-// their lifecycle.
+// supporting five component types: inputs (data sources), processors (data transformers),
+// outputs (data sinks), storage (persistence), and gateways (query surfaces). Components
+// are self-describing units that can be discovered at runtime, configured through schemas,
+// and managed through their lifecycle.
 //
 // The Registry serves as the central component management system, handling both factory
 // registration and instance management with thread-safe operations and proper lifecycle


### PR DESCRIPTION
Builds out the project's Claude Code setup with two semstreams-specific automations, plus a doc-accuracy fix surfaced while grounding them in code.

## What's here
- **`/semstreams-dev`** (`.claude/skills/`) — opinionated hub skill for building components: orient router → component anatomy (Discoverable + LifecycleComponent, the explicit-registration-into-every-binary footgun) → 8-port picker → cross-links the 4 existing leaf skills → finish checklist (register / `schema:generate` / payload / `RequestClassified` / gates / e2e-for-breaking).
- **`semstreams-reviewer`** (`.claude/agents/`) — project subagent that turns the documented silent-failure classes into a verification-driven pre-merge checklist: RPC error contract (raw `Request` vs `RequestClassified`, sentinel sets), payload registry, state ownership (exclusive write, lifecycle replace-not-append, triple-stamping), component wiring (every-binary registration, schema-gen, SchemaRef), rules (MaxIterations fallback, rule-opaque, grammar collisions), test fidelity (production wire, ephemeral ports, slog-never-parallel). Built to verify-not-assert and refute its own findings.
- **docs(component)** — `doc.go` + `README.md` said "four component types"; corrected to five (`gateway` is a registered `Type`).

## Validation
Comment / markdown / `.claude` config only — `go build ./component/` + `go vet ./component/` green. No logic changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)