### PR TITLE
fix(natsclient+gated-dag): readiness-gated read for cold-start responder races (gh#420)

### DIFF
--- a/docs/operations/07-nats-request-retry.md
+++ b/docs/operations/07-nats-request-retry.md
@@ -7,9 +7,15 @@ If the call writes state (mutation):
   → use RequestWithRetry with DefaultRetryConfig
   → MUST be idempotent on the responder side
 
-If the call reads state (query):
-  → use bare Request
+If the call reads state (query) in STEADY STATE (responder already up):
+  → use bare Request / RequestClassified
   → timeout = real signal; surface to the caller
+
+If the call reads state at COLD START / initial reconcile / post-reconnect
+(the responder may not be subscribed yet):
+  → use RequestReady / RequestReadyClassified
+  → short probe timeout + bounded budget
+  → "not ready yet" is retried; a hung responder still fails within the budget
 ```
 
 This rule is permanent. Don't make ad-hoc choices per call site.
@@ -33,8 +39,67 @@ For a **query**, retry-on-any-error is wrong. A genuinely hung
 responder turns a 5s timeout into ~12.7s of wallclock retry storm.
 That masks "responder is broken" as latency, breaks alerting, and
 delays user-visible error surfacing. The right behavior for a
-query is: timeout → return the error → caller decides whether to
-retry, fall back, or surface to the user.
+**steady-state** query is: timeout → return the error → caller
+decides whether to retry, fall back, or surface to the user.
+
+## The third bucket: cold-start / readiness-gated reads (gh#420)
+
+The steady-state query rule assumes the responder **exists** — so a
+timeout means "hung." That assumption breaks for a read issued at
+**cold start**, on a component's **initial reconcile**, or right
+after a **NATS reconnect**, where the responder may simply not be
+subscribed yet. There, a timeout means "not ready yet," and bare
+`Request` degrades badly: whether an absent responder surfaces as a
+fast `nats.ErrNoResponders` or a full-timeout hang is **server-config
+dependent** (see `request_integration_test.go`), so the read can burn
+the entire query timeout before failing — then the caller skips a
+pass and waits for a backstop. gh#420 (gated-dag's boot read hanging
+the full 30s `query_timeout`) is the canonical case.
+
+`RequestReady` / `RequestReadyClassified` handle this without
+reintroducing the query anti-pattern:
+
+- **Short per-attempt probe timeout** + **bounded total budget**. A
+  not-yet-subscribed responder fails a probe fast and is retried;
+  the moment the responder comes up, the next probe succeeds.
+- **A received reply — including a handler-error reply — STOPS the
+  loop.** A reply means the responder is up; only a *silent* responder
+  (never replies) is retried, and only until the budget is spent. So a
+  genuinely hung responder is **bounded by the total budget** (via the
+  short per-attempt probe) rather than hanging on one long timeout — the
+  short probe is what saves you, not the retry, so keep the probe short.
+- Use `IsNoResponders(err)` to distinguish a never-appeared responder
+  from a hung one *when the server fast-fails*. But the loop must
+  retry on a plain probe **timeout** too — fast-fail is server-config
+  dependent (see `request_integration_test.go`), so a no-fast-fail
+  server surfaces an absent responder as a timeout, not `ErrNoResponders`.
+  Never "optimize" the loop to retry only `IsNoResponders`.
+
+**Only the OUTERMOST lifecycle-triggered reader uses `RequestReady*`.**
+A steady-state handler that *forwards* to a downstream responder (e.g.
+a `graph-query` handler serving an inbound query by calling
+`graph.ingest.query.*`) stays `Request*` — even though the very first
+request at cold system boot can race the downstream's readiness.
+Readiness tolerance belongs to the outermost lifecycle-triggered read
+(the component reading on its own `Start()`/reconcile), **not** the
+intermediate request-driven hop. Converting a passthrough hop reintroduces
+the hung-responder mask for *all* steady-state traffic through it, and
+double-counts the budget inside the caller's own timeout. When in doubt:
+*is this read triggered by the component's own lifecycle, or by an
+inbound request?* Only the former converts.
+
+**Signal a never-appeared responder — don't let it go silent.** A
+misconfigured subject (typo, responder never deployed) now burns the
+whole budget on every boot/reconcile and then classifies transient — a
+lifecycle loop will log-and-skip forever, laundering a config error into
+a permanent slow-loop. Callers of `RequestReady*` MUST, on budget
+exhaustion, check `IsNoResponders(err)` and emit a **distinct, actionable
+signal** (a one-shot Warn naming the subject + a metric where the
+component has one) so "responder never appeared" is loud, not silence.
+
+This is a **cold-start / first-read** tool. Once readiness is
+established, subsequent reads are steady-state — keep using `Request`
+so a later hung responder surfaces immediately.
 
 ## Idempotency rule (mutation responders)
 
@@ -61,13 +126,28 @@ respData, err := natsClient.RequestWithRetry(
 ```
 
 ```go
-// QUERY: no retry, surface timeout
+// STEADY-STATE QUERY: no retry, surface timeout
 respData, err := natsClient.Request(
     ctx, querySubject, reqData, queryTimeout,
 )
 ```
 
-## Current call-site survey (2026-04-28, beta.20)
+```go
+// COLD-START / RECONCILE READ: short probe + bounded budget
+respData, err := natsClient.RequestReadyClassified(
+    ctx, querySubject, reqData,
+    natsclient.DefaultReadinessProbeTimeout, // per-attempt (2s)
+    natsclient.DefaultReadinessBudget,       // total (30s)
+)
+```
+
+## Current call-site survey (2026-04-28, beta.20 — pre-gh#420)
+
+> This snapshot predates the readiness bucket. It lists "Queries" as
+> bare `Request`, but most now use `RequestClassified` (ADR-060). The
+> gh#420 sweep re-classifies the lifecycle-triggered reads within it
+> into the readiness bucket; treat the categories below as the
+> mutation/steady-state split, not the final inventory.
 
 ### Mutations (using RequestWithRetry)
 
@@ -90,9 +170,17 @@ respData, err := natsClient.Request(
   gateway query proxies
 - `graph/llm/nats_content_fetcher.go` — content fetch
 
-If you find a new call site that doesn't fit either bucket, the
-default is to surface it: open a ticket with the call site path,
-the subject, and what state (if any) it writes.
+If you find a new call site that doesn't fit a bucket, the default
+is to surface it: open a ticket with the call site path, the
+subject, and what state (if any) it writes.
+
+**Cold-start reads (gh#420) are a distinct third category.** A query
+issued during a component's own `Start()` / initial reconcile /
+post-reconnect resubscribe belongs in the readiness bucket
+(`RequestReady*`), not the steady-state query bucket — the responder
+may not be up yet. The distinguishing test: *is this read triggered by
+an incoming request/event (steady state) or by the component's own
+lifecycle (cold start)?* The latter uses `RequestReady*`.
 
 ## History
 

--- a/natsclient/errors.go
+++ b/natsclient/errors.go
@@ -301,6 +301,39 @@ func (c *Client) RequestWithRetryClassified(
 	return ClassifyReply(msg)
 }
 
+// RequestReadyClassified is the classified sibling of RequestReady (the
+// readiness-gated read — the third bucket of the request doctrine). It runs the
+// short-timeout, budget-bounded readiness loop, then runs the final reply
+// through ClassifyReply so transport failures (no-responders / probe timeout,
+// retried until the budget) and handler failures (X-Error-Class/Code headers)
+// arrive uniformly.
+//
+// Use for the FIRST read on boot / initial reconcile / after a reconnect, where
+// a not-yet-subscribed responder must not degrade to a full-query-timeout hang.
+// For steady-state reads use RequestClassified (timeout = real signal). See
+// docs/operations/07-nats-request-retry.md.
+func (c *Client) RequestReadyClassified(
+	ctx context.Context, subject string, data []byte, probeTimeout, budget time.Duration,
+) ([]byte, error) {
+	msg, err := c.requestMsgReady(ctx, subject, data, probeTimeout, budget)
+	if err != nil {
+		return nil, err
+	}
+	return ClassifyReply(msg)
+}
+
+// IsNoResponders reports whether err is (or wraps) the NATS "no responders"
+// transport error — the responder is not subscribed. This is TRANSIENT at
+// startup / after a reconnect (retry via a readiness-gated read), and distinct
+// from a timeout of an EXISTING responder (which signals it is hung — surface,
+// don't retry). Note (per request_integration_test.go): whether an absent
+// responder surfaces as ErrNoResponders vs a plain timeout is server-config
+// dependent, so a false here does NOT prove a responder exists — it only
+// confirms the fast-fail no-responders signal when the server sends it.
+func IsNoResponders(err error) bool {
+	return errors.Is(err, nats.ErrNoResponders)
+}
+
 // classForHeader returns the lowercase ErrorClass string that should
 // be stamped in the X-Error-Class header for the given error.
 func classForHeader(err error) string {

--- a/natsclient/readiness_integration_test.go
+++ b/natsclient/readiness_integration_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+package natsclient
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func readyTestClient(ctx context.Context, t *testing.T) *Client {
+	t.Helper()
+	natsContainer, natsURL := startNATSContainer(ctx, t)
+	t.Cleanup(func() { _ = natsContainer.Terminate(ctx) })
+	client, err := NewClient(natsURL)
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	t.Cleanup(func() { _ = client.Close(ctx) })
+	return client
+}
+
+// A responder that subscribes AFTER the reader starts must still be found: this
+// is the cold-start race gated-dag hit (gh#420). A single-shot short request
+// would fail; RequestReady retries within its budget and succeeds once the
+// responder is up.
+func TestIntegration_RequestReady_ResponderAppearsLate(t *testing.T) {
+	ctx := context.Background()
+	client := readyTestClient(ctx, t)
+	const subject = "test.ready.late"
+
+	// Subscribe the responder only after a delay that exceeds the probe timeout,
+	// so success proves the loop RETRIED (a single 300ms probe would have failed).
+	go func() {
+		time.Sleep(700 * time.Millisecond)
+		_, _ = client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+			return []byte("pong"), nil
+		})
+	}()
+
+	start := time.Now()
+	// probe 300ms (< the 700ms responder delay), budget 10s (generous).
+	resp, err := client.RequestReady(ctx, subject, []byte("ping"), 300*time.Millisecond, 10*time.Second)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "readiness read must succeed once the responder appears")
+	assert.Equal(t, []byte("pong"), resp)
+	// Well under the budget — proves it converged on the responder, not the cap.
+	assert.Less(t, elapsed, 5*time.Second, "should return shortly after the responder appears, not near the budget")
+}
+
+// No responder ever appears: the read must surface an error BOUNDED by the
+// budget, not hang to a full per-attempt query timeout (the gh#420 30s hang).
+func TestIntegration_RequestReady_NeverReady_BoundedByBudget(t *testing.T) {
+	ctx := context.Background()
+	client := readyTestClient(ctx, t)
+
+	start := time.Now()
+	_, err := client.RequestReady(ctx, "test.ready.absent", []byte("ping"), 300*time.Millisecond, 1*time.Second)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	// Bounded by the budget (1s) with a ≥3× ceiling for CI/container jitter.
+	// The point is it does NOT hang past the budget.
+	assert.Less(t, elapsed, 3*time.Second, "must be bounded by the readiness budget, not a full query timeout")
+}
+
+// An immediately-available responder returns on the first attempt.
+func TestIntegration_RequestReady_ImmediateResponder(t *testing.T) {
+	ctx := context.Background()
+	client := readyTestClient(ctx, t)
+	const subject = "test.ready.immediate"
+
+	_, err := client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+		return []byte("pong"), nil
+	})
+	require.NoError(t, err)
+
+	// No sleep: RequestReady tolerates not-yet-propagated interest by retrying —
+	// that is the whole point. A present responder returns quickly.
+	resp, err := client.RequestReady(ctx, subject, []byte("ping"), 300*time.Millisecond, 10*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("pong"), resp)
+}
+
+// A reply — even a handler-ERROR reply — means the responder is UP, so the loop
+// must STOP (not retry to the budget) and return the classified error promptly.
+func TestIntegration_RequestReadyClassified_HandlerErrorStopsLoop(t *testing.T) {
+	ctx := context.Background()
+	client := readyTestClient(ctx, t)
+	const subject = "test.ready.handlererr"
+
+	const marker = "handler-rejected-marker"
+	_, err := client.SubscribeForRequests(ctx, subject, func(_ context.Context, _ []byte) ([]byte, error) {
+		return nil, errors.New(marker) // handler error → classified error reply
+	})
+	require.NoError(t, err)
+
+	start := time.Now()
+	// Budget is large; if the loop wrongly retried the handler error it would burn
+	// the whole budget. It must return promptly because a reply WAS received.
+	_, err = client.RequestReadyClassified(ctx, subject, []byte("ping"), 300*time.Millisecond, 10*time.Second)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	// The error must be the round-tripped HANDLER error (proving a reply was
+	// received + classified), not a transport/budget error (which would say
+	// "readiness budget" or "no responders").
+	assert.Contains(t, err.Error(), marker, "must return the classified handler error, not a transport error")
+	assert.NotContains(t, err.Error(), "readiness budget", "must not have retried to budget exhaustion")
+	assert.Less(t, elapsed, 3*time.Second, "a received (error) reply means responder is up — must not retry to the budget")
+}

--- a/natsclient/readiness_test.go
+++ b/natsclient/readiness_test.go
@@ -1,0 +1,31 @@
+package natsclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestIsNoResponders(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"direct", nats.ErrNoResponders, true},
+		{"wrapped", fmt.Errorf("readiness budget exhausted: %w", nats.ErrNoResponders), true},
+		{"timeout is not no-responders", context.DeadlineExceeded, false},
+		{"other", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsNoResponders(tc.err); got != tc.want {
+				t.Fatalf("IsNoResponders(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/natsclient/request.go
+++ b/natsclient/request.go
@@ -4,6 +4,7 @@ package natsclient
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/nats-io/nats.go"
@@ -11,6 +12,124 @@ import (
 
 // DefaultRequestTimeout is the default timeout for request/reply operations.
 const DefaultRequestTimeout = 5 * time.Second
+
+// Readiness-gated read defaults (ADR-060 sibling doctrine, third bucket — see
+// docs/operations/07-nats-request-retry.md). A readiness-gated read tolerates a
+// not-yet-subscribed responder at cold start / after reconnect: it retries with
+// a SHORT per-attempt timeout up to a bounded TOTAL budget, returning the first
+// reply. Because the per-attempt timeout is short and the total is bounded, a
+// genuinely hung responder fails within the budget rather than a full-timeout×N
+// storm — so it does NOT mask a hung responder the way retrying a full-timeout
+// query would. Distinct from Request (steady-state query: timeout = real signal,
+// no retry) and RequestWithRetry (mutation: retry-any at full timeout).
+const (
+	// DefaultReadinessProbeTimeout bounds each attempt. Short so a
+	// not-yet-subscribed responder fails fast and retries instead of consuming a
+	// full query timeout per attempt.
+	DefaultReadinessProbeTimeout = 2 * time.Second
+	// DefaultReadinessBudget bounds the TOTAL wall-clock spent waiting for the
+	// responder to come up before the error surfaces.
+	DefaultReadinessBudget = 30 * time.Second
+
+	readinessInitialBackoff = 100 * time.Millisecond
+	readinessMaxBackoff     = 1 * time.Second
+)
+
+// RequestReady performs a readiness-gated read: a QUERY that tolerates a
+// not-yet-subscribed responder at cold start / after reconnect. It retries with
+// probeTimeout per attempt up to a total budget, returning the first reply's
+// data. Zero probeTimeout/budget use the Default* values above.
+//
+// Use for the FIRST read on boot / initial reconcile / after a reconnect, where
+// "no responder" means "not ready yet." For steady-state reads use Request
+// (timeout = real signal). See docs/operations/07-nats-request-retry.md.
+func (c *Client) RequestReady(
+	ctx context.Context, subject string, data []byte, probeTimeout, budget time.Duration,
+) ([]byte, error) {
+	msg, err := c.requestMsgReady(ctx, subject, data, probeTimeout, budget)
+	if err != nil {
+		return nil, err
+	}
+	return msg.Data, nil
+}
+
+// requestMsgReady is the shared readiness-retry loop. Returns the raw *nats.Msg
+// so callers extract .Data (RequestReady) or run ClassifyReply
+// (RequestReadyClassified in errors.go) — kept in lockstep with the other
+// request families so a future tweak doesn't drift between them.
+//
+// It retries only on TRANSPORT failure (no reply received: no-responders or
+// probe timeout). Any received reply — including a handler-error reply — stops
+// the loop, because a reply means the responder is UP; the readiness contract is
+// satisfied and the (possibly-error) reply is returned for classification. Only
+// a truly-silent (never-replies) responder is retried, and only until the budget
+// is spent.
+func (c *Client) requestMsgReady(
+	ctx context.Context, subject string, data []byte, probeTimeout, budget time.Duration,
+) (*nats.Msg, error) {
+	c.mu.RLock()
+	conn := c.conn
+	c.mu.RUnlock()
+
+	if conn == nil || !conn.IsConnected() {
+		return nil, ErrNotConnected
+	}
+	if c.Status() == StatusCircuitOpen {
+		return nil, ErrCircuitOpen
+	}
+
+	if probeTimeout <= 0 {
+		probeTimeout = DefaultReadinessProbeTimeout
+	}
+	if budget <= 0 {
+		budget = DefaultReadinessBudget
+	}
+
+	// Auto-generate trace once for all attempts.
+	if _, ok := TraceContextFromContext(ctx); !ok {
+		ctx = ContextWithTrace(ctx, NewTraceContext())
+	}
+
+	overallCtx, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	backoff := readinessInitialBackoff
+	var lastErr error
+	for {
+		attemptCtx, attemptCancel := context.WithTimeout(overallCtx, probeTimeout)
+		msg := nats.NewMsg(subject)
+		msg.Data = data
+		InjectTrace(ctx, msg)
+		reply, err := conn.RequestMsgWithContext(attemptCtx, msg)
+		attemptCancel()
+
+		if err == nil {
+			c.resetCircuit()
+			return reply, nil
+		}
+		lastErr = err
+		// Deliberately do NOT recordFailure() here. A readiness miss (no-responder
+		// / probe timeout) is the EXPECTED condition this primitive tolerates — the
+		// responder isn't up yet, not a connection fault. Counting it would let a
+		// single boot-time RequestReady burst (against briefly-absent responders)
+		// trip the shared per-client circuit breaker and fast-fail UNRELATED calls
+		// with ErrCircuitOpen. Genuine connection loss still surfaces via the
+		// up-front IsConnected check and per-attempt errors, and stays bounded by
+		// the budget.
+
+		// Wait before the next probe, bounded by the overall readiness budget.
+		select {
+		case <-overallCtx.Done():
+			// %w preserves errors.Is(…, nats.ErrNoResponders) for callers that
+			// want to distinguish a never-appeared responder from a hung one.
+			return nil, fmt.Errorf("readiness budget %s exhausted: %w", budget, lastErr)
+		case <-time.After(backoff):
+		}
+		if backoff *= 2; backoff > readinessMaxBackoff {
+			backoff = readinessMaxBackoff
+		}
+	}
+}
 
 // Request performs a synchronous request/reply operation.
 // It publishes a message to the subject and waits for a response.

--- a/processor/gated-dag/component.go
+++ b/processor/gated-dag/component.go
@@ -117,21 +117,42 @@ func (c *Component) Start(ctx context.Context) error {
 		}
 	}
 
+	execMetrics := newMetrics(c.metricsReg)
 	exec := &executor{
 		cfg:     c.cfg,
 		log:     c.logger,
 		mgr:     c.mgr,
 		nc:      c.natsClient,
 		stall:   stall,
-		metrics: newMetrics(c.metricsReg),
+		metrics: execMetrics,
 		reader: &natsGraphReader{
 			nc:       c.natsClient,
 			prefix:   c.cfg.UnitEntityPrefix,
 			maxUnits: c.cfg.MaxUnits,
 			timeout:  qTimeout,
+			// Cold-start read (gh#420): short probes up to the existing query
+			// timeout as the readiness budget — succeeds the moment graph-ingest is
+			// up, instead of hanging the full timeout on the boot race.
+			readyProbe:  natsclient.DefaultReadinessProbeTimeout,
+			readyBudget: qTimeout,
 			onTrunc: func(returned, capN int) {
 				c.logger.Warn("gated-dag: unit set exceeded max_units; reading a truncated set",
 					slog.Int("returned", returned), slog.Int("max_units", capN))
+			},
+			onNeverReady: func(err error) {
+				execMetrics.coldStartWait.Inc()
+				if natsclient.IsNoResponders(err) {
+					c.logger.Warn("gated-dag: graph-ingest prefix responder never appeared within the "+
+						"readiness budget — is graph-ingest deployed/subscribed? (gh#420)",
+						slog.String("subject", prefixQuerySubject), slog.Any("error", err))
+				} else {
+					// Covers both cold-start failure modes: readiness budget exhausted
+					// (responder slow/absent) OR a handler-error reply (responder up but
+					// errored) — the latter stops the readiness loop and returns verbatim.
+					c.logger.Warn("gated-dag: cold-start authoritative read failed before graph-ingest "+
+						"was confirmed ready (budget exhausted, or the responder replied with an error) (gh#420)",
+						slog.String("subject", prefixQuerySubject), slog.Any("error", err))
+				}
 			},
 		},
 		claimer: &natsClaimer{nc: c.natsClient, predicate: c.cfg.ClaimPredicate},

--- a/processor/gated-dag/metrics.go
+++ b/processor/gated-dag/metrics.go
@@ -11,12 +11,13 @@ const metricsService = "gated-dag"
 // constructed (they operate standalone); they are only registered with the
 // shared registry when one is provided, so increments are always nil-safe.
 type metrics struct {
-	stall       prometheus.Gauge
-	claimed     prometheus.Counter
-	claimErr    prometheus.Counter
-	dispatched  prometheus.Counter
-	dispatchErr prometheus.Counter
-	evals       prometheus.Counter
+	stall         prometheus.Gauge
+	claimed       prometheus.Counter
+	claimErr      prometheus.Counter
+	dispatched    prometheus.Counter
+	dispatchErr   prometheus.Counter
+	evals         prometheus.Counter
+	coldStartWait prometheus.Counter
 }
 
 // newMetrics builds the collectors and registers them with reg when non-nil.
@@ -46,6 +47,10 @@ func newMetrics(reg *metric.MetricsRegistry) *metrics {
 			Name: "gated_dag_evaluations_total",
 			Help: "Re-evaluation passes (watch-triggered + backstop ticks).",
 		}),
+		coldStartWait: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "gated_dag_cold_start_read_unready_total",
+			Help: "Cold-start authoritative reads that exhausted their readiness budget because graph-ingest never answered (gh#420). A sustained nonzero rate means the graph-ingest prefix responder is not deployed/subscribed — the executor cannot reconcile its unit set.",
+		}),
 	}
 	if reg != nil {
 		// Best-effort registration: a duplicate (e.g. two flows) is logged by the
@@ -56,6 +61,7 @@ func newMetrics(reg *metric.MetricsRegistry) *metrics {
 		_ = reg.RegisterCounter(metricsService, "units_dispatched_total", m.dispatched)
 		_ = reg.RegisterCounter(metricsService, "dispatch_errors_total", m.dispatchErr)
 		_ = reg.RegisterCounter(metricsService, "evaluations_total", m.evals)
+		_ = reg.RegisterCounter(metricsService, "cold_start_read_unready_total", m.coldStartWait)
 	}
 	return m
 }

--- a/processor/gated-dag/reader.go
+++ b/processor/gated-dag/reader.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
-	"github.com/c360studio/semstreams/natsclient"
 	"github.com/c360studio/semstreams/pkg/gateddag"
 )
 
@@ -20,16 +19,41 @@ type graphReader interface {
 	ReadUnitSet(ctx context.Context) ([]graph.EntityState, error)
 }
 
+// requester is the minimal request surface natsGraphReader needs: the
+// readiness-gated cold-start read and the steady-state read (both classified).
+// *natsclient.Client satisfies it; a unit test injects a fake to assert the
+// cold-start → steady-state switch and the never-ready signal.
+type requester interface {
+	RequestReadyClassified(ctx context.Context, subject string, data []byte, probeTimeout, budget time.Duration) ([]byte, error)
+	RequestClassified(ctx context.Context, subject string, data []byte, timeout time.Duration) ([]byte, error)
+}
+
 // natsGraphReader reads the unit set via the graph.query.prefix contract
 // (returns full EntityStates incl. markers). Bounded by maxUnits: it follows the
 // opaque cursor up to the cap and logs a truncation warning rather than
 // silently dropping units past it.
 type natsGraphReader struct {
-	nc       *natsclient.Client
+	nc       requester
 	prefix   string
 	maxUnits int
 	timeout  time.Duration
 	onTrunc  func(returned, capN int)
+
+	// Readiness-gated cold start (gh#420). The executor fires its FIRST
+	// authoritative read on boot, racing graph-ingest's query-handler
+	// registration — a bare request there degrades to a full-timeout hang. Until
+	// this reader has seen graph-ingest answer once (warmed), it reads via
+	// RequestReadyClassified: short probes up to readyBudget, succeeding the moment
+	// the responder is up. After the first success reads are steady-state
+	// (RequestClassified, timeout = real signal) so a LATER hung responder is not
+	// masked. See docs/operations/07-nats-request-retry.md.
+	readyProbe  time.Duration
+	readyBudget time.Duration
+	warmed      bool
+	// onNeverReady fires when the cold-start read exhausts its readiness budget
+	// (graph-ingest never answered) — a distinct, actionable signal so a missing
+	// responder is loud, not a silent skipped pass.
+	onNeverReady func(err error)
 }
 
 // prefixQuerySubject is the authoritative whole-set enumeration contract. The
@@ -61,10 +85,20 @@ func (r *natsGraphReader) ReadUnitSet(ctx context.Context) ([]graph.EntityState,
 		if err != nil {
 			return nil, fmt.Errorf("marshal prefix request: %w", err)
 		}
-		respData, err := r.nc.RequestClassified(ctx, prefixQuerySubject, reqData, r.timeout)
+		var respData []byte
+		if r.warmed {
+			respData, err = r.nc.RequestClassified(ctx, prefixQuerySubject, reqData, r.timeout)
+		} else {
+			respData, err = r.nc.RequestReadyClassified(ctx, prefixQuerySubject, reqData, r.readyProbe, r.readyBudget)
+		}
 		if err != nil {
+			if !r.warmed && r.onNeverReady != nil {
+				r.onNeverReady(err)
+			}
 			return nil, fmt.Errorf("%s: %w", prefixQuerySubject, err)
 		}
+		// graph-ingest answered — subsequent reads are steady-state.
+		r.warmed = true
 		var resp graph.PrefixQueryResponse
 		if err := json.Unmarshal(respData, &resp); err != nil {
 			return nil, fmt.Errorf("unmarshal prefix response: %w", err)

--- a/processor/gated-dag/reader_readiness_test.go
+++ b/processor/gated-dag/reader_readiness_test.go
@@ -1,0 +1,87 @@
+package gateddagexec
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRequester records which request family the reader used per attempt.
+type fakeRequester struct {
+	readyCalls    int
+	classifyCalls int
+	readyErr      error // when set, RequestReadyClassified fails
+	resp          []byte
+}
+
+func (f *fakeRequester) RequestReadyClassified(_ context.Context, _ string, _ []byte, _, _ time.Duration) ([]byte, error) {
+	f.readyCalls++
+	if f.readyErr != nil {
+		return nil, f.readyErr
+	}
+	return f.resp, nil
+}
+
+func (f *fakeRequester) RequestClassified(_ context.Context, _ string, _ []byte, _ time.Duration) ([]byte, error) {
+	f.classifyCalls++
+	return f.resp, nil
+}
+
+func newTestReader(nc requester, onNeverReady func(error)) *natsGraphReader {
+	return &natsGraphReader{
+		nc:           nc,
+		prefix:       "org.plat.dom.sys.type",
+		maxUnits:     100,
+		timeout:      5 * time.Second,
+		readyProbe:   time.Second,
+		readyBudget:  2 * time.Second,
+		onNeverReady: onNeverReady,
+	}
+}
+
+// gh#420: the FIRST read is readiness-gated (cold start), then the reader warms
+// and subsequent reads are steady-state so a later hung responder isn't masked.
+func TestReader_ColdStartUsesReadinessThenSteadyState(t *testing.T) {
+	emptyResp, err := json.Marshal(graph.PrefixQueryResponse{})
+	require.NoError(t, err)
+	fr := &fakeRequester{resp: emptyResp}
+	r := newTestReader(fr, nil)
+
+	// First read → readiness path.
+	_, err = r.ReadUnitSet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, fr.readyCalls, "cold-start read must use the readiness-gated path")
+	require.Equal(t, 0, fr.classifyCalls)
+	require.True(t, r.warmed)
+
+	// Second read → steady-state path (responder is proven up).
+	_, err = r.ReadUnitSet(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, fr.readyCalls, "readiness must not be used again after warming")
+	require.Equal(t, 1, fr.classifyCalls, "warmed reads use the steady-state path")
+}
+
+// A cold-start read that exhausts its readiness budget fires the distinct
+// signal and stays UNWARMED so the next attempt retries readiness (not
+// steady-state) — graph-ingest still hasn't answered.
+func TestReader_ColdStartNeverReadyFiresSignalAndStaysUnwarmed(t *testing.T) {
+	fr := &fakeRequester{readyErr: errors.New("readiness budget exhausted: no responders")}
+	fired := 0
+	r := newTestReader(fr, func(error) { fired++ })
+
+	_, err := r.ReadUnitSet(context.Background())
+	require.Error(t, err)
+	require.Equal(t, 1, fired, "onNeverReady must fire on cold-start budget exhaustion")
+	require.False(t, r.warmed, "must stay unwarmed so the next read retries readiness")
+
+	// Next read still uses readiness (never warmed), NOT steady-state.
+	_, _ = r.ReadUnitSet(context.Background())
+	require.Equal(t, 2, fr.readyCalls)
+	require.Equal(t, 0, fr.classifyCalls)
+	require.Equal(t, 2, fired)
+}


### PR DESCRIPTION
## Problem (gh#420)

gated-dag's executor fires its **first** authoritative read (`graph.ingest.query.prefix`) on boot — racing graph-ingest's query-handler registration. A bare request there **hung the full 30s `query_timeout`** (no-responders fast-fail is server-config dependent), skipped the pass, and logged a generic Warn. semspec hit this reproducibly on `v1.0.0-beta.124`.

The root cause isn't gated-dag — it's a **missing natsclient capability**: the request doctrine only covered steady-state queries ("timeout = real signal, don't retry"), which is *wrong* for a cold-start read where a timeout means "responder not subscribed yet." ~47 query call-sites inherit this blind spot.

## Fix

**1. natsclient — the "third bucket": `RequestReady` / `RequestReadyClassified`.** Retry with a **short per-attempt probe timeout** up to a **bounded total budget**; the first reply (incl. a handler-error reply) stops the loop. A silent responder fails within the budget — not a full-timeout hang — so it does **not** mask a hung responder (the short probe is the saving grace). `IsNoResponders(err)` distinguishes a never-appeared responder from a hung one. Readiness misses do **not** count against the circuit breaker (Gate-1 fix).

**2. Doctrine** (`docs/operations/07-nats-request-retry.md`) — the third bucket, and the rule that **only the outermost lifecycle-triggered reader converts** (intermediate request-driven hops stay `Request*`), plus a mandate to signal a never-appeared responder.

**3. gated-dag conversion** — the reader uses the readiness-gated read for its cold start, then `warmed=true` → steady-state `RequestClassified` (a later hung graph-ingest still surfaces immediately). A distinct `cold_start_read_unready_total` metric + actionable Warn on budget exhaustion.

## Scope (audit + Gate 2)

Audited all ~41 production query call-sites. **Only gated-dag** is a genuine cold-start read. All 15 `graph-query` passthrough hops, both gateways, tool executors, research adapters, and agentic-loop reads are correctly **steady-state** (left as `Request*`). The audit also corrected a "dead code" mislabel — `fusionnats` is **live** in semsource (the ADR-063 convergence), not dead. Filed **#421** (client-library readiness variants for downstream cold-start callers) and **#422** (genuinely-unused exported query API).

## Reviews (gated, per request)

- **Gate 1** (primitive + doctrine, *before* the sweep): go-reviewer + semstreams-reviewer. Caught a circuit-breaker self-trip (HIGH) and the intermediate-hop scope rule (HIGH) — both folded in.
- **Gate 2** (classification/scope): audit narrowed the sweep to 1 site; verified the borderline clustering read is a non-candidate.
- **Gate 3** (conversion): semstreams-reviewer **MERGE**; the one LOW (warn wording) fixed.

## Validation

Build ✓ · lint ✓ · vet ✓ · schema no-drift ✓ · `go test -race ./...` ✓ · natsclient readiness integration tests ✓ (responder-appears-late, budget-bounded, handler-reply-stops-loop) · gated-dag reader unit tests ✓ (cold-start→steady-state switch, never-ready signal).

Closes #420. Refs #421, #422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)