### PR TITLE
feat(storage): shared StorageInstance→store resolver — ADR-063 Phase 1 (gh#415)

### DIFF
--- a/component/dependencies.go
+++ b/component/dependencies.go
@@ -11,6 +11,8 @@ import (
 	"github.com/c360studio/semstreams/payloadregistry"
 	"github.com/c360studio/semstreams/pkg/lifecycle"
 	"github.com/c360studio/semstreams/pkg/security"
+	"github.com/c360studio/semstreams/storage"
+	"github.com/c360studio/semstreams/storage/storeregistry"
 	"github.com/c360studio/semstreams/types"
 )
 
@@ -22,6 +24,19 @@ type PlatformMeta = types.PlatformMeta
 // Lazy lookup avoids stale pointers when ComponentManager restarts components.
 type Lookup interface {
 	Component(name string) Discoverable
+}
+
+// StoreProvider is implemented by storage components that own one or more stores
+// addressable by StorageInstance name (ADR-063). The ComponentManager reads this
+// AFTER the component Starts to populate the shared StoreRegistry, and clears
+// those entries when the component Stops — so a reconfig swaps the live handle.
+//
+// The map is keyed by the StorageInstance name each store STAMPS into refs
+// (store.InstanceName()), so the registry key, the store-provide port token, and
+// the ref's StorageInstance are the same value by construction. Returns nil/empty
+// before Start (no store yet) or for a component that provides no store.
+type StoreProvider interface {
+	ProvidedStores() map[string]storage.StreamableStore
 }
 
 // ToolRegistryReader is the dependency-side surface of the agentic-
@@ -80,6 +95,18 @@ type Dependencies struct {
 	// pay zero cost, and the consumers that DO read this field
 	// loud-fail with a wiring error rather than silently no-op'ing.
 	LifecycleManager *lifecycle.Manager
+
+	// StoreRegistry is the shared {StorageInstance → storage.StreamableStore}
+	// resolver (ADR-063). The ComponentManager populates it from storage
+	// components' store-provide ports at Start and clears entries at Stop;
+	// content-fetch consumers (graph-embedding, fusion) resolve a StorageRef's
+	// StorageInstance through it, lazily per-fetch. Concrete framework-leaf type
+	// per the PayloadRegistry / LifecycleManager precedent.
+	//
+	// Can be nil — deployments with no offloaded-content fetch pay zero cost;
+	// consumers degrade (embedding falls back to its local store-read store or
+	// reports content-unresolved) rather than panicking.
+	StoreRegistry *storeregistry.Registry
 }
 
 // GetLogger returns the configured logger or a default logger if none is provided

--- a/component/port_provide.go
+++ b/component/port_provide.go
@@ -1,0 +1,35 @@
+package component
+
+import "fmt"
+
+// StoreProvidePort declares that a storage component OWNS (provides) a store
+// instance, addressable by its StorageInstance name (ADR-063). It is the
+// flowgraph marker for store ownership and complements the StoreProvider
+// interface the ComponentManager reads to populate the shared StoreRegistry.
+//
+// Non-exclusive by design. Duplicate-ownership detection lives at
+// registry-population time (storeregistry.Register errors when two live
+// components claim the same instance), NOT via port-conflict exclusivity:
+// the ComponentManager clears cm.resources only on RemoveComponent, not on the
+// reconfig/reconcile-stop paths, so an exclusive port would make a restarted
+// owner collide with its own stale entry and silently fall back to old config
+// (ADR-063 B1). Keeping this non-exclusive avoids that landmine.
+type StoreProvidePort struct {
+	Instance string `json:"instance"` // StorageInstance name this component owns
+}
+
+// ResourceID returns a unique identifier for store provide ports.
+func (s StoreProvidePort) ResourceID() string {
+	return fmt.Sprintf("store-provide:%s", s.Instance)
+}
+
+// IsExclusive returns false — ownership conflicts are caught at
+// registry-population time, not here (see the type doc).
+func (s StoreProvidePort) IsExclusive() bool {
+	return false
+}
+
+// Type returns the port type identifier.
+func (s StoreProvidePort) Type() string {
+	return "store-provide"
+}

--- a/docs/adr/063-store-substrate-and-resolver.md
+++ b/docs/adr/063-store-substrate-and-resolver.md
@@ -1,0 +1,420 @@
+# ADR-063: Store-as-substrate & the `StorageInstance` resolver
+
+## Status
+
+**Proposed — 2026-07-02. Design-reviewed (adversarial, 5-lens) — findings resolved in
+this revision.** Scopes gh#415 (shared `{StorageInstance → storage.Store}` resolver —
+converge fusion + embedding content fetch). Follow-on to ADR-062 (deterministic graph
+fusion) increment-6 convergence; parent gh#376, tracker gh#411. Companion to the
+already-shipped loud-fix for the silent case (gh#414, #416).
+
+**Review outcome (2026-07-02).** A pre-Accept adversarial review verified every factual
+claim against code and returned one BLOCKING + two HIGH findings, all resolved here:
+
+- **B1 (blocking) — reconfig vs. exclusive ports.** `cm.unregisterPorts` is called ONLY
+  from `RemoveComponent` (`component_manager.go:719`); the reconfig
+  (`restartComponentWithNewConfig`) and reconcile-stop (`stopAndRemoveComponent`) paths
+  delete the component + `registry.UnregisterInstance` but never clear `cm.resources`. So an
+  **exclusive** `store-provide` port would make a restarted owner fail its own
+  `checkPortConflicts` and silently fall back to old config. **Resolution:** `store-provide`
+  is **non-exclusive**; duplicate-ownership detection moves to registry-population time (we
+  own those hooks). The pre-existing `unregisterPorts` asymmetry (latent for `NetworkPort`
+  too) is filed as separate framework work (gh#417), not a dependency of this ADR.
+- **H1 — port token vs. registry key.** The registry keys on `store.InstanceName()` (what
+  refs carry); the `store-provide` token is declared by the component from its OWN internal
+  instance name (the same value), never the ComponentManager map-key. Token, registry key,
+  and ref value are one value by construction.
+- **H2 — behavior change.** This is additive in WIRING but **behavior-changing by design**:
+  offloaded bodies currently excluded (configs that wire no `store-read`) will now resolve
+  and embed. See Consequences.
+
+**Phase 1 validated on `e2e:semantic` (2026-07-02).** `Scenario completed successfully`,
+`validation_errors:0`, `embedding_failed_total:0`. The registry path was exercised live:
+`content_resolved_total:189` (offloaded bodies fetched via the registry — previously excluded
+under `configs/semantic.json`, which wires no `store-read`), `content_resolve_error_total:0`,
+`content_unresolved_total:0`. The H2 inclusion is demonstrated, not just non-regressive.
+
+## Decision
+
+Treat a **Store as a data-plane substrate that lives *below* the flow layer**, and give
+the framework a single authoritative way to resolve the federation name a `StorageRef`
+carries — `StorageInstance` — to a live store handle. Three complementary layers:
+
+1. **Substrate** — `storage.Store` / `storage.StreamableStore` stay pure byte-storage
+   interfaces. A store is not a flow participant; it has no ports, no flowgraph
+   presence, no lifecycle stages. It is the moral equivalent of a DB connection that a
+   component holds and calls in-process.
+
+2. **Declaration (ports)** — add a **`store-provide:<instance>`** (non-exclusive) port so a
+   storage component declares *"I own store instance X"*, and evolve **`store-read`** so
+   a consumer declares read access — either to a specific instance (static edge) or to
+   the store federation (capability edge, for federated consumers that read whatever
+   instance a ref names). Ports remain **declarations**: flowgraph visibility, reconfig
+   triggers, and — new here — the **population source for the registry**. Duplicate-ownership
+   detection lives at registry-population time (not on the exclusive-port path, which is
+   reconfig-fragile — see B1).
+
+3. **Resolution (registry)** — a small concurrent-safe **`StorageInstance →
+   storage.StreamableStore`** registry, injected through `component.Dependencies`,
+   **populated by the ComponentManager from `store-provide` ports at component Start and
+   torn down at Stop**, and **resolved lazily per-fetch** by consumers (graph-embedding,
+   fusion). The registry is the live handle-lookup the data plane calls; it is *fed by*
+   the flow model's own declarations, so reconfig-correctness falls out of the manager's
+   existing lifecycle ownership.
+
+The registry **interface is the deployment seam**: in-process it holds local
+`objectstore.Store` handles (fast, streaming); a standalone/remote consumer populates the
+*same* interface with a NATS-backed remote store. We do not pick a single transport — we
+make the handle's backend pluggable behind `StorageInstance → StreamableStore` and keep
+the data plane in-process wherever it can be.
+
+`pkg/fusion` stays a leaf (imports only `message` + `storage`); its `StoreResolver`
+interface is unchanged and the populated registry satisfies it.
+
+## Context
+
+### The problem: `StorageInstance` is a name, not an address
+
+A `message.StorageReference` carries `{StorageInstance, Key, …}`. gh#400 canonicalized
+`StorageInstance` to the **producing component's instance name** (`objectstore.Store.
+InstanceName()`, `store.go:73`) — *deliberately decoupled from the bucket*. So a consumer
+holding `ref.StorageInstance` **cannot derive a handle on its own**: it doesn't know the
+bucket, the backend (ObjectStore today; a filestore/S3 tomorrow), or the connection. Only
+the owning component knows that, and it can change at runtime (reconfig swaps the
+instance; a future backend swap changes the physical binding entirely).
+
+That is what rules out every registry-free alternative:
+
+- *Each reader builds its own handle from the ref* → needs the bucket, which it can't get
+  from the instance name → circular; and the handle wouldn't track the owner's reconfig
+  (built once at the reader's Start).
+- *Reconstruct-on-demand* → same "name isn't an address" wall, and provably wrong the
+  moment the owner switches backend or bucket.
+
+So a central authority is **mandatory, not convenient**: it is the one place the owner
+publishes *"instance X = this live handle, right now,"* and readers resolve current truth
+instead of guessing or caching a stale derivation. **Reconfig is the forcing function.**
+
+### The live gap (gh#414 / gh#415)
+
+Two content-fetch paths are each half-built:
+
+- **fusion** (`pkg/fusion/hydrate.go`, ADR-062 #399) defines `StoreResolver`
+  (`Store(instance) (storage.Store, bool)`) + `MapStoreResolver` + `BodyResolver`, but
+  **nothing populates them in production** — `MapStoreResolver` appears only in hydrate.go
+  + tests. Dormant seam.
+- **graph-embedding** has a *working* fetch, but it is **single-bucket and
+  instance-blind**: `createContentStore` (`component.go:759`) builds one
+  `objectstore.Store` from the first `store-read` port, and `worker.fetchTextFromStorage`
+  (`worker.go:397`) calls `contentStore.Open(ctx, ref.Key)` — **`ref.StorageInstance` is
+  ignored**. A ref naming any *other* instance cannot be fetched, so its offloaded body is
+  silently excluded from the embedding (and thus BM25/search).
+
+gh#414 made the silent case **loud** (metric `graph_embedding_content_unresolved_total`
++ a one-shot warning, #416). This ADR is the actual convergence: one populated resolver
+both paths consume.
+
+### Stores are already a below-the-flow substrate (grounded)
+
+This is not a new architectural stance — it is what the code already does, made explicit:
+
+- **`store-read` is a declaration, not an edge.** `StoreReadPort` (`port_store.go`)
+  carries only `{Bucket, Interface}`, `IsExclusive()==false`, `ResourceID
+  "store-read:BUCKET"`. It is a config marker with a resource id for conflict tracking. It
+  produces **no wired edge today** — precisely: `classifyInteractionPattern`
+  (`flowgraph/flowgraph.go`) has no case for it, so it falls through to `default:
+  PatternStream` with the junk connection id `"unknown_type_component.StoreReadPort"`, and
+  `connectStreamPorts` never matches it because no output port carries that id. So the
+  absence of an edge is a fallthrough side-effect, not a designed classification — which is
+  why increment 5 (static/federation edges) is a real flowgraph-classification change, not
+  free visibility (see Migration).
+- **Components already build store handles directly and call them in-process.**
+  `graph-embedding` (`component.go:775`) and `agentic-loop` (`component.go:563`) each call
+  `objectstore.NewStoreWithConfig(ctx, c.natsClient, …)` and read the handle in-process.
+  The `store-read` port just tells them *which bucket name* to pass.
+- **This is how the whole data plane works** — not special to stores. graph-embedding gets
+  its KV access the same way (`natsClient.CreateKeyValueBucket`, `js.KeyValue`,
+  `bucket.WatchAll` — `component.go:474,822,841`). **Ports are declarations** (visibility,
+  conflict detection, stream derivation, reconfig triggers); **actual data access is an
+  in-process handle the component pulls from natsClient.** NATS is *encapsulated inside*
+  the handle.
+
+So a store registry introduces **no new NATS reach** — components already encapsulate NATS
+inside these handles. It changes only *where the handle comes from*: shared-from-owner vs
+privately-reconstructed, keyed by the federation identity instead of a static bucket name.
+
+### Reconfig, precisely
+
+Runtime config change is honored by `restartComponentWithNewConfig`
+(`component_manager.go:1256`): Stop old → cancel ctx → unregister → create-with-new-config
+→ start. A config change **replaces the instance**; on Stop, the objectstore Component
+`Close()`s its store (`Close` defined `store.go:371`, called from objectstore `component.go:291` Stop). That is exactly the
+point a registry must respect, and it dictates the registry's lifecycle contract (below).
+
+## The three layers
+
+### 1. Substrate — unchanged interfaces
+
+`storage.Store` (Put/Get/List/Delete) and `storage.StreamableStore` (adds `Open`) stay as
+they are (`storage/storage.go`). `objectstore.Store` implements both (`store.go:24-27`).
+No store gains ports or flowgraph presence. The registry keys **`StreamableStore`** (the
+superset — objectstore implements it), which reconciles the type mismatch: fusion's
+`StoreResolver.Store()` returns `storage.Store` and is satisfied by auto-upcast; embedding
+needs `Open` and gets it directly. One registry, both consumers.
+
+### 2. Declaration — the `store-provide` / `store-read` port pair
+
+**`store-provide:<instance>` (new, NON-exclusive).** A storage component declares the
+instances it owns. The token is derived by the component from **its own internal instance
+name** (the value it stamps into refs via `store.InstanceName()`) — never the
+ComponentManager map-key — so the port token, the registry key, and the ref's
+`StorageInstance` are the **same value by construction** (resolves H1). Two jobs:
+
+- **Flowgraph visibility** of ownership — statically true, cleanly declarable.
+- **Population source for the registry** — the ComponentManager, which already owns
+  Start/Stop/reconcile, reads a started component's provide-ports, obtains the live handle
+  via a narrow provider interface, and registers it. Register-on-Start / deregister-on-Stop
+  becomes a **structural property of the manager**, not something each store component
+  re-implements. This is the ports-are-declarations model applied to stores.
+
+**Why NOT exclusive (B1).** An earlier draft made `store-provide` exclusive to catch
+duplicate ownership at `checkPortConflicts`. Adversarial review found this unsafe: the
+manager calls `unregisterPorts` **only** from `RemoveComponent` (`component_manager.go:719`);
+the reconfig (`restartComponentWithNewConfig`) and reconcile-stop (`stopAndRemoveComponent`)
+paths delete the component + `registry.UnregisterInstance` but leave `cm.resources` stale.
+An exclusive `store-provide:X` would therefore make a *restarted* owner collide with its own
+lingering entry and fail reconfig — the exact silent-fallback this ADR exists to prevent.
+So **duplicate-ownership detection moves to registry-population time**: `Register(instance,
+handle)` errors (loud, at Start) if `instance` is already held by a different live
+component. This keys on the real `InstanceName()`, is owned by the hooks we add (so the
+reconfig swap is correct by construction — deregister-on-Stop then register-on-Start), and
+does not depend on the manager's `cm.resources` symmetry. The pre-existing `unregisterPorts`
+asymmetry (which also makes any exclusive port — today only `NetworkPort` — reconfig-fragile)
+is filed as **separate framework work (gh#417)**, not a prerequisite here.
+
+**`store-read` (evolve).** Consumer read declaration, two flavors:
+
+- **Specific instance** (static consumer, e.g. a fixed single content bucket) → a real
+  static edge; a strict upgrade over today's bucket-keyed `store-read`, now keyed by
+  instance so it lines up with what refs carry.
+- **Federation** (federated consumer — embedding, fusion — reads *whatever instance a ref
+  names*) → a **capability edge**: "reads from the store federation." The specific instance
+  is chosen by the producer at runtime, so this is the honest declaration.
+
+The resulting graph is a **bipartite federation**:
+
+```
+[objectstore-A] ─provide─┐
+[filestore-B]   ─provide─┤→ (store federation / registry) →┌─read─ [graph-embedding]
+[objectstore-C] ─provide─┘                                 └─read─ [fusion gateway]
+```
+
+Every provider→federation and federation→consumer edge is graphed. The **only** thing that
+stays dynamic is the *exact* runtime pairing (embedding read instance-C for entity-42) —
+inherent to federation, and not a gap: you need "who can provide" and "who can consume,"
+which the ports give you; nobody needs the per-ref edge statically.
+
+### 3. Resolution — the registry contract
+
+A small type (proposed home: `storage/storeregistry`, keeping `storage` a leaf and
+`pkg/fusion` a leaf):
+
+```go
+// StoreRegistry maps a StorageReference.StorageInstance to the live store that
+// backs it. Concurrent-safe. Populated by the ComponentManager from store-provide
+// ports; resolved lazily per-fetch by consumers.
+type StoreRegistry interface {
+    // Streamable returns the streaming store for instance, and whether one is
+    // registered right now. Consumers MUST call per-fetch and MUST NOT cache the
+    // handle (see the lifecycle contract).
+    Streamable(instance string) (storage.StreamableStore, bool)
+}
+```
+
+The concrete impl also satisfies `fusion.StoreResolver` (`Store(instance) (storage.Store,
+bool)`) by upcast, so fusion consumes the same registry with no change to `pkg/fusion`.
+
+**Lifecycle contract (the two rules that keep it flow-consistent):**
+
+1. **Register on Start, deregister on Stop** — the entry is lifecycle-bound to the owning
+   component and owned by the manager. A reconfig (Stop→Start of a fresh instance) *swaps*
+   the entry automatically, via the same restart mechanism that already honors reconfig for
+   components.
+2. **Consumers resolve per-fetch (lazy), never cache the handle** — body fetch is already
+   per-entity at runtime, so this is natural. Each fetch gets the *current* handle; a
+   stale/closed handle is never held. A fetch racing a Close just errors → hydration
+   degrades for that entity and retries — no worse than today.
+
+**Ownership.** The registrant (owner) owns `Close`; **borrowers must not Close**. This is a
+change from today, where each consumer builds and Closes its own handle — it must be
+explicit in the borrowing consumers (graph-embedding stops Closing a borrowed store).
+
+**Injection.** A new nil-able `component.Dependencies.StoreRegistry` field (PayloadRegistry
+/ LifecycleManager precedent — a framework-owned leaf type, not a pluggable external
+surface). It is **constructed and owned by the `ComponentManager`** (`storeregistry.New()` in
+the constructor) and injected via the single `buildComponentDependencies`, so every binary
+that runs components through the manager gets a populated registry with no per-`main.go`
+wiring to forget — this deliberately sidesteps the half-migrated-`main` failure class (a
+`cmd/` that gets the wiring while another doesn't). A standalone/remote consumer that does
+NOT use the ComponentManager constructs and populates its own registry instance.
+
+**In-process / remote seam.** In-process, the registry holds local `objectstore.Store`
+handles (direct method call, streaming). A standalone consumer (standalone fusion service,
+semsource ADR-0006) populates its *own* registry with a NATS-backed remote store that
+implements `StreamableStore` by RPC to the owner's store port. The framework ships the type
++ in-process population; remote-handle wiring is the cross-process consumer's job.
+
+### Read contract (raw body, not envelope)
+
+Orthogonal to resolution but recorded so producers and readers agree: **the store a ref
+points at holds the RAW body bytes at `Key`** (written via `Put` / the fusion `CONTENT`
+bucket, gh#395), *not* a `StoreContent` JSON envelope (whose `map[string]string` fields
+corrupt non-UTF-8 and would embed as JSON noise). Consumers read raw via `Get`/`Open`.
+Embedding already warns when a read starts with `{` (`worker.go:421`) — that stays as the
+guard. The resolver does not unwrap envelopes; the write-format contract is the producer's
+responsibility.
+
+**Observability — keep the two failure classes distinct (M1).** gh#414's
+`graph_embedding_content_unresolved_total` means *"no store registered for this instance"*
+(a wiring/config fault). A registered store that errors mid-fetch (network blip, bucket
+deleted, closed-mid-fetch) is a **different class** — an infra fault — and must NOT fold
+into the generic `markFailed` "text extraction failed" path (`worker.go:270`), or we
+regress the diagnosability gh#414 just bought. Add a distinct observable —
+`graph_embedding_content_resolve_error_total` (instance resolved, fetch errored) — separate
+from `content_unresolved` (instance not registered). An operator must be able to tell a
+missing registration from a failing backend.
+
+## Consequences
+
+### Positive
+
+- **Federation actually works** — a ref naming any provided instance resolves; offloaded
+  bodies stop being silently excluded from embeddings/search (closes the gh#414 class at the
+  root, not just loudly).
+- **One resolver, both consumers** — fusion's dormant hydration activates and embedding's
+  instance-blind fetch is retired, via the same registry.
+- **Reconfig-correctness is structural** — owned by the manager's existing lifecycle, not
+  re-implemented per store component. *More* correct than today (today a `store-read` bucket
+  change is only honored if the consumer itself restarts).
+- **Ownership conflicts are loud** — registry-population-time detection turns duplicate
+  ownership into a startup error at `Register` instead of a silent registry clobber (and
+  without the reconfig-fragile exclusive-port path — B1).
+- **Flowgraph keeps its story** — store edges become a visible provider→federation→consumer
+  bipartite structure instead of invisible in-process reach.
+- **Leaves stay leaves** — `pkg/fusion` and `storage` unchanged as leaf packages; the
+  registry and manager wiring live where the coupling already is.
+- **Additive in wiring** — nil-safe Dependencies field, additive population, and
+  registry-primary-with-`store-read`-fallback in embedding (below). No config or API breaks.
+
+### Negative / cost
+
+- **Behavior-changing by design (H2)** — this is additive in wiring but NOT output-neutral.
+  Configs that wire no `store-read` today (e.g. `configs/semantic.json`) currently EXCLUDE
+  offloaded bodies from embeddings (loud since gh#414); once refs resolve through the
+  registry, those bodies WILL embed — shifting BM25/neural embedding and search output for
+  the semantic tier. That is the intended gh#414 root fix, not a regression, but golden /
+  search assertions may move and the `e2e:semantic` gate is mandatory before tag. Make the
+  newly-included content observable (the resolve metric above); this is the *inclusion*
+  mirror of `feedback_gate_silent_exclusion_flips_with_cost_ledger` — same discipline: the
+  output delta must be observable, not silent.
+- **The exact runtime store edge is not statically graphable** — inherent to federation
+  (producer chooses the instance). Mitigated to a capability edge by the ports, but the
+  per-ref pairing is dynamic by nature.
+- **Cross-component lifecycle coupling** — a borrowed handle dies when its owner stops. Lazy
+  per-fetch lookup + graceful fallback bounds the blast radius (next fetch misses/retries),
+  but the coupling is real and must be documented in borrowing consumers.
+- **New surface** — a port type, a provider interface, a registry type, and manager wiring.
+  More than "component calls `registry.Register` in Start" — bought deliberately for
+  flowgraph visibility + manager-owned reconfig correctness + ownership-conflict detection.
+
+### Risks
+
+- **Ordering** — mitigated by lazy lookup: a ref cannot exist unless its producer already
+  ran and registered. No eager-before-register trap (contrast the buckets case,
+  `feedback_eager_resource_creation_before_consumer_register`).
+- **Handle staleness** — mitigated by the no-cache rule for BORROWED handles: the worker
+  resolves the registry per-fetch and never stores the resolved handle (the owned `store-read`
+  fallback store, by contrast, may be retained — the component owns and closes it). Enforce
+  with a test that a post-reconfig fetch resolves the NEW handle, and never Close a borrowed
+  store.
+- **Instance-name drift** — the objectstore factory currently hardcodes
+  `instanceName := "objectstore"` (`component.go:135`) and does not receive the
+  ComponentManager map-key; the registry keys on `store.InstanceName()` (the value actually
+  stamped into refs), so it is robust to that drift. But `store-provide:<instance>` should
+  derive from the *store's* instance name, not the map-key, to stay aligned. (Worth a
+  follow-up to thread the map-key into the factory so multi-instance objectstore gets
+  distinct names — out of scope here.)
+
+## Migration path (increments)
+
+Additive in wiring but output-changing where refs newly resolve (H2); `e2e:semantic`
+(touches the embedding path) is **mandatory** before any tag, per the breaking-change
+discipline — the tier covers the seam and will surface embedding/search output shifts.
+
+1. **Registry type + Dependencies field** — `storage/storeregistry` + nil-able
+   `Dependencies.StoreRegistry`, built in both `cmd/` mains. No consumer yet.
+2. **`store-provide` port + manager population** — non-exclusive port type, narrow provider
+   interface (`ProvidedStores() map[string]storage.StreamableStore`) on storage components,
+   ComponentManager `syncStoreRegistry` helper wired into `startSingleComponent` (register)
+   and `stopAndRemoveComponent` / `restartComponentWithNewConfig` (deregister). objectstore
+   Component declares `store-provide:<instance>` (token from its own instance name) and
+   exposes its handle. Duplicate-ownership → loud error at `Register`.
+3. **graph-embedding consumption (the live gap)** — a WORKER CODE change (M2), not a doc
+   note: inject a narrow `StoreResolver` into the `Worker` and resolve
+   `resolver.Streamable(ref.StorageInstance)` **per-fetch** inside `fetchTextFromStorage`.
+   The registry-resolved handle is **BORROWED** — resolved fresh each fetch, never stored on
+   the worker, never Closed by the worker (the owning storage component Closes it). The
+   worker's existing `contentStore` field is **repurposed as the OWNED fallback** (built from
+   a `store-read` port, Closed by the component) — used only when the registry cannot resolve
+   the ref's instance, preserving single-bucket BM25 deploys (strictly additive). The
+   component gate (`shouldFetchViaStorageRef`) allows the StorageRef path when the registry
+   resolves the instance OR the fallback store is wired; otherwise it reports the exclusion
+   loudly (gh#414) and extracts inline text. Add the resolve-error metric (M1).
+4. **fusion adapter-ready** — the registry satisfies `fusion.StoreResolver`; wiring can pass
+   it to `NewBodyResolver`. The **live** fusion cmd/ consumer (gateway/tool building
+   `Engine` + `BodyResolver`) stays semsource convergence #6 (gh#411) — mirrors the B2
+   adapter-without-live-consumer pattern (`feedback_dont_ground_on_no_producer_in_framework_binaries`).
+5. **`store-read` federation flavor** — a flowgraph-CLASSIFICATION change (M3), not free
+   visibility: add `StoreProvidePort` / `StoreReadPort` cases to `classifyInteractionPattern`
+   AND `extractConnectionID` (`flowgraph/flowgraph.go`), keying provider `store-provide:X`
+   and consumer `store-read:X` to the SAME connection id so the edge actually forms (today
+   store-read falls through to `default: PatternStream` with a junk id and forms none).
+   Federation-capability flavor for embedding/fusion; specific-instance flavor keeps the
+   static edge. Deferred to Phase 2.
+
+## Open questions
+
+- **Provider interface shape** — the registry is a **standalone injectable type** (the noun);
+  **`ComponentManager` owns population** (the verb), hooked next to the existing
+  `registerPorts`/`unregisterPorts` calls in `startSingleComponent` /
+  `stopAndRemoveComponent` / `restartComponentWithNewConfig`. No separate "store manager" —
+  that would be a parallel lifecycle observer with no lifecycle of its own. Open detail:
+  `ProvidedStores() map[string]storage.StreamableStore` on the storage component, read by
+  ComponentManager after Start (leaning this, both register and deregister manager-owned for
+  reconfig symmetry), kept as a small unit-testable `syncStoreRegistry` helper.
+- **Does `store-read` need to be *enforced*** (a consumer may only resolve instances it
+  declared) or purely advisory for visibility? Enforcement would re-introduce static
+  wireability at the cost of federation flexibility.
+- **Multi-instance objectstore naming** — thread the map-key into the factory (retire the
+  hardcoded `"objectstore"`), or leave single-instance-only for now?
+- **Remote store impl** — does semstreams ship a `StreamableStore`-over-NATS reference impl,
+  or leave it entirely to the cross-process consumer? (Out of scope for gh#415; note the
+  seam.)
+
+## Related decisions
+
+- **ADR-062** (deterministic graph fusion) — parent; #399 defined the `StoreResolver` this
+  ADR populates; #400 canonicalized `StorageInstance`.
+- **ADR-047 / ADR-048** — substrate-convention precedent (Lifecycle harness, BoundedDispatcher):
+  framework provides the primitive + lifecycle; apps/consumers own work logic.
+- **ADR-055/056** — StorageRef lifting onto EntityState at the ingest seam (the producer of
+  the refs this resolver consumes).
+
+## References
+
+- gh#415 (this), gh#414 / #416 (loud fix), gh#411 (convergence tracker), gh#376 (parent ask).
+- `pkg/fusion/hydrate.go`, `graph/embedding/worker.go`, `processor/graph-embedding/component.go`,
+  `storage/objectstore/{store,component}.go`, `component/port_store.go`,
+  `service/component_manager.go`.
+</content>
+</invoke>

--- a/graph/embedding/worker.go
+++ b/graph/embedding/worker.go
@@ -51,6 +51,25 @@ type WorkerMetrics interface {
 	IncFailed()
 	// SetPending sets the current pending embeddings gauge
 	SetPending(count float64)
+	// IncContentResolveError counts a body fetch that FAILED after a store was
+	// resolved (an infra fault: read error, deleted bucket) — distinct from the
+	// component-side content_unresolved (no store wired at all). Preserves the
+	// gh#414 diagnosability the ADR-063 resolver would otherwise blur (M1).
+	IncContentResolveError()
+	// IncContentResolved counts a body successfully fetched from a resolved store.
+	// This is the POSITIVE observable for the ADR-063 H2 behavior change: offloaded
+	// bodies that configs without a store-read port previously excluded now embed —
+	// a rising value is that inclusion happening, not merely content_unresolved
+	// falling (the cost-ledger "make the delta observable" discipline).
+	IncContentResolved()
+}
+
+// StoreResolver resolves a StorageReference.StorageInstance to its live
+// streaming store (ADR-063). *storeregistry.Registry satisfies it. The worker
+// resolves per-fetch and never caches the returned handle — it is owned by the
+// storage component, not the worker.
+type StoreResolver interface {
+	Streamable(instance string) (storage.StreamableStore, bool)
 }
 
 // Worker processes pending embedding requests asynchronously
@@ -65,8 +84,15 @@ type Worker struct {
 	indexBucket jetstream.KeyValue
 	watcher     jetstream.KeyWatcher
 
-	// Content store for fetching body text from ObjectStore via streaming
+	// Content store for fetching body text from ObjectStore via streaming.
+	// This is the OWNED fallback (built from a store-read port, closed by the
+	// component). Federated resolution goes through storeResolver first.
 	contentStore storage.StreamableStore
+
+	// storeResolver resolves a StorageRef's StorageInstance to the live store
+	// that owns it (ADR-063 shared registry). Primary path; per-fetch; the
+	// resolved handle is BORROWED and never cached or closed by the worker.
+	storeResolver StoreResolver
 
 	// Callbacks
 	onGenerated GeneratedCallback // Called when embedding is generated
@@ -115,11 +141,21 @@ func (w *Worker) WithWorkers(n int) *Worker {
 	return w
 }
 
-// WithContentStore sets the content store for streaming body text retrieval.
-// When set, the worker can fetch raw content from storage for records
-// that have StorageRef instead of SourceText.
+// WithContentStore sets the OWNED fallback content store for streaming body text
+// retrieval. Used only when the shared resolver cannot resolve a ref's
+// StorageInstance (single-bucket / legacy store-read deploys). The component owns
+// and closes this store.
 func (w *Worker) WithContentStore(store storage.StreamableStore) *Worker {
 	w.contentStore = store
+	return w
+}
+
+// WithStoreResolver sets the shared store resolver (ADR-063). This is the primary
+// content-fetch path: a StorageRef's StorageInstance is resolved to the live
+// store that owns it, so the worker fetches offloaded bodies from ANY registered
+// storage instance, not just one wired bucket. Resolved per-fetch; never cached.
+func (w *Worker) WithStoreResolver(r StoreResolver) *Worker {
+	w.storeResolver = r
 	return w
 }
 
@@ -391,17 +427,37 @@ func truncateAtWord(text string, maxLen int) string {
 	return truncated
 }
 
+// resolveStore returns the store that backs a StorageInstance: the shared
+// registry first (federated — resolves ANY registered storage instance), then
+// the worker's OWNED fallback store (single wired store-read bucket). Resolves
+// per-fetch and returns a BORROWED handle from the registry path — callers must
+// not close it. Returns nil when neither path can serve the instance.
+func (w *Worker) resolveStore(instance string) storage.StreamableStore {
+	if w.storeResolver != nil && instance != "" {
+		if s, ok := w.storeResolver.Streamable(instance); ok {
+			return s
+		}
+	}
+	return w.contentStore // owned fallback (may be nil)
+}
+
 // fetchTextFromStorage streams raw content from the store, reading only up to
 // maxSourceTextLen bytes. ObjectStore holds raw bytes (plain text, not JSON-wrapped).
 // Triples carry metadata (mime type, hash); the store is format-agnostic.
 func (w *Worker) fetchTextFromStorage(ref *StorageRef) (string, error) {
-	if w.contentStore == nil {
+	store := w.resolveStore(ref.StorageInstance)
+	if store == nil {
 		return "", fmt.Errorf("content store not configured")
 	}
 
-	reader, err := w.contentStore.Open(w.ctx, ref.Key)
+	reader, err := store.Open(w.ctx, ref.Key)
 	if err != nil {
-		return "", fmt.Errorf("failed to open content: %w", err)
+		// A store resolved but the read failed: an infra fault, not a wiring gap.
+		// Count it distinctly so it is not confused with content_unresolved (M1).
+		if w.metrics != nil {
+			w.metrics.IncContentResolveError()
+		}
+		return "", fmt.Errorf("failed to open content from instance %q: %w", ref.StorageInstance, err)
 	}
 	defer reader.Close()
 
@@ -412,7 +468,10 @@ func (w *Worker) fetchTextFromStorage(ref *StorageRef) (string, error) {
 	}
 	data, err := io.ReadAll(io.LimitReader(reader, int64(limit)))
 	if err != nil {
-		return "", fmt.Errorf("failed to read content: %w", err)
+		if w.metrics != nil {
+			w.metrics.IncContentResolveError()
+		}
+		return "", fmt.Errorf("failed to read content from instance %q: %w", ref.StorageInstance, err)
 	}
 
 	// Detect likely JSON-wrapped content (StoredContent envelope).
@@ -422,6 +481,12 @@ func (w *Worker) fetchTextFromStorage(ref *StorageRef) (string, error) {
 		w.logger.Debug("stored content appears JSON-wrapped, expected raw text",
 			slog.String("key", ref.Key),
 			slog.String("hint", "use Put() for raw body text, not StoreContent()"))
+	}
+
+	// Positive observable for the ADR-063 H2 inclusion: an offloaded body was
+	// resolved and fetched (previously excluded where no store-read was wired).
+	if w.metrics != nil {
+		w.metrics.IncContentResolved()
 	}
 
 	return string(data), nil

--- a/graph/embedding/worker_storeresolver_test.go
+++ b/graph/embedding/worker_storeresolver_test.go
@@ -1,0 +1,121 @@
+package embedding
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/c360studio/semstreams/storage"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeResolver struct {
+	stores map[string]storage.StreamableStore
+}
+
+func (f fakeResolver) Streamable(instance string) (storage.StreamableStore, bool) {
+	s, ok := f.stores[instance]
+	return s, ok
+}
+
+type readerStore struct {
+	data    string
+	openErr error
+}
+
+func (s readerStore) Put(context.Context, string, []byte) error      { return nil }
+func (s readerStore) Get(context.Context, string) ([]byte, error)    { return []byte(s.data), nil }
+func (s readerStore) List(context.Context, string) ([]string, error) { return nil, nil }
+func (s readerStore) Delete(context.Context, string) error           { return nil }
+func (s readerStore) Open(context.Context, string) (io.ReadCloser, error) {
+	if s.openErr != nil {
+		return nil, s.openErr
+	}
+	return io.NopCloser(strings.NewReader(s.data)), nil
+}
+
+type countingMetrics struct{ dedup, failed, resolveErr, resolved int }
+
+func (m *countingMetrics) IncDedupHits()           { m.dedup++ }
+func (m *countingMetrics) IncFailed()              { m.failed++ }
+func (m *countingMetrics) SetPending(float64)      {}
+func (m *countingMetrics) IncContentResolveError() { m.resolveErr++ }
+func (m *countingMetrics) IncContentResolved()     { m.resolved++ }
+
+// --- tests ---------------------------------------------------------------
+
+func TestFetchText_RegistryResolvesByInstance(t *testing.T) {
+	m := &countingMetrics{}
+	w := &Worker{
+		ctx:              context.Background(),
+		maxSourceTextLen: 100,
+		metrics:          m,
+		// Fallback points at DIFFERENT content, to prove the registry path wins.
+		contentStore:  readerStore{data: "FALLBACK"},
+		storeResolver: fakeResolver{stores: map[string]storage.StreamableStore{"objectstore": readerStore{data: "FROM-REGISTRY"}}},
+	}
+
+	got, err := w.fetchTextFromStorage(&StorageRef{StorageInstance: "objectstore", Key: "k"})
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got != "FROM-REGISTRY" {
+		t.Fatalf("got %q, want registry content (registry must win over fallback)", got)
+	}
+	if m.resolveErr != 0 {
+		t.Fatalf("resolveErr = %d, want 0", m.resolveErr)
+	}
+	if m.resolved != 1 {
+		t.Fatalf("resolved = %d, want 1 (successful fetch must count the positive observable)", m.resolved)
+	}
+}
+
+func TestFetchText_FallsBackToOwnedStoreWhenInstanceAbsent(t *testing.T) {
+	w := &Worker{
+		ctx:              context.Background(),
+		maxSourceTextLen: 100,
+		contentStore:     readerStore{data: "FALLBACK"},
+		// Registry has some OTHER instance, not the one the ref names.
+		storeResolver: fakeResolver{stores: map[string]storage.StreamableStore{"other": readerStore{data: "X"}}},
+	}
+
+	got, err := w.fetchTextFromStorage(&StorageRef{StorageInstance: "objectstore", Key: "k"})
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if got != "FALLBACK" {
+		t.Fatalf("got %q, want fallback content", got)
+	}
+}
+
+func TestFetchText_NoStoreConfigured(t *testing.T) {
+	w := &Worker{ctx: context.Background(), maxSourceTextLen: 100}
+	_, err := w.fetchTextFromStorage(&StorageRef{StorageInstance: "objectstore", Key: "k"})
+	if err == nil {
+		t.Fatal("expected error when neither registry nor fallback can serve the ref")
+	}
+}
+
+func TestFetchText_ResolveErrorMetricOnReadFailure(t *testing.T) {
+	m := &countingMetrics{}
+	w := &Worker{
+		ctx:              context.Background(),
+		maxSourceTextLen: 100,
+		metrics:          m,
+		storeResolver: fakeResolver{stores: map[string]storage.StreamableStore{
+			"objectstore": readerStore{openErr: errors.New("bucket deleted")},
+		}},
+	}
+
+	_, err := w.fetchTextFromStorage(&StorageRef{StorageInstance: "objectstore", Key: "k"})
+	if err == nil {
+		t.Fatal("expected error when a resolved store fails to open")
+	}
+	// A resolved-but-failed fetch is the distinct M1 class, NOT a plain failure.
+	if m.resolveErr != 1 {
+		t.Fatalf("resolveErr = %d, want 1 (must count resolve errors distinctly)", m.resolveErr)
+	}
+}

--- a/processor/graph-embedding/component.go
+++ b/processor/graph-embedding/component.go
@@ -22,6 +22,7 @@ import (
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/pkg/resource"
 	"github.com/c360studio/semstreams/storage/objectstore"
+	"github.com/c360studio/semstreams/storage/storeregistry"
 	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -203,7 +204,12 @@ type Component struct {
 	embedder     embedding.Embedder
 	storage      *embedding.Storage
 	worker       *embedding.Worker
-	contentStore *objectstore.Store // ContentStorable access (owned lifecycle)
+	contentStore *objectstore.Store // ContentStorable access (owned lifecycle; fallback only)
+	// storeRegistry is the shared {StorageInstance → store} resolver (ADR-063).
+	// Primary content-fetch path: resolves a StorageRef against ANY registered
+	// storage instance. Nil when the deployment wires no registry; the worker then
+	// falls back to contentStore (single store-read bucket).
+	storeRegistry *storeregistry.Registry
 	// noContentStoreWarn fires the "offloaded content excluded, no content store
 	// wired" warning exactly once (gh#414) — the per-entity metric carries the
 	// count; the log stays a single actionable line rather than a flood.
@@ -271,6 +277,7 @@ func CreateGraphEmbedding(rawConfig json.RawMessage, deps component.Dependencies
 		logger:        logger,
 		modelRegistry: deps.ModelRegistry,
 		metrics:       getMetrics(deps.MetricsRegistry),
+		storeRegistry: deps.StoreRegistry, // ADR-063 shared resolver (may be nil)
 	}
 
 	// Initialize last activity
@@ -740,9 +747,17 @@ func (c *Component) initStorageAndWorker(ctx context.Context, indexBucket, dedup
 			c.logger.Debug("embedding generated", "entity_id", entityID)
 		})
 
-	// Wire content store for ContentStorable support (body text retrieval).
-	// Reads bucket name from store-read port config, creates ObjectStore handle.
-	// Store is owned by Component and closed in Stop().
+	// Wire the shared store resolver (ADR-063) as the PRIMARY content-fetch path:
+	// resolves a StorageRef against any registered storage instance. Guard the nil
+	// case explicitly — passing a nil *storeregistry.Registry through the interface
+	// would be a non-nil interface over a nil pointer and panic on use.
+	if c.storeRegistry != nil {
+		c.worker = c.worker.WithStoreResolver(c.storeRegistry)
+	}
+
+	// Wire the OWNED fallback content store (single store-read bucket) for
+	// deployments without a registry entry for the ref's instance. Reads bucket
+	// name from the store-read port config; owned by Component, closed in Stop().
 	c.contentStore = c.createContentStore(ctx)
 	if c.contentStore != nil {
 		c.worker = c.worker.WithContentStore(c.contentStore)
@@ -1005,15 +1020,25 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 }
 
 // shouldFetchViaStorageRef reports whether an entity's offloaded content should
-// be fetched from ObjectStore via its StorageRef. It requires BOTH a StorageRef
-// on the entity AND a wired content store: without the latter, the embedding
-// worker's fetchTextFromStorage hard-fails ("content store not configured") and
-// markFailed fires, silently collapsing all embedding/search for offloaded
-// entities. When the content store is absent we fall back to inline text
-// extraction instead (see queueEntityForEmbedding for the #264 regression
-// context). Configs WITH a content store are unaffected.
+// be fetched via its StorageRef. It requires a StorageRef AND a store that can
+// serve it — either (ADR-063) the shared registry can resolve the ref's owning
+// StorageInstance (federated: ANY registered instance), or the legacy single
+// wired content store is present as a fallback. Without either, the worker's
+// fetchTextFromStorage hard-fails ("content store not configured") and markFailed
+// fires, silently collapsing all embedding/search for offloaded entities; so we
+// fall back to inline text extraction instead and report the exclusion loudly
+// (gh#414, see queueEntityForEmbedding). Configs that can serve the ref are
+// unaffected.
 func (c *Component) shouldFetchViaStorageRef(state *graph.EntityState) bool {
-	return state.StorageRef != nil && c.contentStore != nil
+	if state.StorageRef == nil {
+		return false
+	}
+	if c.storeRegistry != nil {
+		if _, ok := c.storeRegistry.Streamable(state.StorageRef.StorageInstance); ok {
+			return true
+		}
+	}
+	return c.contentStore != nil
 }
 
 // reportOffloadedContentExcluded makes the silent-loss case observable (gh#414):

--- a/processor/graph-embedding/metrics.go
+++ b/processor/graph-embedding/metrics.go
@@ -22,6 +22,17 @@ type embeddingMetrics struct {
 	// any inline text triples it carries; a rising value means offloaded body
 	// text is being dropped from embeddings — wire a store-read port.
 	contentUnresolved prometheus.Counter
+	// contentResolveError counts body fetches that FAILED after a store was
+	// resolved (ADR-063 M1): the StorageInstance resolved to a live store, but the
+	// Open/read errored (network fault, deleted bucket, closed handle). Distinct
+	// from contentUnresolved (no store at all) so operators can tell a wiring gap
+	// from a failing backend.
+	contentResolveError prometheus.Counter
+	// contentResolved counts offloaded bodies successfully fetched from a resolved
+	// store — the POSITIVE observable for the ADR-063 H2 behavior change (configs
+	// without a store-read port now embed bodies they previously excluded). Rising
+	// value = the inclusion happening, not merely content_unresolved falling.
+	contentResolved prometheus.Counter
 }
 
 // Package-level metrics (registered once to avoid duplicate registration errors)
@@ -82,6 +93,20 @@ func getMetrics(registry *metric.MetricsRegistry) *embeddingMetrics {
 				Name:      "content_unresolved_total",
 				Help:      "Entities whose offloaded body (StorageRef) was excluded from embedding because no content store is wired; inline text, if any, is still embedded (gh#414)",
 			}),
+
+			contentResolveError: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_embedding",
+				Name:      "content_resolve_error_total",
+				Help:      "Offloaded body fetches that failed after a store was resolved (infra fault: read error, deleted bucket); distinct from content_unresolved which is a missing wiring (ADR-063)",
+			}),
+
+			contentResolved: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace: "semstreams",
+				Subsystem: "graph_embedding",
+				Name:      "content_resolved_total",
+				Help:      "Offloaded bodies successfully fetched from a resolved store — the positive signal that ADR-063 federated resolution is including bodies previously excluded",
+			}),
 		}
 
 		// Register metrics with the metrics registry if available
@@ -93,6 +118,8 @@ func getMetrics(registry *metric.MetricsRegistry) *embeddingMetrics {
 			_ = registry.RegisterCounter("graph-embedding", "dedup_hits_total", metrics.embeddingDedupHits)
 			_ = registry.RegisterGauge("graph-embedding", "pending", metrics.embeddingPending)
 			_ = registry.RegisterCounter("graph-embedding", "content_unresolved_total", metrics.contentUnresolved)
+			_ = registry.RegisterCounter("graph-embedding", "content_resolve_error_total", metrics.contentResolveError)
+			_ = registry.RegisterCounter("graph-embedding", "content_resolved_total", metrics.contentResolved)
 		} else {
 			// Fallback to default prometheus registry for testing
 			_ = prometheus.DefaultRegisterer.Register(metrics.embedderType)
@@ -102,6 +129,8 @@ func getMetrics(registry *metric.MetricsRegistry) *embeddingMetrics {
 			_ = prometheus.DefaultRegisterer.Register(metrics.embeddingDedupHits)
 			_ = prometheus.DefaultRegisterer.Register(metrics.embeddingPending)
 			_ = prometheus.DefaultRegisterer.Register(metrics.contentUnresolved)
+			_ = prometheus.DefaultRegisterer.Register(metrics.contentResolveError)
+			_ = prometheus.DefaultRegisterer.Register(metrics.contentResolved)
 		}
 	})
 	return metrics
@@ -148,6 +177,18 @@ func (m *embeddingMetrics) recordContentUnresolved() {
 	m.contentUnresolved.Inc()
 }
 
+// recordContentResolveError increments the counter for offloaded content that
+// resolved to a store but failed to fetch (ADR-063 M1).
+func (m *embeddingMetrics) recordContentResolveError() {
+	m.contentResolveError.Inc()
+}
+
+// recordContentResolved increments the counter for offloaded content
+// successfully fetched from a resolved store (ADR-063 H2 positive observable).
+func (m *embeddingMetrics) recordContentResolved() {
+	m.contentResolved.Inc()
+}
+
 // setPending sets the pending embeddings gauge.
 func (m *embeddingMetrics) setPending(count float64) {
 	m.embeddingPending.Set(count)
@@ -177,6 +218,20 @@ func (a *workerMetricsAdapter) IncFailed() {
 func (a *workerMetricsAdapter) SetPending(count float64) {
 	if a.metrics != nil {
 		a.metrics.setPending(count)
+	}
+}
+
+// IncContentResolveError implements embedding.WorkerMetrics.
+func (a *workerMetricsAdapter) IncContentResolveError() {
+	if a.metrics != nil {
+		a.metrics.recordContentResolveError()
+	}
+}
+
+// IncContentResolved implements embedding.WorkerMetrics.
+func (a *workerMetricsAdapter) IncContentResolved() {
+	if a.metrics != nil {
+		a.metrics.recordContentResolved()
 	}
 }
 

--- a/service/component_manager.go
+++ b/service/component_manager.go
@@ -20,6 +20,7 @@ import (
 	"github.com/c360studio/semstreams/pkg/lifecycle"
 	"github.com/c360studio/semstreams/pkg/retry"
 	"github.com/c360studio/semstreams/pkg/security"
+	"github.com/c360studio/semstreams/storage/storeregistry"
 	"github.com/c360studio/semstreams/types"
 )
 
@@ -47,6 +48,17 @@ type ComponentManager struct {
 	components       map[string]*component.ManagedComponent // Track managed components
 	startOrder       []string                               // Track start order for reverse stop
 	resources        map[string][]string                    // resourceID → component names
+
+	// storeRegistry is the shared {StorageInstance → store} resolver (ADR-063),
+	// populated from storage components' store-provide ports at Start and cleared
+	// at Stop. Plumbed to every managed component via deps.StoreRegistry so
+	// content-fetch consumers resolve refs against the same live handles the
+	// storage components own. storeProvided tracks which instances each component
+	// registered, so a stopping component is deregistered without re-reading its
+	// (possibly already-closed) store; storeMu guards it.
+	storeRegistry *storeregistry.Registry
+	storeProvided map[string][]string
+	storeMu       sync.Mutex
 
 	// Config management
 	natsClient           *natsclient.Client
@@ -171,6 +183,8 @@ func NewComponentManager(rawConfig json.RawMessage, deps *Dependencies) (Service
 		components:           make(map[string]*component.ManagedComponent),
 		startOrder:           make([]string, 0),
 		resources:            make(map[string][]string),
+		storeRegistry:        storeregistry.New(),
+		storeProvided:        make(map[string][]string),
 		configManager:        configManager,
 		configUpdates:        configUpdates,
 		modelRegistryUpdates: modelRegistryUpdates,
@@ -384,6 +398,7 @@ func (cm *ComponentManager) startComponentAsync(name string, mc *component.Manag
 	}
 
 	cm.updateComponentState(name, component.StateStarted, nil)
+	cm.registerProvidedStores(name, mc.Component)
 	cm.logger.Debug("Component started successfully", "name", name, "type", mc.Component.Meta().Type)
 	if cm.onComponentStart != nil {
 		cm.onComponentStart(mc.Context, name, mc.Component)
@@ -548,6 +563,10 @@ func (cm *ComponentManager) stopLifecycleComponent(
 		}
 	}
 
+	// Clear this component's stores from the shared registry before Stop closes
+	// them (ADR-063), so no consumer resolves a closing handle.
+	cm.deregisterProvidedStores(name)
+
 	// Call Stop with timeout - interface now supports it properly
 	if err := lifecycle.Stop(timeout); err != nil {
 		cm.updateComponentState(name, component.StateFailed, err)
@@ -706,6 +725,9 @@ func (cm *ComponentManager) RemoveComponent(instanceName string) error {
 		mc.Cancel = nil
 		mc.Context = nil
 	}
+
+	// Clear this component's stores from the shared registry before Stop (ADR-063).
+	cm.deregisterProvidedStores(instanceName)
 
 	// Stop it if it supports stopping
 	if lifecycle, ok := component.AsLifecycleComponent(mc.Component); ok {
@@ -1261,6 +1283,11 @@ func (cm *ComponentManager) restartComponentWithNewConfig(
 		return fmt.Errorf("cannot restart component %s: component not found", name)
 	}
 
+	// Deregister the OLD instance's stores before Stop closes them, so the
+	// new instance can re-register the same StorageInstance without colliding
+	// (ADR-063: this is what makes reconfig swap the live handle).
+	cm.deregisterProvidedStores(name)
+
 	// Step 1: Gracefully stop the existing component
 	if lifecycle, ok := component.AsLifecycleComponent(existingComp.Component); ok {
 		if err := lifecycle.Stop(30 * time.Second); err != nil {
@@ -1351,6 +1378,9 @@ func (cm *ComponentManager) stopAndRemoveComponent(
 	if existingComp == nil {
 		return fmt.Errorf("cannot stop component %s: component not found", name)
 	}
+
+	// Clear this component's stores from the shared registry before Stop (ADR-063).
+	cm.deregisterProvidedStores(name)
 
 	// Step 1: Gracefully stop the component
 	if lifecycle, ok := component.AsLifecycleComponent(existingComp.Component); ok {
@@ -1463,6 +1493,7 @@ func (cm *ComponentManager) startSingleComponent(ctx context.Context, name strin
 
 		// Update component state
 		cm.updateComponentState(name, component.StateStarted, nil)
+		cm.registerProvidedStores(name, mc.Component)
 
 		// Call start hook if registered
 		if cm.onComponentStart != nil {
@@ -1542,9 +1573,84 @@ func (cm *ComponentManager) buildComponentDependencies() component.Dependencies 
 		PayloadRegistry:   cm.payloadRegistry,
 		ComponentRegistry: cm.registry,
 		LifecycleManager:  cm.lifecycleManager,
+		StoreRegistry:     cm.storeRegistry,
 	}
 
 	return deps
+}
+
+// registerProvidedStores registers a just-started component's provided stores
+// into the shared StoreRegistry (ADR-063). Called after a component reaches
+// StateStarted. A duplicate-ownership collision (two live components claiming the
+// same StorageInstance) is logged loudly and skipped rather than clobbering the
+// incumbent. The component call happens OUTSIDE any manager lock; only the
+// storeProvided tracking map is guarded (storeMu).
+func (cm *ComponentManager) registerProvidedStores(name string, comp component.Discoverable) {
+	if cm.storeRegistry == nil {
+		return
+	}
+	provider, ok := comp.(component.StoreProvider)
+	if !ok {
+		return
+	}
+	// Liveness guard: skip if a concurrent stop/reconfig already removed or
+	// halted this component between Start and here. Without it, a reconfig that
+	// deregistered the old instance could be shadowed by this late register,
+	// leaving the registry pointing at a store the teardown is closing (ADR-063
+	// late-register window). Read under cm.mu (register otherwise holds no cm
+	// lock, so cm.mu stays outermost — no ordering inversion). A vanishingly
+	// small TOCTOU remains after this check; it is self-healing (the stale
+	// handle's next fetch errors loudly via content_resolve_error and per-fetch
+	// resolution retries) and is bounded per the lazy no-cache contract.
+	cm.mu.RLock()
+	mc, tracked := cm.components[name]
+	live := tracked && mc.State == component.StateStarted
+	cm.mu.RUnlock()
+	if !live {
+		return
+	}
+	provided := provider.ProvidedStores()
+	if len(provided) == 0 {
+		return
+	}
+	registered := make([]string, 0, len(provided))
+	for instance, store := range provided {
+		if store == nil || instance == "" {
+			continue
+		}
+		if err := cm.storeRegistry.Register(instance, store); err != nil {
+			cm.logger.Error("store registry: refusing duplicate store ownership",
+				"component", name, "instance", instance, "error", err)
+			continue
+		}
+		registered = append(registered, instance)
+		cm.logger.Debug("store registry: registered store", "component", name, "instance", instance)
+	}
+	if len(registered) > 0 {
+		cm.storeMu.Lock()
+		cm.storeProvided[name] = append(cm.storeProvided[name], registered...)
+		cm.storeMu.Unlock()
+	}
+}
+
+// deregisterProvidedStores clears a stopping/removed component's stores from the
+// shared StoreRegistry (ADR-063). Idempotent and keyed by the tracked instance
+// names, so it never re-reads a component whose store may already be closed. Call
+// BEFORE the component's Stop() closes the underlying store, so the registry does
+// not briefly point at a closing handle. A no-op when the component provided no
+// store.
+func (cm *ComponentManager) deregisterProvidedStores(name string) {
+	if cm.storeRegistry == nil {
+		return
+	}
+	cm.storeMu.Lock()
+	instances := cm.storeProvided[name]
+	delete(cm.storeProvided, name)
+	cm.storeMu.Unlock()
+	for _, instance := range instances {
+		cm.storeRegistry.Deregister(instance)
+		cm.logger.Debug("store registry: deregistered store", "component", name, "instance", instance)
+	}
 }
 
 // GetComponentHealth returns current health status for all managed components

--- a/service/component_manager_storeregistry_test.go
+++ b/service/component_manager_storeregistry_test.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/storage"
+	"github.com/c360studio/semstreams/storage/storeregistry"
+)
+
+// fakeStreamable is a minimal StreamableStore for manager-wiring tests.
+type fakeStreamable struct{ id string }
+
+func (f *fakeStreamable) Put(context.Context, string, []byte) error      { return nil }
+func (f *fakeStreamable) Get(context.Context, string) ([]byte, error)    { return []byte(f.id), nil }
+func (f *fakeStreamable) List(context.Context, string) ([]string, error) { return nil, nil }
+func (f *fakeStreamable) Delete(context.Context, string) error           { return nil }
+func (f *fakeStreamable) Open(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader([]byte(f.id))), nil
+}
+
+// storeProviderComponent is a Discoverable that also owns a store (ADR-063).
+type storeProviderComponent struct {
+	mockDiscoverableComponent
+	provided map[string]storage.StreamableStore
+}
+
+func (s *storeProviderComponent) ProvidedStores() map[string]storage.StreamableStore {
+	return s.provided
+}
+
+var _ component.StoreProvider = (*storeProviderComponent)(nil)
+
+func newStoreRegistryTestManager() *ComponentManager {
+	return &ComponentManager{
+		BaseService:   NewBaseServiceWithOptions("component-manager", nil),
+		components:    make(map[string]*component.ManagedComponent),
+		registry:      component.NewRegistry(),
+		storeRegistry: storeregistry.New(),
+		storeProvided: make(map[string][]string),
+	}
+}
+
+func provider(instance string) *storeProviderComponent {
+	return &storeProviderComponent{
+		provided: map[string]storage.StreamableStore{instance: &fakeStreamable{id: instance}},
+	}
+}
+
+// registerStarted mirrors the real start path: the component is tracked as
+// StateStarted (the liveness precondition registerProvidedStores enforces)
+// before its stores are registered.
+func registerStarted(cm *ComponentManager, name string, comp component.Discoverable) {
+	cm.components[name] = &component.ManagedComponent{Component: comp, State: component.StateStarted}
+	cm.registerProvidedStores(name, comp)
+}
+
+func TestRegisterProvidedStores_PopulatesRegistry(t *testing.T) {
+	cm := newStoreRegistryTestManager()
+	registerStarted(cm, "objectstore", provider("objectstore"))
+
+	if _, ok := cm.storeRegistry.Streamable("objectstore"); !ok {
+		t.Fatal("store not registered after start")
+	}
+	// A non-provider component is a silent no-op (not every component owns a store).
+	registerStarted(cm, "plain", &mockDiscoverableComponent{})
+	if got := len(cm.storeRegistry.Instances()); got != 1 {
+		t.Fatalf("registry has %d instances, want 1", got)
+	}
+}
+
+func TestRegisterProvidedStores_SkipsWhenNotLive(t *testing.T) {
+	cm := newStoreRegistryTestManager()
+	// A component that started but was already removed/halted by a concurrent
+	// stop/reconfig (not tracked as StateStarted) must NOT register — otherwise a
+	// late register shadows a teardown that already deregistered (ADR-063 M1).
+	cm.registerProvidedStores("ghost", provider("ghost"))
+	if _, ok := cm.storeRegistry.Streamable("ghost"); ok {
+		t.Fatal("registered a store for an untracked/non-live component")
+	}
+}
+
+func TestDeregisterProvidedStores_ClearsRegistry(t *testing.T) {
+	cm := newStoreRegistryTestManager()
+	registerStarted(cm, "objectstore", provider("objectstore"))
+	cm.deregisterProvidedStores("objectstore")
+
+	if _, ok := cm.storeRegistry.Streamable("objectstore"); ok {
+		t.Fatal("store still registered after stop")
+	}
+	// Tracking is cleared, so a redundant deregister is a no-op.
+	cm.deregisterProvidedStores("objectstore")
+}
+
+func TestDuplicateOwnership_RefusedNotClobbered(t *testing.T) {
+	cm := newStoreRegistryTestManager()
+	first := provider("objectstore")
+	registerStarted(cm, "owner-a", first)
+
+	// A second live component claims the same instance — refused, incumbent kept.
+	registerStarted(cm, "owner-b", provider("objectstore"))
+
+	got, _ := cm.storeRegistry.Streamable("objectstore")
+	if fs, _ := got.(*fakeStreamable); fs == nil || fs != first.provided["objectstore"] {
+		t.Fatalf("duplicate ownership clobbered the incumbent store: %v", got)
+	}
+	// owner-b registered nothing, so deregistering it must not evict owner-a's store.
+	cm.deregisterProvidedStores("owner-b")
+	if _, ok := cm.storeRegistry.Streamable("objectstore"); !ok {
+		t.Fatal("deregistering the refused owner evicted the incumbent")
+	}
+}
+
+func TestReconfigSwapsHandle(t *testing.T) {
+	cm := newStoreRegistryTestManager()
+
+	oldComp := provider("objectstore")
+	registerStarted(cm, "objectstore", oldComp)
+
+	// Reconfig: deregister the old instance, then register the fresh one under the
+	// same StorageInstance. No collision, and the new handle wins.
+	cm.deregisterProvidedStores("objectstore")
+	freshComp := provider("objectstore")
+	registerStarted(cm, "objectstore", freshComp)
+
+	got, _ := cm.storeRegistry.Streamable("objectstore")
+	if got != freshComp.provided["objectstore"] {
+		t.Fatal("post-reconfig resolve did not return the fresh handle")
+	}
+}

--- a/storage/objectstore/component.go
+++ b/storage/objectstore/component.go
@@ -20,6 +20,7 @@ import (
 	"github.com/c360studio/semstreams/metric"
 	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/errs"
+	"github.com/c360studio/semstreams/storage"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 )
@@ -93,6 +94,21 @@ type Event struct {
 // Ensure Component implements required interfaces
 var _ component.Discoverable = (*Component)(nil)
 var _ component.LifecycleComponent = (*Component)(nil)
+var _ component.StoreProvider = (*Component)(nil)
+
+// ProvidedStores exposes this component's live store to the ComponentManager for
+// registration in the shared StoreRegistry (ADR-063). Keyed by the store's
+// stamped StorageInstance (store.InstanceName()) — the same value it writes into
+// every StorageReference, so consumers resolving a ref land on this store.
+// Returns nil before Start (no store yet).
+func (c *Component) ProvidedStores() map[string]storage.StreamableStore {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.store == nil {
+		return nil
+	}
+	return map[string]storage.StreamableStore{c.store.InstanceName(): c.store}
+}
 
 // Initialize sets up the component (no I/O operations)
 func (c *Component) Initialize() error {
@@ -874,16 +890,26 @@ func (c *Component) InputPorts() []component.Port {
 
 // OutputPorts returns the output ports for this component
 func (c *Component) OutputPorts() []component.Port {
-	if c.config.Ports == nil {
-		return []component.Port{}
+	ports := make([]component.Port, 0)
+	if c.config.Ports != nil {
+		for _, portDef := range c.config.Ports.Outputs {
+			// Use BuildPortFromDefinition to properly handle different port types (nats, jetstream, etc.)
+			port := component.BuildPortFromDefinition(portDef, component.DirectionOutput)
+			ports = append(ports, port)
+		}
 	}
 
-	ports := make([]component.Port, 0)
-	for _, portDef := range c.config.Ports.Outputs {
-		// Use BuildPortFromDefinition to properly handle different port types (nats, jetstream, etc.)
-		port := component.BuildPortFromDefinition(portDef, component.DirectionOutput)
-		ports = append(ports, port)
-	}
+	// Declare store ownership (ADR-063): this component owns the store instance
+	// it stamps into every StorageReference (c.instanceName). Non-exclusive; the
+	// ComponentManager reads ProvidedStores() to populate the shared
+	// StoreRegistry that content-fetch consumers resolve against.
+	ports = append(ports, component.Port{
+		Name:        "store-provide",
+		Direction:   component.DirectionOutput,
+		Description: "Owns the store instance addressable as StorageInstance=" + c.instanceName,
+		Config:      component.StoreProvidePort{Instance: c.instanceName},
+	})
+
 	return ports
 }
 

--- a/storage/storeregistry/storeregistry.go
+++ b/storage/storeregistry/storeregistry.go
@@ -1,0 +1,115 @@
+// Package storeregistry provides a concurrency-safe registry mapping a
+// message.StorageReference.StorageInstance to the live store that backs it
+// (ADR-063).
+//
+// StorageInstance is a logical federation NAME (the producing storage
+// component's instance name, gh#400), not a physical address — a reader holding
+// a StorageRef cannot derive a handle on its own (it does not know the bucket,
+// backend, or connection, and the owner may change them at runtime). This
+// registry is the single place the owner publishes "instance X = this live
+// store, right now"; readers resolve current truth instead of guessing or
+// caching a stale derivation.
+//
+// Lifecycle contract (enforced by the populator, the ComponentManager):
+//   - Register on component Start, Deregister on Stop — so a reconfig
+//     (Stop→Start of a fresh instance) swaps the entry.
+//   - Consumers resolve LAZILY per-fetch and MUST NOT cache the handle, so a
+//     stale/closed store is never held.
+//
+// Ownership: the registrant (the storage component that owns the store's
+// lifecycle) owns Close. Borrowers (graph-embedding, fusion) MUST NOT Close a
+// resolved store.
+//
+// The Registry keys on storage.StreamableStore (the superset — objectstore.Store
+// implements it) and also exposes Store(), so it satisfies fusion's
+// StoreResolver (Store(instance) (storage.Store, bool)) structurally while
+// serving graph-embedding's streaming Open() — one registry, both consumers.
+// Kept a leaf: imports only storage.
+package storeregistry
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/c360studio/semstreams/storage"
+)
+
+// Registry maps a StorageInstance name to the live StreamableStore that backs
+// it. Safe for concurrent use. The zero value is not usable — construct with
+// New.
+type Registry struct {
+	mu     sync.RWMutex
+	stores map[string]storage.StreamableStore
+}
+
+// New returns an empty Registry.
+func New() *Registry {
+	return &Registry{stores: make(map[string]storage.StreamableStore)}
+}
+
+// Register binds instance to s. It errors on an empty name, a nil store, or a
+// duplicate: an instance already held by a live component. Duplicate ownership
+// (two components claiming the same StorageInstance) is a wiring fault surfaced
+// loud at Start rather than a silent registry clobber — the ADR-063 replacement
+// for exclusive-port conflict detection, which is reconfig-fragile (B1). The
+// populator Deregisters on Stop, so a normal reconfig (Stop→Start) never
+// collides here; a collision means two live owners.
+func (r *Registry) Register(instance string, s storage.StreamableStore) error {
+	if instance == "" {
+		return fmt.Errorf("storeregistry: cannot register an empty instance name")
+	}
+	if s == nil {
+		return fmt.Errorf("storeregistry: cannot register a nil store for instance %q", instance)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.stores[instance]; ok {
+		return fmt.Errorf("storeregistry: instance %q already registered by a live component (duplicate ownership)", instance)
+	}
+	r.stores[instance] = s
+	return nil
+}
+
+// Deregister removes instance from the registry. Idempotent: deregistering an
+// absent instance is a no-op. Deregister does NOT Close the store — the owning
+// component Closes it on its own Stop.
+func (r *Registry) Deregister(instance string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.stores, instance)
+}
+
+// Streamable returns the streaming store registered under instance, and whether
+// one exists right now. Consumers MUST call this per-fetch and MUST NOT cache
+// the returned handle (see the lifecycle contract).
+func (r *Registry) Streamable(instance string) (storage.StreamableStore, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	s, ok := r.stores[instance]
+	return s, ok
+}
+
+// Store returns the store registered under instance as a storage.Store (Get),
+// and whether one exists. This method makes *Registry satisfy fusion's
+// StoreResolver interface structurally (no fusion import here — keeps this a
+// leaf). Same lazy, no-cache contract as Streamable.
+func (r *Registry) Store(instance string) (storage.Store, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	s, ok := r.stores[instance]
+	return s, ok
+}
+
+// Instances returns the currently-registered instance names in sorted order.
+// For observability and tests; the slice is a snapshot and safe to mutate.
+func (r *Registry) Instances() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.stores))
+	for name := range r.stores {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/storage/storeregistry/storeregistry_test.go
+++ b/storage/storeregistry/storeregistry_test.go
@@ -1,0 +1,131 @@
+package storeregistry_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/c360studio/semstreams/pkg/fusion"
+	"github.com/c360studio/semstreams/storage"
+	"github.com/c360studio/semstreams/storage/storeregistry"
+)
+
+// fakeStore is a minimal StreamableStore for registry tests. Pointer-backed, so
+// two fakes are distinct instances.
+type fakeStore struct{ id string }
+
+func (f *fakeStore) Put(context.Context, string, []byte) error      { return nil }
+func (f *fakeStore) Get(context.Context, string) ([]byte, error)    { return []byte(f.id), nil }
+func (f *fakeStore) List(context.Context, string) ([]string, error) { return nil, nil }
+func (f *fakeStore) Delete(context.Context, string) error           { return nil }
+func (f *fakeStore) Open(context.Context, string) (io.ReadCloser, error) {
+	return io.NopCloser(bytes.NewReader([]byte(f.id))), nil
+}
+
+var _ storage.StreamableStore = (*fakeStore)(nil)
+
+// The registry must satisfy fusion's StoreResolver so fusion consumes it with
+// no adapter (ADR-063 type reconcile).
+var _ fusion.StoreResolver = (*storeregistry.Registry)(nil)
+
+func TestRegisterAndResolve(t *testing.T) {
+	r := storeregistry.New()
+	s := &fakeStore{id: "objectstore"}
+
+	if err := r.Register("objectstore", s); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Streamable resolves the same handle.
+	got, ok := r.Streamable("objectstore")
+	if !ok || got != s {
+		t.Fatalf("Streamable: got (%v,%v), want (%v,true)", got, ok, s)
+	}
+
+	// Store() (fusion path) resolves the same underlying store.
+	gotStore, ok := r.Store("objectstore")
+	if !ok || gotStore != storage.Store(s) {
+		t.Fatalf("Store: got (%v,%v), want the same store", gotStore, ok)
+	}
+
+	// Unknown instance resolves to (nil,false), not a panic.
+	if _, ok := r.Streamable("nope"); ok {
+		t.Fatal("Streamable(unknown) returned ok=true")
+	}
+}
+
+func TestRegisterDuplicateOwnershipErrors(t *testing.T) {
+	r := storeregistry.New()
+	if err := r.Register("objectstore", &fakeStore{id: "a"}); err != nil {
+		t.Fatalf("first Register: %v", err)
+	}
+	// A second, different component claiming the same instance is a wiring fault.
+	err := r.Register("objectstore", &fakeStore{id: "b"})
+	if err == nil {
+		t.Fatal("duplicate ownership did not error")
+	}
+	// The first owner is unchanged (no silent clobber).
+	got, _ := r.Streamable("objectstore")
+	if fs, _ := got.(*fakeStore); fs == nil || fs.id != "a" {
+		t.Fatalf("duplicate register clobbered the entry: %v", got)
+	}
+}
+
+func TestDeregisterThenReregister_Reconfig(t *testing.T) {
+	r := storeregistry.New()
+	old := &fakeStore{id: "old"}
+	if err := r.Register("objectstore", old); err != nil {
+		t.Fatalf("Register old: %v", err)
+	}
+
+	// Reconfig: Stop deregisters, Start of the fresh instance re-registers. No
+	// collision, and the new handle wins.
+	r.Deregister("objectstore")
+	fresh := &fakeStore{id: "fresh"}
+	if err := r.Register("objectstore", fresh); err != nil {
+		t.Fatalf("re-register after deregister must succeed, got: %v", err)
+	}
+	got, _ := r.Streamable("objectstore")
+	if got != fresh {
+		t.Fatalf("post-reconfig resolve got %v, want the fresh handle", got)
+	}
+}
+
+func TestDeregisterIsIdempotentAndDoesNotClose(t *testing.T) {
+	r := storeregistry.New()
+	// Deregistering an absent instance is a no-op, not a panic.
+	r.Deregister("absent")
+	if len(r.Instances()) != 0 {
+		t.Fatalf("registry not empty after no-op deregister: %v", r.Instances())
+	}
+	// The registry stays usable after a no-op deregister.
+	if err := r.Register("x", &fakeStore{id: "x"}); err != nil {
+		t.Fatalf("Register after no-op deregister: %v", err)
+	}
+}
+
+func TestRegisterGuards(t *testing.T) {
+	r := storeregistry.New()
+	if err := r.Register("", &fakeStore{}); err == nil {
+		t.Fatal("empty instance name should error")
+	}
+	if err := r.Register("x", nil); err == nil {
+		t.Fatal("nil store should error")
+	}
+}
+
+func TestInstancesSnapshot(t *testing.T) {
+	r := storeregistry.New()
+	_ = r.Register("a", &fakeStore{id: "a"})
+	_ = r.Register("b", &fakeStore{id: "b"})
+	got := r.Instances()
+	if len(got) != 2 {
+		t.Fatalf("Instances len = %d, want 2 (%v)", len(got), got)
+	}
+	// Mutating the snapshot must not affect the registry.
+	got[0] = "mutated"
+	if len(r.Instances()) != 2 {
+		t.Fatal("Instances snapshot is not a copy")
+	}
+}


### PR DESCRIPTION
Phase 1 of **ADR-063** (`docs/adr/063-store-substrate-and-resolver.md`), closing the gh#415 convergence: a populated `{StorageInstance → storage.StreamableStore}` registry that unifies the two content-fetch paths — fusion's dormant `StoreResolver` and graph-embedding's single-bucket, instance-blind fetch.

## Why
`StorageInstance` is a logical federation *name* (gh#400 = the producing component's instance name), not an address — a reader holding a `StorageRef` can't derive a handle on its own, and the owner can change the physical binding at runtime. So resolution needs a live central registry; **reconfig is the forcing function** that makes it mandatory (a static/derived binding is wrong the moment the owner restarts).

Before this, graph-embedding's `worker.fetchTextFromStorage` did `Open(ctx, ref.Key)` and **ignored `ref.StorageInstance`** — any offloaded body not in the single wired bucket was silently excluded (the gh#414 class).

## What
- **`storage/storeregistry`** — concurrent `{instance → StreamableStore}` registry; `Register` errors on a live duplicate (loud, not clobber); satisfies `fusion.StoreResolver` structurally (compile-asserted).
- **`component.Dependencies.StoreRegistry`** + **`StoreProvider`** iface + non-exclusive **`StoreProvidePort`**.
- **`ComponentManager`** owns the registry, populates it from `store-provide` ports at Start (liveness-guarded) / clears at Stop — so a reconfig swaps the live handle. Lock order `cm.mu → cm.storeMu → r.mu`, never inverted.
- **objectstore** declares ownership + exposes its store.
- **graph-embedding** resolves `ref.StorageInstance` per-fetch (federated, borrowed handle never cached/closed), with the owned `store-read` store as fallback. New distinct metrics: `content_resolve_error_total` (resolved-but-failed) and `content_resolved_total` (positive inclusion signal).

**Design note (B1):** `store-provide` is non-exclusive; duplicate-ownership detection lives at registry-population time, *not* exclusive-port conflict — the manager doesn't clear `cm.resources` on the reconfig/stop paths, so an exclusive port would be reconfig-fragile. That underlying asymmetry is filed separately as **gh#417**.

## Behavior change (H2)
Additive in wiring, but **behavior-changing by design**: configs with no `store-read` port (e.g. `configs/semantic.json`) now embed offloaded bodies previously excluded. Intended gh#414 root fix.

## Validation
- Build ✓ · lint ✓ · vet (default/integration/live_llm) ✓ · schema no-drift ✓ · `go test -race ./...` ✓
- **Reviewed pre-merge**: semstreams-reviewer + go-reviewer both APPROVE (0 blocking, 0 high); all findings folded in (M1 liveness guard, M2 positive metric, sorted `Instances()`).
- **`e2e:semantic` green** — `Scenario completed successfully`, `validation_errors:0`, `embedding_failed_total:0`. Registry exercised live: `content_resolved_total:189`, `content_resolve_error_total:0`, `content_unresolved_total:0`. The H2 inclusion is demonstrated, not just non-regressive.

## Not in scope (Phase 2, follow-on)
`store-read` federation flowgraph edges (a flowgraph-classification change with an open enforce-vs-advisory decision) + fusion's live cmd/ consumer (semsource convergence #6). The `store-provide` port renders as a benign, non-critical flowgraph orphan until then.

Closes #415. Refs #376, #411, #417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)