### PR TITLE
fix(gated-dag): write terminal markers reliably to kill the full-stack flake (gh#373)

### DIFF
--- a/processor/gated-dag/fullstack_integration_test.go
+++ b/processor/gated-dag/fullstack_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/payloadregistry"
+	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
 	gateddagexec "github.com/c360studio/semstreams/processor/gated-dag"
 	graphingest "github.com/c360studio/semstreams/processor/graph-ingest"
@@ -189,9 +190,21 @@ func setupFullStack(t *testing.T, opts fsOpts) *fullStack {
 
 	dispatched := &dispatchLog{}
 
-	// Demo consumer: on each dispatch, complete the unit (or fail it). This is
-	// the work-completion loop a real consumer (semspec) provides; here it just
-	// writes the terminal marker so the executor's next backstop advances the DAG.
+	// markerCtx scopes the demo consumer's marker-write goroutines; cancelled at
+	// teardown (registered after NewTestClient so it runs BEFORE client.Close in
+	// LIFO cleanup) so no retry loop outlives the test or races the closing client.
+	markerCtx, cancelMarkers := context.WithCancel(context.Background())
+	t.Cleanup(cancelMarkers)
+
+	// Demo consumer: on each dispatch, complete the unit (or fail it). This is the
+	// work-completion loop a real consumer (semspec) provides; here it writes the
+	// terminal marker so the executor's next backstop advances the DAG. The marker
+	// write is synchronous in the callback (dispatch is recorded first, so the
+	// dispatch assertions are unaffected). A retrying write head-of-line-blocks
+	// sibling units on this single-threaded subscription callback, but bounded at
+	// addMarker's 25s — under fsEventually's 30s even in the worst case — and a
+	// goroutine-per-marker alternative measurably worsened scheduling contention
+	// under constrained CPU, so synchronous is the right trade here.
 	dec := newDispatchDecoder(t)
 	sub, err := nc.Subscribe(ctx, subject, func(_ context.Context, msg *nats.Msg) {
 		unitID, ok := dec(msg.Data)
@@ -203,7 +216,7 @@ func setupFullStack(t *testing.T, opts fsOpts) *fullStack {
 		if failUnits[unitID] {
 			pred = pFailed
 		}
-		addMarker(nc, unitID, pred)
+		addMarker(markerCtx, nc, unitID, pred)
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sub.Unsubscribe() })
@@ -299,9 +312,26 @@ func (fs *fullStack) unitHasPredicate(t *testing.T, id, predicate string) bool {
 	return false
 }
 
-// addMarker appends a presence marker (best-effort; called from the consumer
-// goroutine so it must not touch *testing.T).
-func addMarker(nc *natsclient.Client, unitID, predicate string) {
+// addMarker writes a terminal marker, retrying until the mutation lands, a 25s
+// deadline elapses, ctx is cancelled, or the error is permanent. A real work
+// consumer must write terminal markers reliably (at-least-once); the prior
+// fire-and-forget (single RequestWithRetry, error DISCARDED) silently LOST the
+// marker whenever a transport-level failure — graph-ingest's mutation subject
+// momentarily slow/unready under CI Docker contention — blew RequestWithRetry's
+// transport-retry budget. A lost marker leaves the unit dispatched-but-never-
+// terminal, stalling the dependent assertions for the full Eventually window
+// (gh#373, the real root cause behind the "flake"). 25s sits under fsEventually
+// (30s) so a genuinely-failing mutation still surfaces as the assertion failure.
+//
+// ctx is the test-scoped marker context, cancelled at teardown so no loop
+// outlives the test or races client.Close. Synchronous in the consumer callback
+// (see setupFullStack for the head-of-line-blocking trade-off). Must not touch
+// *testing.T.
+//
+// NOTE: this makes the TEST consumer infallible. Production has no such
+// guarantee and a stranded claimed-but-unmarked unit is not auto-recovered —
+// tracked separately as a production gap (gh#373 follow-up).
+func addMarker(ctx context.Context, nc *natsclient.Client, unitID, predicate string) {
 	req := gtypes.AddTripleRequest{Triple: message.Triple{
 		Subject: unitID, Predicate: predicate, Object: true, Timestamp: time.Now(), Confidence: 1.0,
 	}}
@@ -309,7 +339,18 @@ func addMarker(nc *natsclient.Client, unitID, predicate string) {
 	if err != nil {
 		return
 	}
-	_, _ = nc.RequestWithRetryClassified(context.Background(), "graph.mutation.triple.add", data, 5*time.Second, natsclient.DefaultRetryConfig())
+	deadline := time.Now().Add(25 * time.Second)
+	for {
+		_, err := nc.RequestWithRetryClassified(ctx, "graph.mutation.triple.add", data, 5*time.Second, natsclient.DefaultRetryConfig())
+		if err == nil || errs.IsInvalid(err) || time.Now().After(deadline) {
+			return // success, permanent rejection (won't pass on retry), or deadline
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
 }
 
 func fsUnit(scenario, suffix string) string {


### PR DESCRIPTION
Closes #373. Supersedes #374's timeout band-aid with the actual root-cause fix. Refs #385 (production follow-up).

## Root cause (not slowness)

The full-stack tests' demo consumer wrote each unit's terminal marker via a single fire-and-forget `RequestWithRetry` whose **error was discarded** (`_, _ =`). Under CI Docker contention a transport-level failure (graph-ingest's mutation subject momentarily slow/unready) blows the transport-retry budget; the swallowed failure leaves the unit **dispatched-but-never-terminal**, stalling dependent assertions for the full Eventually window. #380's recurrence failed at **30.81s** — past the 30s bound #374 widened to — confirming a real stall, exactly what #374's own comment said warranted investigation rather than another bump.

## Fix

`addMarker` retries until the mutation lands, a 25s deadline elapses (under `fsEventually`'s 30s, so a genuinely-failing mutation still surfaces as the assertion failure), the test-scoped marker ctx is cancelled at teardown, or the error is permanent (`errs.IsInvalid` → fail fast). Happy path unchanged (sub-second). Kept **synchronous** in the consumer callback — a goroutine-per-marker variant measurably worsened scheduling contention under constrained CPU; head-of-line-blocking is bounded under `fsEventually` and dispatch is recorded before the write.

## Pre-merge review (semstreams-reviewer)

Ran before merge. Verified the diagnosis (dispatch assertion passes first → lost *marker*, not lost dispatch) and adversarially worked the alternatives (lost core-NATS dispatch — ruled out by ordering; CAS storm — absorbed by 10 internal CAS retries). Findings addressed: ctx-leak (now test-scoped ctx + `select` on `Done()`), retry-budget comment precision (corrected to transport-level), fail-fast on permanent errors. **The key finding** — that this makes the *test* consumer infallible while **production has a real stranded-claimed-unit recovery gap** (no claim TTL, stall suppressed for claimed+non-terminal) — is filed as **#385**, not absorbed silently.

## Verification

Three previously-flaky tests pass **8× under `GOMAXPROCS=2 -race`**; full gated-dag integration suite green; vet/gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)