### PR TITLE
fix(rule): reset per-(rule,entity) $state on entity delete (gh#358)

### DIFF
--- a/processor/rule/entity_watcher.go
+++ b/processor/rule/entity_watcher.go
@@ -362,6 +362,21 @@ func (rp *Processor) handleEntityUpdates(ctx context.Context, watcher jetstream.
 				}
 				rp.evaluateRulesForEntityState(ctx, entityKey,
 					entitySnapshot{Action: action, Revision: revision}, bootstrap)
+				// Clean up the deleted entity's rule $state. (Rule evaluation
+				// itself is skipped on delete — the call above short-circuits on
+				// the nil State — so order relative to it is immaterial; we run
+				// after it for symmetry with the update path.) Without this
+				// cleanup, per-(rule,entity) state — most importantly an
+				// exhausted max_iterations retry budget — is orphaned: a later
+				// entity reused or recreated at the same ID inherits the stale
+				// budget and silently never re-fires (gh#358). Best-effort: a
+				// cleanup failure is logged, never blocks delete handling.
+				if rp.stateTracker != nil {
+					if err := rp.stateTracker.DeleteAllForEntity(ctx, entityKey); err != nil {
+						rp.logger.Warn("Failed to clean up rule state for deleted entity",
+							"entity", entityKey, "error", err)
+					}
+				}
 				continue
 			}
 

--- a/processor/rule/state_cleanup_integration_test.go
+++ b/processor/rule/state_cleanup_integration_test.go
@@ -1,0 +1,88 @@
+//go:build integration
+
+package rule
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// TestEntityWatcher_DeletedEntityCleansRuleState is the gh#358 regression lock:
+// when an entity is deleted, the watcher cleans up its per-(rule,entity) $state,
+// so an entity recreated/reused at the same ID does not inherit a stale,
+// exhausted max_iterations budget (which would silently never re-fire). It also
+// proves the boundary-aware match: a prefix-sibling's state survives.
+func TestEntityWatcher_DeletedEntityCleansRuleState(t *testing.T) {
+	testClient := natsclient.NewTestClient(t, natsclient.WithJetStream(), natsclient.WithKV())
+	t.Cleanup(func() { _ = testClient.Terminate() })
+	nc := testClient.Client
+	ctx := context.Background()
+
+	js, err := nc.JetStream()
+	require.NoError(t, err)
+	kv, err := js.KeyValue(ctx, "ENTITY_STATES")
+	if err != nil {
+		kv, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "ENTITY_STATES"})
+		require.NoError(t, err)
+	}
+
+	config := DefaultConfig()
+	config.EntityWatchPatterns = []string{"gh358.test.>"}
+	proc, err := NewProcessor(nc, &config)
+	require.NoError(t, err)
+	require.NoError(t, proc.Initialize())
+	require.NoError(t, proc.Start(ctx))
+	t.Cleanup(func() { _ = proc.Stop(5 * time.Second) })
+	require.NotNil(t, proc.stateTracker, "state tracker must initialize")
+
+	const ruleID = "retry-rule"
+	const x = "gh358.test.dom.sys.unit.1"
+	const x10 = "gh358.test.dom.sys.unit.10"   // dotted prefix sibling of x
+	const xUnd = "gh358.test.dom.sys.unit.1_a" // underscore prefix sibling of x (live entity)
+
+	siblings := []string{x, x10, xUnd}
+
+	// Seed all entities into ENTITY_STATES so the watcher has live keys.
+	for _, id := range siblings {
+		data, merr := json.Marshal(gtypes.EntityState{ID: id})
+		require.NoError(t, merr)
+		_, perr := kv.Put(ctx, id, data)
+		require.NoError(t, perr)
+	}
+
+	// Pre-set an EXHAUSTED retry budget (Iteration == MaxIterations) for each —
+	// the state a prior run would have left behind.
+	for _, id := range siblings {
+		require.NoError(t, proc.stateTracker.Set(ctx, MatchState{
+			RuleID: ruleID, EntityKey: id, IsMatching: true,
+			Iteration: 3, MaxIterations: 3, LastChecked: time.Now(),
+		}))
+	}
+
+	// Delete x — the watcher's DELETED branch must clean x's rule state.
+	require.NoError(t, kv.Delete(ctx, x))
+
+	// x's state is cleaned up (the watcher processes the delete asynchronously).
+	require.Eventually(t, func() bool {
+		_, gerr := proc.stateTracker.Get(ctx, ruleID, x)
+		return errors.Is(gerr, ErrStateNotFound)
+	}, 5*time.Second, 50*time.Millisecond, "deleted entity's rule state must be cleaned up")
+
+	// The prefix siblings survive — the exact suffix match did not over-delete.
+	// x10 guards the dotted-prefix case; xUnd guards the underscore-prefix case
+	// ("_" is legal in an instance segment, so "unit.1" must not match "unit.1_a").
+	for _, sib := range []string{x10, xUnd} {
+		got, gerr := proc.stateTracker.Get(ctx, ruleID, sib)
+		require.NoErrorf(t, gerr, "prefix-sibling %q rule state must NOT be deleted", sib)
+		require.Equalf(t, 3, got.Iteration, "sibling %q budget untouched", sib)
+	}
+}

--- a/processor/rule/state_tracker.go
+++ b/processor/rule/state_tracker.go
@@ -179,8 +179,22 @@ func (st *StateTracker) Delete(ctx context.Context, ruleID, entityKey string) er
 	return nil
 }
 
-// DeleteAllForEntity removes all rule states associated with an entity.
-// This is called when an entity is deleted to clean up orphaned state.
+// DeleteAllForEntity removes the per-(rule,entity) SINGLE-ENTITY state for the
+// given entity (matched exactly via stateKeyBelongsToEntity). Relationship-rule
+// pair state is intentionally not touched — see stateKeyBelongsToEntity for why
+// the key scheme makes precise pair matching impossible and TTL the right
+// backstop.
+//
+// Called from the entity watcher's delete path (entity_watcher.go) when an
+// entity is deleted, so a later entity recreated or reused at the same ID
+// starts with a fresh match/iteration budget rather than inheriting the deleted
+// entity's exhausted retry budget (gh#358). entityID must be a canonical 6-part
+// entity ID (the watcher always passes one) for the suffix match to be exact.
+//
+// Cost note: this lists every key in the state bucket. Entity deletes are
+// infrequent relative to updates, so the O(state-keys) scan is acceptable; if a
+// high-delete-rate workload ever makes it hot, switch to constructing the exact
+// per-rule keys from the loaded rule set.
 func (st *StateTracker) DeleteAllForEntity(ctx context.Context, entityID string) error {
 	// Handle nil bucket (for tests)
 	if st.bucket == nil {
@@ -194,8 +208,7 @@ func (st *StateTracker) DeleteAllForEntity(ctx context.Context, entityID string)
 	}
 
 	for _, key := range keys {
-		// Check if key contains the entityID (either as single entity or in pair)
-		if containsEntityID(key, entityID) {
+		if stateKeyBelongsToEntity(key, entityID) {
 			if err := st.bucket.Delete(ctx, key); err != nil && !errors.Is(err, jetstream.ErrKeyNotFound) {
 				st.logger.Warn("Failed to delete rule state",
 					"key", key,
@@ -214,11 +227,29 @@ func buildStateKey(ruleID, entityKey string) string {
 	return ruleID + "." + entityKey
 }
 
-// containsEntityID checks if a state key contains the given entity ID.
-// Key format: ruleID.entityKey where entityKey is either "entityID" or "entityID1_entityID2"
-// Since both ruleID and entityKey may contain dots, we just check if the key contains the entityID.
-func containsEntityID(key, entityID string) bool {
-	return strings.Contains(key, entityID)
+// stateKeyBelongsToEntity reports whether a SINGLE-ENTITY state key is owned by
+// entityID. A single-entity key is buildStateKey(ruleID, entityID) =
+// "ruleID.entityID", so the test is an exact suffix match on the ruleID/entity
+// separator: the key ends with "." + entityID.
+//
+// This is EXACT (not a substring/boundary heuristic) and that exactness is
+// load-bearing. "_" is a legal character inside an entity-ID instance segment
+// (message.isEntityIDChar), so a boundary check that treats "_" as a delimiter
+// over-deletes: deleting "org.plat.dom.sys.drone.a" would also match a LIVE
+// sibling "org.plat.dom.sys.drone.a_x" (a different entity whose instance is
+// "a_x"), silently wiping its retry budget. The suffix match avoids this — the
+// key for "a_x" ends with ".a_x", not ".a". Entity IDs are canonical 6-part IDs
+// with no internal dots, so no 6-part ID is a dotted-suffix of another and the
+// match never collides.
+//
+// Relationship-rule PAIR keys (buildStateKey(ruleID, buildPairKey(a,b)) =
+// "ruleID.a_b") are intentionally NOT matched: "_" is both the pair separator
+// and a legal instance char, so a pair key cannot be split into its components
+// unambiguously, and matching one would risk deleting a live entity's state.
+// Orphaned pair state is left to TTL-based invalidation (gh#358 option 3) rather
+// than risked here.
+func stateKeyBelongsToEntity(key, entityID string) bool {
+	return entityID != "" && strings.HasSuffix(key, "."+entityID)
 }
 
 // buildPairKey creates a canonical entity pair key with IDs sorted alphabetically.

--- a/processor/rule/state_tracker_test.go
+++ b/processor/rule/state_tracker_test.go
@@ -10,6 +10,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestStateKeyBelongsToEntity covers the EXACT single-entity key match used by
+// DeleteAllForEntity. The load-bearing cases are the over-deletion guards: a
+// 6-part ID must not match a dotted prefix-sibling (drone.1 vs drone.10) NOR an
+// underscore prefix-sibling (drone.a vs the live entity drone.a_x — "_" is legal
+// inside an instance segment). Pair keys are deliberately not matched.
+func TestStateKeyBelongsToEntity(t *testing.T) {
+	t.Parallel()
+
+	const a = "org.plat.dom.sys.drone.1"
+	const a10 = "org.plat.dom.sys.drone.10" // dotted prefix sibling
+	const au = "org.plat.dom.sys.drone.a"
+	const aux = "org.plat.dom.sys.drone.a_x" // underscore prefix sibling (live entity)
+	const b = "org.plat.dom.sys.drone.2"
+
+	tests := []struct {
+		name     string
+		key      string
+		entityID string
+		want     bool
+	}{
+		{"single entity exact", buildStateKey("rule-x", a), a, true},
+		{"single entity, dotted ruleID", buildStateKey("rule.with.dots", a), a, true},
+		{"dotted prefix sibling must NOT match", buildStateKey("rule-x", a10), a, false},
+		{"underscore prefix sibling must NOT match", buildStateKey("rule-x", aux), au, false},
+		{"underscore sibling matches itself", buildStateKey("rule-x", aux), aux, true},
+		{"different entity", buildStateKey("rule-x", b), a, false},
+		// Pair keys are intentionally NOT matched (key scheme can't split them
+		// unambiguously; over-matching would risk a live entity's budget).
+		{"pair key first component not matched", buildStateKey("rule-x", buildPairKey(a, b)), a, false},
+		{"pair key second component not matched", buildStateKey("rule-x", buildPairKey(a, b)), b, false},
+		{"empty entityID", buildStateKey("rule-x", a), "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stateKeyBelongsToEntity(tt.key, tt.entityID),
+				"key=%q entityID=%q", tt.key, tt.entityID)
+		})
+	}
+}
+
 // T032: Test MatchState struct
 func TestMatchState(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Stage D of the gated-DAG program (ADR-046 Phase 2) — a standalone, framework-only fix. Closes the `$state` reset gap filed as gh#358 (companion precondition to #357). Independent of #361 (different package); reviewable on its own.

## The bug

`StateTracker.DeleteAllForEntity` (`processor/rule/state_tracker.go`) was documented as *"called when an entity is deleted to clean up orphaned state"* but had **zero callers**. So per-`(rule,entity)` `$state` — the `Iteration`/`MaxIterations` retry budget used by `max_iterations` in `when` clauses — was **never reset**. An entity recreated or reused at the same ID inherited a stale, often-exhausted budget and silently never re-fired (looks idle). Also a doc-vs-reality drift.

## The fix

1. **Wire it on delete.** The entity watcher's `DELETED` branch now calls `DeleteAllForEntity` (gated on a configured `StateTracker`, best-effort — a cleanup failure is logged, never blocks delete handling). Rule evaluation is already skipped on delete (nil-state short-circuit), so the cleanup runs orphan-free.

2. **Exact match, not a boundary heuristic.** A single-entity state key is `ruleID.entityID`, so the test is `HasSuffix(key, "."+entityID)`. This is load-bearing: `_` is **legal inside an entity instance segment** (`message.isEntityIDChar`), so a boundary check treating `_` as a delimiter over-deletes — deleting `…drone.a` would wipe a **live** sibling `…drone.a_x`, worst on high-churn agent-loop IDs. The suffix match is exact for canonical 6-part IDs.

3. **Scope.** Relationship-rule **pair** state is intentionally not matched (`_` is both the pair separator and a legal instance char → pair keys can't be split unambiguously); orphaned pair state is left to TTL invalidation (gh#358 option 3) rather than risked against a live entity's budget. **In-place reset** (without delete) is deferred — no current consumer (the gated-DAG executor sidesteps rule `$state`).

## Tests

- **Unit** (`TestStateKeyBelongsToEntity`): exact match; dotted prefix-sibling (`drone.1` vs `drone.10`) and **underscore** prefix-sibling (`drone.a` vs live `drone.a_x`) must NOT match; pair keys not matched.
- **Integration** (`state_cleanup_integration_test.go`, drives the production wire — real processor + KV delete through the watcher): the deleted entity's exhausted budget is cleared while **both** prefix-siblings survive.
- Full gate green: build, unit `-race ./...` (127 pkgs/0 fail), rule integration suite, revive, gofmt, `vet -tags=integration ./...`, no schema drift.

## Review

Pre-merge **semstreams-reviewer** caught a **BLOCKING** over-deletion bug in an earlier boundary-heuristic cut (the `_`-sibling case above) — fixed to the exact suffix match, with the underscore case added to both the unit table and the integration test. Verified against `message/triple.go` (underscores legal) and `message_handler.go` (delete-path nil-state short-circuit).

Closes #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)