### PR TITLE
feat(openapi): fail generation on dangling $refs (gh#228)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,11 @@ cmd/e2e/e2e
 cmd/semstreams/semstreams
 /semstreams
 bin/
-openapi-generator
+# Binary only — the bare pattern matched the cmd/openapi-generator/ source dir
+# too, silently ignoring new source files there (gh#228). Anchor it like the
+# siblings above.
+cmd/openapi-generator/openapi-generator
+/openapi-generator
 
 # Test profile output
 test/e2e/results/profiles/

--- a/cmd/openapi-generator/main.go
+++ b/cmd/openapi-generator/main.go
@@ -96,6 +96,13 @@ func main() {
 		})
 
 		openapi := generateOpenAPISpec(componentSchemas, serviceSpecs, *outDir)
+
+		// gh#228: fail fast on dangling $refs rather than writing a spec that
+		// passes the drift gate but breaks downstream openapi-typescript codegen.
+		if err := validateOpenAPIRefs(openapi); err != nil {
+			log.Fatalf("OpenAPI ref validation failed: %v", err)
+		}
+
 		if err := writeYAMLFile(*openapiOut, openapi); err != nil {
 			log.Fatalf("Failed to write OpenAPI spec: %v", err)
 		}

--- a/cmd/openapi-generator/validate.go
+++ b/cmd/openapi-generator/validate.go
@@ -5,9 +5,77 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/xeipuuv/gojsonschema"
+	"gopkg.in/yaml.v3"
 )
+
+// validateOpenAPIRefs fails if any `$ref: "#/components/schemas/<Name>"` in the
+// document points at a schema not present under components.schemas. The generator
+// only emits components.schemas for registered types (ResponseTypes /
+// RequestBodyTypes), so a SchemaRef to an unregistered type produces a dangling
+// pointer: it regenerates deterministically (no drift), ships clean through the
+// schema-drift gate, and breaks downstream openapi-typescript codegen at the
+// sister repos. This check turns that silent omission into a local generation
+// failure at the point of the mistake (gh#228).
+func validateOpenAPIRefs(doc OpenAPIDocument) error {
+	defined := make(map[string]bool, len(doc.Components.Schemas))
+	for name := range doc.Components.Schemas {
+		defined[name] = true
+	}
+
+	// Round-trip through a generic tree so $refs are caught ANYWHERE — operation
+	// request/response bodies, nested schema properties, array items — not just the
+	// top-level operation refs. yaml.v3 yields map[string]any (not map[any]any).
+	raw, err := yaml.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("marshal OpenAPI doc for ref check: %w", err)
+	}
+	var generic any
+	if err := yaml.Unmarshal(raw, &generic); err != nil {
+		return fmt.Errorf("unmarshal OpenAPI doc for ref check: %w", err)
+	}
+
+	const prefix = "#/components/schemas/"
+	unresolved := make(map[string]bool)
+	var walk func(n any)
+	walk = func(n any) {
+		switch v := n.(type) {
+		case map[string]any:
+			for k, val := range v {
+				if k == "$ref" {
+					if s, ok := val.(string); ok && strings.HasPrefix(s, prefix) {
+						if name := strings.TrimPrefix(s, prefix); !defined[name] {
+							unresolved[s] = true
+						}
+					}
+				}
+				walk(val)
+			}
+		case []any:
+			for _, item := range v {
+				walk(item)
+			}
+		}
+	}
+	walk(generic)
+
+	if len(unresolved) > 0 {
+		names := make([]string, 0, len(unresolved))
+		for s := range unresolved {
+			names = append(names, s)
+		}
+		sort.Strings(names)
+		return fmt.Errorf(
+			"OpenAPI spec has %d dangling $ref(s) — referenced schema(s) absent from components.schemas; "+
+				"register the type in the owning service spec's ResponseTypes/RequestBodyTypes (gh#228): %s",
+			len(names), strings.Join(names, ", "),
+		)
+	}
+	return nil
+}
 
 // validateSchema validates a component schema against the meta-schema
 func validateSchema(schema ComponentSchema, metaSchemaPath string) error {

--- a/cmd/openapi-generator/validate_refs_test.go
+++ b/cmd/openapi-generator/validate_refs_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateOpenAPIRefs_FlagsDanglingRefs is the gh#228 regression lock: a
+// $ref to a schema absent from components.schemas must fail generation. It also
+// proves the walker descends into nested schema properties AND array items (not
+// just top-level operation refs), since that's where dangling refs hide and
+// where the drift gate is blind.
+func TestValidateOpenAPIRefs_FlagsDanglingRefs(t *testing.T) {
+	doc := OpenAPIDocument{
+		Components: ComponentsObject{
+			Schemas: map[string]any{
+				"Defined": map[string]any{"type": "object"},
+				"Referencer": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"child": map[string]any{"$ref": "#/components/schemas/MissingNested"},
+						"ok":    map[string]any{"$ref": "#/components/schemas/Defined"},
+						"list": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"$ref": "#/components/schemas/MissingItem"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := validateOpenAPIRefs(doc)
+	if err == nil {
+		t.Fatal("expected a dangling-ref error for MissingNested + MissingItem")
+	}
+	for _, want := range []string{"MissingNested", "MissingItem"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must name the dangling ref %q, got: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "Defined") {
+		t.Errorf("a resolved ref (Defined) must not be reported: %v", err)
+	}
+}
+
+// TestValidateOpenAPIRefs_FlagsDanglingRefInOperationBody locks the regression at
+// the ACTUAL production seam (gh#227/gh#228): a SchemaRef.Ref in an operation
+// response or request body pointing at an unregistered schema. Reflection-
+// generated component schemas inline nested structs (no $ref), so dangling refs
+// only ever originate from operation bodies — this is the shape that shipped in
+// gh#227 (StatePatchRequest on POST /workflows/{type}/{id}/state).
+func TestValidateOpenAPIRefs_FlagsDanglingRefInOperationBody(t *testing.T) {
+	doc := OpenAPIDocument{
+		Components: ComponentsObject{
+			Schemas: map[string]any{"DefinedResponse": map[string]any{"type": "object"}},
+		},
+		Paths: map[string]PathItem{
+			"/widgets": {
+				Get: &Operation{
+					Summary: "list widgets",
+					Responses: map[string]Response{
+						"200": {
+							Description: "ok",
+							Content: map[string]MediaType{
+								"application/json": {Schema: SchemaRef{Ref: "#/components/schemas/MissingResponse"}},
+							},
+						},
+					},
+				},
+				Post: &Operation{
+					Summary: "create widget",
+					RequestBody: &RequestBodyObject{
+						Content: map[string]MediaType{
+							"application/json": {Schema: SchemaRef{Ref: "#/components/schemas/MissingRequest"}},
+						},
+					},
+					Responses: map[string]Response{
+						"201": {
+							Description: "created",
+							Content: map[string]MediaType{
+								"application/json": {Schema: SchemaRef{Ref: "#/components/schemas/DefinedResponse"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := validateOpenAPIRefs(doc)
+	if err == nil {
+		t.Fatal("expected dangling-ref error for the operation response + request bodies")
+	}
+	for _, want := range []string{"MissingResponse", "MissingRequest"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error must name dangling ref %q, got: %v", want, err)
+		}
+	}
+	if strings.Contains(err.Error(), "DefinedResponse") {
+		t.Errorf("resolved ref DefinedResponse must not be reported: %v", err)
+	}
+}
+
+// TestValidateOpenAPIRefs_PassesWhenAllResolve is the false-positive guard.
+func TestValidateOpenAPIRefs_PassesWhenAllResolve(t *testing.T) {
+	doc := OpenAPIDocument{
+		Components: ComponentsObject{
+			Schemas: map[string]any{
+				"Defined": map[string]any{"type": "object"},
+				"Referencer": map[string]any{
+					"properties": map[string]any{
+						"child": map[string]any{"$ref": "#/components/schemas/Defined"},
+					},
+				},
+			},
+		},
+	}
+	if err := validateOpenAPIRefs(doc); err != nil {
+		t.Fatalf("all refs resolve; expected no error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #228.

## Problem
The generator only emits `components.schemas` for registered types. A `SchemaRef` to an unregistered type produced a dangling `$ref` that regenerated deterministically (no drift), shipped clean through the schema-drift gate, and broke downstream `openapi-typescript` codegen at sister repos — exactly what bit gh#227 (`StatePatchRequest`).

## Fix
`validateOpenAPIRefs` walks the generated doc **generically** (catches `$ref`s anywhere — operation bodies, nested schema properties, array items, not just top-level operation refs) and fails generation listing any `#/components/schemas/<Name>` absent from `components.schemas`. Wired before write, so `task schema:generate` (→ CI Schema Validation job) fails at the point of the mistake.

**Soundness:** the walker recurses the *same* doc that `writeYAMLFile` marshals, so anything in the shipped spec is checked — exhaustive by construction.

## Also fixed (latent silent-drop, found while committing)
`.gitignore` had a bare `openapi-generator` pattern (meant for the built binary) that **also matched the `cmd/openapi-generator/` source dir** — silently ignoring new source files there (my test file was swallowed on first commit). Anchored it to the binary path like its siblings (`cmd/semstreams/semstreams`).

## Validation
Current spec passes — all 18 refs resolve post-ADR-060 (no diff). Tests cover a dangling nested-property ref + a dangling array-item ref (both caught) and the all-resolved false-positive guard.