### PR TITLE
feat(graph-index-temporal): event-time (observation timestamp) primary (gh#370)

### DIFF
--- a/docs/advanced/05-index-reference.md
+++ b/docs/advanced/05-index-reference.md
@@ -165,12 +165,24 @@ query {
 
 ### TEMPORAL_INDEX
 
-**Key pattern:** Timestamp-based
-**Value:** Entities at that time
+**Key pattern:** Time bucket (`YYYY.MM.DD.HH`)
+**Value:** Events for entities observed in that bucket
 
-**Created by:** Triples with timestamp values
+**Created by:** Entities keyed on their **observation timestamp** by precedence —
+`time.observation.recorded` (event-time) when present, else `UpdatedAt` (last-write fallback).
+The `entities_indexed_total{source}` metric reports the observed-vs-fallback split.
 **Used for:** "Find entities in time range"
 **Clustering:** Not yet integrated. Temporal queries (time range) are fully operational.
+
+### TEMPORAL_INDEX_REVERSE
+
+**Key pattern:** Entity ID
+**Value:** The entity's current TEMPORAL_INDEX bucket key
+
+**Created by:** graph-index-temporal, alongside each TEMPORAL_INDEX write.
+**Used for:** Removing an entity's stale event from its prior bucket when it is re-observed (its
+observation timestamp changed) or deleted, so a range query never returns an entity from a window it has
+since left.
 
 ### EMBEDDING_INDEX
 

--- a/docs/concepts/30-spatial-temporal-queries.md
+++ b/docs/concepts/30-spatial-temporal-queries.md
@@ -57,23 +57,27 @@ that is where you apply the lon-first convention.
 
 ### Time
 
-The temporal index keys on the entity's **`UpdatedAt`** timestamp — last-write time
-(`processor/graph-index-temporal/component.go:653-665`). It is a **freshness** index. The triple-based
-fallback (`core.time.timestamp`, `time.observation.recorded`, etc.) fires only when `UpdatedAt` is zero,
-which never happens in production because graph-ingest stamps `UpdatedAt` on every write. **Do not** rely
-on `time.observation.recorded` being indexed — it is not.
+The temporal index keys on the entity's **observation timestamp**, by explicit precedence
+(`processor/graph-index-temporal/component.go`, `resolveIndexTimestamp`):
 
-> **Proposed change (#370):** make the observation timestamp (`time.observation.recorded`) the *primary*
-> temporal key, with `UpdatedAt` as a fallback. Until that lands, the index keys on `UpdatedAt` as
-> described above; this section will be updated when #370 ships.
+1. `time.observation.recorded` — **event-time** (the latest value when several are present). This is the
+   canonical normalized predicate; emit it to make an entity queryable by *when it was observed*.
+2. `UpdatedAt` — **processing-time** (last write), used only as a fallback when no observation predicate
+   is present.
 
-For current-state queries ("what is fresh near here now") last-write freshness is the correct key and
-requires no product action. `UpdatedAt` is framework-owned and cannot be pinned by a product.
+This is event-time-primary on purpose: every consumer of the temporal index is a "what's *in* this
+window" range search, and write-time is a processing artifact (batched, delayed, replayed). Emitting
+`time.observation.recorded` is the normalization step — the same discipline as the numeric lat/lon pair
+on the spatial side. The `entities_indexed_total{source="observed"|"write_fallback"}` metric exposes how
+many entities still fall back, so the fallback is observable rather than silent and can be retired as
+producers adopt the predicate.
 
-**Out of scope:** historical observed-time windows ("what was *observed* between T1 and T2", independent
-of when the row was last touched). The framework has no observed-time historical index today. That is a
-separate, explicitly out-of-scope concern for this recipe — not something location/time normalization
-solves.
+Re-observation **moves** an entity to its new bucket (the prior bucket is cleaned up), and entity deletion
+removes it — so a range query never returns an entity from a window it has since left.
+
+**Out of scope:** a general historical event store (arbitrary-cardinality "every observation ever"
+replay). The temporal index holds an entity's *current* observed-time, not its full observation history;
+products needing dense historical replay should keep that in their own store.
 
 ## The compose pattern
 

--- a/graph/constants.go
+++ b/graph/constants.go
@@ -14,7 +14,12 @@ const (
 	BucketAliasIndex    = "ALIAS_INDEX"
 	BucketSpatialIndex  = "SPATIAL_INDEX"
 	BucketTemporalIndex = "TEMPORAL_INDEX"
-	BucketContextIndex  = "CONTEXT_INDEX"
+	// BucketTemporalIndexReverse maps entityID -> current temporal bucket key.
+	// It lets graph-index-temporal remove an entity's stale event from its prior
+	// time bucket when the entity is re-indexed (observed-time changed) or deleted,
+	// so a range query never returns an entity from a bucket it has since left.
+	BucketTemporalIndexReverse = "TEMPORAL_INDEX_REVERSE"
+	BucketContextIndex         = "CONTEXT_INDEX"
 
 	// Semantic tier buckets
 	BucketEmbeddingsCache = "EMBEDDINGS_CACHE"

--- a/processor/graph-index-temporal/README.md
+++ b/processor/graph-index-temporal/README.md
@@ -102,14 +102,33 @@ The TEMPORAL_INDEX uses time bucket as key:
 }
 ```
 
-## Timestamp Extraction
+## Timestamp Resolution
 
-The component extracts timestamps from:
+The component keys each entity on a timestamp chosen by explicit precedence:
 
-- Entity `updated_at` field
-- Entity `created_at` field
-- `timestamp` predicate in triples
-- `observation.timestamp` predicate
+1. `time.observation.recorded` triple — **event-time** (the latest value when several are present). This
+   is the canonical predicate; emit it to index an entity by *when it was observed*.
+2. Entity `UpdatedAt` field — **processing-time** (last write), used only as a fallback when no
+   observation predicate is present.
+
+The `entities_indexed_total{source="observed"|"write_fallback"}` metric reports how many entities use
+each path, so the fallback is observable and can be retired as producers adopt the predicate.
+
+Re-observation moves an entity to its new time bucket (the prior bucket entry is cleaned up via the
+`TEMPORAL_INDEX_REVERSE` map), and entity deletion removes it — so range queries never return an entity
+from a window it has since left.
+
+## Upgrading (event-time flip, gh#370)
+
+This index now keys on event-time (`time.observation.recorded`) instead of write-time
+(`UpdatedAt`), and tracks each entity's current bucket in `TEMPORAL_INDEX_REVERSE` for cleanup.
+Entities indexed by an **earlier** version of this component have no reverse-map entry, so the
+stale-entry cleanup cannot locate their old (write-time) bucket — those entries are orphaned.
+
+`TEMPORAL_INDEX` is a derived, rebuildable index. On upgrade, **purge `TEMPORAL_INDEX` and
+`TEMPORAL_INDEX_REVERSE`**; the component re-delivers every entity via `WatchAll` on start and
+rebuilds both cleanly into event-time buckets. Skipping the purge is non-fatal (queries still
+return current entities) but leaves pre-upgrade orphans in old buckets until the purge is done.
 
 ## Temporal Queries
 
@@ -131,9 +150,9 @@ The gateway component uses this index for:
 
 | Metric | Type | Description |
 |--------|------|-------------|
-| `graph_temporal_indexed_total` | counter | Total entities indexed |
-| `graph_temporal_buckets_active` | gauge | Active time buckets |
-| `graph_temporal_errors_total` | counter | Indexing errors |
+| `semstreams_graph_index_temporal_entities_indexed_total{source}` | counter | Entities indexed, labelled `observed` (event-time) or `write_fallback` (UpdatedAt). A rising `write_fallback` ratio means producers have not adopted `time.observation.recorded`. |
+| `semstreams_graph_index_temporal_stale_bucket_removals_total` | counter | Entity events removed from a prior bucket on re-index/delete. |
+| `semstreams_graph_index_temporal_reverse_index_errors_total` | counter | Reverse-map write/delete failures (forward/reverse drift). |
 
 ## Health
 

--- a/processor/graph-index-temporal/component.go
+++ b/processor/graph-index-temporal/component.go
@@ -171,6 +171,13 @@ type Component struct {
 
 	// Domain resources
 	temporalBucket jetstream.KeyValue
+	// reverseBucket maps entityID -> current temporal bucket key so a re-indexed
+	// or deleted entity can be removed from its prior bucket (gh#370 stale-entry
+	// cleanup). Nil-safe: cleanup is skipped when this is unset.
+	reverseBucket jetstream.KeyValue
+
+	// Prometheus metrics (event-time vs write-fallback split, stale removals)
+	metrics *temporalMetrics
 
 	// Lifecycle state
 	mu          sync.RWMutex
@@ -226,6 +233,7 @@ func CreateGraphIndexTemporal(rawConfig json.RawMessage, deps component.Dependen
 		config:     config,
 		natsClient: natsClient,
 		logger:     logger,
+		metrics:    getMetrics(deps.MetricsRegistry),
 	}
 
 	// Initialize last activity
@@ -469,6 +477,21 @@ func (c *Component) Start(ctx context.Context) error {
 	}
 	c.temporalBucket = temporalBucket
 
+	// Create the reverse index bucket (entityID -> current bucket key) used for
+	// stale-entry cleanup on re-index and delete.
+	reverseBucket, err := c.natsClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      graph.BucketTemporalIndexReverse,
+		Description: "Temporal index reverse map (entity -> current time bucket) for stale-entry cleanup",
+	})
+	if err != nil {
+		cancel()
+		if ctx.Err() != nil {
+			return errs.Wrap(ctx.Err(), "Component", "Start", "context cancelled during reverse bucket creation")
+		}
+		return errs.Wrap(err, "Component", "Start", fmt.Sprintf("KV bucket creation: %s", graph.BucketTemporalIndexReverse))
+	}
+	c.reverseBucket = reverseBucket
+
 	// Initialize lifecycle reporter early for dependency waiting visibility
 	c.initLifecycleReporter(ctx)
 
@@ -650,24 +673,24 @@ func (c *Component) processEntityUpdate(ctx context.Context, entry jetstream.Key
 		entityID = state.Triples[0].Subject
 	}
 
-	// Use entity's UpdatedAt timestamp (matching indexmanager/indexes.go pattern)
-	// The UpdatedAt field is always set when the entity is stored, providing
-	// consistent temporal indexing without relying on triple predicates
-	ts := state.UpdatedAt
-	if ts.IsZero() {
-		// Fallback to triple-based extraction if UpdatedAt is not set
-		if extracted := c.extractTimestamp(state.Triples); extracted != nil {
-			ts = *extracted
-		} else {
-			// Skip if no timestamp available
-			return
-		}
+	// Resolve the index timestamp by explicit precedence: the observation
+	// timestamp (event-time) when present, else UpdatedAt (processing-time).
+	ts, source, ok := resolveIndexTimestamp(state)
+	if !ok {
+		// No usable timestamp — entity is not temporally indexable.
+		return
 	}
 
 	// Calculate time bucket based on resolution
 	timeBucket := c.calculateTimeBucket(ts)
 
-	// Update temporal index
+	// Look up the entity's prior bucket before mutating anything.
+	prevBucket, hadPrev := c.getReverseBucket(ctx, entityID)
+
+	// Add/refresh the entity in its (new) bucket FIRST. If this fails we return
+	// before touching the prior bucket, so the entity stays queryable at its old
+	// location rather than disappearing — the safe failure mode for an index
+	// feeding "what's in this window" (upsert by entity within the bucket).
 	if err := c.updateTemporalIndex(ctx, timeBucket, entityID, ts); err != nil {
 		c.logger.Warn("failed to update temporal index",
 			slog.String("entity", entityID),
@@ -677,48 +700,91 @@ func (c *Component) processEntityUpdate(ctx context.Context, entry jetstream.Key
 		return
 	}
 
+	// Then remove the stale entry from the prior bucket if the entity moved. A
+	// failure here degrades to a transient duplicate (range queries dedup by
+	// entity), not a disappearance.
+	if hadPrev && prevBucket != timeBucket {
+		c.removeEntityFromBucket(ctx, prevBucket, entityID)
+	}
+
+	// Record the entity's current bucket for future cleanup, and the source split.
+	c.setReverseBucket(ctx, entityID, timeBucket)
+	c.metrics.recordIndexed(source)
+
 	c.logger.Debug("indexed entity temporal data",
 		slog.String("entity", entityID),
 		slog.String("bucket", timeBucket),
+		slog.String("timestamp_source", source),
 		slog.Time("timestamp", ts))
 
 	atomic.AddInt64(&c.messagesProcessed, 1)
 	c.lastActivity.Store(time.Now())
 }
 
-// extractTimestamp extracts a timestamp from entity triples
-func (c *Component) extractTimestamp(triples []message.Triple) *time.Time {
+// predicateObservationRecorded is the canonical event-time (observation) predicate.
+// When present it is the PRIMARY temporal index key; UpdatedAt is the fallback.
+const predicateObservationRecorded = "time.observation.recorded"
+
+// resolveIndexTimestamp picks the timestamp to index an entity under, by explicit
+// precedence (gh#370):
+//
+//  1. time.observation.recorded — event-time (latest value when several present)
+//  2. EntityState.UpdatedAt     — processing-time (last-write) fallback
+//
+// The returned source is indexSourceObserved or indexSourceWriteFallback. ok is
+// false only when neither a parseable observation timestamp nor a non-zero
+// UpdatedAt is available.
+func resolveIndexTimestamp(state graph.EntityState) (ts time.Time, source string, ok bool) {
+	if observed, found := latestObservationTime(state.Triples); found {
+		return observed, indexSourceObserved, true
+	}
+	if !state.UpdatedAt.IsZero() {
+		return state.UpdatedAt, indexSourceWriteFallback, true
+	}
+	return time.Time{}, "", false
+}
+
+// latestObservationTime returns the most recent parseable value of the
+// observation predicate across the triples, if any. Observation timestamps
+// should be authored single-valued (replace-on-update); when more than one is
+// present the latest wins rather than an arbitrary first-match.
+func latestObservationTime(triples []message.Triple) (time.Time, bool) {
+	var latest time.Time
+	found := false
 	for _, triple := range triples {
-		switch triple.Predicate {
-		case "core.time.timestamp", "timestamp", "time.timestamp", "time.observation.recorded", "created_at", "updated_at":
-			// Try to parse the object as various time formats
-			switch v := triple.Object.(type) {
-			case time.Time:
-				return &v
-			case string:
-				// Try RFC3339 first
-				if t, err := time.Parse(time.RFC3339, v); err == nil {
-					return &t
-				}
-				// Try RFC3339Nano
-				if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
-					return &t
-				}
-				// Try common ISO format
-				if t, err := time.Parse("2006-01-02T15:04:05Z", v); err == nil {
-					return &t
-				}
-			case float64:
-				// Unix timestamp
-				t := time.Unix(int64(v), 0)
-				return &t
-			case int64:
-				t := time.Unix(v, 0)
-				return &t
+		if triple.Predicate != predicateObservationRecorded {
+			continue
+		}
+		if t, ok := parseTripleTime(triple.Object); ok {
+			if !found || t.After(latest) {
+				latest = t
+				found = true
 			}
 		}
 	}
-	return nil
+	return latest, found
+}
+
+// parseTripleTime parses a triple object into a time.Time, accepting time.Time,
+// RFC3339 / RFC3339Nano / common-ISO strings, and Unix-seconds numerics.
+func parseTripleTime(obj any) (time.Time, bool) {
+	switch v := obj.(type) {
+	case time.Time:
+		return v, true
+	case string:
+		for _, layout := range []string{time.RFC3339, time.RFC3339Nano, "2006-01-02T15:04:05Z"} {
+			if t, err := time.Parse(layout, v); err == nil {
+				return t, true
+			}
+		}
+	case float64:
+		return time.Unix(int64(v), 0).UTC(), true
+	case int64:
+		return time.Unix(v, 0).UTC(), true
+	case int:
+		return time.Unix(int64(v), 0).UTC(), true
+	}
+	return time.Time{}, false
 }
 
 // calculateTimeBucket calculates the time bucket key based on configured resolution
@@ -761,13 +827,24 @@ func (c *Component) updateTemporalIndex(ctx context.Context, timeBucket, entityI
 	// Get or create events array
 	events, _ := temporalData["events"].([]interface{})
 
-	// Append new event (accumulate all events, matching indexmanager pattern)
+	// Upsert by entity: drop any existing event for this entity in this bucket,
+	// then append the current one. Keeps re-indexing the same entity to the same
+	// bucket idempotent (e.g. restart WatchAll re-delivery) and one-event-per-entity.
+	filtered := make([]interface{}, 0, len(events)+1)
+	for _, evt := range events {
+		if m, ok := evt.(map[string]interface{}); ok {
+			if e, _ := m["entity"].(string); e == entityID {
+				continue
+			}
+		}
+		filtered = append(filtered, evt)
+	}
 	newEvent := map[string]interface{}{
 		"entity":    entityID,
 		"type":      "update",
 		"timestamp": ts.Format(time.RFC3339),
 	}
-	events = append(events, newEvent)
+	events = append(filtered, newEvent)
 	temporalData["events"] = events
 
 	// Track unique entity count
@@ -800,8 +877,120 @@ func (c *Component) updateTemporalIndex(ctx context.Context, timeBucket, entityI
 	return nil
 }
 
-// handleEntityDelete handles entity deletion from the temporal index
-func (c *Component) handleEntityDelete(_ context.Context, entityID string) {
-	c.logger.Debug("entity deleted - temporal cleanup not fully implemented",
-		slog.String("entity", entityID))
+// handleEntityDelete removes a deleted entity from its temporal bucket and its
+// reverse mapping, so range queries no longer return it.
+func (c *Component) handleEntityDelete(ctx context.Context, entityID string) {
+	prevBucket, found := c.getReverseBucket(ctx, entityID)
+	if !found {
+		c.logger.Debug("entity deleted - no temporal reverse entry to clean",
+			slog.String("entity", entityID))
+		return
+	}
+	c.removeEntityFromBucket(ctx, prevBucket, entityID)
+	c.deleteReverseBucket(ctx, entityID)
+	c.logger.Debug("entity deleted - temporal cleanup done",
+		slog.String("entity", entityID),
+		slog.String("bucket", prevBucket))
+}
+
+// removeEntityFromBucket removes all events for entityID from the given time
+// bucket, deleting the bucket key if it becomes empty. Best-effort: missing
+// buckets and transient errors are logged at debug and swallowed.
+func (c *Component) removeEntityFromBucket(ctx context.Context, bucket, entityID string) {
+	entry, err := c.temporalBucket.Get(ctx, bucket)
+	if err != nil {
+		return // bucket already gone — nothing to remove
+	}
+
+	var temporalData map[string]interface{}
+	if err := json.Unmarshal(entry.Value(), &temporalData); err != nil {
+		return
+	}
+
+	events, _ := temporalData["events"].([]interface{})
+	filtered := make([]interface{}, 0, len(events))
+	removed := false
+	for _, evt := range events {
+		if m, ok := evt.(map[string]interface{}); ok {
+			if e, _ := m["entity"].(string); e == entityID {
+				removed = true
+				continue
+			}
+		}
+		filtered = append(filtered, evt)
+	}
+	if !removed {
+		return
+	}
+
+	if len(filtered) == 0 {
+		// No events left — drop the bucket key entirely.
+		if err := c.temporalBucket.Delete(ctx, bucket); err != nil {
+			c.logger.Debug("failed to delete empty temporal bucket",
+				slog.String("bucket", bucket), slog.Any("error", err))
+		}
+		c.metrics.recordStaleRemoval()
+		return
+	}
+
+	// Recompute unique entity count and write back.
+	uniqueEntities := make(map[string]bool)
+	for _, evt := range filtered {
+		if m, ok := evt.(map[string]interface{}); ok {
+			if e, ok := m["entity"].(string); ok {
+				uniqueEntities[e] = true
+			}
+		}
+	}
+	temporalData["events"] = filtered
+	temporalData["entity_count"] = len(uniqueEntities)
+
+	data, err := json.Marshal(temporalData)
+	if err != nil {
+		return
+	}
+	if _, err := c.temporalBucket.Update(ctx, bucket, data, entry.Revision()); err != nil {
+		c.logger.Debug("failed to write temporal bucket after stale removal",
+			slog.String("bucket", bucket), slog.Any("error", err))
+		return
+	}
+	c.metrics.recordStaleRemoval()
+}
+
+// getReverseBucket returns the time bucket the entity is currently indexed in.
+func (c *Component) getReverseBucket(ctx context.Context, entityID string) (string, bool) {
+	if c.reverseBucket == nil {
+		return "", false
+	}
+	entry, err := c.reverseBucket.Get(ctx, entityID)
+	if err != nil {
+		return "", false
+	}
+	return string(entry.Value()), true
+}
+
+// setReverseBucket records the time bucket the entity is currently indexed in.
+func (c *Component) setReverseBucket(ctx context.Context, entityID, bucket string) {
+	if c.reverseBucket == nil {
+		return
+	}
+	if _, err := c.reverseBucket.Put(ctx, entityID, []byte(bucket)); err != nil {
+		// Drift risk: a missing reverse entry means a later delete/re-index can't
+		// clean this entity's bucket. Warn + count so it is observable.
+		c.logger.Warn("failed to write temporal reverse index (forward/reverse may drift)",
+			slog.String("entity", entityID), slog.Any("error", err))
+		c.metrics.recordReverseError()
+	}
+}
+
+// deleteReverseBucket removes the entity's reverse mapping.
+func (c *Component) deleteReverseBucket(ctx context.Context, entityID string) {
+	if c.reverseBucket == nil {
+		return
+	}
+	if err := c.reverseBucket.Delete(ctx, entityID); err != nil {
+		c.logger.Warn("failed to delete temporal reverse index",
+			slog.String("entity", entityID), slog.Any("error", err))
+		c.metrics.recordReverseError()
+	}
 }

--- a/processor/graph-index-temporal/event_time_test.go
+++ b/processor/graph-index-temporal/event_time_test.go
@@ -1,0 +1,292 @@
+package graphindextemporal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newEventTimeTestComponent builds a Component wired to in-memory mock buckets
+// for exercising the indexing logic directly (no NATS).
+func newEventTimeTestComponent() (*Component, *mockKVBucket, *mockKVBucket) {
+	tb := newMockKVBucket()
+	rb := newMockKVBucket()
+	c := &Component{
+		name:              "graph-index-temporal",
+		config:            Config{TimeResolution: "hour"},
+		logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		temporalBucket:    tb,
+		reverseBucket:     rb,
+		metrics:           getMetrics(nil),
+		lifecycleReporter: component.NewNoOpLifecycleReporter(),
+	}
+	c.lastActivity.Store(time.Now())
+	return c, tb, rb
+}
+
+func entityEntry(t *testing.T, state graph.EntityState) jetstream.KeyValueEntry {
+	t.Helper()
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	return &mockKVEntry{data: data}
+}
+
+// bucketEntities returns the entity IDs present in a temporal bucket key, or nil
+// if the bucket key does not exist.
+func bucketEntities(t *testing.T, tb *mockKVBucket, key string) []string {
+	t.Helper()
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	raw, ok := tb.data[key]
+	if !ok {
+		return nil
+	}
+	var d struct {
+		Events []struct {
+			Entity string `json:"entity"`
+		} `json:"events"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &d))
+	ids := make([]string, 0, len(d.Events))
+	for _, e := range d.Events {
+		ids = append(ids, e.Entity)
+	}
+	return ids
+}
+
+func observedTriple(entityID, ts string) message.Triple {
+	return message.Triple{Subject: entityID, Predicate: predicateObservationRecorded, Object: ts, Source: "test"}
+}
+
+// ---------------------------------------------------------------------------
+// resolveIndexTimestamp precedence
+// ---------------------------------------------------------------------------
+
+func TestResolveIndexTimestamp_ObservedTakesPrecedence(t *testing.T) {
+	observed := time.Date(2026, 1, 7, 14, 30, 0, 0, time.UTC)
+	updated := time.Date(2026, 1, 8, 9, 0, 0, 0, time.UTC)
+	state := graph.EntityState{
+		ID:        "acme.ops.robotics.gcs.drone.001",
+		Triples:   []message.Triple{observedTriple("acme.ops.robotics.gcs.drone.001", observed.Format(time.RFC3339))},
+		UpdatedAt: updated,
+	}
+
+	ts, source, ok := resolveIndexTimestamp(state)
+	require.True(t, ok)
+	assert.Equal(t, indexSourceObserved, source)
+	assert.True(t, observed.Equal(ts), "expected observed time %v, got %v", observed, ts)
+}
+
+func TestResolveIndexTimestamp_FallsBackToUpdatedAt(t *testing.T) {
+	updated := time.Date(2026, 1, 8, 9, 0, 0, 0, time.UTC)
+	state := graph.EntityState{
+		ID:        "acme.ops.robotics.gcs.drone.001",
+		Triples:   []message.Triple{{Subject: "acme.ops.robotics.gcs.drone.001", Predicate: "robotics.status.armed", Object: true}},
+		UpdatedAt: updated,
+	}
+
+	ts, source, ok := resolveIndexTimestamp(state)
+	require.True(t, ok)
+	assert.Equal(t, indexSourceWriteFallback, source)
+	assert.True(t, updated.Equal(ts))
+}
+
+func TestResolveIndexTimestamp_MultipleObserved_LatestWins(t *testing.T) {
+	early := time.Date(2026, 1, 7, 10, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 1, 7, 18, 0, 0, 0, time.UTC)
+	id := "acme.ops.robotics.gcs.drone.001"
+	state := graph.EntityState{
+		ID: id,
+		// Deliberately out of order to prove latest-wins, not first/last-match.
+		Triples: []message.Triple{
+			observedTriple(id, late.Format(time.RFC3339)),
+			observedTriple(id, early.Format(time.RFC3339)),
+		},
+		UpdatedAt: time.Date(2026, 1, 9, 0, 0, 0, 0, time.UTC),
+	}
+
+	ts, source, ok := resolveIndexTimestamp(state)
+	require.True(t, ok)
+	assert.Equal(t, indexSourceObserved, source)
+	assert.True(t, late.Equal(ts), "expected latest observed %v, got %v", late, ts)
+}
+
+func TestResolveIndexTimestamp_NoTimestamp_NotIndexable(t *testing.T) {
+	state := graph.EntityState{
+		ID:      "acme.ops.robotics.gcs.drone.001",
+		Triples: []message.Triple{{Subject: "x", Predicate: "robotics.status.armed", Object: true}},
+		// UpdatedAt zero, no observation predicate.
+	}
+	_, _, ok := resolveIndexTimestamp(state)
+	assert.False(t, ok)
+}
+
+func TestResolveIndexTimestamp_UnparseableObserved_FallsBack(t *testing.T) {
+	updated := time.Date(2026, 1, 8, 9, 0, 0, 0, time.UTC)
+	id := "acme.ops.robotics.gcs.drone.001"
+	state := graph.EntityState{
+		ID:        id,
+		Triples:   []message.Triple{observedTriple(id, "not-a-timestamp")},
+		UpdatedAt: updated,
+	}
+	ts, source, ok := resolveIndexTimestamp(state)
+	require.True(t, ok)
+	assert.Equal(t, indexSourceWriteFallback, source)
+	assert.True(t, updated.Equal(ts))
+}
+
+// ---------------------------------------------------------------------------
+// processEntityUpdate: bucketing + cleanup
+// ---------------------------------------------------------------------------
+
+func TestProcessEntityUpdate_IndexesByObservedTime_NotWriteTime(t *testing.T) {
+	c, tb, rb := newEventTimeTestComponent()
+	ctx := context.Background()
+
+	id := "acme.ops.robotics.gcs.drone.001"
+	observedBucket := "2026.01.07.14"
+	writeBucket := "2026.01.08.09"
+
+	state := graph.EntityState{
+		ID:        id,
+		Triples:   []message.Triple{observedTriple(id, "2026-01-07T14:30:00Z")},
+		UpdatedAt: time.Date(2026, 1, 8, 9, 0, 0, 0, time.UTC),
+	}
+	c.processEntityUpdate(ctx, entityEntry(t, state))
+
+	assert.Contains(t, bucketEntities(t, tb, observedBucket), id, "entity should be in the OBSERVED-time bucket")
+	assert.Nil(t, bucketEntities(t, tb, writeBucket), "entity must NOT be in the write-time bucket")
+
+	rev, _ := rb.Get(ctx, id)
+	require.NotNil(t, rev)
+	assert.Equal(t, observedBucket, string(rev.Value()), "reverse index should point at the observed bucket")
+}
+
+func TestProcessEntityUpdate_ReindexMovesEntity_NoStaleEntry(t *testing.T) {
+	c, tb, _ := newEventTimeTestComponent()
+	ctx := context.Background()
+	id := "acme.ops.robotics.gcs.drone.001"
+
+	first := graph.EntityState{ID: id, Triples: []message.Triple{observedTriple(id, "2026-01-07T14:30:00Z")}}
+	c.processEntityUpdate(ctx, entityEntry(t, first))
+	require.Contains(t, bucketEntities(t, tb, "2026.01.07.14"), id)
+
+	// Re-observe later — entity must move buckets and leave no stale entry behind.
+	second := graph.EntityState{ID: id, Triples: []message.Triple{observedTriple(id, "2026-01-07T16:30:00Z")}}
+	c.processEntityUpdate(ctx, entityEntry(t, second))
+
+	assert.Contains(t, bucketEntities(t, tb, "2026.01.07.16"), id, "entity should be in the new bucket")
+	assert.NotContains(t, bucketEntities(t, tb, "2026.01.07.14"), id, "entity must NOT linger in the prior bucket")
+}
+
+func TestProcessEntityUpdate_SameBucketReindex_Idempotent(t *testing.T) {
+	c, tb, _ := newEventTimeTestComponent()
+	ctx := context.Background()
+	id := "acme.ops.robotics.gcs.drone.001"
+
+	state := graph.EntityState{ID: id, Triples: []message.Triple{observedTriple(id, "2026-01-07T14:30:00Z")}}
+	c.processEntityUpdate(ctx, entityEntry(t, state))
+	c.processEntityUpdate(ctx, entityEntry(t, state)) // e.g. restart WatchAll re-delivery
+
+	got := bucketEntities(t, tb, "2026.01.07.14")
+	count := 0
+	for _, e := range got {
+		if e == id {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "re-indexing to the same bucket must not duplicate the entity event")
+}
+
+func TestProcessEntityUpdate_DistinctEntitiesShareBucket(t *testing.T) {
+	c, tb, _ := newEventTimeTestComponent()
+	ctx := context.Background()
+
+	for _, id := range []string{"a.b.c.d.e.1", "a.b.c.d.e.2", "a.b.c.d.e.3"} {
+		state := graph.EntityState{ID: id, Triples: []message.Triple{observedTriple(id, "2026-01-07T14:05:00Z")}}
+		c.processEntityUpdate(ctx, entityEntry(t, state))
+	}
+	got := bucketEntities(t, tb, "2026.01.07.14")
+	assert.ElementsMatch(t, []string{"a.b.c.d.e.1", "a.b.c.d.e.2", "a.b.c.d.e.3"}, got)
+}
+
+func TestProcessEntityUpdate_AddFailure_DoesNotRemoveFromPriorBucket(t *testing.T) {
+	c, tb, _ := newEventTimeTestComponent()
+	ctx := context.Background()
+	id := "acme.ops.robotics.gcs.drone.001"
+
+	// Index at T1 -> bucket "2026.01.07.14".
+	first := graph.EntityState{ID: id, Triples: []message.Triple{observedTriple(id, "2026-01-07T14:30:00Z")}}
+	c.processEntityUpdate(ctx, entityEntry(t, first))
+	require.Contains(t, bucketEntities(t, tb, "2026.01.07.14"), id)
+
+	// Ensure the destination bucket exists (so the write takes the Update path),
+	// then make every write fail.
+	tb.mu.Lock()
+	tb.data["2026.01.07.16"] = []byte(`{"events":[{"entity":"other.e.1","type":"update","timestamp":"2026-01-07T16:00:00Z"}],"entity_count":1}`)
+	tb.mu.Unlock()
+	tb.putFunc = func(_ context.Context, _ string, _ []byte) (uint64, error) {
+		return 0, errors.New("injected write failure")
+	}
+
+	// Re-observe at T2 — the move's add fails; the prior-bucket removal must not run.
+	second := graph.EntityState{ID: id, Triples: []message.Triple{observedTriple(id, "2026-01-07T16:30:00Z")}}
+	c.processEntityUpdate(ctx, entityEntry(t, second))
+
+	tb.putFunc = nil
+	assert.Contains(t, bucketEntities(t, tb, "2026.01.07.14"), id,
+		"on add failure the entity must remain queryable in its prior bucket (no remove-before-add)")
+}
+
+func TestHandleEntityDelete_RemovesFromBucketAndReverse(t *testing.T) {
+	c, tb, rb := newEventTimeTestComponent()
+	ctx := context.Background()
+	id := "acme.ops.robotics.gcs.drone.001"
+
+	state := graph.EntityState{ID: id, Triples: []message.Triple{observedTriple(id, "2026-01-07T14:30:00Z")}}
+	c.processEntityUpdate(ctx, entityEntry(t, state))
+	require.Contains(t, bucketEntities(t, tb, "2026.01.07.14"), id)
+
+	c.handleEntityDelete(ctx, id)
+
+	assert.NotContains(t, bucketEntities(t, tb, "2026.01.07.14"), id, "deleted entity must be gone from its bucket")
+	_, err := rb.Get(ctx, id)
+	assert.ErrorIs(t, err, jetstream.ErrKeyNotFound, "reverse entry should be removed")
+}
+
+// ---------------------------------------------------------------------------
+// metric split
+// ---------------------------------------------------------------------------
+
+func TestProcessEntityUpdate_MetricSplit_ObservedVsFallback(t *testing.T) {
+	c, _, _ := newEventTimeTestComponent()
+	ctx := context.Background()
+
+	observedBefore := testutil.ToFloat64(c.metrics.indexed.WithLabelValues(indexSourceObserved))
+	fallbackBefore := testutil.ToFloat64(c.metrics.indexed.WithLabelValues(indexSourceWriteFallback))
+
+	withObserved := graph.EntityState{ID: "a.b.c.d.e.1", Triples: []message.Triple{observedTriple("a.b.c.d.e.1", "2026-01-07T14:30:00Z")}}
+	c.processEntityUpdate(ctx, entityEntry(t, withObserved))
+
+	withoutObserved := graph.EntityState{
+		ID:        "a.b.c.d.e.2",
+		Triples:   []message.Triple{{Subject: "a.b.c.d.e.2", Predicate: "robotics.status.armed", Object: true}},
+		UpdatedAt: time.Date(2026, 1, 8, 9, 0, 0, 0, time.UTC),
+	}
+	c.processEntityUpdate(ctx, entityEntry(t, withoutObserved))
+
+	assert.Equal(t, observedBefore+1, testutil.ToFloat64(c.metrics.indexed.WithLabelValues(indexSourceObserved)))
+	assert.Equal(t, fallbackBefore+1, testutil.ToFloat64(c.metrics.indexed.WithLabelValues(indexSourceWriteFallback)))
+}

--- a/processor/graph-index-temporal/metrics.go
+++ b/processor/graph-index-temporal/metrics.go
@@ -1,0 +1,109 @@
+// Package graphindextemporal provides Prometheus metrics for the graph-index-temporal component.
+package graphindextemporal
+
+import (
+	"sync"
+
+	"github.com/c360studio/semstreams/metric"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Index timestamp-source labels for temporalMetrics.indexed.
+const (
+	// indexSourceObserved means the entity was indexed by its observation
+	// timestamp (time.observation.recorded) — the correct event-time key.
+	indexSourceObserved = "observed"
+	// indexSourceWriteFallback means the entity had no observation predicate
+	// and was indexed by its UpdatedAt (last-write) timestamp instead. A high
+	// or rising ratio of this label means producers have not yet adopted the
+	// observation predicate — it is the visible ledger for retiring the fallback.
+	indexSourceWriteFallback = "write_fallback"
+)
+
+// temporalMetrics holds Prometheus metrics for the graph-index-temporal component.
+type temporalMetrics struct {
+	// indexed counts entities indexed, labelled by the timestamp source that
+	// keyed them (observed | write_fallback). Surfaces the event-time vs
+	// processing-time split so the managed UpdatedAt fallback is observable,
+	// not silent (gh#370).
+	indexed *prometheus.CounterVec
+	// staleRemovals counts entity events removed from a prior time bucket on
+	// re-index or delete — the cleanup that keeps range queries from returning
+	// an entity out of a bucket it has since left.
+	staleRemovals prometheus.Counter
+	// reverseErrors counts failures writing or deleting the reverse map. A
+	// nonzero value means the forward index and the reverse map may have drifted
+	// (e.g. an entity could survive deletion in range queries) — paired with a
+	// Warn log at the call site so the drift is observable, not silent.
+	reverseErrors prometheus.Counter
+}
+
+// Package-level metrics (registered once to avoid duplicate registration errors).
+var (
+	metricsOnce sync.Once
+	metrics     *temporalMetrics
+)
+
+// getMetrics returns the singleton metrics instance, creating and registering it if needed.
+func getMetrics(registry *metric.MetricsRegistry) *temporalMetrics {
+	metricsOnce.Do(func() {
+		metrics = &temporalMetrics{
+			indexed: prometheus.NewCounterVec(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_index_temporal",
+				Name:      "entities_indexed_total",
+				Help:      "Entities indexed by timestamp source: observed (time.observation.recorded) or write_fallback (UpdatedAt). A rising write_fallback ratio means producers have not adopted the observation predicate.",
+			}, []string{"source"}),
+
+			staleRemovals: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_index_temporal",
+				Name:      "stale_bucket_removals_total",
+				Help:      "Entity events removed from a prior time bucket on re-index or delete (stale-entry cleanup).",
+			}),
+
+			reverseErrors: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_index_temporal",
+				Name:      "reverse_index_errors_total",
+				Help:      "Failures writing/deleting the reverse map (entity -> bucket). Nonzero means the forward index and reverse map may have drifted.",
+			}),
+		}
+
+		if registry != nil {
+			_ = registry.RegisterCounterVec("graph-index-temporal", "entities_indexed_total", metrics.indexed)
+			_ = registry.RegisterCounter("graph-index-temporal", "stale_bucket_removals_total", metrics.staleRemovals)
+			_ = registry.RegisterCounter("graph-index-temporal", "reverse_index_errors_total", metrics.reverseErrors)
+		} else {
+			// Fallback to default prometheus registry for testing.
+			_ = prometheus.DefaultRegisterer.Register(metrics.indexed)
+			_ = prometheus.DefaultRegisterer.Register(metrics.staleRemovals)
+			_ = prometheus.DefaultRegisterer.Register(metrics.reverseErrors)
+		}
+	})
+	return metrics
+}
+
+// recordIndexed records an entity indexed under the given timestamp source.
+func (m *temporalMetrics) recordIndexed(source string) {
+	if m == nil {
+		return
+	}
+	m.indexed.WithLabelValues(source).Inc()
+}
+
+// recordStaleRemoval records an entity event removed from a prior time bucket.
+func (m *temporalMetrics) recordStaleRemoval() {
+	if m == nil {
+		return
+	}
+	m.staleRemovals.Inc()
+}
+
+// recordReverseError records a reverse-map write/delete failure (index drift).
+func (m *temporalMetrics) recordReverseError() {
+	if m == nil {
+		return
+	}
+	m.reverseErrors.Inc()
+}


### PR DESCRIPTION
Closes #370.

## What

The temporal index now keys entities on **event-time** — `time.observation.recorded` (latest value) — as PRIMARY, falling back to `UpdatedAt` (last-write) only when the observation predicate is absent. Surfaced triaging #368: the index is an append-only event log feeding range searches, and every consumer (GraphQL `temporalSearch`, the globalSearch temporal strategy, `research-graph-execute`) asks "what's *in* this window" — for which write-time is a processing artifact and event-time is the meaning intended.

- **Explicit precedence** (`resolveIndexTimestamp`) replaces the old first-match-wins grab-bag; takes the **latest** observation value, not an arbitrary match.
- **Observable managed fallback**: `entities_indexed_total{source="observed"|"write_fallback"}` exposes how many entities still fall back, so it can be retired as producers adopt the predicate.
- **Stale-entry cleanup** (`TEMPORAL_INDEX_REVERSE` map): re-observation **moves** an entity to its new bucket (prior bucket cleaned), deletion removes it — so a range query never returns an entity from a window it has since left. `handleEntityDelete` (previously a no-op) is now implemented.
- **Upsert-by-entity** makes restart `WatchAll` re-delivery idempotent.

## Pre-merge review (semstreams-reviewer) — addressed

- **HIGH (ordering):** the bucket move now writes the new bucket **before** removing from the old, so a mid-update failure degrades to a query-deduped duplicate rather than a temporary disappearance. New test `TestProcessEntityUpdate_AddFailure_DoesNotRemoveFromPriorBucket`.
- **HIGH (migration):** entities indexed by a prior version have no reverse entry → pre-upgrade orphans. `TEMPORAL_INDEX` is rebuildable; documented the one-time purge in the package README "Upgrading" section.
- **MEDIUM (observability):** reverse-map write failures are now Warn-logged + counted (`reverse_index_errors_total`).
- Cleared: KV key validity (entityID is already the ENTITY_STATES key), query-path collision (separate bucket), precedence/timezone correctness, metrics house-pattern, test fidelity (drives `processEntityUpdate`/`handleEntityDelete`).

## Compatibility / e2e

Backward-compatible for entities **without** an observation predicate — they fall through to `UpdatedAt` unchanged. The e2e structural tier's temporal test (`temporalSearch`) uses such data (no `observed_at` anywhere in `test/e2e/`), so it exercises the **fallback path** and is unaffected. **Coverage gap:** there is no e2e exercising the observation-predicate temporal path — worth filing before any BREAKING tag that includes this. Per the project's e2e-before-tag rule, run a temporal-covering tier (or confirm the gap) at tag time.

## Gates

`gofmt` clean · `go vet` (default + integration tags) · `revive` clean · `go build ./...` · `go test -race ./processor/graph-index-temporal/... ./graph/...` · integration tests (`-tags=integration -race`, real NATS) · schema:generate no-diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)