### PR TITLE
feat(fusion): extract pkg/fusion deterministic engine (ADR-062, gh#376)

### DIFF
--- a/agentic/research/execution_output.go
+++ b/agentic/research/execution_output.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // ExecutionOutput is the execute_subqueries component's emit:
@@ -33,7 +34,7 @@ type ExecutionOutput struct {
 	// may have produced no hits — assess_sufficiency surfaces this
 	// to the LLM as "you have nothing to synthesize from"; the
 	// chain doesn't error on empty).
-	Evidence []Evidence `json:"evidence,omitempty"`
+	Evidence []fusion.Evidence `json:"evidence,omitempty"`
 
 	// SubQueryCount is the number of sub-queries the materializer
 	// produced for this execution. Operator observability: tracks

--- a/agentic/research/result.go
+++ b/agentic/research/result.go
@@ -6,64 +6,8 @@ import (
 	"strings"
 
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
-
-// Evidence is one item in SearchResult.Evidence — a single entity hit
-// or evidence snippet the chain surfaced. Provenance is mandatory:
-// every evidence item carries enough metadata (EntityID + Tier +
-// Source) for the caller to verify it back against the graph and for
-// synthesize_answer's quote-back validation to reject fabricated refs.
-//
-// ObjectStoreRef is set when the body of the evidence (long text,
-// document, etc.) lives in ObjectStore; consumers read it via that
-// ref. SnippetText carries a short inline preview for prompt-injection
-// readability without triggering ObjectStore round-trips on every hit.
-type Evidence struct {
-	// EntityID is the graph entity this evidence refers to. Required.
-	EntityID string `json:"entity_id"`
-
-	// Tier is the retrieval tier that surfaced this hit: "0" (rules /
-	// predicate queries), "1" (BM25), or "2" (neural — deferred to
-	// Phase 2). Operators may use it to filter evidence by retrieval
-	// method.
-	Tier string `json:"tier"`
-
-	// Source is the retrieval source within the tier — e.g.
-	// "classifier", "predicate_walk", "bm25_index". Required.
-	Source string `json:"source"`
-
-	// Score is the within-tier ranking score (higher = better).
-	// Cross-tier comparison is not meaningful in Phase 1 (per-tier
-	// ordering + recency tie-break); Phase 2 may add a learned ranker.
-	Score float64 `json:"score,omitempty"`
-
-	// SnippetText is a short inline preview (prompt-injection
-	// friendly). Omit when the evidence has no readable preview.
-	SnippetText string `json:"snippet_text,omitempty"`
-
-	// ObjectStoreRef is the ObjectStore key for the full body when
-	// the evidence has bulk content. Empty when the evidence is fully
-	// expressed in the EntityID + triples on the graph.
-	ObjectStoreRef string `json:"objectstore_ref,omitempty"`
-}
-
-// Validate checks the required fields and rejects unknown tier values.
-func (e *Evidence) Validate() error {
-	if strings.TrimSpace(e.EntityID) == "" {
-		return fmt.Errorf("entity_id required")
-	}
-	if strings.TrimSpace(e.Source) == "" {
-		return fmt.Errorf("source required")
-	}
-	switch e.Tier {
-	case "0", "1", "2":
-		// Accepted set. "2" is reserved for Phase 2 but accepted at
-		// the schema level so Phase 1 fixtures can probe forward-compat.
-	default:
-		return fmt.Errorf("tier %q must be \"0\", \"1\", or \"2\"", e.Tier)
-	}
-	return nil
-}
 
 // DecompTrace records what decomposition the chain actually performed,
 // for operator review of router quality. The shape is deliberately
@@ -98,7 +42,7 @@ type SearchResult struct {
 	// Evidence is the set of hits that informed Synthesis. Every
 	// evidence item synthesize_answer references must appear here;
 	// quote-back validation enforces this in PR 5.
-	Evidence []Evidence `json:"evidence,omitempty"`
+	Evidence []fusion.Evidence `json:"evidence,omitempty"`
 
 	// Synthesis is the natural-language answer produced by
 	// synthesize_answer. Refs quoted in the prose must resolve to

--- a/agentic/research/roundtrip_test.go
+++ b/agentic/research/roundtrip_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/c360studio/semstreams/agentic/research"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/payloadbuiltins"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // Production-decoder round-trip tests for the three ADR-045 payload
@@ -68,7 +69,7 @@ func TestResearchIntent_RoundTripThroughDecoder(t *testing.T) {
 
 func TestSearchResult_RoundTripThroughDecoder(t *testing.T) {
 	original := &research.SearchResult{
-		Evidence: []research.Evidence{
+		Evidence: []fusion.Evidence{
 			{
 				EntityID:    "acme.ops.robotics.gcs.drone.001",
 				Tier:        "0",
@@ -414,7 +415,7 @@ func TestEvidence_ValidateAcceptsPhase2Tier(t *testing.T) {
 	// tighten the enum without realising Phase 2 fixtures depend on it.
 	for _, tier := range []string{"0", "1", "2"} {
 		t.Run("tier_"+tier, func(t *testing.T) {
-			e := &research.Evidence{EntityID: "x", Tier: tier, Source: "s"}
+			e := &fusion.Evidence{EntityID: "x", Tier: tier, Source: "s"}
 			if err := e.Validate(); err != nil {
 				t.Errorf("Validate(tier=%q) = %v, want nil", tier, err)
 			}
@@ -437,7 +438,7 @@ func TestSearchResult_ValidateRejectsInvalidEvidence(t *testing.T) {
 			name: "evidence missing entity_id",
 			result: research.SearchResult{
 				Synthesis: "x",
-				Evidence:  []research.Evidence{{Tier: "0", Source: "classifier"}},
+				Evidence:  []fusion.Evidence{{Tier: "0", Source: "classifier"}},
 			},
 			wantSub: "entity_id required",
 		},
@@ -445,7 +446,7 @@ func TestSearchResult_ValidateRejectsInvalidEvidence(t *testing.T) {
 			name: "evidence bad tier",
 			result: research.SearchResult{
 				Synthesis: "x",
-				Evidence:  []research.Evidence{{EntityID: "e", Tier: "bogus", Source: "x"}},
+				Evidence:  []fusion.Evidence{{EntityID: "e", Tier: "bogus", Source: "x"}},
 			},
 			wantSub: "tier",
 		},
@@ -726,7 +727,7 @@ func TestExecutionOutput_RoundTripThroughDecoder(t *testing.T) {
 	original := &research.ExecutionOutput{
 		Topic:  "drone-001 maintenance events in the last 24 hours",
 		Action: research.ActionWalkSeeds,
-		Evidence: []research.Evidence{
+		Evidence: []fusion.Evidence{
 			{EntityID: "acme.ops.robotics.gcs.drone.001", Tier: "0", Source: "walk_seeds.entity_state", Score: 0.95},
 			{EntityID: "acme.ops.robotics.gcs.event.maint-001", Tier: "0", Source: "walk_seeds.predicate_walk", Score: 0.82, SnippetText: "scheduled maintenance window"},
 			{EntityID: "acme.ops.robotics.gcs.alert.battery", Tier: "1", Source: "walk_seeds.bm25_coverage", Score: 0.55},
@@ -823,7 +824,7 @@ func TestExecutionOutput_ValidateRejectsInvalid(t *testing.T) {
 			output: research.ExecutionOutput{
 				Topic:    "x",
 				Action:   research.ActionWalkSeeds,
-				Evidence: []research.Evidence{{EntityID: "e", Tier: "bogus", Source: "x"}},
+				Evidence: []fusion.Evidence{{EntityID: "e", Tier: "bogus", Source: "x"}},
 			},
 			wantSub: "tier",
 		},

--- a/pkg/fusion/client.go
+++ b/pkg/fusion/client.go
@@ -1,0 +1,29 @@
+package fusion
+
+import "context"
+
+// GraphQueryClient is the narrow retrieval surface the fusion engine
+// consumes. Production implementations wrap NATS-direct subjects;
+// tests substitute in-memory fakes so the test matrix doesn't need a
+// live graph stack.
+//
+// Per-method semantics:
+//
+//   - EntityState: returns the current Triples for the named
+//     entities, projected into Evidence (one per entity).
+//   - PredicateWalk: from each seed, returns Evidence for entities
+//     reachable within MaxHops via Predicates (empty Predicates =
+//     all).
+//   - TemporalRange: returns Evidence for entities within the time
+//     window, optionally filtered by topic.
+//   - BM25: text search via graph-query's existing BM25 surface.
+//
+// All methods MUST stamp Tier + Source on every returned Evidence
+// (taken from the SubQuery they were dispatched for) so provenance
+// stays honest end-to-end. The engine does NOT re-stamp.
+type GraphQueryClient interface {
+	EntityState(ctx context.Context, args EntityStateArgs, tier, source string, limit int) ([]Evidence, error)
+	PredicateWalk(ctx context.Context, args PredicateWalkArgs, tier, source string, limit int) ([]Evidence, error)
+	TemporalRange(ctx context.Context, args TemporalRangeArgs, tier, source string, limit int) ([]Evidence, error)
+	BM25(ctx context.Context, args BM25Args, tier, source string, limit int) ([]Evidence, error)
+}

--- a/pkg/fusion/doc.go
+++ b/pkg/fusion/doc.go
@@ -1,0 +1,7 @@
+// Package fusion is the generic deterministic-fusion engine: fan-out
+// sub-query dispatch, dedup, rank, and budget enforcement over a
+// GraphQueryClient. It is a pure leaf package — no NATS, no research-domain
+// types (Intent, ExecutionOutput, RouteAction). Domain-coupled callers
+// (processor/research-graph-execute) compose this engine and wrap the result
+// in their own payload types.
+package fusion

--- a/pkg/fusion/engine.go
+++ b/pkg/fusion/engine.go
@@ -1,0 +1,332 @@
+package fusion
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Default engine constants. Callers that pass zero-value FuseOptions
+// fields fall through to these.
+const (
+	// DefaultMaxParallelism caps concurrent sub-query execution.
+	// Keeps fan-out from saturating the responding gateways under
+	// a wide-decompose scenario; operators can raise for staging
+	// environments with more capacity.
+	DefaultMaxParallelism = 8
+
+	// DefaultMaxResultsPerSubquery caps per-sub-query result count
+	// before ranking + budget enforcement run. Prevents a single
+	// runaway sub-query from dominating the evidence array.
+	DefaultMaxResultsPerSubquery = 50
+
+	// DefaultBudgetTokens is the fallback evidence-budget when the
+	// caller doesn't supply one. Should never normally fire when
+	// callers supply a domain default, but acts as a safety net.
+	DefaultBudgetTokens = 4000
+
+	// DefaultPerSubqueryTimeoutFraction is the fraction of the
+	// overall context deadline each sub-query gets as its per-call
+	// timeout. 0.5 leaves slack for fan-out overhead and ranking.
+	DefaultPerSubqueryTimeoutFraction = 0.5
+
+	// DefaultExecuteTimeout is the fallback per-query timeout when
+	// the caller's context has no deadline. Used only to bound
+	// per-sub-query execution when ctx has no deadline set.
+	DefaultExecuteTimeout = 60 * time.Second
+)
+
+// FuseOptions controls the engine's concurrency, per-subquery result
+// cap, and evidence budget. Zero values fall through to the
+// Default* constants.
+type FuseOptions struct {
+	// MaxParallelism caps concurrent sub-query execution. 0 uses DefaultMaxParallelism.
+	MaxParallelism int
+
+	// MaxResultsPerSubquery caps result count per sub-query before
+	// ranking + budget enforcement run. 0 uses DefaultMaxResultsPerSubquery.
+	MaxResultsPerSubquery int
+
+	// BudgetTokens is the estimated-token budget for the returned
+	// evidence set. 0 uses DefaultBudgetTokens.
+	BudgetTokens int
+}
+
+// FuseResult is the engine's output: dedup'd + ranked + budget-enforced
+// evidence, plus observability fields.
+type FuseResult struct {
+	// Evidence is the kept evidence set after dedup, sort, and budget
+	// enforcement. May be empty (degraded path or zero queries).
+	Evidence []Evidence
+
+	// Degraded flags incomplete fan-out — e.g. one or more sub-query
+	// errors or a timeout. The caller should surface this to operators
+	// or downstream LLM consumers as low-confidence input.
+	Degraded bool
+
+	// DegradedReason explains why Degraded is set. Multiple per-sub-query
+	// failures are joined with "; ".
+	DegradedReason string
+
+	// BudgetTokensUsed is the estimated token cost of the kept evidence
+	// array after budget enforcement. Useful for operator observability
+	// and tuning budget parameters.
+	BudgetTokensUsed int
+}
+
+// Fuse runs the materialized sub-query set in parallel, deduplicates
+// by EntityID (across tiers), sorts by tier + score + entity-ID
+// tie-break, enforces the token budget, and returns a FuseResult.
+//
+// gq must not be nil. An empty queries slice is not an error — it
+// returns FuseResult{Degraded: true, DegradedReason: "..."}.
+//
+// Per-sub-query failures are degrading, NOT chain-failing: they set
+// FuseResult.Degraded and append to DegradedReason without cancelling
+// sibling sub-queries. The only hard-fail is a parent-context
+// cancellation, which returns a non-nil error.
+//
+// The logger parameter is optional; nil uses slog.Default().
+func Fuse(ctx context.Context, gq GraphQueryClient, queries []SubQuery, opts FuseOptions, logger *slog.Logger) (FuseResult, error) {
+	if gq == nil {
+		return FuseResult{}, fmt.Errorf("graph-query client is nil")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	maxParallelism := opts.MaxParallelism
+	if maxParallelism <= 0 {
+		maxParallelism = DefaultMaxParallelism
+	}
+	maxResultsPerSubquery := opts.MaxResultsPerSubquery
+	if maxResultsPerSubquery <= 0 {
+		maxResultsPerSubquery = DefaultMaxResultsPerSubquery
+	}
+	budget := opts.BudgetTokens
+	if budget <= 0 {
+		budget = DefaultBudgetTokens
+	}
+
+	if len(queries) == 0 {
+		return FuseResult{
+			Degraded:       true,
+			DegradedReason: "materializer produced zero sub-queries",
+		}, nil
+	}
+
+	// Per-sub-query timeout = ctx's remaining deadline * DefaultPerSubqueryTimeoutFraction.
+	perQueryTimeout := derivePerQueryTimeout(ctx)
+
+	var (
+		mu          sync.Mutex
+		allEvidence []Evidence
+		degraded    bool
+		reasons     []string
+	)
+
+	// Bounded-concurrency errgroup. SetLimit clamps how many
+	// sub-queries dispatch in parallel; remaining queries queue.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxParallelism)
+
+	for i := range queries {
+		q := queries[i]
+		g.Go(func() error {
+			qctx := gctx
+			if perQueryTimeout > 0 {
+				var cancel context.CancelFunc
+				qctx, cancel = context.WithTimeout(gctx, perQueryTimeout)
+				defer cancel()
+			}
+			evidence, err := executeSubQuery(qctx, gq, q, maxResultsPerSubquery)
+			if err != nil {
+				logger.Warn("sub-query failed; degrading",
+					slog.String("type", string(q.Type)),
+					slog.String("source", q.Source),
+					slog.Any("error", err))
+				mu.Lock()
+				degraded = true
+				reasons = append(reasons, fmt.Sprintf("%s:%s failed: %v", q.Type, q.Source, err))
+				mu.Unlock()
+				// Per-sub-query failure is degrading, NOT chain-failing.
+				// Return nil so errgroup doesn't cancel sibling sub-queries.
+				return nil
+			}
+			mu.Lock()
+			allEvidence = append(allEvidence, evidence...)
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		// errgroup returns the first non-nil error from a goroutine.
+		// We return nil from per-sub-query failures, so this only fires
+		// on a hard cancellation (parent ctx done).
+		return FuseResult{}, fmt.Errorf("fan-out: %w", err)
+	}
+
+	// Dedup by EntityID (cross-tier collapses), preserve highest-tier
+	// + highest-score Evidence for the duplicate set.
+	deduped := dedupEvidence(allEvidence)
+
+	// Per-tier ordering + recency tie-break.
+	sortEvidence(deduped)
+
+	// Budget enforcement. Drop lowest-scoring until under budget.
+	enforced, usedTokens := enforceBudget(deduped, budget)
+
+	result := FuseResult{
+		Evidence:         enforced,
+		BudgetTokensUsed: usedTokens,
+	}
+	if degraded {
+		result.Degraded = true
+		result.DegradedReason = strings.Join(reasons, "; ")
+	}
+
+	return result, nil
+}
+
+// executeSubQuery dispatches one sub-query to the right GraphQueryClient
+// method. Returns Evidence with Tier + Source already stamped by the
+// implementing executor (interface contract).
+func executeSubQuery(ctx context.Context, gq GraphQueryClient, q SubQuery, limit int) ([]Evidence, error) {
+	switch q.Type {
+	case SubQueryTypeEntityState:
+		return gq.EntityState(ctx, *q.EntityState, q.Tier, q.Source, limit)
+	case SubQueryTypePredicateWalk:
+		return gq.PredicateWalk(ctx, *q.PredicateWalk, q.Tier, q.Source, limit)
+	case SubQueryTypeTemporalRange:
+		return gq.TemporalRange(ctx, *q.TemporalRange, q.Tier, q.Source, limit)
+	case SubQueryTypeBM25:
+		return gq.BM25(ctx, *q.BM25, q.Tier, q.Source, limit)
+	}
+	return nil, fmt.Errorf("unknown sub-query type %q", q.Type)
+}
+
+// dedupEvidence collapses duplicates by EntityID. When the same entity
+// surfaces in multiple sub-queries, the dedup picks the "best" Evidence:
+// lower Tier wins (Tier 0 > Tier 1), and within the same tier higher
+// Score wins.
+//
+// Provenance is preserved by stamping the WINNING evidence's Source.
+// Phase 2 may extend Evidence with a multi-source list so the agent
+// can quote any path that surfaced the entity; Phase 1 ships
+// single-source-per-entity.
+func dedupEvidence(in []Evidence) []Evidence {
+	if len(in) == 0 {
+		return nil
+	}
+	best := make(map[string]Evidence, len(in))
+	for _, e := range in {
+		if e.EntityID == "" {
+			continue
+		}
+		existing, ok := best[e.EntityID]
+		if !ok {
+			best[e.EntityID] = e
+			continue
+		}
+		if evidenceBeats(e, existing) {
+			best[e.EntityID] = e
+		}
+	}
+	out := make([]Evidence, 0, len(best))
+	for _, e := range best {
+		out = append(out, e)
+	}
+	return out
+}
+
+// evidenceBeats returns true when a should replace b in dedup.
+// Tier 0 beats Tier 1 unconditionally; within the same tier, higher
+// Score wins; ties broken by EntityID ascending (deterministic
+// across map iteration).
+func evidenceBeats(a, b Evidence) bool {
+	if a.Tier != b.Tier {
+		return a.Tier < b.Tier // "0" < "1" lexically — Tier 0 wins
+	}
+	if a.Score != b.Score {
+		return a.Score > b.Score
+	}
+	return a.EntityID < b.EntityID
+}
+
+// sortEvidence applies Phase 1's ordering rule: lower-tier first
+// (Tier 0 before Tier 1), then higher Score, then EntityID ascending
+// for tie-break. Stable sort preserves input order within ties for
+// replay determinism.
+func sortEvidence(ev []Evidence) {
+	sort.SliceStable(ev, func(i, j int) bool {
+		if ev[i].Tier != ev[j].Tier {
+			return ev[i].Tier < ev[j].Tier
+		}
+		if ev[i].Score != ev[j].Score {
+			return ev[i].Score > ev[j].Score
+		}
+		return ev[i].EntityID < ev[j].EntityID
+	})
+}
+
+// enforceBudget drops lowest-ranked evidence (from the tail of the
+// sorted slice) until the estimated token cost fits within budget.
+// Returns the kept slice and the estimated token cost actually retained.
+//
+// Token estimation: ~4 chars/token (industry rule of thumb) across the
+// rendered evidence — EntityID + SnippetText + Source + ObjectStoreRef.
+// Crude but stable; Phase 2 may swap a tokenizer.
+func enforceBudget(in []Evidence, budget int) ([]Evidence, int) {
+	if len(in) == 0 || budget <= 0 {
+		return in, 0
+	}
+	out := make([]Evidence, 0, len(in))
+	used := 0
+	for _, e := range in {
+		cost := estimateEvidenceTokens(e)
+		if used+cost > budget {
+			// Drop this and everything after (in sorted order, they're
+			// lower-ranked). Phase 1 strategy: sharp cutoff.
+			break
+		}
+		out = append(out, e)
+		used += cost
+	}
+	return out, used
+}
+
+// estimateEvidenceTokens approximates the prompt-cost of one Evidence
+// entry. Sums character counts of the rendered fields and divides by 4.
+// Always returns at least 1 to prevent empty Evidence from being "free".
+func estimateEvidenceTokens(e Evidence) int {
+	chars := len(e.EntityID) + len(e.SnippetText) + len(e.Source) + len(e.ObjectStoreRef)
+	tokens := chars / 4
+	if tokens < 1 {
+		tokens = 1
+	}
+	return tokens
+}
+
+// derivePerQueryTimeout returns the per-sub-query deadline as a
+// fraction of the parent ctx's remaining time. When the parent has no
+// deadline (test ctx.Background, or operator-disabled component
+// timeout), falls back to a fraction of DefaultExecuteTimeout so a
+// wedged sub-query can't hang the fan-out indefinitely.
+func derivePerQueryTimeout(ctx context.Context) time.Duration {
+	dl, ok := ctx.Deadline()
+	if !ok {
+		return time.Duration(float64(DefaultExecuteTimeout) * DefaultPerSubqueryTimeoutFraction)
+	}
+	remaining := time.Until(dl)
+	if remaining <= 0 {
+		return 0
+	}
+	return time.Duration(float64(remaining) * DefaultPerSubqueryTimeoutFraction)
+}

--- a/pkg/fusion/engine_test.go
+++ b/pkg/fusion/engine_test.go
@@ -1,0 +1,331 @@
+package fusion
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeGraphQuery records what was called and returns canned evidence
+// per sub-query type.
+type fakeGraphQuery struct {
+	mu sync.Mutex
+
+	entityStateCalls   int
+	predicateWalkCalls int
+	temporalRangeCalls int
+	bm25Calls          int
+
+	entityStateOut   []Evidence
+	predicateWalkOut []Evidence
+	temporalRangeOut []Evidence
+	bm25Out          []Evidence
+
+	entityStateErr   error
+	predicateWalkErr error
+	temporalRangeErr error
+	bm25Err          error
+}
+
+func (f *fakeGraphQuery) EntityState(_ context.Context, _ EntityStateArgs, tier, source string, _ int) ([]Evidence, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.entityStateCalls++
+	if f.entityStateErr != nil {
+		return nil, f.entityStateErr
+	}
+	return stampEvidence(f.entityStateOut, tier, source), nil
+}
+
+func (f *fakeGraphQuery) PredicateWalk(_ context.Context, _ PredicateWalkArgs, tier, source string, _ int) ([]Evidence, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.predicateWalkCalls++
+	if f.predicateWalkErr != nil {
+		return nil, f.predicateWalkErr
+	}
+	return stampEvidence(f.predicateWalkOut, tier, source), nil
+}
+
+func (f *fakeGraphQuery) TemporalRange(_ context.Context, _ TemporalRangeArgs, tier, source string, _ int) ([]Evidence, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.temporalRangeCalls++
+	if f.temporalRangeErr != nil {
+		return nil, f.temporalRangeErr
+	}
+	return stampEvidence(f.temporalRangeOut, tier, source), nil
+}
+
+func (f *fakeGraphQuery) BM25(_ context.Context, _ BM25Args, tier, source string, _ int) ([]Evidence, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.bm25Calls++
+	if f.bm25Err != nil {
+		return nil, f.bm25Err
+	}
+	return stampEvidence(f.bm25Out, tier, source), nil
+}
+
+// stampEvidence applies the Tier + Source the GraphQueryClient contract
+// requires. Test fixtures supply Evidence with just EntityID + Score;
+// the contract-stamping mirrors what production adapters do.
+func stampEvidence(in []Evidence, tier, source string) []Evidence {
+	out := make([]Evidence, len(in))
+	for i, e := range in {
+		e.Tier = tier
+		e.Source = source
+		out[i] = e
+	}
+	return out
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// --- Fuse: orchestration ---
+
+func TestFuse_HappyPath(t *testing.T) {
+	gq := &fakeGraphQuery{
+		entityStateOut:   []Evidence{{EntityID: "e1", Score: 0.9}},
+		predicateWalkOut: []Evidence{{EntityID: "e2", Score: 0.7}},
+		bm25Out:          []Evidence{{EntityID: "e3", Score: 0.5}},
+	}
+	queries := []SubQuery{
+		{Type: SubQueryTypeEntityState, Tier: "0", Source: "es", EntityState: &EntityStateArgs{EntityIDs: []string{"e1"}}},
+		{Type: SubQueryTypePredicateWalk, Tier: "0", Source: "pw", PredicateWalk: &PredicateWalkArgs{Seeds: []string{"e1"}}},
+		{Type: SubQueryTypeBM25, Tier: "1", Source: "bm", BM25: &BM25Args{Query: "q"}},
+	}
+	opts := FuseOptions{BudgetTokens: 10000}
+	result, err := Fuse(context.Background(), gq, queries, opts, quietLogger())
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	if len(result.Evidence) != 3 {
+		t.Errorf("evidence count: got %d, want 3 (e1+e2+e3)", len(result.Evidence))
+	}
+	if result.Degraded {
+		t.Errorf("Degraded should be false on happy path: reason=%q", result.DegradedReason)
+	}
+	if result.BudgetTokensUsed <= 0 {
+		t.Errorf("budget_tokens_used should be > 0, got %d", result.BudgetTokensUsed)
+	}
+	if gq.entityStateCalls != 1 || gq.predicateWalkCalls != 1 || gq.bm25Calls != 1 {
+		t.Errorf("call counts: es=%d pw=%d bm=%d, want all 1", gq.entityStateCalls, gq.predicateWalkCalls, gq.bm25Calls)
+	}
+}
+
+func TestFuse_PerSubqueryErrorIsDegrading(t *testing.T) {
+	gq := &fakeGraphQuery{
+		entityStateOut: []Evidence{{EntityID: "e1", Score: 0.9}},
+		bm25Err:        errors.New("BM25 down"),
+	}
+	queries := []SubQuery{
+		{Type: SubQueryTypeEntityState, Tier: "0", Source: "es", EntityState: &EntityStateArgs{EntityIDs: []string{"e1"}}},
+		{Type: SubQueryTypeBM25, Tier: "1", Source: "bm", BM25: &BM25Args{Query: "q"}},
+	}
+	opts := FuseOptions{BudgetTokens: 10000}
+	result, err := Fuse(context.Background(), gq, queries, opts, quietLogger())
+	if err != nil {
+		t.Fatalf("Fuse should not chain-fail on per-sub-query err: %v", err)
+	}
+	if !result.Degraded {
+		t.Error("Degraded should be true after BM25 error")
+	}
+	if !strings.Contains(result.DegradedReason, "bm25:bm failed") {
+		t.Errorf("degraded reason should name BM25 failure: %q", result.DegradedReason)
+	}
+	if len(result.Evidence) != 1 {
+		t.Errorf("evidence should still include EntityState hit despite BM25 failure: got %d, want 1", len(result.Evidence))
+	}
+}
+
+func TestFuse_EmptyQueriesIsDegraded(t *testing.T) {
+	result, err := Fuse(context.Background(), &fakeGraphQuery{}, nil, FuseOptions{}, quietLogger())
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	if !result.Degraded {
+		t.Error("Degraded should be true when materializer produced no queries")
+	}
+	if !strings.Contains(result.DegradedReason, "zero sub-queries") {
+		t.Errorf("degraded reason should explain empty queries: %q", result.DegradedReason)
+	}
+}
+
+func TestFuse_NilClientErrors(t *testing.T) {
+	_, err := Fuse(context.Background(), nil, nil, FuseOptions{}, nil)
+	if err == nil {
+		t.Error("Fuse with nil client should return error")
+	}
+}
+
+// --- dedup ---
+
+func TestDedupEvidence_TierZeroWinsOverTierOne(t *testing.T) {
+	in := []Evidence{
+		{EntityID: "e1", Tier: "1", Source: "bm25", Score: 0.9}, // tier 1, high score
+		{EntityID: "e1", Tier: "0", Source: "es", Score: 0.3},   // tier 0, low score — should win
+		{EntityID: "e2", Tier: "0", Source: "pw", Score: 0.7},
+	}
+	out := dedupEvidence(in)
+	if len(out) != 2 {
+		t.Fatalf("dedup count: got %d, want 2", len(out))
+	}
+	var foundE1 Evidence
+	for _, e := range out {
+		if e.EntityID == "e1" {
+			foundE1 = e
+		}
+	}
+	if foundE1.Tier != "0" || foundE1.Source != "es" {
+		t.Errorf("dedup should pick Tier 0 e1, got %+v", foundE1)
+	}
+}
+
+func TestDedupEvidence_HigherScoreWinsWithinTier(t *testing.T) {
+	in := []Evidence{
+		{EntityID: "e1", Tier: "0", Source: "a", Score: 0.3},
+		{EntityID: "e1", Tier: "0", Source: "b", Score: 0.9}, // should win
+	}
+	out := dedupEvidence(in)
+	if len(out) != 1 {
+		t.Fatalf("dedup count: got %d, want 1", len(out))
+	}
+	if out[0].Source != "b" || out[0].Score != 0.9 {
+		t.Errorf("dedup should pick higher-score evidence within tier, got %+v", out[0])
+	}
+}
+
+func TestDedupEvidence_SkipsEmptyEntityID(t *testing.T) {
+	in := []Evidence{
+		{EntityID: "", Tier: "0", Source: "x"},
+		{EntityID: "e1", Tier: "0", Source: "x"},
+	}
+	out := dedupEvidence(in)
+	if len(out) != 1 {
+		t.Errorf("dedup should skip empty-ID evidence; got %d entries", len(out))
+	}
+}
+
+// --- sort ---
+
+func TestSortEvidence_TierThenScoreThenID(t *testing.T) {
+	ev := []Evidence{
+		{EntityID: "z", Tier: "1", Score: 0.9},
+		{EntityID: "a", Tier: "0", Score: 0.3},
+		{EntityID: "b", Tier: "0", Score: 0.9},
+		{EntityID: "c", Tier: "0", Score: 0.9},
+	}
+	sortEvidence(ev)
+	// Want: Tier 0 sorted by score-desc then ID-asc, then Tier 1.
+	wantOrder := []string{"b", "c", "a", "z"}
+	for i, want := range wantOrder {
+		if ev[i].EntityID != want {
+			t.Errorf("sortEvidence[%d]: got %q, want %q (full order: %v)", i, ev[i].EntityID, want, evIDs(ev))
+		}
+	}
+}
+
+func evIDs(ev []Evidence) []string {
+	out := make([]string, len(ev))
+	for i, e := range ev {
+		out[i] = e.EntityID
+	}
+	return out
+}
+
+// --- budget enforcement ---
+
+func TestEnforceBudget_DropsLowestRanked(t *testing.T) {
+	// 3 evidence entries, each ~5 tokens (estimateEvidenceTokens rough).
+	// Budget 8 should keep 1.
+	in := []Evidence{
+		{EntityID: "first", Tier: "0", Source: "src", SnippetText: "snip"},
+		{EntityID: "secnd", Tier: "0", Source: "src", SnippetText: "snip"},
+		{EntityID: "third", Tier: "0", Source: "src", SnippetText: "snip"},
+	}
+	out, used := enforceBudget(in, 8)
+	if len(out) < 1 || len(out) > 2 {
+		t.Errorf("budget enforcement should keep 1-2 evidence under tight budget; got %d (used=%d)", len(out), used)
+	}
+	if used > 8 {
+		t.Errorf("used %d exceeded budget 8", used)
+	}
+}
+
+func TestEnforceBudget_GenerousBudgetKeepsAll(t *testing.T) {
+	in := []Evidence{
+		{EntityID: "e1", Tier: "0", Source: "x"},
+		{EntityID: "e2", Tier: "1", Source: "x"},
+	}
+	out, _ := enforceBudget(in, 1_000_000)
+	if len(out) != 2 {
+		t.Errorf("generous budget should keep all evidence: got %d, want 2", len(out))
+	}
+}
+
+// --- concurrency ---
+
+func TestFuse_ConcurrentDispatchUnderParallelismCap(t *testing.T) {
+	// 20 BM25 sub-queries — verify the engine dispatches them all and
+	// returns aggregate evidence, with bounded parallelism.
+	gq := &countingDelayedGQ{delay: 5 * time.Millisecond}
+	queries := make([]SubQuery, 20)
+	for i := range queries {
+		queries[i] = SubQuery{
+			Type:   SubQueryTypeBM25,
+			Tier:   "1",
+			Source: "bm",
+			BM25:   &BM25Args{Query: "q"},
+		}
+	}
+	start := time.Now()
+	opts := FuseOptions{MaxParallelism: 4, BudgetTokens: 100000}
+	result, err := Fuse(context.Background(), gq, queries, opts, quietLogger())
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	// With parallelism=4 and per-query delay=5ms, expect roughly
+	// ceil(20/4)*5ms = 25ms. Generous upper bound 200ms guards against
+	// host-load flakiness while still catching a serial bug.
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("parallelism=4 with 20 5ms queries should complete < 200ms, took %v", elapsed)
+	}
+	// 20 calls all executed.
+	if calls := atomic.LoadInt64(&gq.calls); calls != 20 {
+		t.Errorf("BM25 call count: got %d, want 20", calls)
+	}
+	_ = result
+}
+
+// countingDelayedGQ counts BM25 calls and sleeps to model network
+// delay so the concurrency test can assert parallel dispatch behaviour
+// without being purely timing-driven.
+type countingDelayedGQ struct {
+	calls int64
+	delay time.Duration
+}
+
+func (g *countingDelayedGQ) EntityState(_ context.Context, _ EntityStateArgs, _, _ string, _ int) ([]Evidence, error) {
+	return nil, nil
+}
+func (g *countingDelayedGQ) PredicateWalk(_ context.Context, _ PredicateWalkArgs, _, _ string, _ int) ([]Evidence, error) {
+	return nil, nil
+}
+func (g *countingDelayedGQ) TemporalRange(_ context.Context, _ TemporalRangeArgs, _, _ string, _ int) ([]Evidence, error) {
+	return nil, nil
+}
+func (g *countingDelayedGQ) BM25(_ context.Context, _ BM25Args, tier, source string, _ int) ([]Evidence, error) {
+	atomic.AddInt64(&g.calls, 1)
+	time.Sleep(g.delay)
+	return []Evidence{{EntityID: "e", Tier: tier, Source: source, Score: 0.5}}, nil
+}

--- a/pkg/fusion/evidence.go
+++ b/pkg/fusion/evidence.go
@@ -1,0 +1,64 @@
+package fusion
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Evidence is one item in a fused evidence set — a single entity hit
+// or evidence snippet the retrieval fan-out surfaced. Provenance is
+// mandatory: every evidence item carries enough metadata (EntityID +
+// Tier + Source) for the caller to verify it back against the graph
+// and for downstream consumers (e.g. synthesize_answer's quote-back
+// validation) to reject fabricated refs.
+//
+// ObjectStoreRef is set when the body of the evidence (long text,
+// document, etc.) lives in ObjectStore; consumers read it via that
+// ref. SnippetText carries a short inline preview for prompt-injection
+// readability without triggering ObjectStore round-trips on every hit.
+type Evidence struct {
+	// EntityID is the graph entity this evidence refers to. Required.
+	EntityID string `json:"entity_id"`
+
+	// Tier is the retrieval tier that surfaced this hit: "0" (rules /
+	// predicate queries), "1" (BM25), or "2" (neural — deferred to
+	// Phase 2). Operators may use it to filter evidence by retrieval
+	// method.
+	Tier string `json:"tier"`
+
+	// Source is the retrieval source within the tier — e.g.
+	// "classifier", "predicate_walk", "bm25_index". Required.
+	Source string `json:"source"`
+
+	// Score is the within-tier ranking score (higher = better).
+	// Cross-tier comparison is not meaningful in Phase 1 (per-tier
+	// ordering + recency tie-break); Phase 2 may add a learned ranker.
+	Score float64 `json:"score,omitempty"`
+
+	// SnippetText is a short inline preview (prompt-injection
+	// friendly). Omit when the evidence has no readable preview.
+	SnippetText string `json:"snippet_text,omitempty"`
+
+	// ObjectStoreRef is the ObjectStore key for the full body when
+	// the evidence has bulk content. Empty when the evidence is fully
+	// expressed in the EntityID + triples on the graph.
+	ObjectStoreRef string `json:"objectstore_ref,omitempty"`
+}
+
+// Validate checks the required fields and rejects unknown tier values.
+func (e *Evidence) Validate() error {
+	if strings.TrimSpace(e.EntityID) == "" {
+		return fmt.Errorf("entity_id required")
+	}
+	if strings.TrimSpace(e.Source) == "" {
+		return fmt.Errorf("source required")
+	}
+	switch e.Tier {
+	case "0", "1", "2":
+		// Accepted set. "2" is reserved for Phase 2 but accepted at
+		// the schema level so Phase 1 fixtures can probe forward-compat.
+	default:
+		return fmt.Errorf("tier %q must be \"0\", \"1\", or \"2\"", e.Tier)
+	}
+	return nil
+}

--- a/pkg/fusion/subquery.go
+++ b/pkg/fusion/subquery.go
@@ -1,0 +1,119 @@
+package fusion
+
+import (
+	"fmt"
+	"strings"
+)
+
+// SubQuery is a typed retrieval request. Each variant carries the
+// minimum fields its tier executor needs; the Type discriminator
+// drives dispatch in the engine's executeSubQuery.
+//
+// Tier and Source travel with the SubQuery so the per-tier executor
+// can stamp them onto every Evidence it produces without re-deriving
+// — keeps provenance honest end-to-end.
+type SubQuery struct {
+	Type   SubQueryType `json:"type"`
+	Tier   string       `json:"tier"`   // "0" (predicate) or "1" (BM25)
+	Source string       `json:"source"` // e.g. "walk_seeds:drone-001"; surfaces on Evidence.Source
+
+	// Per-type args. Exactly one is populated based on Type — the
+	// executor switch enforces. Optional fields allow tests + future
+	// templates to omit per-type primitives that don't apply.
+	EntityState   *EntityStateArgs   `json:"entity_state,omitempty"`
+	PredicateWalk *PredicateWalkArgs `json:"predicate_walk,omitempty"`
+	TemporalRange *TemporalRangeArgs `json:"temporal_range,omitempty"`
+	BM25          *BM25Args          `json:"bm25,omitempty"`
+}
+
+// SubQueryType is the closed set of Tier 0+1 primitives. Phase 2
+// adds spatial_polygon + neural; Phase 1 stays minimal.
+type SubQueryType string
+
+const (
+	// SubQueryTypeEntityState fetches current state of named
+	// entities. Tier 0; used for walk_seeds anchoring + decompose's
+	// entity_type axis when classifier candidates are present.
+	SubQueryTypeEntityState SubQueryType = "entity_state"
+
+	// SubQueryTypePredicateWalk traverses predicate(s) from seed
+	// entities. Tier 0; used for walk_seeds neighborhood expansion +
+	// decompose's free-form axis fallback.
+	SubQueryTypePredicateWalk SubQueryType = "predicate_walk"
+
+	// SubQueryTypeTemporalRange queries entities within a time
+	// window. Tier 0; used for decompose's time axis. Phase 1 ships
+	// the type but the executor falls through to BM25 on topic when
+	// graph-index-temporal isn't wired — operators see the
+	// "temporal degrade" hint on the produced Evidence.
+	SubQueryTypeTemporalRange SubQueryType = "temporal_range"
+
+	// SubQueryTypeBM25 text-searches via graph-query's existing
+	// BM25 surface. Tier 1; always added to widen coverage beyond
+	// purely-structural retrieval (intent-shaped routing can miss
+	// keyword matches the classifier surfaced).
+	SubQueryTypeBM25 SubQueryType = "bm25"
+)
+
+// EntityStateArgs carries IDs to fetch.
+type EntityStateArgs struct {
+	EntityIDs []string `json:"entity_ids"`
+}
+
+// PredicateWalkArgs carries seed IDs + optional predicate filter.
+// MaxHops 0 resolves to 1 at the executor.
+type PredicateWalkArgs struct {
+	Seeds      []string `json:"seeds"`
+	Predicates []string `json:"predicates,omitempty"`
+	MaxHops    int      `json:"max_hops,omitempty"`
+}
+
+// TemporalRangeArgs carries start/end + an optional topic filter.
+// Empty Topic widens to all entities in the window (may be heavy;
+// callers should always pass a topic in practice).
+type TemporalRangeArgs struct {
+	// Start / End are RFC3339 strings; timezone handling stays in the
+	// executor where the upstream graph-index-temporal surface lives.
+	Start string `json:"start"`
+	End   string `json:"end"`
+	Topic string `json:"topic,omitempty"`
+}
+
+// BM25Args carries the text query + result cap.
+type BM25Args struct {
+	Query string `json:"query"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+// Validate returns a non-nil error when required per-type fields are
+// missing. Called by the materializer before fan-out so a malformed
+// sub-query surfaces before any retrieval work runs.
+func (q SubQuery) Validate() error {
+	if q.Tier != "0" && q.Tier != "1" {
+		return fmt.Errorf("subquery tier %q is not canonical (want \"0\" or \"1\")", q.Tier)
+	}
+	if strings.TrimSpace(q.Source) == "" {
+		return fmt.Errorf("subquery source required for provenance")
+	}
+	switch q.Type {
+	case SubQueryTypeEntityState:
+		if q.EntityState == nil || len(q.EntityState.EntityIDs) == 0 {
+			return fmt.Errorf("entity_state subquery: entity_ids required")
+		}
+	case SubQueryTypePredicateWalk:
+		if q.PredicateWalk == nil || len(q.PredicateWalk.Seeds) == 0 {
+			return fmt.Errorf("predicate_walk subquery: seeds required")
+		}
+	case SubQueryTypeTemporalRange:
+		if q.TemporalRange == nil || q.TemporalRange.Start == "" || q.TemporalRange.End == "" {
+			return fmt.Errorf("temporal_range subquery: start + end required")
+		}
+	case SubQueryTypeBM25:
+		if q.BM25 == nil || strings.TrimSpace(q.BM25.Query) == "" {
+			return fmt.Errorf("bm25 subquery: query required")
+		}
+	default:
+		return fmt.Errorf("subquery type %q is not a Phase 1 primitive", q.Type)
+	}
+	return nil
+}

--- a/pkg/fusion/subquery_test.go
+++ b/pkg/fusion/subquery_test.go
@@ -1,0 +1,83 @@
+package fusion
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSubQuery_Validate_HappyPaths(t *testing.T) {
+	cases := []SubQuery{
+		{Type: SubQueryTypeEntityState, Tier: "0", Source: "x", EntityState: &EntityStateArgs{EntityIDs: []string{"a"}}},
+		{Type: SubQueryTypePredicateWalk, Tier: "0", Source: "x", PredicateWalk: &PredicateWalkArgs{Seeds: []string{"a"}}},
+		{Type: SubQueryTypeTemporalRange, Tier: "0", Source: "x", TemporalRange: &TemporalRangeArgs{Start: "2026-06-02T00:00:00Z", End: "2026-06-03T00:00:00Z"}},
+		{Type: SubQueryTypeBM25, Tier: "1", Source: "x", BM25: &BM25Args{Query: "q"}},
+	}
+	for _, c := range cases {
+		t.Run(string(c.Type), func(t *testing.T) {
+			if err := c.Validate(); err != nil {
+				t.Errorf("Validate: %v", err)
+			}
+		})
+	}
+}
+
+func TestSubQuery_Validate_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		q       SubQuery
+		wantSub string
+	}{
+		{"bad tier", SubQuery{Type: SubQueryTypeBM25, Tier: "2", Source: "x", BM25: &BM25Args{Query: "q"}}, "tier"},
+		{"missing source", SubQuery{Type: SubQueryTypeBM25, Tier: "1", BM25: &BM25Args{Query: "q"}}, "source"},
+		{"entity_state missing ids", SubQuery{Type: SubQueryTypeEntityState, Tier: "0", Source: "x", EntityState: &EntityStateArgs{}}, "entity_ids"},
+		{"predicate_walk missing seeds", SubQuery{Type: SubQueryTypePredicateWalk, Tier: "0", Source: "x", PredicateWalk: &PredicateWalkArgs{}}, "seeds"},
+		{"temporal missing start", SubQuery{Type: SubQueryTypeTemporalRange, Tier: "0", Source: "x", TemporalRange: &TemporalRangeArgs{End: "x"}}, "start"},
+		{"bm25 empty query", SubQuery{Type: SubQueryTypeBM25, Tier: "1", Source: "x", BM25: &BM25Args{Query: "  "}}, "query"},
+		{"unknown type", SubQuery{Type: "neural", Tier: "0", Source: "x"}, "Phase 1 primitive"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.q.Validate()
+			if err == nil {
+				t.Fatalf("Validate = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("error %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}
+
+func TestEvidence_Validate_HappyPaths(t *testing.T) {
+	for _, tier := range []string{"0", "1", "2"} {
+		t.Run("tier_"+tier, func(t *testing.T) {
+			e := &Evidence{EntityID: "x", Tier: tier, Source: "s"}
+			if err := e.Validate(); err != nil {
+				t.Errorf("Validate(tier=%q) = %v, want nil", tier, err)
+			}
+		})
+	}
+}
+
+func TestEvidence_Validate_Rejects(t *testing.T) {
+	cases := []struct {
+		name    string
+		e       Evidence
+		wantSub string
+	}{
+		{"missing entity_id", Evidence{Tier: "0", Source: "x"}, "entity_id"},
+		{"missing source", Evidence{EntityID: "e", Tier: "0"}, "source"},
+		{"bad tier", Evidence{EntityID: "e", Tier: "bogus", Source: "x"}, "tier"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.e.Validate()
+			if err == nil {
+				t.Fatalf("Validate = nil, want error containing %q", c.wantSub)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("error %q, want substring %q", err, c.wantSub)
+			}
+		})
+	}
+}

--- a/processor/research-graph-assess/component_test.go
+++ b/processor/research-graph-assess/component_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // fakeLoopStore replaces the natsLoopStore for handler integration
@@ -85,7 +86,7 @@ func TestComponent_HandleMessage_SufficientHappyPath(t *testing.T) {
 		exec: &research.ExecutionOutput{
 			Topic:    "drone-001 maintenance events",
 			Action:   research.ActionWalkSeeds,
-			Evidence: []research.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x", Score: 0.9}},
+			Evidence: []fusion.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x", Score: 0.9}},
 		},
 	}
 	a := &fakeAssessor{
@@ -129,7 +130,7 @@ func TestComponent_HandleMessage_RefinePath(t *testing.T) {
 		exec: &research.ExecutionOutput{
 			Topic:    "fleet status",
 			Action:   research.ActionDecompose,
-			Evidence: []research.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x"}},
+			Evidence: []fusion.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x"}},
 		},
 	}
 	a := &fakeAssessor{
@@ -208,7 +209,7 @@ func TestComponent_HandleMessage_ExecMissingEmitsDegraded(t *testing.T) {
 func TestComponent_HandleMessage_AssessorErrorEmitsDegraded(t *testing.T) {
 	loops := &fakeLoopStore{
 		intent: &research.Intent{Topic: "x"},
-		exec:   &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose, Evidence: []research.Evidence{{EntityID: "e", Tier: "0", Source: "s"}}},
+		exec:   &research.ExecutionOutput{Topic: "x", Action: research.ActionDecompose, Evidence: []fusion.Evidence{{EntityID: "e", Tier: "0", Source: "s"}}},
 	}
 	a := &fakeAssessor{content: `not a JSON object at all`}
 	c := newTestComponent(loops, a)

--- a/processor/research-graph-assess/handler_test.go
+++ b/processor/research-graph-assess/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // fakeAssessor returns canned content / error per scenario. Records
@@ -70,7 +71,7 @@ func TestAssessSufficiency_SufficientPath(t *testing.T) {
 	exec := &research.ExecutionOutput{
 		Topic:  "drone-001 maintenance events",
 		Action: research.ActionWalkSeeds,
-		Evidence: []research.Evidence{
+		Evidence: []fusion.Evidence{
 			{EntityID: "drone-001", Tier: "0", Source: "walk_seeds.entity_state", Score: 0.9, SnippetText: "Drone 001 maintenance window 14:32Z"},
 		},
 	}
@@ -109,7 +110,7 @@ func TestAssessSufficiency_RefinePath(t *testing.T) {
 	exec := &research.ExecutionOutput{
 		Topic:    "drone status across the fleet",
 		Action:   research.ActionWalkSeeds,
-		Evidence: []research.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x"}},
+		Evidence: []fusion.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x"}},
 	}
 	got, err := assessSufficiency(context.Background(), a, intent, exec, 1024, 20, 280, quietLogger())
 	if err != nil {

--- a/processor/research-graph-assess/prompt.go
+++ b/processor/research-graph-assess/prompt.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // buildSystemPrompt returns the static system message that frames the
@@ -161,11 +162,11 @@ func buildUserPrompt(intent *research.Intent, exec *research.ExecutionOutput, ma
 // assessor sees evidence in the same order downstream synthesize
 // will quote it back in. Replay-determinism: same input list always
 // produces a byte-identical prompt.
-func orderedEvidence(in []research.Evidence, limit int) []research.Evidence {
+func orderedEvidence(in []fusion.Evidence, limit int) []fusion.Evidence {
 	if limit <= 0 || len(in) == 0 {
 		return nil
 	}
-	out := make([]research.Evidence, len(in))
+	out := make([]fusion.Evidence, len(in))
 	copy(out, in)
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Tier != out[j].Tier {

--- a/processor/research-graph-execute/adapters.go
+++ b/processor/research-graph-execute/adapters.go
@@ -12,6 +12,7 @@ import (
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/payloadregistry"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // Graph-query NATS-direct subjects this component requests against.
@@ -24,7 +25,7 @@ const (
 	subjectGraphQuerySearchGraph   = "graph.query.searchGraph"
 )
 
-// graphQueryAdapter wraps natsclient.Client into the GraphQueryClient
+// graphQueryAdapter wraps natsclient.Client into the fusion.GraphQueryClient
 // interface. Production wires this adapter via Start; tests inject a
 // fake GraphQueryClient directly into the Component and skip this
 // path entirely.
@@ -46,13 +47,13 @@ func newGraphQueryAdapter(client *natsclient.Client, timeout time.Duration) *gra
 	return &graphQueryAdapter{client: client, timeout: timeout}
 }
 
-// EntityState implements GraphQueryClient via graph.query.batch
+// EntityState implements fusion.GraphQueryClient via graph.query.batch
 // (passthrough to graph-ingest's handleQueryBatchNATS). Returns one
 // Evidence per requested entity ID that resolves; missing IDs are
 // silently omitted by the upstream handler. Verified shapes:
 // request `{ids: [...]}`, response `{entities: [<EntityState>...]}`
 // where each entity uses the `id` field (graph/types.go EntityState).
-func (a *graphQueryAdapter) EntityState(ctx context.Context, args EntityStateArgs, tier, source string, limit int) ([]research.Evidence, error) {
+func (a *graphQueryAdapter) EntityState(ctx context.Context, args EntityStateArgs, tier, source string, limit int) ([]fusion.Evidence, error) {
 	if a == nil || a.client == nil {
 		return nil, errors.New("nats client not configured")
 	}
@@ -78,7 +79,7 @@ func (a *graphQueryAdapter) EntityState(ctx context.Context, args EntityStateArg
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return nil, fmt.Errorf("decode entity_state response: %w", err)
 	}
-	out := make([]research.Evidence, 0, len(resp.Entities))
+	out := make([]fusion.Evidence, 0, len(resp.Entities))
 	for i, e := range resp.Entities {
 		if limit > 0 && i >= limit {
 			break
@@ -86,7 +87,7 @@ func (a *graphQueryAdapter) EntityState(ctx context.Context, args EntityStateArg
 		if strings.TrimSpace(e.ID) == "" {
 			continue
 		}
-		out = append(out, research.Evidence{
+		out = append(out, fusion.Evidence{
 			EntityID: e.ID,
 			Tier:     tier,
 			Source:   source,
@@ -95,7 +96,7 @@ func (a *graphQueryAdapter) EntityState(ctx context.Context, args EntityStateArg
 	return out, nil
 }
 
-// PredicateWalk implements GraphQueryClient via
+// PredicateWalk implements fusion.GraphQueryClient via
 // graph.query.relationships. Per-seed call (relationships handler
 // is single-entity per request); errgroup at the orchestrator
 // parallelises across seeds. Verified shapes: request
@@ -112,14 +113,14 @@ func (a *graphQueryAdapter) EntityState(ctx context.Context, args EntityStateArg
 // args.Predicates is accepted but the handler doesn't currently
 // filter — kept on the SubQuery type for forward-compat with a
 // Phase 2 handler extension.
-func (a *graphQueryAdapter) PredicateWalk(ctx context.Context, args PredicateWalkArgs, tier, source string, limit int) ([]research.Evidence, error) {
+func (a *graphQueryAdapter) PredicateWalk(ctx context.Context, args PredicateWalkArgs, tier, source string, limit int) ([]fusion.Evidence, error) {
 	if a == nil || a.client == nil {
 		return nil, errors.New("nats client not configured")
 	}
 	if len(args.Seeds) == 0 {
 		return nil, nil
 	}
-	var allEvidence []research.Evidence
+	var allEvidence []fusion.Evidence
 	for _, seed := range args.Seeds {
 		if strings.TrimSpace(seed) == "" {
 			continue
@@ -150,7 +151,7 @@ func (a *graphQueryAdapter) PredicateWalk(ctx context.Context, args PredicateWal
 			if id == "" || id == seed {
 				continue
 			}
-			allEvidence = append(allEvidence, research.Evidence{
+			allEvidence = append(allEvidence, fusion.Evidence{
 				EntityID: id,
 				Tier:     tier,
 				Source:   source,
@@ -160,7 +161,7 @@ func (a *graphQueryAdapter) PredicateWalk(ctx context.Context, args PredicateWal
 	return allEvidence, nil
 }
 
-// TemporalRange implements GraphQueryClient via
+// TemporalRange implements fusion.GraphQueryClient via
 // graph.query.temporal (passthrough to graph-index-temporal's
 // handleQueryRangeNATS). Verified shapes: request
 // `{startTime, endTime, limit}` (RFC3339 strings), response is a
@@ -172,7 +173,7 @@ func (a *graphQueryAdapter) PredicateWalk(ctx context.Context, args PredicateWal
 // Temporal index is optional in operator deployments; an unwired
 // index returns transport error → RequestClassified surfaces it →
 // orchestrator marks degraded.
-func (a *graphQueryAdapter) TemporalRange(ctx context.Context, args TemporalRangeArgs, tier, source string, limit int) ([]research.Evidence, error) {
+func (a *graphQueryAdapter) TemporalRange(ctx context.Context, args TemporalRangeArgs, tier, source string, limit int) ([]fusion.Evidence, error) {
 	if a == nil || a.client == nil {
 		return nil, errors.New("nats client not configured")
 	}
@@ -194,7 +195,7 @@ func (a *graphQueryAdapter) TemporalRange(ctx context.Context, args TemporalRang
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return nil, fmt.Errorf("decode temporal_range response: %w", err)
 	}
-	out := make([]research.Evidence, 0, len(resp))
+	out := make([]fusion.Evidence, 0, len(resp))
 	for i, r := range resp {
 		if limit > 0 && i >= limit {
 			break
@@ -202,7 +203,7 @@ func (a *graphQueryAdapter) TemporalRange(ctx context.Context, args TemporalRang
 		if strings.TrimSpace(r.ID) == "" {
 			continue
 		}
-		out = append(out, research.Evidence{
+		out = append(out, fusion.Evidence{
 			EntityID: r.ID,
 			Tier:     tier,
 			Source:   source,
@@ -211,12 +212,12 @@ func (a *graphQueryAdapter) TemporalRange(ctx context.Context, args TemporalRang
 	return out, nil
 }
 
-// BM25 implements GraphQueryClient via graph.query.searchGraph —
+// BM25 implements fusion.GraphQueryClient via graph.query.searchGraph —
 // the same surface research-graph-classify uses for initial
 // candidate retrieval. Sharing the surface keeps the evidence
 // schema consistent (Evidence here ≡ subset of GlobalSearchResponse
 // entity digests, same projection as nl_classify's Candidate).
-func (a *graphQueryAdapter) BM25(ctx context.Context, args BM25Args, tier, source string, limit int) ([]research.Evidence, error) {
+func (a *graphQueryAdapter) BM25(ctx context.Context, args BM25Args, tier, source string, limit int) ([]fusion.Evidence, error) {
 	if a == nil || a.client == nil {
 		return nil, errors.New("nats client not configured")
 	}
@@ -247,7 +248,7 @@ func (a *graphQueryAdapter) BM25(ctx context.Context, args BM25Args, tier, sourc
 	// BM25 surface uses a different ID field name (id, not entity_id)
 	// and exposes relevance instead of score. Project to the unified
 	// Evidence shape inline.
-	out := make([]research.Evidence, 0, len(resp.EntityDigests))
+	out := make([]fusion.Evidence, 0, len(resp.EntityDigests))
 	for i, d := range resp.EntityDigests {
 		if i >= limitCap && limitCap > 0 {
 			break
@@ -255,7 +256,7 @@ func (a *graphQueryAdapter) BM25(ctx context.Context, args BM25Args, tier, sourc
 		if strings.TrimSpace(d.ID) == "" {
 			continue
 		}
-		out = append(out, research.Evidence{
+		out = append(out, fusion.Evidence{
 			EntityID: d.ID,
 			Tier:     tier,
 			Source:   source,

--- a/processor/research-graph-execute/component_test.go
+++ b/processor/research-graph-execute/component_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // fakeLoopStore replaces natsLoopStore for handleMessage tests.
@@ -111,11 +112,11 @@ func TestComponent_HandleMessage_WalkSeedsHappyPath(t *testing.T) {
 		},
 	}
 	gq := &fakeGraphQuery{
-		entityStateOut: []research.Evidence{{EntityID: "acme.ops.robotics.gcs.drone.001"}},
-		predicateWalkOut: []research.Evidence{
+		entityStateOut: []fusion.Evidence{{EntityID: "acme.ops.robotics.gcs.drone.001"}},
+		predicateWalkOut: []fusion.Evidence{
 			{EntityID: "acme.ops.robotics.gcs.event.maint-001", Score: 0.7},
 		},
-		bm25Out: []research.Evidence{{EntityID: "acme.ops.robotics.gcs.alert.battery", Score: 0.5}},
+		bm25Out: []fusion.Evidence{{EntityID: "acme.ops.robotics.gcs.alert.battery", Score: 0.5}},
 	}
 	c := newTestComponent(loops, gq)
 	c.handleMessage(context.Background(), "component.execute_subqueries.loop-1", nil)
@@ -150,9 +151,9 @@ func TestComponent_HandleMessage_DecomposeHappyPath(t *testing.T) {
 		},
 	}
 	gq := &fakeGraphQuery{
-		entityStateOut:   []research.Evidence{{EntityID: "sensor-001"}},
-		temporalRangeOut: []research.Evidence{{EntityID: "event-T1"}},
-		bm25Out:          []research.Evidence{{EntityID: "doc-abc", Score: 0.3}},
+		entityStateOut:   []fusion.Evidence{{EntityID: "sensor-001"}},
+		temporalRangeOut: []fusion.Evidence{{EntityID: "event-T1"}},
+		bm25Out:          []fusion.Evidence{{EntityID: "doc-abc", Score: 0.3}},
 	}
 	c := newTestComponent(loops, gq)
 	c.handleMessage(context.Background(), "component.execute_subqueries.loop-2", nil)

--- a/processor/research-graph-execute/doc.go
+++ b/processor/research-graph-execute/doc.go
@@ -9,7 +9,7 @@
 // AGENT_LOOPS, materializes one or more typed sub-queries from
 // the routing intent, executes them in parallel across multiple
 // retrieval tiers, normalises + dedups results, enforces the
-// caller's token budget, and writes a research.Evidence array
+// caller's token budget, and writes a fusion.Evidence array
 // envelope plus an execute.complete.<loop_id> trigger key that R3
 // watches to dispatch the assess_sufficiency stage.
 //
@@ -38,9 +38,10 @@
 //     research-graph-classify uses for initial candidate retrieval).
 //     Tier 2 (neural) is deferred to Phase 2.
 //
-//   - Sub-query types are component-internal — defined here, not in
-//     agentic/research/. Reshapeable without cross-package churn if
-//     Phase 2 learns better primitives.
+//   - Sub-query types live in pkg/fusion (generic leaf package).
+//     Reshapeable without cross-package churn if Phase 2 learns
+//     better primitives. Type aliases in subquery.go keep this
+//     package's call sites unchanged.
 //
 //   - Parallel fan-out via errgroup with a bounded concurrency cap
 //     (config-driven). Per-tier ordering with recency tie-break;

--- a/processor/research-graph-execute/handler.go
+++ b/processor/research-graph-execute/handler.go
@@ -4,14 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sort"
 	"strings"
-	"sync"
-	"time"
-
-	"golang.org/x/sync/errgroup"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // GraphQueryClient is the narrow surface this component consumes
@@ -20,26 +16,11 @@ import (
 // etc.); tests substitute an in-memory fake so the matrix doesn't
 // need a live graph stack.
 //
-// Per-method semantics:
-//
-//   - EntityState: returns the current Triples for the named
-//     entities, projected into Evidence (one per entity).
-//   - PredicateWalk: from each seed, returns Evidence for entities
-//     reachable within MaxHops via Predicates (empty Predicates =
-//     all).
-//   - TemporalRange: returns Evidence for entities within the time
-//     window, optionally filtered by topic.
-//   - BM25: text search via graph-query's existing BM25 surface.
-//
-// All methods MUST stamp Tier + Source on every returned Evidence
-// (taken from the SubQuery they were dispatched for) so provenance
-// stays honest end-to-end. The orchestrator does NOT re-stamp.
-type GraphQueryClient interface {
-	EntityState(ctx context.Context, args EntityStateArgs, tier, source string, limit int) ([]research.Evidence, error)
-	PredicateWalk(ctx context.Context, args PredicateWalkArgs, tier, source string, limit int) ([]research.Evidence, error)
-	TemporalRange(ctx context.Context, args TemporalRangeArgs, tier, source string, limit int) ([]research.Evidence, error)
-	BM25(ctx context.Context, args BM25Args, tier, source string, limit int) ([]research.Evidence, error)
-}
+// This is a type alias for fusion.GraphQueryClient — the interface
+// is defined in pkg/fusion; this alias keeps the component's imports
+// tidy without an extra indirection for callers already working
+// inside this package.
+type GraphQueryClient = fusion.GraphQueryClient
 
 // LoopStore is the AGENT_LOOPS read/write surface this component
 // consumes. Production wraps natsclient.KVStore; tests substitute
@@ -177,7 +158,7 @@ func resolveSeedRefByName(ref string, candidates []research.Candidate) (string, 
 func executeAll(
 	ctx context.Context,
 	gq GraphQueryClient,
-	queries []SubQuery,
+	queries []fusion.SubQuery,
 	intent *research.Intent,
 	decisionAction string,
 	maxParallelism int,
@@ -190,245 +171,33 @@ func executeAll(
 	if gq == nil {
 		return nil, fmt.Errorf("graph-query client is nil")
 	}
-	if logger == nil {
-		logger = slog.Default()
+
+	budget := intent.ResolvedBudgetTokens()
+	if budget <= 0 {
+		budget = fusion.DefaultBudgetTokens
 	}
-	if maxParallelism <= 0 {
-		maxParallelism = DefaultMaxParallelism
+
+	opts := fusion.FuseOptions{
+		MaxParallelism:        maxParallelism,
+		MaxResultsPerSubquery: maxResultsPerSubquery,
+		BudgetTokens:          budget,
 	}
-	if maxResultsPerSubquery <= 0 {
-		maxResultsPerSubquery = DefaultMaxResultsPerSubquery
+
+	result, err := fusion.Fuse(ctx, gq, queries, opts, logger)
+	if err != nil {
+		return nil, err
 	}
 
 	output := &research.ExecutionOutput{
-		Topic:         intent.Topic,
-		Action:        decisionAction,
-		SubQueryCount: len(queries),
+		Topic:            intent.Topic,
+		Action:           decisionAction,
+		SubQueryCount:    len(queries),
+		Evidence:         result.Evidence,
+		BudgetTokensUsed: result.BudgetTokensUsed,
 	}
-
-	if len(queries) == 0 {
+	if result.Degraded {
 		output.Degraded = true
-		output.DegradedReason = "materializer produced zero sub-queries"
-		return output, nil
+		output.DegradedReason = result.DegradedReason
 	}
-
-	// Per-sub-query timeout = ExecuteTimeout * DefaultPerSubqueryTimeoutFraction.
-	// Derived from the parent ctx's remaining deadline so the cap is
-	// the MIN of operator config + caller's remaining budget.
-	perQueryTimeout := derivePerQueryTimeout(ctx)
-
-	var (
-		mu          sync.Mutex
-		allEvidence []research.Evidence
-		degraded    bool
-		reasons     []string
-	)
-
-	// Bounded-concurrency errgroup. SetLimit clamps how many
-	// sub-queries dispatch in parallel; remaining queries queue.
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(maxParallelism)
-
-	for i := range queries {
-		q := queries[i]
-		g.Go(func() error {
-			qctx := gctx
-			if perQueryTimeout > 0 {
-				var cancel context.CancelFunc
-				qctx, cancel = context.WithTimeout(gctx, perQueryTimeout)
-				defer cancel()
-			}
-			evidence, err := executeSubQuery(qctx, gq, q, maxResultsPerSubquery)
-			if err != nil {
-				logger.Warn("sub-query failed; degrading",
-					slog.String("type", string(q.Type)),
-					slog.String("source", q.Source),
-					slog.Any("error", err))
-				mu.Lock()
-				degraded = true
-				reasons = append(reasons, fmt.Sprintf("%s:%s failed: %v", q.Type, q.Source, err))
-				mu.Unlock()
-				// Per-sub-query failure is degrading, NOT chain-failing.
-				// Return nil so errgroup doesn't cancel sibling
-				// sub-queries that may still succeed.
-				return nil
-			}
-			mu.Lock()
-			allEvidence = append(allEvidence, evidence...)
-			mu.Unlock()
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		// errgroup returns the first non-nil error from a Go-routine.
-		// We return nil from per-sub-query failures, so this only
-		// fires on a hard cancellation (parent ctx done).
-		return nil, fmt.Errorf("fan-out: %w", err)
-	}
-
-	// Dedup by EntityID (cross-tier collapses), preserve highest-tier
-	// + highest-score Evidence for the duplicate set.
-	deduped := dedupEvidence(allEvidence)
-
-	// Per-tier ordering + recency tie-break.
-	sortEvidence(deduped)
-
-	// Budget enforcement. Drop lowest-scoring until under budget.
-	budget := intent.ResolvedBudgetTokens()
-	if budget <= 0 {
-		budget = DefaultBudgetTokens
-	}
-	enforced, usedTokens := enforceBudget(deduped, budget)
-
-	output.Evidence = enforced
-	output.BudgetTokensUsed = usedTokens
-	if degraded {
-		output.Degraded = true
-		output.DegradedReason = strings.Join(reasons, "; ")
-	}
-
 	return output, nil
-}
-
-// executeSubQuery dispatches one sub-query to the right GraphQueryClient
-// method. Returns Evidence with Tier + Source already stamped by the
-// implementing executor (interface contract).
-func executeSubQuery(ctx context.Context, gq GraphQueryClient, q SubQuery, limit int) ([]research.Evidence, error) {
-	switch q.Type {
-	case SubQueryTypeEntityState:
-		return gq.EntityState(ctx, *q.EntityState, q.Tier, q.Source, limit)
-	case SubQueryTypePredicateWalk:
-		return gq.PredicateWalk(ctx, *q.PredicateWalk, q.Tier, q.Source, limit)
-	case SubQueryTypeTemporalRange:
-		return gq.TemporalRange(ctx, *q.TemporalRange, q.Tier, q.Source, limit)
-	case SubQueryTypeBM25:
-		return gq.BM25(ctx, *q.BM25, q.Tier, q.Source, limit)
-	}
-	return nil, fmt.Errorf("unknown sub-query type %q", q.Type)
-}
-
-// dedupEvidence collapses duplicates by EntityID. When the same
-// entity surfaces in multiple sub-queries, the dedup picks the
-// "best" Evidence: lower Tier wins (Tier 0 > Tier 1), and within
-// the same tier higher Score wins.
-//
-// Provenance is preserved by stamping the WINNING evidence's
-// Source. Phase 2 may extend Evidence with a multi-source list so
-// the agent can quote any path that surfaced the entity; Phase 1
-// ships single-source-per-entity.
-func dedupEvidence(in []research.Evidence) []research.Evidence {
-	if len(in) == 0 {
-		return nil
-	}
-	best := make(map[string]research.Evidence, len(in))
-	for _, e := range in {
-		if e.EntityID == "" {
-			continue
-		}
-		existing, ok := best[e.EntityID]
-		if !ok {
-			best[e.EntityID] = e
-			continue
-		}
-		if evidenceBeats(e, existing) {
-			best[e.EntityID] = e
-		}
-	}
-	out := make([]research.Evidence, 0, len(best))
-	for _, e := range best {
-		out = append(out, e)
-	}
-	return out
-}
-
-// evidenceBeats returns true when a should replace b in dedup.
-// Tier 0 beats Tier 1 unconditionally; within the same tier, higher
-// Score wins; ties broken by EntityID ascending (deterministic
-// across map iteration).
-func evidenceBeats(a, b research.Evidence) bool {
-	if a.Tier != b.Tier {
-		return a.Tier < b.Tier // "0" < "1" lexically — Tier 0 wins
-	}
-	if a.Score != b.Score {
-		return a.Score > b.Score
-	}
-	return a.EntityID < b.EntityID
-}
-
-// sortEvidence applies Phase 1's ordering rule: lower-tier first
-// (Tier 0 before Tier 1), then higher Score, then EntityID
-// ascending for tie-break. Stable sort preserves input order
-// within ties for replay determinism.
-func sortEvidence(ev []research.Evidence) {
-	sort.SliceStable(ev, func(i, j int) bool {
-		if ev[i].Tier != ev[j].Tier {
-			return ev[i].Tier < ev[j].Tier
-		}
-		if ev[i].Score != ev[j].Score {
-			return ev[i].Score > ev[j].Score
-		}
-		return ev[i].EntityID < ev[j].EntityID
-	})
-}
-
-// enforceBudget drops lowest-ranked evidence (from the tail of the
-// sorted slice) until the estimated token cost fits within budget.
-// Returns the kept slice and the estimated token cost actually
-// retained.
-//
-// Token estimation: ~4 chars/token (industry rule of thumb) across
-// the rendered evidence — EntityID + Label + Type + SnippetText +
-// Source. Crude but stable; Phase 2 may swap a tokenizer.
-func enforceBudget(in []research.Evidence, budget int) ([]research.Evidence, int) {
-	if len(in) == 0 || budget <= 0 {
-		return in, 0
-	}
-	out := make([]research.Evidence, 0, len(in))
-	used := 0
-	for _, e := range in {
-		cost := estimateEvidenceTokens(e)
-		if used+cost > budget {
-			// Drop this and everything after (in sorted order, they're
-			// lower-ranked). Phase 1 strategy: sharp cutoff. Phase 2
-			// may try greedier per-item drop.
-			break
-		}
-		out = append(out, e)
-		used += cost
-	}
-	return out, used
-}
-
-// estimateEvidenceTokens approximates the prompt-cost of one
-// Evidence entry. Sums character counts of the rendered fields
-// (matches the rough shape a downstream synthesizer would inline
-// in its prompt) and divides by 4. Always returns at least 1 to
-// prevent empty Evidence from being "free" (still costs a JSON
-// boundary in the array).
-func estimateEvidenceTokens(e research.Evidence) int {
-	chars := len(e.EntityID) + len(e.SnippetText) + len(e.Source) + len(e.ObjectStoreRef)
-	tokens := chars / 4
-	if tokens < 1 {
-		tokens = 1
-	}
-	return tokens
-}
-
-// derivePerQueryTimeout returns the per-sub-query deadline as a
-// fraction of the parent ctx's remaining time. When the parent
-// has no deadline (test ctx.Background, or operator-disabled
-// component timeout), falls back to a fraction of
-// DefaultExecuteTimeout so a wedged sub-query can't hang the
-// fan-out indefinitely.
-func derivePerQueryTimeout(ctx context.Context) time.Duration {
-	dl, ok := ctx.Deadline()
-	if !ok {
-		return time.Duration(float64(DefaultExecuteTimeout) * DefaultPerSubqueryTimeoutFraction)
-	}
-	remaining := time.Until(dl)
-	if remaining <= 0 {
-		return 0
-	}
-	return time.Duration(float64(remaining) * DefaultPerSubqueryTimeoutFraction)
 }

--- a/processor/research-graph-execute/handler_test.go
+++ b/processor/research-graph-execute/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // fakeGraphQuery records what was called and returns canned
@@ -26,10 +27,10 @@ type fakeGraphQuery struct {
 	temporalRangeCalls int
 	bm25Calls          int
 
-	entityStateOut   []research.Evidence
-	predicateWalkOut []research.Evidence
-	temporalRangeOut []research.Evidence
-	bm25Out          []research.Evidence
+	entityStateOut   []fusion.Evidence
+	predicateWalkOut []fusion.Evidence
+	temporalRangeOut []fusion.Evidence
+	bm25Out          []fusion.Evidence
 
 	entityStateErr   error
 	predicateWalkErr error
@@ -37,7 +38,7 @@ type fakeGraphQuery struct {
 	bm25Err          error
 }
 
-func (f *fakeGraphQuery) EntityState(_ context.Context, _ EntityStateArgs, tier, source string, _ int) ([]research.Evidence, error) {
+func (f *fakeGraphQuery) EntityState(_ context.Context, _ EntityStateArgs, tier, source string, _ int) ([]fusion.Evidence, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.entityStateCalls++
@@ -47,7 +48,7 @@ func (f *fakeGraphQuery) EntityState(_ context.Context, _ EntityStateArgs, tier,
 	return stampEvidence(f.entityStateOut, tier, source), nil
 }
 
-func (f *fakeGraphQuery) PredicateWalk(_ context.Context, _ PredicateWalkArgs, tier, source string, _ int) ([]research.Evidence, error) {
+func (f *fakeGraphQuery) PredicateWalk(_ context.Context, _ PredicateWalkArgs, tier, source string, _ int) ([]fusion.Evidence, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.predicateWalkCalls++
@@ -57,7 +58,7 @@ func (f *fakeGraphQuery) PredicateWalk(_ context.Context, _ PredicateWalkArgs, t
 	return stampEvidence(f.predicateWalkOut, tier, source), nil
 }
 
-func (f *fakeGraphQuery) TemporalRange(_ context.Context, _ TemporalRangeArgs, tier, source string, _ int) ([]research.Evidence, error) {
+func (f *fakeGraphQuery) TemporalRange(_ context.Context, _ TemporalRangeArgs, tier, source string, _ int) ([]fusion.Evidence, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.temporalRangeCalls++
@@ -67,7 +68,7 @@ func (f *fakeGraphQuery) TemporalRange(_ context.Context, _ TemporalRangeArgs, t
 	return stampEvidence(f.temporalRangeOut, tier, source), nil
 }
 
-func (f *fakeGraphQuery) BM25(_ context.Context, _ BM25Args, tier, source string, _ int) ([]research.Evidence, error) {
+func (f *fakeGraphQuery) BM25(_ context.Context, _ BM25Args, tier, source string, _ int) ([]fusion.Evidence, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.bm25Calls++
@@ -81,8 +82,8 @@ func (f *fakeGraphQuery) BM25(_ context.Context, _ BM25Args, tier, source string
 // contract requires. Test fixtures supply Evidence with just
 // EntityID + Score (the discriminating fields); the contract-
 // stamping mirrors what production adapters do.
-func stampEvidence(in []research.Evidence, tier, source string) []research.Evidence {
-	out := make([]research.Evidence, len(in))
+func stampEvidence(in []fusion.Evidence, tier, source string) []fusion.Evidence {
+	out := make([]fusion.Evidence, len(in))
 	for i, e := range in {
 		e.Tier = tier
 		e.Source = source
@@ -166,9 +167,9 @@ func TestResolveSeedRefs_AllDropped(t *testing.T) {
 
 func TestExecuteAll_HappyPath(t *testing.T) {
 	gq := &fakeGraphQuery{
-		entityStateOut:   []research.Evidence{{EntityID: "e1", Score: 0.9}},
-		predicateWalkOut: []research.Evidence{{EntityID: "e2", Score: 0.7}},
-		bm25Out:          []research.Evidence{{EntityID: "e3", Score: 0.5}},
+		entityStateOut:   []fusion.Evidence{{EntityID: "e1", Score: 0.9}},
+		predicateWalkOut: []fusion.Evidence{{EntityID: "e2", Score: 0.7}},
+		bm25Out:          []fusion.Evidence{{EntityID: "e3", Score: 0.5}},
 	}
 	queries := []SubQuery{
 		{Type: SubQueryTypeEntityState, Tier: "0", Source: "es", EntityState: &EntityStateArgs{EntityIDs: []string{"e1"}}},
@@ -200,8 +201,8 @@ func TestExecuteAll_HappyPath(t *testing.T) {
 
 func TestExecuteAll_PerSubqueryErrorIsDegrading(t *testing.T) {
 	gq := &fakeGraphQuery{
-		entityStateOut: []research.Evidence{{EntityID: "e1", Score: 0.9}},
-		bm25Err:        errors.New("BM25 down"),
+		entityStateOut: []fusion.Evidence{{EntityID: "e1", Score: 0.9}},
+		bm25Err:        errBM25Down,
 	}
 	queries := []SubQuery{
 		{Type: SubQueryTypeEntityState, Tier: "0", Source: "es", EntityState: &EntityStateArgs{EntityIDs: []string{"e1"}}},
@@ -224,6 +225,8 @@ func TestExecuteAll_PerSubqueryErrorIsDegrading(t *testing.T) {
 	}
 }
 
+var errBM25Down = errors.New("BM25 down")
+
 func TestExecuteAll_EmptyQueriesIsDegraded(t *testing.T) {
 	out, err := executeAll(context.Background(), &fakeGraphQuery{}, nil,
 		&research.Intent{Topic: "x"}, research.ActionWalkSeeds, 4, 10, quietLogger())
@@ -235,111 +238,6 @@ func TestExecuteAll_EmptyQueriesIsDegraded(t *testing.T) {
 	}
 	if !strings.Contains(out.DegradedReason, "zero sub-queries") {
 		t.Errorf("degraded reason should explain empty queries: %q", out.DegradedReason)
-	}
-}
-
-// --- dedup ---
-
-func TestDedupEvidence_TierZeroWinsOverTierOne(t *testing.T) {
-	in := []research.Evidence{
-		{EntityID: "e1", Tier: "1", Source: "bm25", Score: 0.9}, // tier 1, high score
-		{EntityID: "e1", Tier: "0", Source: "es", Score: 0.3},   // tier 0, low score — should win
-		{EntityID: "e2", Tier: "0", Source: "pw", Score: 0.7},
-	}
-	out := dedupEvidence(in)
-	if len(out) != 2 {
-		t.Fatalf("dedup count: got %d, want 2", len(out))
-	}
-	var foundE1 research.Evidence
-	for _, e := range out {
-		if e.EntityID == "e1" {
-			foundE1 = e
-		}
-	}
-	if foundE1.Tier != "0" || foundE1.Source != "es" {
-		t.Errorf("dedup should pick Tier 0 e1, got %+v", foundE1)
-	}
-}
-
-func TestDedupEvidence_HigherScoreWinsWithinTier(t *testing.T) {
-	in := []research.Evidence{
-		{EntityID: "e1", Tier: "0", Source: "a", Score: 0.3},
-		{EntityID: "e1", Tier: "0", Source: "b", Score: 0.9}, // should win
-	}
-	out := dedupEvidence(in)
-	if len(out) != 1 {
-		t.Fatalf("dedup count: got %d, want 1", len(out))
-	}
-	if out[0].Source != "b" || out[0].Score != 0.9 {
-		t.Errorf("dedup should pick higher-score evidence within tier, got %+v", out[0])
-	}
-}
-
-func TestDedupEvidence_SkipsEmptyEntityID(t *testing.T) {
-	in := []research.Evidence{
-		{EntityID: "", Tier: "0", Source: "x"},
-		{EntityID: "e1", Tier: "0", Source: "x"},
-	}
-	out := dedupEvidence(in)
-	if len(out) != 1 {
-		t.Errorf("dedup should skip empty-ID evidence; got %d entries", len(out))
-	}
-}
-
-// --- sort ---
-
-func TestSortEvidence_TierThenScoreThenID(t *testing.T) {
-	ev := []research.Evidence{
-		{EntityID: "z", Tier: "1", Score: 0.9},
-		{EntityID: "a", Tier: "0", Score: 0.3},
-		{EntityID: "b", Tier: "0", Score: 0.9},
-		{EntityID: "c", Tier: "0", Score: 0.9},
-	}
-	sortEvidence(ev)
-	// Want: Tier 0 sorted by score-desc then ID-asc, then Tier 1.
-	wantOrder := []string{"b", "c", "a", "z"}
-	for i, want := range wantOrder {
-		if ev[i].EntityID != want {
-			t.Errorf("sortEvidence[%d]: got %q, want %q (full order: %v)", i, ev[i].EntityID, want, evIDs(ev))
-		}
-	}
-}
-
-func evIDs(ev []research.Evidence) []string {
-	out := make([]string, len(ev))
-	for i, e := range ev {
-		out[i] = e.EntityID
-	}
-	return out
-}
-
-// --- budget enforcement ---
-
-func TestEnforceBudget_DropsLowestRanked(t *testing.T) {
-	// 3 evidence entries, each ~5 tokens (estimateEvidenceTokens
-	// rough). Budget 8 should keep 1.
-	in := []research.Evidence{
-		{EntityID: "first", Tier: "0", Source: "src", SnippetText: "snip"},
-		{EntityID: "secnd", Tier: "0", Source: "src", SnippetText: "snip"},
-		{EntityID: "third", Tier: "0", Source: "src", SnippetText: "snip"},
-	}
-	out, used := enforceBudget(in, 8)
-	if len(out) < 1 || len(out) > 2 {
-		t.Errorf("budget enforcement should keep 1-2 evidence under tight budget; got %d (used=%d)", len(out), used)
-	}
-	if used > 8 {
-		t.Errorf("used %d exceeded budget 8", used)
-	}
-}
-
-func TestEnforceBudget_GenerousBudgetKeepsAll(t *testing.T) {
-	in := []research.Evidence{
-		{EntityID: "e1", Tier: "0", Source: "x"},
-		{EntityID: "e2", Tier: "1", Source: "x"},
-	}
-	out, _ := enforceBudget(in, 1_000_000)
-	if len(out) != 2 {
-		t.Errorf("generous budget should keep all evidence: got %d, want 2", len(out))
 	}
 }
 
@@ -389,17 +287,17 @@ type countingDelayedGQ struct {
 	delay time.Duration
 }
 
-func (g *countingDelayedGQ) EntityState(_ context.Context, _ EntityStateArgs, _, _ string, _ int) ([]research.Evidence, error) {
+func (g *countingDelayedGQ) EntityState(_ context.Context, _ EntityStateArgs, _, _ string, _ int) ([]fusion.Evidence, error) {
 	return nil, nil
 }
-func (g *countingDelayedGQ) PredicateWalk(_ context.Context, _ PredicateWalkArgs, _, _ string, _ int) ([]research.Evidence, error) {
+func (g *countingDelayedGQ) PredicateWalk(_ context.Context, _ PredicateWalkArgs, _, _ string, _ int) ([]fusion.Evidence, error) {
 	return nil, nil
 }
-func (g *countingDelayedGQ) TemporalRange(_ context.Context, _ TemporalRangeArgs, _, _ string, _ int) ([]research.Evidence, error) {
+func (g *countingDelayedGQ) TemporalRange(_ context.Context, _ TemporalRangeArgs, _, _ string, _ int) ([]fusion.Evidence, error) {
 	return nil, nil
 }
-func (g *countingDelayedGQ) BM25(_ context.Context, _ BM25Args, tier, source string, _ int) ([]research.Evidence, error) {
+func (g *countingDelayedGQ) BM25(_ context.Context, _ BM25Args, tier, source string, _ int) ([]fusion.Evidence, error) {
 	atomic.AddInt64(&g.calls, 1)
 	time.Sleep(g.delay)
-	return []research.Evidence{{EntityID: "e", Tier: tier, Source: source, Score: 0.5}}, nil
+	return []fusion.Evidence{{EntityID: "e", Tier: tier, Source: source, Score: 0.5}}, nil
 }

--- a/processor/research-graph-execute/subquery.go
+++ b/processor/research-graph-execute/subquery.go
@@ -6,124 +6,39 @@ import (
 	"strings"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
-// SubQuery is a typed retrieval request. Component-internal —
-// reshapeable without cross-package churn if Phase 2 learns better
-// primitives. Each variant carries the minimum fields its tier
-// executor needs; the Type discriminator drives dispatch in
-// executeSubQuery.
-//
-// Tier and Source travel with the SubQuery so the per-tier executor
-// can stamp them onto every research.Evidence it produces without
-// re-deriving — keeps provenance honest end-to-end.
-type SubQuery struct {
-	Type   SubQueryType `json:"type"`
-	Tier   string       `json:"tier"`   // "0" (predicate) or "1" (BM25)
-	Source string       `json:"source"` // e.g. "walk_seeds:drone-001"; surfaces on Evidence.Source
+// These aliases let the materialization code below construct sub-query values
+// without a fusion. qualifier on every line. The cross-package break is complete
+// (no research.SubQuery exists) — convenience aliases, not a compatibility layer.
 
-	// Per-type args. Exactly one is populated based on Type — the
-	// executor switch enforces. Optional fields allow tests + future
-	// templates to omit per-type primitives that don't apply.
-	EntityState   *EntityStateArgs   `json:"entity_state,omitempty"`
-	PredicateWalk *PredicateWalkArgs `json:"predicate_walk,omitempty"`
-	TemporalRange *TemporalRangeArgs `json:"temporal_range,omitempty"`
-	BM25          *BM25Args          `json:"bm25,omitempty"`
-}
+// SubQuery aliases fusion.SubQuery.
+type SubQuery = fusion.SubQuery
 
-// SubQueryType is the closed set of Tier 0+1 primitives PR 4
-// ships. Phase 2 adds spatial_polygon + neural; Phase 1 stays
-// minimal.
-type SubQueryType string
+// SubQueryType aliases fusion.SubQueryType.
+type SubQueryType = fusion.SubQueryType
 
+// EntityStateArgs aliases fusion.EntityStateArgs.
+type EntityStateArgs = fusion.EntityStateArgs
+
+// PredicateWalkArgs aliases fusion.PredicateWalkArgs.
+type PredicateWalkArgs = fusion.PredicateWalkArgs
+
+// TemporalRangeArgs aliases fusion.TemporalRangeArgs.
+type TemporalRangeArgs = fusion.TemporalRangeArgs
+
+// BM25Args aliases fusion.BM25Args.
+type BM25Args = fusion.BM25Args
+
+// Re-export the SubQueryType constants from fusion so existing usages
+// in this package and its tests compile unchanged.
 const (
-	// SubQueryTypeEntityState fetches current state of named
-	// entities. Tier 0; used for walk_seeds anchoring + decompose's
-	// entity_type axis when classifier candidates are present.
-	SubQueryTypeEntityState SubQueryType = "entity_state"
-
-	// SubQueryTypePredicateWalk traverses predicate(s) from seed
-	// entities. Tier 0; used for walk_seeds neighborhood expansion +
-	// decompose's free-form axis fallback.
-	SubQueryTypePredicateWalk SubQueryType = "predicate_walk"
-
-	// SubQueryTypeTemporalRange queries entities within a time
-	// window. Tier 0; used for decompose's time axis. Phase 1 ships
-	// the type but the executor falls through to BM25 on topic when
-	// graph-index-temporal isn't wired — operators see the
-	// "temporal degrade" hint on the produced Evidence.
-	SubQueryTypeTemporalRange SubQueryType = "temporal_range"
-
-	// SubQueryTypeBM25 text-searches via graph-query's existing
-	// BM25 surface. Tier 1; always added to widen coverage beyond
-	// purely-structural retrieval (intent-shaped routing can miss
-	// keyword matches the classifier surfaced).
-	SubQueryTypeBM25 SubQueryType = "bm25"
+	SubQueryTypeEntityState   = fusion.SubQueryTypeEntityState
+	SubQueryTypePredicateWalk = fusion.SubQueryTypePredicateWalk
+	SubQueryTypeTemporalRange = fusion.SubQueryTypeTemporalRange
+	SubQueryTypeBM25          = fusion.SubQueryTypeBM25
 )
-
-// EntityStateArgs carries IDs to fetch.
-type EntityStateArgs struct {
-	EntityIDs []string `json:"entity_ids"`
-}
-
-// PredicateWalkArgs carries seed IDs + optional predicate filter.
-// MaxHops 0 resolves to 1 at the executor.
-type PredicateWalkArgs struct {
-	Seeds      []string `json:"seeds"`
-	Predicates []string `json:"predicates,omitempty"`
-	MaxHops    int      `json:"max_hops,omitempty"`
-}
-
-// TemporalRangeArgs carries start/end + an optional topic filter.
-// Empty Topic widens to all entities in the window (may be heavy;
-// callers should always pass a topic in practice).
-type TemporalRangeArgs struct {
-	// Start / End are RFC3339 strings; component-internal so
-	// timezone handling stays in the executor where the upstream
-	// graph-index-temporal surface lives.
-	Start string `json:"start"`
-	End   string `json:"end"`
-	Topic string `json:"topic,omitempty"`
-}
-
-// BM25Args carries the text query + result cap.
-type BM25Args struct {
-	Query string `json:"query"`
-	Limit int    `json:"limit,omitempty"`
-}
-
-// Validate returns a non-nil error when required per-type fields
-// are missing. Called by the materializer before fan-out so a
-// malformed sub-query surfaces before any retrieval work runs.
-func (q SubQuery) Validate() error {
-	if q.Tier != "0" && q.Tier != "1" {
-		return fmt.Errorf("subquery tier %q is not canonical (want \"0\" or \"1\")", q.Tier)
-	}
-	if strings.TrimSpace(q.Source) == "" {
-		return fmt.Errorf("subquery source required for provenance")
-	}
-	switch q.Type {
-	case SubQueryTypeEntityState:
-		if q.EntityState == nil || len(q.EntityState.EntityIDs) == 0 {
-			return fmt.Errorf("entity_state subquery: entity_ids required")
-		}
-	case SubQueryTypePredicateWalk:
-		if q.PredicateWalk == nil || len(q.PredicateWalk.Seeds) == 0 {
-			return fmt.Errorf("predicate_walk subquery: seeds required")
-		}
-	case SubQueryTypeTemporalRange:
-		if q.TemporalRange == nil || q.TemporalRange.Start == "" || q.TemporalRange.End == "" {
-			return fmt.Errorf("temporal_range subquery: start + end required")
-		}
-	case SubQueryTypeBM25:
-		if q.BM25 == nil || strings.TrimSpace(q.BM25.Query) == "" {
-			return fmt.Errorf("bm25 subquery: query required")
-		}
-	default:
-		return fmt.Errorf("subquery type %q is not a Phase 1 primitive", q.Type)
-	}
-	return nil
-}
 
 // materializeForWalkSeeds builds the sub-query set for a walk_seeds
 // decision. Strategy: (a) entity_state for the resolved seeds so

--- a/processor/research-graph-synthesize/component_test.go
+++ b/processor/research-graph-synthesize/component_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // fakeLoopStore replaces natsLoopStore. Records reads + writes so
@@ -110,7 +111,7 @@ func TestComponent_HandleMessage_HappyPath(t *testing.T) {
 		exec: &research.ExecutionOutput{
 			Topic:    "drone-001 maintenance",
 			Action:   research.ActionWalkSeeds,
-			Evidence: []research.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x", Score: 0.9}},
+			Evidence: []fusion.Evidence{{EntityID: "drone-001", Tier: "0", Source: "x", Score: 0.9}},
 		},
 		route: &research.RouteDecision{
 			Action: research.ActionWalkSeeds,
@@ -206,7 +207,7 @@ func TestComponent_HandleMessage_RouteMissingProceeds(t *testing.T) {
 		exec: &research.ExecutionOutput{
 			Topic:    "x",
 			Action:   research.ActionSynthesizeDirectly,
-			Evidence: []research.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
+			Evidence: []fusion.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
 		},
 		// route: nil
 	}
@@ -229,7 +230,7 @@ func TestComponent_HandleMessage_SynthesizerFailEmitsDegraded(t *testing.T) {
 		intent: &research.Intent{Topic: "x"},
 		exec: &research.ExecutionOutput{
 			Topic: "x", Action: research.ActionDecompose,
-			Evidence: []research.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
+			Evidence: []fusion.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
 		},
 	}
 	s := &fakeSynthesizer{content: `not JSON at all`}

--- a/processor/research-graph-synthesize/handler.go
+++ b/processor/research-graph-synthesize/handler.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 
 	"github.com/c360studio/semstreams/agentic/research"
-	"github.com/c360studio/semstreams/processor/research-graph-llmwrap"
+	"github.com/c360studio/semstreams/pkg/fusion"
+	llmwrap "github.com/c360studio/semstreams/processor/research-graph-llmwrap"
 )
 
 // Synthesizer is the narrow LLM surface this component consumes.
@@ -193,7 +194,7 @@ func callAndDecodeSynthesis(ctx context.Context, synthesizer Synthesizer, intent
 // checking each against the set of valid refs in the input evidence
 // (every EntityID + every non-empty ObjectStoreRef). Duplicates and
 // whitespace-only refs are silently dropped.
-func quoteBackValidate(emittedRefs []string, evidence []research.Evidence) (kept, dropped []string) {
+func quoteBackValidate(emittedRefs []string, evidence []fusion.Evidence) (kept, dropped []string) {
 	validRefs := make(map[string]struct{}, len(evidence)*2)
 	for _, e := range evidence {
 		if e.EntityID != "" {
@@ -229,7 +230,7 @@ func quoteBackValidate(emittedRefs []string, evidence []research.Evidence) (kept
 // the matching items (preserving input order); otherwise echo the
 // top-by-score items as a fallback (capped at len(in) since smaller
 // fixtures should round-trip cleanly).
-func selectEchoedEvidence(in []research.Evidence, keptRefs []string) []research.Evidence {
+func selectEchoedEvidence(in []fusion.Evidence, keptRefs []string) []fusion.Evidence {
 	if len(in) == 0 {
 		return nil
 	}
@@ -245,7 +246,7 @@ func selectEchoedEvidence(in []research.Evidence, keptRefs []string) []research.
 		if n > fallbackEchoCount {
 			n = fallbackEchoCount
 		}
-		out := make([]research.Evidence, n)
+		out := make([]fusion.Evidence, n)
 		copy(out, in[:n])
 		return out
 	}
@@ -253,7 +254,7 @@ func selectEchoedEvidence(in []research.Evidence, keptRefs []string) []research.
 	for _, r := range keptRefs {
 		want[r] = struct{}{}
 	}
-	out := make([]research.Evidence, 0, len(keptRefs))
+	out := make([]fusion.Evidence, 0, len(keptRefs))
 	for _, e := range in {
 		if _, ok := want[e.EntityID]; ok {
 			out = append(out, e)

--- a/processor/research-graph-synthesize/handler_test.go
+++ b/processor/research-graph-synthesize/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // fakeSynthesizer returns canned content / error per scenario.
@@ -64,7 +65,7 @@ func TestSynthesizeAnswer_HappyPath_QuoteBackKeepsValidRefs(t *testing.T) {
 	exec := &research.ExecutionOutput{
 		Topic:  "drone fleet maintenance events",
 		Action: research.ActionWalkSeeds,
-		Evidence: []research.Evidence{
+		Evidence: []fusion.Evidence{
 			{EntityID: "acme.ops.robotics.gcs.drone.001", Tier: "0", Source: "walk_seeds", Score: 0.9, SnippetText: "Drone 001 maintenance window 14:32Z"},
 			{EntityID: "acme.ops.robotics.gcs.drone.014", Tier: "1", Source: "bm25", Score: 0.7, ObjectStoreRef: "objstore://research/evidence-014.txt"},
 		},
@@ -94,7 +95,7 @@ func TestSynthesizeAnswer_QuoteBack_StripsFabricatedRefs(t *testing.T) {
 	exec := &research.ExecutionOutput{
 		Topic:  "x",
 		Action: research.ActionWalkSeeds,
-		Evidence: []research.Evidence{
+		Evidence: []fusion.Evidence{
 			{EntityID: "real-1", Tier: "0", Source: "x"},
 			{EntityID: "real-2", Tier: "0", Source: "x"},
 		},
@@ -121,7 +122,7 @@ func TestSynthesizeAnswer_QuoteBack_NoValidRefsDegrades(t *testing.T) {
 	exec := &research.ExecutionOutput{
 		Topic:    "x",
 		Action:   research.ActionWalkSeeds,
-		Evidence: []research.Evidence{{EntityID: "real-1", Tier: "0", Source: "x"}},
+		Evidence: []fusion.Evidence{{EntityID: "real-1", Tier: "0", Source: "x"}},
 	}
 	s := &fakeSynthesizer{
 		content: `{"synthesis":"answer makes things up","evidence_refs":["fake-only","another-fake"]}`,
@@ -164,7 +165,7 @@ func TestSynthesizeAnswer_DecompTrace_FromRouteWalkSeeds(t *testing.T) {
 	exec := &research.ExecutionOutput{
 		Topic:    "x",
 		Action:   research.ActionWalkSeeds,
-		Evidence: []research.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
+		Evidence: []fusion.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
 	}
 	route := &research.RouteDecision{
 		Action: research.ActionWalkSeeds,
@@ -197,7 +198,7 @@ func TestSynthesizeAnswer_DecompTrace_NilRouteFallsBackToExecAction(t *testing.T
 	exec := &research.ExecutionOutput{
 		Topic:    "x",
 		Action:   research.ActionSynthesizeDirectly,
-		Evidence: []research.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
+		Evidence: []fusion.Evidence{{EntityID: "e1", Tier: "0", Source: "x"}},
 	}
 	s := &fakeSynthesizer{content: `{"synthesis":"x","evidence_refs":["e1"]}`}
 	got, err := synthesizeAnswer(context.Background(), s,
@@ -250,7 +251,7 @@ func TestSynthesizeAnswer_DedupRefs(t *testing.T) {
 	exec := &research.ExecutionOutput{
 		Topic:  "x",
 		Action: research.ActionWalkSeeds,
-		Evidence: []research.Evidence{
+		Evidence: []fusion.Evidence{
 			{EntityID: "e1", Tier: "0", Source: "x"},
 		},
 	}

--- a/processor/research-graph-synthesize/prompt.go
+++ b/processor/research-graph-synthesize/prompt.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/c360studio/semstreams/agentic/research"
+	"github.com/c360studio/semstreams/pkg/fusion"
 )
 
 // buildSystemPrompt returns the static system message that frames the
@@ -138,11 +139,11 @@ func buildUserPrompt(intent *research.Intent, exec *research.ExecutionOutput, ma
 // prompt-time ordering and the SearchResult.Evidence echo ordering
 // stay in lockstep (operator trajectory replay reads the same shape
 // at both ends).
-func orderedEvidence(in []research.Evidence, limit int) []research.Evidence {
+func orderedEvidence(in []fusion.Evidence, limit int) []fusion.Evidence {
 	if limit <= 0 || len(in) == 0 {
 		return nil
 	}
-	out := make([]research.Evidence, len(in))
+	out := make([]fusion.Evidence, len(in))
 	copy(out, in)
 	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Tier != out[j].Tier {


### PR DESCRIPTION
Increment 2 of ADR-062. Extracts the generic deterministic-fusion engine out of `processor/research-graph-execute` + `agentic/research` into a new leaf package **`pkg/fusion`** — the deterministic sibling of `research_graph`, now a reusable substrate.

## The transform

`executeAll` (fan-out + dedup/rank/budget, wrapping `research.Intent` → `research.ExecutionOutput`) splits into a generic **`fusion.Fuse(ctx, gq, []SubQuery, FuseOptions, logger) (FuseResult, error)`** pure engine, called by a thin `executeAll` wrapper that builds the research `ExecutionOutput` from the `FuseResult`.

- **Moved to `pkg/fusion`** (clean break — `research.Evidence` fully removed): `Evidence`, `GraphQueryClient` + `*Args`, `SubQuery`/`SubQueryType`, the engine internals (`executeSubQuery`/`dedupEvidence`/`sortEvidence`/`enforceBudget`/`estimateEvidenceTokens`/`derivePerQueryTimeout`) + `Default*` consts. **Pure leaf**: stdlib + errgroup only, no `agentic/research`/`processor` imports.
- **Stays in `agentic/research`**: `ExecutionOutput` (now `[]fusion.Evidence`), `SearchResult`, `Action`/`RouteAction`, all payload registrations.
- **Stays in `research-graph-execute`**: the NATS `GraphQueryClient` adapter, materialization, the thin wrapper. Local `type SubQuery = fusion.SubQuery` aliases kept as idiomatic local sugar (a per-package decision; the cross-package break is complete).

## Review + gates

**semstreams-reviewer: APPROVE.** Verified the `executeAll`→`Fuse` split **line-by-line** (fan-out + `SetLimit`, timeout derivation, degrade-on-failure-no-sibling-cancel, dedup tier/score, sort ordering, budget cutoff + token estimate, every `ExecutionOutput` field, all defaults) — no off-by-one, dropped field, changed default, or reorder. Payload registry, provenance contract (Tier+Source stamped by the adapter, engine never re-stamps), and production-decoder round-trip intact. **Wire-identical** (Evidence JSON tags unchanged).

Green: `go build ./...`, `vet`, `gofmt -l`, `go test -race` across `pkg/fusion` + `agentic/research` + `research-graph-{execute,assess,synthesize}`, and `-tags=integration ./processor/research-graph-execute/...`.

## e2e

The `research-graph` e2e tier currently fails at an **unrelated graph-ingest health precondition** (2.8ms, before reaching research_graph logic; not in this diff; consistent across runs with leaked sister-project containers present). Tracked as a separate tier/substrate issue. The change is wire-identical, so unit+integration+review is the merge gate; the e2e must be resolved + green before any tag that includes this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)