### PR TITLE
feat(fusion): hydration handle-resolution helper (ADR-062 increment 4, gh#376)

### DIFF
--- a/pkg/fusion/doc.go
+++ b/pkg/fusion/doc.go
@@ -1,8 +1,9 @@
 // Package fusion is the generic deterministic-fusion engine: fan-out
 // sub-query dispatch, dedup, rank, and budget enforcement over a
 // GraphQueryClient, plus the product-supplied Lens SPI (lens.go). It is a
-// near-leaf package — its only domain dependency is the message package (for
-// Triple in Entity and StorageReference as the Hydrate handle); no NATS, no
+// near-leaf package — its only domain dependencies are the message package (for
+// Triple in Entity and StorageReference as the Hydrate handle) and the leaf
+// storage interface package (the Hydrate backend-deref contract); no NATS, no
 // research-domain types (Intent, ExecutionOutput, RouteAction). Domain-coupled
 // callers (processor/research-graph-execute) compose this engine and wrap the
 // result in their own payload types; products supply a Lens.

--- a/pkg/fusion/hydrate.go
+++ b/pkg/fusion/hydrate.go
@@ -92,6 +92,9 @@ func (b *BodyResolver) ResolveBody(ctx context.Context, ref *message.StorageRefe
 	if ref.StorageInstance == "" {
 		return nil, fmt.Errorf("hydrate: storage reference has no StorageInstance (key=%q)", ref.Key)
 	}
+	if ref.Key == "" {
+		return nil, fmt.Errorf("hydrate: storage reference has no Key (instance=%q)", ref.StorageInstance)
+	}
 	if b.resolver == nil {
 		return nil, fmt.Errorf("hydrate: no store resolver configured; cannot resolve instance %q", ref.StorageInstance)
 	}

--- a/pkg/fusion/hydrate.go
+++ b/pkg/fusion/hydrate.go
@@ -1,0 +1,92 @@
+package fusion
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/storage"
+)
+
+// The hydration handle-resolution helper (ADR-062 increment 4, the "crux").
+//
+// A Lens.Hydrate returns a *message.StorageReference HANDLE, never bytes. This
+// helper is what the engine uses to turn that handle into the verbatim body:
+// resolve the handle's StorageInstance to a registered storage.Store and Get
+// the Key. The contract binds to the backend-agnostic storage.Store INTERFACE +
+// the StorageReference handle — never a concrete backend — so each
+// deployment/content-type plugs in its own store (NATS ObjectStore for
+// small/immutable text, a filestore / S3 for large binaries). This is what makes
+// fusion deployment-independent: a remote caller of a standalone fusion service
+// (semsource ADR-0006, headless mode removed) can't read the service worktree,
+// so bodies must be addressable through a store, not a filesystem path.
+//
+// Bodies ride storage.Store.Get([]byte) — NOT the text StoredContent envelope
+// (whose map[string]string fields corrupt non-UTF-8 to U+FFFD). Byte-exact by
+// construction.
+
+// StoreResolver maps a StorageReference.StorageInstance name (e.g.
+// "objectstore-primary", "filestore-media") to the storage.Store that holds its
+// data. Wiring supplies it — typically MapStoreResolver over the deployment's
+// registered stores. Kept as an interface so the engine never assumes one
+// backend and tests can substitute fakes.
+type StoreResolver interface {
+	// Store returns the store registered under instance, and whether one exists.
+	Store(instance string) (storage.Store, bool)
+}
+
+// MapStoreResolver is a static StoreResolver over a name→Store map. The zero
+// value (nil map) resolves nothing. Safe for concurrent reads (Go map reads are
+// safe without writers; the map is build-once at wiring time).
+type MapStoreResolver map[string]storage.Store
+
+// Store implements StoreResolver.
+func (m MapStoreResolver) Store(instance string) (storage.Store, bool) {
+	s, ok := m[instance]
+	return s, ok
+}
+
+// BodyResolver dereferences a Lens.Hydrate handle to its verbatim bytes. It is
+// the engine-side helper the assemble step uses to populate a node body from the
+// handle a lens returned — backend-agnostic via the injected StoreResolver.
+type BodyResolver struct {
+	resolver StoreResolver
+}
+
+// NewBodyResolver builds a BodyResolver over the given StoreResolver. A nil
+// resolver is permitted (ResolveBody then errors on any non-nil handle) so a
+// deployment with no verbatim-body stores still constructs cleanly.
+func NewBodyResolver(r StoreResolver) *BodyResolver {
+	return &BodyResolver{resolver: r}
+}
+
+// ResolveBody returns the verbatim body bytes for a Hydrate handle.
+//
+//   - A nil ref means "no verbatim body" — returns (nil, nil), NOT an error.
+//     (Lens.Hydrate returns (nil, nil) for body-less entities; this preserves
+//     that signal end-to-end.)
+//   - A non-nil ref with an empty StorageInstance, or an instance with no
+//     registered store, is a wiring/producer fault — returns an error so the
+//     caller can degrade the node (the engine omits the body; hydration is
+//     best-effort and does not fail the fuse — see Lens.Hydrate).
+//   - The store's Get error is propagated wrapped.
+func (b *BodyResolver) ResolveBody(ctx context.Context, ref *message.StorageReference) ([]byte, error) {
+	if ref == nil {
+		return nil, nil
+	}
+	if ref.StorageInstance == "" {
+		return nil, fmt.Errorf("hydrate: storage reference has no StorageInstance (key=%q)", ref.Key)
+	}
+	if b.resolver == nil {
+		return nil, fmt.Errorf("hydrate: no store resolver configured; cannot resolve instance %q", ref.StorageInstance)
+	}
+	store, ok := b.resolver.Store(ref.StorageInstance)
+	if !ok {
+		return nil, fmt.Errorf("hydrate: no storage.Store registered for instance %q", ref.StorageInstance)
+	}
+	data, err := store.Get(ctx, ref.Key)
+	if err != nil {
+		return nil, fmt.Errorf("hydrate: get %q from instance %q: %w", ref.Key, ref.StorageInstance, err)
+	}
+	return data, nil
+}

--- a/pkg/fusion/hydrate.go
+++ b/pkg/fusion/hydrate.go
@@ -25,11 +25,20 @@ import (
 // (whose map[string]string fields corrupt non-UTF-8 to U+FFFD). Byte-exact by
 // construction.
 
-// StoreResolver maps a StorageReference.StorageInstance name (e.g.
-// "objectstore-primary", "filestore-media") to the storage.Store that holds its
-// data. Wiring supplies it — typically MapStoreResolver over the deployment's
-// registered stores. Kept as an interface so the engine never assumes one
-// backend and tests can substitute fakes.
+// StoreResolver maps a StorageReference.StorageInstance name to the
+// storage.Store that holds its data. Wiring supplies it — typically
+// MapStoreResolver over the deployment's registered stores. Kept as an interface
+// so the engine never assumes one backend and tests can substitute fakes.
+//
+// Canonical key (gh#376 coordination with semsource): StorageInstance is the
+// storage COMPONENT INSTANCE NAME (e.g. "objectstore", "filestore-media"), per
+// StorageReference's own doc ("identifies which storage component holds the
+// data … enables federation across multiple storage instances") — NOT the bucket
+// name. Producers stamp the component instance name; wiring registers each store
+// under that same name. (semstreams' own auto-stamp is inconsistent today —
+// component.go uses the instance name, store.go uses the bucket — tracked
+// separately; this helper, the first consumer, fixes the convention at
+// instance-name.)
 type StoreResolver interface {
 	// Store returns the store registered under instance, and whether one exists.
 	Store(instance string) (storage.Store, bool)
@@ -61,6 +70,12 @@ func NewBodyResolver(r StoreResolver) *BodyResolver {
 }
 
 // ResolveBody returns the verbatim body bytes for a Hydrate handle.
+//
+// Key granularity (gh#376 coordination): the handle's Key addresses the EXACT
+// verbatim body — one pre-sliced body blob per entity (keyed by entity ID or
+// content hash) — so Get returns the body byte-for-byte with NO engine-side line
+// math. The lens's Locator (path + line range) is for citation/display only; the
+// body comes pre-sliced through the handle, not by trimming a whole file.
 //
 //   - A nil ref means "no verbatim body" — returns (nil, nil), NOT an error.
 //     (Lens.Hydrate returns (nil, nil) for body-less entities; this preserves

--- a/pkg/fusion/hydrate_test.go
+++ b/pkg/fusion/hydrate_test.go
@@ -1,0 +1,109 @@
+package fusion_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/fusion"
+)
+
+// fakeStore is a minimal storage.Store for hydration tests. Only Get is
+// exercised; the rest satisfy the interface. getErr, when set, is returned from
+// Get to exercise the propagation path.
+type fakeStore struct {
+	data   map[string][]byte
+	getErr error
+}
+
+func (f *fakeStore) Get(_ context.Context, key string) ([]byte, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	b, ok := f.data[key]
+	if !ok {
+		return nil, errors.New("key not found")
+	}
+	return b, nil
+}
+func (f *fakeStore) Put(context.Context, string, []byte) error      { return nil }
+func (f *fakeStore) List(context.Context, string) ([]string, error) { return nil, nil }
+func (f *fakeStore) Delete(context.Context, string) error           { return nil }
+
+// TestBodyResolver_LocationIndependence proves the crux of ADR-062 increment 4:
+// ONE BodyResolver derefs handles across DIFFERENT backends, picked by the
+// handle's StorageInstance — the engine never assumes one concrete store. A
+// handle into "objectstore-primary" and a handle into "filestore-media" both
+// resolve through the same resolver to their own backend's bytes.
+func TestBodyResolver_LocationIndependence(t *testing.T) {
+	objectStore := &fakeStore{data: map[string][]byte{"code/on_event.go": []byte("package handlers")}}
+	fileStore := &fakeStore{data: map[string][]byte{"media/diagram.bin": {0x00, 0xff, 0x00}}}
+
+	r := fusion.NewBodyResolver(fusion.MapStoreResolver{
+		"objectstore-primary": objectStore,
+		"filestore-media":     fileStore,
+	})
+
+	// Handle into the object store → that backend's bytes.
+	got, err := r.ResolveBody(context.Background(), &message.StorageReference{
+		StorageInstance: "objectstore-primary", Key: "code/on_event.go",
+	})
+	if err != nil {
+		t.Fatalf("ResolveBody(objectstore): %v", err)
+	}
+	if string(got) != "package handlers" {
+		t.Errorf("objectstore body = %q, want %q", got, "package handlers")
+	}
+
+	// Handle into the filestore → that backend's (binary, non-UTF-8) bytes,
+	// byte-exact (no StoredContent envelope corruption).
+	got, err = r.ResolveBody(context.Background(), &message.StorageReference{
+		StorageInstance: "filestore-media", Key: "media/diagram.bin",
+	})
+	if err != nil {
+		t.Fatalf("ResolveBody(filestore): %v", err)
+	}
+	if len(got) != 3 || got[1] != 0xff {
+		t.Errorf("filestore body = %v, want [0 255 0] byte-exact", got)
+	}
+}
+
+func TestBodyResolver_NilRefIsNoBody(t *testing.T) {
+	r := fusion.NewBodyResolver(fusion.MapStoreResolver{})
+	got, err := r.ResolveBody(context.Background(), nil)
+	if err != nil || got != nil {
+		t.Errorf("ResolveBody(nil) = (%v, %v), want (nil, nil) — no body is not an error", got, err)
+	}
+}
+
+func TestBodyResolver_FaultPaths(t *testing.T) {
+	store := &fakeStore{data: map[string][]byte{"k": []byte("v")}}
+	r := fusion.NewBodyResolver(fusion.MapStoreResolver{"inst": store})
+
+	// Empty StorageInstance on a non-nil handle = producer fault.
+	if _, err := r.ResolveBody(context.Background(), &message.StorageReference{Key: "k"}); err == nil {
+		t.Error("expected error for empty StorageInstance")
+	}
+	// Unknown instance = wiring fault.
+	if _, err := r.ResolveBody(context.Background(), &message.StorageReference{StorageInstance: "nope", Key: "k"}); err == nil {
+		t.Error("expected error for unregistered instance")
+	}
+	// Store Get error propagates.
+	failing := fusion.NewBodyResolver(fusion.MapStoreResolver{"inst": &fakeStore{getErr: errors.New("backend down")}})
+	if _, err := failing.ResolveBody(context.Background(), &message.StorageReference{StorageInstance: "inst", Key: "k"}); err == nil {
+		t.Error("expected the store Get error to propagate")
+	}
+}
+
+func TestBodyResolver_NilResolverErrorsOnHandle(t *testing.T) {
+	r := fusion.NewBodyResolver(nil)
+	// nil handle is still no-body (no resolver needed).
+	if _, err := r.ResolveBody(context.Background(), nil); err != nil {
+		t.Errorf("nil handle with nil resolver should be (nil,nil), got err %v", err)
+	}
+	// A real handle with no resolver configured is a wiring fault.
+	if _, err := r.ResolveBody(context.Background(), &message.StorageReference{StorageInstance: "inst", Key: "k"}); err == nil {
+		t.Error("expected error resolving a handle with no resolver configured")
+	}
+}

--- a/pkg/fusion/hydrate_test.go
+++ b/pkg/fusion/hydrate_test.go
@@ -85,6 +85,11 @@ func TestBodyResolver_FaultPaths(t *testing.T) {
 	if _, err := r.ResolveBody(context.Background(), &message.StorageReference{Key: "k"}); err == nil {
 		t.Error("expected error for empty StorageInstance")
 	}
+	// Empty Key on a non-nil handle = producer fault (explicit, not a backend
+	// not-found) — surfaces a clear message the engine can degrade on.
+	if _, err := r.ResolveBody(context.Background(), &message.StorageReference{StorageInstance: "inst"}); err == nil {
+		t.Error("expected error for empty Key")
+	}
 	// Unknown instance = wiring fault.
 	if _, err := r.ResolveBody(context.Background(), &message.StorageReference{StorageInstance: "nope", Key: "k"}); err == nil {
 		t.Error("expected error for unregistered instance")


### PR DESCRIPTION
Closes #395.

## What
The ADR-062 **"crux"**: turn a `Lens.Hydrate` handle (`*message.StorageReference`) into verbatim body bytes **without coupling the engine to any concrete store**. The engine resolves the handle's `StorageInstance` to a registered `storage.Store` and `Get`s the `Key` — backend-agnostic (NATS ObjectStore / filestore / S3 all plug in under their instance name).

- `StoreResolver` (`StorageInstance`→`storage.Store`) + `MapStoreResolver`.
- `BodyResolver.ResolveBody(ref)` → `[]byte`: `nil` ref → `(nil, nil)` "no body" (not an error); empty/unknown instance or nil resolver → error (degrade the node, don't fail the fuse — hydration is best-effort per `Lens.Hydrate`); `Get` error wrapped.

## Why this shape
Makes fusion **deployment-independent**: a remote caller of a standalone fusion service (semsource ADR-0006, headless removed) can't read the service worktree, so bodies are addressable through a store, not a filesystem path. Bytes ride `storage.Store.Get([]byte)` — **byte-exact**, never the text `StoredContent` envelope (which corrupts non-UTF-8 to U+FFFD).

## Tests
Prove **location-independence**: one `BodyResolver`, two backends (`objectstore-primary` + `filestore-media`, incl. a non-UTF-8 byte-exactness check) + every fault path (nil ref, empty instance, unknown instance, nil resolver, propagated `Get` error).

## Notes
- `pkg/fusion` stays near-leaf (+`storage`, which imports only `context`/`io`; no cycle). Additive only.
- **Follow-on:** wiring this into the engine's assemble step lands with the lens-driven engine entry (the SPI's `ResolveMode`/`Edges`/`Hydrate` consumer), deferred from increment 3.
- **Open coordination (#395 comment):** which `storage.Store` backend semsource stamps for verbatim bodies (ObjectStore vs filestore) only affects the first **e2e** path — the contract is backend-agnostic, so it doesn't gate this helper.

Builds on #398 (Lens SPI). semstreams-reviewer to follow. Tests + vet + revive clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)