### PR TITLE
feat(gateddag): gated-DAG dispatch executor (ADR-046 Phase 2.2, gh#357)

### DIFF
--- a/componentregistry/register.go
+++ b/componentregistry/register.go
@@ -26,6 +26,7 @@ import (
 	agenticloop "github.com/c360studio/semstreams/processor/agentic-loop"
 	agenticmodel "github.com/c360studio/semstreams/processor/agentic-model"
 	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
+	gateddagexec "github.com/c360studio/semstreams/processor/gated-dag"
 	graphclustering "github.com/c360studio/semstreams/processor/graph-clustering"
 	graphembedding "github.com/c360studio/semstreams/processor/graph-embedding"
 	graphindex "github.com/c360studio/semstreams/processor/graph-index"
@@ -244,6 +245,12 @@ func registerSemanticLayer(registry *component.Registry) error {
 	// Rule processor
 	if err := rule.Register(registry); err != nil {
 		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "Rule processor component registration")
+	}
+
+	// Gated-DAG dispatch executor (ADR-046 Phase 2): dispatches DAG units in
+	// dependency order with restart recovery, failure isolation, stall detection.
+	if err := gateddagexec.Register(registry); err != nil {
+		return pkgerrs.WrapInvalid(err, "ComponentRegistry", "Register", "gated-dag executor component registration")
 	}
 
 	return nil

--- a/payloadbuiltins/register.go
+++ b/payloadbuiltins/register.go
@@ -24,6 +24,7 @@ import (
 	"github.com/c360studio/semstreams/message/oms"
 	"github.com/c360studio/semstreams/payloadregistry"
 	agenticdispatch "github.com/c360studio/semstreams/processor/agentic-dispatch"
+	gateddagexec "github.com/c360studio/semstreams/processor/gated-dag"
 	"github.com/c360studio/semstreams/storage/objectstore"
 )
 
@@ -49,6 +50,7 @@ func Register(reg *payloadregistry.Registry) error {
 	track(agentic.RegisterPayloads(reg))
 	track(research.RegisterPayloads(reg))
 	track(agenticdispatch.RegisterPayloads(reg))
+	track(gateddagexec.RegisterPayloads(reg))
 	track(githubwebhook.RegisterPayloads(reg))
 	track(objectstore.RegisterPayloads(reg))
 	track(governance.RegisterPayloads(reg))

--- a/processor/gated-dag/claim.go
+++ b/processor/gated-dag/claim.go
@@ -1,0 +1,81 @@
+package gateddagexec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// subjectUpdateWithTriples is the mutation subject used to commit the durable
+// claim marker. It is the same atomic replace-by-predicate path replace_owned
+// uses (graph-ingest SubjectEntityUpdateWithTriples).
+const subjectUpdateWithTriples = "graph.mutation.entity.update_with_triples"
+
+// claimMutationTimeout bounds a single claim round-trip.
+const claimMutationTimeout = 5 * time.Second
+
+// claimer commits the durable in-flight claim marker on a unit BEFORE its
+// dispatch is published (ADR-046 invariant #2). It is an interface so unit
+// tests record claim ordering against a fake.
+type claimer interface {
+	// Claim writes the claim marker on unitID. Returns an error if the write
+	// fails (the caller then does NOT publish — the unit is retried next eval).
+	Claim(ctx context.Context, unitID string) error
+}
+
+// natsClaimer writes the claim via the atomic replace-by-predicate mutation
+// (RemoveTriples drops any prior claim, AddTriples sets the new one — a watcher
+// never sees the predicate absent between the two).
+type natsClaimer struct {
+	nc        *natsclient.Client
+	predicate string
+}
+
+// Claim commits the durable claim marker.
+//
+// ExpectedRevision is left zero: this is owned-current-state reconciliation
+// (last-write-wins), NOT a CAS transition. Mutual exclusion comes from
+// single-flight execution + one instance per fan-out (ADR-046 invariant #1), not
+// from this write.
+//
+// CAS-UPGRADE POINT: if cross-writer / multi-instance exclusion is ever needed,
+// switch this to an ExpectedRevision-based CAS write — populate
+// graph.UpdateEntityWithTriplesRequest.ExpectedRevision with the unit's read
+// revision and let the graph-ingest handler reject a stale claim. The brain and
+// the rest of the executor are unaffected.
+func (c *natsClaimer) Claim(ctx context.Context, unitID string) error {
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:        &graph.EntityState{ID: unitID},
+		RemoveTriples: []string{c.predicate},
+		AddTriples: []message.Triple{{
+			Subject:    unitID,
+			Predicate:  c.predicate,
+			Object:     unitID,
+			Source:     "gateddag-executor",
+			Timestamp:  time.Now(),
+			Confidence: 1.0,
+		}},
+		// OwnerToken empty: the lease check is skipped (two-state contract). We do
+		// not rely on the lease for exclusion — see invariant #1.
+	}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal claim request: %w", err)
+	}
+	// Retry-classified: the replace is idempotent (replace-by-predicate converges
+	// to the same single-valued state on a duplicate delivery), so retry is safe.
+	respData, err := c.nc.RequestWithRetryClassified(ctx, subjectUpdateWithTriples, reqData, claimMutationTimeout, natsclient.DefaultRetryConfig())
+	if err != nil {
+		return fmt.Errorf("claim mutation failed for %s: %w", unitID, err)
+	}
+	var resp graph.UpdateEntityWithTriplesResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return fmt.Errorf("unmarshal claim response for %s: %w", unitID, err)
+	}
+	return nil
+}

--- a/processor/gated-dag/component.go
+++ b/processor/gated-dag/component.go
@@ -1,0 +1,209 @@
+package gateddagexec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/metric"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+)
+
+const componentName = "gated-dag"
+
+// Register registers the gated-DAG executor factory with the component registry.
+func Register(registry *component.Registry) error {
+	return registry.RegisterFactory(componentName, &component.Registration{
+		Name:        componentName,
+		Type:        "processor",
+		Protocol:    "nats",
+		Domain:      "graph",
+		Description: "Gated-DAG dispatch executor (ADR-046 Phase 2): dispatches DAG units in dependency order with restart recovery, failure isolation, and stall detection.",
+		Version:     "1.0.0",
+		Factory:     CreateGatedDag,
+		Schema:      DefaultConfig().Schema(),
+	})
+}
+
+// Component is the gated-DAG executor processor.
+type Component struct {
+	cfg        Config
+	natsClient *natsclient.Client
+	mgr        *lifecycle.Manager
+	metricsReg *metric.MetricsRegistry
+	logger     *slog.Logger
+
+	mu        sync.RWMutex
+	running   bool
+	startTime time.Time
+	exec      *executor
+}
+
+// CreateGatedDag is the component.Factory for the gated-DAG executor.
+func CreateGatedDag(rawConfig json.RawMessage, deps component.Dependencies) (component.Discoverable, error) {
+	return NewComponent(rawConfig, deps)
+}
+
+// NewComponent parses + validates config and wires dependencies.
+func NewComponent(rawConfig json.RawMessage, deps component.Dependencies) (*Component, error) {
+	var cfg Config
+	if len(rawConfig) > 0 {
+		if err := json.Unmarshal(rawConfig, &cfg); err != nil {
+			return nil, fmt.Errorf("unmarshal gated-dag config: %w", err)
+		}
+	}
+	cfg = cfg.withDefaults()
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid gated-dag config: %w", err)
+	}
+	return &Component{
+		cfg:        cfg,
+		natsClient: deps.NATSClient,
+		mgr:        deps.LifecycleManager,
+		metricsReg: deps.MetricsRegistry,
+		logger:     deps.GetLoggerWithComponent(componentName),
+	}, nil
+}
+
+// Initialize self-registers the framework FanOut workflow when the config uses
+// the default workflow name, so mgr.Watch resolves it. A consumer that points
+// FanOutWorkflow at its own workflow is responsible for registering that one.
+// The executor requires a lifecycle Manager (it is the Watch substrate); a nil
+// Manager is a wiring error surfaced loudly here rather than a silent no-op.
+func (c *Component) Initialize() error {
+	if c.mgr == nil {
+		return fmt.Errorf("gated-dag: LifecycleManager is required (the Watch re-eval/recovery substrate) but was not wired")
+	}
+	if c.cfg.FanOutWorkflow == FanOutWorkflow {
+		if err := c.mgr.Register(WorkflowDeclaration()); err != nil && !errors.Is(err, lifecycle.ErrWorkflowAlreadyRegistered) {
+			return fmt.Errorf("gated-dag: register FanOut workflow: %w", err)
+		}
+	}
+	return nil
+}
+
+// Start builds the executor and begins the eval loop.
+func (c *Component) Start(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.running {
+		return fmt.Errorf("gated-dag: already running")
+	}
+	if c.natsClient == nil {
+		return fmt.Errorf("gated-dag: NATS client is required")
+	}
+	if c.mgr == nil {
+		return fmt.Errorf("gated-dag: LifecycleManager is required")
+	}
+
+	qTimeout, err := c.cfg.queryTimeout()
+	if err != nil {
+		return err
+	}
+
+	exec := &executor{
+		cfg:     c.cfg,
+		log:     c.logger,
+		mgr:     c.mgr,
+		metrics: newMetrics(c.metricsReg),
+		reader: &natsGraphReader{
+			nc:       c.natsClient,
+			prefix:   c.cfg.UnitEntityPrefix,
+			maxUnits: c.cfg.MaxUnits,
+			timeout:  qTimeout,
+			onTrunc: func(returned, capN int) {
+				c.logger.Warn("gated-dag: unit set exceeded max_units; reading a truncated set",
+					slog.Int("returned", returned), slog.Int("max_units", capN))
+			},
+		},
+		claimer: &natsClaimer{nc: c.natsClient, predicate: c.cfg.ClaimPredicate},
+		pub:     &natsPublisher{nc: c.natsClient, subject: c.cfg.DispatchSubject, fanOutWorkflow: c.cfg.FanOutWorkflow},
+	}
+	if err := exec.start(ctx); err != nil {
+		return fmt.Errorf("gated-dag: start executor: %w", err)
+	}
+
+	c.exec = exec
+	c.running = true
+	c.startTime = time.Now()
+	c.logger.Info("gated-dag executor started",
+		slog.String("fan_out_workflow", c.cfg.FanOutWorkflow),
+		slog.String("unit_prefix", c.cfg.UnitEntityPrefix),
+		slog.String("dispatch_subject", c.cfg.DispatchSubject),
+		slog.Int("workers", c.cfg.Workers),
+		slog.String("backstop", c.cfg.BackstopInterval))
+	return nil
+}
+
+// Stop gracefully stops the executor.
+func (c *Component) Stop(timeout time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.running {
+		return nil
+	}
+	if c.exec != nil {
+		c.exec.stop(timeout)
+	}
+	c.running = false
+	c.logger.Info("gated-dag executor stopped")
+	return nil
+}
+
+// Meta returns component metadata.
+func (c *Component) Meta() component.Metadata {
+	return component.Metadata{
+		Name:        componentName,
+		Type:        "processor",
+		Description: "Gated-DAG dispatch executor (ADR-046 Phase 2)",
+		Version:     "1.0.0",
+	}
+}
+
+// InputPorts returns the input ports — none (re-eval rides the lifecycle Watch,
+// not a configured port).
+func (c *Component) InputPorts() []component.Port { return []component.Port{} }
+
+// OutputPorts returns the dispatch subject as the single output port.
+func (c *Component) OutputPorts() []component.Port {
+	return []component.Port{{
+		Name:        "dispatch",
+		Direction:   component.DirectionOutput,
+		Required:    true,
+		Description: "Dispatch reference (unit entity ID) for a dispatchable unit",
+		Config:      component.NATSPort{Subject: c.cfg.DispatchSubject},
+	}}
+}
+
+// ConfigSchema returns the configuration schema.
+func (c *Component) ConfigSchema() component.ConfigSchema { return c.cfg.Schema() }
+
+// Health returns current health status.
+func (c *Component) Health() component.HealthStatus {
+	c.mu.RLock()
+	running, startTime := c.running, c.startTime
+	c.mu.RUnlock()
+
+	status := "stopped"
+	if running {
+		status = "running"
+	}
+	return component.HealthStatus{
+		Healthy:   running,
+		LastCheck: time.Now(),
+		Uptime:    time.Since(startTime),
+		Status:    status,
+	}
+}
+
+// DataFlow returns data-flow metrics (the executor is event/timer driven; rate
+// metrics are exposed via the prometheus collectors in metrics.go).
+func (c *Component) DataFlow() component.FlowMetrics {
+	return component.FlowMetrics{LastActivity: time.Now()}
+}

--- a/processor/gated-dag/component_test.go
+++ b/processor/gated-dag/component_test.go
@@ -1,0 +1,74 @@
+package gateddagexec
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewComponent_HappyPath(t *testing.T) {
+	raw := json.RawMessage(`{"unit_entity_prefix":"acme.ops.plan.fanout.unit","dispatch_subject":"gateddag.dispatch.unit"}`)
+	c, err := NewComponent(raw, component.Dependencies{})
+	require.NoError(t, err)
+	require.Equal(t, FanOutWorkflow, c.cfg.FanOutWorkflow)
+	require.Equal(t, defaultClaimPredicate, c.cfg.ClaimPredicate)
+}
+
+func TestNewComponent_BadJSON(t *testing.T) {
+	_, err := NewComponent(json.RawMessage(`{not json`), component.Dependencies{})
+	require.Error(t, err)
+}
+
+func TestNewComponent_MissingRequiredFails(t *testing.T) {
+	// No unit_entity_prefix / dispatch_subject → Validate rejects.
+	_, err := NewComponent(json.RawMessage(`{}`), component.Dependencies{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "required")
+}
+
+func TestComponent_Discoverable(t *testing.T) {
+	raw := json.RawMessage(`{"unit_entity_prefix":"acme.ops.plan.fanout.unit","dispatch_subject":"gateddag.dispatch.unit"}`)
+	c, err := NewComponent(raw, component.Dependencies{})
+	require.NoError(t, err)
+
+	require.Equal(t, componentName, c.Meta().Name)
+	require.Equal(t, "processor", c.Meta().Type)
+	require.Empty(t, c.InputPorts())
+
+	out := c.OutputPorts()
+	require.Len(t, out, 1)
+	require.Equal(t, component.DirectionOutput, out[0].Direction)
+	require.Equal(t, "gateddag.dispatch.unit", out[0].Config.(component.NATSPort).Subject)
+
+	require.Contains(t, c.ConfigSchema().Required, "unit_entity_prefix")
+	require.Contains(t, c.ConfigSchema().Required, "dispatch_subject")
+
+	// Health before start.
+	h := c.Health()
+	require.False(t, h.Healthy)
+	require.Equal(t, "stopped", h.Status)
+}
+
+func TestComponent_InitializeRequiresManager(t *testing.T) {
+	raw := json.RawMessage(`{"unit_entity_prefix":"acme.ops.plan.fanout.unit","dispatch_subject":"gateddag.dispatch.unit"}`)
+	c, err := NewComponent(raw, component.Dependencies{}) // nil LifecycleManager
+	require.NoError(t, err)
+	err = c.Initialize()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "LifecycleManager is required")
+}
+
+func TestComponent_StopBeforeStartIsNoop(t *testing.T) {
+	raw := json.RawMessage(`{"unit_entity_prefix":"acme.ops.plan.fanout.unit","dispatch_subject":"gateddag.dispatch.unit"}`)
+	c, err := NewComponent(raw, component.Dependencies{})
+	require.NoError(t, err)
+	require.NoError(t, c.Stop(time.Second))
+}
+
+func TestRegister(t *testing.T) {
+	reg := component.NewRegistry()
+	require.NoError(t, Register(reg))
+}

--- a/processor/gated-dag/config.go
+++ b/processor/gated-dag/config.go
@@ -1,0 +1,219 @@
+package gateddagexec
+
+import (
+	"fmt"
+	"time"
+)
+
+// Default predicate vocabulary. Consumers may override any of these; the
+// framework defaults give a working out-of-the-box configuration.
+const (
+	defaultCompletedPredicate = "gateddag.completed"
+	defaultFailedPredicate    = "gateddag.failed"
+	defaultDirtiedPredicate   = "gateddag.dirtied"
+	defaultDependsOnPredicate = "gateddag.depends_on"
+	defaultClaimPredicate     = "gateddag.claim"
+
+	defaultWorkers          = 4
+	defaultQueueSize        = 256
+	defaultBackstopInterval = "30s"
+	defaultQueryTimeout     = "30s"
+	defaultMaxUnits         = 1000
+
+	// FailurePolicyContinueOthers keeps independent branches flowing when a unit
+	// fails (its dependents stay Blocked; everything else proceeds). Default.
+	FailurePolicyContinueOthers = "continue_others"
+	// FailurePolicyStopOnFirstFailure halts all new dispatch once any unit has
+	// failed (in-flight units still finish). A blunt circuit-breaker.
+	FailurePolicyStopOnFirstFailure = "stop_on_first_failure"
+)
+
+// Config parameterizes the gated-DAG executor. The zero value is NOT valid —
+// NewComponent applies DefaultConfig for unset fields then calls Validate.
+type Config struct {
+	// FanOutWorkflow is the lifecycle.Workflow.Name this executor watches for
+	// re-eval triggers. Defaults to the framework FanOut workflow; a consumer
+	// may point it at its own registered workflow. The executor self-registers
+	// the framework default when this is left at the default (see component.go).
+	FanOutWorkflow string `json:"fan_out_workflow,omitempty"`
+
+	// UnitEntityPrefix is the graph.query.prefix scope read authoritatively each
+	// evaluation — the blast radius of one fan-out. REQUIRED (no default: it is
+	// the set of entities this executor will act on).
+	UnitEntityPrefix string `json:"unit_entity_prefix"`
+
+	// DispatchSubject is published (with the unit entity ID as a reference, never
+	// content) when a unit becomes dispatchable. The consumer wires its own
+	// handler here. REQUIRED.
+	DispatchSubject string `json:"dispatch_subject"`
+
+	// Marker / edge predicate vocabulary. Must be pairwise distinct after
+	// defaulting — a collision would make e.g. a completed marker read as a
+	// claim, silently corrupting dispatch.
+	CompletedPredicate string `json:"completed_predicate,omitempty"`
+	FailedPredicate    string `json:"failed_predicate,omitempty"`
+	DirtiedPredicate   string `json:"dirtied_predicate,omitempty"`
+	DependsOnPredicate string `json:"depends_on_predicate,omitempty"`
+	ClaimPredicate     string `json:"claim_predicate,omitempty"`
+
+	// Workers / QueueSize bound the dispatch concurrency leg (pkg/dispatch).
+	Workers   int `json:"workers,omitempty"`
+	QueueSize int `json:"queue_size,omitempty"`
+
+	// BackstopInterval is the period of the unconditional re-eval tick that
+	// closes the missed-watch-event hole and surfaces stalls (invariant #4).
+	BackstopInterval string `json:"backstop_interval,omitempty"`
+
+	// QueryTimeout bounds each authoritative graph.query.prefix read.
+	QueryTimeout string `json:"query_timeout,omitempty"`
+
+	// MaxUnits caps the authoritative whole-set read (QueryPrefixAll bound),
+	// guarding reply size / memory. A fan-out larger than this logs a truncation
+	// warning rather than silently dropping units.
+	MaxUnits int `json:"max_units,omitempty"`
+
+	// FailurePolicy selects how a failed unit affects new dispatch. One of
+	// FailurePolicyContinueOthers (default) or FailurePolicyStopOnFirstFailure.
+	FailurePolicy string `json:"failure_policy,omitempty"`
+}
+
+// DefaultConfig returns the framework defaults. Required fields
+// (UnitEntityPrefix, DispatchSubject) are intentionally left empty — Validate
+// rejects a config that does not set them.
+func DefaultConfig() Config {
+	return Config{
+		FanOutWorkflow:     FanOutWorkflow,
+		CompletedPredicate: defaultCompletedPredicate,
+		FailedPredicate:    defaultFailedPredicate,
+		DirtiedPredicate:   defaultDirtiedPredicate,
+		DependsOnPredicate: defaultDependsOnPredicate,
+		ClaimPredicate:     defaultClaimPredicate,
+		Workers:            defaultWorkers,
+		QueueSize:          defaultQueueSize,
+		BackstopInterval:   defaultBackstopInterval,
+		QueryTimeout:       defaultQueryTimeout,
+		MaxUnits:           defaultMaxUnits,
+		FailurePolicy:      FailurePolicyContinueOthers,
+	}
+}
+
+// withDefaults returns a copy of c with unset fields filled from DefaultConfig.
+func (c Config) withDefaults() Config {
+	d := DefaultConfig()
+	if c.FanOutWorkflow == "" {
+		c.FanOutWorkflow = d.FanOutWorkflow
+	}
+	if c.CompletedPredicate == "" {
+		c.CompletedPredicate = d.CompletedPredicate
+	}
+	if c.FailedPredicate == "" {
+		c.FailedPredicate = d.FailedPredicate
+	}
+	if c.DirtiedPredicate == "" {
+		c.DirtiedPredicate = d.DirtiedPredicate
+	}
+	if c.DependsOnPredicate == "" {
+		c.DependsOnPredicate = d.DependsOnPredicate
+	}
+	if c.ClaimPredicate == "" {
+		c.ClaimPredicate = d.ClaimPredicate
+	}
+	if c.Workers == 0 {
+		c.Workers = d.Workers
+	}
+	if c.QueueSize == 0 {
+		c.QueueSize = d.QueueSize
+	}
+	if c.BackstopInterval == "" {
+		c.BackstopInterval = d.BackstopInterval
+	}
+	if c.QueryTimeout == "" {
+		c.QueryTimeout = d.QueryTimeout
+	}
+	if c.MaxUnits == 0 {
+		c.MaxUnits = d.MaxUnits
+	}
+	if c.FailurePolicy == "" {
+		c.FailurePolicy = d.FailurePolicy
+	}
+	return c
+}
+
+// Validate checks a defaulted config. Call withDefaults first (NewComponent
+// does). Returns the first violation found.
+func (c Config) Validate() error {
+	if c.UnitEntityPrefix == "" {
+		return fmt.Errorf("unit_entity_prefix is required (it scopes the unit set this executor reads)")
+	}
+	if c.DispatchSubject == "" {
+		return fmt.Errorf("dispatch_subject is required (it is where a dispatchable unit's reference is published)")
+	}
+	if c.FanOutWorkflow == "" {
+		return fmt.Errorf("fan_out_workflow must not be empty")
+	}
+	if c.Workers <= 0 {
+		return fmt.Errorf("workers must be > 0 (got %d)", c.Workers)
+	}
+	if c.QueueSize <= 0 {
+		return fmt.Errorf("queue_size must be > 0 (got %d)", c.QueueSize)
+	}
+	if c.MaxUnits <= 0 {
+		return fmt.Errorf("max_units must be > 0 (got %d)", c.MaxUnits)
+	}
+	if _, err := c.backstopInterval(); err != nil {
+		return fmt.Errorf("backstop_interval: %w", err)
+	}
+	if _, err := c.queryTimeout(); err != nil {
+		return fmt.Errorf("query_timeout: %w", err)
+	}
+	switch c.FailurePolicy {
+	case FailurePolicyContinueOthers, FailurePolicyStopOnFirstFailure:
+	default:
+		return fmt.Errorf("failure_policy must be %q or %q (got %q)",
+			FailurePolicyContinueOthers, FailurePolicyStopOnFirstFailure, c.FailurePolicy)
+	}
+	// Predicates must be pairwise distinct: a collision silently mis-reads one
+	// marker class as another.
+	preds := map[string]string{
+		"completed_predicate":  c.CompletedPredicate,
+		"failed_predicate":     c.FailedPredicate,
+		"dirtied_predicate":    c.DirtiedPredicate,
+		"depends_on_predicate": c.DependsOnPredicate,
+		"claim_predicate":      c.ClaimPredicate,
+	}
+	seen := make(map[string]string, len(preds))
+	for name, val := range preds {
+		if val == "" {
+			return fmt.Errorf("%s must not be empty", name)
+		}
+		if other, dup := seen[val]; dup {
+			return fmt.Errorf("predicate %q is used by both %s and %s; they must be distinct", val, other, name)
+		}
+		seen[val] = name
+	}
+	return nil
+}
+
+// backstopInterval parses BackstopInterval; must be > 0.
+func (c Config) backstopInterval() (time.Duration, error) {
+	d, err := time.ParseDuration(c.BackstopInterval)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", c.BackstopInterval, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("must be > 0 (got %s)", d)
+	}
+	return d, nil
+}
+
+// queryTimeout parses QueryTimeout; must be > 0.
+func (c Config) queryTimeout() (time.Duration, error) {
+	d, err := time.ParseDuration(c.QueryTimeout)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", c.QueryTimeout, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("must be > 0 (got %s)", d)
+	}
+	return d, nil
+}

--- a/processor/gated-dag/config_test.go
+++ b/processor/gated-dag/config_test.go
@@ -1,0 +1,94 @@
+package gateddagexec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func validCfg() Config {
+	c := DefaultConfig()
+	c.UnitEntityPrefix = "acme.ops.plan.fanout.unit"
+	c.DispatchSubject = "gateddag.dispatch.unit"
+	return c
+}
+
+func TestConfig_DefaultsFillUnsetFields(t *testing.T) {
+	c := Config{UnitEntityPrefix: "p", DispatchSubject: "s"}.withDefaults()
+	require.Equal(t, FanOutWorkflow, c.FanOutWorkflow)
+	require.Equal(t, defaultCompletedPredicate, c.CompletedPredicate)
+	require.Equal(t, defaultClaimPredicate, c.ClaimPredicate)
+	require.Equal(t, defaultWorkers, c.Workers)
+	require.Equal(t, defaultQueueSize, c.QueueSize)
+	require.Equal(t, defaultMaxUnits, c.MaxUnits)
+	require.Equal(t, FailurePolicyContinueOthers, c.FailurePolicy)
+	require.NoError(t, c.Validate())
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		errSub string
+	}{
+		{"missing prefix", func(c *Config) { c.UnitEntityPrefix = "" }, "unit_entity_prefix is required"},
+		{"missing subject", func(c *Config) { c.DispatchSubject = "" }, "dispatch_subject is required"},
+		{"empty workflow", func(c *Config) { c.FanOutWorkflow = "" }, "fan_out_workflow"},
+		{"zero workers", func(c *Config) { c.Workers = 0 }, "workers must be > 0"},
+		{"negative workers", func(c *Config) { c.Workers = -1 }, "workers must be > 0"},
+		{"zero queue", func(c *Config) { c.QueueSize = 0 }, "queue_size must be > 0"},
+		{"zero max units", func(c *Config) { c.MaxUnits = 0 }, "max_units must be > 0"},
+		{"bad backstop", func(c *Config) { c.BackstopInterval = "nope" }, "backstop_interval"},
+		{"nonpositive backstop", func(c *Config) { c.BackstopInterval = "0s" }, "backstop_interval"},
+		{"bad query timeout", func(c *Config) { c.QueryTimeout = "" }, "query_timeout"},
+		{"bad failure policy", func(c *Config) { c.FailurePolicy = "panic" }, "failure_policy"},
+		{"predicate collision", func(c *Config) { c.ClaimPredicate = c.CompletedPredicate }, "must be distinct"},
+		{"empty predicate", func(c *Config) { c.DirtiedPredicate = "" }, "must not be empty"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validCfg()
+			// Bad-failure-policy & empty-predicate paths need the field set
+			// post-default, so mutate the already-defaulted config.
+			tt.mutate(&c)
+			err := c.Validate()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errSub)
+		})
+	}
+}
+
+func TestConfig_ValidateHappy(t *testing.T) {
+	require.NoError(t, validCfg().Validate())
+}
+
+// TestConfig_JSONRoundTrip exercises EVERY operator-reachable field with a
+// non-default value through marshal→unmarshal and asserts it survives. A
+// mistyped struct tag would silently fall back to the default otherwise
+// (operator-configurable-surface discipline). Uses non-default values so a
+// dropped field is caught by inequality rather than coinciding with a default.
+func TestConfig_JSONRoundTrip(t *testing.T) {
+	in := Config{
+		FanOutWorkflow:     "custom-fanout",
+		UnitEntityPrefix:   "acme.ops.plan.fanout.unit",
+		DispatchSubject:    "custom.dispatch",
+		CompletedPredicate: "x.done",
+		FailedPredicate:    "x.failed",
+		DirtiedPredicate:   "x.reset",
+		DependsOnPredicate: "x.needs",
+		ClaimPredicate:     "x.inflight",
+		Workers:            7,
+		QueueSize:          99,
+		BackstopInterval:   "12s",
+		QueryTimeout:       "8s",
+		MaxUnits:           250,
+		FailurePolicy:      FailurePolicyStopOnFirstFailure,
+	}
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	var out Config
+	require.NoError(t, json.Unmarshal(data, &out))
+	require.Equal(t, in, out, "every operator field must survive a JSON round-trip")
+}

--- a/processor/gated-dag/doc.go
+++ b/processor/gated-dag/doc.go
@@ -1,0 +1,68 @@
+// Package gateddagexec is the executor component for gated-DAG dispatch
+// (ADR-046 Phase 2, gh#357). It composes the pure selection brain
+// (pkg/gateddag) with live framework substrate so a set of work units with
+// depends_on edges is dispatched in dependency order, exactly once per unit,
+// with restart recovery, failure isolation, and stall detection.
+//
+// # Why a component (not a rule action or condition)
+//
+// Gated-DAG dispatch needs a whole-set, authoritative, re-evaluated-on-every-
+// change view of the unit set. The rule engine evaluates against the changed
+// entity plus one related read (processor/rule/entity_watcher.go →
+// evaluateRulesForEntityState) and a gate on a dependent never re-fires when a
+// prerequisite completes (the engine evaluates rules against the prerequisite,
+// not the dependent). A component watching the unit set provides the whole-set
+// view natively. See ADR-046 "Why a component".
+//
+// # The wedge it kills: derived, never mutated
+//
+// Each evaluation re-reads the whole unit set authoritatively from the graph
+// and re-derives every unit's status from marker membership (pkg/gateddag is a
+// pure function of markers + edges). There is no projected status field to go
+// stale and nothing to race the markers — the root of the wedge family that
+// reverse-edge propagation could not escape (ADR-046 correctness requirement
+// #1). The only state this component writes is the durable claim marker, which
+// the brain ignores and the executor reads authoritatively for in-flight dedup.
+//
+// # The four load-bearing invariants (do not regress)
+//
+// An adversarial review of an earlier ADR draft caught it asserting guarantees
+// the substrate does NOT provide. These hold here:
+//
+//  1. Single-flight per fan-out, one instance per fan-out. replace_owned is
+//     last-write-wins, not CAS, and the owner-lease fence is default-off +
+//     cross-incarnation only — neither provides concurrent mutual exclusion.
+//     Dedup holds only because reEvaluate runs one pass at a time per instance
+//     (evalMu + a single eval goroutine) and exactly one component instance owns
+//     a given fan-out (singleton in the flow). If true cross-writer exclusion is
+//     ever needed, switch the claim to an ExpectedRevision-based CAS write (see
+//     the CAS-UPGRADE POINT in claim.go).
+//  2. Claim before dispatch. The claim marker is committed BEFORE the dispatch
+//     is published. A crash between publish and claim would re-derive the unit
+//     as Ready on restart and double-run.
+//  3. Re-eval + recovery ride the lifecycle Watch (which wraps KV WatchAll's
+//     bootstrap replay), NOT the pkg/dispatch completion-watcher (which
+//     suppresses bootstrap replay). The dispatcher is the bounded-concurrency
+//     leg only.
+//  4. Stall detection + the periodic backstop are net-new. No production code
+//     implements them; they are the core build of this phase, not reuse.
+//
+// # The reset contract (hard requirement on consumers)
+//
+// To re-dispatch a unit (recovery / re-run), the consumer MUST clear the unit's
+// terminal markers (completed/failed) AND the claim marker, and set the dirtied
+// marker. The brain's Dirtied precedence then re-derives the unit as Ready. As a
+// defensive measure this executor treats a dirtied unit's stale claim as absent
+// (dirtied overrides claim), so a reset that forgot to clear the claim still
+// re-dispatches rather than wedging idle.
+//
+// # Framework / consumer boundary
+//
+// This component is domain-agnostic. It consumes a resolved depends_on edge set
+// plus completion/failure/reset markers on per-unit entities, and on a
+// dispatchable unit it (1) commits a durable claim marker then (2) publishes a
+// reference (the unit entity ID — never content) to the configured dispatch
+// subject. The consumer derives the edge set, mints fresh-per-run unit IDs,
+// layers any domain gate, and wires its own handler on the dispatch subject to
+// turn the reference into real work. See ADR-046 "Framework/consumer boundary".
+package gateddagexec

--- a/processor/gated-dag/executor.go
+++ b/processor/gated-dag/executor.go
@@ -1,0 +1,264 @@
+package gateddagexec
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/c360studio/semstreams/pkg/dispatch"
+	"github.com/c360studio/semstreams/pkg/gateddag"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+)
+
+// dispatchJob is the bounded-dispatcher work item: one dispatchable unit.
+type dispatchJob struct {
+	unitID string
+}
+
+// executor runs the gated-DAG eval loop. It is constructed by the Component
+// wrapper; its collaborators (reader/claimer/pub) are interfaces so the loop is
+// unit-testable without NATS.
+type executor struct {
+	cfg     Config
+	log     *slog.Logger
+	mgr     *lifecycle.Manager
+	reader  graphReader
+	claimer claimer
+	pub     publisher
+	metrics *metrics
+
+	backstop time.Duration
+
+	disp *dispatch.BoundedDispatcher[dispatchJob]
+	// submit enqueues a dispatchable unit. Defaults to disp.Submit; unit tests
+	// override it with a recorder so reEvaluate's selection is testable without a
+	// live dispatcher.
+	submit func(dispatchJob) error
+
+	// evalMu enforces single-flight: exactly one reEvaluate pass runs at a time
+	// per instance (ADR-046 invariant #1). The single eval goroutine already
+	// serializes passes; the mutex makes the contract explicit and testable.
+	evalMu sync.Mutex
+	// trigger coalesces a burst of watch events into <=1 queued pass (cap 1).
+	trigger chan struct{}
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// start wires the dispatcher, the watch pump, and the eval goroutine. The
+// lifecycle Watch bootstrap-replays current FanOut instances on subscribe (the
+// restart-recovery substrate); the periodic backstop is the correctness floor
+// that picks up unit-completion-driven state and surfaces stalls even if a watch
+// event is missed (invariants #3, #4). Each pass reads the authoritative unit
+// set, so any trigger converges on the latest state.
+func (e *executor) start(ctx context.Context) error {
+	backstop, err := e.cfg.backstopInterval()
+	if err != nil {
+		return err
+	}
+	e.backstop = backstop
+	e.trigger = make(chan struct{}, 1)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	e.cancel = cancel
+
+	// Concurrency leg only: NO CompletionKVBucket (its completion-watcher
+	// suppresses bootstrap replay; re-eval/recovery ride the lifecycle Watch
+	// below — invariant #3). Process commits the claim then publishes.
+	disp, err := dispatch.New[dispatchJob](runCtx, dispatch.Config[dispatchJob]{
+		Workers:   e.cfg.Workers,
+		QueueSize: e.cfg.QueueSize,
+		Process: func(ctx context.Context, job dispatchJob) error {
+			return e.claimThenDispatch(ctx, job.unitID)
+		},
+	}, dispatch.Deps{Logger: e.log})
+	if err != nil {
+		cancel()
+		return err
+	}
+	e.disp = disp
+	if e.submit == nil {
+		e.submit = func(j dispatchJob) error { return e.disp.Submit(j) }
+	}
+
+	// Watch pump: lifecycle Watch over the FanOut workflow. Bootstrap replay =
+	// restart recovery; live FanOut-instance writes nudge a re-eval. Each
+	// delivery coalesces into the trigger channel.
+	ch, err := e.mgr.Watch(runCtx, e.cfg.FanOutWorkflow)
+	if err != nil {
+		_ = e.disp.Stop(runCtx)
+		cancel()
+		return err
+	}
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case _, ok := <-ch:
+				if !ok {
+					return
+				}
+				e.nudge()
+			}
+		}
+	}()
+
+	// Eval goroutine: single consumer of trigger + backstop ticker ⇒ passes are
+	// serialized (single-flight). Fire one initial pass so a cold bucket still
+	// reconciles its unit set on boot.
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		ticker := time.NewTicker(e.backstop)
+		defer ticker.Stop()
+		e.reEvaluate(runCtx) // initial reconcile
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case <-e.trigger:
+				e.reEvaluate(runCtx)
+			case <-ticker.C:
+				e.reEvaluate(runCtx)
+			}
+		}
+	}()
+
+	return nil
+}
+
+// nudge requests a re-eval, coalescing with any already-pending request.
+func (e *executor) nudge() {
+	select {
+	case e.trigger <- struct{}{}:
+	default: // a pass is already queued; it will read the latest state
+	}
+}
+
+// stop cancels the run context and waits for goroutines + the dispatcher.
+func (e *executor) stop(timeout time.Duration) {
+	if e.cancel != nil {
+		e.cancel()
+	}
+	if e.disp != nil {
+		stopCtx, c := context.WithTimeout(context.Background(), timeout)
+		_ = e.disp.Stop(stopCtx)
+		c()
+	}
+	e.wg.Wait()
+}
+
+// reEvaluate is one authoritative pass. Single-flight via evalMu (invariant #1).
+func (e *executor) reEvaluate(ctx context.Context) {
+	e.evalMu.Lock()
+	defer e.evalMu.Unlock()
+
+	if e.metrics != nil {
+		e.metrics.evals.Inc()
+	}
+
+	states, err := e.reader.ReadUnitSet(ctx)
+	if err != nil {
+		// Transient read failure: skip this pass; the backstop retries. Never
+		// panic the loop.
+		e.log.Warn("gated-dag: authoritative read failed; skipping pass", slog.String("error", err.Error()))
+		return
+	}
+
+	view := extractGraph(states, e.cfg)
+	decisions := gateddag.Evaluate(view.unitIDs, view.dependsOn, view.markers)
+
+	// Stall surfacing (#8): pure observability, computed BEFORE dispatch so a
+	// stalled plan alerts even when nothing dispatches. Subtract in-flight
+	// (claimed, non-terminal) units so running work is not mistaken for a stall.
+	stalled := stallAfterInflight(gateddag.Stalled(view.unitIDs, view.dependsOn, view.markers), view)
+	if e.metrics != nil {
+		e.metrics.stall.Set(float64(len(stalled)))
+	}
+	if len(stalled) > 0 {
+		e.log.Warn("gated-dag: stalled — held-ready units with no forward progress (depends_on cycle or all-blocked-behind-failure); recovery is reset-driven",
+			slog.Any("units", stalled))
+	}
+
+	stopAll := e.cfg.FailurePolicy == FailurePolicyStopOnFirstFailure && anyFailed(view.markers)
+
+	for _, d := range decisions {
+		if !d.Dispatchable {
+			continue
+		}
+		// In-flight dedup (#6): a unit already carrying the claim is skipped.
+		// V4 robustness: a dirtied unit's stale claim is treated as absent so a
+		// reset that cleared the terminal marker but not the claim still
+		// re-dispatches (dirtied overrides claim).
+		if view.claimed[d.UnitID] && !view.markers.Dirtied[d.UnitID] {
+			continue
+		}
+		if stopAll {
+			continue // stop_on_first_failure: hold all new dispatch
+		}
+		if err := e.submit(dispatchJob{unitID: d.UnitID}); err != nil {
+			// Queue full: drop this pass's submit; the next eval re-selects it
+			// (it carries no claim yet, so it is not deduped away).
+			e.log.Warn("gated-dag: dispatch queue full; will retry next eval",
+				slog.String("unit", d.UnitID), slog.String("error", err.Error()))
+		}
+	}
+}
+
+// claimThenDispatch is the bounded worker body: commit the durable claim BEFORE
+// publishing the dispatch reference (invariant #2). A claim error returns
+// without publishing (the unit is retried next eval). A publish error AFTER the
+// claim is surfaced but the claim is NOT rolled back — rolling it back would
+// re-open the double-run window; recovery is reset-driven.
+func (e *executor) claimThenDispatch(ctx context.Context, unitID string) error {
+	if err := e.claimer.Claim(ctx, unitID); err != nil {
+		e.log.Warn("gated-dag: claim failed; not dispatching (retried next eval)",
+			slog.String("unit", unitID), slog.String("error", err.Error()))
+		return err
+	}
+	if e.metrics != nil {
+		e.metrics.claimed.Inc()
+	}
+	if err := e.pub.Dispatch(ctx, unitID); err != nil {
+		if e.metrics != nil {
+			e.metrics.dispatchErr.Inc()
+		}
+		e.log.Error("gated-dag: dispatch publish failed AFTER claim committed; unit may be stranded until reset",
+			slog.String("unit", unitID), slog.String("error", err.Error()))
+		return err
+	}
+	if e.metrics != nil {
+		e.metrics.dispatched.Inc()
+	}
+	e.log.Debug("gated-dag: dispatched unit", slog.String("unit", unitID))
+	return nil
+}
+
+// stallAfterInflight suppresses a stall alert while genuine work is in flight: a
+// unit that is claimed but not yet terminal (and not dirtied) is running, so the
+// plan is progressing even if the brain reports held-ready units (S1). Returns
+// the original stalled set only when nothing is in flight.
+func stallAfterInflight(stalled []string, view graphView) []string {
+	if len(stalled) == 0 {
+		return nil
+	}
+	for id := range view.claimed {
+		if view.markers.Dirtied[id] {
+			continue // reset in progress, not in-flight
+		}
+		if !view.markers.Completed[id] && !view.markers.Failed[id] {
+			return nil // a claimed, non-terminal unit is running ⇒ not stalled
+		}
+	}
+	return stalled
+}
+
+// anyFailed reports whether any unit carries the failure marker.
+func anyFailed(m gateddag.MarkerSet) bool {
+	return len(m.Failed) > 0
+}

--- a/processor/gated-dag/executor_integration_test.go
+++ b/processor/gated-dag/executor_integration_test.go
@@ -1,0 +1,204 @@
+//go:build integration
+
+package gateddagexec
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/payloadregistry"
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+	graphingest "github.com/c360studio/semstreams/processor/graph-ingest"
+)
+
+const (
+	itestPrefix          = "itest.ops.plan.fanout.unit"
+	itestDispatchSubject = "gateddag.itest.dispatch"
+)
+
+// startStack boots a real NATS testcontainer + graph-ingest + lifecycle.Manager
+// + the gated-DAG executor wired through NewComponent (the production wire, not
+// internal helpers). cfg's FanOutWorkflow/UnitEntityPrefix/DispatchSubject are
+// pre-set by the caller; the rest defaults.
+func startStack(t *testing.T, backstop string) (*graphingest.Component, *natsclient.Client, *Component) {
+	t.Helper()
+	ctx := context.Background()
+
+	streams := []natsclient.TestStreamConfig{{Name: "ENTITY", Subjects: []string{"entity.>"}}}
+	tc := natsclient.NewTestClient(t, natsclient.WithKV(), natsclient.WithStreams(streams...))
+	nc := tc.Client
+
+	// graph-ingest serves graph.ingest.query.prefix + graph.mutation.entity.*
+	giJSON, err := json.Marshal(graphingest.DefaultConfig())
+	require.NoError(t, err)
+	giDisc, err := graphingest.CreateGraphIngest(giJSON, component.Dependencies{NATSClient: nc})
+	require.NoError(t, err)
+	gi := giDisc.(*graphingest.Component)
+	require.NoError(t, gi.Initialize())
+	require.NoError(t, gi.Start(ctx))
+	t.Cleanup(func() { _ = gi.Stop(5 * time.Second) })
+
+	mgr := lifecycle.NewManager(nc, nil)
+
+	cfg := Config{
+		UnitEntityPrefix: itestPrefix,
+		DispatchSubject:  itestDispatchSubject,
+		BackstopInterval: backstop,
+	}
+	cfgJSON, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	execDisc, err := NewComponent(cfgJSON, component.Dependencies{NATSClient: nc, LifecycleManager: mgr})
+	require.NoError(t, err)
+	require.NoError(t, execDisc.Initialize())
+
+	time.Sleep(100 * time.Millisecond) // let graph-ingest subscriptions stabilise
+	require.NoError(t, execDisc.Start(ctx))
+	t.Cleanup(func() { _ = execDisc.Stop(5 * time.Second) })
+
+	return gi, nc, execDisc
+}
+
+// seedUnit creates a unit entity with the given (predicate, object) triples via
+// the real graph-ingest create path.
+func seedUnit(t *testing.T, gi *graphingest.Component, id string, triples ...message.Triple) {
+	t.Helper()
+	for i := range triples {
+		triples[i].Subject = id
+		if triples[i].Timestamp.IsZero() {
+			triples[i].Timestamp = time.Now()
+		}
+	}
+	require.NoError(t, gi.CreateEntity(context.Background(), &graph.EntityState{
+		ID: id, Triples: triples, Version: 1, UpdatedAt: time.Now(),
+	}))
+}
+
+func unitID(suffix string) string { return itestPrefix + "." + suffix }
+
+// dispatchCapture collects the unit IDs published to the dispatch subject.
+type dispatchCapture struct {
+	mu  sync.Mutex
+	ids []string
+	dec *message.Decoder
+}
+
+func subscribeDispatch(t *testing.T, nc *natsclient.Client) *dispatchCapture {
+	t.Helper()
+	reg := payloadregistry.New()
+	require.NoError(t, RegisterPayloads(reg))
+	dc := &dispatchCapture{dec: message.NewDecoder(reg)}
+	sub, err := nc.Subscribe(context.Background(), itestDispatchSubject, func(_ context.Context, msg *nats.Msg) {
+		base, derr := dc.dec.Decode(msg.Data)
+		if derr != nil {
+			return
+		}
+		dm, ok := base.Payload().(*DispatchMessage)
+		if !ok {
+			return
+		}
+		dc.mu.Lock()
+		dc.ids = append(dc.ids, dm.UnitEntityID)
+		dc.mu.Unlock()
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	return dc
+}
+
+func (c *dispatchCapture) snapshot() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.ids))
+	copy(out, c.ids)
+	return out
+}
+
+// completed/dependsOn marker triples for seeding (using the executor's config).
+func completedTri(c *Component) message.Triple {
+	return message.Triple{Predicate: c.cfg.CompletedPredicate, Object: true, Confidence: 1.0}
+}
+func dependsTri(c *Component, prereq string) message.Triple {
+	return message.Triple{Predicate: c.cfg.DependsOnPredicate, Object: prereq, Confidence: 1.0}
+}
+
+// TestIntegration_GatedDispatch_DependsOnAndDedup drives the whole wire: a
+// prerequisite completes, its dependent is dispatched exactly once, the dispatch
+// commits a durable claim, and a later backstop pass does not re-dispatch.
+func TestIntegration_GatedDispatch_DependsOnAndDedup(t *testing.T) {
+	gi, nc, exec := startStack(t, "300ms")
+	c := exec
+	capt := subscribeDispatch(t, nc)
+
+	a, b := unitID("a"), unitID("b")
+	seedUnit(t, gi, a, completedTri(c))  // a is Done
+	seedUnit(t, gi, b, dependsTri(c, a)) // b depends on a → dispatchable
+
+	// Wait for b to be dispatched (a backstop pass picks up the seeded units).
+	require.Eventually(t, func() bool {
+		ids := capt.snapshot()
+		return len(ids) == 1 && ids[0] == b
+	}, 5*time.Second, 50*time.Millisecond, "b should be dispatched exactly once; a (Done) never")
+
+	// b must now carry the durable claim marker (read authoritatively).
+	require.Eventually(t, func() bool {
+		states := readPrefix(t, nc, itestPrefix)
+		for _, s := range states {
+			if s.ID == b && s.GetTriple(c.cfg.ClaimPredicate) != nil {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond, "b should carry the claim marker after dispatch")
+
+	// Let several more backstop passes run; b must NOT be re-dispatched (dedup).
+	time.Sleep(1 * time.Second)
+	require.Equal(t, []string{b}, capt.snapshot(), "claim dedup prevents re-dispatch across passes")
+}
+
+// TestIntegration_BootReconcile proves restart recovery: seeding BEFORE the
+// executor starts, the initial reconcile (boot read of authoritative KV)
+// dispatches the ready-unclaimed dependent with no external trigger.
+func TestIntegration_BootReconcile(t *testing.T) {
+	// Long backstop so the dispatch we observe came from the boot reconcile, not
+	// a backstop tick.
+	gi, nc, exec := startStack(t, "10m")
+	capt := subscribeDispatch(t, nc)
+	c := exec
+
+	a, b := unitID("a"), unitID("b")
+	seedUnit(t, gi, a, completedTri(c))
+	seedUnit(t, gi, b, dependsTri(c, a))
+
+	// startStack already called Start. The initial reEvaluate fires on Start —
+	// but seeding happened after Start here, so nudge a fresh reconcile by
+	// restarting the executor against the now-seeded bucket.
+	require.NoError(t, exec.Stop(5*time.Second))
+	require.NoError(t, exec.Start(context.Background()))
+
+	require.Eventually(t, func() bool {
+		ids := capt.snapshot()
+		return len(ids) >= 1 && ids[len(ids)-1] == b
+	}, 5*time.Second, 50*time.Millisecond, "boot reconcile should dispatch b from authoritative KV with no backstop tick")
+}
+
+// readPrefix reads the authoritative unit set directly from graph-ingest.
+func readPrefix(t *testing.T, nc *natsclient.Client, prefix string) []graph.EntityState {
+	t.Helper()
+	reqData, err := json.Marshal(graph.PrefixQueryRequest{Prefix: prefix, Limit: 100})
+	require.NoError(t, err)
+	respData, err := nc.RequestClassified(context.Background(), "graph.ingest.query.prefix", reqData, 5*time.Second)
+	require.NoError(t, err)
+	var resp graph.PrefixQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	return resp.Entities
+}

--- a/processor/gated-dag/executor_test.go
+++ b/processor/gated-dag/executor_test.go
@@ -1,0 +1,317 @@
+package gateddagexec
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/gateddag"
+	"github.com/stretchr/testify/require"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// --- fakes ---
+
+type fakeReader struct {
+	mu      sync.Mutex
+	calls   int
+	scripts [][]graph.EntityState // returned in order; last reused after exhausted
+	err     error
+	// concurrency probe (single-flight test)
+	active     int32
+	maxActive  int32
+	blockEnter chan struct{} // if non-nil, ReadUnitSet blocks on it after entering
+}
+
+func (f *fakeReader) ReadUnitSet(_ context.Context) ([]graph.EntityState, error) {
+	n := atomic.AddInt32(&f.active, 1)
+	for {
+		old := atomic.LoadInt32(&f.maxActive)
+		if n <= old || atomic.CompareAndSwapInt32(&f.maxActive, old, n) {
+			break
+		}
+	}
+	defer atomic.AddInt32(&f.active, -1)
+	if f.blockEnter != nil {
+		<-f.blockEnter
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	if len(f.scripts) == 0 {
+		return nil, nil
+	}
+	idx := f.calls - 1
+	if idx >= len(f.scripts) {
+		idx = len(f.scripts) - 1
+	}
+	return f.scripts[idx], nil
+}
+
+type fakeClaimer struct {
+	mu    sync.Mutex
+	calls []string
+	err   error
+}
+
+func (f *fakeClaimer) Claim(_ context.Context, unitID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.calls = append(f.calls, unitID)
+	return nil
+}
+
+type fakePublisher struct {
+	mu    sync.Mutex
+	calls []string
+	err   error
+}
+
+func (f *fakePublisher) Dispatch(_ context.Context, unitID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return f.err
+	}
+	f.calls = append(f.calls, unitID)
+	return nil
+}
+
+// recordingSubmit captures submitted unit IDs.
+type recordingSubmit struct {
+	mu   sync.Mutex
+	jobs []string
+}
+
+func (r *recordingSubmit) fn(j dispatchJob) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.jobs = append(r.jobs, j.unitID)
+	return nil
+}
+
+func (r *recordingSubmit) ids() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.jobs))
+	copy(out, r.jobs)
+	return out
+}
+
+// newEvalExecutor builds an executor wired for reEvaluate-only tests (no live
+// dispatcher; submit is the recorder).
+func newEvalExecutor(cfg Config, reader graphReader, sub func(dispatchJob) error) *executor {
+	return &executor{cfg: cfg, log: discardLogger(), reader: reader, submit: sub}
+}
+
+// --- claimThenDispatch ordering (invariant #2) ---
+
+func TestClaimThenDispatch_ClaimBeforePublish(t *testing.T) {
+	cl, pub := &fakeClaimer{}, &fakePublisher{}
+	e := &executor{cfg: validCfg(), log: discardLogger(), claimer: cl, pub: pub}
+	require.NoError(t, e.claimThenDispatch(context.Background(), "u1"))
+	require.Equal(t, []string{"u1"}, cl.calls)
+	require.Equal(t, []string{"u1"}, pub.calls)
+}
+
+func TestClaimThenDispatch_ClaimErrorSkipsPublish(t *testing.T) {
+	cl := &fakeClaimer{err: errors.New("boom")}
+	pub := &fakePublisher{}
+	e := &executor{cfg: validCfg(), log: discardLogger(), claimer: cl, pub: pub}
+	require.Error(t, e.claimThenDispatch(context.Background(), "u1"))
+	require.Empty(t, pub.calls, "publish must not run when claim fails")
+}
+
+func TestClaimThenDispatch_PublishErrorAfterClaimDoesNotRollBack(t *testing.T) {
+	cl := &fakeClaimer{}
+	pub := &fakePublisher{err: errors.New("net down")}
+	e := &executor{cfg: validCfg(), log: discardLogger(), claimer: cl, pub: pub}
+	require.Error(t, e.claimThenDispatch(context.Background(), "u1"))
+	require.Equal(t, []string{"u1"}, cl.calls, "claim stays committed (no rollback — avoids double-run window)")
+}
+
+// --- reEvaluate selection ---
+
+// presence builds a presence-marker triple (object value is irrelevant for
+// completed/failed/dirtied/claim — extractGraph keys on the predicate).
+func presence(pred string) message.Triple { return tri(pred, "x") }
+
+func TestReEvaluate_DiamondSelection(t *testing.T) {
+	cfg := validCfg()
+	// a -> {b,c} -> d. Only a complete: b,c dispatch; d held.
+	states := []graph.EntityState{
+		unit("a", presence(cfg.CompletedPredicate)),
+		unit("b", tri(cfg.DependsOnPredicate, "a")),
+		unit("c", tri(cfg.DependsOnPredicate, "a")),
+		unit("d", tri(cfg.DependsOnPredicate, "b"), tri(cfg.DependsOnPredicate, "c")),
+	}
+	sub := &recordingSubmit{}
+	e := newEvalExecutor(cfg, &fakeReader{scripts: [][]graph.EntityState{states}}, sub.fn)
+	e.reEvaluate(context.Background())
+	require.ElementsMatch(t, []string{"b", "c"}, sub.ids())
+}
+
+func TestReEvaluate_InFlightDedup(t *testing.T) {
+	cfg := validCfg()
+	// b is Ready (a complete) but already claimed → must NOT re-dispatch.
+	states := []graph.EntityState{
+		unit("a", presence(cfg.CompletedPredicate)),
+		unit("b", tri(cfg.DependsOnPredicate, "a"), presence(cfg.ClaimPredicate)),
+	}
+	sub := &recordingSubmit{}
+	e := newEvalExecutor(cfg, &fakeReader{scripts: [][]graph.EntityState{states}}, sub.fn)
+	e.reEvaluate(context.Background())
+	require.Empty(t, sub.ids())
+}
+
+func TestReEvaluate_DirtiedOverridesStaleClaim(t *testing.T) {
+	cfg := validCfg()
+	// b carries a stale claim AND a dirtied marker (reset that forgot to clear
+	// the claim) → V4: dirtied overrides claim, so b re-dispatches.
+	states := []graph.EntityState{
+		unit("a", presence(cfg.CompletedPredicate)),
+		unit("b",
+			tri(cfg.DependsOnPredicate, "a"),
+			presence(cfg.ClaimPredicate),
+			presence(cfg.DirtiedPredicate)),
+	}
+	sub := &recordingSubmit{}
+	e := newEvalExecutor(cfg, &fakeReader{scripts: [][]graph.EntityState{states}}, sub.fn)
+	e.reEvaluate(context.Background())
+	require.Equal(t, []string{"b"}, sub.ids())
+}
+
+func TestReEvaluate_BackstopPicksUpLateDependent(t *testing.T) {
+	cfg := validCfg()
+	// Pass 1: c is in-flight (claimed, not complete) → deduped; d held (c not
+	// done). Pass 2: c completes → d becomes dispatchable. A later pass (the
+	// backstop) re-reads authoritative state and releases the dependent.
+	pass1 := []graph.EntityState{
+		unit("c", presence(cfg.ClaimPredicate)),
+		unit("d", tri(cfg.DependsOnPredicate, "c")),
+	}
+	pass2 := []graph.EntityState{
+		unit("c", presence(cfg.CompletedPredicate)),
+		unit("d", tri(cfg.DependsOnPredicate, "c")),
+	}
+	sub := &recordingSubmit{}
+	e := newEvalExecutor(cfg, &fakeReader{scripts: [][]graph.EntityState{pass1, pass2}}, sub.fn)
+	e.reEvaluate(context.Background()) // pass 1: c claimed (deduped), d held
+	require.Empty(t, sub.ids())
+	e.reEvaluate(context.Background()) // pass 2 (backstop): d now ready
+	require.Equal(t, []string{"d"}, sub.ids())
+}
+
+func TestReEvaluate_ReadErrorIsResilient(t *testing.T) {
+	cfg := validCfg()
+	sub := &recordingSubmit{}
+	r := &fakeReader{err: errors.New("store unavailable")}
+	e := newEvalExecutor(cfg, r, sub.fn)
+	require.NotPanics(t, func() { e.reEvaluate(context.Background()) })
+	require.Empty(t, sub.ids())
+}
+
+func TestReEvaluate_StopOnFirstFailureHoldsIndependentBranch(t *testing.T) {
+	cfg := validCfg()
+	cfg.FailurePolicy = FailurePolicyStopOnFirstFailure
+	// a failed; independent ready unit z. continue_others would dispatch z;
+	// stop_on_first_failure holds it.
+	states := []graph.EntityState{
+		unit("a", presence(cfg.FailedPredicate)),
+		unit("z"),
+	}
+	sub := &recordingSubmit{}
+	e := newEvalExecutor(cfg, &fakeReader{scripts: [][]graph.EntityState{states}}, sub.fn)
+	e.reEvaluate(context.Background())
+	require.Empty(t, sub.ids(), "stop_on_first_failure holds all new dispatch")
+
+	// continue_others (default) dispatches the independent branch.
+	cfg.FailurePolicy = FailurePolicyContinueOthers
+	sub2 := &recordingSubmit{}
+	e2 := newEvalExecutor(cfg, &fakeReader{scripts: [][]graph.EntityState{states}}, sub2.fn)
+	e2.reEvaluate(context.Background())
+	require.Equal(t, []string{"z"}, sub2.ids())
+}
+
+func TestReEvaluate_SingleFlightSerializes(t *testing.T) {
+	cfg := validCfg()
+	r := &fakeReader{
+		scripts:    [][]graph.EntityState{{unit("a")}},
+		blockEnter: make(chan struct{}),
+	}
+	sub := &recordingSubmit{}
+	e := newEvalExecutor(cfg, r, sub.fn)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); e.reEvaluate(context.Background()) }()
+	}
+	// Let both goroutines reach ReadUnitSet; release them.
+	time.Sleep(20 * time.Millisecond)
+	close(r.blockEnter)
+	wg.Wait()
+	require.Equal(t, int32(1), r.maxActive, "evalMu must serialize passes (never two concurrent reads)")
+}
+
+// --- stall ---
+
+func TestReEvaluate_StallSurfacedNothingDispatched(t *testing.T) {
+	cfg := validCfg()
+	// Cycle a<->b: nothing dispatchable, both held-ready ⇒ stall.
+	states := []graph.EntityState{
+		unit("a", tri(cfg.DependsOnPredicate, "b")),
+		unit("b", tri(cfg.DependsOnPredicate, "a")),
+	}
+	sub := &recordingSubmit{}
+	e := newEvalExecutor(cfg, &fakeReader{scripts: [][]graph.EntityState{states}}, sub.fn)
+	e.reEvaluate(context.Background())
+	require.Empty(t, sub.ids(), "a cycle dispatches nothing")
+}
+
+func TestStallAfterInflight(t *testing.T) {
+	mk := func(completed, failed, dirtied, claimed []string) graphView {
+		v := graphView{claimed: map[string]bool{}}
+		for _, id := range claimed {
+			v.claimed[id] = true
+		}
+		v.markers = gateddag.NewMarkerSet(completed, failed, dirtied)
+		return v
+	}
+
+	t.Run("no stalled units → nil", func(t *testing.T) {
+		require.Nil(t, stallAfterInflight(nil, mk(nil, nil, nil, nil)))
+	})
+	t.Run("stalled and nothing in-flight → reported", func(t *testing.T) {
+		got := stallAfterInflight([]string{"a", "b"}, mk(nil, nil, nil, nil))
+		require.Equal(t, []string{"a", "b"}, got)
+	})
+	t.Run("stalled but a claimed non-terminal unit is in-flight → suppressed", func(t *testing.T) {
+		got := stallAfterInflight([]string{"a"}, mk(nil, nil, nil, []string{"c"}))
+		require.Nil(t, got, "running work is not a stall")
+	})
+	t.Run("claimed unit is terminal → not in-flight, stall reported", func(t *testing.T) {
+		got := stallAfterInflight([]string{"a"}, mk([]string{"c"}, nil, nil, []string{"c"}))
+		require.Equal(t, []string{"a"}, got)
+	})
+	t.Run("claimed unit is dirtied → reset, not in-flight, stall reported", func(t *testing.T) {
+		got := stallAfterInflight([]string{"a"}, mk(nil, nil, []string{"c"}, []string{"c"}))
+		require.Equal(t, []string{"a"}, got)
+	})
+}

--- a/processor/gated-dag/metrics.go
+++ b/processor/gated-dag/metrics.go
@@ -1,0 +1,55 @@
+package gateddagexec
+
+import (
+	"github.com/c360studio/semstreams/metric"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const metricsService = "gated-dag"
+
+// metrics holds the executor's prometheus collectors. The collectors are always
+// constructed (they operate standalone); they are only registered with the
+// shared registry when one is provided, so increments are always nil-safe.
+type metrics struct {
+	stall       prometheus.Gauge
+	claimed     prometheus.Counter
+	dispatched  prometheus.Counter
+	dispatchErr prometheus.Counter
+	evals       prometheus.Counter
+}
+
+// newMetrics builds the collectors and registers them with reg when non-nil.
+func newMetrics(reg *metric.MetricsRegistry) *metrics {
+	m := &metrics{
+		stall: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "gated_dag_stalled_units",
+			Help: "Number of units held-ready with no forward progress and nothing in-flight (a depends_on cycle or all-blocked-behind-failure). 0 = healthy.",
+		}),
+		claimed: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "gated_dag_units_claimed_total",
+			Help: "Durable claim markers committed (before dispatch).",
+		}),
+		dispatched: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "gated_dag_units_dispatched_total",
+			Help: "Dispatch references published after a successful claim.",
+		}),
+		dispatchErr: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "gated_dag_dispatch_errors_total",
+			Help: "Dispatch publishes that failed after the claim was committed (the unit may be stranded until reset).",
+		}),
+		evals: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "gated_dag_evaluations_total",
+			Help: "Re-evaluation passes (watch-triggered + backstop ticks).",
+		}),
+	}
+	if reg != nil {
+		// Best-effort registration: a duplicate (e.g. two flows) is logged by the
+		// registry and does not abort the executor.
+		_ = reg.RegisterGauge(metricsService, "stalled_units", m.stall)
+		_ = reg.RegisterCounter(metricsService, "units_claimed_total", m.claimed)
+		_ = reg.RegisterCounter(metricsService, "units_dispatched_total", m.dispatched)
+		_ = reg.RegisterCounter(metricsService, "dispatch_errors_total", m.dispatchErr)
+		_ = reg.RegisterCounter(metricsService, "evaluations_total", m.evals)
+	}
+	return m
+}

--- a/processor/gated-dag/participant.go
+++ b/processor/gated-dag/participant.go
@@ -1,0 +1,81 @@
+package gateddagexec
+
+import (
+	"reflect"
+
+	"github.com/c360studio/semstreams/pkg/lifecycle"
+)
+
+// FanOutWorkflow is the framework-default lifecycle workflow name the executor
+// watches and self-registers when the consumer does not supply its own.
+const FanOutWorkflow = "gateddag-fanout"
+
+// FanOutEntityIDPattern matches FanOut instance entities. Six-segment
+// org.platform.domain.system.type.instance shape: org + platform + instance
+// wildcard; domain (`gateddag`), system (`fanout`), type (`instance`) pin the
+// canonical shape.
+const FanOutEntityIDPattern = "*.*.gateddag.fanout.instance.*"
+
+// PredicateFanOutPhase is the FanOut phase predicate. lifecycle.Watch only
+// delivers entries carrying this predicate, so the watched entities MUST carry
+// it (the periodic backstop is the safety net for any entity that does not).
+const PredicateFanOutPhase = "gateddag.fanout.phase"
+
+// FanOut phases. The instance is `dispatching` while units remain, then a
+// terminal phase. Terminal detection is derived from the Transitions table.
+const (
+	PhaseDispatching = "dispatching"
+	PhaseCompleted   = "completed"
+	PhaseFailed      = "failed"
+)
+
+// Transitions is the FanOut phase graph:
+//
+//	dispatching ──> completed
+//	            └─> failed
+//
+// completed + failed are terminal (no out-edges).
+var Transitions = lifecycle.Transitions{
+	PhaseDispatching: {PhaseCompleted, PhaseFailed},
+	PhaseCompleted:   {},
+	PhaseFailed:      {},
+}
+
+// FanOut is the lifecycle.Participant for a gated-DAG fan-out instance
+// (ADR-047). It is a thin named instance carrying restart recovery + operator
+// gateway visibility; the unit set + edges + markers live on the per-unit
+// entities under Config.UnitEntityPrefix, not here.
+type FanOut struct {
+	EntityIDField string `json:"entity_id" lifecycle:"id"`
+	PhaseField    string `json:"phase" lifecycle:"phase,predicate=gateddag.fanout.phase"`
+}
+
+// WorkflowDeclaration returns the framework FanOut workflow ready for
+// Manager.Register. The executor registers this when FanOutWorkflow is left at
+// its default; a consumer that points Config.FanOutWorkflow at its own workflow
+// registers that one itself.
+func WorkflowDeclaration() lifecycle.Workflow {
+	return lifecycle.Workflow{
+		Name:            FanOutWorkflow,
+		EntityIDPattern: FanOutEntityIDPattern,
+		Phases:          []string{PhaseDispatching, PhaseCompleted, PhaseFailed},
+		Transitions:     Transitions,
+		PhasePredicate:  PredicateFanOutPhase,
+		Schema:          reflect.TypeOf(FanOut{}),
+	}
+}
+
+// EntityID returns the federated 6-part identifier.
+func (f *FanOut) EntityID() string { return f.EntityIDField }
+
+// Workflow returns the registered workflow type name.
+func (f *FanOut) Workflow() string { return FanOutWorkflow }
+
+// Phase returns the current phase.
+func (f *FanOut) Phase() string { return f.PhaseField }
+
+// IsTerminal reports whether the current phase has no declared out-edges.
+func (f *FanOut) IsTerminal() bool { return Transitions.IsTerminal(f.PhaseField) }
+
+// ParentEntityID returns "" — fan-out instances have no parent workflow here.
+func (f *FanOut) ParentEntityID() string { return "" }

--- a/processor/gated-dag/payload.go
+++ b/processor/gated-dag/payload.go
@@ -1,0 +1,78 @@
+package gateddagexec
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadregistry"
+)
+
+// Payload registry coordinates for the dispatch envelope.
+const (
+	// Domain groups gated-DAG executor payloads.
+	Domain = "gateddag"
+	// SchemaVersion is the payload schema version.
+	SchemaVersion = "v1"
+	// CategoryDispatch is the dispatch-reference envelope category.
+	CategoryDispatch = "dispatch"
+)
+
+// DispatchMessage is the reference envelope published to Config.DispatchSubject
+// when a unit becomes dispatchable. Per the orchestration rule "rules/dispatch
+// carry references, never content", it carries only identifiers — the consumer
+// retrieves the unit's details from the graph on demand.
+//
+// It is a registered payload (wrapped in a BaseMessage at publish time) so the
+// publish honors the payload-registry contract even though the immediate
+// consumer may read it raw.
+type DispatchMessage struct {
+	// UnitEntityID is the 6-part federated ID of the dispatchable unit. The
+	// consumer turns this reference into real work (e.g. a publish_agent).
+	UnitEntityID string `json:"unit_entity_id"`
+	// FanOutWorkflow is the workflow name of the fan-out instance that owns this
+	// unit (provenance / routing for the consumer).
+	FanOutWorkflow string `json:"fan_out_workflow,omitempty"`
+}
+
+// Schema returns the type discriminator for registry routing.
+func (d *DispatchMessage) Schema() message.Type {
+	return message.Type{Domain: Domain, Category: CategoryDispatch, Version: SchemaVersion}
+}
+
+// Validate checks required fields.
+func (d *DispatchMessage) Validate() error {
+	if d.UnitEntityID == "" {
+		return errors.New("dispatch message: unit_entity_id is required")
+	}
+	return nil
+}
+
+// MarshalJSON marshals the payload fields (alias avoids MarshalJSON recursion).
+func (d *DispatchMessage) MarshalJSON() ([]byte, error) {
+	type Alias DispatchMessage
+	return json.Marshal((*Alias)(d))
+}
+
+// UnmarshalJSON unmarshals the payload fields (alias avoids recursion).
+func (d *DispatchMessage) UnmarshalJSON(data []byte) error {
+	type Alias DispatchMessage
+	return json.Unmarshal(data, (*Alias)(d))
+}
+
+// RegisterPayloads registers the gated-DAG executor payload types with the
+// supplied registry. Wired into payloadbuiltins.Register so every binary that
+// can run the executor can decode its dispatch envelope.
+func RegisterPayloads(reg *payloadregistry.Registry) error {
+	registrations := []*payloadregistry.Registration{
+		{Domain: Domain, Category: CategoryDispatch, Version: SchemaVersion, Description: "Gated-DAG dispatch reference", Factory: func() any { return &DispatchMessage{} }},
+	}
+	var errs []error
+	for _, r := range registrations {
+		if err := reg.Register(r); err != nil {
+			errs = append(errs, fmt.Errorf("register %s.%s.%s: %w", r.Domain, r.Category, r.Version, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/processor/gated-dag/payload_roundtrip_test.go
+++ b/processor/gated-dag/payload_roundtrip_test.go
@@ -1,0 +1,35 @@
+package gateddagexec_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/payloadbuiltins"
+	gateddagexec "github.com/c360studio/semstreams/processor/gated-dag"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDispatchMessage_ProductionDecoderRoundTrip drives the real publish wrap
+// (NewBaseMessage) through the production decoder (every builtin registered) to
+// prove the dispatch envelope is registered + decodable end-to-end — not a
+// shape-cast against an anonymous struct (production-decoder round-trip
+// discipline). Lives in an external _test package to avoid the
+// payloadbuiltins → gated-dag import cycle.
+func TestDispatchMessage_ProductionDecoderRoundTrip(t *testing.T) {
+	msg := &gateddagexec.DispatchMessage{
+		UnitEntityID:   "acme.ops.plan.fanout.unit.7",
+		FanOutWorkflow: gateddagexec.FanOutWorkflow,
+	}
+	base := message.NewBaseMessage(msg.Schema(), msg, "test")
+	data, err := json.Marshal(base)
+	require.NoError(t, err)
+
+	decoded, err := payloadbuiltins.NewTestDecoder(t).Decode(data)
+	require.NoError(t, err)
+
+	got, ok := decoded.Payload().(*gateddagexec.DispatchMessage)
+	require.Truef(t, ok, "decoded payload must be *DispatchMessage, got %T", decoded.Payload())
+	require.Equal(t, "acme.ops.plan.fanout.unit.7", got.UnitEntityID)
+	require.Equal(t, gateddagexec.FanOutWorkflow, got.FanOutWorkflow)
+}

--- a/processor/gated-dag/publisher.go
+++ b/processor/gated-dag/publisher.go
@@ -1,0 +1,39 @@
+package gateddagexec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// publisher publishes the dispatch reference for a dispatchable unit. It is an
+// interface so unit tests record dispatch ordering against a fake.
+type publisher interface {
+	// Dispatch publishes the unit's reference envelope to the dispatch subject.
+	Dispatch(ctx context.Context, unitID string) error
+}
+
+// natsPublisher wraps the reference in a BaseMessage envelope (payload-registry
+// contract) and publishes it to the configured subject.
+type natsPublisher struct {
+	nc             *natsclient.Client
+	subject        string
+	fanOutWorkflow string
+}
+
+// Dispatch publishes the registry-wrapped DispatchMessage reference.
+func (p *natsPublisher) Dispatch(ctx context.Context, unitID string) error {
+	msg := &DispatchMessage{UnitEntityID: unitID, FanOutWorkflow: p.fanOutWorkflow}
+	base := message.NewBaseMessage(msg.Schema(), msg, "gateddag-executor")
+	data, err := json.Marshal(base)
+	if err != nil {
+		return fmt.Errorf("marshal dispatch message for %s: %w", unitID, err)
+	}
+	if err := p.nc.Publish(ctx, p.subject, data); err != nil {
+		return fmt.Errorf("publish dispatch for %s to %s: %w", unitID, p.subject, err)
+	}
+	return nil
+}

--- a/processor/gated-dag/reader.go
+++ b/processor/gated-dag/reader.go
@@ -1,0 +1,141 @@
+package gateddagexec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/gateddag"
+)
+
+// graphReader reads the authoritative whole unit set for one evaluation. It is
+// an interface so unit tests inject a scripted reader and the executor never
+// caches derived state (ADR-046 requirement #1: derived, never mutated).
+type graphReader interface {
+	// ReadUnitSet returns the full EntityState set under the configured prefix,
+	// triples included, read fresh from the graph.
+	ReadUnitSet(ctx context.Context) ([]graph.EntityState, error)
+}
+
+// natsGraphReader reads the unit set via the graph.query.prefix contract
+// (returns full EntityStates incl. markers). Bounded by maxUnits: it follows the
+// opaque cursor up to the cap and logs a truncation warning rather than
+// silently dropping units past it.
+type natsGraphReader struct {
+	nc       *natsclient.Client
+	prefix   string
+	maxUnits int
+	timeout  time.Duration
+	onTrunc  func(returned, capN int)
+}
+
+// prefixQuerySubject is the authoritative whole-set enumeration contract. The
+// executor reads the graph-ingest handler DIRECTLY (graph.ingest.query.prefix)
+// rather than the public graph.query.prefix passthrough: it is an internal
+// framework component, and the direct subject preserves error-class fidelity
+// (the public passthrough coerces a transient graph-ingest failure to Invalid).
+const prefixQuerySubject = "graph.ingest.query.prefix"
+
+// ReadUnitSet pages graph.query.prefix following the cursor up to maxUnits.
+// Each page gets its own r.timeout budget (not a shared deadline across pages),
+// so a large multi-page fan-out is not cancelled mid-paging by a single overall
+// deadline; the parent ctx still cancels the whole read on shutdown.
+func (r *natsGraphReader) ReadUnitSet(ctx context.Context) ([]graph.EntityState, error) {
+	var all []graph.EntityState
+	cursor := ""
+	for {
+		remaining := r.maxUnits - len(all)
+		if remaining <= 0 {
+			// Hit the cap; surface truncation so a too-large fan-out is visible
+			// rather than silently partial.
+			if r.onTrunc != nil {
+				r.onTrunc(len(all), r.maxUnits)
+			}
+			return all, nil
+		}
+		req := graph.PrefixQueryRequest{Prefix: r.prefix, Limit: remaining, Cursor: cursor}
+		reqData, err := json.Marshal(req)
+		if err != nil {
+			return nil, fmt.Errorf("marshal prefix request: %w", err)
+		}
+		respData, err := r.nc.RequestClassified(ctx, prefixQuerySubject, reqData, r.timeout)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", prefixQuerySubject, err)
+		}
+		var resp graph.PrefixQueryResponse
+		if err := json.Unmarshal(respData, &resp); err != nil {
+			return nil, fmt.Errorf("unmarshal prefix response: %w", err)
+		}
+		all = append(all, resp.Entities...)
+		if resp.NextCursor == "" {
+			return all, nil // exhausted
+		}
+		cursor = resp.NextCursor
+	}
+}
+
+// graphView is the brain input extracted from an authoritative unit-set read,
+// plus the executor-only claimed set used for in-flight dedup.
+type graphView struct {
+	unitIDs   []string
+	dependsOn map[string][]string
+	markers   gateddag.MarkerSet
+	claimed   map[string]bool
+}
+
+// extractGraph derives the brain inputs (unit IDs, depends_on edges, marker
+// membership) and the executor's claimed set from an authoritative unit-set
+// read. Pure — no I/O — so it is exhaustively table-testable.
+//
+// Marker semantics are presence-based: a unit is in a marker set iff it carries
+// at least one triple with the configured predicate (the Object value is
+// irrelevant for completed/failed/dirtied/claim). depends_on is the exception —
+// its Object is the prerequisite unit ID, collected as a directed edge.
+func extractGraph(states []graph.EntityState, cfg Config) graphView {
+	view := graphView{
+		unitIDs:   make([]string, 0, len(states)),
+		dependsOn: make(map[string][]string),
+		claimed:   make(map[string]bool),
+	}
+	var completed, failed, dirtied []string
+
+	for i := range states {
+		s := &states[i]
+		view.unitIDs = append(view.unitIDs, s.ID)
+		for j := range s.Triples {
+			t := &s.Triples[j]
+			switch t.Predicate {
+			case cfg.CompletedPredicate:
+				completed = append(completed, s.ID)
+			case cfg.FailedPredicate:
+				failed = append(failed, s.ID)
+			case cfg.DirtiedPredicate:
+				dirtied = append(dirtied, s.ID)
+			case cfg.ClaimPredicate:
+				view.claimed[s.ID] = true
+			case cfg.DependsOnPredicate:
+				if dep, ok := objectAsEntityID(t.Object); ok {
+					view.dependsOn[s.ID] = append(view.dependsOn[s.ID], dep)
+				}
+			}
+		}
+	}
+
+	view.markers = gateddag.NewMarkerSet(completed, failed, dirtied)
+	return view
+}
+
+// objectAsEntityID coerces a triple Object to an entity-ID string. depends_on
+// edges store the prerequisite ID as a string; anything else is not a valid edge
+// target and is skipped (the substitution layer never produces a non-string
+// edge object, but the graph stores Object as any).
+func objectAsEntityID(o any) (string, bool) {
+	s, ok := o.(string)
+	if !ok || s == "" {
+		return "", false
+	}
+	return s, true
+}

--- a/processor/gated-dag/reader_test.go
+++ b/processor/gated-dag/reader_test.go
@@ -1,0 +1,69 @@
+package gateddagexec
+
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/stretchr/testify/require"
+)
+
+// unit builds an EntityState with the given (predicate, object) triples.
+func unit(id string, triples ...message.Triple) graph.EntityState {
+	return graph.EntityState{ID: id, Triples: triples}
+}
+
+func tri(pred string, obj any) message.Triple {
+	return message.Triple{Predicate: pred, Object: obj}
+}
+
+func TestExtractGraph(t *testing.T) {
+	cfg := validCfg()
+
+	t.Run("presence markers + edges + claim", func(t *testing.T) {
+		states := []graph.EntityState{
+			unit("a", tri(cfg.CompletedPredicate, "a")),
+			unit("b",
+				tri(cfg.DependsOnPredicate, "a"),
+				tri(cfg.FailedPredicate, true)),
+			unit("c",
+				tri(cfg.DependsOnPredicate, "a"),
+				tri(cfg.DependsOnPredicate, "b"),
+				tri(cfg.ClaimPredicate, "c")),
+			unit("d", tri(cfg.DirtiedPredicate, "d")),
+		}
+		v := extractGraph(states, cfg)
+
+		require.ElementsMatch(t, []string{"a", "b", "c", "d"}, v.unitIDs)
+		require.True(t, v.markers.Completed["a"])
+		require.True(t, v.markers.Failed["b"])
+		require.True(t, v.markers.Dirtied["d"])
+		require.ElementsMatch(t, []string{"a"}, v.dependsOn["b"])
+		require.ElementsMatch(t, []string{"a", "b"}, v.dependsOn["c"])
+		require.True(t, v.claimed["c"])
+		require.False(t, v.claimed["a"])
+	})
+
+	t.Run("non-string depends_on object is skipped", func(t *testing.T) {
+		states := []graph.EntityState{
+			unit("x", tri(cfg.DependsOnPredicate, 42)), // not an entity-ID string
+			unit("y", tri(cfg.DependsOnPredicate, "")), // empty string skipped
+		}
+		v := extractGraph(states, cfg)
+		require.Empty(t, v.dependsOn["x"])
+		require.Empty(t, v.dependsOn["y"])
+	})
+
+	t.Run("unit with no triples has no markers or edges", func(t *testing.T) {
+		v := extractGraph([]graph.EntityState{unit("lonely")}, cfg)
+		require.Equal(t, []string{"lonely"}, v.unitIDs)
+		require.Empty(t, v.markers.Completed)
+		require.Empty(t, v.dependsOn["lonely"])
+		require.False(t, v.claimed["lonely"])
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		v := extractGraph(nil, cfg)
+		require.Empty(t, v.unitIDs)
+	})
+}

--- a/processor/gated-dag/schema.go
+++ b/processor/gated-dag/schema.go
@@ -1,0 +1,96 @@
+package gateddagexec
+
+import "github.com/c360studio/semstreams/component"
+
+// Schema returns the component configuration schema (static metadata used by
+// the registry + operator UI). Mirrors the field set in Config.
+func (c Config) Schema() component.ConfigSchema {
+	return component.ConfigSchema{
+		Properties: map[string]component.PropertySchema{
+			"fan_out_workflow": {
+				Type:        "string",
+				Description: "lifecycle.Workflow.Name watched for re-eval triggers. Defaults to the framework FanOut workflow (self-registered).",
+				Default:     FanOutWorkflow,
+				Category:    "basic",
+			},
+			"unit_entity_prefix": {
+				Type:        "string",
+				Description: "graph.query.prefix scope read authoritatively each evaluation — the blast radius of one fan-out. Required.",
+				Category:    "basic",
+			},
+			"dispatch_subject": {
+				Type:        "string",
+				Description: "Subject published with the unit entity ID reference when a unit is dispatchable. The consumer wires its handler here. Required.",
+				Category:    "basic",
+			},
+			"completed_predicate": {
+				Type:        "string",
+				Description: "Triple predicate marking a unit complete.",
+				Default:     defaultCompletedPredicate,
+				Category:    "advanced",
+			},
+			"failed_predicate": {
+				Type:        "string",
+				Description: "Triple predicate marking a unit failed.",
+				Default:     defaultFailedPredicate,
+				Category:    "advanced",
+			},
+			"dirtied_predicate": {
+				Type:        "string",
+				Description: "Triple predicate marking a unit reset/dirtied (re-derives Ready over any stale terminal marker).",
+				Default:     defaultDirtiedPredicate,
+				Category:    "advanced",
+			},
+			"depends_on_predicate": {
+				Type:        "string",
+				Description: "Triple predicate carrying a unit's prerequisite unit IDs (multi-valued; one triple per edge).",
+				Default:     defaultDependsOnPredicate,
+				Category:    "advanced",
+			},
+			"claim_predicate": {
+				Type:        "string",
+				Description: "Triple predicate carrying the durable in-flight claim (the dedup record committed before dispatch).",
+				Default:     defaultClaimPredicate,
+				Category:    "advanced",
+			},
+			"workers": {
+				Type:        "int",
+				Description: "Bounded dispatch concurrency.",
+				Default:     defaultWorkers,
+				Category:    "advanced",
+			},
+			"queue_size": {
+				Type:        "int",
+				Description: "Dispatch submit-queue bound.",
+				Default:     defaultQueueSize,
+				Category:    "advanced",
+			},
+			"backstop_interval": {
+				Type:        "string",
+				Description: "Period of the unconditional re-eval tick that closes the missed-watch-event hole and surfaces stalls.",
+				Default:     defaultBackstopInterval,
+				Category:    "advanced",
+			},
+			"query_timeout": {
+				Type:        "string",
+				Description: "Timeout bounding each authoritative graph.query.prefix read.",
+				Default:     defaultQueryTimeout,
+				Category:    "advanced",
+			},
+			"max_units": {
+				Type:        "int",
+				Description: "Cap on the authoritative whole-set read; a larger fan-out logs a truncation warning.",
+				Default:     defaultMaxUnits,
+				Category:    "advanced",
+			},
+			"failure_policy": {
+				Type:        "enum",
+				Description: "How a failed unit affects new dispatch.",
+				Enum:        []string{FailurePolicyContinueOthers, FailurePolicyStopOnFirstFailure},
+				Default:     FailurePolicyContinueOthers,
+				Category:    "advanced",
+			},
+		},
+		Required: []string{"unit_entity_prefix", "dispatch_subject"},
+	}
+}

--- a/processor/graph-ingest/cache_coherence_integration_test.go
+++ b/processor/graph-ingest/cache_coherence_integration_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// queryEntityViaPrefix reads a single entity back through the cached
+// graph.ingest.query.prefix path (the read path the gated-DAG executor and other
+// whole-set readers use). Returns nil if absent.
+func queryEntityViaPrefix(t *testing.T, ctx context.Context, nc *natsclient.Client, id string) *graph.EntityState {
+	t.Helper()
+	reqData, err := json.Marshal(graph.PrefixQueryRequest{Prefix: id, Limit: 10})
+	require.NoError(t, err)
+	respData, err := nc.RequestClassified(ctx, "graph.ingest.query.prefix", reqData, 5*time.Second)
+	require.NoError(t, err)
+	var resp graph.PrefixQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	for i := range resp.Entities {
+		if resp.Entities[i].ID == id {
+			return &resp.Entities[i]
+		}
+	}
+	return nil
+}
+
+// TestIntegration_CacheCoherence_UpdateWithTriplesVisibleAfterPrefixRead is the
+// regression lock for the read-after-write gap the gated-DAG executor surfaced:
+// the entity-query cache (30s TTL) was NOT invalidated by the NATS mutation
+// handlers, so a query within the TTL after an update_with_triples / triple.add
+// returned the pre-write entity. The executor read a unit's claim marker as
+// absent right after committing it and re-dispatched on every pass.
+func TestIntegration_CacheCoherence_UpdateWithTriplesVisibleAfterPrefixRead(t *testing.T) {
+	ctx := context.Background()
+	c, nc := startPrefixTestComponent(t)
+
+	const id = "coh.ops.dom.sys.type.entity1"
+	seedPrefixEntity(t, ctx, c, id)
+
+	// Prime the cache: read once via the prefix path.
+	got := queryEntityViaPrefix(t, ctx, nc, id)
+	require.NotNil(t, got)
+	require.Nil(t, got.GetTriple("coh.marker"), "marker not present yet")
+
+	// Commit a new predicate via update_with_triples (the executor's claim path).
+	updReq := graph.UpdateEntityWithTriplesRequest{
+		Entity:     &graph.EntityState{ID: id},
+		AddTriples: []message.Triple{{Subject: id, Predicate: "coh.marker", Object: "v1", Timestamp: time.Now(), Confidence: 1.0}},
+	}
+	updData, err := json.Marshal(updReq)
+	require.NoError(t, err)
+	_, err = nc.RequestClassified(ctx, "graph.mutation.entity.update_with_triples", updData, 5*time.Second)
+	require.NoError(t, err)
+
+	// The very next prefix read MUST reflect the new marker (no stale cache).
+	got = queryEntityViaPrefix(t, ctx, nc, id)
+	require.NotNil(t, got)
+	require.NotNil(t, got.GetTriple("coh.marker"), "update_with_triples must be visible on the next prefix read (cache invalidated)")
+
+	// Same contract for triple.add.
+	addReq := graph.AddTripleRequest{Triple: message.Triple{Subject: id, Predicate: "coh.added", Object: "v2", Timestamp: time.Now(), Confidence: 1.0}}
+	addData, err := json.Marshal(addReq)
+	require.NoError(t, err)
+	_, err = nc.RequestClassified(ctx, "graph.mutation.triple.add", addData, 5*time.Second)
+	require.NoError(t, err)
+
+	got = queryEntityViaPrefix(t, ctx, nc, id)
+	require.NotNil(t, got)
+	require.NotNil(t, got.GetTriple("coh.added"), "triple.add must be visible on the next prefix read (cache invalidated)")
+}

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -2181,6 +2181,20 @@ func (c *Component) DeleteEntity(ctx context.Context, entityID string) error {
 // Triple Operations
 // ============================================================================
 
+// invalidateEntityCacheEntry drops a stale entity-query-cache entry after a
+// direct entityBucket write, preserving read-after-write coherence for callers
+// that query via graph.ingest.query.* (e.g. the gated-DAG executor reading the
+// whole unit set right after committing a claim, or any read-after-mutate via
+// the NATS mutation API). The high-level CreateEntity/UpdateEntity/DeleteEntity/
+// MergeEntity methods already invalidate inline; the triple-add and
+// update_with_triples write paths did not, so a query within the 30s cache TTL
+// returned the pre-write entity. No-op when the cache is disabled.
+func (c *Component) invalidateEntityCacheEntry(id string) {
+	if c.entityCache != nil {
+		c.entityCache.Delete(id) //nolint:errcheck
+	}
+}
+
 // AddTriple adds a triple to an entity using CAS for concurrency safety
 func (c *Component) AddTriple(ctx context.Context, triple message.Triple) error {
 	if triple.Subject == "" {
@@ -2224,6 +2238,9 @@ func (c *Component) AddTriple(ctx context.Context, triple message.Triple) error 
 		return errs.Wrap(err, "Component", "AddTriple", "CAS update")
 	}
 
+	// Read-after-write coherence: the entity-query cache must not serve the
+	// pre-add state on the next graph.ingest.query.* read.
+	c.invalidateEntityCacheEntry(triple.Subject)
 	return nil
 }
 
@@ -2331,6 +2348,9 @@ func (c *Component) AddTriples(ctx context.Context, triples []message.Triple) (w
 			}
 			continue
 		}
+		// Read-after-write coherence: invalidate the just-written subject's
+		// cached entity so the next query reflects the appended triples.
+		c.invalidateEntityCacheEntry(subject)
 		writtenCount += len(group)
 	}
 
@@ -2424,6 +2444,9 @@ func (c *Component) RemoveTriple(ctx context.Context, subject, predicate string)
 		return errs.Wrap(err, "Component", "RemoveTriple", "CAS update")
 	}
 
+	// Read-after-write coherence: drop the cached entity so a query reflects
+	// the removed predicate (consumers clear markers via remove on reset).
+	c.invalidateEntityCacheEntry(subject)
 	return nil
 }
 

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -752,7 +752,11 @@ func (c *Component) handleEntityUpdateWithTriples(ctx context.Context, data []by
 		return nil, rejectInternal(err)
 	}
 
-	// Primary update committed — route foreign edges onto their own subjects.
+	// Primary update committed — invalidate the entity-query cache so a
+	// read-after-write via graph.ingest.query.* sees the new triples (the
+	// gated-DAG executor's claim-then-reread relies on this), then route any
+	// foreign edges onto their own subjects.
+	c.invalidateEntityCacheEntry(req.Entity.ID)
 	c.routeForeignEdges(ctx, req.Entity.ID, req.Entity.MessageType, foreign)
 
 	stored, rev, err := c.fetchEntityState(ctx, req.Entity.ID)
@@ -860,6 +864,10 @@ func (c *Component) handleEntityUpdateWithTriplesCAS(ctx context.Context, req *g
 		}
 		return nil, rejectInternal(err)
 	}
+	// CAS-path cache invalidation is owned by updateEntityAtRevision (it Deletes
+	// the cache entry after a successful CAS commit), so no invalidate is needed
+	// here — unlike the non-CAS UpdateWithRetry path above, which writes the
+	// bucket directly and must invalidate itself.
 
 	// Read back for response. Degraded path handles read-back failure
 	// (write committed, read-back failed → operator sees Success +

--- a/schemas/gated-dag.v1.json
+++ b/schemas/gated-dag.v1.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "gated-dag.v1.json",
+  "type": "object",
+  "title": "gated-dag Configuration",
+  "description": "Gated-DAG dispatch executor (ADR-046 Phase 2): dispatches DAG units in dependency order with restart recovery, failure isolation, and stall detection.",
+  "properties": {
+    "backstop_interval": {
+      "type": "string",
+      "description": "Period of the unconditional re-eval tick that closes the missed-watch-event hole and surfaces stalls.",
+      "default": "30s",
+      "category": "advanced"
+    },
+    "claim_predicate": {
+      "type": "string",
+      "description": "Triple predicate carrying the durable in-flight claim (the dedup record committed before dispatch).",
+      "default": "gateddag.claim",
+      "category": "advanced"
+    },
+    "completed_predicate": {
+      "type": "string",
+      "description": "Triple predicate marking a unit complete.",
+      "default": "gateddag.completed",
+      "category": "advanced"
+    },
+    "depends_on_predicate": {
+      "type": "string",
+      "description": "Triple predicate carrying a unit's prerequisite unit IDs (multi-valued; one triple per edge).",
+      "default": "gateddag.depends_on",
+      "category": "advanced"
+    },
+    "dirtied_predicate": {
+      "type": "string",
+      "description": "Triple predicate marking a unit reset/dirtied (re-derives Ready over any stale terminal marker).",
+      "default": "gateddag.dirtied",
+      "category": "advanced"
+    },
+    "dispatch_subject": {
+      "type": "string",
+      "description": "Subject published with the unit entity ID reference when a unit is dispatchable. The consumer wires its handler here. Required.",
+      "category": "basic"
+    },
+    "failed_predicate": {
+      "type": "string",
+      "description": "Triple predicate marking a unit failed.",
+      "default": "gateddag.failed",
+      "category": "advanced"
+    },
+    "failure_policy": {
+      "type": "string",
+      "description": "How a failed unit affects new dispatch.",
+      "default": "continue_others",
+      "enum": [
+        "continue_others",
+        "stop_on_first_failure"
+      ],
+      "category": "advanced"
+    },
+    "fan_out_workflow": {
+      "type": "string",
+      "description": "lifecycle.Workflow.Name watched for re-eval triggers. Defaults to the framework FanOut workflow (self-registered).",
+      "default": "gateddag-fanout",
+      "category": "basic"
+    },
+    "max_units": {
+      "type": "integer",
+      "description": "Cap on the authoritative whole-set read; a larger fan-out logs a truncation warning.",
+      "default": 1000,
+      "category": "advanced"
+    },
+    "query_timeout": {
+      "type": "string",
+      "description": "Timeout bounding each authoritative graph.query.prefix read.",
+      "default": "30s",
+      "category": "advanced"
+    },
+    "queue_size": {
+      "type": "integer",
+      "description": "Dispatch submit-queue bound.",
+      "default": 256,
+      "category": "advanced"
+    },
+    "unit_entity_prefix": {
+      "type": "string",
+      "description": "graph.query.prefix scope read authoritatively each evaluation — the blast radius of one fan-out. Required.",
+      "category": "basic"
+    },
+    "workers": {
+      "type": "integer",
+      "description": "Bounded dispatch concurrency.",
+      "default": 4,
+      "category": "advanced"
+    }
+  },
+  "required": [
+    "unit_entity_prefix",
+    "dispatch_subject"
+  ],
+  "x-component-metadata": {
+    "name": "gated-dag",
+    "type": "processor",
+    "protocol": "nats",
+    "domain": "graph",
+    "version": "1.0.0"
+  }
+}

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -1308,6 +1308,7 @@ components:
                         - $ref: ../schemas/directory-bridge.v1.json
                         - $ref: ../schemas/file.v1.json
                         - $ref: ../schemas/file_input.v1.json
+                        - $ref: ../schemas/gated-dag.v1.json
                         - $ref: ../schemas/github_webhook.v1.json
                         - $ref: ../schemas/graph-clustering.v1.json
                         - $ref: ../schemas/graph-embedding.v1.json


### PR DESCRIPTION
Stage C of ADR-046 Phase 2 — the **gated-DAG dispatch executor**. Builds on the merged ADR amendment (#359) and the pure selection brain (#360, `pkg/gateddag`).

## What this adds

A domain-agnostic processor (`processor/gated-dag/`) that dispatches DAG work units in dependency order with restart recovery, failure isolation, and stall detection. It composes existing substrate, each in a specific role:

- **lifecycle `Watch`** (KV `WatchAll` bootstrap replay) — re-eval + restart-recovery driver.
- **periodic backstop tick** — the correctness floor for unit-completion-driven re-eval (the FanOut-workflow watch does not fire on unit-entity marker writes; see V5 note in `doc.go`).
- **`graph.ingest.query.prefix`** — authoritative whole-set read each pass.
- **`pkg/dispatch` BoundedDispatcher** — bounded-concurrency leg only (built with **no** `CompletionKVBucket`, which would suppress bootstrap replay).
- **`update_with_triples`** (replace_owned shape, `ExpectedRevision=0` = LWW) — durable in-flight claim, committed **before** dispatch.
- **ADR-047 FanOut `Participant`** — named instance / operator visibility.

Dispatch is **reference-only**: on a dispatchable unit the executor commits a claim then publishes a registered `DispatchMessage` carrying the unit entity ID (never content) to a configured subject; the consumer turns the reference into work.

### The four ADR-046 load-bearing invariants (held in code, reviewer-verified)
1. Single-flight per fan-out (`evalMu` + one eval goroutine); the LWW claim is the durable record, **not** the mutual-exclusion mechanism.
2. Claim committed **before** dispatch (crash → no double-run).
3. Re-eval/recovery ride lifecycle `Watch`, **not** the dispatch completion-watcher.
4. Stall detection + periodic backstop are net-new.

Plus: a *dirtied* unit overrides a stale claim, so a reset re-dispatches even if the claim wasn't cleared.

## Bundled fix: graph-ingest read-after-write coherence

The executor's claim-then-reread surfaced a latent bug: the entity-query cache (30s TTL) was invalidated by the high-level `CreateEntity`/`UpdateEntity`/`DeleteEntity`/`MergeEntity` methods but **not** by the NATS mutation handlers (`AddTriple`, `AddTriples`, `RemoveTriple`, non-CAS `update_with_triples`). Any consumer that writes via the mutation API and reads via `graph.ingest.query.prefix` got up to 30s of stale reads. Fixed at each direct-write success point (commit `fd1a08af`), with a regression-lock integration test. Kept as a separate commit because it affects more than the executor.

## Testing

- Unit (`-race`): selection/dedup/stall/single-flight/backstop/failure-policy + `extractGraph` table + config (incl. full JSON round-trip) + production-decoder payload round-trip.
- Integration (real NATS + graph-ingest + lifecycle Manager, driven through `NewComponent`+`Initialize`+`Start`): depends_on dispatch, claim dedup across passes, boot reconcile; graph-ingest cache-coherence lock.
- Full local gate green: build, unit `-race ./...`, revive, gofmt, schema no-drift, `vet -tags=integration`/`-tags=live_llm`, targeted integration sweep (gated-dag/graph-ingest/lifecycle/rule/graph-query).
- **semstreams-reviewer: APPROVE-WITH-NITS** — all nits addressed.

## Follow-ups (out of scope)
- Stage D — wire `StateTracker.DeleteAllForEntity` for `$state` retry-budget reset (gh#358).
- Stage E — e2e tier (depends_on under concurrent completion; reset survives evicted row; failed node releases independent branches; cycle → stall).

Closes part of gh#357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)