### PR TITLE
fix(graph-embedding): fall back to inline text when no content store is wired (StorageRef regression since #264)

### DIFF
--- a/processor/graph-embedding/component.go
+++ b/processor/graph-embedding/component.go
@@ -957,10 +957,26 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 		return
 	}
 
-	// ContentStorable path: if StorageRef is present, use it
-	if entityState.StorageRef != nil {
+	// ContentStorable path: prefer the StorageRef → ObjectStore fetch, but ONLY
+	// when a content store is actually wired (a store-read port is configured).
+	//
+	// #264 (ADR-055 Wave 0) began lifting StorageRef onto the EntityState at the
+	// ingest seam. Without a content store, the worker's fetchTextFromStorage
+	// hard-fails ("content store not configured") and markFailed fires — which
+	// silently collapses ALL embedding (and therefore BM25/search) for every
+	// entity whose content was offloaded. Configs without a content store (e.g.
+	// the BM25 statistical tier, which wires no store-read port) have no way to
+	// honour a StorageRef, so degrade gracefully to inline text extraction from
+	// the entity's content triples instead of failing. Configs WITH a content
+	// store keep the offloaded-content fetch path unchanged.
+	if c.shouldFetchViaStorageRef(&entityState) {
 		c.queueEmbeddingWithStorageRef(ctx, entityID, &entityState)
 		return
+	}
+	if entityState.StorageRef != nil {
+		c.logger.Debug("entity has StorageRef but no content store is configured; "+
+			"falling back to inline text extraction",
+			slog.String("entity", entityID))
 	}
 
 	// Legacy path: Extract text from triples
@@ -984,6 +1000,18 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 	c.logger.Debug("queued embedding for generation",
 		slog.String("entity", entityID),
 		slog.Int("text_length", len(text)))
+}
+
+// shouldFetchViaStorageRef reports whether an entity's offloaded content should
+// be fetched from ObjectStore via its StorageRef. It requires BOTH a StorageRef
+// on the entity AND a wired content store: without the latter, the embedding
+// worker's fetchTextFromStorage hard-fails ("content store not configured") and
+// markFailed fires, silently collapsing all embedding/search for offloaded
+// entities. When the content store is absent we fall back to inline text
+// extraction instead (see queueEntityForEmbedding for the #264 regression
+// context). Configs WITH a content store are unaffected.
+func (c *Component) shouldFetchViaStorageRef(state *graph.EntityState) bool {
+	return state.StorageRef != nil && c.contentStore != nil
 }
 
 // queueEmbeddingWithStorageRef queues an embedding using ContentStorable pattern

--- a/processor/graph-embedding/storageref_fallback_test.go
+++ b/processor/graph-embedding/storageref_fallback_test.go
@@ -1,0 +1,91 @@
+package graphembedding
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/storage/objectstore"
+)
+
+// Regression guard for the gh#354-session find: #264 (ADR-055 Wave 0) began
+// lifting StorageRef onto the EntityState at the ingest seam. graph-embedding
+// then committed to the StorageRef→ObjectStore fetch path whenever a StorageRef
+// was present — but in configs with no content store wired (e.g. the BM25
+// statistical tier), fetchTextFromStorage hard-fails ("content store not
+// configured"), markFailed fires, and ALL embedding/search silently collapses
+// (statistical known-answer 7/7→0/7, shipped beta.113–115, masked as e2e
+// warnings).
+//
+// The fix: only take the StorageRef path when a content store is actually wired;
+// otherwise fall back to inline text extraction. shouldFetchViaStorageRef
+// encodes that decision.
+func TestShouldFetchViaStorageRef(t *testing.T) {
+	storageRef := &message.StorageReference{StorageInstance: "objstore", Key: "k/1"}
+
+	cases := []struct {
+		name         string
+		hasRef       bool
+		contentStore *objectstore.Store // nil => no store-read port configured
+		want         bool
+	}{
+		{
+			name:         "StorageRef + content store wired -> fetch offloaded content",
+			hasRef:       true,
+			contentStore: &objectstore.Store{},
+			want:         true,
+		},
+		{
+			name:         "StorageRef but NO content store -> fall back to inline (the regression)",
+			hasRef:       true,
+			contentStore: nil,
+			want:         false,
+		},
+		{
+			name:         "no StorageRef -> inline path regardless",
+			hasRef:       false,
+			contentStore: &objectstore.Store{},
+			want:         false,
+		},
+		{
+			name:         "no StorageRef, no content store -> inline path",
+			hasRef:       false,
+			contentStore: nil,
+			want:         false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			es := &graph.EntityState{ID: "c360.platform.test.sys.widget.001"}
+			if tc.hasRef {
+				es.StorageRef = storageRef
+			}
+			c := &Component{contentStore: tc.contentStore}
+			assert.Equal(t, tc.want, c.shouldFetchViaStorageRef(es))
+		})
+	}
+}
+
+// TestExtractTextForEmbedding_RecoversInlineContentForStorageRefEntity locks the
+// other half of the fallback: an entity that carries BOTH a StorageRef and
+// inline content triples (the exact shape of the e2e document/sensor entities)
+// still yields non-empty text via inline extraction, so the no-content-store
+// fallback path actually has something to embed.
+func TestExtractTextForEmbedding_RecoversInlineContentForStorageRefEntity(t *testing.T) {
+	c := &Component{}
+	es := &graph.EntityState{
+		ID:         "c360.logistics.maintenance.work.completed.maint-001",
+		StorageRef: &message.StorageReference{StorageInstance: "objstore", Key: "k/maint-001"},
+		Triples: []message.Triple{
+			{Subject: "x", Predicate: "maintenance.title", Object: "Hydraulic pump service"},
+			{Subject: "x", Predicate: "maintenance.description", Object: "Replaced seals on hydraulic reservoir"},
+		},
+	}
+	got := c.extractTextForEmbedding(es)
+	assert.NotEmpty(t, got, "inline content triples must still be extractable so the no-content-store fallback can embed")
+	assert.Contains(t, got, "Hydraulic pump service")
+	assert.Contains(t, got, "Replaced seals")
+}


### PR DESCRIPTION
## Summary

`graph-embedding` was **hard-failing all embedding (and therefore BM25/search)** for any entity whose content was offloaded to ObjectStore, in every config that wires no `store-read` port — e.g. the BM25 **statistical** tier. Statistical search collapsed from **known-answer 7/7 → 0/7** and shipped silently in **beta.113, .114, .115**.

Discovered while validating the tag-safety of the gh#354 fix + the stacked ADR-061 breaking change: an `e2e:statistical` run on main showed `embedding_failed_total≈190` and `known_answer 0/7`, and comparison against 20+ historical runs pinned the regression to between 2026-05-31 and 2026-06-25.

## Root cause

**#264 (ADR-055 Wave 0, 2026-06-12)** began lifting `StorageRef` onto the `EntityState` at the graph-ingest seam (before it, the StorageRef was dropped, so entities used inline text). After #264, `queueEntityForEmbedding` committed to the StorageRef→ObjectStore fetch path whenever `entityState.StorageRef != nil`:

| | StorageRef at ingest | embedding path | result |
|---|---|---|---|
| **Pre-#264** | dropped (nil) | inline content triples → `SourceText` | BM25 embeds → search 7/7 |
| **Post-#264** | lifted (non-nil) | StorageRef → ObjectStore | `contentStore==nil` → `"content store not configured"` → `markFailed` → **0/7** |

The statistical config (and every BM25 config) wires no content store, so `fetchTextFromStorage` hard-fails. #264 was itself a fix ("offloaded content stops embedding") but exposed this latent gap. It shipped silently because the e2e treats embedding failure as a **warning**, not a hard failure.

## Fix

Take the StorageRef path **only when a content store is actually wired**:

```go
func (c *Component) shouldFetchViaStorageRef(state *graph.EntityState) bool {
    return state.StorageRef != nil && c.contentStore != nil
}
```

Otherwise fall back to inline text extraction from the entity's content triples (graceful degradation, not hard-fail).

- Configs **with** a content store: byte-identical (StorageRef fetch path unchanged).
- Configs **without** one: embed the inline content that's already on the entity.
- Entities with neither inline content nor a fetchable store: skip gracefully via the existing empty-text path — never hard-fail.

## Verification (live `e2e:statistical`)

| Metric | Before | After | pre-#264 baseline |
|---|---|---|---|
| `embedding_failed_total` | 191 | **0** | 0 |
| `embedding_generated_total` | 160 | **349** | 349 |
| `known_answer_tests` | 0/7 | **7/7** | 7/7 |
| `search_quality_score` | 0.03 | **0.287** | ~0.287 |

Byte-identical to the last good run. Community detection unaffected (15 communities). Full unit suite (126 pkgs, `-race`) green, lint clean, no schema drift. Pre-merge **semstreams-reviewer: APPROVE** (no blocking/high).

## Recommended follow-up (separate)

The real reason this shipped silently for 3 betas: the `e2e:statistical` tier **warns** (not fails) on embedding failures / known-answer collapse. A hard gate there (fail when `embedding_failed_total` exceeds a small floor, or known-answer drops) would catch this class — tracked separately to avoid the over-strict-gate footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)