### PR TITLE
feat(fusion): lens-driven engine entry — Engine.Fuse + Response contract (ADR-062, gh#376)

### DIFF
--- a/pkg/fusion/contract.go
+++ b/pkg/fusion/contract.go
@@ -1,0 +1,164 @@
+package fusion
+
+// The fused response contract (ADR-062 lens-driven entry). Lifted from
+// semsource's validated source/fusion contract.go — the response shape an agent
+// acts on: verbatim body + the structure around it, keyed by what a human reads
+// (never an entity ID), with an honesty envelope (readiness + provenance) so a
+// caller can calibrate trust and never mistake "not ready" for "not found".
+//
+// Paths/Impact facets and ontology-coherence ranking are deliberately deferred
+// (a follow-on + gh#376 increment 5); this contract carries Nodes + relations +
+// the honesty envelope + misses.
+
+// ContractVersion identifies the wire shape of Request/Response.
+const ContractVersion = "1"
+
+// Want enumerates the optional facets a caller can request. Empty defaults to
+// body plus immediate relations.
+type Want string
+
+// The requestable facets. (WantPaths/WantImpact are reserved for the facets
+// follow-on; the engine ignores them today.)
+const (
+	WantBody      Want = "body"      // verbatim source/passage
+	WantRelations Want = "relations" // callers/callees, links/sections
+	WantPaths     Want = "paths"     // bounded relation paths from the seed (deferred)
+	WantImpact    Want = "impact"    // transitive reverse-relation closure (deferred)
+)
+
+// Budget bounds a response. Zero fields take engine defaults.
+type Budget struct {
+	MaxNodes int `json:"max_nodes,omitempty"`
+	MaxBytes int `json:"max_bytes,omitempty"`
+}
+
+// Request is the fused query, keyed by what an agent already knows — never an
+// entity ID.
+type Request struct {
+	Query  string `json:"query"`
+	Want   []Want `json:"want,omitempty"`
+	Budget Budget `json:"budget,omitzero"`
+}
+
+// Provenance records how an answer was produced so callers can calibrate trust.
+type Provenance string
+
+// The provenance tiers, in increasing order of uncertainty.
+const (
+	ProvenanceDeterministic Provenance = "deterministic" // exact lookup + structural walk
+	ProvenanceEmbedding     Provenance = "embedding"     // seeds came from semantic search
+	ProvenanceLLM           Provenance = "llm"           // an LLM reasoned over the result
+)
+
+// IndexState mirrors the graph readiness phase.
+type IndexState string
+
+// The readiness phases. Only Ready permits a not-found conclusion.
+const (
+	StateBuilding IndexState = "building"
+	StateReady    IndexState = "ready"
+	StateDegraded IndexState = "degraded"
+)
+
+// IndexStatus is attached to every response. Ready is load-bearing: when false
+// the caller must fall back (e.g. to grep) rather than treat empty as not-found.
+type IndexStatus struct {
+	Ready      bool       `json:"ready"`
+	State      IndexState `json:"state"`
+	Revision   string     `json:"revision,omitempty"`
+	LastSynced string     `json:"last_synced,omitempty"`
+}
+
+// Ref points to a node by what a human reads — never the entity ID.
+type Ref struct {
+	Name     string `json:"name"`
+	Path     string `json:"path,omitempty"`
+	Fragment string `json:"fragment,omitempty"`
+	Line     int    `json:"line,omitempty"`
+}
+
+// Node is one fused result: verbatim body plus the structure around it. Domains
+// differ only in which roles populate Relations (code: callers/callees; docs:
+// links/sections).
+type Node struct {
+	Name     string `json:"name"`
+	Kind     string `json:"kind,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Fragment string `json:"fragment,omitempty"`
+	// Lines is [start,end] for code, nil for line-less domains (docs) — a slice
+	// so omitempty actually omits it rather than emitting a spurious [0,0].
+	Lines     []int            `json:"lines,omitempty"`
+	Body      string           `json:"body,omitempty"`
+	Relations map[string][]Ref `json:"relations,omitempty"`
+	// Class is the BFO/CCO class IRI (provenance/debug; the agent ignores it).
+	Class string `json:"class,omitempty"`
+	// Handle is an opaque continuation token (internally the entity ID). Not an
+	// addressing scheme: never parse or construct it.
+	Handle string `json:"handle,omitempty"`
+}
+
+// Miss reports a query that resolved to nothing while the graph was ready, with
+// near-matches. A Miss only appears when Ready is true.
+type Miss struct {
+	Query      string   `json:"query"`
+	DidYouMean []string `json:"did_you_mean,omitempty"`
+}
+
+// Response is the fused answer. Nodes is the payload; Index and Provenance are
+// the honesty envelope. (Paths/Impact facets are a deferred follow-on.)
+type Response struct {
+	Index           IndexStatus `json:"index"`
+	Provenance      Provenance  `json:"provenance"`
+	Nodes           []Node      `json:"nodes,omitempty"`
+	Misses          []Miss      `json:"misses,omitempty"`
+	Truncated       bool        `json:"truncated"`
+	ContractVersion string      `json:"contract_version"`
+}
+
+const (
+	defaultMaxNodes = 20
+	defaultMaxBytes = 60000
+)
+
+// wantSet expands a Want slice into a lookup set, applying defaults when empty.
+func wantSet(wants []Want) map[Want]bool {
+	if len(wants) == 0 {
+		return map[Want]bool{WantBody: true, WantRelations: true}
+	}
+	set := make(map[Want]bool, len(wants))
+	for _, w := range wants {
+		set[w] = true
+	}
+	return set
+}
+
+// budgeter accumulates nodes up to the request budget, reporting truncation.
+type budgeter struct {
+	maxNodes, maxBytes, nodes, bytes int
+}
+
+// newBudget builds a budgeter from a request budget, applying defaults.
+func newBudget(b Budget) *budgeter {
+	bg := &budgeter{maxNodes: b.MaxNodes, maxBytes: b.MaxBytes}
+	if bg.maxNodes <= 0 {
+		bg.maxNodes = defaultMaxNodes
+	}
+	if bg.maxBytes <= 0 {
+		bg.maxBytes = defaultMaxBytes
+	}
+	return bg
+}
+
+// admit reports whether a node carrying bodyBytes still fits, updating totals.
+// At least one node is always admitted so a single oversized node is not dropped.
+func (b *budgeter) admit(bodyBytes int) bool {
+	if b.nodes >= b.maxNodes {
+		return false
+	}
+	if b.nodes > 0 && b.bytes+bodyBytes > b.maxBytes {
+		return false
+	}
+	b.nodes++
+	b.bytes += bodyBytes
+	return true
+}

--- a/pkg/fusion/engine_lens.go
+++ b/pkg/fusion/engine_lens.go
@@ -1,0 +1,266 @@
+package fusion
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+// The lens-driven engine entry (ADR-062). Resolves a query against the graph
+// through a Lens and returns a fused Response — the deterministic counterpart to
+// research_graph's chain (same resolve→expand→assemble shape, no LLM). Ported
+// from semsource's validated source/fusion engine, generalized: a string
+// ResolveMode, verbatim bodies hydrated via the handle-deref BodyResolver
+// (ADR-062 increment 4) rather than a lens filesystem read, and (for now)
+// resolve-order + lexical ranking with the ontology-coherence signal and the
+// paths/impact facets deferred (gh#376 increment 5 + a facets follow-on).
+//
+// DISTINCT from the package-level Fuse(queries) — that runs a pre-built
+// sub-query set over GraphQueryClient; this resolves a raw query through a Lens
+// over RetrievalClient.
+
+// Engine bounds keep the multi-hop traversal cheap and predictable.
+const (
+	resolveLimit        = 40
+	maxRelationsPerNode = 12
+)
+
+// Ranking weights. Resolve order (the graph's own index/semantic ranking) is the
+// base signal; lexical name match reorders locally. Ontology-coherence reordering
+// is gh#376 increment 5.
+const (
+	lexExact     = 40.0
+	lexPrefix    = 20.0
+	lexContains  = 8.0
+	resolveScale = 4.0 // base score per resolve-rank position
+)
+
+// ontologyClassPredicate is the stamped BFO/CCO class triple (semsource ADR-0005).
+// Read for Node.Class when present; ID-derived class fallback is increment 5.
+const ontologyClassPredicate = "entity.ontology.class"
+
+// Engine runs the lens-driven deterministic fusion pipeline over a
+// RetrievalClient, hydrating verbatim bodies through a BodyResolver.
+type Engine struct {
+	graph RetrievalClient
+	body  *BodyResolver
+}
+
+// NewEngine builds a lens-driven engine. body may be nil — node bodies are then
+// omitted (the response degrades gracefully rather than panicking).
+func NewEngine(graph RetrievalClient, body *BodyResolver) *Engine {
+	return &Engine{graph: graph, body: body}
+}
+
+// Fuse resolves req against the graph through lens and returns the fused
+// response. Readiness is load-bearing: a not-ready graph yields an empty
+// envelope (the caller must fall back); ready+absent yields a miss with
+// near-matches — never an ambiguous empty. A backend failure fetching seeds is
+// surfaced as an error, NOT silently turned into a "not found" (that would
+// violate the ready≠not-found contract).
+func (e *Engine) Fuse(ctx context.Context, req Request, lens Lens) (Response, error) {
+	status, err := e.graph.Status(ctx)
+	if err != nil {
+		return Response{}, err
+	}
+	if !status.Ready {
+		return Response{Index: status, Provenance: ProvenanceDeterministic, ContractVersion: ContractVersion}, nil
+	}
+
+	mode := lens.ResolveMode(req.Query)
+	seeds, err := e.graph.Resolve(ctx, req.Query, mode, resolveLimit)
+	if err != nil {
+		return Response{}, err
+	}
+	entities, err := e.graph.Entities(ctx, seeds)
+	if err != nil {
+		return Response{}, err
+	}
+	if len(entities) == 0 {
+		return e.miss(ctx, status, mode, req.Query), nil
+	}
+
+	names := make([]string, len(entities))
+	for i, ent := range entities {
+		names[i] = lens.Label(ent)
+	}
+	ranked := rankEntities(entities, names, req.Query)
+
+	wants := wantSet(req.Want)
+	resp := Response{Index: status, Provenance: ProvenanceForMode(mode), ContractVersion: ContractVersion}
+	resp.Nodes, resp.Truncated = e.buildNodes(ctx, ranked, lens, wants, newBudget(req.Budget))
+	if len(resp.Nodes) == 0 {
+		resp.Misses = []Miss{{Query: req.Query}}
+	}
+	return resp, nil
+}
+
+// miss builds a ready+absent response with near-matches.
+func (e *Engine) miss(ctx context.Context, status IndexStatus, mode ResolveMode, query string) Response {
+	names, _ := e.graph.Names(ctx, query, 5)
+	return Response{
+		Index:           status,
+		Provenance:      ProvenanceForMode(mode),
+		Misses:          []Miss{{Query: query, DidYouMean: names}},
+		ContractVersion: ContractVersion,
+	}
+}
+
+// buildNodes materializes ranked entities into Nodes within the budget.
+func (e *Engine) buildNodes(ctx context.Context, ranked []*Entity, lens Lens, wants map[Want]bool, bg *budgeter) ([]Node, bool) {
+	var nodes []Node
+	for _, ent := range ranked {
+		node := e.nodeFor(ctx, ent, lens, wants)
+		if !bg.admit(len(node.Body)) {
+			return nodes, true
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes, false
+}
+
+// nodeFor builds one Node, including only the requested facets. The body is
+// hydrated by dereferencing the lens's Hydrate HANDLE through the BodyResolver
+// (ADR-062 increment 4). Hydration is best-effort: a Hydrate or deref error omits
+// the body and does not fail the node (degrade-don't-fail).
+func (e *Engine) nodeFor(ctx context.Context, ent *Entity, lens Lens, wants map[Want]bool) Node {
+	loc := lens.Location(ent)
+	node := Node{
+		Name:     lens.Label(ent),
+		Kind:     lens.Kind(ent),
+		Path:     loc.Path,
+		Fragment: loc.Fragment,
+		Lines:    lineRange(loc.Lines),
+		Class:    classOf(ent),
+		Handle:   ent.ID,
+	}
+	if wants[WantBody] && e.body != nil {
+		if ref, err := lens.Hydrate(ctx, ent); err == nil && ref != nil {
+			if body, derr := e.body.ResolveBody(ctx, ref); derr == nil {
+				node.Body = string(body)
+			}
+		}
+	}
+	if wants[WantRelations] {
+		node.Relations = e.relations(ctx, ent, lens)
+	}
+	return node
+}
+
+// relations expands a node's forward and reverse edges into role → refs.
+func (e *Engine) relations(ctx context.Context, ent *Entity, lens Lens) map[string][]Ref {
+	preds, fwd, rev := edgePredicates(lens.Edges())
+	if len(preds) == 0 {
+		return nil
+	}
+	rels := map[string][]Ref{}
+	e.collectEdges(ctx, ent.ID, preds, Outgoing, fwd, lens, rels)
+	e.collectEdges(ctx, ent.ID, preds, Incoming, rev, lens, rels)
+	if len(rels) == 0 {
+		return nil
+	}
+	return rels
+}
+
+// collectEdges appends refs for one direction's edges, capped per role.
+func (e *Engine) collectEdges(ctx context.Context, id string, preds []string, dir Direction, roleByPred map[string]string, lens Lens, rels map[string][]Ref) {
+	edges, err := e.graph.Neighbors(ctx, id, preds, dir)
+	if err != nil {
+		return
+	}
+	for _, ed := range edges {
+		role := roleByPred[ed.Predicate]
+		if role == "" || len(rels[role]) >= maxRelationsPerNode {
+			continue
+		}
+		if ref, ok := e.refFor(ctx, ed.Target, lens); ok {
+			rels[role] = append(rels[role], ref)
+		}
+	}
+}
+
+// refFor resolves a target entity ID to a human Ref.
+func (e *Engine) refFor(ctx context.Context, id string, lens Lens) (Ref, bool) {
+	te, err := e.graph.Entity(ctx, id)
+	if err != nil || te == nil {
+		return Ref{}, false
+	}
+	loc := lens.Location(te)
+	return Ref{Name: lens.Label(te), Path: loc.Path, Fragment: loc.Fragment, Line: loc.Lines[0]}, true
+}
+
+// edgePredicates flattens a lens's EdgeSpecs into the predicate list and the
+// forward/reverse role lookups used during expansion.
+func edgePredicates(specs []EdgeSpec) (preds []string, fwd, rev map[string]string) {
+	fwd = make(map[string]string, len(specs))
+	rev = make(map[string]string, len(specs))
+	for _, s := range specs {
+		preds = append(preds, s.Predicate)
+		if s.OutgoingRole != "" {
+			fwd[s.Predicate] = s.OutgoingRole
+		}
+		if s.IncomingRole != "" {
+			rev[s.Predicate] = s.IncomingRole
+		}
+	}
+	return preds, fwd, rev
+}
+
+// classOf returns an entity's stamped BFO/CCO class IRI (entity.ontology.class),
+// or "". ID-derived class fallback + ontology-distance ranking are gh#376 increment 5.
+func classOf(e *Entity) string {
+	return e.First(ontologyClassPredicate)
+}
+
+// lineRange renders a [start,end] pair as a wire slice, or nil for line-less
+// domains so the field is omitted.
+func lineRange(l [2]int) []int {
+	if l[0] == 0 && l[1] == 0 {
+		return nil
+	}
+	return []int{l[0], l[1]}
+}
+
+// rankEntities orders entities (given in resolve order) by resolve-rank base +
+// lexical name match. names[i] is entity[i]'s display name. Ontology-coherence
+// reordering is gh#376 increment 5; until then resolve order + lexical is the
+// deterministic signal.
+func rankEntities(entities []*Entity, names []string, query string) []*Entity {
+	q := strings.ToLower(strings.TrimSpace(query))
+	type scored struct {
+		e   *Entity
+		s   float64
+		pos int
+	}
+	arr := make([]scored, len(entities))
+	for i, ent := range entities {
+		s := resolveScale * float64(len(entities)-i)
+		s += lexicalScore(q, strings.ToLower(names[i]))
+		arr[i] = scored{ent, s, i}
+	}
+	sort.SliceStable(arr, func(a, b int) bool {
+		if arr[a].s != arr[b].s {
+			return arr[a].s > arr[b].s
+		}
+		return arr[a].pos < arr[b].pos
+	})
+	out := make([]*Entity, len(arr))
+	for i := range arr {
+		out[i] = arr[i].e
+	}
+	return out
+}
+
+// lexicalScore scores a name against a lowercased query.
+func lexicalScore(q, name string) float64 {
+	switch {
+	case name == q:
+		return lexExact
+	case strings.HasPrefix(name, q):
+		return lexPrefix
+	case strings.Contains(name, q):
+		return lexContains
+	default:
+		return 0
+	}
+}

--- a/pkg/fusion/engine_lens.go
+++ b/pkg/fusion/engine_lens.go
@@ -37,6 +37,8 @@ const (
 
 // ontologyClassPredicate is the stamped BFO/CCO class triple (semsource ADR-0005).
 // Read for Node.Class when present; ID-derived class fallback is increment 5.
+// Keep in sync with semsource's ontology.ClassPredicate — increment 5 (#396),
+// which lifts the ontology helpers framework-side, is where these unify.
 const ontologyClassPredicate = "entity.ontology.class"
 
 // Engine runs the lens-driven deterministic fusion pipeline over a

--- a/pkg/fusion/engine_lens_test.go
+++ b/pkg/fusion/engine_lens_test.go
@@ -16,6 +16,7 @@ type fakeGraph struct {
 	seeds      map[string][]string       // query → seed IDs
 	entities   map[string]*fusion.Entity // id → entity
 	out        map[string][]fusion.Edge  // id → outgoing edges
+	in         map[string][]fusion.Edge  // id → incoming edges
 	names      []string                  // did_you_mean suggestions
 	statusErr  error
 	resolveErr error
@@ -47,7 +48,7 @@ func (g *fakeGraph) Neighbors(_ context.Context, id string, _ []string, dir fusi
 	if dir == fusion.Outgoing {
 		return g.out[id], nil
 	}
-	return nil, nil
+	return g.in[id], nil
 }
 func (g *fakeGraph) Names(_ context.Context, _ string, _ int) ([]string, error) {
 	return g.names, nil
@@ -200,13 +201,87 @@ func TestEngine_BudgetTruncation(t *testing.T) {
 	}
 }
 
-// TestEngine_BackendErrorSurfaced: a backend failure fetching seeds is an ERROR,
-// not silently a not-found (that would violate the ready≠not-found contract).
+// TestEngine_BackendErrorSurfaced: a backend failure fetching seeds OR entities
+// is an ERROR, not silently a not-found (that would violate ready≠not-found).
 func TestEngine_BackendErrorSurfaced(t *testing.T) {
-	g := &fakeGraph{status: readyStatus(), resolveErr: errors.New("graph down")}
+	cases := map[string]*fakeGraph{
+		"resolve error":  {status: readyStatus(), resolveErr: errors.New("graph down")},
+		"entities error": {status: readyStatus(), seeds: map[string][]string{"q": {"id"}}, entErr: errors.New("batch down")},
+	}
+	for name, g := range cases {
+		t.Run(name, func(t *testing.T) {
+			eng := fusion.NewEngine(g, fusion.NewBodyResolver(fusion.MapStoreResolver{}))
+			if _, err := eng.Fuse(context.Background(), fusion.Request{Query: "q"}, refLens{}); err == nil {
+				t.Error("expected a backend error to surface, not a silent miss")
+			}
+		})
+	}
+}
+
+// TestEngine_HydrateError_DegradesBody: a hydrate/deref failure omits the body
+// and does NOT fail the node or the fuse (degrade-don't-fail). Here the entity
+// points at a store key that doesn't exist, so ResolveBody errors.
+func TestEngine_HydrateError_DegradesBody(t *testing.T) {
+	store := &fakeStore{getErr: errors.New("backend down")}
+	ent := entity("acme.ops.code.repo.symbol.OnEvent", "OnEvent", "h/on_event.go",
+		message.Triple{Predicate: refStorageInstancePr, Object: "objectstore"},
+		message.Triple{Predicate: refStorageKeyPr, Object: "missing"},
+	)
+	g := &fakeGraph{status: readyStatus(), seeds: map[string][]string{"OnEvent": {ent.ID}}, entities: map[string]*fusion.Entity{ent.ID: ent}}
+	eng := fusion.NewEngine(g, fusion.NewBodyResolver(fusion.MapStoreResolver{"objectstore": store}))
+
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "OnEvent", Want: []fusion.Want{fusion.WantBody}}, refLens{})
+	if err != nil {
+		t.Fatalf("a hydrate fault must NOT fail the fuse, got %v", err)
+	}
+	if len(resp.Nodes) != 1 {
+		t.Fatalf("expected the node to still ship, got %d nodes", len(resp.Nodes))
+	}
+	if resp.Nodes[0].Body != "" {
+		t.Errorf("expected an empty body on hydrate fault, got %q", resp.Nodes[0].Body)
+	}
+}
+
+// TestEngine_IncomingRelations: reverse edges populate the lens's IncomingRole —
+// the reverse-direction path the port added over the seed walk.
+func TestEngine_IncomingRelations(t *testing.T) {
+	caller := entity("acme.ops.code.repo.symbol.Caller", "Caller", "caller.go")
+	seed := entity("acme.ops.code.repo.symbol.OnEvent", "OnEvent", "on_event.go")
+	g := &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"OnEvent": {seed.ID}},
+		entities: map[string]*fusion.Entity{seed.ID: seed, caller.ID: caller},
+		in: map[string][]fusion.Edge{
+			seed.ID: {{Predicate: "ref.relationship.references", Target: caller.ID}},
+		},
+	}
 	eng := fusion.NewEngine(g, fusion.NewBodyResolver(fusion.MapStoreResolver{}))
 
-	if _, err := eng.Fuse(context.Background(), fusion.Request{Query: "q"}, refLens{}); err == nil {
-		t.Error("expected a backend resolve error to surface, not a silent miss")
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "OnEvent", Want: []fusion.Want{fusion.WantRelations}}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	refs := resp.Nodes[0].Relations["referrer"] // refLens's IncomingRole
+	if len(refs) != 1 || refs[0].Name != "Caller" {
+		t.Errorf("expected one 'referrer' ref to Caller, got %+v", resp.Nodes[0].Relations)
+	}
+}
+
+// TestEngine_NilBodyResolver: a nil BodyResolver omits bodies without panicking
+// (the e.body != nil guard) — a deployment with no verbatim-body store still works.
+func TestEngine_NilBodyResolver(t *testing.T) {
+	ent := entity("acme.ops.code.repo.symbol.OnEvent", "OnEvent", "h/on_event.go",
+		message.Triple{Predicate: refStorageInstancePr, Object: "objectstore"},
+		message.Triple{Predicate: refStorageKeyPr, Object: "k"},
+	)
+	g := &fakeGraph{status: readyStatus(), seeds: map[string][]string{"OnEvent": {ent.ID}}, entities: map[string]*fusion.Entity{ent.ID: ent}}
+	eng := fusion.NewEngine(g, nil) // no body resolver
+
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "OnEvent", Want: []fusion.Want{fusion.WantBody}}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse with nil BodyResolver must not error, got %v", err)
+	}
+	if len(resp.Nodes) != 1 || resp.Nodes[0].Body != "" {
+		t.Errorf("expected one node with empty body, got %+v", resp.Nodes)
 	}
 }

--- a/pkg/fusion/engine_lens_test.go
+++ b/pkg/fusion/engine_lens_test.go
@@ -1,0 +1,212 @@
+package fusion_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/fusion"
+)
+
+// fakeGraph is an in-memory RetrievalClient for lens-driven engine tests — no
+// NATS, deterministic inputs. Error fields inject backend failures.
+type fakeGraph struct {
+	status     fusion.IndexStatus
+	seeds      map[string][]string       // query → seed IDs
+	entities   map[string]*fusion.Entity // id → entity
+	out        map[string][]fusion.Edge  // id → outgoing edges
+	names      []string                  // did_you_mean suggestions
+	statusErr  error
+	resolveErr error
+	entErr     error
+}
+
+func (g *fakeGraph) Status(context.Context) (fusion.IndexStatus, error) {
+	return g.status, g.statusErr
+}
+func (g *fakeGraph) Resolve(_ context.Context, query string, _ fusion.ResolveMode, _ int) ([]string, error) {
+	return g.seeds[query], g.resolveErr
+}
+func (g *fakeGraph) Entity(_ context.Context, id string) (*fusion.Entity, error) {
+	return g.entities[id], nil
+}
+func (g *fakeGraph) Entities(_ context.Context, ids []string) ([]*fusion.Entity, error) {
+	if g.entErr != nil {
+		return nil, g.entErr
+	}
+	var out []*fusion.Entity
+	for _, id := range ids {
+		if e, ok := g.entities[id]; ok {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+func (g *fakeGraph) Neighbors(_ context.Context, id string, _ []string, dir fusion.Direction) ([]fusion.Edge, error) {
+	if dir == fusion.Outgoing {
+		return g.out[id], nil
+	}
+	return nil, nil
+}
+func (g *fakeGraph) Names(_ context.Context, _ string, _ int) ([]string, error) {
+	return g.names, nil
+}
+
+func readyStatus() fusion.IndexStatus {
+	return fusion.IndexStatus{Ready: true, State: fusion.StateReady}
+}
+
+func entity(id, title, path string, extra ...message.Triple) *fusion.Entity {
+	tr := []message.Triple{
+		{Predicate: refTitlePredicate, Object: title},
+		{Predicate: refPathPredicate, Object: path},
+	}
+	return &fusion.Entity{ID: id, Triples: append(tr, extra...)}
+}
+
+// TestEngine_NotReady_EmptyEnvelope: a not-ready graph yields an empty envelope
+// the caller must fall back on — NEVER an authoritative empty result.
+func TestEngine_NotReady_EmptyEnvelope(t *testing.T) {
+	g := &fakeGraph{status: fusion.IndexStatus{Ready: false, State: fusion.StateBuilding}}
+	eng := fusion.NewEngine(g, fusion.NewBodyResolver(fusion.MapStoreResolver{}))
+
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "OnEvent"}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	if resp.Index.Ready {
+		t.Error("expected not-ready envelope")
+	}
+	if len(resp.Nodes) != 0 || len(resp.Misses) != 0 {
+		t.Errorf("not-ready must yield no nodes and no misses, got %d nodes / %d misses", len(resp.Nodes), len(resp.Misses))
+	}
+}
+
+// TestEngine_ResolveBuildsNodes: the happy path — resolve → entity → Node with
+// lens fields + a hydrated body (Hydrate handle → BodyResolver → bytes).
+func TestEngine_ResolveBuildsNodes(t *testing.T) {
+	store := &fakeStore{data: map[string][]byte{"k/on_event": []byte("package handlers // body")}}
+	ent := entity("acme.ops.code.repo.symbol.OnEvent", "OnEvent", "handlers/on_event.go",
+		message.Triple{Predicate: refKindPredicate, Object: "function"},
+		message.Triple{Predicate: "entity.ontology.class", Object: "http://x/Algorithm"},
+		message.Triple{Predicate: refStorageInstancePr, Object: "objectstore"},
+		message.Triple{Predicate: refStorageKeyPr, Object: "k/on_event"},
+	)
+	g := &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"OnEvent": {ent.ID}},
+		entities: map[string]*fusion.Entity{ent.ID: ent},
+	}
+	eng := fusion.NewEngine(g, fusion.NewBodyResolver(fusion.MapStoreResolver{"objectstore": store}))
+
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "OnEvent", Want: []fusion.Want{fusion.WantBody}}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	if resp.Provenance != fusion.ProvenanceDeterministic {
+		t.Errorf("provenance = %q, want deterministic (symbol resolve)", resp.Provenance)
+	}
+	if len(resp.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(resp.Nodes))
+	}
+	n := resp.Nodes[0]
+	if n.Name != "OnEvent" || n.Kind != "function" || n.Path != "handlers/on_event.go" {
+		t.Errorf("node fields wrong: %+v", n)
+	}
+	if n.Handle != ent.ID {
+		t.Errorf("Handle = %q, want the entity ID %q", n.Handle, ent.ID)
+	}
+	if n.Class != "http://x/Algorithm" {
+		t.Errorf("Class = %q, want the stamped ontology class", n.Class)
+	}
+	if n.Body != "package handlers // body" {
+		t.Errorf("Body = %q, want the hydrated bytes", n.Body)
+	}
+}
+
+// TestEngine_Relations: WantRelations expands a node's outgoing edges into
+// role→refs via the lens's EdgeSpecs.
+func TestEngine_Relations(t *testing.T) {
+	target := entity("acme.ops.code.repo.symbol.Helper", "Helper", "handlers/helper.go")
+	seed := entity("acme.ops.code.repo.symbol.OnEvent", "OnEvent", "handlers/on_event.go")
+	g := &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"OnEvent": {seed.ID}},
+		entities: map[string]*fusion.Entity{seed.ID: seed, target.ID: target},
+		out: map[string][]fusion.Edge{
+			seed.ID: {{Predicate: "ref.relationship.references", Target: target.ID}},
+		},
+	}
+	eng := fusion.NewEngine(g, fusion.NewBodyResolver(fusion.MapStoreResolver{}))
+
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "OnEvent", Want: []fusion.Want{fusion.WantRelations}}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	if len(resp.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(resp.Nodes))
+	}
+	refs := resp.Nodes[0].Relations["referent"] // refLens's OutgoingRole
+	if len(refs) != 1 || refs[0].Name != "Helper" {
+		t.Errorf("expected one 'referent' ref to Helper, got %+v", resp.Nodes[0].Relations)
+	}
+}
+
+// TestEngine_Miss: ready + resolved-to-nothing yields a Miss with did_you_mean —
+// never an ambiguous empty.
+func TestEngine_Miss(t *testing.T) {
+	g := &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"Ghost": {"acme.ops.code.repo.symbol.Ghost"}}, // resolves an id…
+		entities: map[string]*fusion.Entity{},                                       // …but it doesn't exist
+		names:    []string{"OnEvent", "OnError"},
+	}
+	eng := fusion.NewEngine(g, fusion.NewBodyResolver(fusion.MapStoreResolver{}))
+
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "Ghost"}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	if len(resp.Nodes) != 0 {
+		t.Errorf("expected no nodes on a miss, got %d", len(resp.Nodes))
+	}
+	if len(resp.Misses) != 1 || resp.Misses[0].Query != "Ghost" {
+		t.Fatalf("expected one Miss for Ghost, got %+v", resp.Misses)
+	}
+	if len(resp.Misses[0].DidYouMean) != 2 {
+		t.Errorf("expected 2 did_you_mean suggestions, got %v", resp.Misses[0].DidYouMean)
+	}
+}
+
+// TestEngine_BudgetTruncation: a MaxNodes cap admits the budgeted prefix and
+// flags truncation.
+func TestEngine_BudgetTruncation(t *testing.T) {
+	a := entity("acme.ops.code.repo.symbol.A", "A", "a.go")
+	b := entity("acme.ops.code.repo.symbol.B", "B", "b.go")
+	g := &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"q": {a.ID, b.ID}},
+		entities: map[string]*fusion.Entity{a.ID: a, b.ID: b},
+	}
+	eng := fusion.NewEngine(g, fusion.NewBodyResolver(fusion.MapStoreResolver{}))
+
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "q", Budget: fusion.Budget{MaxNodes: 1}}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	if len(resp.Nodes) != 1 || !resp.Truncated {
+		t.Errorf("expected 1 node + Truncated=true, got %d nodes / Truncated=%v", len(resp.Nodes), resp.Truncated)
+	}
+}
+
+// TestEngine_BackendErrorSurfaced: a backend failure fetching seeds is an ERROR,
+// not silently a not-found (that would violate the ready≠not-found contract).
+func TestEngine_BackendErrorSurfaced(t *testing.T) {
+	g := &fakeGraph{status: readyStatus(), resolveErr: errors.New("graph down")}
+	eng := fusion.NewEngine(g, fusion.NewBodyResolver(fusion.MapStoreResolver{}))
+
+	if _, err := eng.Fuse(context.Background(), fusion.Request{Query: "q"}, refLens{}); err == nil {
+		t.Error("expected a backend resolve error to surface, not a silent miss")
+	}
+}

--- a/pkg/fusion/lens.go
+++ b/pkg/fusion/lens.go
@@ -2,6 +2,7 @@ package fusion
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/c360studio/semstreams/message"
 )
@@ -24,6 +25,48 @@ import (
 type Entity struct {
 	ID      string
 	Triples []message.Triple
+}
+
+// First returns the first object for predicate rendered as a string, or "". A
+// convenience for lenses/ranker so they read triple objects without touching the
+// triple shape.
+func (e *Entity) First(predicate string) string {
+	for i := range e.Triples {
+		if e.Triples[i].Predicate == predicate {
+			return objectString(e.Triples[i].Object)
+		}
+	}
+	return ""
+}
+
+// FirstInt returns the first object for predicate as an int, or 0.
+func (e *Entity) FirstInt(predicate string) int {
+	for i := range e.Triples {
+		if e.Triples[i].Predicate == predicate {
+			switch v := e.Triples[i].Object.(type) {
+			case int:
+				return v
+			case int64:
+				return int(v)
+			case float64:
+				return int(v)
+			}
+		}
+	}
+	return 0
+}
+
+// objectString renders a triple object as a string (objects are string IRIs/
+// literals, or numeric literals).
+func objectString(o any) string {
+	switch v := o.(type) {
+	case string:
+		return v
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
 }
 
 // ResolveMode picks how the engine turns a raw query string into seed entities.
@@ -123,13 +166,13 @@ type Lens interface {
 // that. CAUTION: this means any NEW deterministic mode added to the enum MUST be
 // added to the deterministic case below, or it silently degrades to embedding
 // (no compile error — open string enum).
-func ProvenanceForMode(mode ResolveMode) string {
+func ProvenanceForMode(mode ResolveMode) Provenance {
 	switch mode {
 	case ResolveModeSymbol, ResolveModePrefix:
-		return "deterministic"
+		return ProvenanceDeterministic
 	case ResolveModeNL:
-		return "embedding"
+		return ProvenanceEmbedding
 	default:
-		return "embedding"
+		return ProvenanceEmbedding
 	}
 }

--- a/pkg/fusion/lens_test.go
+++ b/pkg/fusion/lens_test.go
@@ -150,11 +150,11 @@ func TestResolveMode_Classification(t *testing.T) {
 }
 
 func TestProvenanceForMode(t *testing.T) {
-	cases := map[fusion.ResolveMode]string{
-		fusion.ResolveModeSymbol: "deterministic",
-		fusion.ResolveModePrefix: "deterministic",
-		fusion.ResolveModeNL:     "embedding",
-		fusion.ResolveMode("?"):  "embedding", // unknown is conservatively non-deterministic
+	cases := map[fusion.ResolveMode]fusion.Provenance{
+		fusion.ResolveModeSymbol: fusion.ProvenanceDeterministic,
+		fusion.ResolveModePrefix: fusion.ProvenanceDeterministic,
+		fusion.ResolveModeNL:     fusion.ProvenanceEmbedding,
+		fusion.ResolveMode("?"):  fusion.ProvenanceEmbedding, // unknown is conservatively non-deterministic
 	}
 	for mode, want := range cases {
 		if got := fusion.ProvenanceForMode(mode); got != want {

--- a/pkg/fusion/retrieval.go
+++ b/pkg/fusion/retrieval.go
@@ -1,0 +1,49 @@
+package fusion
+
+import "context"
+
+// RetrievalClient is the resolve/expand surface the lens-driven Engine composes
+// over (ADR-062 lens-driven entry). It is DISTINCT from GraphQueryClient (the
+// sub-query executor surface the package-level Fuse consumes): this one maps a
+// query to seeds and walks structure, whereas GraphQueryClient runs pre-built
+// sub-queries. The ADR's eventual convergence unifies them; for now they serve
+// the two engine entries side by side.
+//
+// Production wraps NATS request/reply (graph.query.{status,byName,prefix,
+// semantic,batch,relationships,entity}); tests use an in-memory fake. Keeping the
+// engine behind this interface is what lets it stay deterministic and
+// unit-testable without a live graph (the production impl + the readiness status
+// subject are PR B / gh#397).
+type RetrievalClient interface {
+	// Status reports graph readiness. The honesty envelope's Ready flag is
+	// load-bearing — only Ready permits a not-found conclusion.
+	Status(ctx context.Context) (IndexStatus, error)
+	// Resolve maps a query to seed entity IDs by mode, most relevant first.
+	Resolve(ctx context.Context, query string, mode ResolveMode, limit int) ([]string, error)
+	// Entity returns an entity by ID, or (nil, nil) if absent.
+	Entity(ctx context.Context, id string) (*Entity, error)
+	// Entities batch-fetches entities by ID. Absent IDs are omitted; a non-nil
+	// error means a BACKEND failure, which callers MUST distinguish from genuine
+	// absence (an empty result on a Ready graph is a miss, not a fault).
+	Entities(ctx context.Context, ids []string) ([]*Entity, error)
+	// Neighbors returns edges from id along the given predicates in a direction.
+	Neighbors(ctx context.Context, id string, predicates []string, dir Direction) ([]Edge, error)
+	// Names suggests entity display names near a query (for a miss's did_you_mean).
+	Names(ctx context.Context, query string, limit int) ([]string, error)
+}
+
+// Direction selects edge traversal direction.
+type Direction int
+
+// Outgoing follows a subject's predicates to targets; Incoming follows the
+// reverse (who points at this entity).
+const (
+	Outgoing Direction = iota
+	Incoming
+)
+
+// Edge is a relationship from a subject entity to a target entity.
+type Edge struct {
+	Predicate string
+	Target    string
+}


### PR DESCRIPTION
The consumable **lens-driven entry** that wires the Lens SPI (#398) + hydration helper (#399) together into a usable surface — ADR-062. `query + Lens → resolve → rank → assemble → Response{Nodes, honesty envelope}`. The deterministic counterpart to `research_graph`'s chain (same resolve→expand→assemble shape, no LLM). Ported from semsource's **validated** `source/fusion` engine, generalized.

## What
- **`contract.go`** — `Request`/`Want`/`Budget` + the honesty envelope (`Provenance`, `IndexStatus`/`IndexState`) + `Node`/`Ref`/`Miss`/`Response` + `budgeter`. Lifted from semsource `contract.go`.
- **`retrieval.go`** — `RetrievalClient` (`Status/Resolve/Entity/Entities/Neighbors/Names`) + `Direction`/`Edge` — the resolve/expand surface, **distinct** from the existing `GraphQueryClient` (sub-query executors). Two engine entries side by side; the ADR's convergence unifies them later.
- **`engine_lens.go`** — `(*Engine).Fuse`: readiness gate (not-ready → empty envelope, **never a false not-found**); resolve via `lens.ResolveMode`; rank (resolve-order + lexical); assemble `Node`s via `Label/Kind/Location` + **`Hydrate`-handle → `BodyResolver.ResolveBody`** (the increment-4 deref) + `WantRelations` via `Neighbors`; ready+absent → `Miss` with `did_you_mean`.
- `Entity.First/FirstInt` accessors; `ProvenanceForMode` now returns the typed `Provenance`.

## Naming / scope (per plan, confirmed)
- New entry is `(*Engine).Fuse` (method); the existing package-level `Fuse(queries)` (sub-query) is untouched.
- **Deferred** (noted in code): `WantPaths`/`WantImpact` facets + per-request caching (follow-on); ontology-coherence ranking (#396); production NATS `RetrievalClient` + readiness `status` subject (**PR B / #397**).

## Tests
Fully unit-tested with a fake `RetrievalClient` + the reference lens: not-ready→empty, resolve→Nodes (fields + hydrated body via handle deref), relations from `Neighbors`, budget truncation, miss+did_you_mean, backend-error-surfaced (not a silent miss). Additive only; `-race` + vet + revive clean.

Builds on #398 + #399. semstreams-reviewer to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)