### PR TITLE
chore(claude): add /preflight, /tag-release, /e2e-doctor skills + task check:push

### DIFF
--- a/.claude/skills/e2e-doctor/SKILL.md
+++ b/.claude/skills/e2e-doctor/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: e2e-doctor
+description: Diagnose and clear Docker substrate problems before running e2e/integration tests — disk starvation, leaked testcontainers, port conflicts. Use before an e2e tier, or when testcontainers time out (~60s "port 4222/tcp not found") and you suspect infra not code.
+argument-hint: [optional: tier name, e.g. structural]
+---
+
+# E2E doctor — Docker substrate preflight
+
+semstreams e2e/integration spins up many NATS testcontainers fast. Under Docker disk/IO pressure,
+container startup blows past the ~60s ready deadline and fails with
+`mapped port: ... port "4222/tcp" not found, ctx err: context deadline exceeded` — which **reads
+exactly like a code/test failure but is infra** (the beta.115 trap: a 46h-leaked container + 29 GB
+build cache caused two integration packages to "fail"; both passed clean after reclaim). Check this
+FIRST when integration/e2e goes red at ~60s.
+
+## Step 1 — Disk pressure
+
+```bash
+docker system df
+```
+
+Flags:
+- **Build Cache** reclaimable more than ~10 GB → `docker builder prune -f` (safe; just rebuilds slower).
+- **Images** huge with few ACTIVE → most are likely *other projects'*; see Step 4 before pruning.
+
+## Step 2 — Leaked testcontainers / orphans
+
+```bash
+docker ps -a --format '{{.Names}}\t{{.Status}}\t{{.Image}}'
+```
+
+Look for old NATS/ryuk/e2e containers **up for hours** (testcontainers' ryuk should reap them but
+sometimes doesn't — e.g. `*-e2e-nats-*`, `*-nats-*`). Kill stragglers:
+
+```bash
+docker rm -f <name>            # leaked container holding a port / disk
+```
+
+## Step 3 — Port conflicts
+
+```bash
+task e2e:check-ports
+```
+
+If a port is held, find and stop the holder (often a previous tier left `... up -d` running —
+`task e2e:<tier>:down` or `docker compose -f docker/compose/tiered.yml down -v`).
+
+## Step 4 — Safe reclaim recipe
+
+Default safe sweep (frees the most for the least risk):
+
+```bash
+docker rm -f <leaked containers from Step 2>
+docker builder prune -f          # reclaim build cache
+docker image prune -f            # dangling images only
+docker system df                 # confirm the drop
+```
+
+**Do NOT blanket `docker image prune -a`.** On this laptop the big images are sister-project /
+sim artifacts (e.g. `seminstruct:qwen3-8b` ~10 GB, `px4-gazebo` ~10 GB, semspec/semteams sandboxes)
+— expensive to re-pull and not needed for semstreams tiers. Remove a specific giant only if the
+human confirms.
+
+## Step 5 — Clean teardown after
+
+e2e tiers end with `... down -v --timeout 15`; confirm `docker ps -aq | wc -l` is back to 0 so the
+next run starts clean. Leftover containers from a killed run are the #1 source of the next flake
+(`feedback_substrate_flake_discipline`).

--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: preflight
+description: Run the full pre-push / pre-PR gate the semstreams way — scope the diff, Docker-preflight if needed, run the right gates (mirrors CI), and detect breaking changes that demand an e2e tier. Use before pushing a branch, opening a PR, or whenever you want a green-light read on local changes.
+argument-hint: [optional: base ref, defaults to main]
+---
+
+# Preflight — pre-push gate with judgment
+
+The deterministic core is `task check:push`. This skill adds the judgment CI can't: **what scope of
+gate this diff actually needs**, **Docker health before integration/e2e**, and **whether the change
+is BREAKING** (which forces an e2e tier before it can land — CLAUDE.md HARD RULE).
+
+Base ref: $ARGUMENTS (default `main`).
+
+## Step 0 — Scope the diff
+
+```bash
+git diff <base>...HEAD --stat        # committed
+git status -s                        # uncommitted
+```
+
+Classify (pick the *highest* that matches — gates are cumulative):
+
+| Diff shape | Gate to run |
+|---|---|
+| **A. Docs / markdown / `.claude/` only** | `task build:default` + `task lint` + (if any `schema:`/component config touched) `task schema:generate` && `task schema:check-changes` |
+| **B. Go logic, no NATS/graph/integration surface** | `task check` (lint + unit) + `go test ./test/contract/...` |
+| **C. Touches `natsclient/`, `component/`, `graph*`, `pkg/`, validator, vocabulary, or any integration-tagged test** | **`task check:push`** (the full gauntlet) — framework-package changes need the integration sweep (`feedback_framework_change_needs_branch_integration_sweep`) |
+| **D. BREAKING** (see Step 2) | C **plus** a relevant **e2e tier green** before it lands |
+
+When unsure between B and C, run C. False-cheap; a missed integration break is expensive.
+
+## Step 1 — Docker preflight (only if Step 0 = C/D, i.e. integration/e2e will run)
+
+Run `/e2e-doctor` first (or inline: `docker system df`, check for leaked testcontainers, `task
+e2e:check-ports`). A starved daemon makes testcontainers time out at ~60s and *looks* like a code
+failure (the beta.115 trap). Reclaim before running, not after a confusing red.
+
+## Step 2 — Detect BREAKING
+
+A change is breaking if ANY of:
+- the commit/PR title carries `!` (e.g. `feat(x)!:`) or a `BREAKING CHANGE:` footer
+- a **removed/renamed exported symbol** in a `pkg/`, `natsclient`, `graph`, `component`, or message type
+- a **wire-contract change** (request/response struct fields, NATS subject semantics, error envelope)
+- a registry/singleton retirement or factory+payload split (the half-migrated-binary class)
+
+If breaking: pick the e2e tier that covers the touched path and confirm it **green before merge** —
+this is non-negotiable (`feedback_e2e_required_for_breaking_changes`). Rough map:
+
+| Touched path | Tier |
+|---|---|
+| rules / structural inference / graph wire / mutation error contract | `task e2e:structural` |
+| BM25 / statistical | `task e2e:statistical` |
+| embeddings / neural / LLM | `task e2e:semantic` |
+| agent loop / tools | `task e2e:agentic` |
+| CRUD round-trip / pattern-B | `task e2e:crud-tools` |
+| lifecycle harness | `task e2e:lifecycle` |
+
+If no tier covers it, that's a coverage gap — file it before merging, don't wave it through.
+
+## Step 3 — Run the gate & report
+
+Run the gate from Step 0. Report a per-step checklist (✅/❌). On red, **show the actual failing
+output** and stop — do not push. Common reds and what they mean:
+- `schema:check-changes` fails → you forgot to commit a `schemas/`/`specs/` diff after a config change.
+- integration timeout at ~60s with `port "4222/tcp" not found` → Docker starvation, NOT your code → `/e2e-doctor`.
+- one known pre-existing flake: rule `TestEntityWatcher_RuleTriggerDebouncing` (load-induced; passes in isolation) — re-run it alone to confirm before blaming the diff (`feedback_investigate_before_classifying_as_flake`).
+
+## Step 4 — Green → next
+
+All green: safe to push / open the PR. Note this repo has **no required CI checks**, so a local
+green IS the merge gate; if you still want CI-gated merge, `gh run watch <id> --exit-status` to green
+THEN merge (`feedback_repo_no_required_checks_auto_merges_immediately`). For a non-trivial Go change,
+run `semstreams-reviewer` before merge. To cut a tag, use `/tag-release`.

--- a/.claude/skills/tag-release/SKILL.md
+++ b/.claude/skills/tag-release/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: tag-release
+description: Cut a semstreams release tag the house way — preflight green, pre-tag build-tag sweep, e2e-before-breaking, compute the next beta version, annotated tag in house format, push, never re-tag. User-invoked only (tagging is irreversible and outward-facing).
+argument-hint: [optional: explicit version like v1.0.0-beta.NNN, else next is computed]
+disable-model-invocation: true
+---
+
+# Tag a release
+
+Tagging is **irreversible** (the Go module proxy pins a version on first fetch — `feedback_never_retag`)
+and **outward-facing** (for a breaking tag, sister repos conform against it). Do every step; never
+skip to the tag. Confirm the version with the human before pushing.
+
+## Step 1 — Preconditions
+
+```bash
+git checkout main && git pull origin main --ff-only   # on main, up to date
+git status -s                                          # working tree CLEAN
+```
+
+If not on main / not clean, stop. Tags go on a merged `main` commit, not a branch.
+
+## Step 2 — Gates green
+
+Run `/preflight` (or `task check:push`) — must be fully green on the commit you're about to tag.
+
+**Pre-tag build-tag sweep (mandatory, both tags):**
+
+```bash
+go vet -tags=integration ./...
+go vet -tags=live_llm ./...
+```
+
+Plain `go vet` does NOT cover tagged files; a broken integration/live_llm file ships otherwise
+(`feedback_pre_tag_sweep_includes_build_tags`).
+
+## Step 3 — Breaking? → e2e BEFORE the tag (HARD RULE)
+
+If this release contains a BREAKING change (see `/preflight` Step 2 for the test), at least one
+relevant **e2e tier must be green before the tag lands** (`feedback_e2e_required_for_breaking_changes`).
+Pick the tier by touched path (table in `/preflight`). No green tier → do not tag.
+
+After a registry-retirement / factory+payload-split style migration, grep every binary for the
+migrated symbol to confirm none is half-migrated:
+
+```bash
+grep -rn "<migrated-symbol>" cmd/    # must appear in cmd/semstreams AND cmd/e2e-semstreams
+```
+
+## Step 4 — Compute the version
+
+```bash
+git tag --sort=-creatordate | head -3        # current latest, e.g. v1.0.0-beta.114
+git tag -l '<candidate>'                       # MUST be empty (available)
+```
+
+Bump the beta number by one unless the human gave an explicit `$ARGUMENTS` version. **Confirm the
+exact version with the human before proceeding** — this is the one number you can't take back.
+
+## Step 5 — Annotated tag (house format)
+
+Tags here are **annotated** with subject `vX — <short summary>`:
+
+```bash
+git tag -a <version> <commit> -m "<version> — <summary>
+<optional body: what changed; for BREAKING, name the lockstep + migration doc>"
+
+# verify it points where you think:
+git rev-parse <version>^{commit} HEAD          # both hashes must match
+```
+
+## Step 6 — Push
+
+```bash
+git push origin <version>
+```
+
+## Step 7 — After the tag
+
+- **Breaking?** The tag is the lockstep trigger — hand each sister team the migration doc
+  (`docs/adr/0NN-*-summary.md`), pinned to the tag URL (a fixed ref won't drift under them). Do NOT
+  touch the sister repos yourself unless asked.
+- Close the issues the release resolves; record the tag in the relevant project memory.
+- If you got the version wrong: **do not move the tag** — cut the next number. Re-tagging a pushed
+  version corrupts the module-proxy cache for everyone.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -89,6 +89,19 @@ tasks:
       - task: lint:default
       - task: test:default
 
+  check:push:
+    desc: "Full pre-push gate, mirrors CI (~8min, needs Docker): build, lint, vet integration+live_llm, schema drift, contract, race unit + integration. Use /preflight for the judgment layer (diff scope, breaking->e2e)."
+    cmds:
+      - task: build:default
+      - task: lint:default
+      - go vet -tags=integration ./...
+      - go vet -tags=live_llm ./...
+      - task: schema:generate
+      - task: schema:check-changes
+      - go test ./test/contract/...
+      - go test -race ./...
+      - go test -race -tags=integration ./...
+
   # E2E composite tasks
   e2e:tiers:
     desc: Run all tier E2E tests (structural -> statistical -> semantic)


### PR DESCRIPTION
Continues the Claude Code setup buildout (after #345) with the three workflow skills from the roadmap, plus the deterministic gate target they lean on.

## What's here
- **`task check:push`** (Taskfile.yml) — canonical full pre-push gate: build · lint · `go vet` ×2 tags · schema generate + drift check · contract · `-race` unit + integration. The deterministic core, mirrors CI; reusable by humans, a future git hook, or the skill.
- **`/preflight`** — judgment layer over `check:push`: scopes the diff (docs-only → light; framework surface → full), Docker-preflights when integration/e2e will run, and detects BREAKING changes that force an e2e tier before merge (CLAUDE.md hard rule). Encodes the gate I hand-ran for beta.115.
- **`/tag-release`** (user-invoked only) — tagging discipline: preflight green → pre-tag build-tag sweep → e2e-before-breaking → next beta version (confirmed) → annotated house-format tag → push → never-re-tag.
- **`/e2e-doctor`** — Docker substrate preflight (disk pressure, leaked testcontainers, port conflicts) that diagnoses the ~60s testcontainer port-timeout = infra-not-code class (the beta.115 trap).

## Validation
Config + markdown only. `task --list` parses; `task check:push --summary` lists all 9 steps. No Go changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)