### PR TITLE
feat(graph): deterministic name→ranked-IDs index + graph.query.byName (gh#376)

### DIFF
--- a/docs/advanced/05-index-reference.md
+++ b/docs/advanced/05-index-reference.md
@@ -151,8 +151,16 @@ query {
 **Key pattern:** `{alias}`
 **Value:** Canonical entity ID
 
-**Created by:** Triples with `alias.*` predicates
+**Created by:** Triples with `alias.*` predicates (resolvable AliasTypes only — `AliasTypeLabel` is excluded)
 **Used for:** Resolve "drone-alpha" → "acme.robotics.aerial.drone.drone-007"
+
+### NAME_INDEX
+
+**Key pattern:** `sha256(lower(trim(name)))` (names contain non-KV-key-safe chars; case-folded for recall)
+**Value:** `NameIndexEntry{name, items[]}` — every entity carrying that name, with its label predicate + salience
+
+**Created by:** Triples whose predicate is a display-name label (`AliasType==AliasTypeLabel`, e.g. `dc.terms.title`) — exactly the set ALIAS_INDEX excludes. Register product label predicates via `vocabulary.Register(pred, WithAlias(AliasTypeLabel, priority))`.
+**Used for:** Deterministic `graph.query.byName` — name/title → ranked entity IDs (exact-case first, then label salience, then ID). gh#376 ask #5; sharpens deterministic symbol/title resolution that otherwise falls back to semantic search.
 
 ### SPATIAL_INDEX
 

--- a/graph/constants.go
+++ b/graph/constants.go
@@ -11,7 +11,12 @@ const (
 	BucketOutgoingIndex  = "OUTGOING_INDEX"
 
 	// Lookup indexes
-	BucketAliasIndex    = "ALIAS_INDEX"
+	BucketAliasIndex = "ALIAS_INDEX"
+	// BucketNameIndex maps a normalized (case-folded) human-readable name/title
+	// to the entities carrying it, for deterministic name→ranked-IDs lookup
+	// (graph.query.byName, gh#376). Complements ALIAS_INDEX, which excludes
+	// display-name (AliasTypeLabel) predicates.
+	BucketNameIndex     = "NAME_INDEX"
 	BucketSpatialIndex  = "SPATIAL_INDEX"
 	BucketTemporalIndex = "TEMPORAL_INDEX"
 	// BucketTemporalIndexReverse maps entityID -> current temporal bucket key.

--- a/graph/query_name_types.go
+++ b/graph/query_name_types.go
@@ -1,0 +1,37 @@
+package graph
+
+// Types for deterministic name→ranked-IDs lookup (graph.query.byName, gh#376).
+
+// NameMatch is one entity whose name/title matched a graph.query.byName lookup,
+// carrying the signals a deterministic caller needs to calibrate trust (gh#376).
+type NameMatch struct {
+	// EntityID is the matched entity (an opaque handle for the caller).
+	EntityID string `json:"entity_id"`
+	// MatchedName is the name as stored on the entity (original case).
+	MatchedName string `json:"matched_name"`
+	// Predicate is the label predicate that carried the name (e.g. dc.terms.title).
+	Predicate string `json:"predicate"`
+	// ExactCase is true when MatchedName equals the query verbatim (case included);
+	// such matches rank above case-folded-only matches.
+	ExactCase bool `json:"exact_case"`
+}
+
+// NameData contains the ranked entities for a name lookup. Order IS the ranking:
+// exact-case matches first, then by label-predicate salience, then entity ID.
+type NameData struct {
+	Matches []NameMatch `json:"matches"`
+}
+
+// NameIndexItem is one entity's claim on a name, stored in NAME_INDEX.
+type NameIndexItem struct {
+	EntityID  string `json:"entity_id"`
+	Name      string `json:"name"`      // original-case name as stored on the entity
+	Predicate string `json:"predicate"` // the label predicate carrying it
+	Priority  int    `json:"priority"`  // label-predicate salience (lower = higher)
+}
+
+// NameIndexEntry is the NAME_INDEX value for one normalized (case-folded) name.
+type NameIndexEntry struct {
+	Name  string          `json:"name"` // the folded name (key source)
+	Items []NameIndexItem `json:"items"`
+}

--- a/processor/graph-index/component.go
+++ b/processor/graph-index/component.go
@@ -206,6 +206,7 @@ type Component struct {
 	aliasBucket        *natsclient.KVStore
 	predicateBucket    *natsclient.KVStore
 	contextBucket      *natsclient.KVStore
+	nameBucket         *natsclient.KVStore
 	entityStatesBucket jetstream.KeyValue // raw: read-only watcher, no CAS needed
 
 	// Lifecycle state
@@ -232,6 +233,10 @@ type Component struct {
 
 	// Alias predicates from vocabulary (cached at startup for performance)
 	aliasPredicates map[string]int
+
+	// Label (display-name) predicates from vocabulary, cached at startup. Keys
+	// the NAME_INDEX for graph.query.byName (gh#376); value = salience priority.
+	namePredicates map[string]int
 
 	// Query subscriptions (for cleanup)
 	querySubscriptions []*natsclient.Subscription
@@ -470,6 +475,7 @@ func (c *Component) Start(ctx context.Context) error {
 
 	// Cache alias predicates from vocabulary for fast lookup during indexing
 	c.aliasPredicates = vocabulary.DiscoverAliasPredicates()
+	c.namePredicates = vocabulary.DiscoverLabelPredicates()
 	c.logger.Debug("cached alias predicates from vocabulary", slog.Int("count", len(c.aliasPredicates)))
 
 	// Check context before proceeding
@@ -616,6 +622,18 @@ func (c *Component) createOutputBuckets(ctx context.Context) error {
 		return errs.Wrap(err, "Component", "createOutputBuckets", fmt.Sprintf("KV bucket: %s", graph.BucketContextIndex))
 	}
 	c.contextBucket = c.natsClient.NewKVStore(contextBucket)
+
+	// Create NAME_INDEX bucket for name→ranked-IDs lookup (gh#376). Internal like
+	// CONTEXT_INDEX — not a declared output port, so existing configs don't need
+	// to add it.
+	nameBucket, err := c.natsClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      graph.BucketNameIndex,
+		Description: "Name/title → entities index for deterministic name lookup",
+	})
+	if err != nil {
+		return errs.Wrap(err, "Component", "createOutputBuckets", fmt.Sprintf("KV bucket: %s", graph.BucketNameIndex))
+	}
+	c.nameBucket = c.natsClient.NewKVStore(nameBucket)
 	return nil
 }
 
@@ -868,6 +886,21 @@ func (c *Component) processEntityUpdateFromData(ctx context.Context, entityID st
 				if err := c.UpdateAliasIndex(ctx, alias, resolvedID); err != nil {
 					c.logger.Debug("failed to update alias index",
 						slog.String("alias", alias),
+						slog.String("entity", resolvedID),
+						slog.String("predicate", triple.Predicate),
+						slog.Any("error", err))
+				}
+			}
+		}
+
+		// Index display-name (label) predicates into NAME_INDEX for
+		// graph.query.byName (gh#376). These are exactly the predicates the alias
+		// index excludes (AliasTypeLabel).
+		if priority, isName := c.namePredicates[triple.Predicate]; isName {
+			if name, ok := triple.Object.(string); ok && name != "" {
+				if err := c.UpdateNameIndex(ctx, name, resolvedID, triple.Predicate, priority); err != nil {
+					c.logger.Debug("failed to update name index",
+						slog.String("name", name),
 						slog.String("entity", resolvedID),
 						slog.String("predicate", triple.Predicate),
 						slog.Any("error", err))

--- a/processor/graph-index/name_index.go
+++ b/processor/graph-index/name_index.go
@@ -1,0 +1,185 @@
+package graphindex
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// nameIndexKey is the NAME_INDEX KV key for a name: the hex sha256 of the
+// case-folded, trimmed name. Names contain arbitrary characters (spaces,
+// punctuation, unicode) that are not KV-key-safe, so the index keys on a hash;
+// the original-case name rides in the stored value for exact-case ranking.
+// Folding the key gives case-insensitive recall.
+func nameIndexKey(name string) string {
+	sum := sha256.Sum256([]byte(normalizeName(name)))
+	return hex.EncodeToString(sum[:])
+}
+
+// normalizeName case-folds and trims a name for case-insensitive matching.
+func normalizeName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// UpdateNameIndex records that entityID carries name under the given label
+// predicate. CAS read-modify-write; de-duplicates by (entityID, predicate) so
+// re-indexing the same entity is idempotent. Multiple entities may share a name
+// (names are not unique) — all are kept and ranked at query time.
+func (c *Component) UpdateNameIndex(ctx context.Context, name, entityID, predicate string, priority int) error {
+	if name == "" {
+		return errs.WrapInvalid(errs.ErrInvalidData, "Component", "UpdateNameIndex", "name cannot be empty")
+	}
+	if entityID == "" {
+		return errs.WrapInvalid(errs.ErrInvalidData, "Component", "UpdateNameIndex", "entity ID cannot be empty")
+	}
+	if ctx == nil {
+		return errs.WrapInvalid(errs.ErrInvalidData, "Component", "UpdateNameIndex", "context cannot be nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return errs.Wrap(err, "Component", "UpdateNameIndex", "context cancelled")
+	}
+
+	key := nameIndexKey(name)
+	err := c.nameBucket.UpdateWithRetry(ctx, key, func(current []byte) ([]byte, error) {
+		var entry graph.NameIndexEntry
+		if len(current) > 0 {
+			if unmarshalErr := json.Unmarshal(current, &entry); unmarshalErr != nil {
+				entry = graph.NameIndexEntry{}
+			}
+		}
+		entry.Name = normalizeName(name)
+
+		// De-dup by (entityID, predicate): an entity carrying the same name under
+		// the same predicate updates in place (refresh original-case + priority);
+		// the same name under a different predicate is a distinct item.
+		for i := range entry.Items {
+			if entry.Items[i].EntityID == entityID && entry.Items[i].Predicate == predicate {
+				entry.Items[i].Name = name
+				entry.Items[i].Priority = priority
+				return json.Marshal(entry)
+			}
+		}
+		entry.Items = append(entry.Items, graph.NameIndexItem{
+			EntityID:  entityID,
+			Name:      name,
+			Predicate: predicate,
+			Priority:  priority,
+		})
+		return json.Marshal(entry)
+	})
+	if err != nil {
+		atomic.AddInt64(&c.errors, 1)
+		return errs.Wrap(err, "Component", "UpdateNameIndex", "CAS update")
+	}
+
+	atomic.AddInt64(&c.messagesProcessed, 1)
+	c.lastActivity.Store(time.Now())
+	if c.metrics != nil {
+		c.metrics.recordIndexUpdate("name")
+		c.metrics.recordKVOperation("put", "name")
+	}
+	return nil
+}
+
+// handleQueryByNameNATS resolves a name to ranked entity IDs (gh#376). Request
+// {name, limit}; response graph.NameData with matches ordered exact-case-first,
+// then by label-predicate salience, then entity ID. Empty matches (not an error)
+// when the name is unknown — the caller distinguishes ready-but-absent from a
+// backend failure (the latter is a classified error).
+func (c *Component) handleQueryByNameNATS(ctx context.Context, data []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var req struct {
+		Name  string `json:"name"`
+		Limit int    `json:"limit,omitempty"`
+	}
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, errs.ClassifiedCode(errs.ErrorInvalid, graph.ErrorCodeInvalidRequest, errors.New("invalid request"))
+	}
+	if req.Name == "" {
+		return nil, errs.ClassifiedCode(errs.ErrorInvalid, graph.ErrorCodeInvalidRequest, errors.New("invalid request: empty name"))
+	}
+
+	entry, err := c.nameBucket.Get(ctx, nameIndexKey(req.Name))
+	if err != nil {
+		if natsclient.IsKVNotFoundError(err) {
+			return json.Marshal(graph.NewQueryResponse(graph.NameData{Matches: []graph.NameMatch{}}))
+		}
+		return nil, errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("internal error"))
+	}
+
+	var stored graph.NameIndexEntry
+	if unmarshalErr := json.Unmarshal(entry.Value, &stored); unmarshalErr != nil {
+		return nil, errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("internal error"))
+	}
+
+	matches := rankNameMatches(stored.Items, req.Name, req.Limit)
+	return json.Marshal(graph.NewQueryResponse(graph.NameData{Matches: matches}))
+}
+
+// nameRank pairs a wire match with its label-predicate priority for ordering.
+type nameRank struct {
+	match    graph.NameMatch
+	priority int
+}
+
+// nameRankLess is the total order for name ranking, used both to pick an
+// entity's best item and to sort the final result: exact-case before fold-only,
+// then lower predicate priority (higher salience), then entity ID ascending.
+func nameRankLess(a, b nameRank) bool {
+	if a.match.ExactCase != b.match.ExactCase {
+		return a.match.ExactCase // exact-case first
+	}
+	if a.priority != b.priority {
+		return a.priority < b.priority // lower priority = higher salience
+	}
+	return a.match.EntityID < b.match.EntityID
+}
+
+// rankNameMatches orders stored items for a query: exact-case match first, then
+// label-predicate salience (lower priority = higher), then entity ID for a
+// deterministic tiebreak. Collapses to one match per entity (its best-ranked
+// item), then applies limit (<=0 means unbounded).
+func rankNameMatches(items []graph.NameIndexItem, query string, limit int) []graph.NameMatch {
+	best := make(map[string]nameRank)
+	for _, it := range items {
+		cand := nameRank{
+			match: graph.NameMatch{
+				EntityID:    it.EntityID,
+				MatchedName: it.Name,
+				Predicate:   it.Predicate,
+				ExactCase:   it.Name == query,
+			},
+			priority: it.Priority,
+		}
+		if cur, seen := best[it.EntityID]; !seen || nameRankLess(cand, cur) {
+			best[it.EntityID] = cand
+		}
+	}
+
+	out := make([]nameRank, 0, len(best))
+	for _, r := range best {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return nameRankLess(out[i], out[j]) })
+
+	matches := make([]graph.NameMatch, 0, len(out))
+	for _, r := range out {
+		matches = append(matches, r.match)
+	}
+	if limit > 0 && len(matches) > limit {
+		matches = matches[:limit]
+	}
+	return matches
+}

--- a/processor/graph-index/name_index_test.go
+++ b/processor/graph-index/name_index_test.go
@@ -1,0 +1,126 @@
+package graphindex
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- pure ranking + normalization ---
+
+func TestNormalizeName_FoldsAndTrims(t *testing.T) {
+	assert.Equal(t, "foo", normalizeName("  Foo "))
+	assert.Equal(t, "foo bar", normalizeName("FOO BAR"))
+	// Same key for case variants, distinct key for distinct names.
+	assert.Equal(t, nameIndexKey("OnEvent"), nameIndexKey("onevent"))
+	assert.NotEqual(t, nameIndexKey("OnEvent"), nameIndexKey("OnEvents"))
+}
+
+func TestRankNameMatches(t *testing.T) {
+	items := []graph.NameIndexItem{
+		{EntityID: "e.pref", Name: "foo", Predicate: "skos.core.prefLabel", Priority: 0}, // high salience, not exact-case
+		{EntityID: "e.exact", Name: "Foo", Predicate: "dc.terms.title", Priority: 1},     // exact-case
+		{EntityID: "e.upper", Name: "FOO", Predicate: "dc.terms.title", Priority: 1},     // fold-only
+	}
+
+	got := rankNameMatches(items, "Foo", 0)
+	require.Len(t, got, 3)
+	// 1) exact-case wins over higher salience.
+	assert.Equal(t, "e.exact", got[0].EntityID)
+	assert.True(t, got[0].ExactCase)
+	// 2) among fold-only, lower priority (higher salience) wins.
+	assert.Equal(t, "e.pref", got[1].EntityID)
+	assert.False(t, got[1].ExactCase)
+	// 3) remaining fold-only by entity ID.
+	assert.Equal(t, "e.upper", got[2].EntityID)
+}
+
+func TestRankNameMatches_DedupsByEntityKeepingBest(t *testing.T) {
+	// Same entity carries the name under two predicates; keep its best (exact + salient).
+	items := []graph.NameIndexItem{
+		{EntityID: "e1", Name: "FOO", Predicate: "dc.terms.title", Priority: 1},
+		{EntityID: "e1", Name: "Foo", Predicate: "skos.core.prefLabel", Priority: 0},
+	}
+	got := rankNameMatches(items, "Foo", 0)
+	require.Len(t, got, 1)
+	assert.Equal(t, "skos.core.prefLabel", got[0].Predicate)
+	assert.True(t, got[0].ExactCase)
+}
+
+func TestRankNameMatches_Limit(t *testing.T) {
+	items := []graph.NameIndexItem{
+		{EntityID: "e3", Name: "x", Priority: 1},
+		{EntityID: "e1", Name: "x", Priority: 1},
+		{EntityID: "e2", Name: "x", Priority: 1},
+	}
+	got := rankNameMatches(items, "x", 2)
+	require.Len(t, got, 2)
+	assert.Equal(t, "e1", got[0].EntityID) // tiebreak by entity ID asc
+	assert.Equal(t, "e2", got[1].EntityID)
+}
+
+// --- KV round-trip through the real Update + query handler ---
+
+func newNameTestComponent(t *testing.T) *Component {
+	t.Helper()
+	comp := createTestComponentWithMockKV(t)
+	nc, err := natsclient.NewClient("nats://localhost:4222")
+	require.NoError(t, err)
+	comp.nameBucket = nc.NewKVStore(newMockKVBucket())
+	return comp
+}
+
+func queryByName(t *testing.T, comp *Component, name string, limit int) []graph.NameMatch {
+	t.Helper()
+	req, err := json.Marshal(map[string]any{"name": name, "limit": limit})
+	require.NoError(t, err)
+	respData, err := comp.handleQueryByNameNATS(context.Background(), req)
+	require.NoError(t, err)
+	var resp graph.QueryResponse[graph.NameData]
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	return resp.Data.Matches
+}
+
+func TestUpdateNameIndex_RoundTripRankingAndRecall(t *testing.T) {
+	comp := newNameTestComponent(t)
+	ctx := context.Background()
+
+	require.NoError(t, comp.UpdateNameIndex(ctx, "Foo", "org.p.d.s.t.exact", "dc.terms.title", 1))
+	require.NoError(t, comp.UpdateNameIndex(ctx, "FOO", "org.p.d.s.t.upper", "dc.terms.title", 1))
+	require.NoError(t, comp.UpdateNameIndex(ctx, "foo", "org.p.d.s.t.pref", "skos.core.prefLabel", 0))
+
+	// Case-insensitive recall: a lowercase query finds all three.
+	got := queryByName(t, comp, "Foo", 0)
+	require.Len(t, got, 3)
+	assert.Equal(t, "org.p.d.s.t.exact", got[0].EntityID, "exact-case ranks first")
+	assert.Equal(t, "org.p.d.s.t.pref", got[1].EntityID, "then highest salience")
+	assert.Equal(t, "org.p.d.s.t.upper", got[2].EntityID)
+}
+
+func TestUpdateNameIndex_IdempotentReindex(t *testing.T) {
+	comp := newNameTestComponent(t)
+	ctx := context.Background()
+	require.NoError(t, comp.UpdateNameIndex(ctx, "Doc", "org.p.d.s.t.1", "dc.terms.title", 1))
+	require.NoError(t, comp.UpdateNameIndex(ctx, "Doc", "org.p.d.s.t.1", "dc.terms.title", 1)) // re-index same
+
+	got := queryByName(t, comp, "Doc", 0)
+	require.Len(t, got, 1, "re-indexing the same (entity,predicate) must not duplicate")
+}
+
+func TestHandleQueryByName_UnknownNameIsEmptyNotError(t *testing.T) {
+	comp := newNameTestComponent(t)
+	got := queryByName(t, comp, "nothing-here", 0)
+	assert.Empty(t, got, "unknown name returns empty matches (ready-but-absent), not an error")
+}
+
+func TestHandleQueryByName_EmptyNameRejected(t *testing.T) {
+	comp := newNameTestComponent(t)
+	req, _ := json.Marshal(map[string]any{"name": ""})
+	_, err := comp.handleQueryByNameNATS(context.Background(), req)
+	require.Error(t, err)
+}

--- a/processor/graph-index/query.go
+++ b/processor/graph-index/query.go
@@ -66,6 +66,13 @@ func (c *Component) setupQueryHandlers(ctx context.Context) error {
 	}
 	c.querySubscriptions = append(c.querySubscriptions, sub)
 
+	// Subscribe to name query (gh#376 — deterministic name→ranked-IDs)
+	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.index.query.byName", c.handleQueryByNameNATS)
+	if err != nil {
+		return errs.Wrap(err, "Component", "setupQueryHandlers", "subscribe byName query")
+	}
+	c.querySubscriptions = append(c.querySubscriptions, sub)
+
 	c.logger.Info("query handlers registered",
 		slog.Any("subjects", []string{
 			"graph.index.query.outgoing",
@@ -75,6 +82,7 @@ func (c *Component) setupQueryHandlers(ctx context.Context) error {
 			"graph.index.query.predicateList",
 			"graph.index.query.predicateStats",
 			"graph.index.query.predicateCompound",
+			"graph.index.query.byName",
 		}))
 
 	return nil

--- a/processor/graph-query/query.go
+++ b/processor/graph-query/query.go
@@ -45,6 +45,8 @@ func (c *Component) setupQueryHandlers(ctx context.Context) error {
 		// searchGraph — wraps globalSearch with a semantic fallback
 		// when GraphRAG strategies return empty.
 		{"graph.query.searchGraph", c.handleSearchGraph},
+		// byName — deterministic name→ranked-IDs (gh#376), passthrough to graph-index.
+		{"graph.query.byName", c.handleQueryByName},
 	}
 
 	subjects := make([]string, 0, len(registrations))
@@ -535,6 +537,23 @@ func (c *Component) handleQueryTemporal(ctx context.Context, data []byte) ([]byt
 		return nil, err
 	}
 
+	c.recordSuccess(len(data), len(response))
+	return response, nil
+}
+
+// handleQueryByName handles deterministic name→ranked-IDs requests (gh#376),
+// a passthrough to graph-index's graph.index.query.byName.
+func (c *Component) handleQueryByName(ctx context.Context, data []byte) ([]byte, error) {
+	subject := c.router.Route("byName")
+	if subject == "" {
+		return nil, errs.WrapTransient(errors.New("byName query routing not available"), "GraphQuery", "handleQueryByName", "route query")
+	}
+	// ADR-060: propagate the downstream classified error UNWRAPPED (see handleQueryEntity).
+	response, err := c.natsClient.RequestClassified(ctx, subject, data, c.config.QueryTimeout)
+	if err != nil {
+		c.recordError(err)
+		return nil, err
+	}
 	c.recordSuccess(len(data), len(response))
 	return response, nil
 }

--- a/processor/graph-query/router.go
+++ b/processor/graph-query/router.go
@@ -28,6 +28,7 @@ func NewStaticRouter(logger *slog.Logger) *StaticRouter {
 			"predicateList":     "graph.index.query.predicateList",
 			"predicateStats":    "graph.index.query.predicateStats",
 			"predicateCompound": "graph.index.query.predicateCompound",
+			"byName":            "graph.index.query.byName",
 
 			// Spatial/Temporal -> specialized indexes
 			"spatial":  "graph.spatial.query.bounds",

--- a/processor/graph-query/router_test.go
+++ b/processor/graph-query/router_test.go
@@ -39,6 +39,7 @@ func TestNewStaticRouter(t *testing.T) {
 			"predicateList":     "graph.index.query.predicateList",
 			"predicateStats":    "graph.index.query.predicateStats",
 			"predicateCompound": "graph.index.query.predicateCompound",
+			"byName":            "graph.index.query.byName",
 
 			// Spatial/Temporal
 			"spatial":  "graph.spatial.query.bounds",

--- a/vocabulary/labels.go
+++ b/vocabulary/labels.go
@@ -1,0 +1,31 @@
+package vocabulary
+
+// Label (display-name) predicate registrations.
+//
+// These predicates carry human-readable names/titles. They are registered with
+// AliasTypeLabel, which CanResolveToEntityID()==false — so the ALIAS_INDEX
+// deliberately excludes them (a display name is ambiguous as an identity), while
+// the NAME_INDEX keys on exactly this set for name→ranked-IDs lookup
+// (graph.query.byName, gh#376 ask #5).
+//
+// The framework registers the one cross-product convention it knows is emitted
+// (dc.terms.title). Products register their own label predicates the same way —
+// Register(pred, WithAlias(AliasTypeLabel, priority)) — and the name index picks
+// them up automatically via DiscoverLabelPredicates(). Lower priority = higher
+// salience in name-match ranking.
+func init() {
+	Register(DCTermsTitle,
+		WithDescription("Human-readable title/name of the entity (display label, not an identity)"),
+		WithDataType("string"),
+		WithIRI(DcTitle),
+		WithAlias(AliasTypeLabel, labelPriorityTitle))
+}
+
+// Label-predicate salience priorities (lower = higher salience). A preferred
+// label outranks a title, which outranks an alternate label, when the same name
+// matches entities through different predicates.
+const (
+	labelPriorityPreferred = 0
+	labelPriorityTitle     = 1
+	labelPriorityAlternate = 2
+)

--- a/vocabulary/labels_test.go
+++ b/vocabulary/labels_test.go
@@ -1,0 +1,24 @@
+package vocabulary
+
+import "testing"
+
+func TestDiscoverLabelPredicates_IncludesTitleExcludesResolvable(t *testing.T) {
+	labels := DiscoverLabelPredicates()
+
+	// dc.terms.title is registered as AliasTypeLabel and must appear.
+	if _, ok := labels[DCTermsTitle]; !ok {
+		t.Fatalf("DiscoverLabelPredicates missing %q; got %v", DCTermsTitle, labels)
+	}
+
+	// Label predicates must NOT appear in the alias (resolvable) set, and vice
+	// versa — the two sets are disjoint by AliasType.
+	aliases := DiscoverAliasPredicates()
+	if _, ok := aliases[DCTermsTitle]; ok {
+		t.Fatalf("%q is a label predicate and must not be alias-resolvable", DCTermsTitle)
+	}
+	for name := range labels {
+		if _, ok := aliases[name]; ok {
+			t.Fatalf("predicate %q appears in BOTH label and alias sets — AliasType is ambiguous", name)
+		}
+	}
+}

--- a/vocabulary/registry.go
+++ b/vocabulary/registry.go
@@ -354,6 +354,31 @@ func DiscoverAliasPredicates() map[string]int {
 	return aliasPredicates
 }
 
+// DiscoverLabelPredicates discovers all predicates marked as human-readable
+// labels (AliasTypeLabel) in the registry. Returns predicate name → priority
+// (lower number = higher salience).
+//
+// These are the display-name predicates the alias index deliberately EXCLUDES
+// (labels are ambiguous for ID resolution — CanResolveToEntityID is false for
+// AliasTypeLabel), and are exactly what the name index keys on for
+// name→ranked-IDs lookup. Applications register their own label predicates via
+// Register(pred, WithAlias(AliasTypeLabel, priority)), the same mechanism as
+// aliases. Empty when none are registered.
+func DiscoverLabelPredicates() map[string]int {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	labelPredicates := make(map[string]int)
+
+	for name, meta := range predicateRegistry {
+		if meta.IsAlias && meta.AliasType == AliasTypeLabel {
+			labelPredicates[name] = meta.AliasPriority
+		}
+	}
+
+	return labelPredicates
+}
+
 // GetInversePredicate returns the inverse predicate name, if defined.
 // Returns an empty string if no inverse is defined for the given predicate.
 //


### PR DESCRIPTION
Refs #376 (semsource deterministic-fusion ask #5). The resolve-side precursor semsource is blocked on.

## What

A `NAME_INDEX` + **`graph.query.byName`** subject: a bare name/title → ranked entity IDs, deterministically. Today `ALIAS_INDEX` deliberately excludes display-name (`AliasTypeLabel`) predicates, so exact-name lookup silently falls back to semantic search — making a "deterministic" provenance label optimistic. This closes that gap (and sharpens `research-graph-execute`'s resolve).

- **vocabulary:** `DiscoverLabelPredicates()` (complement of `DiscoverAliasPredicates`); registers the one cross-product convention (`dc.terms.title`) as `AliasTypeLabel`. Products register their own label predicates the same way — `Register(pred, WithAlias(AliasTypeLabel, priority))`.
- **graph-index:** `NAME_INDEX` bucket (internal, like `CONTEXT_INDEX` — not a required output port, so existing configs are unaffected). `UpdateNameIndex` CAS-upserts name→entities, deduped by `(entity, predicate)`. `handleQueryByNameNATS`: case-insensitive recall (key = sha256 of folded name), ranked **exact-case-first → label salience → entity ID**, one match per entity, limit-bounded. Unknown name → empty (not error).
- **graph-query:** `graph.query.byName` passthrough (`RequestClassified`, ADR-060).

**Match semantics** confirmed with the consumer: case-insensitive recall with exact-case ranked first (serves code symbols precisely AND doc titles).

## Review

semstreams-reviewer ran **pre-merge**. Verdict APPROVE after one blocking fmt fix (stray trailing blank line, fixed — `query_index_types.go` is now identical to main). Verified clean: ADR-060 error contract (both directions), eager bucket creation + config compat, CAS-under-contention correctness, ranking total-order, vocabulary isolation (label predicates excluded from alias resolution), stale-entry consistency with existing indexes. Two non-blocking notes: CAS-contention is unit-tested only via the real-KV integration layer (mock ignores revision); unbounded value-growth per hot name is a pre-existing convention shared with `PREDICATE_INDEX` — filed as a follow-up.

## Tests

Ranking (exact-case/salience/dedup/limit), normalization/key folding, KV round-trip through the real `Update`+query handler, unknown-name-empty, empty-name-rejected, `DiscoverLabelPredicates` disjointness from aliases. `-race` unit + `-tags=integration` green; vet/revive/gofmt clean; schema gen no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)