### PR TITLE
fix(lifecycle): reject single-valued vs many-valued predicate collisions (gh#234)

### DIFF
--- a/pkg/lifecycle/manager.go
+++ b/pkg/lifecycle/manager.go
@@ -144,6 +144,11 @@ func (m *Manager) Register(workflow Workflow) error {
 	if err != nil {
 		return err
 	}
+	// Disjointness needs the parsed projection predicates, so it runs here
+	// rather than inside validate() (gh#234).
+	if err := workflow.validateDisjointness(meta); err != nil {
+		return err
+	}
 
 	// Snapshot the ownership wiring + check for a duplicate name under the lock,
 	// then RELEASE it before any NATS I/O. RegisterOwner is a CAS loop with

--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -550,6 +550,60 @@ func TestWorkflowValidateRejectsNon6SegmentPattern(t *testing.T) {
 	}
 }
 
+// TestWorkflow_ValidateDisjointness pins gh#234 — a single-valued predicate
+// (phase, audit, or scalar projection field) that collides with a
+// cardinality-many predicate (child-link or reference) is rejected at Register,
+// since Manager.Transition's RemoveTriples would otherwise delete the
+// many-valued triples. The reference-field-matching-its-own-ReferenceSpec case
+// guards against a false positive.
+func TestWorkflow_ValidateDisjointness(t *testing.T) {
+	t.Parallel()
+	base := lifecycle{}.fixtureWorkflow()
+	meta, err := parseSchemaType(base.Schema)
+	if err != nil {
+		t.Fatalf("parseSchemaType: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(w *Workflow)
+		wantErr bool
+	}{
+		{"valid fixture (no many-valued predicates)", func(_ *Workflow) {}, false},
+		{"child-link collides with phase predicate", func(w *Workflow) {
+			w.ChildWorkflows = []ChildSpec{{Workflow: "child", LinkPredicate: w.PhasePredicate}}
+		}, true},
+		{"child-link collides with an audit predicate", func(w *Workflow) {
+			w.ChildWorkflows = []ChildSpec{{Workflow: "child", LinkPredicate: w.AuditPredicates.At}}
+		}, true},
+		{"reference collides with a scalar projection field", func(w *Workflow) {
+			w.ReferencePredicates = []ReferenceSpec{{Predicate: "mission.owner_org_id"}}
+		}, true},
+		{"reference field matching its own ReferenceSpec is valid", func(w *Workflow) {
+			w.ReferencePredicates = []ReferenceSpec{{Predicate: "mission.assigned_drone"}}
+		}, false},
+		{"distinct child-link is fine", func(w *Workflow) {
+			w.ChildWorkflows = []ChildSpec{{Workflow: "child", LinkPredicate: "mission.subtask"}}
+		}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := base
+			tt.mutate(&w)
+			err := w.validateDisjointness(meta)
+			switch {
+			case tt.wantErr && err == nil:
+				t.Fatal("expected a disjointness error, got nil")
+			case tt.wantErr && !errors.Is(err, ErrInvalidWorkflow):
+				t.Fatalf("expected ErrInvalidWorkflow, got %v", err)
+			case !tt.wantErr && err != nil:
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
 // TestManager_DiffSkipsZeroValueOnMissingPredicate pins B4 — a
 // TransitionWith mutator that touches a zero-value field should not
 // emit a spurious delta against a missing-predicate baseline.

--- a/pkg/lifecycle/workflow.go
+++ b/pkg/lifecycle/workflow.go
@@ -218,6 +218,67 @@ func (w *Workflow) validate() error {
 	return nil
 }
 
+// validateDisjointness asserts that no single-valued predicate (phase, audit,
+// or a scalar projection field) collides with a cardinality-many predicate
+// (a ChildSpec.LinkPredicate or a ReferenceSpec.Predicate). It runs at Register
+// time AFTER the Schema is parsed, because the projection-field predicates live
+// in the parsed structMeta, not on the Workflow struct.
+//
+// Why this matters (gh#234): Manager.Transition replaces rather than appends —
+// it writes RemoveTriples for every predicate in the transition delta (phase +
+// audit). For a VALID schema that is correct (all delta predicates are
+// single-valued). But if a delta predicate ALSO names a child-link or reference
+// predicate, the Transition would delete those many-cardinality triples — silent
+// data loss. No valid schema regresses; this fails the malformed schema loudly
+// at Register rather than dangerously at the first Transition.
+func (w *Workflow) validateDisjointness(meta *structMeta) error {
+	// Cardinality-many predicates: child links and references.
+	many := make(map[string]string) // predicate -> kind (for the error message)
+	for _, ch := range w.ChildWorkflows {
+		many[ch.LinkPredicate] = "child-link"
+	}
+	for _, ref := range w.ReferencePredicates {
+		many[ref.Predicate] = "reference"
+	}
+	if len(many) == 0 {
+		return nil // nothing many-valued to collide with
+	}
+
+	check := func(pred, kind string) error {
+		if pred == "" {
+			return nil
+		}
+		if mk, ok := many[pred]; ok {
+			return fmt.Errorf("%w: workflow %q predicate %q is declared both as %s (single-valued) and %s (cardinality-many) — a Transition would delete the %s triples",
+				ErrInvalidWorkflow, w.Name, pred, kind, mk, mk)
+		}
+		return nil
+	}
+
+	if err := check(w.PhasePredicate, "phase"); err != nil {
+		return err
+	}
+	for _, p := range []string{w.AuditPredicates.Source, w.AuditPredicates.At, w.AuditPredicates.From, w.AuditPredicates.Note} {
+		if err := check(p, "audit"); err != nil {
+			return err
+		}
+	}
+	if meta != nil {
+		for pred, fm := range meta.FieldsByPredicate {
+			// References are themselves cardinality-many (already in `many`);
+			// the phase field is checked above via PhasePredicate. Only scalar
+			// projection fields are single-valued.
+			if fm.IsReference || fm.IsPhase {
+				continue
+			}
+			if err := check(pred, "projection-field"); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // ChildOptions filters the result of Manager.Children. Empty options
 // returns every child of the parent across all declared ChildWorkflows.
 type ChildOptions struct {


### PR DESCRIPTION
Closes #234.

## Problem

`pkg/lifecycle` registration didn't guard against a schema where a **single-valued** predicate (`PhasePredicate`, an `AuditPredicates.*`, or a scalar projection field) collides with a **cardinality-many** predicate (`ChildSpec.LinkPredicate` or `ReferenceSpec.Predicate`).

`Manager.Transition` replaces rather than appends — it writes `RemoveTriples` for every predicate in the transition delta (phase + audit). For a valid schema that's correct, but for a malformed schema where a delta predicate also names a child-link/reference predicate, a Transition would **silently delete** those many-valued triples (data loss). No valid schema regresses; this fails the malformed schema loudly at `Register`.

## Fix

`Workflow.validateDisjointness(meta)`, run in `Manager.Register` right after `parseSchemaType` (projection-field predicates live in the parsed `structMeta`, not on the `Workflow` struct). Reference projection fields (`IsReference`) are excluded from the single-valued set, so a reference field matching its own `ReferenceSpec` is **not** a false positive.

## Test

Table test covers: child-link↔phase collision, child-link↔audit collision, reference↔scalar-projection-field collision (all rejected with `ErrInvalidWorkflow`), the reference-field-matching-its-own-ReferenceSpec false-positive guard, and a distinct-predicate pass. `go test -race ./pkg/lifecycle/` green; `vet`/`gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)