### PR TITLE
feat(fusion): Lens SPI + lensregistry (ADR-062 increment 3, gh#376)

### DIFF
--- a/pkg/fusion/doc.go
+++ b/pkg/fusion/doc.go
@@ -1,7 +1,9 @@
 // Package fusion is the generic deterministic-fusion engine: fan-out
 // sub-query dispatch, dedup, rank, and budget enforcement over a
-// GraphQueryClient. It is a pure leaf package — no NATS, no research-domain
-// types (Intent, ExecutionOutput, RouteAction). Domain-coupled callers
-// (processor/research-graph-execute) compose this engine and wrap the result
-// in their own payload types.
+// GraphQueryClient, plus the product-supplied Lens SPI (lens.go). It is a
+// near-leaf package — its only domain dependency is the message package (for
+// Triple in Entity and StorageReference as the Hydrate handle); no NATS, no
+// research-domain types (Intent, ExecutionOutput, RouteAction). Domain-coupled
+// callers (processor/research-graph-execute) compose this engine and wrap the
+// result in their own payload types; products supply a Lens.
 package fusion

--- a/pkg/fusion/lens.go
+++ b/pkg/fusion/lens.go
@@ -1,0 +1,135 @@
+package fusion
+
+import (
+	"context"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// The Lens SPI is the ONLY domain-specific surface of the deterministic fusion
+// engine (ADR-062 increment 3). The engine owns resolve / expand / rank / budget
+// / envelope; a product-supplied Lens declares which edges to walk, how to read
+// an entity's human-facing fields, and how to hydrate its verbatim body. One
+// engine, many lenses (code, docs, …) — the proof that fusion is a general
+// primitive, not code in disguise.
+//
+// Lifted from semsource's validated `source/fusion` Lens (rule-of-three:
+// semsource code + docs lenses, plus our research-graph retrieval). The one
+// deliberate change from semsource's shape is Hydrate's return type — see the
+// hydration contract below.
+
+// Entity is the minimal projection a Lens reads: the entity's ID and its current
+// triples. Kept deliberately small (no graph.EntityState, no NATS) so pkg/fusion
+// stays a near-leaf — the Lens reads human-facing fields off the triples.
+type Entity struct {
+	ID      string
+	Triples []message.Triple
+}
+
+// ResolveMode picks how the engine turns a raw query string into seed entities.
+// The Lens classifies the query; the engine maps the mode to a resolve strategy
+// (symbol → graph.query.byName exact lookup, prefix → graph.query.prefix, nl →
+// semantic search). Provenance follows from the mode: symbol/prefix are
+// deterministic, nl is embedding.
+type ResolveMode string
+
+const (
+	// ResolveModeNL routes the query to semantic (embedding) search. Seeds are
+	// embedding-ranked, so the response provenance is "embedding", not
+	// "deterministic".
+	ResolveModeNL ResolveMode = "nl"
+
+	// ResolveModeSymbol routes to deterministic exact name/title lookup
+	// (graph.query.byName). The provenance the byName index makes honest.
+	ResolveModeSymbol ResolveMode = "symbol"
+
+	// ResolveModePrefix routes to deterministic prefix lookup
+	// (graph.query.prefix) — e.g. a path or namespace stem.
+	ResolveModePrefix ResolveMode = "prefix"
+)
+
+// EdgeSpec declares one relationship predicate the engine should expand around a
+// seed, with the role labels for its forward and (optional) reverse directions.
+// For code: {Predicate: "code.relationship.calls", OutgoingRole: "callee",
+// IncomingRole: "caller"}. An empty IncomingRole skips the reverse direction.
+type EdgeSpec struct {
+	Predicate    string
+	OutgoingRole string
+	IncomingRole string // "" to skip the reverse direction
+}
+
+// Locator is a domain-general place: a file path or URL, an optional section /
+// anchor fragment (docs), and an optional line range (code). One of Lines or
+// Fragment is typically set, not both.
+type Locator struct {
+	Path     string // file path or URL
+	Fragment string // section / anchor (docs)
+	Lines    [2]int // line range (code); zero value means line-less
+}
+
+// Lens supplies the only domain-specific parts of fusion (ADR-062). The engine
+// owns resolve / expand / rank / budget / envelope; the lens declares which
+// edges to walk, how to read an entity's human-facing fields, and how to hydrate
+// its verbatim body.
+type Lens interface {
+	// Name identifies the lens (e.g. "code", "docs"). Used as the registry key.
+	Name() string
+
+	// ResolveMode picks how to turn the raw query into seeds.
+	ResolveMode(query string) ResolveMode
+
+	// Edges are the relationship predicates to expand around each seed.
+	Edges() []EdgeSpec
+
+	// Label is the entity's human name (e.g. from dc.terms.title).
+	Label(e *Entity) string
+
+	// Kind is a short human kind for the entity (e.g. "function", "doc").
+	Kind(e *Entity) string
+
+	// Location returns the entity's domain-general place (file path or URL,
+	// optional section fragment, optional line range).
+	Location(e *Entity) Locator
+
+	// Hydrate returns a HANDLE to the entity's verbatim body — never the bytes
+	// themselves and never a filesystem read. The engine resolves the handle's
+	// StorageInstance to a registered storage.Store and reads the body with
+	// Get(Key) (ADR-062 hydration contract, increment 4). Returning a handle
+	// (not a string) is what makes fusion deployment-independent: a remote
+	// caller of a standalone fusion service (semsource ADR-0006) cannot read the
+	// service's worktree, so bodies must be addressable through a backend-
+	// agnostic store. Return (nil, nil) when the entity has no verbatim body.
+	//
+	// Error policy (engine contract): hydration is best-effort. A non-nil error
+	// DEGRADES the response — the engine omits that node's body and continues —
+	// it does NOT fail the fuse. This mirrors the engine's degrade-don't-fail
+	// posture for sub-query failures (see Fuse). Lenses should return an error
+	// only for genuine retrieval faults, not for "no body" (use (nil, nil)).
+	Hydrate(ctx context.Context, e *Entity) (*message.StorageReference, error)
+}
+
+// ProvenanceForMode maps a ResolveMode to the honesty-envelope provenance tier:
+// symbol/prefix seeds are deterministic exact lookups; nl seeds come from
+// embedding search. (The research_graph LLM sibling is the only "llm" source —
+// the deterministic engine never sets it.) Exported so the engine's assemble
+// step and any lens-driven caller stamp provenance consistently.
+//
+// Deliberate divergence from semsource's provenanceFor (source/fusion/engine.go),
+// whose catch-all is "deterministic" and only embedding is named: there,
+// ResolveMode is a CLOSED int enum so "unknown" is unreachable. Here ResolveMode
+// is an OPEN string type, so the catch-all must be the conservative tier —
+// "embedding" — because only "deterministic" permits a caller to treat an empty
+// result as an authoritative not-found, and an unclassified seed has not earned
+// that. CAUTION: this means any NEW deterministic mode added to the enum MUST be
+// added to the deterministic case below, or it silently degrades to embedding
+// (no compile error — open string enum).
+func ProvenanceForMode(mode ResolveMode) string {
+	switch mode {
+	case ResolveModeSymbol, ResolveModePrefix:
+		return "deterministic"
+	case ResolveModeNL:
+		return "embedding"
+	default:
+		return "embedding"
+	}
+}

--- a/pkg/fusion/lens_test.go
+++ b/pkg/fusion/lens_test.go
@@ -1,0 +1,164 @@
+package fusion_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/fusion"
+)
+
+// refLens is a minimal but realistic reference Lens proving the SPI is
+// implementable end-to-end (ADR-062 increment 3). It reads human-facing fields
+// off an entity's triples and hydrates via a StorageReference handle — never a
+// filesystem read, never returning bytes (the headless-safe hydration contract).
+// Concrete product lenses (semsource code/docs, a research-graph lens) follow
+// the same shape with domain-specific predicates.
+type refLens struct{}
+
+const (
+	refTitlePredicate    = "dc.terms.title"
+	refKindPredicate     = "entity.kind"
+	refPathPredicate     = "source.path"
+	refStorageInstancePr = "content.storage_instance"
+	refStorageKeyPr      = "content.storage_key"
+)
+
+func (refLens) Name() string { return "ref" }
+
+func (refLens) ResolveMode(query string) fusion.ResolveMode {
+	switch {
+	case strings.HasPrefix(query, "/"):
+		return fusion.ResolveModePrefix
+	case !strings.ContainsAny(query, " \t"): // a bare token reads as a symbol
+		return fusion.ResolveModeSymbol
+	default:
+		return fusion.ResolveModeNL
+	}
+}
+
+func (refLens) Edges() []fusion.EdgeSpec {
+	return []fusion.EdgeSpec{
+		{Predicate: "ref.relationship.references", OutgoingRole: "referent", IncomingRole: "referrer"},
+	}
+}
+
+func (refLens) Label(e *fusion.Entity) string { return stringObject(e, refTitlePredicate) }
+
+func (refLens) Kind(e *fusion.Entity) string {
+	if k := stringObject(e, refKindPredicate); k != "" {
+		return k
+	}
+	return "entity"
+}
+
+func (refLens) Location(e *fusion.Entity) fusion.Locator {
+	return fusion.Locator{Path: stringObject(e, refPathPredicate)}
+}
+
+func (refLens) Hydrate(_ context.Context, e *fusion.Entity) (*message.StorageReference, error) {
+	inst := stringObject(e, refStorageInstancePr)
+	key := stringObject(e, refStorageKeyPr)
+	if inst == "" || key == "" {
+		return nil, nil // no verbatim body for this entity
+	}
+	return &message.StorageReference{StorageInstance: inst, Key: key}, nil
+}
+
+// stringObject returns the first string Object for predicate, or "".
+func stringObject(e *fusion.Entity, predicate string) string {
+	if e == nil {
+		return ""
+	}
+	for _, t := range e.Triples {
+		if t.Predicate == predicate {
+			if s, ok := t.Object.(string); ok {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// compile-time conformance: refLens must satisfy the Lens SPI.
+var _ fusion.Lens = refLens{}
+
+func TestLens_ReferenceImplementation_ReadsFields(t *testing.T) {
+	e := &fusion.Entity{
+		ID: "acme.ops.code.repo.symbol.OnEvent",
+		Triples: []message.Triple{
+			{Predicate: refTitlePredicate, Object: "OnEvent"},
+			{Predicate: refKindPredicate, Object: "function"},
+			{Predicate: refPathPredicate, Object: "handlers/on_event.go"},
+		},
+	}
+	var l fusion.Lens = refLens{}
+	if got := l.Label(e); got != "OnEvent" {
+		t.Errorf("Label = %q, want OnEvent", got)
+	}
+	if got := l.Kind(e); got != "function" {
+		t.Errorf("Kind = %q, want function", got)
+	}
+	if got := l.Location(e); got.Path != "handlers/on_event.go" {
+		t.Errorf("Location.Path = %q, want handlers/on_event.go", got.Path)
+	}
+}
+
+func TestLens_Hydrate_ReturnsHandleNotBytes(t *testing.T) {
+	l := refLens{}
+
+	// Entity with storage triples → a StorageReference handle the engine derefs.
+	withBody := &fusion.Entity{
+		ID: "acme.ops.code.repo.symbol.OnEvent",
+		Triples: []message.Triple{
+			{Predicate: refStorageInstancePr, Object: "objectstore-primary"},
+			{Predicate: refStorageKeyPr, Object: "code/on_event.go"},
+		},
+	}
+	ref, err := l.Hydrate(context.Background(), withBody)
+	if err != nil {
+		t.Fatalf("Hydrate: %v", err)
+	}
+	if ref == nil {
+		t.Fatal("expected a StorageReference handle, got nil")
+	}
+	if ref.StorageInstance != "objectstore-primary" || ref.Key != "code/on_event.go" {
+		t.Errorf("handle = %+v, want {objectstore-primary, code/on_event.go}", ref)
+	}
+
+	// Entity without storage triples → (nil, nil): no verbatim body, not an error.
+	none := &fusion.Entity{ID: "acme.ops.code.repo.symbol.Bare"}
+	ref, err = l.Hydrate(context.Background(), none)
+	if err != nil || ref != nil {
+		t.Errorf("Hydrate(no body) = (%v, %v), want (nil, nil)", ref, err)
+	}
+}
+
+func TestResolveMode_Classification(t *testing.T) {
+	l := refLens{}
+	cases := map[string]fusion.ResolveMode{
+		"OnEvent":             fusion.ResolveModeSymbol,
+		"/handlers":           fusion.ResolveModePrefix,
+		"how does auth work?": fusion.ResolveModeNL,
+	}
+	for query, want := range cases {
+		if got := l.ResolveMode(query); got != want {
+			t.Errorf("ResolveMode(%q) = %q, want %q", query, got, want)
+		}
+	}
+}
+
+func TestProvenanceForMode(t *testing.T) {
+	cases := map[fusion.ResolveMode]string{
+		fusion.ResolveModeSymbol: "deterministic",
+		fusion.ResolveModePrefix: "deterministic",
+		fusion.ResolveModeNL:     "embedding",
+		fusion.ResolveMode("?"):  "embedding", // unknown is conservatively non-deterministic
+	}
+	for mode, want := range cases {
+		if got := fusion.ProvenanceForMode(mode); got != want {
+			t.Errorf("ProvenanceForMode(%q) = %q, want %q", mode, got, want)
+		}
+	}
+}

--- a/pkg/fusion/lensregistry/lensregistry.go
+++ b/pkg/fusion/lensregistry/lensregistry.go
@@ -1,0 +1,89 @@
+// Package lensregistry holds the explicit, instance-scoped registry of fusion
+// Lens factories (ADR-062 increment 3).
+//
+// Registration is EXPLICIT — a bootstrap aggregator calls Register — and is
+// NOT an init()-global like the vocabulary registry. Per ADR-062: lenses are
+// factories that need deps/config (like components and payloads), not stateless
+// metadata like predicates; and the vocabulary registry's last-write-wins
+// override semantics would be exactly wrong for lenses. You want explicit
+// per-product registration that ERRORS on a name collision, never a silent
+// override. The registry is an instance (New) threaded through wiring, not a
+// package global, so two independently-configured engines don't share state.
+package lensregistry
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/c360studio/semstreams/pkg/fusion"
+)
+
+// Factory constructs a configured Lens. Products supply one per lens; the
+// explicit bootstrap aggregator captures the lens's deps/config in the closure,
+// so construction is deferred to Build (when wiring is ready) without leaking
+// those deps into the registry.
+type Factory func() (fusion.Lens, error)
+
+// Registry is an explicit, instance-scoped set of named Lens factories. The
+// zero value is not usable — call New.
+type Registry struct {
+	mu        sync.RWMutex
+	factories map[string]Factory
+}
+
+// New returns an empty registry ready for explicit Register calls.
+func New() *Registry {
+	return &Registry{factories: make(map[string]Factory)}
+}
+
+// Register adds a lens factory under name. Returns an error on an empty name, a
+// nil factory, or a duplicate name — explicit per-product registration, never a
+// silent last-write-wins override (the property that makes this NOT the
+// vocabulary init()-global pattern; ADR-062).
+func (r *Registry) Register(name string, f Factory) error {
+	if name == "" {
+		return fmt.Errorf("lensregistry: empty lens name")
+	}
+	if f == nil {
+		return fmt.Errorf("lensregistry: nil factory for %q", name)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.factories[name]; exists {
+		return fmt.Errorf("lensregistry: lens %q already registered (explicit registration only — no silent override)", name)
+	}
+	r.factories[name] = f
+	return nil
+}
+
+// Build constructs the Lens registered under name. Returns an error when name is
+// unregistered, the factory fails, or the factory returns a nil Lens.
+func (r *Registry) Build(name string) (fusion.Lens, error) {
+	r.mu.RLock()
+	f, ok := r.factories[name]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("lensregistry: no lens registered under %q", name)
+	}
+	lens, err := f()
+	if err != nil {
+		return nil, fmt.Errorf("lensregistry: build lens %q: %w", name, err)
+	}
+	if lens == nil {
+		return nil, fmt.Errorf("lensregistry: factory for %q returned a nil lens", name)
+	}
+	return lens, nil
+}
+
+// Names returns the registered lens names, sorted for deterministic iteration.
+func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.factories))
+	for n := range r.factories {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/fusion/lensregistry/lensregistry_test.go
+++ b/pkg/fusion/lensregistry/lensregistry_test.go
@@ -1,0 +1,114 @@
+package lensregistry_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/fusion"
+	"github.com/c360studio/semstreams/pkg/fusion/lensregistry"
+)
+
+// stubLens is a do-nothing Lens for registry tests — the registry stores and
+// builds factories; it does not care what the lens does.
+type stubLens struct{ name string }
+
+func (s stubLens) Name() string                         { return s.name }
+func (stubLens) ResolveMode(string) fusion.ResolveMode  { return fusion.ResolveModeSymbol }
+func (stubLens) Edges() []fusion.EdgeSpec               { return nil }
+func (stubLens) Label(*fusion.Entity) string            { return "" }
+func (stubLens) Kind(*fusion.Entity) string             { return "" }
+func (stubLens) Location(*fusion.Entity) fusion.Locator { return fusion.Locator{} }
+func (stubLens) Hydrate(context.Context, *fusion.Entity) (*message.StorageReference, error) {
+	return nil, nil
+}
+
+func TestRegistry_RegisterAndBuild(t *testing.T) {
+	r := lensregistry.New()
+	if err := r.Register("code", func() (fusion.Lens, error) { return stubLens{name: "code"}, nil }); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	lens, err := r.Build("code")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if lens.Name() != "code" {
+		t.Errorf("built lens Name = %q, want code", lens.Name())
+	}
+}
+
+func TestRegistry_DuplicateRegistrationErrors(t *testing.T) {
+	r := lensregistry.New()
+	if err := r.Register("code", func() (fusion.Lens, error) { return stubLens{name: "code"}, nil }); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	// Second registration under the same name must ERROR — no silent
+	// last-write-wins override (the property that distinguishes this from the
+	// vocabulary init()-global registry; ADR-062).
+	err := r.Register("code", func() (fusion.Lens, error) { return stubLens{name: "other"}, nil })
+	if err == nil {
+		t.Fatal("expected duplicate registration to error, got nil")
+	}
+	// The original registration must be intact (override refused, not applied).
+	lens, buildErr := r.Build("code")
+	if buildErr != nil {
+		t.Fatalf("Build after refused override: %v", buildErr)
+	}
+	if lens.Name() != "code" {
+		t.Errorf("override leaked: built lens Name = %q, want the original code", lens.Name())
+	}
+}
+
+func TestRegistry_RejectsEmptyNameAndNilFactory(t *testing.T) {
+	r := lensregistry.New()
+	if err := r.Register("", func() (fusion.Lens, error) { return stubLens{}, nil }); err == nil {
+		t.Error("expected error on empty name")
+	}
+	if err := r.Register("x", nil); err == nil {
+		t.Error("expected error on nil factory")
+	}
+}
+
+func TestRegistry_BuildUnregistered(t *testing.T) {
+	r := lensregistry.New()
+	if _, err := r.Build("missing"); err == nil {
+		t.Error("expected error building an unregistered lens")
+	}
+}
+
+func TestRegistry_BuildSurfacesFactoryError(t *testing.T) {
+	r := lensregistry.New()
+	sentinel := errors.New("boom")
+	_ = r.Register("bad", func() (fusion.Lens, error) { return nil, sentinel })
+	_, err := r.Build("bad")
+	if err == nil || !errors.Is(err, sentinel) {
+		t.Errorf("Build should wrap the factory error, got %v", err)
+	}
+}
+
+func TestRegistry_BuildRejectsNilLens(t *testing.T) {
+	r := lensregistry.New()
+	_ = r.Register("nilly", func() (fusion.Lens, error) { return nil, nil })
+	if _, err := r.Build("nilly"); err == nil {
+		t.Error("expected error when factory returns a nil lens with no error")
+	}
+}
+
+func TestRegistry_NamesSorted(t *testing.T) {
+	r := lensregistry.New()
+	for _, n := range []string{"docs", "code", "spec"} {
+		name := n
+		_ = r.Register(name, func() (fusion.Lens, error) { return stubLens{name: name}, nil })
+	}
+	got := r.Names()
+	want := []string{"code", "docs", "spec"}
+	if len(got) != len(want) {
+		t.Fatalf("Names = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Names[%d] = %q, want %q (must be sorted)", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Closes #394.

## What
The product-supplied **Lens SPI** + **lensregistry** for the deterministic fusion engine — ADR-062 increment 3. The engine (`pkg/fusion`, #389) owns resolve/expand/rank/budget/envelope; a `Lens` declares the only domain-specific parts (which edges to walk, how to read an entity's human-facing fields, how to hydrate its verbatim body). One engine, many lenses.

- `pkg/fusion/lens.go` — `Lens` (7 methods) + `Entity`, `ResolveMode` (nl/symbol/prefix), `EdgeSpec`, `Locator`, `ProvenanceForMode`.
- `pkg/fusion/lensregistry` — explicit, instance-scoped factory registry: `Register` errors on duplicate (no silent last-write-wins), **not** an `init()`-global (per ADR-062's factory-aggregation mandate).
- Tests: reference lens proving the SPI is implementable + reads fields off triples + hydrates to a handle; full registry behavior; `var _ fusion.Lens` conformance.

## Faithful lift + the one deliberate change
Lifted from semsource's **validated** `source/fusion` Lens. The one change: `Hydrate` returns `*message.StorageReference` (a **handle**), not semsource's `(string, error)`. That's the ADR-062 hydration crux — increment 4 (#395) implements the engine-side `storage.Store` deref. Reinforced by **semsource ADR-0006 removing headless mode**: a remote caller of a standalone fusion service can't read the service worktree, so bodies must be addressable through a backend-agnostic store.

## Scope boundary
SPI proven via reference-lens conformance tests. A **lens-driven engine entry** + a **real research-graph lens** are a follow-on — `research-graph-execute` is sub-query-driven (route stage builds `SubQuery`s), not `ResolveMode`/`Edges`-driven, so forcing it into a `Lens` would distort the SPI. The first *production* lenses are semsource's code/docs on convergence (increment 6).

## Review
**semstreams-reviewer: APPROVED** (no blocking). Applied its contract-clarity fixes pre-merge: conservative open-enum provenance default documented (+ divergence-from-semsource on record), `Hydrate` error policy documented (best-effort: degrade, don't fail), stale "pure leaf" package doc corrected to "near-leaf (+message)".

Additive only — no existing code changed. Tests + vet + revive clean. Unblocks semsource convergence (increment 6, #376).

🤖 Generated with [Claude Code](https://claude.com/claude-code)