### PR TITLE
feat(fusion): production NATS RetrievalClient — end-to-end lens fusion (ADR-062 B2, gh#376)

### DIFF
--- a/pkg/fusion/fusionnats/client.go
+++ b/pkg/fusion/fusionnats/client.go
@@ -1,0 +1,303 @@
+package fusionnats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/pkg/fusion"
+)
+
+// Public graph query subjects the retrieval client maps onto. These are the
+// stable external surface (graph-query / graph-index passthroughs), NOT the
+// internal graph.ingest.*/graph.embedding.* subjects, so a standalone fusion
+// service reaches them through the same boundary as any other consumer.
+const (
+	subjectStatus        = "graph.index.query.status"
+	subjectByName        = "graph.query.byName"
+	subjectPrefix        = "graph.query.prefix"
+	subjectSemantic      = "graph.query.semantic"
+	subjectEntity        = "graph.query.entity"
+	subjectBatch         = "graph.query.batch"
+	subjectRelationships = "graph.query.relationships"
+)
+
+// defaultTimeout is used when New is given a non-positive timeout. Matches the
+// 5s the existing graph/query client uses for index lookups.
+const defaultTimeout = 5 * time.Second
+
+// requester is the minimal NATS surface the retrieval client needs: classified
+// request/reply. *natsclient.Client satisfies it. Kept as a local interface so
+// the client unit-tests against a fake without a live NATS, and so this package
+// does not have to import natsclient for its production path.
+type requester interface {
+	RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
+}
+
+// Client is the production NATS implementation of fusion.RetrievalClient. It is
+// stateless beyond the request transport and timeout, so it is safe to share
+// across goroutines.
+type Client struct {
+	nats    requester
+	timeout time.Duration
+}
+
+// Compile-time assertion that Client satisfies the engine's retrieval surface.
+var _ fusion.RetrievalClient = (*Client)(nil)
+
+// New builds a retrieval client over the given NATS requester. A non-positive
+// timeout falls back to defaultTimeout.
+func New(nats requester, timeout time.Duration) *Client {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	return &Client{nats: nats, timeout: timeout}
+}
+
+// Status reports graph readiness for the honesty envelope (graph.index.query.status).
+func (c *Client) Status(ctx context.Context) (fusion.IndexStatus, error) {
+	// The handler ignores the body; send an empty object for convention parity
+	// with the other index query callers.
+	raw, err := c.request(ctx, subjectStatus, struct{}{})
+	if err != nil {
+		return fusion.IndexStatus{}, err
+	}
+	var resp graph.IndexStatusResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return fusion.IndexStatus{}, fmt.Errorf("fusionnats: decode status: %w", err)
+	}
+	return fusion.IndexStatus{
+		Ready:      resp.Ready,
+		State:      fusion.IndexState(resp.State),
+		Revision:   resp.Revision,
+		LastSynced: resp.LastSynced,
+	}, nil
+}
+
+// Resolve maps a query to seed entity IDs by mode, most relevant first. The mode
+// selects the subject; an unknown mode is an error rather than a silent default
+// (ResolveMode is an open string enum).
+func (c *Client) Resolve(ctx context.Context, query string, mode fusion.ResolveMode, limit int) ([]string, error) {
+	switch mode {
+	case fusion.ResolveModeSymbol:
+		return c.resolveByName(ctx, query, limit)
+	case fusion.ResolveModePrefix:
+		return c.resolvePrefix(ctx, query, limit)
+	case fusion.ResolveModeNL:
+		return c.resolveSemantic(ctx, query, limit)
+	default:
+		return nil, fmt.Errorf("fusionnats: unsupported resolve mode %q", mode)
+	}
+}
+
+// resolveByName resolves a symbol to ranked entity IDs via graph.query.byName.
+func (c *Client) resolveByName(ctx context.Context, query string, limit int) ([]string, error) {
+	matches, err := c.byNameMatches(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(matches))
+	for _, m := range matches {
+		ids = append(ids, m.EntityID)
+	}
+	return ids, nil
+}
+
+// resolvePrefix resolves an ID prefix to entity IDs via graph.query.prefix. Only
+// the first page is taken — resolve seeds are bounded by limit, not exhaustive.
+func (c *Client) resolvePrefix(ctx context.Context, query string, limit int) ([]string, error) {
+	raw, err := c.request(ctx, subjectPrefix, graph.PrefixQueryRequest{Prefix: query, Limit: limit})
+	if err != nil {
+		return nil, err
+	}
+	var resp graph.PrefixQueryResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("fusionnats: decode prefix: %w", err)
+	}
+	ids := make([]string, 0, len(resp.Entities))
+	for i := range resp.Entities {
+		ids = append(ids, resp.Entities[i].ID)
+	}
+	return ids, nil
+}
+
+// resolveSemantic resolves a natural-language query to embedding-ranked entity
+// IDs via graph.query.semantic.
+func (c *Client) resolveSemantic(ctx context.Context, query string, limit int) ([]string, error) {
+	raw, err := c.request(ctx, subjectSemantic, map[string]any{"query": query, "limit": limit})
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Results []struct {
+			EntityID string `json:"entity_id"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("fusionnats: decode semantic: %w", err)
+	}
+	ids := make([]string, 0, len(resp.Results))
+	for _, r := range resp.Results {
+		if r.EntityID != "" {
+			ids = append(ids, r.EntityID)
+		}
+	}
+	return ids, nil
+}
+
+// Entity returns an entity by ID, or (nil, nil) if absent. The graph-ingest
+// handler classifies a missing entity as ErrorInvalid with code
+// entity_not_found; that is the ONE error we translate to absence — every other
+// error propagates so the engine never reads a backend fault as a not-found.
+func (c *Client) Entity(ctx context.Context, id string) (*fusion.Entity, error) {
+	raw, err := c.request(ctx, subjectEntity, map[string]string{"id": id})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var es graph.EntityState
+	if err := json.Unmarshal(raw, &es); err != nil {
+		return nil, fmt.Errorf("fusionnats: decode entity %q: %w", id, err)
+	}
+	return &fusion.Entity{ID: es.ID, Triples: es.Triples}, nil
+}
+
+// Entities batch-fetches entities by ID via graph.query.batch. Absent IDs are
+// omitted by the handler (partial success); a non-nil error means a backend
+// failure, which the engine distinguishes from genuine absence.
+func (c *Client) Entities(ctx context.Context, ids []string) ([]*fusion.Entity, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	raw, err := c.request(ctx, subjectBatch, map[string]any{"ids": ids})
+	if err != nil {
+		return nil, err
+	}
+	var resp struct {
+		Entities []graph.EntityState `json:"entities"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("fusionnats: decode batch: %w", err)
+	}
+	out := make([]*fusion.Entity, 0, len(resp.Entities))
+	for i := range resp.Entities {
+		out = append(out, &fusion.Entity{ID: resp.Entities[i].ID, Triples: resp.Entities[i].Triples})
+	}
+	return out, nil
+}
+
+// Neighbors returns edges from id along the given predicates in a direction via
+// graph.query.relationships. The handler returns ALL edges in the direction;
+// this filters to the requested predicates (empty predicates means no filter).
+func (c *Client) Neighbors(ctx context.Context, id string, predicates []string, dir fusion.Direction) ([]fusion.Edge, error) {
+	raw, err := c.request(ctx, subjectRelationships, map[string]string{
+		"entity_id": id,
+		"direction": directionString(dir),
+	})
+	if err != nil {
+		return nil, err
+	}
+	var rels []struct {
+		FromEntityID string `json:"from_entity_id"`
+		ToEntityID   string `json:"to_entity_id"`
+		EdgeType     string `json:"edge_type"`
+	}
+	if err := json.Unmarshal(raw, &rels); err != nil {
+		return nil, fmt.Errorf("fusionnats: decode relationships: %w", err)
+	}
+	want := predicateSet(predicates)
+	edges := make([]fusion.Edge, 0, len(rels))
+	for _, r := range rels {
+		if want != nil && !want[r.EdgeType] {
+			continue
+		}
+		// The target is the OTHER end of the edge: outgoing points to
+		// to_entity_id, incoming comes from from_entity_id.
+		target := r.ToEntityID
+		if dir == fusion.Incoming {
+			target = r.FromEntityID
+		}
+		edges = append(edges, fusion.Edge{Predicate: r.EdgeType, Target: target})
+	}
+	return edges, nil
+}
+
+// Names suggests entity display names near a query for a miss's did_you_mean,
+// via graph.query.byName. Multiple entities may share a name; names are
+// de-duplicated preserving rank order and capped at limit.
+func (c *Client) Names(ctx context.Context, query string, limit int) ([]string, error) {
+	matches, err := c.byNameMatches(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(matches))
+	names := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if m.MatchedName == "" || seen[m.MatchedName] {
+			continue
+		}
+		seen[m.MatchedName] = true
+		names = append(names, m.MatchedName)
+		if limit > 0 && len(names) >= limit {
+			break
+		}
+	}
+	return names, nil
+}
+
+// byNameMatches calls graph.query.byName and returns the ranked matches. Shared
+// by Resolve(symbol) (which reads entity IDs) and Names (which reads names).
+func (c *Client) byNameMatches(ctx context.Context, query string, limit int) ([]graph.NameMatch, error) {
+	raw, err := c.request(ctx, subjectByName, map[string]any{"name": query, "limit": limit})
+	if err != nil {
+		return nil, err
+	}
+	var resp graph.QueryResponse[graph.NameData]
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("fusionnats: decode byName: %w", err)
+	}
+	return resp.Data.Matches, nil
+}
+
+// request marshals req and issues a classified request/reply on subject.
+func (c *Client) request(ctx context.Context, subject string, req any) ([]byte, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("fusionnats: marshal %s request: %w", subject, err)
+	}
+	return c.nats.RequestClassified(ctx, subject, body, c.timeout)
+}
+
+// directionString maps a fusion.Direction to the relationship query's wire value.
+func directionString(dir fusion.Direction) string {
+	if dir == fusion.Incoming {
+		return "incoming"
+	}
+	return "outgoing"
+}
+
+// predicateSet builds a lookup set from predicates, or nil when none are given
+// (nil means "no filter" — accept every predicate).
+func predicateSet(predicates []string) map[string]bool {
+	if len(predicates) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(predicates))
+	for _, p := range predicates {
+		set[p] = true
+	}
+	return set
+}
+
+// isNotFound reports whether err is the graph's entity_not_found classified
+// error (the only error Entity treats as absence rather than a fault).
+func isNotFound(err error) bool {
+	var ce *errs.ClassifiedError
+	return errors.As(err, &ce) && ce.Code == graph.ErrorCodeEntityNotFound
+}

--- a/pkg/fusion/fusionnats/client_integration_test.go
+++ b/pkg/fusion/fusionnats/client_integration_test.go
@@ -1,0 +1,147 @@
+//go:build integration
+
+package fusionnats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/pkg/fusion"
+)
+
+// TestIntegration_RetrievalClient_RealWire drives every RetrievalClient method
+// over a REAL NATS round-trip via RequestClassified, against thin handlers that
+// return the production response shapes. This is the consumer-side gate the
+// semstreams-reviewer required when PR #402 (B1) landed without it: it locks the
+// subject strings AND the RequestClassified decode/mapping that a unit test with
+// a fake requester cannot exercise. A wrong subject or a classify mismatch ships
+// red here instead of green (feedback_integration_tests_must_drive_production_wire).
+func TestIntegration_RetrievalClient_RealWire(t *testing.T) {
+	ctx := context.Background()
+	testClient := natsclient.NewTestClient(t)
+	nc := testClient.Client
+
+	// Register a handler on each public subject the client maps onto, returning
+	// the exact production response shape. SubscribeForRequests applies the
+	// ADR-060 classified-error wrapper, so a returned ClassifiedError round-trips
+	// its Code on the wire — which is what Entity's not-found translation needs.
+	subscribe(t, ctx, nc, subjectStatus, func(_ []byte) ([]byte, error) {
+		return json.Marshal(graph.IndexStatusResponse{Ready: true, State: graph.IndexStateReady})
+	})
+	subscribe(t, ctx, nc, subjectByName, func(_ []byte) ([]byte, error) {
+		return json.Marshal(graph.NewQueryResponse(graph.NameData{Matches: []graph.NameMatch{
+			{EntityID: "a.b.c.d.e.1", MatchedName: "Widget"},
+			{EntityID: "a.b.c.d.e.2", MatchedName: "Gadget"},
+		}}))
+	})
+	subscribe(t, ctx, nc, subjectPrefix, func(_ []byte) ([]byte, error) {
+		return json.Marshal(graph.PrefixQueryResponse{Entities: []graph.EntityState{{ID: "a.b.c.d.e.1"}}})
+	})
+	subscribe(t, ctx, nc, subjectSemantic, func(_ []byte) ([]byte, error) {
+		return json.Marshal(map[string]any{"results": []map[string]any{
+			{"entity_id": "a.b.c.d.e.9", "similarity": 0.9},
+		}})
+	})
+	subscribe(t, ctx, nc, subjectEntity, func(data []byte) ([]byte, error) {
+		var req struct {
+			ID string `json:"id"`
+		}
+		_ = json.Unmarshal(data, &req)
+		if req.ID == "missing" {
+			return nil, errs.ClassifiedCode(errs.ErrorInvalid, graph.ErrorCodeEntityNotFound, errors.New("not found"))
+		}
+		return json.Marshal(graph.EntityState{ID: req.ID, Triples: []message.Triple{
+			{Subject: req.ID, Predicate: "dc.terms.title", Object: "Widget"},
+		}})
+	})
+	subscribe(t, ctx, nc, subjectBatch, func(_ []byte) ([]byte, error) {
+		return json.Marshal(map[string]any{"entities": []graph.EntityState{
+			{ID: "a.b.c.d.e.1"}, {ID: "a.b.c.d.e.2"},
+		}})
+	})
+	subscribe(t, ctx, nc, subjectRelationships, func(_ []byte) ([]byte, error) {
+		return json.Marshal([]map[string]any{
+			{"from_entity_id": "seed", "to_entity_id": "callee", "edge_type": "code.calls"},
+		})
+	})
+
+	c := New(nc, 5*time.Second)
+
+	t.Run("Status", func(t *testing.T) {
+		st, err := c.Status(ctx)
+		require.NoError(t, err)
+		require.True(t, st.Ready)
+		require.Equal(t, fusion.StateReady, st.State)
+	})
+
+	t.Run("Resolve_symbol", func(t *testing.T) {
+		ids, err := c.Resolve(ctx, "Widget", fusion.ResolveModeSymbol, 10)
+		require.NoError(t, err)
+		require.Equal(t, []string{"a.b.c.d.e.1", "a.b.c.d.e.2"}, ids)
+	})
+
+	t.Run("Resolve_prefix", func(t *testing.T) {
+		ids, err := c.Resolve(ctx, "a.b.c", fusion.ResolveModePrefix, 10)
+		require.NoError(t, err)
+		require.Equal(t, []string{"a.b.c.d.e.1"}, ids)
+	})
+
+	t.Run("Resolve_nl", func(t *testing.T) {
+		ids, err := c.Resolve(ctx, "find a widget", fusion.ResolveModeNL, 10)
+		require.NoError(t, err)
+		require.Equal(t, []string{"a.b.c.d.e.9"}, ids)
+	})
+
+	t.Run("Entity_found", func(t *testing.T) {
+		ent, err := c.Entity(ctx, "a.b.c.d.e.1")
+		require.NoError(t, err)
+		require.NotNil(t, ent)
+		require.Equal(t, "Widget", ent.First("dc.terms.title"))
+	})
+
+	t.Run("Entity_not_found_is_absence", func(t *testing.T) {
+		ent, err := c.Entity(ctx, "missing")
+		require.NoError(t, err, "entity_not_found must decode to (nil,nil) over the real wire")
+		require.Nil(t, ent)
+	})
+
+	t.Run("Entities", func(t *testing.T) {
+		ents, err := c.Entities(ctx, []string{"a.b.c.d.e.1", "a.b.c.d.e.2"})
+		require.NoError(t, err)
+		require.Len(t, ents, 2)
+	})
+
+	t.Run("Neighbors", func(t *testing.T) {
+		edges, err := c.Neighbors(ctx, "seed", []string{"code.calls"}, fusion.Outgoing)
+		require.NoError(t, err)
+		require.Len(t, edges, 1)
+		require.Equal(t, "callee", edges[0].Target)
+		require.Equal(t, "code.calls", edges[0].Predicate)
+	})
+
+	t.Run("Names", func(t *testing.T) {
+		names, err := c.Names(ctx, "Wid", 5)
+		require.NoError(t, err)
+		require.Equal(t, []string{"Widget", "Gadget"}, names)
+	})
+}
+
+// subscribe registers a request handler on subject, failing the test on error
+// and cleaning up the subscription when the test ends.
+func subscribe(t *testing.T, ctx context.Context, nc *natsclient.Client, subject string, fn func(data []byte) ([]byte, error)) {
+	t.Helper()
+	sub, err := nc.SubscribeForRequests(ctx, subject, func(_ context.Context, data []byte) ([]byte, error) {
+		return fn(data)
+	})
+	require.NoError(t, err, "subscribe %s", subject)
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+}

--- a/pkg/fusion/fusionnats/client_test.go
+++ b/pkg/fusion/fusionnats/client_test.go
@@ -1,0 +1,340 @@
+package fusionnats
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/pkg/fusion"
+)
+
+// fakeRequester records the last request and returns a canned reply, or routes
+// per-subject through responder when set.
+type fakeRequester struct {
+	lastSubject string
+	lastData    []byte
+	resp        []byte
+	err         error
+	responder   func(subject string, data []byte) ([]byte, error)
+}
+
+func (f *fakeRequester) RequestClassified(_ context.Context, subject string, data []byte, _ time.Duration) ([]byte, error) {
+	f.lastSubject = subject
+	f.lastData = append([]byte(nil), data...)
+	if f.responder != nil {
+		return f.responder(subject, data)
+	}
+	return f.resp, f.err
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestStatus_MapsResponse(t *testing.T) {
+	fake := &fakeRequester{resp: mustJSON(t, graph.IndexStatusResponse{
+		Ready: true, State: graph.IndexStateReady, Revision: "42", LastSynced: "now",
+	})}
+	c := New(fake, time.Second)
+
+	got, err := c.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if fake.lastSubject != subjectStatus {
+		t.Errorf("subject = %q, want %q", fake.lastSubject, subjectStatus)
+	}
+	want := fusion.IndexStatus{Ready: true, State: fusion.StateReady, Revision: "42", LastSynced: "now"}
+	if got != want {
+		t.Errorf("status = %+v, want %+v", got, want)
+	}
+}
+
+func TestStatus_NotReady(t *testing.T) {
+	fake := &fakeRequester{resp: mustJSON(t, graph.IndexStatusResponse{Ready: false, State: graph.IndexStateBuilding})}
+	c := New(fake, time.Second)
+
+	got, err := c.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if got.Ready {
+		t.Error("expected not ready")
+	}
+	if got.State != fusion.StateBuilding {
+		t.Errorf("state = %q, want building", got.State)
+	}
+}
+
+func TestResolve_Symbol(t *testing.T) {
+	fake := &fakeRequester{resp: mustJSON(t, graph.NewQueryResponse(graph.NameData{Matches: []graph.NameMatch{
+		{EntityID: "a.b.c.d.e.1", MatchedName: "Widget"},
+		{EntityID: "a.b.c.d.e.2", MatchedName: "Widget"},
+	}}))}
+	c := New(fake, time.Second)
+
+	ids, err := c.Resolve(context.Background(), "Widget", fusion.ResolveModeSymbol, 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if fake.lastSubject != subjectByName {
+		t.Errorf("subject = %q, want %q", fake.lastSubject, subjectByName)
+	}
+	// Request must carry the query under "name" and the limit.
+	var req map[string]any
+	if err := json.Unmarshal(fake.lastData, &req); err != nil {
+		t.Fatalf("request not JSON: %v", err)
+	}
+	if req["name"] != "Widget" {
+		t.Errorf("request name = %v, want Widget", req["name"])
+	}
+	if want := []string{"a.b.c.d.e.1", "a.b.c.d.e.2"}; !equalStrings(ids, want) {
+		t.Errorf("ids = %v, want %v", ids, want)
+	}
+}
+
+func TestResolve_Prefix(t *testing.T) {
+	fake := &fakeRequester{resp: mustJSON(t, graph.PrefixQueryResponse{Entities: []graph.EntityState{
+		{ID: "a.b.c.d.e.1"}, {ID: "a.b.c.d.e.2"},
+	}})}
+	c := New(fake, time.Second)
+
+	ids, err := c.Resolve(context.Background(), "a.b.c", fusion.ResolveModePrefix, 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if fake.lastSubject != subjectPrefix {
+		t.Errorf("subject = %q, want %q", fake.lastSubject, subjectPrefix)
+	}
+	if want := []string{"a.b.c.d.e.1", "a.b.c.d.e.2"}; !equalStrings(ids, want) {
+		t.Errorf("ids = %v, want %v", ids, want)
+	}
+}
+
+func TestResolve_Semantic(t *testing.T) {
+	resp := map[string]any{"results": []map[string]any{
+		{"entity_id": "a.b.c.d.e.1", "similarity": 0.9},
+		{"entity_id": "", "similarity": 0.1}, // empty IDs are dropped
+		{"entity_id": "a.b.c.d.e.2", "similarity": 0.8},
+	}}
+	fake := &fakeRequester{resp: mustJSON(t, resp)}
+	c := New(fake, time.Second)
+
+	ids, err := c.Resolve(context.Background(), "find me a widget", fusion.ResolveModeNL, 10)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if fake.lastSubject != subjectSemantic {
+		t.Errorf("subject = %q, want %q", fake.lastSubject, subjectSemantic)
+	}
+	if want := []string{"a.b.c.d.e.1", "a.b.c.d.e.2"}; !equalStrings(ids, want) {
+		t.Errorf("ids = %v, want %v", ids, want)
+	}
+}
+
+func TestResolve_UnknownMode(t *testing.T) {
+	c := New(&fakeRequester{}, time.Second)
+	_, err := c.Resolve(context.Background(), "x", fusion.ResolveMode("bogus"), 10)
+	if err == nil {
+		t.Fatal("expected error for unknown mode")
+	}
+}
+
+func TestEntity_Found(t *testing.T) {
+	es := graph.EntityState{ID: "a.b.c.d.e.1", Triples: []message.Triple{
+		{Subject: "a.b.c.d.e.1", Predicate: "dc.terms.title", Object: "Widget"},
+	}}
+	fake := &fakeRequester{resp: mustJSON(t, es)}
+	c := New(fake, time.Second)
+
+	ent, err := c.Entity(context.Background(), "a.b.c.d.e.1")
+	if err != nil {
+		t.Fatalf("Entity: %v", err)
+	}
+	if fake.lastSubject != subjectEntity {
+		t.Errorf("subject = %q, want %q", fake.lastSubject, subjectEntity)
+	}
+	if ent == nil || ent.ID != "a.b.c.d.e.1" {
+		t.Fatalf("entity = %+v, want id a.b.c.d.e.1", ent)
+	}
+	if ent.First("dc.terms.title") != "Widget" {
+		t.Errorf("title = %q, want Widget", ent.First("dc.terms.title"))
+	}
+}
+
+func TestEntity_NotFoundIsAbsence(t *testing.T) {
+	fake := &fakeRequester{err: errs.ClassifiedCode(errs.ErrorInvalid, graph.ErrorCodeEntityNotFound, errors.New("not found: x"))}
+	c := New(fake, time.Second)
+
+	ent, err := c.Entity(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("not-found must be (nil,nil), got err: %v", err)
+	}
+	if ent != nil {
+		t.Errorf("entity = %+v, want nil", ent)
+	}
+}
+
+func TestEntity_BackendErrorPropagates(t *testing.T) {
+	fake := &fakeRequester{err: errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("boom"))}
+	c := New(fake, time.Second)
+
+	_, err := c.Entity(context.Background(), "x")
+	if err == nil {
+		t.Fatal("backend error must propagate, not be swallowed as absence")
+	}
+}
+
+func TestEntities_BatchDecodes(t *testing.T) {
+	resp := map[string]any{"entities": []graph.EntityState{
+		{ID: "a.b.c.d.e.1"}, {ID: "a.b.c.d.e.2"},
+	}}
+	fake := &fakeRequester{resp: mustJSON(t, resp)}
+	c := New(fake, time.Second)
+
+	ents, err := c.Entities(context.Background(), []string{"a.b.c.d.e.1", "a.b.c.d.e.2"})
+	if err != nil {
+		t.Fatalf("Entities: %v", err)
+	}
+	if fake.lastSubject != subjectBatch {
+		t.Errorf("subject = %q, want %q", fake.lastSubject, subjectBatch)
+	}
+	if len(ents) != 2 {
+		t.Fatalf("got %d entities, want 2", len(ents))
+	}
+}
+
+func TestEntities_EmptyShortCircuits(t *testing.T) {
+	fake := &fakeRequester{err: errors.New("should not be called")}
+	c := New(fake, time.Second)
+
+	ents, err := c.Entities(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Entities(nil): %v", err)
+	}
+	if ents != nil {
+		t.Errorf("entities = %v, want nil", ents)
+	}
+	if fake.lastSubject != "" {
+		t.Error("empty IDs must not hit the wire")
+	}
+}
+
+func TestNeighbors_OutgoingFiltersPredicates(t *testing.T) {
+	resp := []map[string]any{
+		{"from_entity_id": "seed", "to_entity_id": "callee1", "edge_type": "code.calls"},
+		{"from_entity_id": "seed", "to_entity_id": "other", "edge_type": "code.imports"},
+		{"from_entity_id": "seed", "to_entity_id": "callee2", "edge_type": "code.calls"},
+	}
+	fake := &fakeRequester{resp: mustJSON(t, resp)}
+	c := New(fake, time.Second)
+
+	edges, err := c.Neighbors(context.Background(), "seed", []string{"code.calls"}, fusion.Outgoing)
+	if err != nil {
+		t.Fatalf("Neighbors: %v", err)
+	}
+	if fake.lastSubject != subjectRelationships {
+		t.Errorf("subject = %q, want %q", fake.lastSubject, subjectRelationships)
+	}
+	// direction must be on the wire as "outgoing"
+	var req map[string]string
+	_ = json.Unmarshal(fake.lastData, &req)
+	if req["direction"] != "outgoing" {
+		t.Errorf("direction = %q, want outgoing", req["direction"])
+	}
+	if len(edges) != 2 {
+		t.Fatalf("got %d edges, want 2 (code.imports filtered out)", len(edges))
+	}
+	// outgoing target is to_entity_id
+	if edges[0].Target != "callee1" || edges[0].Predicate != "code.calls" {
+		t.Errorf("edge[0] = %+v, want callee1/code.calls", edges[0])
+	}
+}
+
+func TestNeighbors_IncomingTargetsFromEnd(t *testing.T) {
+	resp := []map[string]any{
+		{"from_entity_id": "caller1", "to_entity_id": "seed", "edge_type": "code.calls"},
+	}
+	fake := &fakeRequester{resp: mustJSON(t, resp)}
+	c := New(fake, time.Second)
+
+	edges, err := c.Neighbors(context.Background(), "seed", []string{"code.calls"}, fusion.Incoming)
+	if err != nil {
+		t.Fatalf("Neighbors: %v", err)
+	}
+	var req map[string]string
+	_ = json.Unmarshal(fake.lastData, &req)
+	if req["direction"] != "incoming" {
+		t.Errorf("direction = %q, want incoming", req["direction"])
+	}
+	if len(edges) != 1 || edges[0].Target != "caller1" {
+		t.Fatalf("incoming target should be from_entity_id; got %+v", edges)
+	}
+}
+
+func TestNeighbors_NoPredicatesMeansNoFilter(t *testing.T) {
+	resp := []map[string]any{
+		{"from_entity_id": "seed", "to_entity_id": "x", "edge_type": "a"},
+		{"from_entity_id": "seed", "to_entity_id": "y", "edge_type": "b"},
+	}
+	fake := &fakeRequester{resp: mustJSON(t, resp)}
+	c := New(fake, time.Second)
+
+	edges, err := c.Neighbors(context.Background(), "seed", nil, fusion.Outgoing)
+	if err != nil {
+		t.Fatalf("Neighbors: %v", err)
+	}
+	if len(edges) != 2 {
+		t.Errorf("got %d edges, want 2 (no filter)", len(edges))
+	}
+}
+
+func TestNames_DedupesAndCaps(t *testing.T) {
+	fake := &fakeRequester{resp: mustJSON(t, graph.NewQueryResponse(graph.NameData{Matches: []graph.NameMatch{
+		{EntityID: "1", MatchedName: "Widget"},
+		{EntityID: "2", MatchedName: "Widget"}, // dup name, distinct entity
+		{EntityID: "3", MatchedName: "Gadget"},
+		{EntityID: "4", MatchedName: "Gizmo"},
+	}}))}
+	c := New(fake, time.Second)
+
+	names, err := c.Names(context.Background(), "Wid", 2)
+	if err != nil {
+		t.Fatalf("Names: %v", err)
+	}
+	if fake.lastSubject != subjectByName {
+		t.Errorf("subject = %q, want %q", fake.lastSubject, subjectByName)
+	}
+	if want := []string{"Widget", "Gadget"}; !equalStrings(names, want) {
+		t.Errorf("names = %v, want %v (deduped, capped at 2)", names, want)
+	}
+}
+
+func TestNew_DefaultsTimeout(t *testing.T) {
+	c := New(&fakeRequester{}, 0)
+	if c.timeout != defaultTimeout {
+		t.Errorf("timeout = %v, want default %v", c.timeout, defaultTimeout)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/fusion/fusionnats/doc.go
+++ b/pkg/fusion/fusionnats/doc.go
@@ -1,0 +1,29 @@
+// Package fusionnats is the production NATS implementation of
+// fusion.RetrievalClient (ADR-062 increment "B2"): it wires the engine's
+// resolve/expand/status surface onto the existing public graph query subjects
+// so the lens-driven fusion engine can run against a live graph.
+//
+// It is a SUBPACKAGE of pkg/fusion deliberately: pkg/fusion is a near-leaf
+// (message only, no NATS) so the engine stays deterministic and unit-testable
+// without a live graph. This package is where the engine touches the wire — it
+// imports natsclient (via a minimal requester interface) and the graph query
+// contracts, and returns the leaf fusion types.
+//
+// Subject mapping (all PUBLIC graph.query.* / graph.index.query.* subjects, the
+// stable external surface a standalone fusion service can reach):
+//
+//	Status              -> graph.index.query.status   (gh#397)
+//	Resolve(symbol)     -> graph.query.byName         (gh#376)
+//	Resolve(prefix)     -> graph.query.prefix
+//	Resolve(nl)         -> graph.query.semantic
+//	Entity              -> graph.query.entity
+//	Entities            -> graph.query.batch
+//	Neighbors           -> graph.query.relationships
+//	Names               -> graph.query.byName         (matched names for did_you_mean)
+//
+// Every call uses RequestClassified, so a classified handler error (ADR-060)
+// surfaces as a typed *errs.ClassifiedError rather than a silently-decoded
+// "error: " body. Entity translates the entity_not_found classified error into
+// (nil, nil) to honor the interface's absence contract; every other error
+// propagates so the engine never mistakes a backend fault for a not-found.
+package fusionnats


### PR DESCRIPTION
## What

Adds `pkg/fusion/fusionnats` — the production implementation of `fusion.RetrievalClient`, wiring the lens-driven fusion engine's resolve/expand/status surface onto the existing **public** graph query subjects. This is the **last piece for an end-to-end production fusion query**: the engine (`Engine.Fuse`, #401), Lens SPI (#398), hydration deref (#399), and readiness status (#402) all compose over this adapter.

## Subject mapping

| RetrievalClient method | Subject |
|---|---|
| `Status` | `graph.index.query.status` (#402) |
| `Resolve(symbol)` / `Names` | `graph.query.byName` (#380) |
| `Resolve(prefix)` | `graph.query.prefix` |
| `Resolve(nl)` | `graph.query.semantic` |
| `Entity` | `graph.query.entity` |
| `Entities` | `graph.query.batch` |
| `Neighbors` | `graph.query.relationships` |

Public `graph.query.*` / `graph.index.query.*` subjects (not the internal `graph.ingest.*` / `graph.embedding.*` ones), so a standalone fusion service reaches them through the same boundary as any other consumer.

## Design

- **Leaf discipline**: lives in a *subpackage* of `pkg/fusion` so `pkg/fusion` itself stays a near-leaf (`message` only, no NATS) and the engine stays deterministic + unit-testable. A local `requester` interface is the only NATS seam; the production path does not import `natsclient`.
- **Error contract (ADR-060)**: every call uses `RequestClassified`, so a classified handler error surfaces as a typed `*errs.ClassifiedError`, never a silently decoded `error:` body. `Entity` translates **only** the `entity_not_found` classified error into `(nil, nil)` to honor the absence contract; **every other error propagates** so the engine never reads a backend fault as a not-found (preserves the ready≠not-found honesty contract).
- **Neighbors** filters the relationship handler's all-edges response to the requested predicates and extracts the *other* end of each edge per direction.

## Tests

- `client_test.go` — 16 unit tests (fake requester): subject/body fidelity, decode, not-found-absence vs backend-error-propagation, unknown-mode error, Neighbors direction/filter/target mapping, Names dedup/cap.
- `client_integration_test.go` (`//go:build integration`) — drives **every** method over a **real NATS round-trip** via `RequestClassified` against production-shaped handlers, including not-found→`(nil,nil)` over the real wire. This is the consumer-side wire gate the `semstreams-reviewer` required when B1 (#402) landed without it.

## Gates

- ✅ `go test -race ./...` (full suite), unit + integration for `fusionnats`
- ✅ `task lint` (revive clean), gofmt clean, `go vet` (default + integration + live_llm)
- ✅ zero schema drift
- ✅ `semstreams-reviewer`: **MERGE** — no blocking/high/medium; error contract verified correct end-to-end on both sides of all 7 wire seams.

Part of ADR-062 deterministic graph fusion (gh#376).

🤖 Generated with [Claude Code](https://claude.com/claude-code)