### PR TITLE
fix(vocabulary): Register amends instead of replaces — stop silent role loss on re-Register (gh#410)

### DIFF
--- a/vocabulary/registry.go
+++ b/vocabulary/registry.go
@@ -245,12 +245,25 @@ func WithWeight(weight float64) Option {
 	}
 }
 
-// Register registers a predicate with its metadata in the global registry.
+// Register registers (or amends) a predicate's metadata in the global registry.
 // This should be called during package initialization (init functions) by domain vocabularies.
 //
 // The predicate name must follow three-level dotted notation: domain.category.property
 //
-// If a predicate is already registered, it will be overwritten (enables domain-specific overrides).
+// AMEND semantics (gh#410): a re-Register of an already-registered predicate
+// starts from the EXISTING metadata, then applies the given options. Options
+// override every field they set; fields the re-Register OMITS are RETAINED, not
+// cleared. This lets a product attach its own Description/IRI to a
+// framework-registered predicate WITHOUT silently stripping the framework's
+// declared roles (e.g. a WithAlias(AliasTypeLabel, …) on dc.terms.title, which
+// the NAME_INDEX / graph.query.byName / fusion-readiness path depends on). A
+// first registration starts from a zero struct, so single-registration behavior
+// is unchanged.
+//
+// Amend cannot CLEAR a field by omitting its option; pass the explicit zero
+// (WithRuleOpaque(false), WithWeight(0), WithDescription(""), …) to clear one.
+// The alias flag has no un-alias option; to fully REPLACE a registration
+// (including removing an alias role), use RegisterPredicate, which overwrites.
 //
 // Example:
 //
@@ -264,21 +277,21 @@ func Register(name string, opts ...Option) {
 	// Parse domain and category from name
 	domain, category := parseDomainCategory(name)
 
-	// Create base metadata
-	meta := PredicateMetadata{
-		Name:     name,
-		Domain:   domain,
-		Category: category,
-	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
 
-	// Apply functional options
+	// Seed from the existing registration when present (zero value if absent), so
+	// options amend rather than replace — a re-Register that omits a field keeps
+	// the previously-declared value instead of silently dropping it (gh#410).
+	meta := predicateRegistry[name]
+	meta.Name = name
+	meta.Domain = domain
+	meta.Category = category
+
+	// Apply functional options (each overrides the field it sets).
 	for _, opt := range opts {
 		opt(&meta)
 	}
-
-	// Store in registry (allows overriding framework defaults)
-	registryMu.Lock()
-	defer registryMu.Unlock()
 
 	predicateRegistry[name] = meta
 }

--- a/vocabulary/registry_test.go
+++ b/vocabulary/registry_test.go
@@ -254,6 +254,83 @@ func TestRegisterOverwrite(t *testing.T) {
 	assert.Equal(t, "test.rel.includes", meta.InverseOf)
 }
 
+// TestRegisterAmend_OmittedFieldsRetained is the gh#410 regression: a re-Register
+// that adds Description/IRI but OMITS the alias role must NOT strip that role.
+// The exact failure semsource hit converging pkg/fusion: re-registering
+// dc.terms.title with a description clobbered its label alias, so the NAME_INDEX
+// (and thus graph.query.byName + graph.index.query.status readiness) went empty.
+func TestRegisterAmend_OmittedFieldsRetained(t *testing.T) {
+	defer SnapshotRegistry()()
+	ClearRegistry()
+
+	// Framework registers a label predicate.
+	Register("dc.terms.title",
+		WithDescription("A name given to the resource"),
+		WithAlias(AliasTypeLabel, 1))
+
+	// A product re-registers to attach its own description/IRI — WITHOUT
+	// re-declaring the alias role (the footgun).
+	Register("dc.terms.title",
+		WithDescription("Product-specific title"),
+		WithIRI("http://purl.org/dc/terms/title"))
+
+	meta := GetPredicateMetadata("dc.terms.title")
+	require.NotNil(t, meta)
+	// New fields overrode.
+	assert.Equal(t, "Product-specific title", meta.Description)
+	assert.Equal(t, "http://purl.org/dc/terms/title", meta.StandardIRI)
+	// Omitted alias role RETAINED (the fix).
+	assert.True(t, meta.IsAlias, "label alias role must survive a role-less re-Register")
+	assert.Equal(t, AliasTypeLabel, meta.AliasType)
+	assert.Equal(t, 1, meta.AliasPriority)
+
+	// Downstream: DiscoverLabelPredicates (what graph-index keys the NAME_INDEX
+	// on) must still return the predicate — the actual signal the bug broke.
+	labels := DiscoverLabelPredicates()
+	priority, ok := labels["dc.terms.title"]
+	assert.True(t, ok, "DiscoverLabelPredicates must still return the re-registered label predicate")
+	assert.Equal(t, 1, priority)
+}
+
+// TestRegisterAmend_RoleAndWeightRetained guards the same clobber class for the
+// increment-5b ranking signals (#408): a re-Register omitting WithRole/WithWeight
+// must not strip a previously-declared salience.
+func TestRegisterAmend_RoleAndWeightRetained(t *testing.T) {
+	defer SnapshotRegistry()()
+	ClearRegistry()
+
+	Register("test.identity.serial",
+		WithRole(RoleIdentity),
+		WithWeight(1.5))
+
+	// Re-register with only a description.
+	Register("test.identity.serial",
+		WithDescription("Serial number"))
+
+	meta := GetPredicateMetadata("test.identity.serial")
+	require.NotNil(t, meta)
+	assert.Equal(t, "Serial number", meta.Description)
+	assert.Equal(t, RoleIdentity, meta.Role, "role must survive a role-less re-Register")
+	assert.Equal(t, 1.5, meta.Weight, "weight must survive a weight-less re-Register")
+}
+
+// TestRegisterAmend_OptionsStillOverride confirms amend does not prevent a
+// re-Register from CHANGING a field (options win over the retained value).
+func TestRegisterAmend_OptionsStillOverride(t *testing.T) {
+	defer SnapshotRegistry()()
+	ClearRegistry()
+
+	Register("test.rel.parent", WithAlias(AliasTypeLabel, 1), WithRuleOpaque(true))
+	// Re-register changing the alias priority and role-opacity is respected.
+	Register("test.rel.parent", WithAlias(AliasTypeIdentity, 5))
+
+	meta := GetPredicateMetadata("test.rel.parent")
+	require.NotNil(t, meta)
+	assert.Equal(t, AliasTypeIdentity, meta.AliasType, "changed alias type must override")
+	assert.Equal(t, 5, meta.AliasPriority, "changed priority must override")
+	assert.True(t, meta.RuleOpaque, "omitted RuleOpaque retained from prior registration")
+}
+
 func TestSymmetricWithIRI(t *testing.T) {
 	originalRegistry := make(map[string]PredicateMetadata)
 	registryMu.RLock()


### PR DESCRIPTION
## Problem

`vocabulary.Register` built a fresh zero `PredicateMetadata` and stored it, so a re-Register that **omitted** a previously-declared field silently dropped it. A product attaching its own description/IRI to a framework **label** predicate — e.g. re-registering `dc.terms.title` **without** re-declaring `WithAlias(AliasTypeLabel, …)` — stripped the label role. Downstream, with **no error**:

- `DiscoverLabelPredicates()` no longer returns it
- graph-index never writes it to the **NAME_INDEX**
- `graph.query.byName` resolves nothing for titles
- `graph.index.query.status` (gh#397) is stuck `building` forever (its ready signal is *NAME_INDEX non-empty*), so the **fusion honesty envelope never goes ready**

semsource hit exactly this converging `source/fusion` onto `pkg/fusion` (beta.122): `fusionnats` readiness pinned `Ready:false`, NAME_INDEX empty despite titled entities.

## Fix

`Register` now **amends**: it seeds from the existing registration (zero value if absent) and applies options on top.

- Options **override** every field they set; **omitted** fields are **retained**, not cleared.
- A first registration seeds from zero → single-registration behavior unchanged; only re-Register changes, in the safe direction.
- Explicit options still clear (`WithRuleOpaque(false)`, `WithWeight(0)`) — only **omission** retains.
- The read-modify-write is now under a single `registryMu.Lock`.

This also protects the increment-5b `Role`/`Weight` ranking signals (#408), which shared the identical clobber.

### Why amend over the alternatives (semsource's options 2/3)
- Fixes the footgun at the **root** — a naive plain-`Register` caller can no longer trip it (option 2's separate `Amend` verb doesn't protect them; option 3's warn-only doesn't fix it).
- Behavior-preserving for the common single-registration case.

## Tests

- `TestRegisterAmend_OmittedFieldsRetained` — label alias role **and the `DiscoverLabelPredicates` downstream** survive a role-less re-Register (the exact broken signal).
- `TestRegisterAmend_RoleAndWeightRetained` — #408 salience survives.
- `TestRegisterAmend_OptionsStillOverride` — changed alias type/priority win; omitted `RuleOpaque` retained.
- Existing `TestRegisterOverwrite` (override with new values) still passes.

## Validation

Full vocabulary unit suite (+ all predicate-registering subpackages); graph-index integration (the NAME_INDEX consumer) and rule integration both green in isolation; lint/gofmt clean; zero schema drift. Confirmed no real framework double-registrations (only doc-comment examples).

Closes #410. Surfaced by ADR-062 increment-6 convergence (#411).

🤖 Generated with [Claude Code](https://claude.com/claude-code)