### PR TITLE
fix(agentic-memory): fail loud on llm_assisted.enabled without a client (gh#317)

### DIFF
--- a/configs/flows/deep-research.json
+++ b/configs/flows/deep-research.json
@@ -162,7 +162,7 @@
         "stream_name": "AGENT",
         "extraction": {
           "llm_assisted": {
-            "enabled": true,
+            "enabled": false,
             "model": "fast",
             "trigger_iteration_interval": 5,
             "trigger_context_threshold": 0.8

--- a/processor/agentic-memory/README.md
+++ b/processor/agentic-memory/README.md
@@ -35,7 +35,7 @@ The `agentic-memory` component bridges the agentic loop system with the knowledg
   "config": {
     "extraction": {
       "llm_assisted": {
-        "enabled": true,
+        "enabled": false,
         "model": "fast",
         "trigger_iteration_interval": 5,
         "trigger_context_threshold": 0.8,
@@ -71,7 +71,7 @@ The `agentic-memory` component bridges the agentic loop system with the knowledg
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `llm_assisted.enabled` | bool | true | Enable LLM-assisted fact extraction |
+| `llm_assisted.enabled` | bool | false | Enable LLM-assisted fact extraction. **Dormant until wired (gh#317 / ADR-059)** — no LLM client is injected yet, so setting this `true` fails component construction rather than silently producing zero triples. |
 | `llm_assisted.model` | string | "fast" | Model alias for extraction |
 | `llm_assisted.trigger_iteration_interval` | int | 5 | Extract every N iterations |
 | `llm_assisted.trigger_context_threshold` | float | 0.8 | Extract at N% utilization |
@@ -269,7 +269,9 @@ agentic-memory integrates with agentic-loop through context events:
 
 ### Extraction not triggering
 
-- Verify `extraction.llm_assisted.enabled` is true
+- **LLM-assisted extraction is dormant** (gh#317 / ADR-059): no LLM client is wired
+  yet, so `extraction.llm_assisted.enabled=true` fails component construction rather
+  than producing triples. It will be activated via the claim surface in ADR-059.
 - Check `trigger_iteration_interval` and `trigger_context_threshold`
 - Ensure agentic-model is running with the configured model alias
 

--- a/processor/agentic-memory/component.go
+++ b/processor/agentic-memory/component.go
@@ -72,7 +72,10 @@ func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (compo
 		return nil, errs.Wrap(err, "Component", "NewComponent", "create hydrator")
 	}
 
-	// Create LLM extractor (LLM client will be provided later during initialization)
+	// Create LLM extractor. No LLM client is wired yet — agentic-memory passes nil,
+	// and NewLLMExtractor rejects extraction.llm_assisted.enabled=true without one
+	// (gh#317, so a config can't advertise a silent no-op). When extraction is wired
+	// (ADR-059, via the claim surface), inject the client here.
 	extractor, err := NewLLMExtractor(config.Extraction, nil)
 	if err != nil {
 		return nil, errs.Wrap(err, "Component", "NewComponent", "create extractor")

--- a/processor/agentic-memory/component_test.go
+++ b/processor/agentic-memory/component_test.go
@@ -181,6 +181,9 @@ func TestNewComponent_InvalidConfigJSON(t *testing.T) {
 
 func TestNewComponent_InvalidExtractionConfig(t *testing.T) {
 	config := agenticmemory.DefaultConfig()
+	// Extraction is dormant-by-default now (gh#317); enable it so the extraction
+	// config validation path runs and catches the invalid interval below.
+	config.Extraction.LLMAssisted.Enabled = true
 	config.Extraction.LLMAssisted.TriggerIterationInterval = -1 // Invalid
 
 	rawConfig, err := json.Marshal(config)

--- a/processor/agentic-memory/config.go
+++ b/processor/agentic-memory/config.go
@@ -24,7 +24,7 @@ type ExtractionConfig struct {
 
 // LLMAssistedConfig holds LLM-assisted extraction settings
 type LLMAssistedConfig struct {
-	Enabled                  bool    `json:"enabled" schema:"type:bool,description:Enable LLM-assisted fact extraction,category:basic,default:true"`
+	Enabled                  bool    `json:"enabled" schema:"type:bool,description:Enable LLM-assisted fact extraction (dormant until wired; see ADR-059),category:basic,default:false"`
 	Model                    string  `json:"model" schema:"type:string,description:Model alias for extraction,category:basic,default:fast"`
 	TriggerIterationInterval int     `json:"trigger_iteration_interval" schema:"type:int,description:Trigger extraction every N iterations,category:advanced,default:5"`
 	TriggerContextThreshold  float64 `json:"trigger_context_threshold" schema:"type:float,description:Trigger when context exceeds threshold (0.0-1.0),category:advanced,default:0.8"`
@@ -241,7 +241,9 @@ func DefaultConfig() Config {
 	return Config{
 		Extraction: ExtractionConfig{
 			LLMAssisted: LLMAssistedConfig{
-				Enabled:                  true,
+				// Dormant until extraction is wired (gh#317 / ADR-059); enabling it
+				// without a client is rejected at construction as a silent no-op.
+				Enabled:                  false,
 				Model:                    "fast",
 				TriggerIterationInterval: 5,
 				TriggerContextThreshold:  0.8,

--- a/processor/agentic-memory/config_test.go
+++ b/processor/agentic-memory/config_test.go
@@ -366,9 +366,11 @@ func TestConfig_Validate_Checkpoints(t *testing.T) {
 func TestDefaultConfig(t *testing.T) {
 	cfg := agenticmemory.DefaultConfig()
 
-	// Verify extraction defaults
-	if !cfg.Extraction.LLMAssisted.Enabled {
-		t.Error("DefaultConfig() extraction.llm_assisted.enabled should be true")
+	// Verify extraction defaults. LLM-assisted extraction is dormant-by-default
+	// (gh#317): there is no client-injection path yet, and NewLLMExtractor rejects
+	// enabled=true without one, so the honest default is disabled (ADR-059 wires it).
+	if cfg.Extraction.LLMAssisted.Enabled {
+		t.Error("DefaultConfig() extraction.llm_assisted.enabled should be false (dormant until wired; gh#317)")
 	}
 	if cfg.Extraction.LLMAssisted.Model != "fast" {
 		t.Errorf("DefaultConfig() extraction.llm_assisted.model = %s, want fast", cfg.Extraction.LLMAssisted.Model)

--- a/processor/agentic-memory/llm_extractor.go
+++ b/processor/agentic-memory/llm_extractor.go
@@ -19,8 +19,22 @@ type LLMExtractor struct {
 	llmClient LLMClient
 }
 
-// NewLLMExtractor creates a new LLMExtractor instance
+// NewLLMExtractor creates a new LLMExtractor instance.
+//
+// Fail loud (gh#317): enabling LLM-assisted extraction without a client is a
+// silent no-op — ExtractFacts returns zero triples and never errors, so the
+// config advertises a feature that produces nothing. Refuse it at construction.
+// When extraction is genuinely wired (ADR-059, routing facts through the claim
+// surface — never direct add_triples), the client is non-nil and this passes.
 func NewLLMExtractor(config ExtractionConfig, llmClient LLMClient) (*LLMExtractor, error) {
+	if config.LLMAssisted.Enabled && llmClient == nil {
+		return nil, errs.WrapInvalid(
+			fmt.Errorf("extraction.llm_assisted.enabled=true but no LLM client is wired (silent no-op); set enabled=false until extraction is wired"),
+			"LLMExtractor",
+			"NewLLMExtractor",
+			"validate llm client",
+		)
+	}
 	return &LLMExtractor{
 		config:    config,
 		llmClient: llmClient,
@@ -49,7 +63,10 @@ func (e *LLMExtractor) ExtractFacts(ctx context.Context, loopID, responseContent
 		return []message.Triple{}, nil
 	}
 
-	// If LLM client is available, use it for extraction
+	// If LLM client is available, use it for extraction. The "enabled ⇒ client
+	// present" invariant is enforced at construction (NewLLMExtractor, gh#317), so
+	// reaching this with enabled=true and a nil client is unreachable today; the
+	// nil branch below remains only for the disabled / not-yet-wired case.
 	if e.llmClient != nil {
 		triples, err := e.llmClient.ExtractFacts(
 			ctx,

--- a/processor/agentic-memory/llm_extractor_test.go
+++ b/processor/agentic-memory/llm_extractor_test.go
@@ -115,7 +115,7 @@ func TestLLMExtractor_UsesModelAlias(t *testing.T) {
 			}
 
 			// Create extractor with specific model
-			extractor, err := agenticmemory.NewLLMExtractor(config, nil)
+			extractor, err := agenticmemory.NewLLMExtractor(config, &MockLLMClient{})
 			if err != nil {
 				t.Fatalf("NewLLMExtractor() failed: %v", err)
 			}
@@ -239,7 +239,7 @@ func TestLLMExtractor_RespectsMaxTokens(t *testing.T) {
 				},
 			}
 
-			extractor, err := agenticmemory.NewLLMExtractor(config, nil)
+			extractor, err := agenticmemory.NewLLMExtractor(config, &MockLLMClient{})
 			if err != nil {
 				t.Fatalf("NewLLMExtractor() failed: %v", err)
 			}
@@ -350,10 +350,38 @@ func createTestExtractor(t *testing.T) *agenticmemory.LLMExtractor {
 	}
 
 	// Create extractor with mock LLM client
-	extractor, err := agenticmemory.NewLLMExtractor(config, nil)
+	extractor, err := agenticmemory.NewLLMExtractor(config, &MockLLMClient{})
 	if err != nil {
 		t.Fatalf("NewLLMExtractor() failed: %v", err)
 	}
 
 	return extractor
+}
+
+// TestNewLLMExtractor_FailsLoudOnEnabledWithoutClient is the gh#317 regression
+// lock: enabling LLM-assisted extraction with no client is a silent no-op
+// (zero triples, no error), so construction must reject it rather than ship a
+// config that advertises a dormant feature.
+func TestNewLLMExtractor_FailsLoudOnEnabledWithoutClient(t *testing.T) {
+	t.Parallel()
+
+	enabled := agenticmemory.ExtractionConfig{
+		LLMAssisted: agenticmemory.LLMAssistedConfig{Enabled: true, Model: "fast", MaxTokens: 1000},
+	}
+	if _, err := agenticmemory.NewLLMExtractor(enabled, nil); err == nil {
+		t.Fatal("NewLLMExtractor(enabled=true, nil client) must fail loud — a nil client makes extraction a silent no-op")
+	}
+
+	// Disabled + nil client is fine (the dormant default).
+	disabled := agenticmemory.ExtractionConfig{
+		LLMAssisted: agenticmemory.LLMAssistedConfig{Enabled: false, Model: "fast", MaxTokens: 1000},
+	}
+	if _, err := agenticmemory.NewLLMExtractor(disabled, nil); err != nil {
+		t.Fatalf("NewLLMExtractor(enabled=false, nil client) must succeed (dormant): %v", err)
+	}
+
+	// Enabled + a real client is fine (the wired path).
+	if _, err := agenticmemory.NewLLMExtractor(enabled, &MockLLMClient{}); err != nil {
+		t.Fatalf("NewLLMExtractor(enabled=true, client) must succeed: %v", err)
+	}
 }


### PR DESCRIPTION
Closes #317.

## Problem
`extraction.llm_assisted` is a silent no-op: the component builds the extractor with a nil `LLMClient` (no injection path exists), `ExtractFacts` returns zero triples without erroring, and handlers short-circuit on the empty result. A config setting `enabled=true` advertises a feature that produces nothing — the shipped `deep-research.json` did exactly that.

## Fix
- `NewLLMExtractor` rejects `enabled=true` with a nil client (fail-fast at construction → propagates through `NewComponent`). The config can no longer lie. When extraction is wired (ADR-059, via the claim surface — never direct `add_triples`), a non-nil client makes it pass.
- `DefaultConfig` + the `enabled` schema-tag default + `deep-research.json` → `false` (dormant default). Schema-neutral (agentic-memory has no generated component schema).
- Fixed the stale `component.go` comment + README (example/table/troubleshooting all advertised `enabled:true`, now a boot-breaking copy-paste).

## Tests
Footgun-fix-surfaces-latent-bugs: the extractor unit suite was exercising the nil-client no-op (`createTestExtractor`'s comment said "mock LLM client" but passed `nil`). Swapped to `&MockLLMClient{}` (returns empty — identical behavior, assertions unchanged) + added a fail-loud regression test. `TestDefaultConfig` / `TestNewComponent_InvalidExtractionConfig` updated for the dormant default.

## Review
`semstreams-reviewer` → APPROVE. Verified: silent no-op closed at the only construction seam; mock-empty ≡ nil-client empty for every assertion; no schema drift; no live consumer relied on default-on; no other config sets `enabled=true`. Its MEDIUM (README drift) is fixed in this PR.