### PR TITLE
feat(trajectory): bash url_fetched first-class attribute (gh#146)

### DIFF
--- a/agentic/trajectory.go
+++ b/agentic/trajectory.go
@@ -31,6 +31,11 @@ type TrajectoryStep struct {
 	ToolStatus    string `json:"tool_status,omitempty"`    // "success" | "failed"
 	ErrorMessage  string `json:"error_message,omitempty"`  // Raw error text; omitted on success
 	ErrorCategory string `json:"error_category,omitempty"` // ToolErrorKind string form; omitted on success
+	// URLsFetched lists external URLs a bash step fetched (curl/wget/httpie),
+	// derived from the command string (gh#146). Lets citation/audit/governance
+	// dashboards filter and count external reach independently of generic shell
+	// activity. Empty/omitted when the step fetched no URL.
+	URLsFetched []string `json:"url_fetched,omitempty"`
 }
 
 // Validate checks if the TrajectoryStep is valid

--- a/agentic/url_fetched.go
+++ b/agentic/url_fetched.go
@@ -1,0 +1,85 @@
+package agentic
+
+import (
+	"regexp"
+	"strings"
+)
+
+// bashToolName is the tool name the bash executor registers. URL derivation
+// only applies to steps from this tool.
+const bashToolName = "bash"
+
+// fetchVerbs are the leading programs that perform an external URL fetch. A URL
+// is only counted when it is an argument to one of these — a URL inside an
+// `echo` string, a `grep` pattern, or a filesystem path (/var/log/http.log) has
+// a non-fetch leading program and is correctly excluded.
+var fetchVerbs = map[string]bool{
+	"curl":  true,
+	"wget":  true,
+	"http":  true, // httpie
+	"https": true, // httpie
+	"fetch": true,
+}
+
+// shellSep splits a command line on the unquoted sequencing operators. Single
+// `&` (background) and `&&`-internal query-string `&` are deliberately NOT
+// separators here; `&&` is matched before single tokens via alternation order.
+var shellSep = regexp.MustCompile(`&&|\|\||;|\||\n`)
+
+// urlPattern matches an http(s) URL token, preserving query strings (`?a=1&b=2`)
+// and stopping only at whitespace, quotes, or shell redirection characters.
+var urlPattern = regexp.MustCompile("https?://[^\\s'\"`<>\\\\]+")
+
+// BashStepURLs returns the external URLs a bash trajectory step fetched, or nil
+// for any other tool or when no fetch URL is present. toolArgs is the step's
+// ToolArguments map; the bash command lives under the "command" key.
+func BashStepURLs(toolName string, toolArgs map[string]any) []string {
+	if toolName != bashToolName {
+		return nil
+	}
+	cmd, _ := toolArgs["command"].(string)
+	if cmd == "" {
+		return nil
+	}
+	return ExtractFetchedURLs(cmd)
+}
+
+// ExtractFetchedURLs derives the external URLs a bash command fetches. It
+// inspects only sub-commands whose leading program is a known fetch verb
+// (curl/wget/httpie), so URLs that appear as data — echo strings, grep
+// patterns, filesystem paths — are excluded. Returns nil when no fetch URL is
+// detected (no false-positive noise); results are order-preserving and
+// de-duplicated. This is a cheap observability heuristic, not a shell parser:
+// it inspects only the leading token, so wrapped/prefixed fetches —
+// `sudo curl ...`, `time curl ...`, `HTTPS_PROXY=x curl ...`, `echo url | curl -`
+// — are known misses (under-count, never over-count).
+func ExtractFetchedURLs(command string) []string {
+	var out []string
+	seen := make(map[string]bool)
+	for _, sub := range shellSep.Split(command, -1) {
+		fields := strings.Fields(sub)
+		if len(fields) == 0 {
+			continue
+		}
+		if !fetchVerbs[leadingProgram(fields[0])] {
+			continue
+		}
+		for _, u := range urlPattern.FindAllString(sub, -1) {
+			u = strings.TrimRight(u, ".,);")
+			if u != "" && !seen[u] {
+				seen[u] = true
+				out = append(out, u)
+			}
+		}
+	}
+	return out
+}
+
+// leadingProgram normalizes a sub-command's first token to the bare program
+// name: strips a leading path (/usr/bin/curl → curl) and lowercases.
+func leadingProgram(tok string) string {
+	if i := strings.LastIndex(tok, "/"); i >= 0 {
+		tok = tok[i+1:]
+	}
+	return strings.ToLower(tok)
+}

--- a/agentic/url_fetched_test.go
+++ b/agentic/url_fetched_test.go
@@ -1,0 +1,65 @@
+package agentic
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractFetchedURLs(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want []string
+	}{
+		// Positive — fetch verbs.
+		{"curl simple", "curl https://x.com", []string{"https://x.com"}},
+		{"curl with flags and query", "curl -sL -o out https://x.com/a?q=b", []string{"https://x.com/a?q=b"}},
+		{"curl multi-param query preserved", "curl https://x.com/a?q=b&r=c", []string{"https://x.com/a?q=b&r=c"}},
+		{"wget", "wget https://x.com/file.tar", []string{"https://x.com/file.tar"}},
+		{"httpie", "http https://api.x.com/v1/items", []string{"https://api.x.com/v1/items"}},
+		{"abs path to curl", "/usr/bin/curl https://x.com", []string{"https://x.com"}},
+		{"multi via semicolon", "curl https://a.com; curl https://b.com", []string{"https://a.com", "https://b.com"}},
+		{"multi via &&", "curl https://a.com && curl https://b.com", []string{"https://a.com", "https://b.com"}},
+		{"dedup repeated", "curl https://a.com; curl https://a.com", []string{"https://a.com"}},
+		{"curl piped to grep keeps only fetched", "curl https://a.com | grep https://b.com", []string{"https://a.com"}},
+
+		// Negative — URL is data, not a fetch.
+		{"echo string", `echo "https://x.com"`, nil},
+		{"grep pattern", "grep https://x logfile", nil},
+		{"filesystem path", "cat /var/log/http.log", nil},
+		{"no url", "ls -la /tmp", nil},
+		{"empty", "", nil},
+		{"http-named file, not fetch", "rm http_notes.txt", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractFetchedURLs(tt.cmd)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("ExtractFetchedURLs(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBashStepURLs(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		args     map[string]any
+		want     []string
+	}{
+		{"bash with fetch", "bash", map[string]any{"command": "curl https://x.com"}, []string{"https://x.com"}},
+		{"bash no fetch", "bash", map[string]any{"command": "ls"}, nil},
+		{"non-bash tool ignored", "read_file", map[string]any{"command": "curl https://x.com"}, nil},
+		{"bash missing command", "bash", map[string]any{}, nil},
+		{"bash non-string command", "bash", map[string]any{"command": 42}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BashStepURLs(tt.toolName, tt.args)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("BashStepURLs(%q, %v) = %v, want %v", tt.toolName, tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -1951,11 +1951,13 @@ func (h *MessageHandler) buildToolTrajectoryStep(toolResult agentic.ToolResult, 
 			errCategory = string(agentic.ToolErrorUnknown)
 		}
 	}
+	toolName := h.loopManager.GetToolName(toolResult.CallID)
+	toolArgs := h.loopManager.GetToolArguments(toolResult.CallID)
 	return agentic.TrajectoryStep{
 		Timestamp:     time.Now(),
 		StepType:      "tool_call",
-		ToolName:      h.loopManager.GetToolName(toolResult.CallID),
-		ToolArguments: h.loopManager.GetToolArguments(toolResult.CallID),
+		ToolName:      toolName,
+		ToolArguments: toolArgs,
 		ToolResult:    toolResult.Content,
 		Duration:      h.computeToolDuration(toolResult.CallID),
 		Provider:      h.resolveProvider(entity.Model),
@@ -1963,6 +1965,9 @@ func (h *MessageHandler) buildToolTrajectoryStep(toolResult agentic.ToolResult, 
 		ToolStatus:    toolStatus,
 		ErrorMessage:  toolResult.Error,
 		ErrorCategory: errCategory,
+		// gh#146: surface external URL fetches from bash steps as a first-class
+		// attribute for citation/audit/governance dashboards.
+		URLsFetched: agentic.BashStepURLs(toolName, toolArgs),
 	}
 }
 

--- a/processor/agentic-tools/executors/bash.go
+++ b/processor/agentic-tools/executors/bash.go
@@ -123,6 +123,13 @@ func (e *BashExecutor) effectiveTimeout() time.Duration {
 }
 
 // ListTools returns the bash tool definition.
+//
+// Observability note (gh#146): when a bash command performs an external fetch
+// (curl/wget/httpie), the resulting trajectory step carries a first-class
+// url_fetched attribute derived from the command string (see
+// agentic.BashStepURLs / ExtractFetchedURLs), so citation/audit/governance
+// dashboards can filter and count external reach independently of generic shell
+// activity.
 func (e *BashExecutor) ListTools() []agentic.ToolDefinition {
 	return []agentic.ToolDefinition{
 		{

--- a/specs/openapi.v3.yaml
+++ b/specs/openapi.v3.yaml
@@ -2265,6 +2265,10 @@ components:
                                 type: string
                             tool_status:
                                 type: string
+                            url_fetched:
+                                items:
+                                    type: string
+                                type: array
                             utilization:
                                 type: number
                         required:
@@ -2515,6 +2519,10 @@ components:
                     type: string
                 tool_status:
                     type: string
+                url_fetched:
+                    items:
+                        type: string
+                    type: array
                 utilization:
                     type: number
             required:


### PR DESCRIPTION
Closes #146. Gap 6/6 from the semteams gatherer case study.

## What

Adds an optional `url_fetched []string` attribute to `TrajectoryStep`, populated for **bash** `tool_call` steps, so citation/audit/governance dashboards can distinguish and count external URL fetches independently of generic shell activity.

- **`agentic.ExtractFetchedURLs(command)`** — separate, testable function (not buried in the trajectory write). Inspects only sub-commands whose leading program is a known fetch verb (`curl`/`wget`/httpie), so URLs that appear as **data** — `echo` strings, `grep` patterns, filesystem paths (`/var/log/http.log`) — are excluded. Handles flags, query strings (`?a=1&b=2` preserved), absolute paths, and multi-URL via `;`/`&&`/`|`; de-duplicated, order-preserving; returns nil when no fetch URL (no false-positive noise). A cheap observability heuristic, not a shell parser.
- **`agentic.BashStepURLs(toolName, toolArgs)`** — glue that guards on the bash tool name + pulls the `command` arg. Wired at the single `tool_call` step-construction site (`handlers.go`).
- Field rides the existing JSON trajectory (`omitempty`) → available via the existing trajectory query interface; **OpenAPI spec regenerated**. Doc note added to the bash executor's `ListTools`.

## Test

`agentic/url_fetched_test.go` — corpus covering positives (simple curl, flags+query, multi-param query preservation, wget, httpie, abs-path, multi-via-`;`/`&&`, dedup, curl-piped-to-grep) and negatives (`echo`, `grep`, `cat /var/log/http.log`, no-url, empty, `http_notes.txt`). Plus `BashStepURLs` guards (non-bash tool, missing/non-string command). `go test -race ./agentic/` + `./processor/agentic-loop/` green; vet/gofmt clean; schema gate satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)