### PR TITLE
feat(gateddag): pure selection brain for gated-DAG dispatch (ADR-046 Phase 2.1, gh#357)

### DIFF
--- a/pkg/gateddag/gateddag.go
+++ b/pkg/gateddag/gateddag.go
@@ -1,0 +1,221 @@
+// Package gateddag is the pure decision brain of gated-DAG dispatch
+// (ADR-046 Phase 2). Given a set of work units with depends_on edges and a
+// completion/failure/reset marker snapshot, it computes — as a side-effect-free
+// function of marker membership — each unit's DERIVED status and the set of
+// units dispatchable right now.
+//
+// It owns no state, performs no I/O, and knows nothing of NATS, the graph, or
+// any consumer domain. There is no Story/owner/file-overlap concept here: a
+// consumer that needs those (e.g. semspec's M:N owner gating, or its
+// file-overlap serialization edges) resolves them into the depends_on map and
+// applies any domain gate on top before/after calling this brain. The executor
+// component (a separate package, ADR-046 Phase 2) reads marker sets from
+// ENTITY_STATES authoritatively, calls this brain, and acts on its verdicts via
+// the dispatch substrate.
+//
+// # Why a pure function (the wedge it kills)
+//
+// Status is DERIVED, never stored or mutated: every evaluation recomputes from
+// the current marker membership, so there is no status field to go stale and
+// nothing to race the markers. A gated dispatcher that maintains a
+// separately-mutated status field reintroduces the wedge family — a reset
+// strands a unit; a re-dispatch idempotent-skips into idle (ADR-046 correctness
+// requirement #1, "the root of the whole wedge family"). The brain re-derives
+// from authoritative marker membership every evaluation; the executor supplies
+// that membership by reading the whole unit set from KV (it cannot be projected
+// onto a single entity, which is why this is a component, not a rule).
+//
+// # Coverage boundary
+//
+// The brain covers the requirements that are a pure function of markers + edges:
+// derived status (#1), wait-for-ALL-prerequisites (#2), generic dependency
+// source (#3, depends_on is opaque), reset/re-derive (#4, Dirtied precedence),
+// the brain half of failure-release (#7, a failed prereq's dependent surfaces
+// via Stalled rather than dispatching), and stall/cycle detection (#8).
+// Fresh-per-run identity (#5) and in-flight dedup (#6) are executor concerns —
+// the brain returns Ready for an in-flight unit (it carries no terminal marker),
+// so the executor MUST exclude already-dispatched units via its durable claim
+// marker. See ADR-046 "Load-bearing invariants".
+package gateddag
+
+import "sort"
+
+// Status is the DERIVED execution status of a unit — a pure function of marker
+// membership. It is never stored or mutated.
+type Status int
+
+const (
+	// StatusReady — no live terminal marker: the unit is eligible to dispatch
+	// once its prerequisites clear. A reset/recovery-dirtied unit also derives
+	// as Ready (its stale terminal markers are ignored — it must re-run).
+	StatusReady Status = iota
+	// StatusDone — the unit appears in the Completed marker set.
+	StatusDone
+	// StatusBlocked — the unit appears in the Failed marker set (and is not
+	// dirtied): terminal failure awaiting recovery.
+	StatusBlocked
+)
+
+// String renders a Status for logs/observability.
+func (s Status) String() string {
+	switch s {
+	case StatusDone:
+		return "done"
+	case StatusBlocked:
+		return "blocked"
+	default:
+		return "ready"
+	}
+}
+
+// MarkerSet is the multi-valued completion/failure/reset marker membership read
+// from the graph at one instant. Membership is the ONLY input to derived
+// status — the brain never reads a mutated status field.
+type MarkerSet struct {
+	// Completed holds unit IDs present in the completion marker.
+	Completed map[string]bool
+	// Failed holds unit IDs present in the failure marker.
+	Failed map[string]bool
+	// Dirtied holds unit IDs that are recovery-dirtied or reset. A dirtied unit
+	// overrides any stale Completed/Failed membership and derives as Ready (it
+	// must re-run), which is the presence-marker re-entry idiom that lets a
+	// reset re-dispatch without a stored status to clear.
+	Dirtied map[string]bool
+}
+
+// NewMarkerSet builds a MarkerSet from the multi-valued marker slices read off
+// the graph (nil slices are fine — they become empty sets).
+func NewMarkerSet(completed, failed, dirtied []string) MarkerSet {
+	return MarkerSet{
+		Completed: toSet(completed),
+		Failed:    toSet(failed),
+		Dirtied:   toSet(dirtied),
+	}
+}
+
+func toSet(ids []string) map[string]bool {
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}
+
+// DeriveStatus computes a unit's status from marker membership alone.
+//
+// Precedence (documented because it is load-bearing):
+//  1. Dirtied wins — a reset/recovery-dirtied unit is Ready regardless of any
+//     stale Completed/Failed marker left from a prior run; it must re-execute.
+//  2. Failed beats Completed — if a unit somehow carries both terminal markers
+//     (a re-failure after a prior completion), the more actionable Blocked
+//     verdict is reported so recovery, not a false "done", is surfaced.
+//  3. Completed → Done.
+//  4. Otherwise → Ready.
+func DeriveStatus(id string, m MarkerSet) Status {
+	if m.Dirtied[id] {
+		return StatusReady
+	}
+	if m.Failed[id] {
+		return StatusBlocked
+	}
+	if m.Completed[id] {
+		return StatusDone
+	}
+	return StatusReady
+}
+
+// Decision is the brain's verdict for one unit, with a reason for observability.
+type Decision struct {
+	UnitID       string
+	Status       Status
+	Dispatchable bool
+	Reason       string
+}
+
+// Evaluate returns a deterministic, unit-ID-sorted decision for every unit: its
+// derived status and whether it is dispatchable right now.
+//
+// A unit is dispatchable when ALL of:
+//   - its derived status is Ready (not Done, not Blocked; a dirtied unit is
+//     Ready and so re-dispatchable);
+//   - every entry in dependsOn[unit] derives as Done — the DAG closure is
+//     "wait for ALL prerequisites", never "any" (a Blocked or still-Ready or
+//     dirtied prerequisite holds the dependent).
+//
+// dependsOn is the resolved edge set: the caller unions whatever sources it
+// needs (semspec unions semantic prerequisites with file-overlap serialization
+// edges) before calling here. A unit with no entry in dependsOn has no
+// prerequisites.
+func Evaluate(unitIDs []string, dependsOn map[string][]string, m MarkerSet) []Decision {
+	decisions := make([]Decision, 0, len(unitIDs))
+	for _, id := range unitIDs {
+		decisions = append(decisions, decideUnit(id, dependsOn, m))
+	}
+	sort.Slice(decisions, func(i, j int) bool {
+		return decisions[i].UnitID < decisions[j].UnitID
+	})
+	return decisions
+}
+
+func decideUnit(id string, dependsOn map[string][]string, m MarkerSet) Decision {
+	d := Decision{UnitID: id, Status: DeriveStatus(id, m)}
+	switch d.Status {
+	case StatusDone:
+		d.Reason = "already complete"
+		return d
+	case StatusBlocked:
+		d.Reason = "failed — awaiting recovery"
+		return d
+	}
+	// Ready: the DAG closure — ALL prerequisites must derive Done.
+	for _, dep := range dependsOn[id] {
+		if DeriveStatus(dep, m) != StatusDone {
+			d.Reason = "waiting on prerequisite " + dep
+			return d
+		}
+	}
+	d.Dispatchable = true
+	d.Reason = "ready"
+	return d
+}
+
+// SelectDispatchable is the convenience projection of Evaluate: the sorted set
+// of unit IDs dispatchable right now.
+func SelectDispatchable(unitIDs []string, dependsOn map[string][]string, m MarkerSet) []string {
+	var ready []string
+	for _, d := range Evaluate(unitIDs, dependsOn, m) {
+		if d.Dispatchable {
+			ready = append(ready, d.UnitID)
+		}
+	}
+	return ready
+}
+
+// Stalled reports the units that are gated with no forward progress possible:
+// there is no dispatchable unit, yet ≥1 unit is non-terminal (Ready but held).
+// That is the silent-idle signature of a depends_on cycle, or of every
+// non-terminal unit waiting behind a Blocked prerequisite — a stuck plan that
+// looks merely idle. The executor surfaces a non-empty result as an ALERT
+// instead of letting it read as benign idleness (ADR-046 requirement #8).
+// Returns nil when work is dispatchable OR everything is terminal (a genuinely
+// complete or genuinely empty plan is not stalled).
+//
+// Pure observability — it does not change dispatch. A non-empty result means
+// nothing can move without recovery (reset a failed prerequisite) or an
+// authoring fix (break a cycle).
+func Stalled(unitIDs []string, dependsOn map[string][]string, m MarkerSet) []string {
+	var heldReady []string
+	dispatchable := false
+	for _, d := range Evaluate(unitIDs, dependsOn, m) {
+		if d.Dispatchable {
+			dispatchable = true
+		}
+		if d.Status == StatusReady && !d.Dispatchable {
+			heldReady = append(heldReady, d.UnitID)
+		}
+	}
+	if dispatchable || len(heldReady) == 0 {
+		return nil
+	}
+	return heldReady // already sorted (Evaluate sorts by unit ID)
+}

--- a/pkg/gateddag/gateddag_test.go
+++ b/pkg/gateddag/gateddag_test.go
@@ -1,0 +1,323 @@
+package gateddag_test
+
+import (
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/gateddag"
+)
+
+// The cases here ARE the ADR-046 correctness requirements the brain owns
+// (#1 derived-not-mutated, #2 wait-for-ALL, #3 generic source, #4 reset,
+// #7 brain-half of failure-release, #8 stall). #5 fresh-identity and #6
+// in-flight dedup are executor concerns, not brain — see the package doc.
+// Generalized from semspec's coordinator suite with all Story/owner cases
+// dropped (M:N gating stays in the consumer).
+
+func contains(ss []string, s string) bool {
+	return slices.Contains(ss, s)
+}
+
+// --- #1 derived-not-mutated: status is a pure function of markers ---
+
+func TestDeriveStatus_PureFunctionOfMarkers(t *testing.T) {
+	m := gateddag.NewMarkerSet(
+		[]string{"u-done"},   // completed
+		[]string{"u-failed"}, // failed
+		nil,                  // dirtied
+	)
+	cases := []struct {
+		id   string
+		want gateddag.Status
+	}{
+		{"u-done", gateddag.StatusDone},
+		{"u-failed", gateddag.StatusBlocked},
+		{"u-unknown", gateddag.StatusReady},
+	}
+	for _, c := range cases {
+		if got := gateddag.DeriveStatus(c.id, m); got != c.want {
+			t.Errorf("DeriveStatus(%q) = %v, want %v", c.id, got, c.want)
+		}
+	}
+}
+
+// TestDeriveStatus_DirtiedOverridesStaleTerminal proves the reset/re-entry
+// idiom: a dirtied unit derives Ready even with a stale completed marker, so a
+// reset re-dispatches with no stored status to clear. Teeth: drop the Dirtied
+// branch and this fails (would report Done).
+func TestDeriveStatus_DirtiedOverridesStaleTerminal(t *testing.T) {
+	m := gateddag.NewMarkerSet(
+		[]string{"u-reset"}, // stale completed
+		nil,
+		[]string{"u-reset"}, // recovery-dirtied
+	)
+	if got := gateddag.DeriveStatus("u-reset", m); got != gateddag.StatusReady {
+		t.Errorf("dirtied unit with stale completed marker: got %v, want Ready", got)
+	}
+}
+
+// TestDeriveStatus_FailedBeatsCompleted pins the precedence: a unit carrying
+// both terminal markers reports the actionable Blocked, not a false Done.
+func TestDeriveStatus_FailedBeatsCompleted(t *testing.T) {
+	m := gateddag.NewMarkerSet([]string{"u"}, []string{"u"}, nil)
+	if got := gateddag.DeriveStatus("u", m); got != gateddag.StatusBlocked {
+		t.Errorf("completed+failed: got %v, want Blocked", got)
+	}
+}
+
+// --- #2 wait-for-ALL-prerequisites ---
+
+// TestSelectDispatchable_WaitsForAllPrerequisites is the "ALL not any" teeth
+// test: a dependent with two prerequisites stays gated while only one is done,
+// and dispatches only once BOTH are done.
+func TestSelectDispatchable_WaitsForAllPrerequisites(t *testing.T) {
+	units := []string{"p1", "p2", "dep"}
+	deps := map[string][]string{"dep": {"p1", "p2"}}
+
+	onlyP1 := gateddag.NewMarkerSet([]string{"p1"}, nil, nil)
+	got := gateddag.SelectDispatchable(units, deps, onlyP1)
+	if contains(got, "dep") {
+		t.Errorf("dep dispatched with only one of two prerequisites complete: %v", got)
+	}
+	if !contains(got, "p2") {
+		t.Errorf("p2 (no prereqs, not done) should be dispatchable: %v", got)
+	}
+
+	bothDone := gateddag.NewMarkerSet([]string{"p1", "p2"}, nil, nil)
+	got = gateddag.SelectDispatchable(units, deps, bothDone)
+	if !contains(got, "dep") {
+		t.Errorf("dep should dispatch once ALL prerequisites complete: %v", got)
+	}
+}
+
+// TestSelectDispatchable_BlockedPrerequisiteHoldsDependent: a FAILED prerequisite
+// (not Done) keeps the dependent gated — a blocked prereq is not "complete".
+func TestSelectDispatchable_BlockedPrerequisiteHoldsDependent(t *testing.T) {
+	units := []string{"p", "dep"}
+	deps := map[string][]string{"dep": {"p"}}
+	m := gateddag.NewMarkerSet(nil, []string{"p"}, nil) // p failed
+	if contains(gateddag.SelectDispatchable(units, deps, m), "dep") {
+		t.Error("dependent dispatched while its prerequisite is Blocked")
+	}
+}
+
+func TestSelectDispatchable_DoneUnitNotRedispatched(t *testing.T) {
+	units := []string{"u"}
+	m := gateddag.NewMarkerSet([]string{"u"}, nil, nil)
+	if contains(gateddag.SelectDispatchable(units, nil, m), "u") {
+		t.Error("a completed unit must not be dispatchable")
+	}
+}
+
+// --- #3 generic dependency source: depends_on is opaque, consumer-resolved ---
+
+// TestSelectDispatchable_HonorsResolvedEdges is the generic of semspec's
+// file-overlap test: two units with no intrinsic relationship serialize purely
+// because the consumer resolved an edge between them into depends_on. The brain
+// does not care where the edge came from (semantic, file-overlap, anything).
+func TestSelectDispatchable_HonorsResolvedEdges(t *testing.T) {
+	units := []string{"a", "b"}
+	deps := map[string][]string{"b": {"a"}} // consumer-resolved: b waits on a
+
+	got := gateddag.SelectDispatchable(units, deps, gateddag.NewMarkerSet(nil, nil, nil))
+	if !contains(got, "a") {
+		t.Errorf("prerequisite a should dispatch: %v", got)
+	}
+	if contains(got, "b") {
+		t.Errorf("b dispatched despite a resolved depends_on edge: %v", got)
+	}
+	got = gateddag.SelectDispatchable(units, deps, gateddag.NewMarkerSet([]string{"a"}, nil, nil))
+	if !contains(got, "b") {
+		t.Errorf("b should dispatch once its resolved prerequisite is done: %v", got)
+	}
+}
+
+// --- #4 reset / re-dispatch authoritative (brain level) ---
+
+func TestSelectDispatchable_DirtiedUnitRedispatches(t *testing.T) {
+	units := []string{"u"}
+	// u was completed, then reset (dirtied) — it must become dispatchable again.
+	m := gateddag.NewMarkerSet([]string{"u"}, nil, []string{"u"})
+	if !contains(gateddag.SelectDispatchable(units, nil, m), "u") {
+		t.Error("a reset (dirtied) unit must re-dispatch, not idle-skip on a stale completed marker")
+	}
+}
+
+// TestSelectDispatchable_DirtiedPrerequisiteHoldsDependent is the teeth test
+// that pins "wait for DeriveStatus(dep) == Done", not a weaker "dep not Failed":
+// a prerequisite that was completed then reset (Dirtied → Ready, re-running) is
+// NOT Done, so its dependent must stay held while the prereq itself re-dispatches
+// to re-produce its output. A closure that checked `!= StatusBlocked` would
+// wrongly dispatch the dependent over a re-running prereq (a #4-reset wedge).
+func TestSelectDispatchable_DirtiedPrerequisiteHoldsDependent(t *testing.T) {
+	units := []string{"p", "dep"}
+	deps := map[string][]string{"dep": {"p"}}
+	// p was completed, now reset → derives Ready (re-running), not Done.
+	m := gateddag.NewMarkerSet([]string{"p"}, nil, []string{"p"})
+
+	got := gateddag.SelectDispatchable(units, deps, m)
+	if contains(got, "dep") {
+		t.Errorf("dep dispatched while its prerequisite p is re-running (Dirtied, not Done): %v", got)
+	}
+	if !contains(got, "p") {
+		t.Errorf("the dirtied prerequisite p must itself re-dispatch: %v", got)
+	}
+	if s := gateddag.Stalled(units, deps, m); s != nil {
+		t.Errorf("not stalled — p is dispatchable: %v", s)
+	}
+}
+
+// TestSelectDispatchable_Diamond verifies multi-level fan-in (a→{b,c}→d): d
+// dispatches only after BOTH mid-nodes complete, and the mid-nodes only after
+// the root. Single-level WaitsForAll does not exercise the transitive case.
+func TestSelectDispatchable_Diamond(t *testing.T) {
+	units := []string{"a", "b", "c", "d"}
+	deps := map[string][]string{"b": {"a"}, "c": {"a"}, "d": {"b", "c"}}
+
+	// a done, only b done (c outstanding) → d held.
+	abDone := gateddag.NewMarkerSet([]string{"a", "b"}, nil, nil)
+	if contains(gateddag.SelectDispatchable(units, deps, abDone), "d") {
+		t.Error("d dispatched with only one of its two mid-level prerequisites done")
+	}
+	// a, b, c done → d dispatchable.
+	abcDone := gateddag.NewMarkerSet([]string{"a", "b", "c"}, nil, nil)
+	if !contains(gateddag.SelectDispatchable(units, deps, abcDone), "d") {
+		t.Error("d should dispatch once both mid-level prerequisites complete")
+	}
+}
+
+// TestStalled_SelfLoop: a 1-node cycle (a→a) derives nothing dispatchable and
+// must surface as stalled (DetectsCycle only covers the 2-node case).
+func TestStalled_SelfLoop(t *testing.T) {
+	units := []string{"a"}
+	deps := map[string][]string{"a": {"a"}}
+	m := gateddag.NewMarkerSet(nil, nil, nil)
+	if got := gateddag.SelectDispatchable(units, deps, m); len(got) != 0 {
+		t.Fatalf("a self-loop leaves nothing dispatchable, got %v", got)
+	}
+	if !contains(gateddag.Stalled(units, deps, m), "a") {
+		t.Error("a self-loop should surface as a stall, not silent idle")
+	}
+}
+
+// --- determinism + Evaluate report ---
+
+func TestEvaluate_IsDeterministicallySorted(t *testing.T) {
+	units := []string{"c", "a", "b"}
+	got := gateddag.Evaluate(units, nil, gateddag.NewMarkerSet(nil, nil, nil))
+	ids := make([]string, len(got))
+	for i, d := range got {
+		ids[i] = d.UnitID
+	}
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(ids, want) {
+		t.Errorf("Evaluate order: got %v, want %v (must be unit-ID sorted for determinism)", ids, want)
+	}
+}
+
+func TestEvaluate_CarriesStatusAndReason(t *testing.T) {
+	units := []string{"done", "dep", "blocked"}
+	deps := map[string][]string{"dep": {"done"}}
+	m := gateddag.NewMarkerSet([]string{"done"}, []string{"blocked"}, nil)
+	byID := map[string]gateddag.Decision{}
+	for _, d := range gateddag.Evaluate(units, deps, m) {
+		byID[d.UnitID] = d
+	}
+	if d := byID["done"]; d.Status != gateddag.StatusDone || d.Dispatchable {
+		t.Errorf("done: %+v", d)
+	}
+	if d := byID["blocked"]; d.Status != gateddag.StatusBlocked || d.Dispatchable {
+		t.Errorf("blocked: %+v", d)
+	}
+	if d := byID["dep"]; !d.Dispatchable {
+		t.Errorf("dep should dispatch (its only prereq is done): %+v", d)
+	}
+}
+
+func TestEvaluate_ReasonStrings(t *testing.T) {
+	units := []string{"p", "dep"}
+	deps := map[string][]string{"dep": {"p"}}
+	byID := map[string]gateddag.Decision{}
+	for _, d := range gateddag.Evaluate(units, deps, gateddag.NewMarkerSet(nil, nil, nil)) {
+		byID[d.UnitID] = d
+	}
+	if r := byID["dep"].Reason; r != "waiting on prerequisite p" {
+		t.Errorf("held-dependent reason: got %q", r)
+	}
+	if r := byID["p"].Reason; r != "ready" {
+		t.Errorf("ready reason: got %q", r)
+	}
+}
+
+// --- #8 stall / cycle detection (and the brain half of #7) ---
+
+// TestStalled_DetectsCycle: a→b, b→a derives nothing dispatchable, nothing
+// terminal — a silent-idle deadlock. Stalled must surface the held units.
+func TestStalled_DetectsCycle(t *testing.T) {
+	units := []string{"a", "b"}
+	deps := map[string][]string{"a": {"b"}, "b": {"a"}}
+	m := gateddag.NewMarkerSet(nil, nil, nil)
+
+	if got := gateddag.SelectDispatchable(units, deps, m); len(got) != 0 {
+		t.Fatalf("a cycle should leave nothing dispatchable, got %v", got)
+	}
+	stalled := gateddag.Stalled(units, deps, m)
+	if !contains(stalled, "a") || !contains(stalled, "b") {
+		t.Errorf("Stalled should surface the deadlocked units, got %v", stalled)
+	}
+}
+
+// TestStalled_AllBlockedWait is also the brain half of #7 (failure-release): a
+// dependent gated behind a Blocked prerequisite is surfaced as stalled (the
+// prereq will never derive Done without recovery) — never SILENTLY stranded.
+func TestStalled_AllBlockedWait(t *testing.T) {
+	units := []string{"p", "dep"}
+	deps := map[string][]string{"dep": {"p"}}
+	m := gateddag.NewMarkerSet(nil, []string{"p"}, nil) // p failed (terminal)
+	stalled := gateddag.Stalled(units, deps, m)
+	if !contains(stalled, "dep") {
+		t.Errorf("dep gated behind a Blocked prereq should be reported stalled: %v", stalled)
+	}
+	if contains(stalled, "p") {
+		t.Errorf("p is Blocked (terminal), not a held-Ready stall: %v", stalled)
+	}
+}
+
+// TestStalled_IndependentBranchFlows pins #7's "independent branches keep
+// flowing": a failed node strands only its own dependents; an unrelated unit
+// stays dispatchable, so the plan is NOT stalled.
+func TestStalled_IndependentBranchFlows(t *testing.T) {
+	units := []string{"p", "dep", "free"}
+	deps := map[string][]string{"dep": {"p"}} // free has no prereqs
+	m := gateddag.NewMarkerSet(nil, []string{"p"}, nil)
+	if got := gateddag.Stalled(units, deps, m); got != nil {
+		t.Errorf("an independent dispatchable unit (free) means not stalled: %v", got)
+	}
+	if !contains(gateddag.SelectDispatchable(units, deps, m), "free") {
+		t.Error("free should dispatch — it does not depend on the failed node")
+	}
+}
+
+func TestStalled_NotStalledWhenProgressing(t *testing.T) {
+	units := []string{"a", "b"}
+	deps := map[string][]string{"b": {"a"}}
+	if got := gateddag.Stalled(units, deps, gateddag.NewMarkerSet(nil, nil, nil)); got != nil {
+		t.Errorf("a plan with dispatchable work (a) is not stalled: %v", got)
+	}
+}
+
+func TestStalled_NotStalledWhenComplete(t *testing.T) {
+	units := []string{"a", "b"}
+	deps := map[string][]string{"b": {"a"}}
+	m := gateddag.NewMarkerSet([]string{"a", "b"}, nil, nil)
+	if got := gateddag.Stalled(units, deps, m); got != nil {
+		t.Errorf("a completed plan is not stalled: %v", got)
+	}
+}
+
+func TestStalled_EmptyPlanNotStalled(t *testing.T) {
+	if got := gateddag.Stalled(nil, nil, gateddag.NewMarkerSet(nil, nil, nil)); got != nil {
+		t.Errorf("an empty plan is not stalled: %v", got)
+	}
+}


### PR DESCRIPTION
## What

Phase 2.1 of ADR-046 gated-DAG dispatch (gh#357, see #359 for the design amendment): the **dependency-free selection brain**.

`pkg/gateddag` computes — as a pure function of a `MarkerSet{Completed,Failed,Dirtied}` and an opaque `dependsOn map[string][]string` — each unit's derived `Status`, the dispatchable set (`SelectDispatchable`), and `Stalled()` (cycle / all-blocked-wait detection). No state, no I/O, no domain types.

## Generalization

Lifted from semspec's `workflow/coordinator` by replacing `(reqs []Requirement, stories []Story)` with `(unitIDs []string, dependsOn map[string][]string)` and **dropping all M:N Story/owner gating** — that stays in the consumer, which resolves its edges (semantic + ADR-044 file-overlap) into `depends_on` and layers any domain gate around the brain.

Pre-merge review (go-reviewer) confirmed the generalization is faithful: line-by-line diff vs the semspec original, `ResolveRequirementBranchPrereqs` equivalence (story-less → raw `depends_on`), M:N removal can only relax verdicts for units that don't exist in a story-less world, and mutation tests prove the "wait-for-ALL" and "Dirtied precedence" invariants have teeth.

## Coverage boundary

| Requirement | Owner |
|---|---|
| #1 derived-not-mutated, #2 wait-for-ALL, #3 generic source, #4 reset re-derive, #7 (brain half), #8 stall/cycle | **brain** (this PR) |
| #5 fresh identity, #6 in-flight dedup | **executor** (Phase 2.2) — the brain returns `Ready` for an in-flight unit, so the executor must exclude already-dispatched units via its durable claim marker |

## Tests

20 tests — the cases *are* the requirements (incl. dirtied-prerequisite-holds-dependent, diamond DAG, self-loop added per review). `-race` + revive clean.

Phase 2.2 (executor component) consumes this next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)