### PR TITLE
feat(flowgraph): render the store federation — ADR-063 Phase 2 (gh#415)

### DIFF
--- a/component/flowgraph/doc.go
+++ b/component/flowgraph/doc.go
@@ -98,6 +98,14 @@
 //   - Not connected in graph; treated like PatternNetwork for orphan detection
 //   - Declared via HTTPClientPort; cadence is owned by a sibling TimerPort
 //
+// PatternStore (ADR-063 store federation):
+//   - StoreProvidePort (a storage component owning a StorageInstance) and
+//     StoreReadPort (a content-fetch consumer)
+//   - Rendered as fan-in edges: every provider → every consumer (advisory
+//     "can read from"; the exact instance is producer-chosen per-fetch)
+//   - Non-exclusive; skipped by orphan detection like PatternNetwork (a store
+//     with no reader, or a federation store-read, is not an orphan)
+//
 // # Connection Matching
 //
 // NATS subject matching follows standard semantics:

--- a/component/flowgraph/flowgraph.go
+++ b/component/flowgraph/flowgraph.go
@@ -67,6 +67,13 @@ const (
 	// findOrphanedPorts skips PatternHTTPClient inputs for the same reason it skips
 	// PatternNetwork inputs — a legitimately unconnected external input is not orphaned.
 	PatternHTTPClient InteractionPattern = "http-client"
+	// PatternStore represents the ADR-063 store federation: StoreProvidePort (a
+	// storage component owning a StorageInstance) and StoreReadPort (a content-fetch
+	// consumer). Advisory/visibility only — the exact instance a consumer resolves
+	// is producer-chosen at runtime, so a store-provide with no consumer, or a
+	// store-read federation port, is not "orphaned"; findOrphanedPorts skips
+	// PatternStore for the same reason it skips PatternHTTPClient.
+	PatternStore InteractionPattern = "store"
 )
 
 // Issue type constants for orphaned port classification
@@ -215,6 +222,10 @@ func (g *FlowGraph) classifyInteractionPattern(portConfig component.Portable) In
 		return PatternNetwork // File I/O is external like network
 	case component.HTTPClientPort:
 		return PatternHTTPClient
+	case component.StoreProvidePort:
+		return PatternStore
+	case component.StoreReadPort:
+		return PatternStore
 	default:
 		return PatternStream // Safe default
 	}
@@ -274,6 +285,16 @@ func (g *FlowGraph) extractConnectionID(portConfig component.Portable) string {
 			return "http_client_missing_url"
 		}
 		return config.URLPattern
+	case component.StoreProvidePort:
+		// A provider is identified by the StorageInstance it owns.
+		if config.Instance == "" {
+			return "store_missing_instance"
+		}
+		return "store:" + config.Instance
+	case component.StoreReadPort:
+		// Advisory federation consumer: reads whatever instance a ref names at
+		// runtime, so it declares the federation, not a specific instance.
+		return "store-federation"
 	default:
 		return fmt.Sprintf("unknown_type_%T", config)
 	}
@@ -294,6 +315,7 @@ func (g *FlowGraph) ConnectComponentsByPatterns() error {
 	g.connectStreamPorts(publishers[PatternStream], subscribers[PatternStream])
 	g.connectRequestPorts(publishers[PatternRequest], subscribers[PatternRequest])
 	g.connectWatchPorts(publishers[PatternWatch], subscribers[PatternWatch], &warnings)
+	g.connectStorePorts(publishers[PatternStore], subscribers[PatternStore])
 
 	// Validate network ports for conflicts
 	conflicts := g.validateNetworkPorts(publishers[PatternNetwork], subscribers[PatternNetwork])
@@ -507,6 +529,42 @@ func (g *FlowGraph) connectStreamPorts(publishers, subscribers map[string][]Comp
 							Metadata:     EdgeMetadata{},
 						})
 					}
+				}
+			}
+		}
+	}
+}
+
+// connectStorePorts renders the ADR-063 store federation: every store-provide
+// (a storage component owning a StorageInstance) connects to every store-read (a
+// content-fetch consumer). Advisory/visibility only — a consumer resolves a
+// producer-chosen instance per-fetch at runtime and MAY read any registered
+// instance, so "can read from" is the honest edge; the exact pairing is dynamic
+// and deliberately not asserted here. The edge connID is the provider's
+// store:<instance>.
+func (g *FlowGraph) connectStorePorts(publishers, subscribers map[string][]ComponentPortRef) {
+	type edgeKey struct{ from, to ComponentPortRef }
+	seen := make(map[edgeKey]bool)
+
+	for pubConnID, pubs := range publishers {
+		for _, subs := range subscribers {
+			for _, pub := range pubs {
+				for _, sub := range subs {
+					if pub.ComponentName == sub.ComponentName {
+						continue
+					}
+					k := edgeKey{pub, sub}
+					if seen[k] {
+						continue
+					}
+					seen[k] = true
+					g.edges = append(g.edges, FlowEdge{
+						From:         pub,
+						To:           sub,
+						Pattern:      PatternStore,
+						ConnectionID: pubConnID,
+						Metadata:     EdgeMetadata{},
+					})
 				}
 			}
 		}
@@ -802,8 +860,11 @@ func (g *FlowGraph) findOrphanedPorts() []OrphanedPort {
 				// PatternNetwork binds a local listener; PatternHTTPClient initiates
 				// an outbound connection. Both are legitimately unmatched in the
 				// internal graph because their "publisher" is outside the system.
-				if port.Pattern == PatternNetwork || port.Pattern == PatternHTTPClient {
-					continue // Not orphaned, it's an external input
+				// PatternStore (ADR-063) is a federation-capability declaration whose
+				// pairing is producer-chosen at runtime — an unmatched store-read is
+				// not orphaned.
+				if port.Pattern == PatternNetwork || port.Pattern == PatternHTTPClient || port.Pattern == PatternStore {
+					continue // Not orphaned, it's an external/federation input
 				}
 
 				// Determine issue type based on pattern
@@ -833,8 +894,10 @@ func (g *FlowGraph) findOrphanedPorts() []OrphanedPort {
 				// Skip external boundary outputs — they ARE the external sink.
 				// PatternHTTPClient is also skipped: the component owns the
 				// outbound connection so no internal subscriber is expected.
-				if port.Pattern == PatternNetwork || port.Pattern == PatternHTTPClient {
-					continue // Not orphaned, it's an external output
+				// PatternStore (ADR-063): a store-provide with no consumer is a
+				// legitimately-unread store, not an orphan.
+				if port.Pattern == PatternNetwork || port.Pattern == PatternHTTPClient || port.Pattern == PatternStore {
+					continue // Not orphaned, it's an external/federation output
 				}
 
 				// Determine issue type based on pattern

--- a/component/flowgraph/store_federation_test.go
+++ b/component/flowgraph/store_federation_test.go
@@ -1,0 +1,89 @@
+package flowgraph
+
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ADR-063 Phase 2: the store federation renders as store-provide → store-read
+// edges (advisory/visibility), and store ports are never reported as orphaned.
+
+func storeProvider(name, instance string) component.Discoverable {
+	return createMockComponentWithPorts(name, "storage", nil,
+		[]component.Port{{
+			Name:      "store-provide",
+			Direction: component.DirectionOutput,
+			Config:    component.StoreProvidePort{Instance: instance},
+		}})
+}
+
+func federationConsumer(name string) component.Discoverable {
+	return createMockComponentWithPorts(name, "processor",
+		[]component.Port{{
+			Name:      "store-federation",
+			Direction: component.DirectionInput,
+			Config:    component.StoreReadPort{},
+		}}, nil)
+}
+
+func storeOrphans(res *FlowAnalysisResult) []OrphanedPort {
+	var out []OrphanedPort
+	for _, o := range res.OrphanedPorts {
+		if o.Pattern == PatternStore {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+func TestStoreFederation_ProviderToConsumerEdge(t *testing.T) {
+	graph := NewFlowGraph()
+	require.NoError(t, graph.AddComponentNode("objectstore", storeProvider("objectstore", "objectstore")))
+	require.NoError(t, graph.AddComponentNode("graph-embedding", federationConsumer("graph-embedding")))
+	require.NoError(t, graph.ConnectComponentsByPatterns())
+
+	edges := graph.GetEdges()
+	require.Len(t, edges, 1)
+	e := edges[0]
+	assert.Equal(t, PatternStore, e.Pattern)
+	assert.Equal(t, "objectstore", e.From.ComponentName)
+	assert.Equal(t, "graph-embedding", e.To.ComponentName)
+	assert.Equal(t, "store:objectstore", e.ConnectionID)
+
+	assert.Empty(t, storeOrphans(graph.AnalyzeConnectivity()), "connected store ports must not be orphaned")
+}
+
+func TestStoreFederation_LoneProviderNotOrphaned(t *testing.T) {
+	graph := NewFlowGraph()
+	require.NoError(t, graph.AddComponentNode("objectstore", storeProvider("objectstore", "objectstore")))
+	require.NoError(t, graph.ConnectComponentsByPatterns())
+
+	assert.Empty(t, graph.GetEdges(), "no consumer → no edge")
+	// A store with no reader is legitimate, not an orphan (this was the L1 wart).
+	assert.Empty(t, storeOrphans(graph.AnalyzeConnectivity()),
+		"a store-provide with no consumer must not be reported orphaned")
+}
+
+func TestStoreFederation_FanIn(t *testing.T) {
+	// Two providers + one federation consumer → the consumer connects to BOTH
+	// (advisory: it may resolve any registered instance at runtime).
+	graph := NewFlowGraph()
+	require.NoError(t, graph.AddComponentNode("objectstore", storeProvider("objectstore", "objectstore")))
+	require.NoError(t, graph.AddComponentNode("filestore", storeProvider("filestore", "filestore-media")))
+	require.NoError(t, graph.AddComponentNode("graph-embedding", federationConsumer("graph-embedding")))
+	require.NoError(t, graph.ConnectComponentsByPatterns())
+
+	edges := graph.GetEdges()
+	require.Len(t, edges, 2, "federation consumer connects to both providers")
+	got := map[string]bool{}
+	for _, e := range edges {
+		assert.Equal(t, PatternStore, e.Pattern)
+		assert.Equal(t, "graph-embedding", e.To.ComponentName)
+		got[e.ConnectionID] = true
+	}
+	assert.True(t, got["store:objectstore"], "edge from objectstore instance")
+	assert.True(t, got["store:filestore-media"], "edge from filestore instance")
+}

--- a/docs/adr/063-store-substrate-and-resolver.md
+++ b/docs/adr/063-store-substrate-and-resolver.md
@@ -374,13 +374,16 @@ discipline — the tier covers the seam and will surface embedding/search output
    it to `NewBodyResolver`. The **live** fusion cmd/ consumer (gateway/tool building
    `Engine` + `BodyResolver`) stays semsource convergence #6 (gh#411) — mirrors the B2
    adapter-without-live-consumer pattern (`feedback_dont_ground_on_no_producer_in_framework_binaries`).
-5. **`store-read` federation flavor** — a flowgraph-CLASSIFICATION change (M3), not free
-   visibility: add `StoreProvidePort` / `StoreReadPort` cases to `classifyInteractionPattern`
-   AND `extractConnectionID` (`flowgraph/flowgraph.go`), keying provider `store-provide:X`
-   and consumer `store-read:X` to the SAME connection id so the edge actually forms (today
-   store-read falls through to `default: PatternStream` with a junk id and forms none).
-   Federation-capability flavor for embedding/fusion; specific-instance flavor keeps the
-   static edge. Deferred to Phase 2.
+5. **`store-read` federation flavor (Phase 2 — DONE, advisory).** A new `PatternStore`
+   interaction pattern: `classifyInteractionPattern` + `extractConnectionID` classify
+   `StoreProvidePort` (connID `store:<instance>`) and `StoreReadPort` (connID
+   `store-federation`); a `connectStorePorts` pass renders the federation as fan-in edges
+   (every store-provide → every store-read — advisory "can read from", since the exact
+   instance is producer-chosen per-fetch); `findOrphanedPorts` skips `PatternStore` (a store
+   with no reader, or a federation store-read, is not an orphan — closes the L1 cosmetic
+   wart). graph-embedding declares a `store-federation` store-read for visibility. Purely
+   flowgraph/visibility — **no runtime effect** (the worker resolves via the injected
+   registry regardless). Fusion's live cmd/ consumer remains semsource convergence #6.
 
 ## Open questions
 
@@ -392,9 +395,13 @@ discipline — the tier covers the seam and will surface embedding/search output
   `ProvidedStores() map[string]storage.StreamableStore` on the storage component, read by
   ComponentManager after Start (leaning this, both register and deregister manager-owned for
   reconfig symmetry), kept as a small unit-testable `syncStoreRegistry` helper.
-- **Does `store-read` need to be *enforced*** (a consumer may only resolve instances it
-  declared) or purely advisory for visibility? Enforcement would re-introduce static
-  wireability at the cost of federation flexibility.
+- ~~**Does `store-read` need to be *enforced***~~ — **RESOLVED (advisory), 2026-07-02.**
+  `store-read` is a federation-capability declaration for flowgraph visibility only; a
+  consumer resolves whatever instance a ref names at runtime (no allowlist). Enforcement was
+  rejected: a federated consumer's read-set is producer-chosen and not statically knowable, so
+  an allowlist would force a "read-any" wildcard (advisory with ceremony) and add a runtime
+  check for no isolation need (semstreams isn't store-layer multi-tenant). Implemented in
+  Phase 2 (increment 5).
 - **Multi-instance objectstore naming** — thread the map-key into the factory (retire the
   hardcoded `"objectstore"`), or leave single-instance-only for now?
 - **Remote store impl** — does semstreams ship a `StreamableStore`-over-NATS reference impl,

--- a/processor/graph-embedding/component.go
+++ b/processor/graph-embedding/component.go
@@ -320,12 +320,30 @@ func (c *Component) InputPorts() []component.Port {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	if c.config.Ports == nil {
-		return []component.Port{}
+	ports := make([]component.Port, 0)
+	hasStoreRead := false
+	if c.config.Ports != nil {
+		for _, portDef := range c.config.Ports.Inputs {
+			p := component.BuildPortFromDefinition(portDef, component.DirectionInput)
+			if _, ok := p.Config.(component.StoreReadPort); ok {
+				hasStoreRead = true
+			}
+			ports = append(ports, p)
+		}
 	}
-	ports := make([]component.Port, 0, len(c.config.Ports.Inputs))
-	for _, portDef := range c.config.Ports.Inputs {
-		ports = append(ports, component.BuildPortFromDefinition(portDef, component.DirectionInput))
+
+	// ADR-063: graph-embedding always consumes the shared store registry
+	// (deps.StoreRegistry), resolving offloaded bodies from ANY registered
+	// storage instance. Declare a federation store-read port for flowgraph
+	// visibility when the config doesn't already wire one — advisory only, no
+	// runtime effect (the worker resolves via the injected registry regardless).
+	if !hasStoreRead {
+		ports = append(ports, component.Port{
+			Name:        "store-federation",
+			Direction:   component.DirectionInput,
+			Description: "Reads offloaded entity content from the store federation (ADR-063)",
+			Config:      component.StoreReadPort{},
+		})
 	}
 	return ports
 }

--- a/processor/graph-embedding/inputports_federation_test.go
+++ b/processor/graph-embedding/inputports_federation_test.go
@@ -1,0 +1,67 @@
+package graphembedding
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/stretchr/testify/require"
+)
+
+// componentFromConfig builds a graph-embedding Component from a Config (no NATS
+// connection needed — InputPorts is pure).
+func componentFromConfig(t *testing.T, config Config) *Component {
+	t.Helper()
+	natsClient, err := natsclient.NewClient("nats://localhost:4222")
+	require.NoError(t, err)
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+	comp, err := CreateGraphEmbedding(configJSON, component.Dependencies{NATSClient: natsClient})
+	require.NoError(t, err)
+	return comp.(*Component)
+}
+
+func countStoreReadPorts(ports []component.Port) (count int, names []string) {
+	for _, p := range ports {
+		if _, ok := p.Config.(component.StoreReadPort); ok {
+			count++
+			names = append(names, p.Name)
+		}
+	}
+	return count, names
+}
+
+// ADR-063 Phase 2: graph-embedding always consumes the store federation, so
+// InputPorts must declare exactly one store-read (federation) port — synthesized
+// when the config wires none, and NOT doubled when the config wires one.
+
+func TestInputPorts_SynthesizesFederationPortWhenConfigHasNone(t *testing.T) {
+	// DefaultConfig wires a store-read content_store; drop it to simulate a config
+	// that wires none (e.g. the semantic tier).
+	config := DefaultConfig()
+	kept := config.Ports.Inputs[:0:0]
+	for _, p := range config.Ports.Inputs {
+		if p.Type != "store-read" {
+			kept = append(kept, p)
+		}
+	}
+	config.Ports.Inputs = kept
+
+	comp := componentFromConfig(t, config)
+	require.NoError(t, comp.Initialize())
+
+	count, names := countStoreReadPorts(comp.InputPorts())
+	require.Equal(t, 1, count, "exactly one federation store-read port must be synthesized, got %v", names)
+	require.Equal(t, "store-federation", names[0])
+}
+
+func TestInputPorts_DoesNotDoubleWhenConfigHasStoreRead(t *testing.T) {
+	// DefaultConfig already wires a store-read content_store — no synthesis.
+	comp := componentFromConfig(t, DefaultConfig())
+	require.NoError(t, comp.Initialize())
+
+	count, names := countStoreReadPorts(comp.InputPorts())
+	require.Equal(t, 1, count, "config store-read must not be duplicated by a synthesized one, got %v", names)
+	require.NotContains(t, names, "store-federation", "must reuse the config store-read, not synthesize")
+}


### PR DESCRIPTION
Phase 2 of **ADR-063** (follow-on to #418): flowgraph rendering of the store federation. **Advisory / visibility only — no runtime behavior change.** The worker already resolves offloaded content via the injected registry (Phase 1); this makes that topology *visible* and stops `store-provide` from rendering as a cosmetic orphan.

## What
- New `PatternStore` interaction pattern; `classifyInteractionPattern` + `extractConnectionID` classify `StoreProvidePort` (connID `store:<instance>`) and `StoreReadPort` (connID `store-federation`).
- `connectStorePorts` fan-in pass: every `store-provide` → every `store-read`. Advisory "can read from" — the exact instance a consumer resolves is producer-chosen per-fetch, so the precise pairing is deliberately not asserted.
- `findOrphanedPorts` skips `PatternStore` (like `PatternNetwork`/`PatternHTTPClient`): a store with no reader, or a federation store-read, is not an orphan — closes the L1 cosmetic wart from #418's review.
- graph-embedding declares a `store-federation` store-read port for visibility when its config wires none (dedup: never doubles an existing config store-read).

## Design decision
`store-read` is **advisory** (visibility), not an enforced allowlist. A federated consumer's read-set is producer-chosen and not statically knowable, so enforcement would force a "read-any" wildcard (advisory with ceremony) and add a runtime check for no isolation need (semstreams isn't store-layer multi-tenant). ADR open question resolved.

## Validation
- Build ✓ · lint ✓ · vet ✓ · schema no-drift ✓ · `go test -race ./...` ✓
- **Reviewed**: semstreams-reviewer **MERGE** (0 blocking/high/medium). Both LOW nits addressed (doc parity + graph-embedding-level dedup tests).
- New tests: `store_federation_test.go` (edge rendering, lone-provider-not-orphaned, fan-in), `inputports_federation_test.go` (synthesize-when-absent, no-double-when-present).

Refs #415, #376, #411. Follows #418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)