### PR TITLE
feat(graph-index): index-readiness status subject for fusion (ADR-062, gh#397)

### DIFF
--- a/graph/index_status.go
+++ b/graph/index_status.go
@@ -1,0 +1,27 @@
+package graph
+
+// IndexStatusResponse is the wire shape of graph.index.query.status (gh#397):
+// the deterministic-fusion honesty envelope's readiness signal.
+//
+// Ready is load-bearing — only Ready permits a caller to treat an empty result
+// as an authoritative not-found; when not Ready the caller must fall back (e.g.
+// to grep) rather than conclude absence. Today Ready means the NAME_INDEX (the
+// index deterministic symbol/prefix resolution depends on) has been populated
+// (non-empty); a not-yet-populated index can't distinguish "absent" from
+// "not-yet-indexed", so it reports not-ready (ADR-062 / gh#397).
+//
+// The JSON field names match pkg/fusion.IndexStatus so the fusion
+// RetrievalClient decodes this response directly into its honesty envelope.
+type IndexStatusResponse struct {
+	Ready      bool   `json:"ready"`
+	State      string `json:"state"` // "building" | "ready" | "degraded"
+	Revision   string `json:"revision,omitempty"`
+	LastSynced string `json:"last_synced,omitempty"`
+}
+
+// Index readiness states. Mirrors pkg/fusion.IndexState string values.
+const (
+	IndexStateBuilding = "building"
+	IndexStateReady    = "ready"
+	IndexStateDegraded = "degraded"
+)

--- a/processor/graph-index/component.go
+++ b/processor/graph-index/component.go
@@ -225,6 +225,12 @@ type Component struct {
 	errors            int64
 	lastActivity      atomic.Value // stores time.Time
 
+	// nameIndexReady is the sticky readiness signal for graph.index.query.status
+	// (gh#397). Set once the NAME_INDEX is known non-empty; an index does not
+	// un-build, so once true it stays true (O(1) steady state). Restart-safe: a
+	// not-yet-true status read does a one-time bucket check (handleQueryStatus).
+	nameIndexReady atomic.Bool
+
 	// Prometheus metrics
 	metrics *indexMetrics
 

--- a/processor/graph-index/name_index.go
+++ b/processor/graph-index/name_index.go
@@ -84,11 +84,53 @@ func (c *Component) UpdateNameIndex(ctx context.Context, name, entityID, predica
 
 	atomic.AddInt64(&c.messagesProcessed, 1)
 	c.lastActivity.Store(time.Now())
+	// gh#397: the NAME_INDEX now has at least this entry — mark ready (sticky).
+	c.nameIndexReady.Store(true)
 	if c.metrics != nil {
 		c.metrics.recordIndexUpdate("name")
 		c.metrics.recordKVOperation("put", "name")
 	}
 	return nil
+}
+
+// nameIndexIsReady reports whether the NAME_INDEX has been populated (gh#397).
+// Sticky-fast once the index is known non-empty; otherwise it does a one-time
+// bucket scan, which handles restart with a pre-populated index (the in-memory
+// sticky flag starts false after a restart). An index does not un-build, so the
+// flag never flips back to false. Any list error — including an empty bucket
+// (ErrNoKeysFound) or a transient backend fault — reports NOT ready, the
+// conservative honest answer (the caller must fall back rather than treat empty
+// as an authoritative not-found).
+func (c *Component) nameIndexIsReady(ctx context.Context) bool {
+	if c.nameIndexReady.Load() {
+		return true
+	}
+	keys, err := c.nameBucket.Keys(ctx)
+	if err != nil || len(keys) == 0 {
+		return false
+	}
+	c.nameIndexReady.Store(true)
+	return true
+}
+
+// handleQueryStatusNATS serves graph.index.query.status (gh#397): the
+// deterministic-fusion honesty-envelope readiness signal. Ready means the
+// NAME_INDEX is populated (see nameIndexIsReady). Takes no request body; the
+// response JSON shape matches pkg/fusion.IndexStatus.
+func (c *Component) handleQueryStatusNATS(ctx context.Context, _ []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	ready := c.nameIndexIsReady(ctx)
+	state := graph.IndexStateBuilding
+	if ready {
+		state = graph.IndexStateReady
+	}
+	data, err := json.Marshal(graph.IndexStatusResponse{Ready: ready, State: state})
+	if err != nil {
+		return nil, errs.Wrap(err, "Component", "handleQueryStatusNATS", "marshal status")
+	}
+	return data, nil
 }
 
 // handleQueryByNameNATS resolves a name to ranked entity IDs (gh#376). Request

--- a/processor/graph-index/name_index_test.go
+++ b/processor/graph-index/name_index_test.go
@@ -124,3 +124,43 @@ func TestHandleQueryByName_EmptyNameRejected(t *testing.T) {
 	_, err := comp.handleQueryByNameNATS(context.Background(), req)
 	require.Error(t, err)
 }
+
+// --- gh#397 index-readiness status ---
+
+func queryStatus(t *testing.T, comp *Component) graph.IndexStatusResponse {
+	t.Helper()
+	respData, err := comp.handleQueryStatusNATS(context.Background(), nil)
+	require.NoError(t, err)
+	var st graph.IndexStatusResponse
+	require.NoError(t, json.Unmarshal(respData, &st))
+	return st
+}
+
+func TestQueryStatus_NotReadyUntilNameIndexPopulated(t *testing.T) {
+	comp := newNameTestComponent(t)
+
+	// Empty index → not ready (building): the caller must fall back, NOT treat an
+	// empty byName result as an authoritative not-found.
+	st := queryStatus(t, comp)
+	assert.False(t, st.Ready, "empty NAME_INDEX must report not-ready")
+	assert.Equal(t, graph.IndexStateBuilding, st.State)
+
+	// After an index update → ready.
+	require.NoError(t, comp.UpdateNameIndex(context.Background(), "Foo", "org.p.d.s.t.x", "dc.terms.title", 1))
+	st = queryStatus(t, comp)
+	assert.True(t, st.Ready, "a populated NAME_INDEX must report ready")
+	assert.Equal(t, graph.IndexStateReady, st.State)
+}
+
+// TestQueryStatus_RestartLazyCheck: after a restart the in-memory sticky flag is
+// false, but a pre-populated bucket must still read ready via the one-time lazy
+// Keys() check (else a warm index would falsely report not-ready post-restart).
+func TestQueryStatus_RestartLazyCheck(t *testing.T) {
+	comp := newNameTestComponent(t)
+	require.NoError(t, comp.UpdateNameIndex(context.Background(), "Foo", "org.p.d.s.t.x", "dc.terms.title", 1))
+
+	comp.nameIndexReady.Store(false) // simulate restart: sticky flag reset, bucket retains data
+
+	st := queryStatus(t, comp)
+	assert.True(t, st.Ready, "a pre-populated index must read ready after restart via the lazy bucket check")
+}

--- a/processor/graph-index/query.go
+++ b/processor/graph-index/query.go
@@ -73,6 +73,14 @@ func (c *Component) setupQueryHandlers(ctx context.Context) error {
 	}
 	c.querySubscriptions = append(c.querySubscriptions, sub)
 
+	// Subscribe to index-readiness status query (gh#397 — deterministic-fusion
+	// honesty envelope; Ready = NAME_INDEX populated).
+	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.index.query.status", c.handleQueryStatusNATS)
+	if err != nil {
+		return errs.Wrap(err, "Component", "setupQueryHandlers", "subscribe status query")
+	}
+	c.querySubscriptions = append(c.querySubscriptions, sub)
+
 	c.logger.Info("query handlers registered",
 		slog.Any("subjects", []string{
 			"graph.index.query.outgoing",
@@ -83,6 +91,7 @@ func (c *Component) setupQueryHandlers(ctx context.Context) error {
 			"graph.index.query.predicateStats",
 			"graph.index.query.predicateCompound",
 			"graph.index.query.byName",
+			"graph.index.query.status",
 		}))
 
 	return nil


### PR DESCRIPTION
Closes #397. **B1 of PR B** (ADR-062 / gh#376 fusion).

## What
Net-new **`graph.index.query.status`** — the readiness signal the deterministic-fusion honesty envelope needs. `Ready` is load-bearing: only `Ready` permits a caller to treat an empty result as an authoritative not-found; otherwise it must fall back (e.g. to grep) rather than conclude absence.

## Readiness semantics (per the decision)
`Ready = the NAME_INDEX is populated (non-empty)` — the index deterministic symbol/prefix resolution depends on. A not-yet-populated index can't distinguish "absent" from "not-yet-indexed", so it reports not-ready.

Implementation: a **sticky `atomic.Bool`** (set on the first NAME_INDEX update — O(1) steady state) + a **one-time lazy `Keys()` scan** for restart-safety (a warm pre-populated index reads ready after restart even though the in-memory flag starts false). Any list error — empty bucket (`ErrNoKeysFound`) or a transient fault — reports **not ready**, the conservative honest answer.

## Pieces
- `graph.IndexStatusResponse` — the wire type; JSON field names match `pkg/fusion.IndexStatus` so the fusion `RetrievalClient` (B2) decodes it directly.
- graph-index: `nameIndexReady` atomic + `nameIndexIsReady` + `handleQueryStatusNATS`; registered `graph.index.query.status`.
- Tests: empty→not-ready/building, populated→ready, restart lazy-check.

## Next
**B2** — the 6-method NATS `RetrievalClient` (`Resolve`/`Entity`/`Entities`/`Neighbors`/`Names` over the existing `graph.query.*` subjects + `Status` over this) — makes the lens-driven engine (#401) callable end-to-end.

Tests + vet + revive + schema-gen clean. Additive only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)