### PR TITLE
fix(gated-dag): ignore referential-integrity stubs before dispatch (gh#429)

### DIFF
--- a/graph/stub.go
+++ b/graph/stub.go
@@ -1,0 +1,50 @@
+package graph
+
+import "github.com/c360studio/semstreams/message"
+
+// StubMessageType is the envelope of a referential-integrity stub: the entity
+// graph-ingest materializes at a referenced-but-not-yet-born ID so a
+// relationship's target always resolves to a node (ADR-056 Decision 4 lane-ii).
+// A stub is PROFILE-LESS and carries only the three stub-marker triples below;
+// no domain content and no depends_on edges.
+//
+// At the referenced entity's TRUE BIRTH the real producer's write overwrites
+// this envelope with its own MessageType — but ONLY on a re-stamping lane:
+// fact-arrival merge (unconditional overwrite), or create_with_triples /
+// update_with_triples carrying a NON-ZERO MessageType (preserve-when-zero,
+// non-zero wins). A birth via triple.add / add_batch, or a zero-typed
+// update_with_triples, does NOT re-stamp the envelope — so a producer that
+// wants its entity to stop reading as a stub must birth it on a re-stamping
+// lane with its real type.
+//
+// Consumers that ENUMERATE entities — notably the gated-DAG executor, which
+// reads every entity under a unit prefix — MUST treat a stub as not-yet-real:
+// dispatching a stub would bypass dependency ordering because it carries no
+// depends_on edges (gh#429). Use [EntityState.IsStub].
+var StubMessageType = message.Type{Domain: "core", Category: "identity.stub", Version: "v1"}
+
+// Stub-marker predicates carried by a referential-integrity stub. Exported so
+// the producer (graph-ingest) and enumerating consumers share one definition.
+const (
+	// PredStubMarker marks the entity as a referential-integrity stub. Note:
+	// this triple PERSISTS after real birth (nothing removes it), so it is NOT a
+	// reliable "still a stub" signal — use [EntityState.IsStub] (envelope-based).
+	PredStubMarker = "core.identity.stub"
+	// PredStubReferencedBy records the entity ID whose relationship triple
+	// caused this stub to be materialized.
+	PredStubReferencedBy = "core.identity.referenced_by"
+	// PredStubOwner records the stub's owner identity (the referencing entity's
+	// type key, or the framework referential producer for an untyped source).
+	PredStubOwner = "core.identity.stub_owner"
+)
+
+// IsStub reports whether this entity is still a bare referential-integrity stub
+// — one whose envelope is StubMessageType, i.e. no real producer has re-stamped
+// it yet. It keys on the ENVELOPE, not the PredStubMarker triple: the triple
+// persists after real birth, whereas the envelope is overwritten by the real
+// producer at birth, so the envelope is the signal that correctly flips from
+// stub → real. See gh#429 and [StubMessageType] for the re-stamping-lane
+// contract.
+func (es EntityState) IsStub() bool {
+	return es.MessageType.Equal(StubMessageType)
+}

--- a/graph/stub_test.go
+++ b/graph/stub_test.go
@@ -1,0 +1,40 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/c360studio/semstreams/message"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntityState_IsStub(t *testing.T) {
+	tests := []struct {
+		name string
+		mt   message.Type
+		want bool
+	}{
+		{"stub envelope is a stub", StubMessageType, true},
+		{"real envelope is not a stub", message.Type{Domain: "workflow", Category: "task-unit", Version: "v1"}, false},
+		{"zero envelope is not a stub", message.Type{}, false},
+		{"same-domain different-category is not a stub", message.Type{Domain: "core", Category: "identity", Version: "v1"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			es := EntityState{ID: "acme.ops.robotics.gcs.drone.001", MessageType: tc.mt}
+			assert.Equal(t, tc.want, es.IsStub())
+		})
+	}
+}
+
+// IsStub keys on the ENVELOPE, not the PredStubMarker triple: the stub triple
+// persists after real birth (nothing removes it), so a triple-based check would
+// wrongly classify an upgraded real unit as a stub forever. This locks the
+// envelope-not-triple discriminator (gh#429).
+func TestEntityState_IsStub_KeysOnEnvelopeNotTriple(t *testing.T) {
+	es := EntityState{
+		ID:          "acme.ops.robotics.gcs.drone.001",
+		MessageType: message.Type{Domain: "workflow", Category: "task-unit", Version: "v1"},
+		Triples:     []message.Triple{{Subject: "acme.ops.robotics.gcs.drone.001", Predicate: PredStubMarker, Object: true}},
+	}
+	assert.False(t, es.IsStub(), "a real-enveloped entity still carrying a persisted stub marker triple is NOT a stub")
+}

--- a/processor/gated-dag/executor.go
+++ b/processor/gated-dag/executor.go
@@ -224,6 +224,12 @@ func (e *executor) reEvaluate(ctx context.Context, fromBackstop bool) {
 	}
 
 	view := extractGraph(states, e.cfg)
+	if e.metrics != nil {
+		// gh#429: referential stubs excluded from the unit set this eval. A
+		// sustained nonzero value is a stuck-stub signal (a referenced unit whose
+		// real content never landed on a re-stamping lane), not a silent wedge.
+		e.metrics.stubsSkipped.Set(float64(view.stubsSkipped))
+	}
 	decisions := gateddag.Evaluate(view.unitIDs, view.dependsOn, view.markers)
 
 	// In-flight bookkeeping: drop units that have gone terminal, been reset

--- a/processor/gated-dag/metrics.go
+++ b/processor/gated-dag/metrics.go
@@ -12,6 +12,7 @@ const metricsService = "gated-dag"
 // shared registry when one is provided, so increments are always nil-safe.
 type metrics struct {
 	stall         prometheus.Gauge
+	stubsSkipped  prometheus.Gauge
 	claimed       prometheus.Counter
 	claimErr      prometheus.Counter
 	dispatched    prometheus.Counter
@@ -26,6 +27,10 @@ func newMetrics(reg *metric.MetricsRegistry) *metrics {
 		stall: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "gated_dag_stalled_units",
 			Help: "Number of units held-ready with no forward progress and nothing in-flight (a depends_on cycle or all-blocked-behind-failure). 0 = healthy.",
+		}),
+		stubsSkipped: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "gated_dag_referential_stubs_skipped",
+			Help: "Entities under the unit prefix excluded this eval because they are referential-integrity stubs (not-yet-born, core.identity.stub envelope) — gh#429. Briefly nonzero during a referenced unit's birth window is expected; a SUSTAINED nonzero value means a referenced unit's real content never landed on a re-stamping lane and it will never dispatch.",
 		}),
 		claimed: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "gated_dag_units_claimed_total",
@@ -56,6 +61,7 @@ func newMetrics(reg *metric.MetricsRegistry) *metrics {
 		// Best-effort registration: a duplicate (e.g. two flows) is logged by the
 		// registry and does not abort the executor.
 		_ = reg.RegisterGauge(metricsService, "stalled_units", m.stall)
+		_ = reg.RegisterGauge(metricsService, "referential_stubs_skipped", m.stubsSkipped)
 		_ = reg.RegisterCounter(metricsService, "units_claimed_total", m.claimed)
 		_ = reg.RegisterCounter(metricsService, "claim_errors_total", m.claimErr)
 		_ = reg.RegisterCounter(metricsService, "units_dispatched_total", m.dispatched)

--- a/processor/gated-dag/reader.go
+++ b/processor/gated-dag/reader.go
@@ -118,6 +118,12 @@ type graphView struct {
 	dependsOn map[string][]string
 	markers   gateddag.MarkerSet
 	claimed   map[string]bool
+	// stubsSkipped counts entities under the unit prefix that were referential
+	// stubs (graph.StubMessageType) and therefore excluded from the unit set
+	// this read (gh#429). A sustained nonzero value means a referenced unit's
+	// real content never landed on a re-stamping lane — an observable stuck-stub
+	// signal rather than a silent never-dispatch.
+	stubsSkipped int
 }
 
 // extractGraph derives the brain inputs (unit IDs, depends_on edges, marker
@@ -128,6 +134,15 @@ type graphView struct {
 // at least one triple with the configured predicate (the Object value is
 // irrelevant for completed/failed/dirtied/claim). depends_on is the exception —
 // its Object is the prerequisite unit ID, collected as a directed edge.
+//
+// Referential stubs are EXCLUDED (gh#429): graph-ingest materializes an
+// entity_id-referenced-but-not-yet-born entity as a graph.StubMessageType stub
+// under this same unit prefix. A stub has no depends_on edges, so the brain
+// would derive it as a dependency-free, immediately-dispatchable unit and
+// dispatch it before its real content lands — bypassing dependency ordering.
+// Skipping stubs is safe for the dependency closure: DeriveStatus keys on
+// marker membership, so a dependent whose prerequisite is a skipped stub is
+// still correctly held (the prerequisite is simply not Done).
 func extractGraph(states []graph.EntityState, cfg Config) graphView {
 	view := graphView{
 		unitIDs:   make([]string, 0, len(states)),
@@ -138,6 +153,12 @@ func extractGraph(states []graph.EntityState, cfg Config) graphView {
 
 	for i := range states {
 		s := &states[i]
+		if s.IsStub() {
+			// Not-yet-born placeholder; the real producer re-stamps the envelope
+			// at birth and the next read picks the unit up with its real edges.
+			view.stubsSkipped++
+			continue
+		}
 		view.unitIDs = append(view.unitIDs, s.ID)
 		for j := range s.Triples {
 			t := &s.Triples[j]

--- a/processor/gated-dag/reader_test.go
+++ b/processor/gated-dag/reader_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/gateddag"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,5 +66,46 @@ func TestExtractGraph(t *testing.T) {
 	t.Run("empty input", func(t *testing.T) {
 		v := extractGraph(nil, cfg)
 		require.Empty(t, v.unitIDs)
+	})
+
+	t.Run("referential stubs excluded by envelope; real + upgraded units kept (gh#429)", func(t *testing.T) {
+		stub := graph.EntityState{
+			ID:          "stub-x",
+			MessageType: graph.StubMessageType,
+			Triples:     []message.Triple{{Predicate: graph.PredStubMarker, Object: true}},
+		}
+		realUnit := unit("real-y", tri(cfg.CompletedPredicate, "real-y"))
+		// Post-birth the stub TRIPLE persists but the ENVELOPE flips to a real
+		// type; such a unit MUST be kept — the filter is envelope-based, not
+		// triple-based, so a persisted stub marker does not exclude a real unit.
+		upgraded := graph.EntityState{
+			ID:          "up-z",
+			MessageType: message.Type{Domain: "workflow", Category: "task-unit", Version: "v1"},
+			Triples: []message.Triple{
+				{Predicate: graph.PredStubMarker, Object: true}, // persisted stub triple
+				tri(cfg.CompletedPredicate, "up-z"),
+			},
+		}
+		v := extractGraph([]graph.EntityState{stub, realUnit, upgraded}, cfg)
+		require.ElementsMatch(t, []string{"real-y", "up-z"}, v.unitIDs)
+		require.Equal(t, 1, v.stubsSkipped)
+		require.True(t, v.markers.Completed["up-z"], "upgraded unit's markers still read despite the persisted stub triple")
+	})
+
+	t.Run("dependent on a stubbed prerequisite is held, not dispatched (gh#429)", func(t *testing.T) {
+		stub := graph.EntityState{
+			ID:          "prereq",
+			MessageType: graph.StubMessageType,
+			Triples:     []message.Triple{{Predicate: graph.PredStubMarker, Object: true}},
+		}
+		dependent := unit("dependent", tri(cfg.DependsOnPredicate, "prereq"))
+		v := extractGraph([]graph.EntityState{stub, dependent}, cfg)
+		require.Equal(t, []string{"dependent"}, v.unitIDs, "the stub prerequisite is filtered out of the unit set")
+		require.Equal(t, 1, v.stubsSkipped)
+		// Dependency-closure correctness: DeriveStatus keys on marker membership,
+		// so a dependent whose prerequisite is a filtered stub is still correctly
+		// held (the prerequisite is not Done) — NOT wrongly dispatched.
+		require.Empty(t, gateddag.SelectDispatchable(v.unitIDs, v.dependsOn, v.markers),
+			"dependent must be held while its prerequisite is an unborn stub")
 	})
 }

--- a/processor/gated-dag/stub_dispatch_integration_test.go
+++ b/processor/gated-dag/stub_dispatch_integration_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+// gh#429: the executor must not dispatch a referential-integrity stub — an
+// entity graph-ingest materializes at an entity_id-referenced-but-not-yet-born
+// ID (under the same unit prefix). A stub carries no depends_on edges, so
+// pre-fix the brain derived it as dependency-free and dispatched it ahead of its
+// real content, bypassing dependency ordering. These drive the REAL graph-ingest
+// mutation/query wire + the executor, proving: (1) a bare stub is never
+// dispatched; (2) it dispatches once its real content lands on a RE-STAMPING
+// lane (update_with_triples, non-zero MessageType) — the self-heal; and (3) a
+// non-re-stamping "birth" (triple.add only) does NOT self-heal — locking the
+// self-heal precondition into CI so a future write-lane change fails loudly
+// rather than silently wedging a paid run.
+package gateddagexec_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// stubByReference materializes targetUnitID as a referential-integrity stub by
+// creating an entity OUTSIDE the unit prefix (so the referencer itself is not a
+// unit) whose relationship triple names targetUnitID. graph-ingest's referential
+// integrity synchronously creates the stub under targetUnitID.
+func (fs *fullStack) stubByReference(t *testing.T, refID, targetUnitID string) {
+	t.Helper()
+	require.NoError(t, fs.gi.CreateEntity(context.Background(), &gtypes.EntityState{
+		ID:          refID,
+		MessageType: message.Type{Domain: "fs", Category: "holder", Version: "v1"},
+		Triples: []message.Triple{
+			{Subject: refID, Predicate: "fs.references", Object: targetUnitID, Timestamp: time.Now(), Confidence: 1.0},
+		},
+		Version:   1,
+		UpdatedAt: time.Now(),
+	}))
+	// Confirm the stub actually landed (and carries the stub envelope) before the
+	// assertions depend on it.
+	require.True(t, fs.unitIsStub(t, targetUnitID), "reference must have materialized %s as a stub", targetUnitID)
+}
+
+// birthRestamping writes real content on a RE-STAMPING lane: update_with_triples
+// with a NON-ZERO MessageType overwrites the stub envelope (preserve-when-zero,
+// non-zero wins), so IsStub flips false.
+func (fs *fullStack) birthRestamping(t *testing.T, id string) {
+	t.Helper()
+	req := gtypes.UpdateEntityWithTriplesRequest{
+		Entity: &gtypes.EntityState{ID: id, MessageType: message.Type{Domain: "fs", Category: "unit", Version: "v1"}},
+		AddTriples: []message.Triple{
+			{Subject: id, Predicate: "fs.unit.ready", Object: true, Timestamp: time.Now(), Confidence: 1.0},
+		},
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	_, err = fs.nc.RequestWithRetryClassified(context.Background(), "graph.mutation.entity.update_with_triples", data, 5*time.Second, natsclient.DefaultRetryConfig())
+	require.NoError(t, err)
+}
+
+// unitIsStub reads the entity authoritatively and reports whether it still
+// carries the stub envelope.
+func (fs *fullStack) unitIsStub(t *testing.T, id string) bool {
+	t.Helper()
+	data, err := json.Marshal(gtypes.PrefixQueryRequest{Prefix: fs.prefix, Limit: 100})
+	require.NoError(t, err)
+	resp, err := fs.nc.RequestClassified(context.Background(), "graph.ingest.query.prefix", data, 5*time.Second)
+	require.NoError(t, err)
+	var pr gtypes.PrefixQueryResponse
+	require.NoError(t, json.Unmarshal(resp, &pr))
+	for i := range pr.Entities {
+		if pr.Entities[i].ID == id {
+			return pr.Entities[i].IsStub()
+		}
+	}
+	return false
+}
+
+func TestFullStack_ReferentialStubNotDispatchedUntilBorn(t *testing.T) {
+	const subject = "fs.dispatch.s8"
+	prefix := "fs.test.s8.fanout.unit"
+	fs := setupFullStack(t, fsOpts{prefix: prefix, subject: subject})
+
+	selfHeal := fsUnit("s8", "selfheal") // stubbed, then born on a re-stamping lane
+	stuck := fsUnit("s8", "stuck")       // stubbed, then "born" via triple.add only
+
+	// 1. Materialize both as referential stubs (referencers live outside the unit
+	//    prefix so they are not themselves units).
+	fs.stubByReference(t, "fs.holder.ref.entity.owner.one", selfHeal)
+	fs.stubByReference(t, "fs.holder.ref.entity.owner.two", stuck)
+
+	// 2. Neither dispatches while a bare stub — several backstop passes prove it.
+	time.Sleep(2 * time.Second)
+	require.Equal(t, 0, fs.dispatched.count(selfHeal), "a bare stub must not be dispatched (gh#429)")
+	require.Equal(t, 0, fs.dispatched.count(stuck), "a bare stub must not be dispatched (gh#429)")
+
+	// 3. Self-heal: birth selfHeal on a re-stamping lane → envelope flips off the
+	//    stub → the executor dispatches it.
+	fs.birthRestamping(t, selfHeal)
+	require.Eventually(t, func() bool { return fs.dispatched.count(selfHeal) == 1 }, fsEventually, 100*time.Millisecond,
+		"once a real producer re-stamps the stub envelope, the unit dispatches (self-heal)")
+
+	// 4. Precondition (negative): "birth" stuck via triple.add only. triple.add
+	//    never touches MessageType, so the stub envelope survives → the unit stays
+	//    filtered → it never dispatches. A future semspec write-lane change to a
+	//    non-re-stamping birth would surface HERE, not as a silent paid-run wedge.
+	addMarker(context.Background(), fs.nc, stuck, "fs.unit.content")
+	require.True(t, fs.unitIsStub(t, stuck), "triple.add must not re-stamp the stub envelope")
+	time.Sleep(2 * time.Second)
+	require.Equal(t, 0, fs.dispatched.count(stuck),
+		"a triple.add-only birth does not re-stamp the envelope, so the unit stays filtered (precondition)")
+}

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -1976,12 +1976,16 @@ func (c *Component) ensureRelationshipTargetsExist(ctx context.Context, entity *
 // PROFILE-LESS so MergeEntity still detects the real producer's later merge as
 // the entity's true birth (reconcileIndexingProfile keys on profile-absence,
 // component.go:1414-1419).
-var stubMessageType = message.Type{Domain: "core", Category: "identity.stub", Version: "v1"}
+// Stub identity now lives in the graph package (graph.StubMessageType +
+// graph.PredStub*) so the producer here and enumerating consumers — notably the
+// gated-DAG executor, which must not dispatch a stub (gh#429) — share one
+// definition. These locals alias the shared contract.
+var stubMessageType = graph.StubMessageType
 
 const (
-	predStubMarker        = "core.identity.stub"
-	predStubReferencedBy  = "core.identity.referenced_by"
-	predStubOwner         = "core.identity.stub_owner"
+	predStubMarker        = graph.PredStubMarker
+	predStubReferencedBy  = graph.PredStubReferencedBy
+	predStubOwner         = graph.PredStubOwner
 	stubReferentialSource = "graph-ingest-referential-integrity"
 )
 
@@ -2029,7 +2033,17 @@ func (c *Component) ensureReferencedEntityExists(ctx context.Context, entityID, 
 		return fmt.Errorf("marshal stub entity: %w", err)
 	}
 
-	if _, err := c.entityBucket.Put(ctx, entityID, data); err != nil {
+	// Atomic create-if-absent (gh#429). The Get above is only a fast-path: a real
+	// producer can birth this entity between that Get (saw absent) and this write.
+	// A Put would clobber the real entity back to a stub envelope — which, once
+	// gated-DAG filters stubs, silently makes a real unit un-dispatchable. Create
+	// returns ErrKVKeyExists on a concurrent create, which we map to a no-op
+	// success — so we stub ONLY if the ID is genuinely still absent and never
+	// overwrite a real (or sibling-stub) entity.
+	if _, err := c.entityBucket.Create(ctx, entityID, data); err != nil {
+		if errors.Is(err, natsclient.ErrKVKeyExists) {
+			return nil // raced with a real (or sibling stub) create — do not clobber
+		}
 		return fmt.Errorf("store stub entity: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Fixes #429. gated-dag was dispatching **referential-integrity stubs** as if they were real units, bypassing dependency ordering — a critical hazard for semspec's long paid runs (a unit could dispatch against an unhydrated workspace before its prerequisites completed).

## Root cause (verified end-to-end)

When an `entity_id` reference names a not-yet-born entity, graph-ingest materializes a `core.identity.stub/v1` at that ID (`ensureReferencedEntityExists`). The trigger is broad: `Triple.IsRelationship()` fires on **any** 6-part-EntityID object, so **`depends_on` edges** stub their targets too, not just semspec's `prepare_target`. A stub carries **no `depends_on` edges**, so gated-dag's `extractGraph` (which appended every prefix entity as a unit) fed the brain a dependency-free unit → `decideUnit` → `Dispatchable = true` → claimed + dispatched, gate bypassed.

## Fix — gated-dag ignores stubs by default

- **`graph/stub.go`** (new): lifts the stub identity into the shared `graph` package (`StubMessageType`, `PredStub*`, `EntityState.IsStub()`) — one definition shared by the producer (graph-ingest) and enumerating consumers.
- **`gated-dag/reader.go`**: `extractGraph` skips `IsStub()` entities. Filters on the **envelope**, not the persistent `core.identity.stub` triple — the triple survives real birth (nothing removes it) while the envelope is overwritten by the real producer on a re-stamping lane, so the envelope is the signal that flips stub→real and **self-heals**. Dependency-closure-safe: `DeriveStatus` keys on marker membership, so a dependent behind a filtered stub prereq stays correctly held.
- **`gated_dag_referential_stubs_skipped`** gauge: a sustained nonzero value is an **observable stuck-stub** signal (a referenced unit whose real content never landed on a re-stamping lane), not a silent never-dispatch.
- **graph-ingest**: the stub write is now atomic **`Create`** (create-if-absent) instead of `Put`, closing a TOCTOU where a stub could clobber a concurrently-born real entity.

## Self-heal precondition (the review's HIGH, verified + locked)

The envelope only flips on a **re-stamping** lane (fact-arrival merge, or non-zero-typed `update_with_triples` / `create_with_triples`) — **not** `triple.add` or zero-typed update. semspec's task-unit birth uses `update_with_triples` with `workflow.task-unit/v1` (non-zero), so it self-heals (verified in `semspec/workflow/graphutil/triple.go`). The integration test **locks** this: positive (re-stamping birth → dispatched) **and** negative (`triple.add`-only birth stays filtered) — so a future consumer write-lane change fails loudly in CI, not as a silent paid-run wedge.

## Tests

- Unit: `IsStub` (envelope-not-triple); `extractGraph` filters stubs, keeps upgraded units carrying a persisted stub triple, holds a dependent behind a filtered stub prereq.
- Integration (real graph-ingest + executor): bare stub not dispatched → re-stamp birth self-heals → dispatched; `triple.add`-only birth stays filtered.

## Review

Diagnosis + design reviewed pre-code (2 agents — one confirmed the diagnosis, one caught the lane-conditional self-heal precondition + the TOCTOU). Implementation reviewed pre-merge (APPROVE, no blocking/high). Relates to ADR-064 (prepare-as-a-unit depends on this fix).

## Gates

gofmt · `go vet` (default + integration) · revive (`./...`) · unit + contract tests green · new integration test 3/3 isolated, full gated-dag suite 3× clean, graph-ingest stub/foreign-edge integration green · no schema drift. Dispatch-path fix → **`e2e:agentic` before the beta.127 tag**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcS2JwsPgB6xyLFjQtjQHQ
