### PR TITLE
test(gated-dag): widen full-stack Eventually windows for CI latency (gh#373)

### DIFF
--- a/processor/gated-dag/fullstack_integration_test.go
+++ b/processor/gated-dag/fullstack_integration_test.go
@@ -54,6 +54,18 @@ const (
 
 const fsBackstop = "250ms"
 
+// fsEventually bounds the full-stack Eventually waits. These tests drive a real
+// multi-component pipeline (NATS → graph-ingest mutation+query → executor →
+// demo consumer doing mutation-with-retry), so a single DAG level is several
+// serial NATS round-trips; a diamond is three of them. The 250ms fsBackstop
+// guarantees forward progress the moment a marker lands, so this window only
+// needs to absorb upstream pipeline latency under CI contention — it does not
+// mask a logic stall (a genuinely stuck DAG never advances regardless of wait).
+// Sized at ~3x the prior 10s, which flaked under heavy CI load (gh#373). A
+// re-flake at this bound would indicate a real stall, not slowness, and warrants
+// deeper investigation rather than a further bump.
+const fsEventually = 30 * time.Second
+
 // dispatchLog is the thread-safe ordered record of units the executor dispatched
 // (decoded off the dispatch subject by the demo consumer).
 type dispatchLog struct {
@@ -322,7 +334,7 @@ func TestFullStack_DependsOnOrderingAndDedup(t *testing.T) {
 	require.Eventually(t, func() bool {
 		s := fs.dispatched.snapshot()
 		return len(s) == 4
-	}, 10*time.Second, 100*time.Millisecond, "all four units should dispatch; got %v", fs.dispatched.snapshot())
+	}, fsEventually, 100*time.Millisecond, "all four units should dispatch; got %v", fs.dispatched.snapshot())
 
 	for _, id := range []string{a, b, c, d} {
 		require.Equalf(t, 1, fs.dispatched.count(id), "unit %s dispatched exactly once (dedup)", id)
@@ -355,9 +367,9 @@ func TestFullStack_ResetSurvivesEvictedRow(t *testing.T) {
 	fs.seedUnit(t, x)
 
 	// First dispatch + completion + durable claim.
-	require.Eventually(t, func() bool { return fs.dispatched.count(x) == 1 }, 10*time.Second, 100*time.Millisecond,
+	require.Eventually(t, func() bool { return fs.dispatched.count(x) == 1 }, fsEventually, 100*time.Millisecond,
 		"x should dispatch once initially")
-	require.Eventually(t, func() bool { return fs.unitHasPredicate(t, x, pClaim) }, 10*time.Second, 100*time.Millisecond,
+	require.Eventually(t, func() bool { return fs.unitHasPredicate(t, x, pClaim) }, fsEventually, 100*time.Millisecond,
 		"x should carry the durable claim after dispatch")
 
 	// Stage D setup: simulate a rule that exhausted its retry budget on x by
@@ -372,12 +384,12 @@ func TestFullStack_ResetSurvivesEvictedRow(t *testing.T) {
 	fs.deleteEntity(t, x)
 
 	// Stage D: x's rule $state is cleared (no stale, exhausted budget survives).
-	require.Eventually(t, func() bool { return !fsRuleStateExists(t, fs.nc, stateKey) }, 10*time.Second, 100*time.Millisecond,
+	require.Eventually(t, func() bool { return !fsRuleStateExists(t, fs.nc, stateKey) }, fsEventually, 100*time.Millisecond,
 		"Stage D: evicting x must clear its rule $state")
 
 	// Recreate x fresh (no markers, no claim) and assert Stage C re-dispatch.
 	fs.seedUnit(t, x)
-	require.Eventually(t, func() bool { return fs.dispatched.count(x) >= 2 }, 10*time.Second, 100*time.Millisecond,
+	require.Eventually(t, func() bool { return fs.dispatched.count(x) >= 2 }, fsEventually, 100*time.Millisecond,
 		"Stage C: recreated x must be re-dispatched (evicted-then-recreated read fresh, not idle-skipped)")
 }
 
@@ -396,8 +408,8 @@ func TestFullStack_FailedNodeHoldsDependents(t *testing.T) {
 	// a and the independent unit both dispatch; a then fails, indep completes.
 	require.Eventually(t, func() bool {
 		return fs.dispatched.count(a) == 1 && fs.dispatched.count(indep) == 1
-	}, 10*time.Second, 100*time.Millisecond, "a and indep should dispatch")
-	require.Eventually(t, func() bool { return fs.unitHasPredicate(t, a, pFailed) }, 10*time.Second, 100*time.Millisecond,
+	}, fsEventually, 100*time.Millisecond, "a and indep should dispatch")
+	require.Eventually(t, func() bool { return fs.unitHasPredicate(t, a, pFailed) }, fsEventually, 100*time.Millisecond,
 		"a should carry the failed marker")
 
 	// b stays held behind its failed prerequisite — give several backstop passes
@@ -420,7 +432,7 @@ func TestFullStack_CycleSurfacesStall(t *testing.T) {
 	fs.seedUnit(t, b, a) // b depends on a → cycle
 
 	// The stall is surfaced (logged) within a couple of backstop passes...
-	require.Eventually(t, func() bool { return logCap.sawContaining("stalled") }, 10*time.Second, 100*time.Millisecond,
+	require.Eventually(t, func() bool { return logCap.sawContaining("stalled") }, fsEventually, 100*time.Millisecond,
 		"a depends_on cycle must surface as a stall, not silent idle")
 	// ...and nothing is ever dispatched.
 	require.Empty(t, fs.dispatched.snapshot(), "a cycle dispatches nothing")
@@ -493,7 +505,7 @@ func TestFullStack_FanOutInstanceAutoCompletes(t *testing.T) {
 	require.Eventually(t, func() bool {
 		inst, err := fs.mgr.Get(ctx, gateddagexec.FanOutWorkflow, instID)
 		return err == nil && inst.Phase() == "dispatching"
-	}, 10*time.Second, 100*time.Millisecond, "FanOut instance should be created in dispatching")
+	}, fsEventually, 100*time.Millisecond, "FanOut instance should be created in dispatching")
 
 	a, b := fsUnit("s6", "a"), fsUnit("s6", "b")
 	fs.seedUnit(t, a)
@@ -502,7 +514,7 @@ func TestFullStack_FanOutInstanceAutoCompletes(t *testing.T) {
 	require.Eventually(t, func() bool {
 		inst, err := fs.mgr.Get(ctx, gateddagexec.FanOutWorkflow, instID)
 		return err == nil && inst.Phase() == "completed"
-	}, 10*time.Second, 100*time.Millisecond, "FanOut instance must auto-complete once every unit is Done")
+	}, fsEventually, 100*time.Millisecond, "FanOut instance must auto-complete once every unit is Done")
 }
 
 // TestFullStack_StallEventPublished (#365.3) proves a depends_on cycle publishes
@@ -542,6 +554,6 @@ func TestFullStack_StallEventPublished(t *testing.T) {
 		got.Lock()
 		defer got.Unlock()
 		return len(got.units) == 2
-	}, 10*time.Second, 100*time.Millisecond, "a cycle must publish a StallEvent naming both held units")
+	}, fsEventually, 100*time.Millisecond, "a cycle must publish a StallEvent naming both held units")
 	require.Empty(t, fs.dispatched.snapshot(), "a cycle dispatches nothing")
 }


### PR DESCRIPTION
Closes #373.

## Diagnosis

`TestFullStack_FanOutInstanceAutoCompletes` and `TestFullStack_DependsOnOrderingAndDedup` flaked on CI **3×** (`Condition never satisfied`), each cleared by a `--failed` re-run. Investigation:

- **Passes 24/24 locally** under `GOMAXPROCS=2 -race -count=12` — does not reproduce, so not a logic bug.
- These are **full-stack** tests: real NATS → graph-ingest (mutation + query) → executor → a demo consumer that writes the terminal marker via `graph.mutation.triple.add` **with retry**. Each DAG level is several serial NATS round-trips; the diamond `a→{b,c}→d` is three of them.
- The **250ms backstop** guarantees forward progress the moment a marker lands (confirmed: dispatch is driven by the backstop within 250ms even if the unit watch misses). So a >10s stall means the upstream **pipeline latency** exceeded the window under CI contention — not a stuck DAG.

Cache coherence was ruled out: `cache_coherence_integration_test.go` already covers `triple.add`/`update_with_triples` invalidating the prefix-read cache (the `fd1a08af` fix), and the markers are written via `triple.add`.

## Fix

Test-only. Introduce `fsEventually = 30s` (~3× the prior 10s, per the ≥3× wall-clock tolerance rule) and apply it to the full-stack `Eventually` calls. Because the backstop guarantees progress once markers land, a longer window only absorbs upstream slowness — it **does not mask a logic stall** (a genuinely stuck DAG never advances regardless of wait). The watch-vs-backstop test keeps its **12s** bound (it asserts watch-driven dispatch beats the 30s backstop — a meaningful upper bound).

A re-flake at 30s would indicate a real stall, not slowness — documented in the constant's comment as the trigger for deeper investigation rather than a further bump.

## Verification

- Full `processor/gated-dag` integration suite green (`-tags=integration -race`).
- The two flaky tests pass 8/8 under `GOMAXPROCS=2 -race -count=8` after the change.
- `go vet -tags=integration`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)