### PR TITLE
fix(graph): birth entities via create_with_triples on must-exist write paths (gh#390)

### DIFF
--- a/agentic/model_endpoint_entity.go
+++ b/agentic/model_endpoint_entity.go
@@ -1,0 +1,32 @@
+package agentic
+
+import "github.com/c360studio/semstreams/message"
+
+// CategoryModelEndpoint is the message category for the model-endpoint entity
+// origin contract. It names the ENTITY type born when the agentic loop registers
+// a model registry endpoint in the graph — distinct from any event payload.
+// Mirrors CategoryLoopExecution.
+const CategoryModelEndpoint = "model_endpoint"
+
+// ModelEndpointMessageType returns the message.Type for the model-endpoint
+// entity origin contract — key "agentic.model_endpoint.v1".
+//
+// Registry decision (mirrors LoopExecutionMessageType, ADR-056 typed-origin —
+// intentionally pinned, not implicit): this type is MUTATION-ONLY. It is stamped
+// on CreateEntityWithTriplesRequest.Entity.MessageType when WriteModelEndpoints
+// births the endpoint entity, purely as PRODUCER IDENTITY for ownership
+// arbitration; it is NEVER published as a BaseMessage payload and is therefore
+// NOT registered in the payload registry (payload_registry.go) and never
+// round-trips through payload decoding. A model endpoint is a config-derived
+// FACT about the world, born once at startup via create_with_triples — not a
+// wire message. If a future producer needs to PUBLISH a model_endpoint message
+// over NATS (not merely stamp it at create), that producer must add the init()
+// registration at that point — until then, registering it would advertise a
+// decode path that does not exist.
+func ModelEndpointMessageType() message.Type {
+	return message.Type{
+		Domain:   Domain,
+		Category: CategoryModelEndpoint,
+		Version:  SchemaVersion,
+	}
+}

--- a/agentic/model_endpoint_entity_test.go
+++ b/agentic/model_endpoint_entity_test.go
@@ -1,0 +1,54 @@
+package agentic_test
+
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/agentic"
+)
+
+// --- ModelEndpointMessageType (gh#390 typed-origin envelope) ---
+
+func TestModelEndpointMessageType_Valid(t *testing.T) {
+	mt := agentic.ModelEndpointMessageType()
+	if mt.Domain == "" {
+		t.Error("MessageType.Domain is empty")
+	}
+	if mt.Category == "" {
+		t.Error("MessageType.Category is empty")
+	}
+	if mt.Version == "" {
+		t.Error("MessageType.Version is empty")
+	}
+	if !mt.IsValid() {
+		t.Errorf("MessageType %v is not valid (IsValid() returned false)", mt)
+	}
+}
+
+func TestModelEndpointMessageType_Distinct(t *testing.T) {
+	// Must not collide with any other agentic category constant — a collision
+	// would let two entity kinds share an origin envelope and silently break
+	// typed-origin ownership arbitration.
+	mt := agentic.ModelEndpointMessageType()
+	others := []string{
+		agentic.CategoryLoopExecution,
+		agentic.CategoryTrajectoryStep,
+		agentic.CategoryLoopCreated,
+		agentic.CategoryLoopCompleted,
+		agentic.CategoryLoopFailed,
+		agentic.CategoryLoopCancelled,
+		agentic.CategoryTask,
+	}
+	for _, cat := range others {
+		if mt.Category == cat {
+			t.Errorf("CategoryModelEndpoint collides with existing category %q", cat)
+		}
+	}
+}
+
+func TestModelEndpointMessageType_KeyFormat(t *testing.T) {
+	key := agentic.ModelEndpointMessageType().Key()
+	want := "agentic.model_endpoint.v1"
+	if key != want {
+		t.Errorf("MessageType.Key() = %q, want %q", key, want)
+	}
+}

--- a/agentic/trajectory_entity.go
+++ b/agentic/trajectory_entity.go
@@ -8,6 +8,32 @@ import (
 	agvocab "github.com/c360studio/semstreams/vocabulary/agentic"
 )
 
+// CategoryTrajectoryStep is the message category for the trajectory-step
+// entity origin contract. It names the ENTITY type born when the agentic loop
+// records a trajectory step in the graph — distinct from any event payload.
+// Mirrors CategoryLoopExecution / CategoryModelEndpoint.
+const CategoryTrajectoryStep = "trajectory_step"
+
+// TrajectoryStepMessageType returns the message.Type for the trajectory-step
+// entity origin contract — key "agentic.trajectory_step.v1".
+//
+// Registry decision (mirrors LoopExecutionMessageType, ADR-056 typed-origin):
+// MUTATION-ONLY. Stamped on CreateEntityWithTriplesRequest.Entity.MessageType
+// when WriteTrajectorySteps births a step entity; NEVER published as a
+// BaseMessage payload, NOT registered in the payload registry, never decoded.
+// A trajectory step is a metadata fact born once via create_with_triples (large
+// content lives in ObjectStore via ContentStorable) — not a wire message. The
+// step entity MUST be created with this envelope, not auto-vivified by
+// triple.add: graph-ingest enforces must-exist and would reject the step's
+// metadata triples otherwise (gh#390).
+func TrajectoryStepMessageType() message.Type {
+	return message.Type{
+		Domain:   Domain,
+		Category: CategoryTrajectoryStep,
+		Version:  SchemaVersion,
+	}
+}
+
 // TrajectoryStepEntity wraps a TrajectoryStep with the context needed to
 // produce a graph entity. It implements message.ContentStorable so that
 // large content (tool results, model responses) is stored in ObjectStore

--- a/agentic/trajectory_entity_test.go
+++ b/agentic/trajectory_entity_test.go
@@ -346,3 +346,50 @@ func objectFor(triples []message.Triple, predicate string) any {
 	}
 	return nil
 }
+
+// --- TrajectoryStepMessageType (gh#390 typed-origin envelope) ---
+
+func TestTrajectoryStepMessageType_Valid(t *testing.T) {
+	mt := agentic.TrajectoryStepMessageType()
+	if mt.Domain == "" {
+		t.Error("MessageType.Domain is empty")
+	}
+	if mt.Category == "" {
+		t.Error("MessageType.Category is empty")
+	}
+	if mt.Version == "" {
+		t.Error("MessageType.Version is empty")
+	}
+	if !mt.IsValid() {
+		t.Errorf("MessageType %v is not valid (IsValid() returned false)", mt)
+	}
+}
+
+func TestTrajectoryStepMessageType_Distinct(t *testing.T) {
+	// Must not collide with any other agentic category constant — a collision
+	// would let two entity kinds share an origin envelope and silently break
+	// typed-origin ownership arbitration.
+	mt := agentic.TrajectoryStepMessageType()
+	others := []string{
+		agentic.CategoryLoopExecution,
+		agentic.CategoryModelEndpoint,
+		agentic.CategoryLoopCreated,
+		agentic.CategoryLoopCompleted,
+		agentic.CategoryLoopFailed,
+		agentic.CategoryLoopCancelled,
+		agentic.CategoryTask,
+	}
+	for _, cat := range others {
+		if mt.Category == cat {
+			t.Errorf("CategoryTrajectoryStep collides with existing category %q", cat)
+		}
+	}
+}
+
+func TestTrajectoryStepMessageType_KeyFormat(t *testing.T) {
+	key := agentic.TrajectoryStepMessageType().Key()
+	want := "agentic.trajectory_step.v1"
+	if key != want {
+		t.Errorf("MessageType.Key() = %q, want %q", key, want)
+	}
+}

--- a/configs/research-graph-e2e.json
+++ b/configs/research-graph-e2e.json
@@ -87,6 +87,14 @@
       }
     }
   },
+  "_streams_doc": "agentic-dispatch consumes user.message.> from the USER stream (required input), but no component in this e2e produces user.message (the scenario injects directly to agent.task.*), so EnsureStreams — which derives streams from OUTPUT ports — never creates USER. Declare it explicitly (mirrors deep-research-test/ops-agent-test/crud-tools-test). AGENT/TOOL are auto-derived from their output-port producers. gh#390.",
+  "streams": {
+    "USER": {
+      "subjects": ["user.>"],
+      "storage": "file",
+      "max_age": "1h"
+    }
+  },
   "components": {
     "agentic-dispatch": {
       "type": "processor",

--- a/processor/agentic-loop/graph_writer.go
+++ b/processor/agentic-loop/graph_writer.go
@@ -160,17 +160,19 @@ func (w *graphWriter) writeBatch(ctx context.Context, triples []message.Triple) 
 	return nil
 }
 
-// createEntityWithTriples sends a CreateEntityWithTriplesRequest to
-// graph.mutation.entity.create_with_triples via NATS request/reply, using the
-// same transport config (timeout, retry) as writeBatch.
+// createEntityWithTriples is the shared entity-birth primitive: it sends a
+// CreateEntityWithTriplesRequest to graph.mutation.entity.create_with_triples via
+// NATS request/reply, using the same transport config (timeout, retry) as
+// writeBatch. Used to birth any typed-origin entity (loop executions via
+// WriteSpawnIdentity, model endpoints via WriteModelEndpoints).
 //
 // Idempotency contract (ADR-056 typed-origin): a response with ErrorCode ==
 // graph.ErrorCodeEntityExists is treated as success ONLY after a read-back
-// confirms the existing entity is the SAME typed origin (MessageType) the spawn
-// intended — a genuine re-spawn / retry. If the pre-existing entity is an
-// envelope-less auto-vivified shell or a foreign entity colliding on the id,
-// EntityExists is a birth FAILURE, never a silent "born." See
-// verifyExistingLoopOrigin.
+// confirms the existing entity is the SAME typed origin (MessageType) the creator
+// intended — a genuine re-create / retry / re-spawn. If the pre-existing entity
+// is an envelope-less auto-vivified shell or a foreign entity colliding on the
+// id, EntityExists is a birth FAILURE, never a silent "born." See
+// verifyExistingEntityOrigin.
 //
 // Returns a non-nil error only on genuine birth failures (transport error,
 // handler-internal error, an EntityExists that is not our typed origin, any
@@ -198,8 +200,12 @@ func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtype
 		// typed-origin contract (ADR-056). Read + verify before treating it as born.
 		var ce *errs.ClassifiedError
 		if errors.As(err, &ce) && ce.Code == gtypes.ErrorCodeEntityExists {
-			// Extract the incoming task_id from the spawn triples so
-			// verifyExistingLoopOrigin can detect divergent-task_id reuse (gh#276).
+			// Extract the incoming task_id from the create triples so
+			// verifyExistingEntityOrigin can detect divergent-task_id reuse
+			// (gh#276). Loop-execution entities carry agent.loop.task; non-loop
+			// entities (e.g. model endpoints) do not, so incomingTaskID stays
+			// empty and the divergent-task check no-ops — only the generic
+			// typed-origin MessageType readback applies.
 			var incomingTaskID string
 			for _, t := range triples {
 				if t.Predicate == agvocab.LoopTask {
@@ -209,7 +215,7 @@ func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtype
 					break
 				}
 			}
-			return w.verifyExistingLoopOrigin(ctx, entity.ID, entity.MessageType, incomingTaskID)
+			return w.verifyExistingEntityOrigin(ctx, entity.ID, entity.MessageType, incomingTaskID)
 		}
 		return fmt.Errorf("NATS create_with_triples request failed: %w", err)
 	}
@@ -217,18 +223,20 @@ func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtype
 	return nil
 }
 
-// verifyExistingLoopOrigin guards the EntityExists idempotency path: it reads the
-// already-existing entity and confirms it carries the SAME typed origin
-// MessageType the spawn intended. A match means a safe idempotent re-birth
-// (retry / redelivery / re-spawn). A mismatch (an envelope-less auto-vivified
-// shell, or a foreign entity colliding on the id) or an unreadable entity is a
-// birth FAILURE the caller halts on — never a silent "born." Reuses the
-// same-package graph.ingest.query.entity read surface (see todos.go).
+// verifyExistingEntityOrigin guards the EntityExists idempotency path for ANY
+// typed-origin entity: it reads the already-existing entity and confirms it
+// carries the SAME typed origin MessageType the creator intended. A match means a
+// safe idempotent re-birth (retry / redelivery / re-create / re-spawn). A
+// mismatch (an envelope-less auto-vivified shell, or a foreign entity colliding
+// on the id) or an unreadable entity is a birth FAILURE the caller halts on —
+// never a silent "born." Reuses the same-package graph.ingest.query.entity read
+// surface (see todos.go).
 //
-// loop_id immutability contract (gh#276): a loop_id is bound to a single task_id
-// at birth. A same-MessageType match is idempotent success — the first spawn's
-// identity triples (role, task, prompt, parent) remain canonical and the new
-// spawn's identity triples are NOT written (create_with_triples returns
+// loop_id immutability contract (gh#276) — applies only to loop-execution
+// entities, which pass a non-empty incomingTaskID: a loop_id is bound to a single
+// task_id at birth. A same-MessageType match is idempotent success — the first
+// spawn's identity triples (role, task, prompt, parent) remain canonical and the
+// new spawn's identity triples are NOT written (create_with_triples returns
 // EntityExists before any merge). When incomingTaskID is non-empty and differs
 // from the existing entity's agent.loop.task triple, this function emits a
 // structured WARNING so operators can detect loop_id reuse across tasks. The
@@ -238,7 +246,11 @@ func (w *graphWriter) createEntityWithTriples(ctx context.Context, entity *gtype
 // violation observable. This is strictly safer than the pre-4c-pre-1
 // triple.add_batch path, which would have APPENDED conflicting role/parent
 // values onto the existing entity.
-func (w *graphWriter) verifyExistingLoopOrigin(ctx context.Context, entityID string, want message.Type, incomingTaskID string) error {
+//
+// Non-loop callers (e.g. WriteModelEndpoints) pass an empty incomingTaskID, so
+// the divergent-task_id check no-ops and only the generic MessageType readback
+// applies — exactly the typed-origin guard those entities need.
+func (w *graphWriter) verifyExistingEntityOrigin(ctx context.Context, entityID string, want message.Type, incomingTaskID string) error {
 	reqData, err := json.Marshal(struct {
 		ID string `json:"id"`
 	}{ID: entityID})
@@ -368,8 +380,27 @@ func (w *graphWriter) WriteSyntheticDecide(ctx context.Context, loopID, modelTex
 		"hint", "model returned text-only at completion — consider setting tool_choice='required' on the rule (#132) to prevent recurrence; high prevalence of this triple signals model/persona mismatch")
 }
 
-// WriteModelEndpoints emits triples for every endpoint in the model registry.
-// Called on component startup so the graph reflects current endpoint configuration.
+// WriteModelEndpoints births a graph entity for every endpoint in the model
+// registry. Called on component startup so the graph reflects current endpoint
+// configuration.
+//
+// Each endpoint entity is CREATED via create_with_triples carrying a
+// model_endpoint typed-origin envelope (agentic.ModelEndpointMessageType) — NOT
+// bare per-triple triple.add. A model endpoint is a config-derived fact whose
+// entity must be born with a MessageType envelope, never auto-vivified:
+// graph-ingest's triple.add enforces must-exist, so a per-triple write to a
+// never-created endpoint entity is rejected ("kv: key not found"), increments
+// graph-ingest's error count, and flips it permanently unhealthy (gh#390).
+// create_with_triples is the correct write-API verb for entity creation
+// (ADR-056 typed-origin; see WriteSpawnIdentity for the loop-execution analogue
+// and the write-API taxonomy — metadata-less creation via triple.add is the
+// defect class this fixes).
+//
+// Idempotent on restart: an EntityExists response for an endpoint already born
+// with the same model_endpoint MessageType is treated as success by
+// createEntityWithTriples (typed-origin readback). Per-endpoint failures are
+// logged and do not abort the remaining endpoints — startup is best-effort,
+// matching the pre-fix per-triple behaviour and every sibling graph-write method.
 func (w *graphWriter) WriteModelEndpoints(ctx context.Context) {
 	if w.natsClient == nil {
 		return
@@ -390,11 +421,14 @@ func (w *graphWriter) WriteModelEndpoints(ctx context.Context) {
 		}
 		entityID := agentic.ModelEndpointEntityID(w.platform.Org, w.platform.Platform, name)
 		triples := buildModelEndpointTriples(entityID, *ep)
-		for _, t := range triples {
-			if err := w.writeTriple(ctx, t); err != nil {
-				w.logger.Warn("graph_writer: failed to write model endpoint triple",
-					"endpoint", name, "predicate", t.Predicate, "error", err)
-			}
+		entity := &gtypes.EntityState{
+			ID:          entityID,
+			MessageType: agentic.ModelEndpointMessageType(),
+			Triples:     triples,
+		}
+		if err := w.createEntityWithTriples(ctx, entity, triples); err != nil {
+			w.logger.Warn("graph_writer: failed to create model endpoint entity",
+				"endpoint", name, "entity_id", entityID, "error", err)
 		}
 	}
 }
@@ -499,10 +533,46 @@ func (w *graphWriter) WriteTrajectorySteps(ctx context.Context, loopID string, t
 
 	loopEntityID := agentic.LoopExecutionEntityID(w.platform.Org, w.platform.Platform, loopID)
 	triples := buildTrajectoryStepTriples(loopEntityID, w.platform.Org, w.platform.Platform, loopID, trajectory)
+
+	// gh#390: the flat triple list mixes two subject kinds per step — the step
+	// ENTITY's metadata triples (Subject = step entity ID, which must be
+	// CREATED) and the LoopHasStep link (Subject = loop entity ID, which
+	// already exists via WriteSpawnIdentity). graph-ingest enforces must-exist
+	// on triple.add, so the step-entity triples must be born via
+	// create_with_triples (a bare add lands "kv: key not found", increments
+	// graph-ingest's error count, and flips it unhealthy). Group by subject and
+	// route: the loop-entity subject is an APPEND (writeTriple); every other
+	// subject is a step entity BIRTH (create_with_triples + typed-origin
+	// envelope). Insertion order is preserved so emission stays deterministic.
+	bySubject := make(map[string][]message.Triple)
+	order := make([]string, 0, len(triples))
 	for _, t := range triples {
-		if err := w.writeTriple(ctx, t); err != nil {
-			w.logger.Warn("graph_writer: failed to write trajectory step triple",
-				"loop_id", loopID, "predicate", t.Predicate, "error", err)
+		if _, seen := bySubject[t.Subject]; !seen {
+			order = append(order, t.Subject)
+		}
+		bySubject[t.Subject] = append(bySubject[t.Subject], t)
+	}
+	for _, subject := range order {
+		group := bySubject[subject]
+		if subject == loopEntityID {
+			// LoopHasStep links — append onto the already-born loop entity.
+			for _, t := range group {
+				if err := w.writeTriple(ctx, t); err != nil {
+					w.logger.Warn("graph_writer: failed to write trajectory link triple",
+						"loop_id", loopID, "predicate", t.Predicate, "error", err)
+				}
+			}
+			continue
+		}
+		// Step entity — birth it with a trajectory-step typed-origin envelope.
+		stepEntity := &gtypes.EntityState{
+			ID:          subject,
+			MessageType: agentic.TrajectoryStepMessageType(),
+			Triples:     group,
+		}
+		if err := w.createEntityWithTriples(ctx, stepEntity, group); err != nil {
+			w.logger.Warn("graph_writer: failed to create trajectory step entity",
+				"loop_id", loopID, "step_entity_id", subject, "error", err)
 		}
 	}
 }

--- a/processor/agentic-loop/graph_writer_integration_test.go
+++ b/processor/agentic-loop/graph_writer_integration_test.go
@@ -204,9 +204,13 @@ func TestWriteModelEndpoints_Integration(t *testing.T) {
 	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
 	ctx := context.Background()
 
-	// Set up triple collector as responder.
-	collector := &tripleCollector{}
-	collector.subscribeMutations(t, ctx, tc.Client)
+	// gh#390: model endpoints are BORN via create_with_triples carrying a
+	// model_endpoint typed-origin envelope — NOT per-triple triple.add. A bare
+	// triple.add to a never-created endpoint entity is must-exist-rejected by
+	// graph-ingest ("kv: key not found"), which increments its error count and
+	// flips it permanently unhealthy. Capture the create requests, not triples.
+	responder := &createWithTriplesResponder{}
+	responder.subscribe(t, ctx, tc.Client)
 
 	// Build a model registry with two endpoints.
 	reg := &model.Registry{
@@ -228,28 +232,82 @@ func TestWriteModelEndpoints_Integration(t *testing.T) {
 		Defaults: model.DefaultsConfig{Model: "claude"},
 	}
 
-	// Create graphWriter directly (it's in same repo, integration test can access internals
-	// through a helper). Since graphWriter is unexported, we use NewComponent approach.
-	// Instead, let's test via a helper that mirrors the graphWriter construction.
 	w := agenticloop.NewGraphWriterForTest(tc.Client, reg, types.PlatformMeta{Org: "acme", Platform: "ops"})
 	w.WriteModelEndpoints(ctx)
 
-	// Each endpoint produces at least 3 required triples (provider, name, supports_tools).
-	// "claude" has optional fields too (max_tokens, input_price, output_price).
-	triples := collector.getTriples()
-
-	// claude: 3 required + 3 optional (max_tokens, input_price, output_price) = 6
-	// local: 3 required = 3
-	// Total: 9
-	if len(triples) < 9 {
-		t.Errorf("expected at least 9 triples, got %d", len(triples))
+	// One create_with_triples request per endpoint.
+	received := responder.getReceived()
+	if len(received) != 2 {
+		t.Fatalf("expected 2 create_with_triples requests (one per endpoint), got %d", len(received))
 	}
 
-	// Verify all triples have valid subjects (6-part entity IDs).
-	for _, tr := range triples {
-		if !message.IsValidEntityID(tr.Subject) {
-			t.Errorf("invalid entity ID: %q", tr.Subject)
+	wantType := agentic.ModelEndpointMessageType()
+	var totalTriples int
+	for _, req := range received {
+		if req.Entity == nil {
+			t.Fatal("create_with_triples request has a nil Entity")
 		}
+		// Typed-origin envelope: the endpoint entity must be born with the
+		// model_endpoint MessageType so graph-ingest creates it (not
+		// envelope-less, not auto-vivified).
+		if req.Entity.MessageType != wantType {
+			t.Errorf("Entity.MessageType = %q, want %q", req.Entity.MessageType.Key(), wantType.Key())
+		}
+		// Subject must be a valid 6-part entity ID.
+		if !message.IsValidEntityID(req.Entity.ID) {
+			t.Errorf("invalid entity ID: %q", req.Entity.ID)
+		}
+		// Every triple in the create body must belong to the entity being born.
+		for _, tr := range req.Triples {
+			if tr.Subject != req.Entity.ID {
+				t.Errorf("triple subject %q != created entity ID %q", tr.Subject, req.Entity.ID)
+			}
+		}
+		totalTriples += len(req.Triples)
+	}
+
+	// claude: 3 required (provider, name, supports_tools) + 3 optional
+	// (max_tokens, input_price, output_price) = 6; local: 3 required = 3.
+	// Total: 9 across both create bodies.
+	if totalTriples < 9 {
+		t.Errorf("expected at least 9 triples across endpoint create bodies, got %d", totalTriples)
+	}
+}
+
+// TestWriteModelEndpoints_IdempotentOnRestart_Integration covers the restart
+// path (gh#390): an endpoint entity already born with the model_endpoint typed
+// origin returns EntityExists, which createEntityWithTriples treats as success
+// after the MessageType read-back. WriteModelEndpoints must not log this as a
+// failure or panic — re-running it on a warm graph is a no-op.
+func TestWriteModelEndpoints_IdempotentOnRestart_Integration(t *testing.T) {
+	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
+	ctx := context.Background()
+
+	// create_with_triples replies EntityExists for every endpoint.
+	responder := &createWithTriplesResponder{alreadyExists: true}
+	responder.subscribe(t, ctx, tc.Client)
+
+	// The read-back must find the SAME model_endpoint typed origin for
+	// EntityExists to count as a safe idempotent re-birth.
+	q := &queryEntityResponder{entity: gtypes.EntityState{
+		ID:          agentic.ModelEndpointEntityID("acme", "ops", "claude"),
+		MessageType: agentic.ModelEndpointMessageType(),
+	}}
+	q.subscribe(t, ctx, tc.Client)
+
+	reg := &model.Registry{
+		Endpoints: map[string]*model.EndpointConfig{
+			"claude": {Provider: "anthropic", Model: "claude-opus-4-5"},
+		},
+	}
+
+	w := agenticloop.NewGraphWriterForTest(tc.Client, reg, types.PlatformMeta{Org: "acme", Platform: "ops"})
+
+	// Must not panic; EntityExists for our typed origin is idempotent success.
+	w.WriteModelEndpoints(ctx)
+
+	if got := len(responder.getReceived()); got != 1 {
+		t.Errorf("expected 1 create_with_triples attempt, got %d", got)
 	}
 }
 
@@ -664,9 +722,14 @@ func TestWriteTrajectorySteps_Integration(t *testing.T) {
 	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup(), natsclient.WithJetStream())
 	ctx := context.Background()
 
-	// Set up triple collector as responder.
+	// Set up triple collector for the LoopHasStep links (triple.add) and a
+	// create_with_triples responder for the step-entity births (gh#390): step
+	// entities are CREATED with a typed-origin envelope, not appended. The two
+	// responders are on disjoint subjects, so they coexist.
 	collector := &tripleCollector{}
 	collector.subscribeMutations(t, ctx, tc.Client)
+	creates := &createWithTriplesResponder{}
+	creates.subscribe(t, ctx, tc.Client)
 
 	// Create ObjectStore for content storage.
 	store, err := objectstore.NewStoreWithConfig(ctx, tc.Client, objectstore.Config{
@@ -720,46 +783,58 @@ func TestWriteTrajectorySteps_Integration(t *testing.T) {
 
 	w.WriteTrajectorySteps(ctx, "loop-traj", trajectory)
 
-	triples := collector.getTriples()
-
-	// Count step entity triples vs LoopHasStep triples.
+	// LoopHasStep links append onto the loop entity via triple.add (captured by
+	// the collector). 4 steps (including compaction) → 4 LoopHasStep triples.
 	loopEntityID := "acme.ops.agent.agentic-loop.execution.loop-traj"
 	var loopHasStepCount int
-	stepEntityIDs := make(map[string]bool)
-	for _, tr := range triples {
+	for _, tr := range collector.getTriples() {
 		if tr.Subject == loopEntityID && tr.Predicate == agvocab.LoopHasStep {
 			loopHasStepCount++
 		}
-		if tr.Predicate == agvocab.StepType {
-			stepEntityIDs[tr.Subject] = true
-		}
 	}
-
-	// 4 steps (including compaction) → 4 LoopHasStep triples.
 	if loopHasStepCount != 4 {
 		t.Errorf("expected 4 LoopHasStep triples, got %d", loopHasStepCount)
 	}
 
-	// 4 step entities created.
-	if len(stepEntityIDs) != 4 {
-		t.Errorf("expected 4 step entities, got %d", len(stepEntityIDs))
+	// Step entities are BORN via create_with_triples (gh#390) — one create per
+	// step, each carrying the trajectory-step typed-origin envelope and the
+	// step's metadata triples. Collect them from the create responder.
+	received := creates.getReceived()
+	if len(received) != 4 {
+		t.Fatalf("expected 4 create_with_triples requests (one per step entity), got %d", len(received))
 	}
-
-	// Verify all step entity IDs are valid.
-	for id := range stepEntityIDs {
-		if !message.IsValidEntityID(id) {
-			t.Errorf("invalid step entity ID: %q", id)
+	wantType := agentic.TrajectoryStepMessageType()
+	stepEntityIDs := make(map[string]bool)
+	stepPreds := make(map[string]bool)
+	for _, req := range received {
+		if req.Entity == nil {
+			t.Fatal("create_with_triples request has a nil Entity")
+		}
+		if req.Entity.MessageType != wantType {
+			t.Errorf("step Entity.MessageType = %q, want %q", req.Entity.MessageType.Key(), wantType.Key())
+		}
+		if !message.IsValidEntityID(req.Entity.ID) {
+			t.Errorf("invalid step entity ID: %q", req.Entity.ID)
+		}
+		stepEntityIDs[req.Entity.ID] = true
+		for _, tr := range req.Triples {
+			stepPreds[tr.Predicate] = true
+			if tr.Subject != req.Entity.ID {
+				t.Errorf("step triple subject %q != created entity ID %q", tr.Subject, req.Entity.ID)
+			}
 		}
 	}
-
-	// Verify tool_call step has StepToolName predicate.
-	preds := collector.predicateSet()
-	if !preds[agvocab.StepToolName] {
+	if len(stepEntityIDs) != 4 {
+		t.Errorf("expected 4 distinct step entities, got %d", len(stepEntityIDs))
+	}
+	// Every step entity carries its type; tool_call carries tool_name; model_call carries tokens_in.
+	if !stepPreds[agvocab.StepType] {
+		t.Error("expected agent.step.type triple on every step entity")
+	}
+	if !stepPreds[agvocab.StepToolName] {
 		t.Error("expected agent.step.tool_name triple for tool_call step")
 	}
-
-	// Verify model_call steps have token predicates.
-	if !preds[agvocab.StepTokensIn] {
+	if !stepPreds[agvocab.StepTokensIn] {
 		t.Error("expected agent.step.tokens_in triple for model_call step")
 	}
 
@@ -799,8 +874,10 @@ func TestWriteTrajectorySteps_NoContentStore_StillWritesTriples(t *testing.T) {
 
 	collector := &tripleCollector{}
 	collector.subscribeMutations(t, ctx, tc.Client)
+	creates := &createWithTriplesResponder{}
+	creates.subscribe(t, ctx, tc.Client)
 
-	// No content store set — triples should still be written.
+	// No content store set — graph writes should still happen.
 	w := agenticloop.NewGraphWriterForTest(tc.Client, nil, types.PlatformMeta{Org: "acme", Platform: "ops"})
 
 	trajectory := &agentic.Trajectory{
@@ -818,17 +895,26 @@ func TestWriteTrajectorySteps_NoContentStore_StillWritesTriples(t *testing.T) {
 
 	w.WriteTrajectorySteps(ctx, "loop-no-store", trajectory)
 
-	triples := collector.getTriples()
-	if len(triples) == 0 {
-		t.Error("expected triples even without content store")
-	}
-
+	// The LoopHasStep link appends to the loop entity via triple.add.
 	preds := collector.predicateSet()
-	if !preds[agvocab.StepToolName] {
-		t.Error("expected agent.step.tool_name triple")
-	}
 	if !preds[agvocab.LoopHasStep] {
 		t.Error("expected agent.loop.has_step triple")
+	}
+
+	// The step entity is BORN via create_with_triples carrying its metadata
+	// triples (gh#390) — not appended via triple.add.
+	received := creates.getReceived()
+	if len(received) != 1 {
+		t.Fatalf("expected 1 step-entity create_with_triples, got %d", len(received))
+	}
+	var sawToolName bool
+	for _, tr := range received[0].Triples {
+		if tr.Predicate == agvocab.StepToolName {
+			sawToolName = true
+		}
+	}
+	if !sawToolName {
+		t.Error("expected agent.step.tool_name triple in the step-entity create")
 	}
 }
 
@@ -947,15 +1033,12 @@ func TestWriteMutationFailure_Integration(t *testing.T) {
 	tc := natsclient.NewTestClient(t, natsclient.WithFastStartup())
 	ctx := context.Background()
 
-	// Respond with failure to verify graceful handling. ADR-060: a hard failure
-	// is a classified error, mirroring the production handler.
-	_, err := tc.Client.SubscribeForRequests(ctx, "graph.mutation.triple.add",
-		func(_ context.Context, _ []byte) ([]byte, error) {
-			return nil, errs.ClassifiedCode(errs.ErrorTransient, gtypes.ErrorCodeInternal, errors.New("test error"))
-		})
-	if err != nil {
-		t.Fatalf("subscribe: %v", err)
-	}
+	// gh#390: WriteModelEndpoints births endpoints via create_with_triples. A
+	// hard failure (ADR-060 classified error, mirroring the production handler)
+	// must be logged and swallowed per-endpoint — never panic, never abort the
+	// remaining endpoints.
+	responder := &createWithTriplesResponder{failWith: "test error"}
+	responder.subscribe(t, ctx, tc.Client)
 
 	reg := &model.Registry{
 		Endpoints: map[string]*model.EndpointConfig{

--- a/processor/agentic-tools/executors/research_graph.go
+++ b/processor/agentic-tools/executors/research_graph.go
@@ -372,11 +372,19 @@ func (e *ResearchGraphExecutor) researchGraph(ctx context.Context, call agentic.
 		persistedIntent.MaxIterations,
 		e.now(),
 	)
-	if stampErr := llmwrap.StampOrchestrationTriples(ctx, e.triplePub, e.logger, "research_graph_tool", loopID, kickoffTriples); stampErr != nil {
-		// StampOrchestrationTriples already logged warn; suppress here so
-		// the tool's success path stays clean. Operator-side diagnosis is
-		// "no research.classify.complete ever appeared" → check graph-
-		// ingest logs for the triple-batch publish failure.
+	// BIRTH, not append: this is the FIRST write to the research-pipeline loop
+	// entity in ENTITY_STATES, so it must CREATE the entity with a
+	// LoopExecution typed-origin envelope via create_with_triples. graph-ingest
+	// enforces must-exist on triple.add / add_batch (gh#390), so a bare
+	// kickoff add_batch to a never-created entity is rejected ("kv: key not
+	// found"), lands written=0, and the chain stalls before R0 fires. The
+	// downstream per-stage stamps (classify/route/execute/synthesize) append
+	// via AddTriplesBatch onto the entity born here.
+	if stampErr := llmwrap.BirthLoopEntityWithTriples(ctx, e.triplePub, e.logger, "research_graph_tool", loopID, loopEntityID, agentic.LoopExecutionMessageType(), kickoffTriples); stampErr != nil {
+		// BirthLoopEntityWithTriples already logged warn; suppress here so the
+		// tool's success path stays clean. Operator-side diagnosis is "no
+		// research.classify.complete ever appeared" → check graph-ingest logs
+		// for the create_with_triples publish failure.
 		_ = stampErr
 	}
 

--- a/processor/research-graph-classify/component_test.go
+++ b/processor/research-graph-classify/component_test.go
@@ -29,6 +29,18 @@ type recordingPublisher struct {
 	addErr error
 }
 
+// CreateEntityWithTriples satisfies the widened llmwrap.TriplePublisher
+// interface. The classify component only APPENDS onto the already-born pipeline
+// loop entity (the kickoff births it — gh#390), so this is never exercised here;
+// present for interface conformance.
+func (r *recordingPublisher) CreateEntityWithTriples(_ context.Context, _ string, _ message.Type, triples []message.Triple) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	dup := append([]message.Triple(nil), triples...)
+	r.batch = append(r.batch, dup)
+	return r.addErr
+}
+
 func (r *recordingPublisher) AddTriple(_ context.Context, triple message.Triple) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/processor/research-graph-llmwrap/triplepub.go
+++ b/processor/research-graph-llmwrap/triplepub.go
@@ -3,12 +3,14 @@ package llmwrap
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
 )
 
 // TriplePublisher is the narrow surface the research-graph chain
@@ -20,19 +22,27 @@ import (
 // paired with their respective complete triples — a partial write would
 // corrupt the dispatch).
 //
-// Two emission shapes:
+// Three emission shapes:
 //
+//   - CreateEntityWithTriples: BIRTH. The FIRST write to a pipeline loop
+//     entity must CREATE it with a typed-origin MessageType envelope —
+//     graph-ingest enforces must-exist on triple.add / add_batch, so a bare
+//     batch to a never-created entity is rejected ("kv: key not found") and
+//     the chain stalls before any rule fires (gh#390). The research_graph
+//     kickoff uses this; subsequent per-stage stamps append.
 //   - AddTriple: single-triple convenience. Available for symmetry with
 //     the agentictools.TriplePublisher pattern; the chain's per-stage
 //     stamps all batch.
-//   - AddTriplesBatch: atomic per-Subject. The graph-ingest handler
-//     groups triples by Subject and CAS-applies them per entity, so a
-//     batch sharing one Subject is fully atomic.
+//   - AddTriplesBatch: atomic per-Subject APPEND onto an already-born
+//     entity. The graph-ingest handler groups triples by Subject and
+//     CAS-applies them per entity, so a batch sharing one Subject is fully
+//     atomic.
 //
 // Production satisfies it with *natsClient adapter; tests substitute an
 // in-memory recorder so the per-component handler suites don't need a
 // live NATS connection.
 type TriplePublisher interface {
+	CreateEntityWithTriples(ctx context.Context, entityID string, msgType message.Type, triples []message.Triple) error
 	AddTriple(ctx context.Context, triple message.Triple) error
 	AddTriplesBatch(ctx context.Context, triples []message.Triple) error
 }
@@ -45,6 +55,12 @@ const (
 	// (ADR-036 Stage 2). Used by AddTriplesBatch for co-located triples
 	// where partial-write orphans would corrupt downstream rule matching.
 	graphMutationAddBatchSubject = "graph.mutation.triple.add_batch"
+
+	// graphMutationCreateWithTriplesSubject births an entity with a
+	// typed-origin envelope, carrying triples atomically. The correct verb
+	// for the FIRST write to a pipeline loop entity (gh#390) — add / add_batch
+	// enforce must-exist and reject a never-created entity.
+	graphMutationCreateWithTriplesSubject = "graph.mutation.entity.create_with_triples"
 
 	// graphMutationTimeout matches the bounds used by decide /
 	// agentic-loop / write_todos against the same handler.
@@ -119,6 +135,53 @@ func (p *natsTriplePublisher) AddTriplesBatch(ctx context.Context, triples []mes
 	return nil
 }
 
+// CreateEntityWithTriples births a graph entity (ENTITY_STATES) with the given
+// typed-origin MessageType envelope, carrying triples atomically via
+// graph.mutation.entity.create_with_triples. This is the correct verb for the
+// FIRST write to a research-pipeline loop entity: graph-ingest enforces
+// must-exist on triple.add / add_batch, so a bare batch to a never-created
+// entity is rejected ("kv: key not found"), the whole batch lands written=0,
+// and the chain stalls before R0 ever fires (gh#390). Subsequent per-stage
+// stamps use AddTriplesBatch to append onto the now-existing entity.
+//
+// EntityExists is treated as idempotent-success: a freshly minted pipeline loop
+// ID should never collide, but a redelivery / retry of the kickoff must not
+// fail the chain. (The agentic-loop spawn path additionally reads back to
+// confirm typed origin — see graph_writer.go — but a unique-per-dispatch rg_*
+// id makes a foreign collision a non-concern here; treating exists as success
+// keeps the best-effort, non-fatal kickoff contract.)
+//
+// PRECONDITION for the blind EntityExists path: the caller MUST mint a
+// unique-per-dispatch entityID (the rg_* loop id is a fresh uuid8 per
+// researchGraph invocation). A caller passing a STABLE/reused entityID (e.g. a
+// config-name or loop+index id) must NOT bless EntityExists blindly — it has to
+// read back and verify the typed origin like graph_writer.createEntityWithTriples
+// does, or a foreign/auto-vivified entity colliding on that stable id would be
+// silently laundered into a "born" pipeline loop.
+func (p *natsTriplePublisher) CreateEntityWithTriples(ctx context.Context, entityID string, msgType message.Type, triples []message.Triple) error {
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{
+			ID:          entityID,
+			MessageType: msgType,
+			Triples:     triples,
+		},
+		Triples: triples,
+	}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal create_with_triples request: %w", err)
+	}
+	// gh#93 Phase 2: Classified variant surfaces handler errors via err.
+	if _, err := p.client.RequestWithRetryClassified(ctx, graphMutationCreateWithTriplesSubject, reqData, graphMutationTimeout, natsclient.DefaultRetryConfig()); err != nil {
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) && ce.Code == graph.ErrorCodeEntityExists {
+			return nil
+		}
+		return fmt.Errorf("request %s: %w", graphMutationCreateWithTriplesSubject, err)
+	}
+	return nil
+}
+
 // StampLogger is the subset of *slog.Logger the StampOrchestrationTriples
 // helper needs. Defined to keep the helper unit-testable without forcing
 // a slog handler into the test (a *slog.Logger satisfies it directly).
@@ -151,6 +214,38 @@ func StampOrchestrationTriples(ctx context.Context, pub TriplePublisher, logger 
 		if logger != nil {
 			logger.Warn("orchestration triple-stamp failed; chain rules may not fire",
 				"stage", stage, "loop_id", loopID, "triple_count", len(triples), "error", err)
+		}
+		return err
+	}
+	return nil
+}
+
+// BirthLoopEntityWithTriples births the research-pipeline loop entity with a
+// typed-origin MessageType envelope, carrying the kickoff triples atomically via
+// create_with_triples. This is the FIRST stamp on a pipeline loop entity — the
+// entity must be CREATED (not auto-vivified) so subsequent per-stage stamps can
+// append onto it; a bare add_batch to a never-created entity is rejected by
+// graph-ingest's must-exist contract and the chain stalls before any rule fires
+// (gh#390).
+//
+// Same degraded-mode + warn-on-failure contract as StampOrchestrationTriples:
+// pub == nil logs warn and returns nil (observability-disabled), and a publish
+// failure is logged warn and returned for handler-level metrics. The kickoff
+// stays best-effort and non-fatal — a birth failure stalls the chain observably
+// (no rule fires; operator sees the gap in trajectory data) rather than crashing
+// the parent loop.
+func BirthLoopEntityWithTriples(ctx context.Context, pub TriplePublisher, logger StampLogger, stage, loopID, entityID string, msgType message.Type, triples []message.Triple) error {
+	if pub == nil {
+		if logger != nil {
+			logger.Warn("orchestration loop-birth skipped: publisher is nil",
+				"stage", stage, "loop_id", loopID, "triple_count", len(triples))
+		}
+		return nil
+	}
+	if err := pub.CreateEntityWithTriples(ctx, entityID, msgType, triples); err != nil {
+		if logger != nil {
+			logger.Warn("orchestration loop-birth failed; chain rules may not fire",
+				"stage", stage, "loop_id", loopID, "entity_id", entityID, "triple_count", len(triples), "error", err)
 		}
 		return err
 	}

--- a/processor/research-graph-llmwrap/triplepub_test.go
+++ b/processor/research-graph-llmwrap/triplepub_test.go
@@ -22,9 +22,23 @@ func TestNewNATSTriplePublisher_NilClient(t *testing.T) {
 // assert orchestration-triple emission in their handler tests. Kept
 // here so the five component test suites share one shape.
 type recordingPublisher struct {
-	addCalls   []message.Triple
-	batchCalls [][]message.Triple
-	err        error
+	addCalls    []message.Triple
+	batchCalls  [][]message.Triple
+	createCalls []recordedCreate
+	err         error
+}
+
+// recordedCreate captures one CreateEntityWithTriples call so birth tests can
+// assert the entity ID, typed-origin envelope, and carried triples.
+type recordedCreate struct {
+	entityID string
+	msgType  message.Type
+	triples  []message.Triple
+}
+
+func (r *recordingPublisher) CreateEntityWithTriples(_ context.Context, entityID string, msgType message.Type, triples []message.Triple) error {
+	r.createCalls = append(r.createCalls, recordedCreate{entityID: entityID, msgType: msgType, triples: triples})
+	return r.err
 }
 
 func (r *recordingPublisher) AddTriple(_ context.Context, triple message.Triple) error {
@@ -44,8 +58,56 @@ func (r *recordingPublisher) AddTriplesBatch(_ context.Context, triples []messag
 func TestTriplePublisher_InterfaceShape(t *testing.T) {
 	var pub TriplePublisher = &recordingPublisher{}
 	assert.NotNil(t, pub)
-	err := pub.AddTriple(context.Background(), message.Triple{Subject: "x", Predicate: "y", Object: "z", Timestamp: time.Now()})
+	err := pub.CreateEntityWithTriples(context.Background(), "c360.ops.agent.agentic-loop.execution.rg_x", message.Type{Domain: "agentic", Category: "loop_execution", Version: "v1"}, []message.Triple{{Subject: "c360.ops.agent.agentic-loop.execution.rg_x", Predicate: "y", Object: "z", Timestamp: time.Now()}})
+	assert.NoError(t, err)
+	err = pub.AddTriple(context.Background(), message.Triple{Subject: "x", Predicate: "y", Object: "z", Timestamp: time.Now()})
 	assert.NoError(t, err)
 	err = pub.AddTriplesBatch(context.Background(), []message.Triple{{Subject: "x", Predicate: "y", Object: "z", Timestamp: time.Now()}})
 	assert.NoError(t, err)
+}
+
+// countingLogger captures Warn calls so the birth-helper degraded/failure
+// contracts can be asserted without a real slog handler.
+type countingLogger struct{ warns int }
+
+func (l *countingLogger) Warn(_ string, _ ...any) { l.warns++ }
+
+// TestBirthLoopEntityWithTriples_NilPublisher_Degraded pins the
+// observability-disabled contract: a nil publisher logs warn and returns nil
+// (the kickoff is best-effort, non-fatal) rather than panicking.
+func TestBirthLoopEntityWithTriples_NilPublisher_Degraded(t *testing.T) {
+	lg := &countingLogger{}
+	err := BirthLoopEntityWithTriples(context.Background(), nil, lg, "research_graph_tool", "rg_x", "c360.ops.agent.agentic-loop.execution.rg_x", message.Type{}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, lg.warns, "nil publisher must log a single degraded warn")
+}
+
+// TestBirthLoopEntityWithTriples_Success births via CreateEntityWithTriples
+// (NOT AddTriplesBatch) carrying the typed-origin envelope + kickoff triples —
+// the gh#390 fix: the FIRST write must CREATE the entity, not append to it.
+func TestBirthLoopEntityWithTriples_Success(t *testing.T) {
+	pub := &recordingPublisher{}
+	entityID := "c360.ops.agent.agentic-loop.execution.rg_x"
+	want := message.Type{Domain: "agentic", Category: "loop_execution", Version: "v1"}
+	triples := []message.Triple{{Subject: entityID, Predicate: "research.topic", Object: "drones", Timestamp: time.Now()}}
+
+	err := BirthLoopEntityWithTriples(context.Background(), pub, &countingLogger{}, "research_graph_tool", "rg_x", entityID, want, triples)
+	assert.NoError(t, err)
+
+	// Must create (birth), never append, on the first write.
+	assert.Len(t, pub.createCalls, 1, "kickoff must CREATE the entity, not append")
+	assert.Empty(t, pub.batchCalls, "kickoff must not use the append path")
+	assert.Equal(t, entityID, pub.createCalls[0].entityID)
+	assert.Equal(t, want, pub.createCalls[0].msgType, "must carry the typed-origin envelope")
+	assert.Equal(t, triples, pub.createCalls[0].triples)
+}
+
+// TestBirthLoopEntityWithTriples_Failure_Propagates pins that a publish failure
+// is logged warn and returned (for handler-level metrics) without panicking.
+func TestBirthLoopEntityWithTriples_Failure_Propagates(t *testing.T) {
+	pub := &recordingPublisher{err: assert.AnError}
+	lg := &countingLogger{}
+	err := BirthLoopEntityWithTriples(context.Background(), pub, lg, "research_graph_tool", "rg_x", "c360.ops.agent.agentic-loop.execution.rg_x", message.Type{}, nil)
+	assert.Error(t, err)
+	assert.Equal(t, 1, lg.warns, "a birth failure must log a single warn")
 }


### PR DESCRIPTION
## Problem (gh#390)
`graph.mutation.triple.add` / `add_batch` enforce **must-exist** (no auto-vivify). Several emitters still wrote the *first* triple to a never-created entity → graph-ingest rejects `kv: key not found` → `errorCount++` → unhealthy → the e2e `verify-components` gate fails. This is the write-API-taxonomy defect class (metadata-less entity CREATION via `triple.add`). The fix is to **birth the entity via `create_with_triples` + a typed-origin MessageType envelope**, never to relax graph-ingest health (which would mask real bugs).

The memo's pinned PRIMARY (`WriteModelEndpoints`) was correct but incomplete — walking the e2e surfaced two more emitter sites and a config gap.

## Fixes (4)
1. **`WriteModelEndpoints`** → `create_with_triples` + new `agentic.ModelEndpointMessageType()`.
2. **research-graph kickoff** (`research_graph.go` + `triplepub.go`) → extend `llmwrap.TriplePublisher` with `CreateEntityWithTriples`; new `BirthLoopEntityWithTriples` helper births the `rg_*` pipeline loop entity with `agentic.LoopExecutionMessageType()` (was `StampOrchestrationTriples`/`add_batch`). Downstream per-stage stamps still append.
3. **`WriteTrajectorySteps`** → group the flat triple list by subject: step-entity subjects are born via `create_with_triples` + new `agentic.TrajectoryStepMessageType()`; the loop-entity `LoopHasStep` links stay `writeTriple` appends. `buildTrajectoryStepTriples` + its 6 unit tests are intentionally unchanged.
4. **`configs/research-graph-e2e.json`** → declare `streams.USER`. agentic-dispatch has a required `user.message` (USER) input but no component produces user.message (the scenario injects to `agent.task.*`), so output-port-derived `EnsureStreams` never created USER → dispatch failed `stream USER not found after 30 retries`. Mirrors the `*-test.json` sibling configs.

Also generalized `verifyExistingLoopOrigin` → `verifyExistingEntityOrigin` (body unchanged; divergent-task warning gated on a non-empty `incomingTaskID`, which only loop entities pass).

## Verification
- **`task e2e:research-graph` GREEN** — all 8 steps, `loops_completed_total:2`.
- **`task e2e:agentic` GREEN** — `graph_model_triples:9` + `trajectory_steps:6` confirm both shared `agentic-loop` fixes land. (Answers the open question: e2e:agentic *was* affected by the same emitters.)
- **semstreams-reviewer: APPROVED** (no blocking/high). Addressed its MEDIUM (added MessageType unit-test trios for the two new types — Valid / KeyFormat / Distinct, the grammar-collision discipline) and LOW (godoc on the blind-EntityExists precondition in `triplepub`).
- Unit + integration (`-race`), `task lint`, and schema-gen all clean.

## Notes
- Unblocks the **ADR-062 #389** tag.
- Follow-up **gh#391**: the e2e mock routes `synthesize_directly`, so the tier validates chain plumbing but never exercises `pkg/fusion` (the engine #389 extracted) — plus an audit note for `register_emit_diagnosis` / `agentrun` milestone writes (same regression class, not covered by these two tiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)