### PR TITLE
fix(graph-embedding): make offloaded-content exclusion loud, not silent (gh#414)

### DIFF
--- a/processor/graph-embedding/component.go
+++ b/processor/graph-embedding/component.go
@@ -200,10 +200,14 @@ type Component struct {
 	modelRegistry model.RegistryReader
 
 	// Domain resources
-	embedder           embedding.Embedder
-	storage            *embedding.Storage
-	worker             *embedding.Worker
-	contentStore       *objectstore.Store // ContentStorable access (owned lifecycle)
+	embedder     embedding.Embedder
+	storage      *embedding.Storage
+	worker       *embedding.Worker
+	contentStore *objectstore.Store // ContentStorable access (owned lifecycle)
+	// noContentStoreWarn fires the "offloaded content excluded, no content store
+	// wired" warning exactly once (gh#414) — the per-entity metric carries the
+	// count; the log stays a single actionable line rather than a flood.
+	noContentStoreWarn sync.Once
 	embeddingBucket    jetstream.KeyValue
 	entityCoalescer    *cache.CoalescingSet
 	entityStatesBucket jetstream.KeyValue
@@ -974,9 +978,7 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 		return
 	}
 	if entityState.StorageRef != nil {
-		c.logger.Debug("entity has StorageRef but no content store is configured; "+
-			"falling back to inline text extraction",
-			slog.String("entity", entityID))
+		c.reportOffloadedContentExcluded(entityID, entityState.StorageRef.StorageInstance)
 	}
 
 	// Legacy path: Extract text from triples
@@ -1012,6 +1014,30 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 // context). Configs WITH a content store are unaffected.
 func (c *Component) shouldFetchViaStorageRef(state *graph.EntityState) bool {
 	return state.StorageRef != nil && c.contentStore != nil
+}
+
+// reportOffloadedContentExcluded makes the silent-loss case observable (gh#414):
+// an entity carries a StorageRef (its BODY is offloaded to a store, NOT inline)
+// but no content store is wired, so the inline fallback cannot see that body and
+// it is EXCLUDED from the embedding (and thus BM25/search). The entity may still
+// be embedded from any inline text triples it carries — only the offloaded body
+// is lost. A per-entity metric carries the count; the warning fires once so the
+// log is a single actionable line, not a flood. Fix on the operator side: wire a
+// store-read port for the StorageInstance that produced the content.
+func (c *Component) reportOffloadedContentExcluded(entityID, storageInstance string) {
+	if c.metrics != nil {
+		c.metrics.recordContentUnresolved()
+	}
+	c.noContentStoreWarn.Do(func() {
+		c.logger.Warn("offloaded body EXCLUDED from embeddings: entity carries a "+
+			"StorageRef but no content store is wired — wire a store-read port for its "+
+			"StorageInstance to embed offloaded bodies (inline text, if any, is still "+
+			"embedded) (gh#414)",
+			slog.String("entity", entityID),
+			slog.String("storage_instance", storageInstance))
+	})
+	c.logger.Debug("entity has StorageRef but no content store; inline fallback",
+		slog.String("entity", entityID))
 }
 
 // queueEmbeddingWithStorageRef queues an embedding using ContentStorable pattern

--- a/processor/graph-embedding/metrics.go
+++ b/processor/graph-embedding/metrics.go
@@ -16,6 +16,12 @@ type embeddingMetrics struct {
 	embeddingDedupHits  prometheus.Counter
 	embeddingPending    prometheus.Gauge
 	kvOperations        *prometheus.CounterVec
+	// contentUnresolved counts entities whose offloaded BODY (a StorageRef)
+	// could not be fetched because no content store is wired, so that body was
+	// excluded from the embedding (gh#414). The entity may still be embedded from
+	// any inline text triples it carries; a rising value means offloaded body
+	// text is being dropped from embeddings — wire a store-read port.
+	contentUnresolved prometheus.Counter
 }
 
 // Package-level metrics (registered once to avoid duplicate registration errors)
@@ -69,6 +75,13 @@ func getMetrics(registry *metric.MetricsRegistry) *embeddingMetrics {
 				Name:      "pending",
 				Help:      "Current number of pending embeddings",
 			}),
+
+			contentUnresolved: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_embedding",
+				Name:      "content_unresolved_total",
+				Help:      "Entities whose offloaded body (StorageRef) was excluded from embedding because no content store is wired; inline text, if any, is still embedded (gh#414)",
+			}),
 		}
 
 		// Register metrics with the metrics registry if available
@@ -79,6 +92,7 @@ func getMetrics(registry *metric.MetricsRegistry) *embeddingMetrics {
 			_ = registry.RegisterCounterVec("graph-embedding", "kv_operations_total", metrics.kvOperations)
 			_ = registry.RegisterCounter("graph-embedding", "dedup_hits_total", metrics.embeddingDedupHits)
 			_ = registry.RegisterGauge("graph-embedding", "pending", metrics.embeddingPending)
+			_ = registry.RegisterCounter("graph-embedding", "content_unresolved_total", metrics.contentUnresolved)
 		} else {
 			// Fallback to default prometheus registry for testing
 			_ = prometheus.DefaultRegisterer.Register(metrics.embedderType)
@@ -87,6 +101,7 @@ func getMetrics(registry *metric.MetricsRegistry) *embeddingMetrics {
 			_ = prometheus.DefaultRegisterer.Register(metrics.kvOperations)
 			_ = prometheus.DefaultRegisterer.Register(metrics.embeddingDedupHits)
 			_ = prometheus.DefaultRegisterer.Register(metrics.embeddingPending)
+			_ = prometheus.DefaultRegisterer.Register(metrics.contentUnresolved)
 		}
 	})
 	return metrics
@@ -125,6 +140,12 @@ func (m *embeddingMetrics) recordKVOperation(operation, bucket string) {
 // recordDedupHit increments the deduplication hits counter.
 func (m *embeddingMetrics) recordDedupHit() {
 	m.embeddingDedupHits.Inc()
+}
+
+// recordContentUnresolved increments the counter for offloaded content that was
+// excluded from embedding because no content store is wired (gh#414).
+func (m *embeddingMetrics) recordContentUnresolved() {
+	m.contentUnresolved.Inc()
 }
 
 // setPending sets the pending embeddings gauge.

--- a/processor/graph-embedding/storageref_fallback_test.go
+++ b/processor/graph-embedding/storageref_fallback_test.go
@@ -1,8 +1,12 @@
 package graphembedding
 
 import (
+	"context"
+	"log/slog"
+	"sync/atomic"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/c360studio/semstreams/graph"
@@ -88,4 +92,40 @@ func TestExtractTextForEmbedding_RecoversInlineContentForStorageRefEntity(t *tes
 	assert.NotEmpty(t, got, "inline content triples must still be extractable so the no-content-store fallback can embed")
 	assert.Contains(t, got, "Hydraulic pump service")
 	assert.Contains(t, got, "Replaced seals")
+}
+
+// warnCounter is a slog handler that counts Warn+ records.
+type warnCounter struct{ n atomic.Int64 }
+
+func (h *warnCounter) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *warnCounter) Handle(_ context.Context, r slog.Record) error {
+	if r.Level >= slog.LevelWarn {
+		h.n.Add(1)
+	}
+	return nil
+}
+func (h *warnCounter) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *warnCounter) WithGroup(string) slog.Handler      { return h }
+
+// TestReportOffloadedContentExcluded_LoudNotSilent locks the gh#414 fix: an
+// entity with offloaded content but no content store must be OBSERVABLE — the
+// content_unresolved_total metric increments per entity, and the actionable
+// warning fires once (not per entity, to avoid a flood).
+func TestReportOffloadedContentExcluded_LoudNotSilent(t *testing.T) {
+	wc := &warnCounter{}
+	c := &Component{
+		metrics: getMetrics(nil), // default prometheus registry
+		logger:  slog.New(wc),
+		// contentStore nil, noContentStoreWarn zero-value Once
+	}
+
+	before := testutil.ToFloat64(c.metrics.contentUnresolved)
+
+	// Two offloaded entities can't be embedded (no content store).
+	c.reportOffloadedContentExcluded("c360.platform.test.sys.doc.001", "objstore")
+	c.reportOffloadedContentExcluded("c360.platform.test.sys.doc.002", "objstore")
+
+	after := testutil.ToFloat64(c.metrics.contentUnresolved)
+	assert.Equal(t, float64(2), after-before, "metric must count every excluded entity")
+	assert.Equal(t, int64(1), wc.n.Load(), "warning must fire once, not per entity (no log flood)")
 }


### PR DESCRIPTION
## Problem

When an entity carries a `StorageRef` (its body is offloaded to a store, **not** in inline triples) but no content store is wired, graph-embedding falls back to inline text extraction — which can't see the offloaded body, so it's **excluded** from the embedding (and thus BM25/search). This was a silent `Debug` log: an operator who offloads content but doesn't wire a matching `store-read` port loses embeddable content with **no signal**. semsource hit exactly this converging `pkg/fusion` (gh#414).

## Fix — make it observable ("at minimum, make it loud")

- New metric **`graph_embedding_content_unresolved_total`**, incremented per entity whose offloaded content is excluded — the aggregable signal that content is being dropped.
- A single actionable **Warning** (fired once via `sync.Once`, so it doesn't flood the log per entity) naming the fix: wire a `store-read` port for the `StorageInstance` that produced the content.
- Extracted `reportOffloadedContentExcluded` so the loud path is unit-testable.

## Scope

This is the **"make it loud"** half of #414. The deeper convergence — instance-aware fetch via a shared `{StorageInstance → storage.Store}` resolver, so embedding resolves **any** offload target the way the fusion engine does — is filed as **#415** (the `StoreResolver` is currently a dormant, unpopulated interface). No fetch-logic change here; purely observability.

## Tests

`content_unresolved_total` counts every excluded entity; the warning fires exactly once. Full package `-race` + graph-embedding integration green; lint/gofmt clean; zero schema drift.

Refs #414. Deeper convergence: #415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)