### PR TITLE
feat(fusion): predicate-salience ranking + ontology/salience ranker consumption (ADR-062 increment 5b, gh#396)

### DIFF
--- a/pkg/fusion/engine_lens.go
+++ b/pkg/fusion/engine_lens.go
@@ -26,13 +26,18 @@ const (
 )
 
 // Ranking weights. Resolve order (the graph's own index/semantic ranking) is the
-// base signal; lexical name match reorders locally. Ontology-coherence reordering
-// is gh#376 increment 5.
+// base signal; lexical name match reorders locally. Ontology specificity and
+// predicate salience (gh#376 increment 5) are SECONDARY reorderings folded in
+// only when RankSignals is attached — deliberately small next to resolveScale
+// (up to resolveScale×N) and lexExact so they break ties / nudge within a
+// resolve-lexical tier rather than dominating the graph's own ranking.
 const (
-	lexExact     = 40.0
-	lexPrefix    = 20.0
-	lexContains  = 8.0
-	resolveScale = 4.0 // base score per resolve-rank position
+	lexExact      = 40.0
+	lexPrefix     = 20.0
+	lexContains   = 8.0
+	resolveScale  = 4.0 // base score per resolve-rank position
+	ontologyScale = 1.5 // per ontology-depth level (class specificity)
+	salienceScale = 3.0 // per unit of an entity's max predicate salience
 )
 
 // ontologyClassPredicate is the stamped BFO/CCO class triple (semsource ADR-0005).
@@ -44,14 +49,24 @@ const ontologyClassPredicate = "entity.ontology.class"
 // Engine runs the lens-driven deterministic fusion pipeline over a
 // RetrievalClient, hydrating verbatim bodies through a BodyResolver.
 type Engine struct {
-	graph RetrievalClient
-	body  *BodyResolver
+	graph   RetrievalClient
+	body    *BodyResolver
+	signals RankSignals // optional; nil → resolve-order + lexical ranking only
 }
 
 // NewEngine builds a lens-driven engine. body may be nil — node bodies are then
 // omitted (the response degrades gracefully rather than panicking).
 func NewEngine(graph RetrievalClient, body *BodyResolver) *Engine {
 	return &Engine{graph: graph, body: body}
+}
+
+// WithSignals attaches the framework ranking signals — ontology specificity +
+// predicate salience (ADR-062 increment 5, gh#396) — folded into ranking on top
+// of resolve-order + lexical. Returns the engine for chaining. Passing nil (the
+// default) keeps ranking at resolve-order + lexical.
+func (e *Engine) WithSignals(s RankSignals) *Engine {
+	e.signals = s
+	return e
 }
 
 // Fuse resolves req against the graph through lens and returns the fused
@@ -86,7 +101,7 @@ func (e *Engine) Fuse(ctx context.Context, req Request, lens Lens) (Response, er
 	for i, ent := range entities {
 		names[i] = lens.Label(ent)
 	}
-	ranked := rankEntities(entities, names, req.Query)
+	ranked := e.rankEntities(entities, names, req.Query)
 
 	wants := wantSet(req.Want)
 	resp := Response{Index: status, Provenance: ProvenanceForMode(mode), ContractVersion: ContractVersion}
@@ -224,10 +239,11 @@ func lineRange(l [2]int) []int {
 }
 
 // rankEntities orders entities (given in resolve order) by resolve-rank base +
-// lexical name match. names[i] is entity[i]'s display name. Ontology-coherence
-// reordering is gh#376 increment 5; until then resolve order + lexical is the
-// deterministic signal.
-func rankEntities(entities []*Entity, names []string, query string) []*Entity {
+// lexical name match, plus — when RankSignals is attached (increment 5) —
+// ontology specificity and predicate salience as secondary reorderings.
+// names[i] is entity[i]'s display name. With no signals the result is exactly
+// resolve order + lexical (increments 1–4).
+func (e *Engine) rankEntities(entities []*Entity, names []string, query string) []*Entity {
 	q := strings.ToLower(strings.TrimSpace(query))
 	type scored struct {
 		e   *Entity
@@ -238,6 +254,10 @@ func rankEntities(entities []*Entity, names []string, query string) []*Entity {
 	for i, ent := range entities {
 		s := resolveScale * float64(len(entities)-i)
 		s += lexicalScore(q, strings.ToLower(names[i]))
+		if e.signals != nil {
+			s += ontologyScale * e.signals.ClassSpecificity(classOf(ent))
+			s += salienceScale * entitySalience(ent, e.signals)
+		}
 		arr[i] = scored{ent, s, i}
 	}
 	sort.SliceStable(arr, func(a, b int) bool {
@@ -251,6 +271,20 @@ func rankEntities(entities []*Entity, names []string, query string) []*Entity {
 		out[i] = arr[i].e
 	}
 	return out
+}
+
+// entitySalience is an entity's ranking salience: the maximum stored weight over
+// its predicates (the single most salient fact it carries). Max, not sum, so a
+// densely-annotated entity does not outrank a sharply-identified one purely on
+// fact count.
+func entitySalience(ent *Entity, sig RankSignals) float64 {
+	var best float64
+	for i := range ent.Triples {
+		if w := sig.PredicateSalience(ent.Triples[i].Predicate); w > best {
+			best = w
+		}
+	}
+	return best
 }
 
 // lexicalScore scores a name against a lowercased query.

--- a/pkg/fusion/engine_lens_test.go
+++ b/pkg/fusion/engine_lens_test.go
@@ -285,3 +285,86 @@ func TestEngine_NilBodyResolver(t *testing.T) {
 		t.Errorf("expected one node with empty body, got %+v", resp.Nodes)
 	}
 }
+
+// fakeSignals is an in-memory RankSignals for ranking tests.
+type fakeSignals struct {
+	depth    map[string]float64 // class IRI → specificity
+	salience map[string]float64 // predicate → weight
+}
+
+func (f fakeSignals) ClassSpecificity(iri string) float64 { return f.depth[iri] }
+func (f fakeSignals) PredicateSalience(p string) float64  { return f.salience[p] }
+
+// rankingPair sets up two entities A,B resolved in that order under a query with
+// NO lexical match, so ranking is pure resolve-order (A ahead of B by
+// resolveScale) unless a signal overcomes the gap.
+func rankingPair(aClass, bClass string, bExtra ...message.Triple) *fakeGraph {
+	a := entity("acme.ops.code.repo.symbol.Apple", "Apple", "a.go",
+		message.Triple{Predicate: "entity.ontology.class", Object: aClass})
+	bTriples := append([]message.Triple{{Predicate: "entity.ontology.class", Object: bClass}}, bExtra...)
+	b := entity("acme.ops.code.repo.symbol.Banana", "Banana", "b.go", bTriples...)
+	return &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"zzz": {a.ID, b.ID}},
+		entities: map[string]*fusion.Entity{a.ID: a, b.ID: b},
+	}
+}
+
+func topName(t *testing.T, eng *fusion.Engine) string {
+	t.Helper()
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "zzz"}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	if len(resp.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(resp.Nodes))
+	}
+	return resp.Nodes[0].Name
+}
+
+// TestEngine_NilSignals_ResolveOrderUnchanged: with no RankSignals, ranking is
+// exactly resolve-order — the increments 1–4 behavior (A resolved first wins).
+func TestEngine_NilSignals_ResolveOrderUnchanged(t *testing.T) {
+	g := rankingPair("http://x/Vague", "http://x/Specific")
+	eng := fusion.NewEngine(g, nil) // no signals
+	if got := topName(t, eng); got != "Apple" {
+		t.Errorf("top = %q, want Apple (resolve order, no signals)", got)
+	}
+}
+
+// TestEngine_Signals_OntologySpecificityReorders: B's deeper ontology class
+// overcomes the one-position resolve gap, so B reorders ahead of A.
+func TestEngine_Signals_OntologySpecificityReorders(t *testing.T) {
+	g := rankingPair("http://x/Vague", "http://x/Specific")
+	// resolve gap = resolveScale (4.0). ontologyScale*depth for B = 1.5*4 = 6 > 4.
+	sig := fakeSignals{depth: map[string]float64{"http://x/Vague": 0, "http://x/Specific": 4}}
+	eng := fusion.NewEngine(g, nil).WithSignals(sig)
+	if got := topName(t, eng); got != "Banana" {
+		t.Errorf("top = %q, want Banana (deeper ontology class reorders ahead)", got)
+	}
+}
+
+// TestEngine_Signals_PredicateSalienceReorders: B carries a high-salience
+// predicate that overcomes the resolve gap.
+func TestEngine_Signals_PredicateSalienceReorders(t *testing.T) {
+	g := rankingPair("http://x/Same", "http://x/Same",
+		message.Triple{Predicate: "acme.identity.serial", Object: "SN-1"})
+	// resolve gap = 4.0. salienceScale*weight for B = 3.0*2.0 = 6 > 4.
+	sig := fakeSignals{salience: map[string]float64{"acme.identity.serial": 2.0}}
+	eng := fusion.NewEngine(g, nil).WithSignals(sig)
+	if got := topName(t, eng); got != "Banana" {
+		t.Errorf("top = %q, want Banana (salient predicate reorders ahead)", got)
+	}
+}
+
+// TestEngine_Signals_TooSmallToReorder: a signal smaller than the resolve gap
+// does NOT flip order — signals are secondary reorderings, not overrides.
+func TestEngine_Signals_TooSmallToReorder(t *testing.T) {
+	g := rankingPair("http://x/Vague", "http://x/Specific")
+	// ontologyScale*1 = 1.5 < resolve gap 4.0 → A (resolved first) stays on top.
+	sig := fakeSignals{depth: map[string]float64{"http://x/Vague": 0, "http://x/Specific": 1}}
+	eng := fusion.NewEngine(g, nil).WithSignals(sig)
+	if got := topName(t, eng); got != "Apple" {
+		t.Errorf("top = %q, want Apple (sub-gap signal must not override resolve order)", got)
+	}
+}

--- a/pkg/fusion/fusionvocab/signals.go
+++ b/pkg/fusion/fusionvocab/signals.go
@@ -1,0 +1,50 @@
+// Package fusionvocab is the production implementation of fusion.RankSignals
+// (ADR-062 increment 5, gh#396): it wires the lens engine's ranking signals onto
+// the vocabulary registry (predicate salience) and the BFO/CCO subclass helper
+// (ontology specificity).
+//
+// It is a SUBPACKAGE of pkg/fusion deliberately: pkg/fusion is a near-leaf
+// (message only) so the engine stays deterministic and unit-testable without the
+// vocabulary/ontology packages. This is where the ranker's framework signals are
+// resolved against those packages — the same split as pkg/fusion/fusionnats for
+// the retrieval surface.
+package fusionvocab
+
+import (
+	"github.com/c360studio/semstreams/pkg/fusion"
+	"github.com/c360studio/semstreams/vocabulary"
+	"github.com/c360studio/semstreams/vocabulary/cco"
+)
+
+// Signals implements fusion.RankSignals over the framework's registries: ontology
+// specificity from the BFO/CCO subclass tree, predicate salience from the
+// vocabulary registry. Stateless — safe to share and pass by value.
+type Signals struct{}
+
+// Compile-time assertion that Signals satisfies the engine's ranking surface.
+var _ fusion.RankSignals = Signals{}
+
+// New returns a production RankSignals. (A trivial constructor for symmetry with
+// the other fusion wiring and to keep the seam explicit at call sites.)
+func New() Signals { return Signals{} }
+
+// ClassSpecificity scores an ontology class IRI by its subclass depth — the
+// number of ancestors up to the root — so a more specific class ranks higher.
+// cco.Parents resolves BOTH CCO and pure-BFO IRIs (it continues up the BFO tree
+// once it crosses the ontology boundary), so it is the single depth function for
+// either namespace. An empty or unknown IRI has depth 0.
+func (Signals) ClassSpecificity(classIRI string) float64 {
+	if classIRI == "" {
+		return 0
+	}
+	return float64(len(cco.Parents(classIRI)))
+}
+
+// PredicateSalience returns a predicate's stored salience weight from the
+// vocabulary registry (0 when unregistered or unweighted).
+func (Signals) PredicateSalience(predicate string) float64 {
+	if meta := vocabulary.GetPredicateMetadata(predicate); meta != nil {
+		return meta.Weight
+	}
+	return 0
+}

--- a/pkg/fusion/fusionvocab/signals_test.go
+++ b/pkg/fusion/fusionvocab/signals_test.go
@@ -1,0 +1,52 @@
+package fusionvocab
+
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/vocabulary"
+	"github.com/c360studio/semstreams/vocabulary/bfo"
+	"github.com/c360studio/semstreams/vocabulary/cco"
+)
+
+func TestClassSpecificity(t *testing.T) {
+	s := New()
+	cases := []struct {
+		iri  string
+		want float64
+	}{
+		{"", 0},                             // unset
+		{"http://example.com/NotAClass", 0}, // unknown
+		{bfo.Entity, 0},                     // root: no ancestors
+		{bfo.Object, 4},                     // Object→MaterialEntity→IndependentContinuant→Continuant→Entity
+		{cco.Sensor, 5},                     // Sensor→Artifact→MaterialEntity→IndependentContinuant→Continuant→Entity
+		{cco.Requirement, 5},                // Requirement→DirectiveICE→ICE→GDC→Continuant→Entity
+	}
+	for _, c := range cases {
+		if got := s.ClassSpecificity(c.iri); got != c.want {
+			t.Errorf("ClassSpecificity(%q) = %v, want %v", c.iri, got, c.want)
+		}
+	}
+	// Monotonicity: a subclass is strictly more specific than its ancestor.
+	if s.ClassSpecificity(cco.Sensor) <= s.ClassSpecificity(cco.Artifact) {
+		t.Error("Sensor should be more specific than its ancestor Artifact")
+	}
+}
+
+func TestPredicateSalience(t *testing.T) {
+	// Save/restore the global registry so the test is isolated.
+	t.Cleanup(vocabulary.SnapshotRegistry())
+
+	vocabulary.Register("test.identity.serial", vocabulary.WithWeight(2.5))
+	vocabulary.Register("test.meta.updated") // no weight → 0
+
+	s := New()
+	if got := s.PredicateSalience("test.identity.serial"); got != 2.5 {
+		t.Errorf("PredicateSalience(weighted) = %v, want 2.5", got)
+	}
+	if got := s.PredicateSalience("test.meta.updated"); got != 0 {
+		t.Errorf("PredicateSalience(unweighted) = %v, want 0", got)
+	}
+	if got := s.PredicateSalience("test.unregistered.field"); got != 0 {
+		t.Errorf("PredicateSalience(unregistered) = %v, want 0", got)
+	}
+}

--- a/pkg/fusion/rank_signals.go
+++ b/pkg/fusion/rank_signals.go
@@ -1,0 +1,22 @@
+package fusion
+
+// RankSignals supplies the framework ranking signals the lens engine folds into
+// rankEntities on top of resolve-order + lexical: ontology specificity and
+// predicate salience (ADR-062 increment 5, gh#396). Injected through an
+// interface so pkg/fusion stays a leaf (no vocabulary / bfo / cco imports);
+// production wires the vocabulary registry + BFO/CCO subclass helper (see
+// pkg/fusion/fusionvocab). A nil RankSignals leaves ranking at resolve-order +
+// lexical — the increments 1–4 behavior — so the signals are strictly additive.
+type RankSignals interface {
+	// ClassSpecificity scores how specific an ontology class IRI is: more
+	// specific (deeper in the BFO/CCO subclass tree) = higher; 0 for an
+	// unknown or unset class. A deeper class carries more information, so within
+	// the same resolve/lexical tier a precisely-typed entity reorders ahead of a
+	// vaguely-typed peer.
+	ClassSpecificity(classIRI string) float64
+
+	// PredicateSalience returns a predicate's stored salience weight (0 =
+	// neutral). Production reads vocabulary PredicateMetadata.Weight so an
+	// entity carrying more salient facts reorders ahead of a sparse peer.
+	PredicateSalience(predicate string) float64
+}

--- a/vocabulary/predicates.go
+++ b/vocabulary/predicates.go
@@ -414,7 +414,43 @@ type PredicateMetadata struct {
 	// avoids LLM-on-LLM checklist Goodhart by keeping content out of
 	// the rule-engine's branching surface.
 	RuleOpaque bool
+
+	// Role is the predicate's semantic role — a first-class, stored ranking
+	// signal (ADR-062 increment 5, gh#396 / semsource ask #2). Consumers (e.g.
+	// the deterministic fusion ranker) read it instead of pattern-matching
+	// predicate names. Empty (RoleUnspecified) when not declared. This is a
+	// semstreams ranking annotation, not an ontology assertion.
+	Role PredicateRole
+
+	// Weight is the predicate's salience weight for ranking (higher = more
+	// salient). 0 means unweighted (neutral). Lets a ranker prefer entities
+	// carrying more salient facts without hard-coding a per-product table.
+	Weight float64
 }
+
+// PredicateRole classifies a predicate's semantic role so a ranker can weigh
+// facts without pattern-matching predicate names (ADR-062 increment 5, semsource
+// ask #2). It is a semstreams ranking annotation, deliberately coarse — not an
+// ontology relation type.
+type PredicateRole string
+
+// The predicate roles. RoleUnspecified is the zero value (not declared).
+const (
+	// RoleUnspecified is the default — no declared role.
+	RoleUnspecified PredicateRole = ""
+	// RoleIdentity uniquely identifies the entity (ids, serials, keys).
+	RoleIdentity PredicateRole = "identity"
+	// RoleLabel is a human-facing display name or title.
+	RoleLabel PredicateRole = "label"
+	// RoleRelationship links the entity to another entity.
+	RoleRelationship PredicateRole = "relationship"
+	// RoleMetric is a measured or quantitative value.
+	RoleMetric PredicateRole = "metric"
+	// RoleDescriptive is free-form descriptive text about the entity.
+	RoleDescriptive PredicateRole = "descriptive"
+	// RoleMetadata is provenance / housekeeping (timestamps, versions, sources).
+	RoleMetadata PredicateRole = "metadata"
+)
 
 // IsValidPredicate checks if a predicate follows the three-level dotted notation
 // and matches the expected format: domain.category.property

--- a/vocabulary/registry.go
+++ b/vocabulary/registry.go
@@ -221,6 +221,30 @@ func WithSymmetric(symmetric bool) Option {
 	}
 }
 
+// WithRole declares the predicate's semantic role — a stored, first-class
+// ranking signal (ADR-062 increment 5, gh#396 / semsource ask #2). Consumers
+// read PredicateMetadata.Role instead of pattern-matching predicate names.
+//
+// Example:
+//
+//	Register("robotics.identity.serial",
+//	    WithRole(RoleIdentity),
+//	    WithWeight(1.0))
+func WithRole(role PredicateRole) Option {
+	return func(m *PredicateMetadata) {
+		m.Role = role
+	}
+}
+
+// WithWeight declares the predicate's salience weight (higher = more salient;
+// 0 = neutral). Lets a ranker prefer entities carrying more salient facts
+// without a per-product weight table (ADR-062 increment 5, semsource ask #2).
+func WithWeight(weight float64) Option {
+	return func(m *PredicateMetadata) {
+		m.Weight = weight
+	}
+}
+
 // Register registers a predicate with its metadata in the global registry.
 // This should be called during package initialization (init functions) by domain vocabularies.
 //

--- a/vocabulary/registry_test.go
+++ b/vocabulary/registry_test.go
@@ -326,3 +326,45 @@ func TestRegisterWithRuleOpaque(t *testing.T) {
 	// at registration time per ADR-036)
 	assert.False(t, IsRuleOpaque("test.unknown.field"))
 }
+
+// TestRegisterWithRoleAndWeight verifies the predicate-salience ranking signal
+// (ADR-062 increment 5, gh#396 / semsource ask #2) round-trips through the
+// registry: WithRole/WithWeight surface on PredicateMetadata, and undeclared
+// predicates default to RoleUnspecified / weight 0.
+func TestRegisterWithRoleAndWeight(t *testing.T) {
+	originalRegistry := make(map[string]PredicateMetadata)
+	registryMu.RLock()
+	for k, v := range predicateRegistry {
+		originalRegistry[k] = v
+	}
+	registryMu.RUnlock()
+	defer func() {
+		registryMu.Lock()
+		predicateRegistry = originalRegistry
+		registryMu.Unlock()
+	}()
+
+	ClearRegistry()
+
+	Register("test.identity.serial",
+		WithDescription("Serial number"),
+		WithRole(RoleIdentity),
+		WithWeight(1.0))
+
+	// A predicate registered without the salience options keeps the zero values.
+	Register("test.meta.updated",
+		WithDescription("Last update timestamp"))
+
+	meta := GetPredicateMetadata("test.identity.serial")
+	require.NotNil(t, meta)
+	assert.Equal(t, RoleIdentity, meta.Role)
+	assert.Equal(t, 1.0, meta.Weight)
+
+	neutral := GetPredicateMetadata("test.meta.updated")
+	require.NotNil(t, neutral)
+	assert.Equal(t, RoleUnspecified, neutral.Role, "undeclared role defaults to unspecified")
+	assert.Equal(t, 0.0, neutral.Weight, "undeclared weight defaults to 0 (neutral)")
+
+	// Unregistered predicates return nil metadata (no role/weight).
+	assert.Nil(t, GetPredicateMetadata("test.unknown.field"))
+}


### PR DESCRIPTION
## What

Completes **ADR-062 increment 5**: the lens engine's deterministic ranker now folds in the two framework ranking signals — **ontology specificity** (from the BFO/CCO subclass helper, #407) and **predicate salience** — instead of per-product heuristics.

### Vocabulary signal (semsource ask #2)
- `PredicateMetadata` gains `Role` (`PredicateRole` enum: identity/label/relationship/metric/descriptive/metadata) and `Weight`, with `WithRole`/`WithWeight` options on `Register`. Salience is now **stored** in the registry — consumers read it instead of pattern-matching predicate names (retires semsource's `status.go` stopgap).

### Ranker consumption (`pkg/fusion`)
- New `RankSignals` interface (`ClassSpecificity` + `PredicateSalience`), injected through the engine so **pkg/fusion stays a leaf** (no vocabulary/bfo/cco import — verified 0 vocabulary deps). Same seam pattern as `RetrievalClient`.
- `Engine.WithSignals` attaches them; `rankEntities` folds ontology specificity + an entity's **max** predicate salience in as **secondary reorderings** on top of resolve-order + lexical. Scales are deliberately small next to `resolveScale`/`lexExact` — signals break ties / nudge within a resolve tier, never override the graph's own ranking. **nil signals → exactly the increments 1–4 behavior** (strictly additive).
- `entitySalience` uses max (not sum) weight so a densely-annotated entity doesn't outrank a sharply-identified one on fact count.

### Production adapter
- `pkg/fusion/fusionvocab.Signals` implements `RankSignals` over the vocabulary registry (weights) + BFO/CCO subclass depth (`cco.Parents` resolves both CCO and pure-BFO IRIs). Subpackage, like `fusionnats`.

## Tests
Registry round-trip (Role/Weight defaults); engine ranker (nil-unchanged, ontology reorder, salience reorder, **sub-gap signal does NOT override**); adapter (class-depth values + monotonicity, predicate-weight lookup).

## Gates
Full `-race` unit suite, lint, gofmt, zero schema drift. pkg/fusion leaf purity verified.

Closes the **gh#396** pair (5a #407 + 5b here). Part of ADR-062 (gh#376).

🤖 Generated with [Claude Code](https://claude.com/claude-code)