### PR TITLE
fix(objectstore): canonicalize StorageInstance on component instance name (ADR-062, gh#400)

### DIFF
--- a/storage/objectstore/component.go
+++ b/storage/objectstore/component.go
@@ -162,6 +162,13 @@ func (c *Component) Start(ctx context.Context) error {
 
 	c.logger.Debug("Creating ObjectStore", "name", c.instanceName, "bucket", c.config.BucketName)
 
+	// gh#400: thread the component instance name into the store so its
+	// StoreContent path stamps the SAME StorageInstance as this component's
+	// StoredMessage emit path (which already uses c.instanceName). Without this
+	// the store would fall back to the bucket name and the two write paths would
+	// disagree, leaving a resolver unable to resolve one of them.
+	c.config.InstanceName = c.instanceName
+
 	// Create the underlying ObjectStore with metrics support
 	store, err := NewStoreWithConfigAndMetrics(ctx, c.natsClient, c.config, c.metricsRegistry)
 	if store != nil {

--- a/storage/objectstore/component_instance_integration_test.go
+++ b/storage/objectstore/component_instance_integration_test.go
@@ -1,0 +1,52 @@
+//go:build integration
+
+package objectstore
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// TestIntegration_GH400_ComponentThreadsInstanceNameIntoStore is a white-box
+// guard for the component-threading line (component.go: c.config.InstanceName =
+// c.instanceName). It boots one real component and asserts the store it built
+// stamps the COMPONENT instance name, not the bucket name. The store-level tests
+// in store_integration_test.go lock StoreContent's stamping given a configured
+// InstanceName; this locks that the component actually supplies it — so deleting
+// or reordering the threading line (which would silently re-introduce gh#400 on
+// the StoreContent path) fails a test instead of shipping green.
+//
+// Internal (package objectstore) so it can read the unexported c.store. Uses its
+// own isolated NATS container — NOT the shared one — because the component's
+// derived subjects all key on the fixed instance name "objectstore" and a second
+// component on a shared bus would collide (the reason a production-wire variant
+// of this test was avoided in favor of this direct assertion).
+func TestIntegration_GH400_ComponentThreadsInstanceNameIntoStore(t *testing.T) {
+	ctx := context.Background()
+	tc := natsclient.NewTestClient(t, natsclient.WithJetStream(), natsclient.WithKV())
+
+	cfg := DefaultConfig()
+	cfg.BucketName = "GH400_THREAD_BUCKET" // deliberately != the instance name
+	cfgJSON, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	disc, err := NewComponent(cfgJSON, component.Dependencies{NATSClient: tc.Client})
+	require.NoError(t, err)
+	c := disc.(*Component)
+	require.NoError(t, c.Initialize())
+	require.NoError(t, c.Start(ctx))
+	t.Cleanup(func() { _ = c.Stop(5 * time.Second) })
+
+	require.NotNil(t, c.store, "component must have built its store on Start")
+	require.Equal(t, c.instanceName, c.store.InstanceName(),
+		"component must thread its instance name into the store (gh#400)")
+	require.NotEqual(t, cfg.BucketName, c.store.InstanceName(),
+		"store must NOT stamp the bucket name on the component path (the gh#400 bug)")
+}

--- a/storage/objectstore/config.go
+++ b/storage/objectstore/config.go
@@ -24,6 +24,15 @@ type Config struct {
 	// BucketName is the NATS JetStream ObjectStore bucket name
 	BucketName string `json:"bucket_name" schema:"type:string,description:NATS ObjectStore bucket name,default:MESSAGES,category:basic"`
 
+	// InstanceName is the storage COMPONENT instance name stamped into every
+	// StorageReference.StorageInstance this store produces (gh#400). It is the
+	// canonical handle a resolver (e.g. the fusion hydration deref helper,
+	// ADR-062 #399) maps back to this store. Set by the objectstore Component
+	// from its instance name; when empty (standalone Store callers) it defaults
+	// to BucketName so the stamped instance is never empty. Internal wiring, not
+	// operator-configured — hence schema-excluded like the pluggable generators.
+	InstanceName string `json:"-" schema:"-"`
+
 	// DataCache configures the in-memory cache for retrieved objects
 	DataCache cache.Config `json:"data_cache" schema:"type:object,description:Cache configuration for stored objects,category:performance"`
 

--- a/storage/objectstore/store.go
+++ b/storage/objectstore/store.go
@@ -34,8 +34,12 @@ var (
 //   - Pluggable MetadataExtractor (inject custom metadata extraction)
 //   - No hardcoded semantic requirements
 type Store struct {
-	client            *natsclient.Client
-	bucketName        string
+	client     *natsclient.Client
+	bucketName string
+	// instanceName is stamped into StorageReference.StorageInstance (gh#400) —
+	// the canonical handle a resolver maps back to this store. Defaults to
+	// bucketName when the config leaves it empty.
+	instanceName      string
 	store             jetstream.ObjectStore
 	dataCache         cache.Cache[[]byte]
 	keyGenerator      storage.KeyGenerator
@@ -61,6 +65,15 @@ func (s *Store) SetDecoder(d *message.Decoder) {
 	s.decoder = d
 }
 
+// InstanceName returns the value this store stamps into
+// StorageReference.StorageInstance (gh#400) — the canonical handle a resolver
+// maps back to this store. It is the component instance name when the config
+// supplied one, else the bucket name. Exported so a consumer (or a test) can
+// confirm what a ref produced by this store will resolve against.
+func (s *Store) InstanceName() string {
+	return s.instanceName
+}
+
 // NewStoreWithConfig creates a new ObjectStore with cache configuration.
 // Uses NATS ObjectStore (NOT KeyValue) for immutable message storage.
 func NewStoreWithConfig(ctx context.Context, client *natsclient.Client, cfg Config) (*Store, error) {
@@ -78,6 +91,15 @@ func NewStoreWithConfigAndMetrics(
 	bucketName := cfg.BucketName
 	if bucketName == "" {
 		bucketName = "MESSAGES"
+	}
+
+	// gh#400: stamp StorageInstance with the component instance name when the
+	// caller provides one; otherwise fall back to the (already-defaulted) bucket
+	// name so the stamped instance is never empty (preserves prior behavior for
+	// standalone callers).
+	instanceName := cfg.InstanceName
+	if instanceName == "" {
+		instanceName = bucketName
 	}
 
 	js, err := client.JetStream()
@@ -127,6 +149,7 @@ func NewStoreWithConfigAndMetrics(
 	return &Store{
 		client:            client,
 		bucketName:        bucketName,
+		instanceName:      instanceName,
 		store:             store,
 		dataCache:         dataCache,
 		keyGenerator:      keyGen,
@@ -428,9 +451,12 @@ func (s *Store) StoreContent(ctx context.Context, cs message.ContentStorable) (*
 		s.dataCache.Set(key, data)
 	}
 
-	// Return reference
+	// Return reference. gh#400: stamp the canonical instance name (not the
+	// bucket name) so a resolver keyed on the component instance name — and the
+	// component's own StoredMessage emit path, which already stamps
+	// instanceName — agree on one StorageInstance for this store.
 	return &message.StorageReference{
-		StorageInstance: s.bucketName,
+		StorageInstance: s.instanceName,
 		Key:             key,
 		ContentType:     "application/json",
 		Size:            int64(len(data)),

--- a/storage/objectstore/store_integration_test.go
+++ b/storage/objectstore/store_integration_test.go
@@ -888,3 +888,64 @@ func TestIntegration_ExtractTextFields_KeyMapping(t *testing.T) {
 	assert.Equal(t, "title", storedContent.ContentFields[message.ContentRoleTitle],
 		"ContentFields should map title role to title fieldName")
 }
+
+// gh#400: StorageReference.StorageInstance must be stamped with the canonical
+// component instance name, consistently across both write paths. Before the
+// fix, the component's StoredMessage emit path stamped c.instanceName while the
+// Store's StoreContent path stamped the bucket name — a resolver (the fusion
+// hydration deref helper, ADR-062 #399, the first reader) keyed on one could
+// not resolve refs stamped with the other.
+
+// TestIntegration_GH400_StoreContentStampsInstanceName locks the fix: when the
+// component threads its instance name into the store config (InstanceName set,
+// distinct from the bucket), StoreContent stamps the INSTANCE name — the same
+// value the component's emitStoredMessage path uses — not the bucket name.
+func TestIntegration_GH400_StoreContentStampsInstanceName(t *testing.T) {
+	natsClient := getSharedNATSClient(t)
+	ctx := context.Background()
+
+	const instanceName = "objectstore" // what the component sets as c.instanceName
+	config := objectstore.Config{
+		BucketName:   "TEST_GH400_INSTANCE", // deliberately != instanceName
+		InstanceName: instanceName,
+	}
+	store, err := objectstore.NewStoreWithConfig(ctx, natsClient, config)
+	require.NoError(t, err)
+	defer store.Close()
+
+	doc := &document.Document{
+		ID: "gh400-doc-001", Title: "Canonical Instance", Description: "ref stamping",
+		Body: "verbatim body", Category: "test", OrgID: "org", Platform: "plat",
+	}
+
+	ref, err := store.StoreContent(ctx, doc)
+	require.NoError(t, err)
+	assert.Equal(t, instanceName, ref.StorageInstance,
+		"StoreContent must stamp the component instance name (gh#400), matching the StoredMessage emit path")
+	assert.NotEqual(t, config.BucketName, ref.StorageInstance,
+		"StoreContent must NOT stamp the bucket name (the gh#400 bug)")
+}
+
+// TestIntegration_GH400_StoreContentDefaultsToBucketName locks the standalone
+// fallback: a Store constructed without an InstanceName (direct callers like
+// agentic-loop / graph-embedding that have no component instance name) stamps
+// the bucket name, preserving prior behavior so the instance is never empty.
+func TestIntegration_GH400_StoreContentDefaultsToBucketName(t *testing.T) {
+	natsClient := getSharedNATSClient(t)
+	ctx := context.Background()
+
+	config := objectstore.Config{BucketName: "TEST_GH400_DEFAULT"} // no InstanceName
+	store, err := objectstore.NewStoreWithConfig(ctx, natsClient, config)
+	require.NoError(t, err)
+	defer store.Close()
+
+	doc := &document.Document{
+		ID: "gh400-doc-002", Title: "Default Bucket", Description: "fallback",
+		Body: "verbatim body", Category: "test", OrgID: "org", Platform: "plat",
+	}
+
+	ref, err := store.StoreContent(ctx, doc)
+	require.NoError(t, err)
+	assert.Equal(t, config.BucketName, ref.StorageInstance,
+		"with no InstanceName, StoreContent defaults StorageInstance to the bucket name")
+}


### PR DESCRIPTION
## What

`message.StorageReference.StorageInstance` was stamped **two different ways** for the same logical objectstore:

| Path | Stamped value |
|---|---|
| `component.go` — StoredMessage emit | `c.instanceName` ✅ |
| `store.go` — `StoreContent` | `s.bucketName` ❌ (the bug) |

`StorageInstance` identifies the storage **component** ("enables federation across multiple storage instances"), so the component instance name is canonical. The divergence was latent until the fusion hydration deref helper (ADR-062 increment 4, #399) became the **first reader** — a resolver keyed on the instance name can't resolve refs stamped with the bucket name.

## Fix

Thread the component instance name into the Store and stamp it from `StoreContent`:

- `Config` gains `InstanceName` (`json:"-" schema:"-"` — internal wiring, like the existing pluggable generators). The objectstore Component sets it from `c.instanceName` before constructing the store, so **both write paths now stamp the same value**.
- `Store` carries `instanceName`, defaulting to `bucketName` when empty — **preserves prior behavior for standalone callers** (agentic-loop, graph-embedding construct a Store directly with no instance name) so the stamped instance is never empty.
- `StoreContent` stamps `s.instanceName`, not `s.bucketName`.
- `Store.InstanceName()` accessor exposes the stamped value.

## Tests (storage/objectstore, integration)

- `StoreContentStampsInstanceName` — InstanceName set distinct from bucket → StoreContent stamps the instance name (regression lock).
- `StoreContentDefaultsToBucketName` — no InstanceName → stamps the bucket name (standalone fallback preserved).
- `ComponentThreadsInstanceNameIntoStore` (white-box) — boots one component and asserts the store it built stamps the component instance name, not the bucket — guards the threading line so deleting it fails a test instead of silently re-introducing the bug.

## Safety

No behavior change for standalone Store callers (default to bucketName, as before); only the Component path now stamps its instance name. No existing consumer reads `StorageInstance` — #399 is the first — so this is pure framework-internal consistency. Verified: full `-race` unit suite, integration sweep across all Store consumers (storage, agentic-loop, graph-embedding, graph-ingest), zero schema drift.

`semstreams-reviewer`: **MERGE** (fix correct + threading verified end-to-end; the one MEDIUM coverage gap it flagged — the component-threading line — is now closed by the white-box test).

Closes #400. Part of ADR-062 (gh#376).

🤖 Generated with [Claude Code](https://claude.com/claude-code)