### PR TITLE
feat(agentic-tools): OwnedFactWriter replace-owned surface for mutable tool facts (gh#425)

### DIFF
--- a/processor/agentic-tools/owned_fact_writer.go
+++ b/processor/agentic-tools/owned_fact_writer.go
@@ -1,0 +1,219 @@
+package agentictools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// OwnedFactWriter is the write surface for agent tools that OWN a MUTABLE
+// PACKAGE of graph facts on an already-born entity and must REPLACE that
+// package on re-emission — a retry / re-plan that can shrink or reshape the
+// package — rather than append a stale second copy.
+//
+// It is deliberately SEPARATE from [TriplePublisher] (append / birth):
+// replace-by-predicate + clear is a sharp tool, and append-only tools (decide,
+// scratchpad, emit_diagnosis) must NOT reach it. Least privilege is enforced by
+// interface, not by convention — a tool that owns a mutable package (semspec
+// emit_change, semteams emit_dev_via_test_plan) takes an OwnedFactWriter; a
+// tool that only appends evidence keeps TriplePublisher. The same concrete
+// natsclient adapter can satisfy both; callers depend on the narrow surface
+// they need.
+//
+// Both methods drive the framework's atomic mutable-fact lane
+// (graph.mutation.entity.update_with_triples for writes,
+// graph.ingest.query.entity for the read-back) — the SAME primitive the rule
+// engine's replace_owned action (processor/rule/triple_mutator.go ReplaceOwned)
+// and pkg/lifecycle use. Prefer this over a hand-rolled remove-then-add loop:
+// that is non-atomic (a watcher can observe the predicate absent between the
+// remove and the add) and costs one RPC per predicate. gh#425.
+//
+// Forward-compat: as ADR-056 owner-token and projection-contract enforcement
+// harden for tool writers, this surface gains the lease/contract hook (the
+// underlying UpdateEntityWithTriplesRequest already carries OwnerToken). New
+// consumers are all in-repo, so threading it later is a single additive change.
+type OwnedFactWriter interface {
+	// ReplaceTriples atomically upserts add (REPLACE-by-predicate: every
+	// predicate present in add has its prior values on the entity fully
+	// replaced — upsert, NOT append) and clears every predicate named in
+	// removePredicates, on the already-born entity entityID, via ONE
+	// update_with_triples mutation. removePredicates runs BEFORE the add merge,
+	// so a predicate present in both is cleared then re-added (net: the new
+	// values).
+	//
+	// Use removePredicates to drop the STALE owned predicates a shrinking
+	// package no longer emits — the add merge alone cannot know a predicate
+	// vanished. Name ONLY predicates your tool owns: the entity is typically
+	// SHARED (lifecycle phase, other tools' facts), and a predicate named here
+	// is deleted regardless of who wrote it. Pair with ReadOwnedPredicates to
+	// compute the owned set safely.
+	//
+	// This lane is UPDATE-only and PRESERVE-envelope: it never sets or changes
+	// the entity's MessageType/Version/StorageRef envelope. That is intentional
+	// — the entity's identity envelope is set once at BIRTH by its owner
+	// (create_with_triples / graph-ingest), and a package-writing tool must not
+	// overwrite a birth-owner's envelope (the ADR-055 provenance / ADR-054
+	// indexing-profile key). MUST-EXIST: on a never-created entity the handler
+	// returns entity_not_found (no auto-vivify) and this returns an error
+	// carrying that classified Code — born the entity first.
+	ReplaceTriples(ctx context.Context, entityID string, add []message.Triple, removePredicates []string) error
+
+	// ReadOwnedPredicates returns the DISTINCT predicates currently present on
+	// entityID whose name begins with ownedPrefix, sorted. It is the read half
+	// of the shrinking-package pattern: read your owned predicates, then pass
+	// them as removePredicates to ReplaceTriples to clear the whole prior
+	// package before writing the revised one — "clear my prefix, then write the
+	// current package."
+	//
+	// ownedPrefix MUST be non-empty and scope the read to predicates your tool
+	// owns (e.g. "change.<slug>."). An empty prefix is REJECTED with an error:
+	// on a shared entity it would return every owner's predicates, which — fed
+	// to ReplaceTriples's removePredicates — would delete facts your tool does
+	// not own. There is no unscoped-read escape hatch by design.
+	//
+	// The read and the subsequent ReplaceTriples are two separate RPCs with no
+	// revision fence between them, so the "clear my prefix, then write" pattern
+	// assumes a SINGLE concurrent writer of the owned package (the retry/re-plan
+	// case it exists for — a loop does not race itself). A second concurrent
+	// writer of the same prefix is not serialized here.
+	//
+	// A never-created entity surfaces as an error carrying the classified
+	// entity_not_found Code — the package's owning entity is expected to exist
+	// by replace time.
+	ReadOwnedPredicates(ctx context.Context, entityID string, ownedPrefix string) ([]string, error)
+}
+
+const (
+	// ownedFactUpdateSubject is the atomic entity+triples update lane
+	// (must match graphingest.SubjectEntityUpdateWithTriples). Drives
+	// replace-by-predicate + clear in a single mutation.
+	ownedFactUpdateSubject = "graph.mutation.entity.update_with_triples"
+	// ownedFactQuerySubject is the single-entity read-back lane used by
+	// ReadOwnedPredicates (must match graphingest query.go).
+	ownedFactQuerySubject = "graph.ingest.query.entity"
+	// ownedFactTimeout bounds a single owned-fact round-trip. Matches the 5s
+	// budget the sibling mutation surfaces (add / add_batch / replace_owned)
+	// use — both are fast KV ops.
+	ownedFactTimeout = 5 * time.Second
+)
+
+// entityQueryRequest is the wire shape graph.ingest.query.entity expects
+// ({"id": "..."}). Kept local: graph exposes the handler, not a request type.
+type entityQueryRequest struct {
+	ID string `json:"id"`
+}
+
+// natsOwnedFactWriter adapts natsclient.Client to OwnedFactWriter, routing
+// replace-by-predicate writes through graph.mutation.entity.update_with_triples
+// and predicate read-back through graph.ingest.query.entity.
+type natsOwnedFactWriter struct {
+	client *natsclient.Client
+}
+
+// NewNATSOwnedFactWriter builds an OwnedFactWriter backed by the shared graph
+// mutation/query NATS surfaces. Wire this into tools that own a mutable
+// graph-backed fact package (gh#425).
+func NewNATSOwnedFactWriter(client *natsclient.Client) OwnedFactWriter {
+	return &natsOwnedFactWriter{client: client}
+}
+
+func (w *natsOwnedFactWriter) ReplaceTriples(ctx context.Context, entityID string, add []message.Triple, removePredicates []string) error {
+	// A bare Entity{ID} delta leaves MessageType/Version/StorageRef at zero, so
+	// graph-ingest's preserve-when-zero path keeps the birth-owner's envelope
+	// intact (this lane never re-stamps identity).
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:        &graph.EntityState{ID: entityID},
+		AddTriples:    add,
+		RemoveTriples: removePredicates,
+	}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal update_with_triples request: %w", err)
+	}
+	// RequestWithRetryClassified handles transient no-responders while
+	// graph-ingest restarts or its subscription is propagating. The replace is
+	// idempotent (replace-by-predicate converges to the same state on a
+	// duplicate delivery), so retry is safe — this is a MUTATION, per the
+	// natsclient mutation-vs-query rule.
+	// gh#93 Phase 2 / ADR-060: handler failures (entity_not_found, internal)
+	// arrive as the classified err below, not an in-body Success=false.
+	respData, err := w.client.RequestWithRetryClassified(ctx, ownedFactUpdateSubject, reqData, ownedFactTimeout, natsclient.DefaultRetryConfig())
+	if err != nil {
+		// Surface the stable Code so callers/operators distinguish a must-exist
+		// failure from transport without substring-matching the message.
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) && ce.Code != "" {
+			return fmt.Errorf("replace_triples mutation failed [%s]: %w", ce.Code, err)
+		}
+		return fmt.Errorf("request %s: %w", ownedFactUpdateSubject, err)
+	}
+	var resp graph.UpdateEntityWithTriplesResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return fmt.Errorf("unmarshal update_with_triples response: %w", err)
+	}
+	return nil
+}
+
+func (w *natsOwnedFactWriter) ReadOwnedPredicates(ctx context.Context, entityID string, ownedPrefix string) ([]string, error) {
+	// Reject the unscoped read: an empty prefix would return every owner's
+	// predicates, and feeding those to ReplaceTriples would clear facts this
+	// tool does not own. Force explicit ownership scoping.
+	if ownedPrefix == "" {
+		return nil, fmt.Errorf("read owned predicates: ownedPrefix must be non-empty (unscoped reads are rejected to prevent clearing predicates you do not own)")
+	}
+	reqData, err := json.Marshal(entityQueryRequest{ID: entityID})
+	if err != nil {
+		return nil, fmt.Errorf("marshal entity query: %w", err)
+	}
+	// RequestClassified (NOT the retry variant): this is a QUERY — retrying a
+	// hung query masks a responder problem as latency (natsclient
+	// mutation-vs-query rule). Matches the sibling query.entity reader in
+	// agentic-loop/todos.go. Handler failures (entity_not_found) still arrive
+	// classified.
+	respData, err := w.client.RequestClassified(ctx, ownedFactQuerySubject, reqData, ownedFactTimeout)
+	if err != nil {
+		var ce *errs.ClassifiedError
+		if errors.As(err, &ce) && ce.Code != "" {
+			return nil, fmt.Errorf("read owned predicates failed [%s]: %w", ce.Code, err)
+		}
+		return nil, fmt.Errorf("request %s: %w", ownedFactQuerySubject, err)
+	}
+	var entity graph.EntityState
+	if err := json.Unmarshal(respData, &entity); err != nil {
+		return nil, fmt.Errorf("unmarshal entity query: %w", err)
+	}
+	return ownedPredicates(entity.Triples, ownedPrefix), nil
+}
+
+// ownedPredicates returns the distinct predicates in triples that begin with
+// prefix, sorted for deterministic output. Empty predicates are skipped. Pure —
+// unit-tested without NATS. (The public ReadOwnedPredicates rejects an empty
+// prefix before reaching here; the empty-prefix-matches-all branch is the
+// natural pure-filter semantics, not a supported call shape.)
+func ownedPredicates(triples []message.Triple, prefix string) []string {
+	seen := make(map[string]struct{})
+	for _, tr := range triples {
+		if tr.Predicate == "" {
+			continue
+		}
+		if prefix != "" && !strings.HasPrefix(tr.Predicate, prefix) {
+			continue
+		}
+		seen[tr.Predicate] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/processor/agentic-tools/owned_fact_writer_integration_test.go
+++ b/processor/agentic-tools/owned_fact_writer_integration_test.go
@@ -1,0 +1,198 @@
+//go:build integration
+
+// Package agentictools_test — integration tests for OwnedFactWriter (gh#425)
+// driven against a REAL graph-ingest update_with_triples + query.entity handler.
+// These exercise the atomic replace-by-predicate contract, the shrinking-package
+// clear (the exact emit_change retry bug that motivated the ask), owned-prefix
+// read-back scoping, and must-exist through live NATS/KV.
+package agentictools_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/component"
+	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+	agentictools "github.com/c360studio/semstreams/processor/agentic-tools"
+	graphingest "github.com/c360studio/semstreams/processor/graph-ingest"
+)
+
+// startGraphIngestForOFW stands up a real graph-ingest Component bound to the
+// test NATS client (already Started). It owns the update_with_triples mutation
+// and query.entity read-back handlers the OwnedFactWriter drives.
+func startGraphIngestForOFW(t *testing.T, natsClient *natsclient.Client) *graphingest.Component {
+	t.Helper()
+	cfg := graphingest.DefaultConfig()
+	configJSON, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	comp, err := graphingest.CreateGraphIngest(configJSON, component.Dependencies{NATSClient: natsClient})
+	require.NoError(t, err)
+
+	gi := comp.(*graphingest.Component)
+	require.NoError(t, gi.Initialize())
+	require.NoError(t, gi.Start(context.Background()))
+	t.Cleanup(func() { _ = gi.Stop(5 * time.Second) })
+
+	// Let the mutation/query subscriptions propagate.
+	time.Sleep(150 * time.Millisecond)
+	return gi
+}
+
+// readEntityKV reads the stored EntityState straight from the ENTITY_STATES KV
+// bucket — a durable post-write probe independent of any read-cache.
+func readEntityKV(t *testing.T, natsClient *natsclient.Client, entityID string) *gtypes.EntityState {
+	t.Helper()
+	js, err := natsClient.JetStream()
+	require.NoError(t, err)
+	kv, err := js.KeyValue(context.Background(), gtypes.BucketEntityStates)
+	require.NoError(t, err)
+	entry, err := kv.Get(context.Background(), entityID)
+	require.NoError(t, err)
+	var es gtypes.EntityState
+	require.NoError(t, json.Unmarshal(entry.Value(), &es))
+	return &es
+}
+
+func predicatesPresent(es *gtypes.EntityState, predicate string) int {
+	n := 0
+	for _, tr := range es.Triples {
+		if tr.Predicate == predicate {
+			n++
+		}
+	}
+	return n
+}
+
+func ofwTestClient(t *testing.T) *natsclient.Client {
+	t.Helper()
+	tc := natsclient.NewTestClient(t,
+		natsclient.WithKV(),
+		natsclient.WithStreams(natsclient.TestStreamConfig{Name: "ENTITY", Subjects: []string{"entity.>"}}),
+	)
+	return tc.Client
+}
+
+func ownedTriple(entityID, predicate, object string) message.Triple {
+	return message.Triple{Subject: entityID, Predicate: predicate, Object: object, Confidence: 1.0, Timestamp: time.Now()}
+}
+
+// --- The motivating bug: a re-plan that SHRINKS the package must not leave
+// stale same-prefix task facts behind, and must not touch sibling owners. ---
+
+func TestIntegration_OwnedFactWriter_ReplaceShrinksPackage(t *testing.T) {
+	ctx := context.Background()
+	natsClient := ofwTestClient(t)
+	gi := startGraphIngestForOFW(t, natsClient)
+
+	const entityID = "acme.spec.openspec.run.change.001"
+	const prefix = "change.demo.task."
+
+	// Seed a 3-task package plus a sibling predicate owned by lifecycle. Stamp
+	// a birth envelope so the replace is proven to PRESERVE it (never clobber).
+	birthType := message.Type{Domain: "spec", Category: "change", Version: "v1"}
+	require.NoError(t, gi.CreateEntity(ctx, &gtypes.EntityState{
+		ID:          entityID,
+		MessageType: birthType,
+		Triples: []message.Triple{
+			ownedTriple(entityID, "change.demo.task.1", "alpha"),
+			ownedTriple(entityID, "change.demo.task.2", "beta"),
+			ownedTriple(entityID, "change.demo.task.3", "gamma"),
+			ownedTriple(entityID, "status.phase", "planning"), // sibling, must survive
+		},
+		Version:   1,
+		UpdatedAt: time.Now(),
+	}))
+
+	w := agentictools.NewNATSOwnedFactWriter(natsClient)
+
+	// A retry shrinks the package to a single, changed task.
+	owned, err := w.ReadOwnedPredicates(ctx, entityID, prefix)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"change.demo.task.1", "change.demo.task.2", "change.demo.task.3"}, owned,
+		"read-back must return exactly the owned-prefix predicates, sorted")
+
+	revised := []message.Triple{ownedTriple(entityID, "change.demo.task.1", "alpha-revised")}
+	require.NoError(t, w.ReplaceTriples(ctx, entityID, revised, owned),
+		"clear the whole owned prefix, then write the revised package")
+
+	es := readEntityKV(t, natsClient, entityID)
+	assert.Equal(t, 1, predicatesPresent(es, "change.demo.task.1"), "task.1 present exactly once")
+	assert.Equal(t, 0, predicatesPresent(es, "change.demo.task.2"), "stale task.2 must be cleared")
+	assert.Equal(t, 0, predicatesPresent(es, "change.demo.task.3"), "stale task.3 must be cleared")
+	assert.Equal(t, 1, predicatesPresent(es, "status.phase"), "sibling owner's predicate must survive")
+	assert.Equal(t, birthType, es.MessageType, "replace must PRESERVE the birth envelope, never re-stamp it")
+
+	// The surviving value is the revised one (replace-by-predicate, not append).
+	for _, tr := range es.Triples {
+		if tr.Predicate == "change.demo.task.1" {
+			assert.Equal(t, "alpha-revised", tr.Object, "task.1 must carry the revised value, not the stale one")
+		}
+	}
+}
+
+// --- ReadOwnedPredicates scopes strictly to the owned prefix. ---
+
+func TestIntegration_OwnedFactWriter_ReadOwnedPredicatesPrefixScoped(t *testing.T) {
+	ctx := context.Background()
+	natsClient := ofwTestClient(t)
+	gi := startGraphIngestForOFW(t, natsClient)
+
+	const entityID = "acme.spec.openspec.run.change.002"
+	require.NoError(t, gi.CreateEntity(ctx, &gtypes.EntityState{
+		ID: entityID,
+		Triples: []message.Triple{
+			ownedTriple(entityID, "change.demo.design", "d"),
+			ownedTriple(entityID, "change.demo.task.1", "a"),
+			ownedTriple(entityID, "change.other.task.1", "x"), // different slug
+			ownedTriple(entityID, "core.identity.type", "run"),
+		},
+		Version:   1,
+		UpdatedAt: time.Now(),
+	}))
+
+	w := agentictools.NewNATSOwnedFactWriter(natsClient)
+	owned, err := w.ReadOwnedPredicates(ctx, entityID, "change.demo.")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"change.demo.design", "change.demo.task.1"}, owned,
+		"only the change.demo.* predicates, never change.other.* or core.*")
+}
+
+// --- Must-exist: replacing a never-created entity errors (no auto-vivify). ---
+
+func TestIntegration_OwnedFactWriter_ReplaceMustExist(t *testing.T) {
+	ctx := context.Background()
+	natsClient := ofwTestClient(t)
+	gi := startGraphIngestForOFW(t, natsClient)
+	_ = gi // handler live; entity deliberately absent.
+
+	const missing = "acme.spec.openspec.run.change.404"
+	w := agentictools.NewNATSOwnedFactWriter(natsClient)
+	err := w.ReplaceTriples(ctx, missing,
+		[]message.Triple{ownedTriple(missing, "change.demo.task.1", "a")}, nil)
+	require.Error(t, err, "replace on a non-existent entity must error (no auto-vivify)")
+	assert.Contains(t, err.Error(), gtypes.ErrorCodeEntityNotFound,
+		"the handler's entity_not_found code must surface to the caller")
+}
+
+// --- ReadOwnedPredicates on a never-created entity surfaces entity_not_found. ---
+
+func TestIntegration_OwnedFactWriter_ReadMissingEntity(t *testing.T) {
+	ctx := context.Background()
+	natsClient := ofwTestClient(t)
+	_ = startGraphIngestForOFW(t, natsClient)
+
+	const missing = "acme.spec.openspec.run.change.405"
+	w := agentictools.NewNATSOwnedFactWriter(natsClient)
+	_, err := w.ReadOwnedPredicates(ctx, missing, "change.demo.")
+	require.Error(t, err, "read-back on a non-existent entity must error")
+	assert.Contains(t, err.Error(), gtypes.ErrorCodeEntityNotFound,
+		"the handler's entity_not_found code must surface to the caller")
+}

--- a/processor/agentic-tools/owned_fact_writer_test.go
+++ b/processor/agentic-tools/owned_fact_writer_test.go
@@ -1,0 +1,102 @@
+package agentictools
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+func tr(predicate string) message.Triple {
+	return message.Triple{Subject: "run.entity", Predicate: predicate, Object: "v"}
+}
+
+func TestOwnedPredicates(t *testing.T) {
+	tests := []struct {
+		name    string
+		triples []message.Triple
+		prefix  string
+		want    []string
+	}{
+		{
+			name: "prefix scopes to owned package, sibling predicates excluded",
+			triples: []message.Triple{
+				tr("change.abc.task.1"),
+				tr("change.abc.task.2"),
+				tr("core.identity.type"), // other owner — must NOT be returned
+				tr("status.phase"),       // lifecycle — must NOT be returned
+			},
+			prefix: "change.abc.",
+			want:   []string{"change.abc.task.1", "change.abc.task.2"},
+		},
+		{
+			name: "distinct: multi-valued predicate collapses to one entry",
+			triples: []message.Triple{
+				{Subject: "run.entity", Predicate: "change.abc.tag", Object: "a"},
+				{Subject: "run.entity", Predicate: "change.abc.tag", Object: "b"},
+			},
+			prefix: "change.abc.",
+			want:   []string{"change.abc.tag"},
+		},
+		{
+			name: "sorted output regardless of triple order",
+			triples: []message.Triple{
+				tr("change.abc.task.3"),
+				tr("change.abc.task.1"),
+				tr("change.abc.task.2"),
+			},
+			prefix: "change.abc.",
+			want:   []string{"change.abc.task.1", "change.abc.task.2", "change.abc.task.3"},
+		},
+		{
+			name: "empty prefix returns every predicate (single-owner escape hatch)",
+			triples: []message.Triple{
+				tr("change.abc.task.1"),
+				tr("core.identity.type"),
+			},
+			prefix: "",
+			want:   []string{"change.abc.task.1", "core.identity.type"},
+		},
+		{
+			name: "empty predicate skipped",
+			triples: []message.Triple{
+				tr(""),
+				tr("change.abc.task.1"),
+			},
+			prefix: "change.abc.",
+			want:   []string{"change.abc.task.1"},
+		},
+		{
+			name:    "no match returns empty, not nil-panic",
+			triples: []message.Triple{tr("other.pred")},
+			prefix:  "change.abc.",
+			want:    []string{},
+		},
+		{
+			name:    "no triples returns empty",
+			triples: nil,
+			prefix:  "change.abc.",
+			want:    []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ownedPredicates(tc.triples, tc.prefix)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestReadOwnedPredicates_RejectsEmptyPrefix locks the typed guard: an unscoped
+// read is refused BEFORE any RPC (nil client is never dereferenced), so a tool
+// can never accidentally clear predicates it does not own on a shared entity.
+func TestReadOwnedPredicates_RejectsEmptyPrefix(t *testing.T) {
+	w := &natsOwnedFactWriter{client: nil}
+	_, err := w.ReadOwnedPredicates(context.Background(), "acme.spec.run.change.001", "")
+	require.Error(t, err, "empty ownedPrefix must be rejected")
+	assert.Contains(t, err.Error(), "non-empty", "error must explain the scoping requirement")
+}


### PR DESCRIPTION
## Summary

Closes #425. Exposes a first-class **replace-owned** graph writer to agent tools so a tool that owns a *mutable* package of graph facts can REPLACE it on a retry/re-plan instead of appending a stale second copy.

The atomic replace-by-predicate primitive already existed in the framework (`processor/rule/triple_mutator.go` `ReplaceOwned`, `pkg/lifecycle`) but was never reachable from the agent-tool surface — `agentictools.TriplePublisher` only had append/birth verbs. So **two products hand-rolled it**: semteams (`emitdevviatestplan/remover.go`, a non-atomic per-predicate remove loop — its own comment marks itself a "collapse onto upstream" target) and semspec (`emitchange/graph_writer.go`, a direct `update_with_triples` adapter). N=2 → lift into the framework.

## What's added (`processor/agentic-tools/owned_fact_writer.go`)

A **separate** `OwnedFactWriter` interface (not a widening of `TriplePublisher` — least privilege; append-only tools `decide`/`scratchpad`/`emit_diagnosis` must not reach replace+clear):

- **`ReplaceTriples(ctx, entityID, add, removePredicates)`** — atomic replace-by-predicate + clear in ONE `graph.mutation.entity.update_with_triples` mutation. **Must-exist** (no auto-vivify) and **preserve-envelope**: deliberately no `entityType` param, because this UPDATE lane must never re-stamp a birth-owner's `MessageType`/`Version` envelope (ADR-055 provenance / ADR-054 indexing key).
- **`ReadOwnedPredicates(ctx, entityID, ownedPrefix)`** — prefix-scoped read-back so a tool computes the remove-set for a *shrinking* package without clearing facts it doesn't own on a shared entity. Empty prefix is **rejected**. Uses `RequestClassified` (query, not the retry/mutation variant).

Both surface classified handler errors (`entity_not_found`) per ADR-060 / gh#93.

## Usage (the collapse for consumers)

```go
w := agentictools.NewNATSOwnedFactWriter(natsClient)
owned, _ := w.ReadOwnedPredicates(ctx, runEntityID, "change."+slug+".")
// clear my whole owned prefix, then write the revised package
_ = w.ReplaceTriples(ctx, runEntityID, revisedTriples, owned)
```

This deletes semspec's `changePackageRemovePredicates` boilerplate and drops its `entityType` arg (it passed `workflow.PlanEntityType`, a same-value no-op on the already-typed run entity — so no behavior change, one less footgun).

## Tests

- Unit: pure prefix-filter (`ownedPredicates`) + the empty-prefix guard.
- Integration (`//go:build integration`, real graph-ingest): a shrink clears stale `task.*`, **preserves** a sibling owner's predicate AND the birth envelope; must-exist errors on an absent entity; read-back surfaces `entity_not_found`.

## Review

`semstreams-reviewer` pre-merge → CHANGES REQUESTED, both HIGH resolved:
1. `ReadOwnedPredicates` now uses `RequestClassified` (query-not-mutation rule; matches sibling `agentic-loop/todos.go`).
2. Dropped `entityType` from `ReplaceTriples` to kill the envelope-clobber footgun structurally (was: non-zero type overwrites the stored envelope). Envelope-preservation now locked by an integration assertion.

## Scope / follow-up

Purely **additive** (new interface + adapter + constructor; no existing signature or behavior changed) → **non-breaking**, no e2e-before-tag rule triggered. Migrating semspec `emitchange` and semteams `emitdevviatestplan` onto the helper is a separate follow-up in those repos once a tag lands.

Gates: gofmt · `go vet` (default + integration) · revive (`./...`) · unit + integration tests green · no schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcS2JwsPgB6xyLFjQtjQHQ
