### PR TITLE
fix(lifecycle): reject child-link/reference predicate collision (gh#234 fix-forward)

### DIFF
--- a/pkg/lifecycle/manager_test.go
+++ b/pkg/lifecycle/manager_test.go
@@ -585,6 +585,10 @@ func TestWorkflow_ValidateDisjointness(t *testing.T) {
 		{"distinct child-link is fine", func(w *Workflow) {
 			w.ChildWorkflows = []ChildSpec{{Workflow: "child", LinkPredicate: "mission.subtask"}}
 		}, false},
+		{"predicate declared as both child-link and reference", func(w *Workflow) {
+			w.ChildWorkflows = []ChildSpec{{Workflow: "child", LinkPredicate: "mission.subtask"}}
+			w.ReferencePredicates = []ReferenceSpec{{Predicate: "mission.subtask"}}
+		}, true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lifecycle/workflow.go
+++ b/pkg/lifecycle/workflow.go
@@ -232,12 +232,20 @@ func (w *Workflow) validate() error {
 // data loss. No valid schema regresses; this fails the malformed schema loudly
 // at Register rather than dangerously at the first Transition.
 func (w *Workflow) validateDisjointness(meta *structMeta) error {
-	// Cardinality-many predicates: child links and references.
+	// Cardinality-many predicates: child links and references. A predicate
+	// declared as BOTH (child-link and reference) is itself a collision —
+	// Manager.Children and Manager.References would both enumerate the same
+	// triples, double-projecting the entity as an owned child AND an unowned
+	// reference. validate()'s dup check only guards child-link-vs-child-link.
 	many := make(map[string]string) // predicate -> kind (for the error message)
 	for _, ch := range w.ChildWorkflows {
 		many[ch.LinkPredicate] = "child-link"
 	}
 	for _, ref := range w.ReferencePredicates {
+		if existing, ok := many[ref.Predicate]; ok {
+			return fmt.Errorf("%w: workflow %q predicate %q is declared both as %s and reference — both are cardinality-many and would double-project the same triples",
+				ErrInvalidWorkflow, w.Name, ref.Predicate, existing)
+		}
 		many[ref.Predicate] = "reference"
 	}
 	if len(many) == 0 {


### PR DESCRIPTION
Fix-forward on #377, addressing the semstreams-reviewer **HIGH** from the post-hoc review.

## Gap

`validateDisjointness` (added in #377) checks single-valued predicates against the cardinality-many set, but built that set by **overwriting on collision**:

```go
for _, ref := range w.ReferencePredicates {
    many[ref.Predicate] = "reference" // silently overwrites a child-link entry
}
```

So a predicate declared as **both** a `ChildSpec.LinkPredicate` and a `ReferenceSpec.Predicate` passed `Register`. At runtime `Manager.Children` and `Manager.References` each enumerate the same triples → the entity is double-projected as an owned child AND an unowned reference. `validate()`'s existing dup check only guards child-link-vs-child-link.

This is read-side ambiguity, not the data-loss class #377 targeted (which is why it wasn't a revert) — but it's the one disjointness pair the "disjointness" check omitted.

## Fix

Detect the within-`many` collision while building the set; fail `Register` with `ErrInvalidWorkflow`. Adds the table case (`predicate declared as both child-link and reference → rejected`). All existing cases still pass, including the reference-field-matching-its-own-ReferenceSpec false-positive guard.

`go test -race ./pkg/lifecycle/` green; vet/gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)