### PR TITLE
feat(fusion): engine-computed Paths/Impact facets (ADR-062, gh#409)

### DIFF
--- a/pkg/fusion/contract.go
+++ b/pkg/fusion/contract.go
@@ -17,13 +17,12 @@ const ContractVersion = "1"
 // body plus immediate relations.
 type Want string
 
-// The requestable facets. (WantPaths/WantImpact are reserved for the facets
-// follow-on; the engine ignores them today.)
+// The requestable facets.
 const (
 	WantBody      Want = "body"      // verbatim source/passage
 	WantRelations Want = "relations" // callers/callees, links/sections
-	WantPaths     Want = "paths"     // bounded relation paths from the seed (deferred)
-	WantImpact    Want = "impact"    // transitive reverse-relation closure (deferred)
+	WantPaths     Want = "paths"     // bounded outgoing relation paths from the seeds
+	WantImpact    Want = "impact"    // transitive reverse-relation closure of the seeds
 )
 
 // Budget bounds a response. Zero fields take engine defaults.
@@ -105,11 +104,14 @@ type Miss struct {
 }
 
 // Response is the fused answer. Nodes is the payload; Index and Provenance are
-// the honesty envelope. (Paths/Impact facets are a deferred follow-on.)
+// the honesty envelope. Paths and Impact are optional facets, present only when
+// the request Wants them (WantPaths / WantImpact).
 type Response struct {
 	Index           IndexStatus `json:"index"`
 	Provenance      Provenance  `json:"provenance"`
 	Nodes           []Node      `json:"nodes,omitempty"`
+	Paths           []Path      `json:"paths,omitempty"`
+	Impact          *Impact     `json:"impact,omitempty"`
 	Misses          []Miss      `json:"misses,omitempty"`
 	Truncated       bool        `json:"truncated"`
 	ContractVersion string      `json:"contract_version"`

--- a/pkg/fusion/engine_facets.go
+++ b/pkg/fusion/engine_facets.go
@@ -1,0 +1,201 @@
+package fusion
+
+import "context"
+
+// Engine-computed Paths/Impact facets (ADR-062 gh#409). These are the outgoing/
+// incoming siblings of the relations facet the engine already owns: same bounded
+// RetrievalClient.Neighbors walk, generalized across lenses so a Want{Paths} or
+// Want{Impact} is honored the way WantRelations is — retiring the per-consumer
+// impact extensions (semsource's source/fusion/impact).
+
+// Path is a bounded outgoing relation walk from a seed, rendered as a sequence
+// of human names (never entity IDs), carried on Response.Paths. Truncated marks a
+// path cut short at the depth cap or a cycle — the partial path is kept, not
+// dropped.
+type Path struct {
+	Names     []string `json:"names"`
+	Truncated bool     `json:"truncated,omitempty"`
+}
+
+// Impact summarizes the transitive reverse-relation closure of the response's
+// seeds — the blast radius of changing them — carried on Response.Impact. It
+// counts distinct affected nodes and files (a lens Location path); Truncated
+// marks the node cap was hit, so the counts are a lower bound.
+type Impact struct {
+	Nodes     int  `json:"nodes"`
+	Files     int  `json:"files"`
+	Truncated bool `json:"truncated"`
+}
+
+// Facet bounds keep the walks cheap and predictable.
+const (
+	// maxImpactNodes caps the reverse-closure BFS; beyond it Impact.Truncated is
+	// set and the counts are a lower bound.
+	maxImpactNodes = 200
+	// maxPaths caps the total number of outgoing paths emitted.
+	maxPaths = 10
+	// maxPathDepth caps a path's length in hops (a path has up to maxPathDepth+1
+	// names).
+	maxPathDepth = 4
+)
+
+// computeImpact returns the transitive reverse-relation closure of the seeds —
+// the blast radius of changing them — as distinct affected-node and file counts.
+// It BFSes Neighbors(…, Incoming) along the lens's edge predicates, excluding the
+// seeds themselves, bounded by maxImpactNodes. Best-effort: a Neighbors/Entity
+// error prunes that branch rather than failing the fuse.
+func (e *Engine) computeImpact(ctx context.Context, seeds []*Entity, lens Lens) *Impact {
+	preds, _, _ := edgePredicates(lens.Edges())
+	imp := &Impact{}
+	if len(preds) == 0 {
+		return imp
+	}
+
+	seedSet := make(map[string]bool, len(seeds))
+	frontier := make([]string, 0, len(seeds))
+	for _, s := range seeds {
+		seedSet[s.ID] = true
+		frontier = append(frontier, s.ID)
+	}
+
+	affected := map[string]bool{}
+	files := map[string]bool{}
+	degraded := false
+	for len(frontier) > 0 {
+		var next []string
+		for _, id := range frontier {
+			edges, ok := e.neighbors(ctx, id, preds, Incoming)
+			if !ok {
+				degraded = true // a walk fault leaves the closure incomplete
+			}
+			for _, ed := range edges {
+				dep := ed.Target // Incoming target is the node pointing AT id
+				if seedSet[dep] || affected[dep] {
+					continue
+				}
+				if len(affected) >= maxImpactNodes {
+					imp.Nodes, imp.Files, imp.Truncated = len(affected), len(files), true
+					return imp
+				}
+				affected[dep] = true
+				if p := e.pathOf(ctx, dep, lens); p != "" {
+					files[p] = true
+				}
+				next = append(next, dep)
+			}
+		}
+		frontier = next
+	}
+	// Truncated is the honesty signal that counts are a lower bound — set it on
+	// either the node cap OR a walk fault (degrade-don't-fail must not masquerade
+	// as an exact closure).
+	imp.Nodes, imp.Files, imp.Truncated = len(affected), len(files), degraded
+	return imp
+}
+
+// computePaths returns up to maxPaths bounded outgoing relation paths from the
+// seeds, each a sequence of human names. DFS over Neighbors(…, Outgoing) along
+// the lens's edge predicates, depth-capped; a cycle truncates that branch (kept,
+// not dropped).
+func (e *Engine) computePaths(ctx context.Context, seeds []*Entity, lens Lens) []Path {
+	preds, _, _ := edgePredicates(lens.Edges())
+	if len(preds) == 0 {
+		return nil
+	}
+	var out []Path
+	for _, s := range seeds {
+		if len(out) >= maxPaths {
+			break
+		}
+		e.dfsPaths(ctx, s.ID, lens, preds, []string{lens.Label(s)}, map[string]bool{s.ID: true}, &out)
+	}
+	return out
+}
+
+// dfsPaths walks outgoing edges from id, emitting a Path at each terminal: a leaf
+// (no forward edges), the depth cap, or a branch whose only continuations are
+// cycles (emitted Truncated). Forward edges are followed; cycle edges are not
+// (no infinite loop), so a node with both forward and cycle edges follows the
+// forward ones without a spurious truncated emit.
+func (e *Engine) dfsPaths(ctx context.Context, id string, lens Lens, preds []string, path []string, onPath map[string]bool, out *[]Path) {
+	if len(*out) >= maxPaths {
+		return
+	}
+	if len(path)-1 >= maxPathDepth { // depth cap in hops
+		*out = append(*out, Path{Names: clonePath(path), Truncated: true})
+		return
+	}
+
+	edges, ok := e.neighbors(ctx, id, preds, Outgoing)
+	if !ok {
+		// Walk fault mid-path: keep the partial path, marked truncated (honest
+		// about incompleteness rather than emitting it as a complete leaf).
+		if len(path) > 1 {
+			*out = append(*out, Path{Names: clonePath(path), Truncated: true})
+		}
+		return
+	}
+
+	var forward []Edge
+	cycle := false
+	for _, ed := range edges {
+		if onPath[ed.Target] {
+			cycle = true
+			continue
+		}
+		forward = append(forward, ed)
+	}
+
+	if len(forward) == 0 {
+		// Leaf, or a branch whose only continuations loop. Don't emit a
+		// single-name path (the seed alone is not a relation path).
+		if len(path) > 1 {
+			*out = append(*out, Path{Names: clonePath(path), Truncated: cycle})
+		}
+		return
+	}
+
+	for _, ed := range forward {
+		if len(*out) >= maxPaths {
+			return
+		}
+		name := e.nameOf(ctx, ed.Target, lens)
+		onPath[ed.Target] = true
+		e.dfsPaths(ctx, ed.Target, lens, preds, append(clonePath(path), name), onPath, out)
+		onPath[ed.Target] = false
+	}
+}
+
+// neighbors returns the edges from id in a direction and whether the fetch
+// succeeded. A fault yields (nil, false) — the caller prunes the walk rather
+// than failing the fuse (degrade-don't-fail), but records the incompleteness in
+// the facet's Truncated flag so a partial result is never reported as exact.
+func (e *Engine) neighbors(ctx context.Context, id string, preds []string, dir Direction) ([]Edge, bool) {
+	edges, err := e.graph.Neighbors(ctx, id, preds, dir)
+	if err != nil {
+		return nil, false
+	}
+	return edges, true
+}
+
+// nameOf resolves an entity ID to its human name via the lens, falling back to
+// the ID when the entity can't be fetched.
+func (e *Engine) nameOf(ctx context.Context, id string, lens Lens) string {
+	if te, err := e.graph.Entity(ctx, id); err == nil && te != nil {
+		return lens.Label(te)
+	}
+	return id
+}
+
+// pathOf resolves an entity ID to its lens Location path, or "" when absent.
+func (e *Engine) pathOf(ctx context.Context, id string, lens Lens) string {
+	if te, err := e.graph.Entity(ctx, id); err == nil && te != nil {
+		return lens.Location(te).Path
+	}
+	return ""
+}
+
+// clonePath copies a name slice so appends on recursive branches don't alias.
+func clonePath(p []string) []string {
+	return append([]string(nil), p...)
+}

--- a/pkg/fusion/engine_facets_test.go
+++ b/pkg/fusion/engine_facets_test.go
@@ -1,0 +1,325 @@
+package fusion_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/fusion"
+)
+
+const refEdgePred = "ref.relationship.references"
+
+func edge(target string) fusion.Edge {
+	return fusion.Edge{Predicate: refEdgePred, Target: target}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// facetGraph builds a fakeGraph whose single seed "S" resolves under query "q",
+// with caller-supplied outgoing/incoming adjacency and entity set.
+func facetGraph(out, in map[string][]fusion.Edge, entities map[string]*fusion.Entity) *fakeGraph {
+	return &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"q": {"S"}},
+		entities: entities,
+		out:      out,
+		in:       in,
+	}
+}
+
+func fuseFacet(t *testing.T, g *fakeGraph, want fusion.Want) fusion.Response {
+	t.Helper()
+	eng := fusion.NewEngine(g, nil)
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "q", Want: []fusion.Want{want}}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	return resp
+}
+
+// --- Impact: transitive reverse-relation closure ---
+
+func TestImpact_TransitiveClosureCountsNodesAndFiles(t *testing.T) {
+	// S ← A, S ← B, A ← C. Reverse closure of S = {A,B,C}; seed S excluded.
+	entities := map[string]*fusion.Entity{
+		"S": entity("S", "S", "s.go"),
+		"A": entity("A", "A", "a.go"),
+		"B": entity("B", "B", "b.go"),
+		"C": entity("C", "C", "c.go"),
+	}
+	in := map[string][]fusion.Edge{
+		"S": {edge("A"), edge("B")}, // A and B point at S
+		"A": {edge("C")},            // C points at A
+	}
+	g := facetGraph(nil, in, entities)
+
+	resp := fuseFacet(t, g, fusion.WantImpact)
+	if resp.Impact == nil {
+		t.Fatal("Impact facet missing")
+	}
+	if resp.Impact.Nodes != 3 {
+		t.Errorf("Impact.Nodes = %d, want 3 (A,B,C; seed excluded)", resp.Impact.Nodes)
+	}
+	if resp.Impact.Files != 3 {
+		t.Errorf("Impact.Files = %d, want 3 (a.go,b.go,c.go)", resp.Impact.Files)
+	}
+	if resp.Impact.Truncated {
+		t.Error("Impact.Truncated = true, want false (well under cap)")
+	}
+}
+
+func TestImpact_ExcludesSeedAndDedupes(t *testing.T) {
+	// Diamond: S ← A, S ← B, A ← D, B ← D (D reaches S two ways) + a self-ref
+	// S ← S that must not count the seed.
+	entities := map[string]*fusion.Entity{
+		"S": entity("S", "S", "s.go"),
+		"A": entity("A", "A", "a.go"),
+		"B": entity("B", "B", "b.go"),
+		"D": entity("D", "D", "d.go"),
+	}
+	in := map[string][]fusion.Edge{
+		"S": {edge("A"), edge("B"), edge("S")}, // self-edge must be ignored
+		"A": {edge("D")},
+		"B": {edge("D")}, // D discovered once (dedup)
+	}
+	g := facetGraph(nil, in, entities)
+
+	resp := fuseFacet(t, g, fusion.WantImpact)
+	if resp.Impact.Nodes != 3 {
+		t.Errorf("Impact.Nodes = %d, want 3 (A,B,D; seed + dup excluded)", resp.Impact.Nodes)
+	}
+}
+
+func TestImpact_NotRequestedIsNil(t *testing.T) {
+	entities := map[string]*fusion.Entity{"S": entity("S", "S", "s.go")}
+	in := map[string][]fusion.Edge{"S": {edge("A")}}
+	g := facetGraph(nil, in, entities)
+
+	resp := fuseFacet(t, g, fusion.WantRelations) // not WantImpact
+	if resp.Impact != nil {
+		t.Errorf("Impact = %+v, want nil (not requested)", resp.Impact)
+	}
+}
+
+// --- Paths: bounded outgoing DFS ---
+
+func TestPaths_LinearChain(t *testing.T) {
+	// S → A → B (leaf).
+	entities := map[string]*fusion.Entity{
+		"S": entity("S", "S", "s.go"),
+		"A": entity("A", "A", "a.go"),
+		"B": entity("B", "B", "b.go"),
+	}
+	out := map[string][]fusion.Edge{
+		"S": {edge("A")},
+		"A": {edge("B")},
+	}
+	g := facetGraph(out, nil, entities)
+
+	resp := fuseFacet(t, g, fusion.WantPaths)
+	if len(resp.Paths) != 1 {
+		t.Fatalf("got %d paths, want 1", len(resp.Paths))
+	}
+	if want := []string{"S", "A", "B"}; !equalStrings(resp.Paths[0].Names, want) {
+		t.Errorf("path = %v, want %v", resp.Paths[0].Names, want)
+	}
+	if resp.Paths[0].Truncated {
+		t.Error("linear chain path must not be truncated")
+	}
+}
+
+func TestPaths_BranchesEmitOnePerLeaf(t *testing.T) {
+	// S → {A, B}, both leaves.
+	entities := map[string]*fusion.Entity{
+		"S": entity("S", "S", "s.go"),
+		"A": entity("A", "A", "a.go"),
+		"B": entity("B", "B", "b.go"),
+	}
+	out := map[string][]fusion.Edge{"S": {edge("A"), edge("B")}}
+	g := facetGraph(out, nil, entities)
+
+	resp := fuseFacet(t, g, fusion.WantPaths)
+	if len(resp.Paths) != 2 {
+		t.Fatalf("got %d paths, want 2", len(resp.Paths))
+	}
+	got := map[string]bool{}
+	for _, p := range resp.Paths {
+		got[p.Names[len(p.Names)-1]] = true
+	}
+	if !got["A"] || !got["B"] {
+		t.Errorf("paths should end at A and B, got %v", resp.Paths)
+	}
+}
+
+func TestPaths_CycleTruncatedNotDropped(t *testing.T) {
+	// S → A → S (cycle back to seed). A's only forward edge loops → truncate.
+	entities := map[string]*fusion.Entity{
+		"S": entity("S", "S", "s.go"),
+		"A": entity("A", "A", "a.go"),
+	}
+	out := map[string][]fusion.Edge{
+		"S": {edge("A")},
+		"A": {edge("S")}, // back to seed (on path)
+	}
+	g := facetGraph(out, nil, entities)
+
+	resp := fuseFacet(t, g, fusion.WantPaths)
+	if len(resp.Paths) != 1 {
+		t.Fatalf("got %d paths, want 1 (cycle kept, not dropped)", len(resp.Paths))
+	}
+	if want := []string{"S", "A"}; !equalStrings(resp.Paths[0].Names, want) {
+		t.Errorf("path = %v, want %v", resp.Paths[0].Names, want)
+	}
+	if !resp.Paths[0].Truncated {
+		t.Error("cycle path must be marked Truncated")
+	}
+}
+
+func TestPaths_DepthCapTruncates(t *testing.T) {
+	// Chain longer than maxPathDepth (4 hops): S→A→B→C→D→E. Path cut at 4 hops.
+	entities := map[string]*fusion.Entity{}
+	out := map[string][]fusion.Edge{}
+	chain := []string{"S", "A", "B", "C", "D", "E"}
+	for i, id := range chain {
+		entities[id] = entity(id, id, id+".go")
+		if i+1 < len(chain) {
+			out[id] = []fusion.Edge{edge(chain[i+1])}
+		}
+	}
+	g := facetGraph(out, nil, entities)
+
+	resp := fuseFacet(t, g, fusion.WantPaths)
+	if len(resp.Paths) != 1 {
+		t.Fatalf("got %d paths, want 1", len(resp.Paths))
+	}
+	// 4 hops → 5 names (S,A,B,C,D), truncated before E.
+	if want := []string{"S", "A", "B", "C", "D"}; !equalStrings(resp.Paths[0].Names, want) {
+		t.Errorf("path = %v, want %v (depth-capped)", resp.Paths[0].Names, want)
+	}
+	if !resp.Paths[0].Truncated {
+		t.Error("depth-capped path must be marked Truncated")
+	}
+}
+
+func TestPaths_ForwardAndCycleFollowsForward(t *testing.T) {
+	// A has both a forward edge (→B, leaf) and a cycle edge (→S, on path). The
+	// forward path is followed and emitted UNtruncated; no spurious truncated
+	// emit for the cycle branch.
+	entities := map[string]*fusion.Entity{
+		"S": entity("S", "S", "s.go"),
+		"A": entity("A", "A", "a.go"),
+		"B": entity("B", "B", "b.go"),
+	}
+	out := map[string][]fusion.Edge{
+		"S": {edge("A")},
+		"A": {edge("B"), edge("S")}, // forward to B, cycle back to S
+	}
+	g := facetGraph(out, nil, entities)
+
+	resp := fuseFacet(t, g, fusion.WantPaths)
+	if len(resp.Paths) != 1 {
+		t.Fatalf("got %d paths, want 1 (forward followed, cycle not a separate emit)", len(resp.Paths))
+	}
+	if want := []string{"S", "A", "B"}; !equalStrings(resp.Paths[0].Names, want) {
+		t.Errorf("path = %v, want %v", resp.Paths[0].Names, want)
+	}
+	if resp.Paths[0].Truncated {
+		t.Error("a branch with a forward continuation must not be marked Truncated")
+	}
+}
+
+func TestPaths_MaxPathsCap(t *testing.T) {
+	// A star with many leaves (> maxPaths) must emit exactly maxPaths(10) paths.
+	entities := map[string]*fusion.Entity{"S": entity("S", "S", "s.go")}
+	var star []fusion.Edge
+	for i := range 25 {
+		id := "leaf" + string(rune('A'+i))
+		entities[id] = entity(id, id, id+".go")
+		star = append(star, edge(id))
+	}
+	g := facetGraph(map[string][]fusion.Edge{"S": star}, nil, entities)
+
+	resp := fuseFacet(t, g, fusion.WantPaths)
+	if len(resp.Paths) != 10 {
+		t.Errorf("got %d paths, want exactly maxPaths=10", len(resp.Paths))
+	}
+}
+
+func TestImpact_NodeCapTruncates(t *testing.T) {
+	// A fan of > maxImpactNodes(200) dependents all pointing at S. Impact caps at
+	// 200 with Truncated set.
+	entities := map[string]*fusion.Entity{"S": entity("S", "S", "s.go")}
+	var deps []fusion.Edge
+	for i := range 250 {
+		id := "dep" + string(rune(i))
+		entities[id] = entity(id, id, id+".go")
+		deps = append(deps, edge(id))
+	}
+	g := facetGraph(nil, map[string][]fusion.Edge{"S": deps}, entities)
+
+	resp := fuseFacet(t, g, fusion.WantImpact)
+	if resp.Impact.Nodes != 200 {
+		t.Errorf("Impact.Nodes = %d, want 200 (capped)", resp.Impact.Nodes)
+	}
+	if !resp.Impact.Truncated {
+		t.Error("Impact.Truncated must be set when the node cap is hit")
+	}
+}
+
+func TestImpact_WalkFaultIsTruncatedNotExact(t *testing.T) {
+	// A Neighbors backend fault must surface as Truncated (counts are a lower
+	// bound), NOT a silent exact-looking zero — the honesty-envelope contract.
+	g := facetGraph(nil, nil, map[string]*fusion.Entity{"S": entity("S", "S", "s.go")})
+	g.neighborsErr = errors.New("backend down")
+
+	resp := fuseFacet(t, g, fusion.WantImpact)
+	if resp.Impact == nil {
+		t.Fatal("Impact facet missing")
+	}
+	if !resp.Impact.Truncated {
+		t.Error("a Neighbors fault must set Impact.Truncated (partial result, not exact)")
+	}
+}
+
+func TestPaths_WalkFaultTruncatesPartialPath(t *testing.T) {
+	// S → A, but Neighbors faults: the seed's own walk fails, so no path is
+	// emitted (nothing beyond the seed is known); a fault deeper would truncate.
+	entities := map[string]*fusion.Entity{
+		"S": entity("S", "S", "s.go"),
+		"A": entity("A", "A", "a.go"),
+	}
+	g := facetGraph(map[string][]fusion.Edge{"S": {edge("A")}}, nil, entities)
+	g.neighborsErr = errors.New("backend down")
+
+	resp := fuseFacet(t, g, fusion.WantPaths)
+	// The seed's Neighbors fails → len(path)==1 → no emit (a single-name path is
+	// never emitted). The point: no PANIC and no false complete path.
+	if len(resp.Paths) != 0 {
+		t.Errorf("got %d paths, want 0 (seed walk faulted before any hop)", len(resp.Paths))
+	}
+}
+
+func TestPaths_NotRequestedIsNil(t *testing.T) {
+	entities := map[string]*fusion.Entity{
+		"S": entity("S", "S", "s.go"),
+		"A": entity("A", "A", "a.go"),
+	}
+	out := map[string][]fusion.Edge{"S": {edge("A")}}
+	g := facetGraph(out, nil, entities)
+
+	resp := fuseFacet(t, g, fusion.WantRelations) // not WantPaths
+	if resp.Paths != nil {
+		t.Errorf("Paths = %v, want nil (not requested)", resp.Paths)
+	}
+}

--- a/pkg/fusion/engine_lens.go
+++ b/pkg/fusion/engine_lens.go
@@ -109,6 +109,14 @@ func (e *Engine) Fuse(ctx context.Context, req Request, lens Lens) (Response, er
 	if len(resp.Nodes) == 0 {
 		resp.Misses = []Miss{{Query: req.Query}}
 	}
+	// Optional facets, computed from the ranked seeds (not the display-budgeted
+	// nodes) so they describe the query's structure, not the page.
+	if wants[WantImpact] {
+		resp.Impact = e.computeImpact(ctx, ranked, lens)
+	}
+	if wants[WantPaths] {
+		resp.Paths = e.computePaths(ctx, ranked, lens)
+	}
 	return resp, nil
 }
 

--- a/pkg/fusion/engine_lens_test.go
+++ b/pkg/fusion/engine_lens_test.go
@@ -12,15 +12,16 @@ import (
 // fakeGraph is an in-memory RetrievalClient for lens-driven engine tests — no
 // NATS, deterministic inputs. Error fields inject backend failures.
 type fakeGraph struct {
-	status     fusion.IndexStatus
-	seeds      map[string][]string       // query → seed IDs
-	entities   map[string]*fusion.Entity // id → entity
-	out        map[string][]fusion.Edge  // id → outgoing edges
-	in         map[string][]fusion.Edge  // id → incoming edges
-	names      []string                  // did_you_mean suggestions
-	statusErr  error
-	resolveErr error
-	entErr     error
+	status       fusion.IndexStatus
+	seeds        map[string][]string       // query → seed IDs
+	entities     map[string]*fusion.Entity // id → entity
+	out          map[string][]fusion.Edge  // id → outgoing edges
+	in           map[string][]fusion.Edge  // id → incoming edges
+	names        []string                  // did_you_mean suggestions
+	statusErr    error
+	resolveErr   error
+	entErr       error
+	neighborsErr error
 }
 
 func (g *fakeGraph) Status(context.Context) (fusion.IndexStatus, error) {
@@ -45,6 +46,9 @@ func (g *fakeGraph) Entities(_ context.Context, ids []string) ([]*fusion.Entity,
 	return out, nil
 }
 func (g *fakeGraph) Neighbors(_ context.Context, id string, _ []string, dir fusion.Direction) ([]fusion.Edge, error) {
+	if g.neighborsErr != nil {
+		return nil, g.neighborsErr
+	}
 	if dir == fusion.Outgoing {
 		return g.out[id], nil
 	}


### PR DESCRIPTION
## What

The lens-driven engine reserved `WantPaths`/`WantImpact` in the contract but ignored them (deferred follow-on). This lifts them into the engine so a `Want{Paths,Impact}` is honored the way `WantRelations` is — the outgoing/incoming siblings of the relations facet, same bounded `RetrievalClient.Neighbors` walk, generalized across lenses. **Retires semsource's local `source/fusion/impact` extension** (their `code_context` "impact" verb) — the point of the increment-6 convergence (#411).

- **Impact** — transitive reverse-relation closure of the ranked seeds (BFS over `Neighbors(…, Incoming)` along the lens edge predicates), excluding the seeds, bounded by `maxImpactNodes(200)`. Summarizes `{nodes, files, truncated}` (counts are a lower bound when truncated). Matches semsource's shipped shape.
- **Paths** — up to `maxPaths(10)` bounded outgoing DFS name-sequences, depth-capped at `maxPathDepth(4)` hops. Cycles are **truncated (kept, not dropped)**; forward edges are followed while a purely-cyclic branch emits a `Truncated` path — no infinite loop.

## Design

- Computed from the **ranked seeds** (not the display-budgeted nodes) so they describe the query's structure, not the page; **opt-in** (zero cost unless the request Wants them).
- **Degrade-don't-fail** like relations: a `Neighbors`/`Entity` error prunes that branch rather than failing the fuse.
- `Response` gains `Paths []Path` + `Impact *Impact` (both `omitempty`). **`ContractVersion` stays "1"** — the facets were already *reserved* in the `Want` enum, so this completes the reserved contract additively (no breaking bump).
- Facet types + computation live in `engine_facets.go`; **pkg/fusion stays a leaf** (only `context` imported).

## Tests

Transitive-closure node/file counts + seed-exclusion/dedup; linear, branch, cycle-truncated, and depth-capped paths; facets absent unless requested. Full `-race` suite, lint, gofmt clean; zero schema drift.

Closes #409. Part of ADR-062 (gh#376) / increment-6 convergence (#411).

🤖 Generated with [Claude Code](https://claude.com/claude-code)