### PR TITLE
fix(graph-index): predicate-index composite-key sharding — fix O(N²) indexing (gh#430)

### DIFF
--- a/docs/adr/065-predicate-index-composite-key-sharding.md
+++ b/docs/adr/065-predicate-index-composite-key-sharding.md
@@ -49,6 +49,18 @@ of magnitude inside the handler's 10s timeout, confirming the "2 round
 trips regardless of corpus size" design property empirically, not just by
 code inspection. See `processor/graph-index/predicate_index_load_test.go`.
 
+Both `task e2e:structural` and `task e2e:semantic` — the breaking-change
+gate this ADR requires (see Breaking-change scope) — ran green:
+`validation_errors:0` on both, all predicate-related scenario steps
+(`test-predicate-list`, `test-predicate-stats`, `test-predicate-compound`)
+passing with sub-10ms latencies against the real Docker stack. The
+semantic tier's `validate-virtual-edges` step — the one exercising the
+rewritten `CountVirtualEdges` end to end — completed in under 2ms via the
+correct "legitimate zero, not an error" path (`total=0,
+auto_applied_anomalies=0`, non-fatal per this test corpus's semantic gaps
+not meeting the 0.85 auto-apply threshold); the hard-fail path this PR
+added was not triggered, as expected, since nothing here should fail.
+
 ## Decision
 
 Replace `PREDICATE_INDEX`'s one-key-per-predicate monolithic JSON blob

--- a/docs/adr/065-predicate-index-composite-key-sharding.md
+++ b/docs/adr/065-predicate-index-composite-key-sharding.md
@@ -1,0 +1,418 @@
+# ADR-065: predicate-index composite-key sharding (fix gh#430 O(N²))
+
+## Status
+
+**Accepted** (2026-07-03, GH #430). Reached after two review rounds: a
+3-way adversarial review (architect, go-reviewer, semstreams-reviewer) that
+found and fixed the raw-predicate-prefix collision bug, then a final
+architect gate-check on this document that returned GO with the
+refinements folded into this revision (single-scan `predicateList`, new
+bucket name for the cutover, catalog key-identity clarification). Adjacent
+correctness gap found during this investigation filed separately as
+GH #433 (entity-delete never cleans up
+PREDICATE_INDEX/NAME_INDEX/ALIAS_INDEX/CONTEXT_INDEX) — explicitly out of
+scope here.
+
+## Decision
+
+Replace `PREDICATE_INDEX`'s one-key-per-predicate monolithic JSON blob
+(CAS read-modify-write on every entity write) with **one KV key per
+(predicate, entity) membership pair**, keyed on a **hash of the predicate**
+rather than the raw predicate string:
+
+```
+key   = sha256Hex(predicate) + "." + entityID   // 1 hash token + 6 entity-ID tokens = fixed 7-token key
+value = small marker (empty or a debug timestamp)
+```
+
+Writes become an unconditional `Put` — no CAS, no read, no JSON parse of
+anything proportional to corpus size, and no contention (no two entities
+ever write the same key). Reads enumerate membership via
+`natsclient.KVStore.KeysByPrefix(sha256Hex(predicate) + ".")`, NATS
+JetStream KV's server-side prefix-filtered key listing.
+
+A second, small **PREDICATE_CATALOG** bucket — its own bucket, not a
+shared keyspace with membership keys — maps `predicate name → exists`,
+updated via the same cheap idempotent `Put` whenever a predicate is first
+seen. Its sole job is being the cheap hash→name recovery source for
+`graph.index.query.predicateList`: **key = the raw predicate name**
+(never hashed), read only via exact `Get` or a full `Keys()` enumeration,
+**never** `KeysByPrefix` on this bucket — the exact-string-only discipline
+of ADR-056 applies to the catalog too, not just membership keys. Note the
+catalog does not, by itself, avoid a full-corpus scan for `predicateList`'s
+per-predicate counts — see the single-scan design in the read-path table
+below for how that's actually avoided.
+
+The NATS wire contract (`graph.PredicateData`, `graph.PredicateListData`,
+`graph.PredicateStatsData`, `graph.CompoundPredicateData`) does not change.
+This is an internal storage-layer swap inside `graph-index`; the query API
+consumers (gateway, GraphQL, `graph-query/summary.go`, semsource's MCP
+tools) do not need to change.
+
+## Context
+
+### The bug (GH #430)
+
+`processor/graph-index/component.go:1287-1358`, `UpdatePredicateIndex`:
+PREDICATE_INDEX stores one KV key per predicate, value =
+`graph.PredicateIndexEntry{Entities []string, ...}` — the full list of
+every entity carrying that predicate. Every entity write CAS-updates this
+key (`UpdateWithRetry`, `component.go:1305-1337`): fetch, unmarshal,
+dedup-scan, append, marshal, CAS-write. For a predicate carried by ~all
+entities (e.g. `code.artifact.type` on 21,265 code entities — the corpus
+that surfaced this bug, dogfooding semsource's MCP `code_context` tools
+against semstreams beta.124 itself), the blob for that one key grows to
+~21k entries; each of the N writes re-parses/re-serializes an O(N) blob ⇒
+**O(N²)** total. A 30s CPU profile during ingest showed
+`UpdatePredicateIndex` at 63% of total CPU (~37% of that in
+`encoding/json`, ~29% in NATS KV round-trip syscalls). Raising `workers`
+1→8 barely moved the needle (9/15→10/15 byName coverage on the same
+corpus) — this is algorithmic, not a concurrency-tuning problem.
+
+Indexing 22k entities currently takes minutes, not seconds; `byName`
+readiness lags for minutes behind `phase: ready`; `graph-embedding` is
+starved during ingest (semantic search effectively non-functional while
+`PREDICATE_INDEX` churns).
+
+### Why composite keys, not a monolithic-blob variant — codebase precedent
+
+Every *other* multi-membership index in this codebase already uses
+per-member composite KV keys + server-side prefix-filtered enumeration,
+not a monolithic blob:
+
+- `graph/inference/storage.go:313-343` (`getByIndexPrefix`) — anomaly
+  type/status indexes.
+- `graph/structural/storage.go:299,341` — pivot-entity / structural
+  indexes.
+- `graph/clustering/storage.go:206`, `processor/graph-clustering/query.go:304`
+  — community detection, keys `<level>.<communityID>`.
+- `processor/graph-index-temporal/query.go:68` — temporal index.
+- `graph/datamanager/batch_ops.go:92,119` — batch operations.
+- Inside `graph-index` itself: `processor/graph-ingest/query.go:150-209`
+  (`handleQueryPrefixNATS`) — entity-ID prefix lookup with sort + cursor
+  pagination, the direct precedent for prefix-filtered enumeration at this
+  layer.
+- Even within `graph-index`'s own indexes: `outgoingBucket` (unconditional
+  `Put`, keyed by owning entity — bounded by that entity's own out-degree)
+  and `incomingBucket` (CAS, keyed by target entity — bounded by that
+  entity's in-degree) both avoid PREDICATE_INDEX's mistake by never being
+  keyed on a low-cardinality *global* dimension. PREDICATE_INDEX is the
+  only index keyed that way, and the only one still using the monolithic
+  pattern the rest of the codebase already migrated away from.
+
+`natsclient.KVStore.KeysByPrefix` (`natsclient/kv.go:349-376`) is the
+underlying primitive: converts a `prefix` to the NATS wildcard `prefix +
+">"`, resolved via a genuinely server-side filtered
+`ListKeysFiltered`/bound ephemeral JetStream consumer (verified against
+the SDK, not a client-side full-bucket scan).
+
+**Facts vs Requests doctrine check**: predicate membership is current
+state ("does entity X currently carry predicate Y"), not a request — KV
+Watch is the correct primitive per this codebase's KV Twofer doctrine. A
+JetStream Stream would be the wrong primitive here. This decision keeps
+membership in KV; it only changes the key layout.
+
+## Rejected alternative: raw predicate string as the KV key prefix
+
+The first draft of this design used `predicate + "." + entityID` directly
+— human-readable keys, no hashing. **Three independent adversarial
+reviews (architect, go-reviewer, semstreams-reviewer subagents), each
+verifying against the live code rather than trusting the draft's
+citations, found the same blocking bug and rejected this variant.**
+
+`KeysByPrefix` converts to the NATS wildcard `prefix + ">"`, which matches
+on **token position, not token value**. A query for predicate `A` via
+`KeysByPrefix(A + ".")` also matches every composite key for any predicate
+`B` where `A` is a dot-token-prefix of `B` — because `B`'s keys
+(`B.<entityID>`) literally begin with the string `A.` followed by more
+tokens (`B`'s remaining tokens, then the entity ID). This silently
+corrupts every read path (`queryPredicateEntities`,
+`handleQueryPredicateStatsNATS`, and especially the AND/OR set math in
+`handleQueryPredicateCompoundNATS`), and none of them re-validate against
+`ENTITY_STATES` in the no-value-filter path.
+
+This is not hypothetical. Confirmed prefix/extension pairs already ship in
+this codebase's vocabulary: `agent.run` / `agent.run.phase`
+(`vocabulary/agentic/predicates.go`), `c360.logistics.sensor` /
+`c360.logistics.sensor.document`. Predicate arity is open — 2-token,
+3-token, and 4-token predicates all ship today (`domain.type`, `rdf.type`,
+`network.traffic.bytes.in`) — so there is no fixed-arity invariant to lean
+on to rule this out. `vocabulary.IsValidPredicate`
+(`vocabulary/predicates.go:455-472`, requiring exactly 2 dots) exists but
+is dead code with zero call sites outside its own tests, and would reject
+predicates already in production use if it were ever wired in.
+
+**This codebase already has this exact lesson on record.**
+`docs/adr/056-authoritative-semantic-state.md:905-913` (re-review HIGH):
+"Predicate sets are EXACT-STRING enumeration only... There is no
+prefix/namespace/glob on predicates... Without this rule the *first*
+namespace-registration attempt would silently false-negative... or
+over-match, and the check would ship feeling-like-coverage while catching
+nothing." The raw-prefix design reintroduces exactly this failure class in
+a sibling subsystem — a $B$ predicate silently reads as membership of its
+prefix $A$, feeling like coverage while corrupting it.
+
+**Fix**: hash the predicate to a fixed-width single token before composing
+the key, mirroring `nameIndexKey` in
+`processor/graph-index/name_index.go:24-27`
+(`sha256(normalizeName(name))`) — the exact same technique this codebase
+already uses one file over for the same reason (names, like predicates,
+are arbitrary-content strings not safe to use as raw multi-token KV key
+material). Fixed-width hex digests cannot dot-token-prefix-collide with
+each other, which eliminates the bug structurally rather than by
+convention or vocabulary discipline.
+
+**Bonus this rejection surfaced**: hashing also collapses the composite
+key to **fixed arity** (1 hash token + the entity ID's fixed 6 tokens = 7
+tokens, always), which the raw-predicate variant did not have (predicate
+token count varies). Fixed arity means "every predicate a given entity
+carries" becomes a single legal NATS filter, `*.<entity's 6 tokens>`
+(leading single-token wildcard, literal suffix) — directly useful for
+GH #433's entity-delete cleanup, whenever that's implemented, without a
+separate reverse-index bucket. The raw-predicate variant could not express
+this filter at all (`>` is trailing-only; a leading wildcard over a
+variable-length predicate prefix has no legal NATS pattern).
+
+## Other rejected alternatives
+
+- **Shard the blob N ways** (`predicate.0`..`predicate.15`, hash(entityID)
+  mod 16): reduces CAS contention by a constant factor but each shard is
+  still O(N/16) and grows the same way — O(N²/16), not O(N). Doesn't fix
+  the algorithmic problem.
+- **Batch/coalesce writes per ingest flush**: fewer, larger CAS cycles,
+  but each flush still reads+parses+rewrites an O(N)-sized blob — same
+  asymptotic total cost amortized over fewer round trips. Might help
+  constants, not the complexity class.
+- **CRDT/set value type**: NATS KV has no native mergeable-value support;
+  building one is unneeded complexity next to composite keys, which
+  sidestep the need for a mergeable value entirely by making the *key*
+  the unit of membership.
+- **JetStream Stream instead of KV**: wrong primitive per Facts-vs-Requests
+  doctrine (see above) — rejected on architectural grounds independent of
+  performance.
+
+## Read-path changes
+
+All four NATS handlers in `processor/graph-index/query.go`:
+
+| Handler | Today | Proposed |
+|---|---|---|
+| `queryPredicateEntities` (→`handleQueryPredicateNATS`) | `predicateBucket.Get(predicate)` → unmarshal `.Entities` | `predicateBucket.KeysByPrefix(sha256Hex(predicate)+".")` → strip prefix per key |
+| `handleQueryPredicateListNATS` | `Keys()` (all predicate keys) then `Get` each | **One** `KeysByPrefix("")` (or `Keys()`) over the whole membership bucket, group by first token (the hash) to get counts; `Keys()` on `PREDICATE_CATALOG` + forward-hash each name to join hash→name. **Not** a per-predicate `KeysByPrefix` fan-out — see below. |
+| `handleQueryPredicateStatsNATS` | `Get(predicate)` → count + slice sample | `KeysByPrefix` → `len(keys)` for count, sorted-first-N for sample |
+| `handleQueryPredicateCompoundNATS` | `Get` per predicate → build set from `.Entities` | `KeysByPrefix` per predicate → build set from stripped keys |
+
+**`handleQueryPredicateListNATS` must not be implemented as N separate
+`KeysByPrefix` calls, one per catalog entry.** `KeysByPrefix` is a bound
+ephemeral-JetStream-consumer operation, not a cheap `Get` — serial fan-out
+over a growing, never-pruned catalog risks the handler's 5s timeout at
+scale, and this handler is now load-bearing for the mandatory
+`CountVirtualEdges` e2e migration (see Breaking-change scope below), so
+its cost is no longer just an admin-query concern. Implement as **one**
+grouped enumeration of the whole membership bucket (single `KeysByPrefix`
+call with an empty/root prefix, or `Keys()`), bucket the returned keys by
+their first token (the hash), then join names via the catalog. This is one
+expensive scan plus one cheap catalog enumeration, with no per-predicate
+round-trip fan-out at all. If a fully grouped scan turns out to be
+impractical during implementation, the fallback is bounded-concurrency
+fan-out (precedent: `defaultMaxConcurrent = 10`, `graph-ingest/query.go:20`)
+with a longer timeout matching `handleQueryPrefixNATS`'s existing 10s
+precedent (`graph-ingest/query.go:153`) — but the single-scan design is
+the target, not the fallback. Load-test either implementation against a
+corpus sized like GH #430's (21k entities) before merge.
+
+`graph.PredicateIndexEntry` becomes fully dead code once these four
+handlers and `UpdatePredicateIndex` no longer construct/consume it.
+Before deleting it, grep the whole repo for `PredicateIndexEntry` (not
+just the four handlers and `component.go` cited above) to confirm nothing
+else constructs or consumes it — the wire response types
+(`PredicateData`, `PredicateListData`, `PredicateStatsData`,
+`CompoundPredicateData`) are a separate set of types and are unaffected;
+only the stored/CAS'd blob type dies.
+
+## Migration
+
+PREDICATE_INDEX is a derived index, not source-of-truth data:
+`watchEntityStates` (`component.go:687-748`) replays full current
+`ENTITY_STATES` before signaling "initial sync complete" (the KV Twofer's
+documented restart semantics), and index writes are idempotent for
+additions (append-with-dedup; not idempotent for *removals*, which is the
+pre-existing gap GH #433 tracks, unrelated to this change).
+
+This makes the storage-format change a **bucket cutover, not a data
+migration**: ship under the new bucket name **`PREDICATE_INDEX_V2`**
+(decided; see rationale below) and let the watcher naturally repopulate it
+from `ENTITY_STATES` on next boot, then retire the old `PREDICATE_INDEX`
+bucket. No custom migration code, no dual-read transitional logic, no
+in-place format detection. This is internal derived state with no
+external mutation compatibility concern (pre-1.0, semstreams owns every
+writer of this bucket).
+
+**Decided: new bucket name, not wipe-in-place.** The old format is never
+read again once `CountVirtualEdges` and the two raw-blob unit tests move
+onto the query API/hashed format in this same PR, so a new bucket name has
+essentially zero transitional cost — point the code at
+`PREDICATE_INDEX_V2`, abandon the old bucket, watcher repopulates clean.
+Wipe-in-place needs a reliable purge step; a partial/failed purge leaves
+orphaned old-format keys mixed into the same bucket as new-format keys.
+Those orphans would be mostly harmless on their own (a raw key like
+`code.artifact.type` can never match `KeysByPrefix(64-hex + ".")`), but
+there's no reason to accept even that residual mess when a new bucket name
+costs nothing extra. `PREDICATE_CATALOG` is provisioned the same way, at
+the same site — see `createOutputBuckets`/`assignBucket`
+(`processor/graph-index/component.go:606-660`), where `PREDICATE_INDEX` is
+currently created; both new buckets must be created eagerly there,
+alongside (not instead of, until the old bucket is fully retired) the
+existing bucket wiring.
+
+## Breaking-change scope (this is NOT purely internal)
+
+The NATS query API is stable, but the raw bucket format is not, and three
+things in this repo read the raw format directly, discovered during
+review:
+
+- `test/e2e/client/nats.go:849-914` (`CountVirtualEdges`) opens
+  `PREDICATE_INDEX` directly via `js.KeyValue`, iterates `Keys()`, and
+  unmarshals each value as the old `{"entities":[...]}` blob. Under the
+  new format this fails to unmarshal on every key, is swallowed by a
+  `continue`, and the function silently returns `Total: 0` forever. Its
+  only caller, `test/e2e/scenarios/tiered_semantic.go:534-588`
+  (`executeValidateVirtualEdges`, wired into `task e2e:semantic`), treats
+  a zero count as a soft warning, not a failure — so this tier would go
+  green while validating nothing. **Must be migrated onto the query API
+  in this PR**, and the e2e stage should be tightened to hard-fail rather
+  than warn on an unparseable/zero result going forward. Note this
+  migration is not just "swap the transport": `CountVirtualEdges`'s band
+  logic (lines 905-909, parsing `inferred.semantic.<band>` out of the raw
+  predicate name) depends on the *human-readable* predicate name, which
+  under hashed keys is only recoverable via `PREDICATE_CATALOG` — route
+  this through `graph.index.query.predicateList` (which does the
+  hash→name join) rather than trying to parse a band out of a raw key.
+- `processor/graph-index/attack_test.go:444-458` and
+  `processor/graph-index/integration_test.go:139-154` read
+  `predicateBucket.Get`/unmarshal the raw blob shape directly. Rewrite in
+  this PR.
+
+Per this project's hard rule on breaking changes, this qualifies:
+`task e2e:structural` and `task e2e:semantic` must be green **before**
+this change merges, with the e2e-client migration in scope for this PR,
+not deferred.
+
+## Consequences
+
+### Positive
+
+- Collapses ingest cost for `UpdatePredicateIndex` from O(N²) to O(N):
+  writes become O(1), unconditional, contention-free.
+- Matches the established idiom used by every sibling index in this
+  codebase — not a novel pattern, finishes a migration already ~90% done
+  elsewhere.
+- Fixed-arity keys make GH #433's entity-delete cleanup tractable for
+  PREDICATE_INDEX specifically, whenever that's tackled, without a
+  separate reverse-index bucket.
+- No NATS wire-contract change for any consumer going through the query
+  API (gateway, GraphQL, `graph-query/summary.go`, semsource).
+
+### Negative / cost
+
+- Real breaking change to the bucket's on-disk format — requires the
+  e2e-client migration and green breaking-change e2e gate described above,
+  not a drop-in refactor.
+- Keys become opaque (hashed); debugging requires the catalog bucket or
+  recomputing the hash. Acceptable — mirrors the existing, already-shipped
+  `NAME_INDEX` tradeoff.
+- `PREDICATE_CATALOG` entries are never pruned (predicate vocabulary
+  treated as a small, effectively monotonic taxonomy, unlike unbounded
+  entity cardinality) — accepted tradeoff, flagged here rather than
+  silently assumed.
+- Full reindex-on-deploy: acceptable because the index already pays this
+  cost on every boot from an empty bucket; this makes every future boot
+  pay it once via replay rather than never triggering a rebuild at all.
+
+### Risks
+
+- `handleQueryPredicateListNATS` cost is resolved by the single-scan
+  design in the read-path table above (not a per-catalog-entry fan-out) —
+  see that section for the mandatory implementation shape and the load-test
+  requirement against a GH #430-sized (21k-entity) corpus.
+- Rebuild window after a cutover has no readiness signal for predicate
+  queries specifically (unlike `NAME_INDEX`, which got the GH #397
+  `graph.index.query.status` envelope). For a 21k-entity corpus the window
+  is short but non-zero; a consumer polling immediately post-boot could
+  observe transient under-counts. Deferred: extending the GH #397 status
+  envelope to cover predicate-index build completion is a reasonable
+  follow-up, not required for this fix (predicate queries are already
+  best-effort/eventually-consistent post-boot today).
+- Unconditional `Put` (no CAS) on this bucket, adjacent in the same file to
+  several `UpdateWithRetry` CAS calls (outgoing/incoming/name/alias), is a
+  legible "someone changes this back to CAS later without understanding
+  why" footgun. Mitigate with an explicit code comment stating the key-
+  uniqueness invariant (no two entities ever write the same composite key)
+  that makes CAS unnecessary here specifically.
+- The "fixed 7-token key" framing (and the GH #433 `*.<entityID>` bonus
+  filter it enables) assumes entity IDs are always exactly 6 dot-tokens
+  with no embedded dots per token — true today (`entityIDRegex`,
+  `graph/datamanager/manager.go:35-36`) and this design's read/write paths
+  don't actually depend on that arity (they strip the fixed hash prefix
+  and take everything after as the entity ID, whatever its length), so
+  this assumption affects only the advertised GH #433 bonus, not this
+  ADR's correctness. Documented here so a future entity-ID format change
+  doesn't silently invalidate that bonus without anyone noticing.
+
+## Open questions
+
+Resolved during the final architect gate-check (folded into this
+revision): bucket naming (`PREDICATE_INDEX_V2`, new bucket — see
+Migration), and `handleQueryPredicateListNATS`'s implementation shape
+(single grouped scan, not per-predicate fan-out — see Read-path changes).
+
+Still open, safe to resolve during implementation:
+
+- Marker value contents: bare empty value, or a debug timestamp? Leaning
+  empty/fixed-constant by construction (see the footgun-comment mitigation
+  above) — a timestamp invites a future reader to treat it as "most
+  recent," which isn't a guarantee this design provides (worker-pool
+  completion order is not ordered across entities).
+- Whether to extend the GH #397 readiness envelope to predicate-index
+  build completion now or defer — leaning defer, flagged as a risk above
+  rather than blocking this fix.
+
+## Related decisions
+
+- **ADR-056** — the exact-string-only predicate doctrine this design's
+  hashed-key fix is required to honor; the rejected raw-prefix variant
+  would have reintroduced the failure class ADR-056 already named HIGH in
+  a sibling subsystem.
+- **GH #376 / `NAME_INDEX`** (`processor/graph-index/name_index.go`) — the
+  direct precedent for hashing arbitrary-content strings into single-token
+  KV keys, reused here for predicates. Note `NAME_INDEX` itself has the
+  identical CAS-blob-per-hash-key shape as PREDICATE_INDEX pre-fix,
+  currently masked by better-behaved cardinality (names are rarely shared
+  by thousands of entities the way a common predicate is) — not addressed
+  by this ADR, flagged as a one-line callout for a future fix if it ever
+  becomes hot.
+- **GH #397** — the index-readiness envelope (`graph.index.query.status`)
+  this ADR's risk section suggests extending to predicate-index build
+  completion, deferred rather than included here.
+- **GH #433** — entity-delete index cleanup, filed separately; this
+  design's fixed-arity key shape makes that fix cheaper whenever it's
+  tackled, but implementing it is explicitly out of scope here.
+
+## References
+
+- GH #430 — the filing, evidence profile, and the issue's own suggested
+  fix direction (which this ADR follows: "append-only per-entity
+  sub-keys... presence marker").
+- `processor/graph-index/component.go:1287-1358` — `UpdatePredicateIndex`,
+  the function being redesigned.
+- `processor/graph-index/query.go:204-489` — the four read handlers being
+  redesigned.
+- `natsclient/kv.go:349-397` — `KeysByPrefix`/`FilteredKeys`, the
+  server-side prefix-filtering primitive this design is built on.
+- `processor/graph-index/name_index.go:24-27` — `nameIndexKey`, the
+  hash-to-single-token precedent this design mirrors.
+- `docs/adr/056-authoritative-semantic-state.md:905-913` — the exact-string
+  predicate doctrine the rejected raw-prefix variant would have violated.
+- `test/e2e/client/nats.go:849-914`, `test/e2e/scenarios/tiered_semantic.go:534-588`
+  — the raw-bucket e2e reader that makes this a breaking change requiring
+  an in-scope migration and a hard-fail (not warn) gate.

--- a/docs/adr/065-predicate-index-composite-key-sharding.md
+++ b/docs/adr/065-predicate-index-composite-key-sharding.md
@@ -191,6 +191,63 @@ variable-length predicate prefix has no legal NATS pattern).
   doctrine (see above) — rejected on architectural grounds independent of
   performance.
 
+## Wildcard-semantics tradeoff (does hashing give up the dotted-key pattern's value?)
+
+Worth stating explicitly, since it's easy to read this ADR as "give up on
+NATS KV's dotted-subject wildcard querying" more broadly than it actually
+does. This codebase leans hard on that pattern elsewhere — entity-ID
+prefix queries (`graph-ingest`'s `handleQueryPrefixNATS`), community
+levels, structural pivot points, anomaly types/status — and it is
+genuinely valuable there: server-side hierarchical filtering with
+SQL-`LIKE`-prefix-style semantics, "for free" from NATS subject matching.
+Hashing the predicate trades that away for `PREDICATE_INDEX` membership
+keys specifically. What's actually given up, and what isn't:
+
+**Given up**: server-side wildcard/prefix filtering on the *predicate*
+axis of `PREDICATE_INDEX` membership keys. You cannot ask NATS KV
+"give me every membership key under the `inferred.semantic.*` namespace"
+directly against the membership bucket anymore — the predicate is now an
+opaque hash there.
+
+**Not given up**:
+- The *entity-ID* axis of every key in this codebase, including this one,
+  is untouched — entity IDs stay raw, dotted, 6-part, and every other
+  index that wildcards on entity ID (not predicate) is completely
+  unaffected by this change. This is a scoped exception to one axis of
+  one index, not a retreat from the dotted-key pattern generally.
+- This codebase's own doctrine already forbids relying on predicate-axis
+  prefix/namespace semantics for anything correctness-sensitive:
+  `docs/adr/056-authoritative-semantic-state.md:905-913`, "Predicate sets
+  are EXACT-STRING enumeration only... no prefix/namespace/glob on
+  predicates." Nothing sanctioned is lost — what's removed is an
+  *accidental*, previously-untested capability (the raw-prefix draft of
+  this design) that turned out to be actively dangerous the moment two
+  predicates happened to nest (§ "Rejected alternative" above). There was
+  no working namespace-query capability on `PREDICATE_INDEX` before this
+  ADR to preserve — today's code requires an *exact* predicate string via
+  `Get`, full stop.
+- A safe, deliberate path to namespace-style predicate queries still
+  exists if a real use case wants one: **`PREDICATE_CATALOG` keys are the
+  raw, unhashed predicate name** (see Decision above) specifically so this
+  door stays open. Prefix-matching there cannot corrupt entity-membership
+  correctness the way it could on the membership bucket, because the
+  catalog carries no membership data — a `KeysByPrefix` there can only
+  return a superset of predicate *names* that share a dotted namespace,
+  which is exactly the intended semantics of a deliberate namespace query
+  (a caller who wants "all predicates under `inferred.semantic.`" and
+  gets `inferred.semantic.high` *and* a hypothetical
+  `inferred.semantic.high.confidence` is seeing correct namespace
+  inclusion, not corruption). The distinction that made the membership-key
+  prefix design unsafe was call-site *intent* — every existing membership
+  read wants an exact single-predicate match, not a namespace scan — not
+  something inherent to prefix-matching on dotted predicate strings in
+  general. This ADR does not implement catalog prefix-querying (no current
+  caller needs it: `CountVirtualEdges` and `predicateList` both filter a
+  small, already-fetched name list client-side, and predicate cardinality
+  is bounded taxonomy-sized, not entity-cardinality-sized) — flagged here
+  as a real, available extension point rather than a foreclosed one, and
+  left for whoever has the first real need.
+
 ## Read-path changes
 
 All four NATS handlers in `processor/graph-index/query.go`:
@@ -239,31 +296,58 @@ documented restart semantics), and index writes are idempotent for
 additions (append-with-dedup; not idempotent for *removals*, which is the
 pre-existing gap GH #433 tracks, unrelated to this change).
 
-This makes the storage-format change a **bucket cutover, not a data
-migration**: ship under the new bucket name **`PREDICATE_INDEX_V2`**
-(decided; see rationale below) and let the watcher naturally repopulate it
-from `ENTITY_STATES` on next boot, then retire the old `PREDICATE_INDEX`
-bucket. No custom migration code, no dual-read transitional logic, no
-in-place format detection. This is internal derived state with no
-external mutation compatibility concern (pre-1.0, semstreams owns every
-writer of this bucket).
+This makes the storage-format change a **bucket cutover**: the code that
+reads/writes `PREDICATE_INDEX` switches from the blob format to the
+hashed composite-key format, and the watcher naturally repopulates
+correctly-formatted entries from `ENTITY_STATES` on next boot. No custom
+migration code, no dual-read transitional logic.
 
-**Decided: new bucket name, not wipe-in-place.** The old format is never
-read again once `CountVirtualEdges` and the two raw-blob unit tests move
-onto the query API/hashed format in this same PR, so a new bucket name has
-essentially zero transitional cost — point the code at
-`PREDICATE_INDEX_V2`, abandon the old bucket, watcher repopulates clean.
-Wipe-in-place needs a reliable purge step; a partial/failed purge leaves
-orphaned old-format keys mixed into the same bucket as new-format keys.
-Those orphans would be mostly harmless on their own (a raw key like
-`code.artifact.type` can never match `KeysByPrefix(64-hex + ".")`), but
-there's no reason to accept even that residual mess when a new bucket name
-costs nothing extra. `PREDICATE_CATALOG` is provisioned the same way, at
-the same site — see `createOutputBuckets`/`assignBucket`
-(`processor/graph-index/component.go:606-660`), where `PREDICATE_INDEX` is
-currently created; both new buckets must be created eagerly there,
-alongside (not instead of, until the old bucket is fully retired) the
-existing bucket wiring.
+**Corrected: same bucket name (`PREDICATE_INDEX`), not a rename —
+reversing this ADR's earlier "new bucket name" decision.** That earlier
+decision assumed the bucket name was purely internal Go plumbing
+(referenced only symbolically via `graph.BucketPredicateIndex`) with "zero
+external mutation compatibility concern." That assumption was wrong: a
+repo-wide grep for the literal string `PREDICATE_INDEX` (not just Go
+source) turned up **~9 operator-facing deployment/reference configs**
+that hardcode `"subject": "PREDICATE_INDEX"` as an output port
+independently of the Go constant —
+`configs/hello-world.json:162`, `configs/semantic.json:532`,
+`configs/graph-backend.json:65`, `configs/structural.json`,
+`configs/statistical.json`, `configs/e2e-structural.json`,
+`configs/semantic-basic.json`, and two files under
+`configs/examples/`. Renaming the bucket via the constant would make
+`Config.Validate()`'s `requiredBuckets` check
+(`processor/graph-index/component.go:59-64`) fail for every one of these
+configs unless each is updated in lockstep — turning an "internal
+storage swap" into an operator-facing config migration across most of
+this repo's reference deployments, which is a materially larger and
+different kind of breaking change than the rest of this ADR scopes for.
+
+Reusing the same bucket name avoids that entirely: `Ports.Outputs`
+subject, `requiredBuckets`, and `assignBucket`'s switch
+(`processor/graph-index/component.go:648-660`) all stay keyed on the
+unchanged string `"PREDICATE_INDEX"`; none of the ~9 configs need to
+change.
+
+**No explicit purge of old-format keys is required for correctness.**
+Old blob-format keys (e.g. a literal key `code.artifact.type` holding the
+old JSON blob) are **structurally inert** under the new read paths: every
+new read either does `KeysByPrefix(sha256Hex(predicate) + ".")` — a
+64-hex-char literal prefix an old plain-predicate key can never match —
+or, in `handleQueryPredicateListNATS`'s grouped scan, splits each key on
+its first `.` and only credits counts to hashes that a `PREDICATE_CATALOG`
+name forward-hashes to; an old key's first token (e.g. `"code"`) is never
+a valid 64-hex-char hash and so is silently dropped from the join, exactly
+like today's code already silently drops unparseable entries. Old-format
+keys become inert storage residue, not a correctness hazard — cosmetic
+cleanup (an optional explicit wipe-then-rebuild, or a TTL) is a reasonable
+follow-up but not required to ship this fix.
+
+`PREDICATE_CATALOG` is a genuinely new bucket (no existing config
+declares it, so no lockstep-update problem) and is provisioned inline in
+`createOutputBuckets`, the same way `NAME_INDEX`/`CONTEXT_INDEX` are today
+— not a declared output port, created eagerly before the entity watcher
+starts (`processor/graph-index/component.go:606-660`).
 
 ## Breaking-change scope (this is NOT purely internal)
 
@@ -361,10 +445,25 @@ not deferred.
 
 ## Open questions
 
-Resolved during the final architect gate-check (folded into this
-revision): bucket naming (`PREDICATE_INDEX_V2`, new bucket — see
-Migration), and `handleQueryPredicateListNATS`'s implementation shape
-(single grouped scan, not per-predicate fan-out — see Read-path changes).
+Resolved during the final architect gate-check
+(`handleQueryPredicateListNATS`'s implementation shape: single grouped
+scan, not per-predicate fan-out — see Read-path changes). Bucket naming
+was also resolved, but the opposite direction the gate-check recommended:
+in-place format cutover on the existing `PREDICATE_INDEX` name, not a
+rename to a new bucket — see the correction in Migration above (found
+during implementation: ~9 operator-facing configs hardcode the bucket
+name as a literal port subject, so a rename is not the zero-cost move it
+appeared to be from Go source alone).
+
+Also resolved during implementation, prompted by a direct question about
+whether this design gives up NATS KV's dotted-subject wildcard/prefix
+query semantics: see the new **Wildcard-semantics tradeoff** section
+below — the answer is that this design gives that capability up only on
+the predicate axis of `PREDICATE_INDEX` specifically, where it was never
+safely available to begin with (ADR-056 already forbids relying on it),
+and preserves it everywhere else, including a deliberate, safe path to
+namespace-style predicate queries via `PREDICATE_CATALOG` if a real use
+case wants it later.
 
 Still open, safe to resolve during implementation:
 

--- a/docs/adr/065-predicate-index-composite-key-sharding.md
+++ b/docs/adr/065-predicate-index-composite-key-sharding.md
@@ -2,12 +2,15 @@
 
 ## Status
 
-**Accepted** (2026-07-03, GH #430). Reached after two review rounds: a
+**Accepted** (2026-07-03, GH #430). Reached after three review rounds: a
 3-way adversarial review (architect, go-reviewer, semstreams-reviewer) that
-found and fixed the raw-predicate-prefix collision bug, then a final
-architect gate-check on this document that returned GO with the
-refinements folded into this revision (single-scan `predicateList`, new
-bucket name for the cutover, catalog key-identity clarification). Adjacent
+found and fixed the raw-predicate-prefix collision bug; a final architect
+gate-check on this document that returned GO with refinements (single-scan
+`predicateList`, catalog key-identity clarification); and a
+during-implementation correction (bucket-name decision reversed back to
+in-place cutover after discovering ~9 operator-facing configs hardcode the
+bucket name, plus explicit sem*-team migration guidance and a wired-up
+namespace-query capability, both prompted directly by Coby). Adjacent
 correctness gap found during this investigation filed separately as
 GH #433 (entity-delete never cleans up
 PREDICATE_INDEX/NAME_INDEX/ALIAS_INDEX/CONTEXT_INDEX) — explicitly out of
@@ -34,14 +37,20 @@ JetStream KV's server-side prefix-filtered key listing.
 A second, small **PREDICATE_CATALOG** bucket — its own bucket, not a
 shared keyspace with membership keys — maps `predicate name → exists`,
 updated via the same cheap idempotent `Put` whenever a predicate is first
-seen. Its sole job is being the cheap hash→name recovery source for
-`graph.index.query.predicateList`: **key = the raw predicate name**
-(never hashed), read only via exact `Get` or a full `Keys()` enumeration,
-**never** `KeysByPrefix` on this bucket — the exact-string-only discipline
-of ADR-056 applies to the catalog too, not just membership keys. Note the
-catalog does not, by itself, avoid a full-corpus scan for `predicateList`'s
-per-predicate counts — see the single-scan design in the read-path table
-below for how that's actually avoided.
+seen. Its keys are **the raw, unhashed predicate name** — deliberately,
+for two reasons: (1) it's the hash→name recovery source for
+`graph.index.query.predicateList`'s unfiltered listing, and (2) unlike the
+membership bucket, `KeysByPrefix` on *this* bucket is safe — it can only
+return a superset of predicate names sharing a dotted namespace, never
+corrupt entity-membership correctness, because it carries no membership
+data. `graph.index.query.predicateList` gains an optional `prefix`
+request field that uses exactly this: a genuine, deliberate,
+namespace-style predicate query (NATS-KV-wildcard "SQL-`LIKE`-prefix"
+semantics, intentionally preserved here rather than given up wholesale —
+see Wildcard-semantics tradeoff below). Note the catalog does not, by
+itself, avoid a full-corpus scan for the *unfiltered* `predicateList`
+call's per-predicate counts — see the single-scan design in the read-path
+table below for how that's actually avoided.
 
 The NATS wire contract (`graph.PredicateData`, `graph.PredicateListData`,
 `graph.PredicateStatsData`, `graph.CompoundPredicateData`) does not change.
@@ -241,12 +250,14 @@ opaque hash there.
   prefix design unsafe was call-site *intent* — every existing membership
   read wants an exact single-predicate match, not a namespace scan — not
   something inherent to prefix-matching on dotted predicate strings in
-  general. This ADR does not implement catalog prefix-querying (no current
-  caller needs it: `CountVirtualEdges` and `predicateList` both filter a
-  small, already-fetched name list client-side, and predicate cardinality
-  is bounded taxonomy-sized, not entity-cardinality-sized) — flagged here
-  as a real, available extension point rather than a foreclosed one, and
-  left for whoever has the first real need.
+  general. **This ADR wires up catalog prefix-querying** (not deferred —
+  see the `prefix` field on `graph.index.query.predicateList` in the
+  Read-path changes table below), specifically because `CountVirtualEdges`'s
+  migration is a concrete, immediate, real caller: it wants exactly "every
+  `inferred.semantic.*` predicate," which is a namespace query, not N
+  exact lookups. This preserves a genuine, useful slice of the dotted-key
+  pattern's SQL-`LIKE`-prefix value rather than only preserving it in
+  the abstract.
 
 ## Read-path changes
 
@@ -255,7 +266,7 @@ All four NATS handlers in `processor/graph-index/query.go`:
 | Handler | Today | Proposed |
 |---|---|---|
 | `queryPredicateEntities` (→`handleQueryPredicateNATS`) | `predicateBucket.Get(predicate)` → unmarshal `.Entities` | `predicateBucket.KeysByPrefix(sha256Hex(predicate)+".")` → strip prefix per key |
-| `handleQueryPredicateListNATS` | `Keys()` (all predicate keys) then `Get` each | **One** `KeysByPrefix("")` (or `Keys()`) over the whole membership bucket, group by first token (the hash) to get counts; `Keys()` on `PREDICATE_CATALOG` + forward-hash each name to join hash→name. **Not** a per-predicate `KeysByPrefix` fan-out — see below. |
+| `handleQueryPredicateListNATS` | `Keys()` (all predicate keys) then `Get` each | Request gains an optional `prefix` field (new — wires up the namespace-query door left open in the Wildcard-semantics tradeoff section, requested explicitly rather than left theoretical). Unfiltered (no `prefix`): **one** `Keys()` over the whole membership bucket, group by first token (the hash) to get counts; `Keys()` on `PREDICATE_CATALOG` + forward-hash each name to join hash→name — **not** a per-predicate fan-out, see below. Filtered (`prefix` set): `PREDICATE_CATALOG.KeysByPrefix(prefix)` for the (now namespace-bounded, small) matching names, then a per-name `KeysByPrefix` against the membership bucket for each — a fan-out is fine here because the namespace filter already bounds the result set, unlike the unfiltered case. |
 | `handleQueryPredicateStatsNATS` | `Get(predicate)` → count + slice sample | `KeysByPrefix` → `len(keys)` for count, sorted-first-N for sample |
 | `handleQueryPredicateCompoundNATS` | `Get` per predicate → build set from `.Entities` | `KeysByPrefix` per predicate → build set from stripped keys |
 
@@ -381,6 +392,39 @@ Per this project's hard rule on breaking changes, this qualifies:
 `task e2e:structural` and `task e2e:semantic` must be green **before**
 this change merges, with the e2e-client migration in scope for this PR,
 not deferred.
+
+### Migration guidance for sem* teams
+
+Project status note (Coby, 2026-07-03): semstreams is pre-1.0/greenfield
+with no external production users, and C360 controls every sem* consumer
+repo directly — breaking changes in beta are acceptable when well
+justified, with direct migration guidance to the sem* teams rather than a
+compatibility shim. This is that guidance for this specific change:
+
+- **No code changes required for any sem* consumer.** Every documented
+  consumer (semsource, semconnect, semteams) reaches `PREDICATE_INDEX`
+  exclusively through the NATS query API
+  (`graph.index.query.predicate*`), which does not change shape. This was
+  explicitly checked during review (semstreams-reviewer's pass) —
+  no evidence of a sister repo reading the raw bucket, only this repo's
+  own e2e test harness did that, and it's fixed in this same PR.
+- **No deployment-config changes required.** The bucket name is unchanged
+  (`PREDICATE_INDEX`); the ~9 configs in this repo that declare it as an
+  output port subject need no edits, and neither does any sem* team's own
+  copy/derivative of a graph-index component config, if one exists.
+- **What silently changes**: any *ad hoc* tooling outside this repo that
+  reads the `PREDICATE_INDEX` bucket directly (NATS CLI inspection
+  scripts, a debugging notebook, etc.) rather than through the query API
+  will see opaque hashed keys instead of readable predicate-named keys
+  after this deploys. If any sem* team has such tooling, it needs to move
+  to `graph.index.query.predicate*` (which now also supports namespace
+  queries via the new `prefix` field on `predicateList` — see Decision).
+- **Operationally**: after this version deploys, `PREDICATE_INDEX` rebuilds
+  from `ENTITY_STATES` via the existing KV-watch replay on next boot (same
+  mechanism as any restart) — no manual migration step. Old blob-format
+  keys are inert and can be left in place; operators who want a clean
+  bucket for storage hygiene may optionally delete-and-let-rebuild, but
+  this is not required for correctness.
 
 ## Consequences
 

--- a/docs/adr/065-predicate-index-composite-key-sharding.md
+++ b/docs/adr/065-predicate-index-composite-key-sharding.md
@@ -16,6 +16,39 @@ GH #433 (entity-delete never cleans up
 PREDICATE_INDEX/NAME_INDEX/ALIAS_INDEX/CONTEXT_INDEX) — explicitly out of
 scope here.
 
+**Implemented and verified** (2026-07-03). A fourth review round — go-reviewer
+and semstreams-reviewer independently reading the actual diff, not the
+design doc — found one real bug the three design-stage rounds couldn't
+have caught because it only exists at the code level: `listPredicatesByNamespace`
+passed a caller-supplied `Prefix` straight into `KeysByPrefix` with no
+trailing-dot normalization. Both reviewers independently spun up a real
+NATS/JetStream container to confirm empirically, not just reason about it:
+`KeysByPrefix(ctx, "agent.run")` (no trailing dot) returns zero matches
+even when `agent.run.phase` exists, taking the full client-side timeout to
+do so, while `KeysByPrefix(ctx, "agent.run.")` correctly matches — the
+exact silent-prefix-matching footgun this whole ADR exists to eliminate,
+reintroduced on the one new externally-facing prefix field. Fixed by
+normalizing in `listPredicatesByNamespace` before the call. Also fixed:
+`attack_test.go`'s new predicate query used raw `Request` against a
+classified handler (inconsistent with the sibling `RequestClassified`
+migration in the same PR); catalog-write failures were logged at Debug
+with no error counter (bumped to Warn + `c.errors`, since a transient
+failure there silently drops a predicate from `predicateList` until
+another entity's write retries the same catalog key). Added unit test
+coverage for `listAllPredicates`/`listPredicatesByNamespace` (including a
+regression test for the trailing-dot bug and the `agent.run`/`agent.run.phase`
+non-contamination case) and the two rewritten stats/compound handlers,
+none of which had coverage in the initial implementation pass.
+
+The load test this ADR's Read-path changes section mandates before merge
+ran against real NATS: 5,020 composite keys across 21 predicates (one hot
+predicate holding 5,000 — the shape that triggers GH #430) seeded in
+123ms via the unconditional-Put write path, and the unfiltered
+`predicateList` grouped-scan read them all back in **12ms** — three orders
+of magnitude inside the handler's 10s timeout, confirming the "2 round
+trips regardless of corpus size" design property empirically, not just by
+code inspection. See `processor/graph-index/predicate_index_load_test.go`.
+
 ## Decision
 
 Replace `PREDICATE_INDEX`'s one-key-per-predicate monolithic JSON blob

--- a/graph/constants.go
+++ b/graph/constants.go
@@ -16,9 +16,16 @@ const (
 	// to the entities carrying it, for deterministic name→ranked-IDs lookup
 	// (graph.query.byName, gh#376). Complements ALIAS_INDEX, which excludes
 	// display-name (AliasTypeLabel) predicates.
-	BucketNameIndex     = "NAME_INDEX"
-	BucketSpatialIndex  = "SPATIAL_INDEX"
-	BucketTemporalIndex = "TEMPORAL_INDEX"
+	BucketNameIndex = "NAME_INDEX"
+	// BucketPredicateCatalog maps a predicate's raw, unhashed name to a
+	// presence marker. Its sole job is hash→name recovery for
+	// PREDICATE_INDEX's hashed composite keys (ADR-065) — deliberately
+	// unhashed itself, so KeysByPrefix on it is a safe, server-side
+	// namespace query over predicate names (unlike PREDICATE_INDEX
+	// membership keys, it carries no membership data to corrupt).
+	BucketPredicateCatalog = "PREDICATE_CATALOG"
+	BucketSpatialIndex     = "SPATIAL_INDEX"
+	BucketTemporalIndex    = "TEMPORAL_INDEX"
 	// BucketTemporalIndexReverse maps entityID -> current temporal bucket key.
 	// It lets graph-index-temporal remove an entity's stale event from its prior
 	// time bucket when the entity is re-indexed (observed-time changed) or deleted,

--- a/graph/query_index_types.go
+++ b/graph/query_index_types.go
@@ -21,13 +21,6 @@ type ContextEntry struct {
 	Predicate string `json:"predicate"`
 }
 
-// PredicateIndexEntry represents entities that have a specific predicate.
-type PredicateIndexEntry struct {
-	Entities  []string `json:"entities"`
-	Predicate string   `json:"predicate"`
-	EntityID  string   `json:"entity_id,omitempty"` // backward compat
-}
-
 // --- Index Query Response Payloads ---
 
 // OutgoingRelationshipsData contains outgoing relationships for an entity.

--- a/graph/query_predicate_types.go
+++ b/graph/query_predicate_types.go
@@ -15,6 +15,15 @@ type PredicateListData struct {
 	Total      int                `json:"total"`
 }
 
+// PredicateListQuery is the request for graph.index.query.predicateList.
+// Prefix, when set, scopes the listing to predicate names sharing that
+// dotted namespace (e.g. "inferred.semantic." matches "inferred.semantic.high"
+// and any deeper nesting under it) — a deliberate, server-side-filtered
+// namespace query. Omitted or empty means "list every predicate" (ADR-065).
+type PredicateListQuery struct {
+	Prefix string `json:"prefix,omitempty"`
+}
+
 // PredicateStatsData contains detailed statistics for a single predicate.
 type PredicateStatsData struct {
 	Predicate      string   `json:"predicate"`

--- a/processor/graph-index/attack_test.go
+++ b/processor/graph-index/attack_test.go
@@ -439,28 +439,22 @@ func TestAttack_MultipleEntitiesSamePredicate(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	// Query predicate index - expect it to contain info about all 3 entities
-	// BUT current implementation only stores last entity
-	predicateEntry, err := graphIndex.predicateBucket.Get(ctx, predicate)
-	require.NoError(t, err, "predicate index should exist")
-
-	var predicateData map[string]interface{}
-	err = json.Unmarshal(predicateEntry.Value, &predicateData)
+	// Query predicate index via the production wire (NATS query API, not
+	// the raw bucket — see ADR-065). Composite per-(predicate,entity) keys
+	// mean there is no longer a "last writer wins" collision: every entity
+	// gets its own key, so all 3 must be present, not just one.
+	request := map[string]string{"predicate": predicate}
+	requestJSON, err := json.Marshal(request)
 	require.NoError(t, err)
 
-	// ATTACK TEST: This demonstrates the bug
-	// Only the last entity is indexed, previous ones are lost
-	storedEntityID := predicateData["entity_id"].(string)
+	respData, err := nc.Request(ctx, "graph.index.query.predicate", requestJSON, 2*time.Second)
+	require.NoError(t, err, "predicate query should succeed")
 
-	// This will fail until the bug is fixed
-	// The predicate index should support multiple entities per predicate
-	// Current implementation: last writer wins
-	_ = storedEntityID
+	var response graph.PredicateQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &response))
 
-	// For now, we just verify that SOME entity is stored
-	// A proper fix would require a different data structure
-	assert.Contains(t, entities, storedEntityID,
-		"predicate index should contain one of the entities (but note: it should contain ALL of them)")
+	assert.ElementsMatch(t, entities, response.Data.Entities,
+		"predicate index must contain ALL entities sharing the predicate, not just the last writer")
 }
 
 func TestAttack_MultipleSourcesSameTarget(t *testing.T) {

--- a/processor/graph-index/attack_test.go
+++ b/processor/graph-index/attack_test.go
@@ -447,7 +447,7 @@ func TestAttack_MultipleEntitiesSamePredicate(t *testing.T) {
 	requestJSON, err := json.Marshal(request)
 	require.NoError(t, err)
 
-	respData, err := nc.Request(ctx, "graph.index.query.predicate", requestJSON, 2*time.Second)
+	respData, err := nc.RequestClassified(ctx, "graph.index.query.predicate", requestJSON, 2*time.Second)
 	require.NoError(t, err, "predicate query should succeed")
 
 	var response graph.PredicateQueryResponse

--- a/processor/graph-index/component.go
+++ b/processor/graph-index/component.go
@@ -1327,8 +1327,17 @@ func (c *Component) UpdatePredicateIndex(ctx context.Context, entityID, predicat
 		return errs.Wrap(err, "Component", "UpdatePredicateIndex", "KV store")
 	}
 
+	// Membership write above is the source of truth and already succeeded;
+	// a catalog-write failure here doesn't corrupt membership, but it does
+	// silently drop this predicate from predicateList's output (both
+	// unfiltered and namespace-filtered — both enumerate via the catalog,
+	// not the membership bucket) until some other entity's write retries
+	// the same catalog Put. That's a real, if narrow, visibility gap —
+	// Warn + count it rather than the Debug-and-forget treatment a merely
+	// cosmetic failure would get.
 	if err := c.updatePredicateCatalog(ctx, predicate); err != nil {
-		c.logger.Debug("failed to update predicate catalog",
+		atomic.AddInt64(&c.errors, 1)
+		c.logger.Warn("failed to update predicate catalog",
 			slog.String("predicate", predicate),
 			slog.Any("error", err))
 	}

--- a/processor/graph-index/component.go
+++ b/processor/graph-index/component.go
@@ -201,13 +201,14 @@ type Component struct {
 	metricsRegistry *metric.MetricsRegistry
 
 	// Domain resources - KV buckets for index storage (wrapped for CAS + retry)
-	outgoingBucket     *natsclient.KVStore
-	incomingBucket     *natsclient.KVStore
-	aliasBucket        *natsclient.KVStore
-	predicateBucket    *natsclient.KVStore
-	contextBucket      *natsclient.KVStore
-	nameBucket         *natsclient.KVStore
-	entityStatesBucket jetstream.KeyValue // raw: read-only watcher, no CAS needed
+	outgoingBucket         *natsclient.KVStore
+	incomingBucket         *natsclient.KVStore
+	aliasBucket            *natsclient.KVStore
+	predicateBucket        *natsclient.KVStore
+	predicateCatalogBucket *natsclient.KVStore
+	contextBucket          *natsclient.KVStore
+	nameBucket             *natsclient.KVStore
+	entityStatesBucket     jetstream.KeyValue // raw: read-only watcher, no CAS needed
 
 	// Lifecycle state
 	mu              sync.RWMutex
@@ -640,6 +641,18 @@ func (c *Component) createOutputBuckets(ctx context.Context) error {
 		return errs.Wrap(err, "Component", "createOutputBuckets", fmt.Sprintf("KV bucket: %s", graph.BucketNameIndex))
 	}
 	c.nameBucket = c.natsClient.NewKVStore(nameBucket)
+
+	// Create PREDICATE_CATALOG bucket for predicate hash→name recovery
+	// (ADR-065, gh#430). Internal like CONTEXT_INDEX/NAME_INDEX — not a
+	// declared output port, so existing configs don't need to add it.
+	predicateCatalogBucket, err := c.natsClient.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{
+		Bucket:      graph.BucketPredicateCatalog,
+		Description: "Predicate hash → name catalog for PREDICATE_INDEX",
+	})
+	if err != nil {
+		return errs.Wrap(err, "Component", "createOutputBuckets", fmt.Sprintf("KV bucket: %s", graph.BucketPredicateCatalog))
+	}
+	c.predicateCatalogBucket = c.natsClient.NewKVStore(predicateCatalogBucket)
 	return nil
 }
 
@@ -1301,43 +1314,23 @@ func (c *Component) UpdatePredicateIndex(ctx context.Context, entityID, predicat
 		return errs.Wrap(err, "Component", "UpdatePredicateIndex", "context cancelled")
 	}
 
-	// CAS update: read-modify-write with automatic retry on conflict
-	err := c.predicateBucket.UpdateWithRetry(ctx, predicate, func(current []byte) ([]byte, error) {
-		var entry graph.PredicateIndexEntry
-		if len(current) > 0 {
-			if unmarshalErr := json.Unmarshal(current, &entry); unmarshalErr != nil {
-				// If unmarshal fails, start fresh (backward compatibility with old format)
-				entry.Entities = []string{}
-				entry.Predicate = predicate
-			}
-		} else {
-			// New entry
-			entry.Entities = []string{}
-			entry.Predicate = predicate
-		}
-
-		// Check if this entity already exists (avoid duplicates)
-		for _, e := range entry.Entities {
-			if e == entityID {
-				// Already exists, return unchanged
-				if len(entry.Entities) > 0 {
-					entry.EntityID = entry.Entities[len(entry.Entities)-1]
-				}
-				return json.Marshal(entry)
-			}
-		}
-
-		// Append new entity
-		entry.Entities = append(entry.Entities, entityID)
-
-		// Set backward compatibility field (last entity)
-		entry.EntityID = entry.Entities[len(entry.Entities)-1]
-
-		return json.Marshal(entry)
-	})
-	if err != nil {
+	// Unconditional Put, no CAS (ADR-065). The key already encodes full
+	// membership identity (hash(predicate) + entityID), so no two entities
+	// ever write the same key — there is nothing a concurrent writer could
+	// clobber. If this bucket's writes ever need CAS again, that means the
+	// key-uniqueness invariant above no longer holds; don't "fix" this back
+	// to UpdateWithRetry without re-establishing it (e.g. gh#433's
+	// entity-delete GC will introduce a Delete against this same key from a
+	// different code path, which needs its own ordering analysis).
+	if _, err := c.predicateBucket.Put(ctx, predicateIndexKey(predicate, entityID), predicateIndexMarker); err != nil {
 		atomic.AddInt64(&c.errors, 1)
-		return errs.Wrap(err, "Component", "UpdatePredicateIndex", "CAS update")
+		return errs.Wrap(err, "Component", "UpdatePredicateIndex", "KV store")
+	}
+
+	if err := c.updatePredicateCatalog(ctx, predicate); err != nil {
+		c.logger.Debug("failed to update predicate catalog",
+			slog.String("predicate", predicate),
+			slog.Any("error", err))
 	}
 
 	// Update metrics
@@ -1396,7 +1389,12 @@ func (c *Component) DeleteFromIndexes(ctx context.Context, entityID string) erro
 	return nil
 }
 
-// DeleteFromPredicateIndex deletes an entity from the predicate index
+// DeleteFromPredicateIndex removes one entity's membership in one
+// predicate. Not currently called from the production entity-delete path
+// (DeleteFromIndexes) — see gh#433: a KV-watch delete event carries only
+// the deleted key, not the entity's former triples, so the caller doesn't
+// yet know which predicates to clean up. Exists for callers that already
+// know the predicate (tests today, gh#433's eventual fix).
 func (c *Component) DeleteFromPredicateIndex(ctx context.Context, entityID, predicate string) error {
 	if entityID == "" {
 		return errs.WrapInvalid(errs.ErrInvalidData, "Component", "DeleteFromPredicateIndex", "entity ID cannot be empty")
@@ -1413,8 +1411,9 @@ func (c *Component) DeleteFromPredicateIndex(ctx context.Context, entityID, pred
 		return errs.Wrap(err, "Component", "DeleteFromPredicateIndex", "context cancelled")
 	}
 
-	// Delete from predicate index
-	if err := c.predicateBucket.Delete(ctx, predicate); err != nil && !natsclient.IsKVNotFoundError(err) {
+	// Delete only this entity's membership in this predicate — a single
+	// composite-key delete (ADR-065), not the whole predicate's membership.
+	if err := c.predicateBucket.Delete(ctx, predicateIndexKey(predicate, entityID)); err != nil && !natsclient.IsKVNotFoundError(err) {
 		atomic.AddInt64(&c.errors, 1)
 		return errs.Wrap(err, "Component", "DeleteFromPredicateIndex", "KV delete")
 	}

--- a/processor/graph-index/component_test.go
+++ b/processor/graph-index/component_test.go
@@ -124,17 +124,25 @@ func (m *mockKVBucket) ListKeys(ctx context.Context, opts ...jetstream.WatchOpt)
 	return nil, errors.New("not implemented")
 }
 
-// ListKeysFiltered gives a prefix-matching approximation of NATS subject
-// filtering: KVStore.KeysByPrefix always calls this with a single filter of
-// the form "<literal prefix>>", so stripping the trailing ">" and doing a
-// literal HasPrefix match is faithful to every call this package makes,
-// without implementing full NATS wildcard-token semantics.
+// ListKeysFiltered replicates real NATS KV prefix-filter semantics closely
+// enough to catch the class of bug this package cares about: KVStore's
+// KeysByPrefix always calls this with a filter of the form "<prefix>>",
+// where NATS wildcard ">" only means "one or more trailing tokens" when it
+// occupies its own token — i.e. prefix must end in ".". A prefix missing
+// that trailing dot is NOT a looser match; empirically (against real NATS)
+// it matches NOTHING. A plain strings.HasPrefix approximation would get
+// this backwards on both axes: it would over-match "agent.run" against
+// "agent.runner.other" (false positive — different tokens, same string
+// prefix) AND under-detect the missing-trailing-dot footgun (it would
+// still match instead of correctly matching nothing). Token-boundary
+// matching here is what makes a future regression of that bug fail a
+// test instead of passing one.
 func (m *mockKVBucket) ListKeysFiltered(ctx context.Context, filters ...string) (jetstream.KeyLister, error) {
 	m.mu.Lock()
 	var matched []string
 	for k := range m.data {
 		for _, filter := range filters {
-			if strings.HasPrefix(k, strings.TrimSuffix(filter, ">")) {
+			if natsPrefixTokenMatch(k, filter) {
 				matched = append(matched, k)
 				break
 			}
@@ -142,6 +150,29 @@ func (m *mockKVBucket) ListKeysFiltered(ctx context.Context, filters ...string) 
 	}
 	m.mu.Unlock()
 	return newMockKeyLister(matched), nil
+}
+
+// natsPrefixTokenMatch reports whether key matches the NATS KeysByPrefix
+// filter "<prefix>>". ">" is only a wildcard when it occupies its own
+// token, i.e. filter must end in ".>" — anything else (a prefix without a
+// trailing dot) is treated as a literal, non-wildcard subject, which in
+// practice never matches a real key.
+func natsPrefixTokenMatch(key, filter string) bool {
+	if !strings.HasSuffix(filter, ".>") {
+		return key == filter // malformed/literal filter: exact match only, never a real key
+	}
+	prefixTokens := strings.Split(strings.TrimSuffix(filter, ">"), ".")
+	prefixTokens = prefixTokens[:len(prefixTokens)-1] // drop the trailing empty token from the "." split
+	keyTokens := strings.Split(key, ".")
+	if len(keyTokens) <= len(prefixTokens) {
+		return false // ">" requires at least one token beyond the literal prefix
+	}
+	for i, pt := range prefixTokens {
+		if keyTokens[i] != pt {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *mockKVBucket) History(ctx context.Context, key string, opts ...jetstream.WatchOpt) ([]jetstream.KeyValueEntry, error) {

--- a/processor/graph-index/component_test.go
+++ b/processor/graph-index/component_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -123,8 +124,24 @@ func (m *mockKVBucket) ListKeys(ctx context.Context, opts ...jetstream.WatchOpt)
 	return nil, errors.New("not implemented")
 }
 
+// ListKeysFiltered gives a prefix-matching approximation of NATS subject
+// filtering: KVStore.KeysByPrefix always calls this with a single filter of
+// the form "<literal prefix>>", so stripping the trailing ">" and doing a
+// literal HasPrefix match is faithful to every call this package makes,
+// without implementing full NATS wildcard-token semantics.
 func (m *mockKVBucket) ListKeysFiltered(ctx context.Context, filters ...string) (jetstream.KeyLister, error) {
-	return nil, errors.New("not implemented")
+	m.mu.Lock()
+	var matched []string
+	for k := range m.data {
+		for _, filter := range filters {
+			if strings.HasPrefix(k, strings.TrimSuffix(filter, ">")) {
+				matched = append(matched, k)
+				break
+			}
+		}
+	}
+	m.mu.Unlock()
+	return newMockKeyLister(matched), nil
 }
 
 func (m *mockKVBucket) History(ctx context.Context, key string, opts ...jetstream.WatchOpt) ([]jetstream.KeyValueEntry, error) {
@@ -138,6 +155,24 @@ func (m *mockKVBucket) PurgeDeletes(ctx context.Context, opts ...jetstream.KVPur
 func (m *mockKVBucket) Status(ctx context.Context) (jetstream.KeyValueStatus, error) {
 	return nil, errors.New("not implemented")
 }
+
+// mockKeyLister is a minimal jetstream.KeyLister backed by a pre-computed
+// key slice, sufficient for ListKeysFiltered's synchronous mock use.
+type mockKeyLister struct {
+	ch chan string
+}
+
+func newMockKeyLister(keys []string) *mockKeyLister {
+	ch := make(chan string, len(keys))
+	for _, k := range keys {
+		ch <- k
+	}
+	close(ch)
+	return &mockKeyLister{ch: ch}
+}
+
+func (l *mockKeyLister) Keys() <-chan string { return l.ch }
+func (l *mockKeyLister) Stop() error         { return nil }
 
 // Mock KV entry for testing
 type mockKVEntry struct {
@@ -841,15 +876,28 @@ func TestComponent_DeleteFromPredicateIndex_ValidData(t *testing.T) {
 	ctx := context.Background()
 
 	entityID := "c360.platform.robotics.mav1.drone.001"
+	otherEntityID := "c360.platform.robotics.mav1.drone.002"
 	predicate := "robotics.status.armed"
 
-	// Add entry first
+	// Two entities share the predicate.
 	require.NoError(t, comp.UpdatePredicateIndex(ctx, entityID, predicate))
+	require.NoError(t, comp.UpdatePredicateIndex(ctx, otherEntityID, predicate))
 
-	// Delete
+	// Deleting one entity's membership must not touch the other's — the
+	// old blob-CAS design deleted the WHOLE predicate key regardless of
+	// entityID (component.go's old DeleteFromPredicateIndex bug, fixed by
+	// the composite-key redesign, ADR-065).
 	err := comp.DeleteFromPredicateIndex(ctx, entityID, predicate)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
+	bucket := predicateMock(comp)
+	bucket.mu.Lock()
+	_, deletedExists := bucket.data[predicateIndexKey(predicate, entityID)]
+	_, otherExists := bucket.data[predicateIndexKey(predicate, otherEntityID)]
+	bucket.mu.Unlock()
+
+	assert.False(t, deletedExists, "deleted entity's membership should be gone")
+	assert.True(t, otherExists, "other entity's membership must survive the delete")
 }
 
 func TestComponent_DeleteFromAliasIndex_ValidData(t *testing.T) {
@@ -1109,10 +1157,11 @@ func createTestComponentWithMockKV(t *testing.T) *Component {
 
 	// Create mock buckets and wrap them in KVStore so the component field types match.
 	mocks := &mockRefs{
-		outgoing:  newMockKVBucket(),
-		incoming:  newMockKVBucket(),
-		alias:     newMockKVBucket(),
-		predicate: newMockKVBucket(),
+		outgoing:         newMockKVBucket(),
+		incoming:         newMockKVBucket(),
+		alias:            newMockKVBucket(),
+		predicate:        newMockKVBucket(),
+		predicateCatalog: newMockKVBucket(),
 	}
 
 	graphIndexComp := comp.(*Component)
@@ -1120,6 +1169,7 @@ func createTestComponentWithMockKV(t *testing.T) *Component {
 	graphIndexComp.incomingBucket = nc.NewKVStore(mocks.incoming)
 	graphIndexComp.aliasBucket = nc.NewKVStore(mocks.alias)
 	graphIndexComp.predicateBucket = nc.NewKVStore(mocks.predicate)
+	graphIndexComp.predicateCatalogBucket = nc.NewKVStore(mocks.predicateCatalog)
 	// Initialize lifecycle reporter (normally done in Start())
 	graphIndexComp.lifecycleReporter = component.NewNoOpLifecycleReporter()
 

--- a/processor/graph-index/index_operations_test.go
+++ b/processor/graph-index/index_operations_test.go
@@ -110,22 +110,22 @@ func TestUpdatePredicateIndex_SerializationFormat(t *testing.T) {
 	err := comp.UpdatePredicateIndex(ctx, entityID, predicate)
 	require.NoError(t, err)
 
-	// Verify data was written
+	// Membership is a composite key, hash(predicate) + "." + entityID —
+	// not a per-predicate JSON blob (ADR-065). The value is a content-free
+	// marker; membership identity lives entirely in the key.
 	bucket := predicateMock(comp)
 	bucket.mu.Lock()
-	data, exists := bucket.data[predicate]
+	_, exists := bucket.data[predicateIndexKey(predicate, entityID)]
 	bucket.mu.Unlock()
+	assert.True(t, exists, "predicate index should have a composite-key entry for this (predicate, entity) pair")
 
-	assert.True(t, exists, "predicate index should have entry")
-	assert.NotEmpty(t, data, "predicate index data should not be empty")
-
-	// Verify serialization format
-	var entry map[string]interface{}
-	err = json.Unmarshal(data, &entry)
-	require.NoError(t, err, "predicate index should serialize as JSON")
-
-	assert.Equal(t, entityID, entry["entity_id"], "should have entity_id field")
-	assert.Equal(t, predicate, entry["predicate"], "should have predicate field")
+	// The predicate's human-readable name is recoverable via the catalog,
+	// keyed on the raw (unhashed) name.
+	catalog := predicateCatalogMock(comp)
+	catalog.mu.Lock()
+	_, catalogExists := catalog.data[predicate]
+	catalog.mu.Unlock()
+	assert.True(t, catalogExists, "predicate catalog should record the predicate's name")
 }
 
 // ====================================================================================

--- a/processor/graph-index/integration_test.go
+++ b/processor/graph-index/integration_test.go
@@ -136,21 +136,16 @@ func TestIntegration_KVWatchToIndexFlow(t *testing.T) {
 	assert.NotNil(t, aliasEntry)
 	assert.Equal(t, entityID, string(aliasEntry.Value))
 
-	// Verify predicate indexes were created (format: {entities: [...], predicate, entity_id})
+	// Verify predicate indexes were created: one composite key per
+	// (predicate, entity) pair, hash(predicate)+"."+entityID (ADR-065) —
+	// not a blob keyed on the raw predicate string.
 	predicates := []string{"robotics.assigned.mission", "robotics.status.armed", "core.identity.alias"}
 	for _, predicate := range predicates {
-		predicateEntry, err := graphIndex.predicateBucket.Get(ctx, predicate)
-		require.NoError(t, err, "predicate index should exist for %s", predicate)
+		_, err := graphIndex.predicateBucket.Get(ctx, predicateIndexKey(predicate, entityID))
+		require.NoError(t, err, "predicate index should have a composite-key entry for %s", predicate)
 
-		var predicateData map[string]interface{}
-		err = json.Unmarshal(predicateEntry.Value, &predicateData)
-		require.NoError(t, err)
-
-		// Check entities array contains our entity
-		entities, ok := predicateData["entities"].([]interface{})
-		require.True(t, ok, "predicate index should have entities array")
-		require.Contains(t, entities, entityID, "entities should contain the entity ID")
-		assert.Equal(t, predicate, predicateData["predicate"])
+		_, err = graphIndex.predicateCatalogBucket.Get(ctx, predicate)
+		require.NoError(t, err, "predicate catalog should record %s", predicate)
 	}
 }
 

--- a/processor/graph-index/mock_helpers_test.go
+++ b/processor/graph-index/mock_helpers_test.go
@@ -7,10 +7,11 @@ import "sync"
 // impossible after injection. This registry maps the component pointer to its underlying
 // mock buckets so tests can inspect state and inject errors.
 type mockRefs struct {
-	outgoing  *mockKVBucket
-	incoming  *mockKVBucket
-	alias     *mockKVBucket
-	predicate *mockKVBucket
+	outgoing         *mockKVBucket
+	incoming         *mockKVBucket
+	alias            *mockKVBucket
+	predicate        *mockKVBucket
+	predicateCatalog *mockKVBucket
 }
 
 var (
@@ -50,4 +51,9 @@ func aliasMock(comp *Component) *mockKVBucket {
 // predicateMock retrieves the mock predicate bucket for a test component.
 func predicateMock(comp *Component) *mockKVBucket {
 	return getMocks(comp).predicate
+}
+
+// predicateCatalogMock retrieves the mock predicate catalog bucket for a test component.
+func predicateCatalogMock(comp *Component) *mockKVBucket {
+	return getMocks(comp).predicateCatalog
 }

--- a/processor/graph-index/predicate_index.go
+++ b/processor/graph-index/predicate_index.go
@@ -1,0 +1,68 @@
+package graphindex
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// predicateIndexMarker is the fixed, content-free value stored at every
+// PREDICATE_INDEX composite key. Empty by construction, not a timestamp:
+// the worker pool that drives indexing has no cross-entity completion
+// order, so a timestamp would invite a future reader to treat it as
+// "most recent," which this design does not guarantee (ADR-065).
+var predicateIndexMarker = []byte{}
+
+// predicateHashHex returns the fixed-width, dot-free hex token used as the
+// PREDICATE_INDEX key prefix for a predicate.
+//
+// Hashing (rather than using the raw predicate string) is required, not a
+// style choice: predicates are an open, self-nesting dotted vocabulary
+// (e.g. "agent.run" vs "agent.run.phase" both ship today), and NATS KV's
+// KeysByPrefix wildcarding matches on token *position*, not token
+// *identity* — a raw dotted prefix would silently absorb membership for
+// any predicate it happens to be a dot-token-prefix of. A fixed-width hex
+// digest can't collide that way. See ADR-065 ("Rejected alternative: raw
+// predicate string as the KV key prefix").
+func predicateHashHex(predicate string) string {
+	sum := sha256.Sum256([]byte(predicate))
+	return hex.EncodeToString(sum[:])
+}
+
+// predicateIndexKey builds the PREDICATE_INDEX composite key for one
+// (predicate, entity) membership pair: hash(predicate) + "." + entityID.
+func predicateIndexKey(predicate, entityID string) string {
+	return predicateHashHex(predicate) + "." + entityID
+}
+
+// predicateIndexPrefix builds the KeysByPrefix argument that enumerates
+// every entity currently carrying the given predicate.
+func predicateIndexPrefix(predicate string) string {
+	return predicateHashHex(predicate) + "."
+}
+
+// entityIDFromPredicateKey strips a known predicate's hash prefix from a
+// PREDICATE_INDEX composite key, recovering the entity ID. The hash
+// prefix is fixed-width, so the split is unambiguous regardless of the
+// entity ID's own token count.
+func entityIDFromPredicateKey(key, predicate string) string {
+	return strings.TrimPrefix(key, predicateIndexPrefix(predicate))
+}
+
+// updatePredicateCatalog records that predicate has been seen, so
+// handleQueryPredicateListNATS can recover human-readable predicate names
+// (and serve namespace-prefix queries) without ever prefix-matching the
+// membership bucket itself. Idempotent and cheap: an unconditional Put
+// keyed on the raw, unhashed predicate name. Safe as a key here (unlike
+// on the membership bucket) because PREDICATE_CATALOG carries no
+// membership data — a stray prefix match can only surface a superset of
+// predicate *names* sharing a namespace, never corrupt which entities
+// carry which predicate. See ADR-065.
+func (c *Component) updatePredicateCatalog(ctx context.Context, predicate string) error {
+	if c.predicateCatalogBucket == nil {
+		return nil
+	}
+	_, err := c.predicateCatalogBucket.Put(ctx, predicate, predicateIndexMarker)
+	return err
+}

--- a/processor/graph-index/predicate_index_load_test.go
+++ b/processor/graph-index/predicate_index_load_test.go
@@ -1,0 +1,126 @@
+//go:build integration
+
+package graphindex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/component"
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPredicateIndex_LoadScale is the ADR-065-mandated load test: it must
+// demonstrate that handleQueryPredicateListNATS's unfiltered path stays a
+// small, fixed number of round trips (2: one membership Keys(), one
+// catalog Keys()) rather than degenerating into a per-predicate fan-out,
+// at a corpus shape proportioned to GH #430's real-world trigger (~21k
+// entities, one predicate carried by nearly all of them).
+//
+// Scaled down from the full 21k-entity corpus to bound CI runtime: 5,000
+// members on the hot predicate is enough to make an accidental N-way
+// fan-out or a real full-bucket-scan-per-predicate design show up
+// immediately in the elapsed time (each fan-out round trip is a bound
+// ephemeral JetStream consumer, not a cheap Get — see ADR-065's Risks
+// section), while keeping the test itself fast. What this test proves:
+// listAllPredicates completes well inside the handler's 10s timeout at
+// this scale. What it does NOT prove: exact wall-clock at the full 21k
+// scale — that's a claim about production ingest throughput, not about
+// this one read handler's round-trip count, which is what was actually
+// in question.
+func TestPredicateIndex_LoadScale(t *testing.T) {
+	const hotPredicateMembers = 5000
+	const otherPredicates = 20
+
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV())
+	nc := testClient.Client
+
+	config := DefaultConfig()
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := CreateGraphIndex(configJSON, component.Dependencies{NATSClient: nc})
+	require.NoError(t, err)
+	graphIndex := comp.(*Component)
+	require.NoError(t, graphIndex.Initialize())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	js, err := nc.JetStream()
+	require.NoError(t, err)
+	_, err = js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket:      graph.BucketEntityStates,
+		Description: "Test entity states",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, graphIndex.Start(ctx))
+	defer graphIndex.Stop(5 * time.Second)
+
+	// Seed directly through the production write path, concurrently —
+	// this test benchmarks the READ side; the write side's own cost is
+	// already covered by the O(N)-vs-O(N²) fix itself (this is exactly
+	// the pattern the old design made catastrophically slow at this
+	// scale — writes here are the unconditional-Put fast path, so
+	// seeding 5k+20 entries should itself be fast, not just the read).
+	seedStart := time.Now()
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 32)
+	for i := 0; i < hotPredicateMembers; i++ {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			entityID := fmt.Sprintf("c360.load.test.corpus.entity.e%d", i)
+			require.NoError(t, graphIndex.UpdatePredicateIndex(ctx, entityID, "code.artifact.type"))
+		}(i)
+	}
+	for i := 0; i < otherPredicates; i++ {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			entityID := fmt.Sprintf("c360.load.test.corpus.other.o%d", i)
+			predicate := fmt.Sprintf("code.artifact.tag%d", i)
+			require.NoError(t, graphIndex.UpdatePredicateIndex(ctx, entityID, predicate))
+		}(i)
+	}
+	wg.Wait()
+	t.Logf("seeded %d composite keys across %d predicates in %v", hotPredicateMembers+otherPredicates, otherPredicates+1, time.Since(seedStart))
+
+	// This is the call under test: the unfiltered predicateList path.
+	readStart := time.Now()
+	respData, err := graphIndex.handleQueryPredicateListNATS(ctx, nil)
+	readElapsed := time.Since(readStart)
+	require.NoError(t, err)
+
+	var resp graph.PredicateListQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+
+	t.Logf("handleQueryPredicateListNATS over %d composite keys took %v", hotPredicateMembers+otherPredicates, readElapsed)
+
+	require.Len(t, resp.Data.Predicates, otherPredicates+1, "must report every predicate, not silently truncate")
+	for _, p := range resp.Data.Predicates {
+		if p.Predicate == "code.artifact.type" {
+			require.Equal(t, hotPredicateMembers, p.EntityCount, "hot predicate's count must reflect all its members, not just a sample")
+		}
+	}
+
+	// The handler's own timeout is 10s (query.go). Requiring well inside
+	// that at 5k+ members is the actual regression signal: an N-way
+	// per-predicate fan-out design would burn most of that budget on
+	// ephemeral-consumer setup alone across even 21 predicates, let alone
+	// scanning 5k members serially.
+	require.Less(t, readElapsed, 3*time.Second,
+		"unfiltered predicateList must stay well inside its 10s timeout at this scale — if this regresses, check for a reintroduced per-predicate KeysByPrefix fan-out (ADR-065)")
+}

--- a/processor/graph-index/predicate_index_test.go
+++ b/processor/graph-index/predicate_index_test.go
@@ -1,0 +1,214 @@
+package graphindex
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedPredicates writes composite-key memberships (and catalog entries)
+// for a map of predicate -> entity IDs, using the production write path
+// so these tests exercise the real key encoding, not a hand-rolled one.
+func seedPredicates(t *testing.T, comp *Component, byPredicate map[string][]string) {
+	t.Helper()
+	ctx := context.Background()
+	for predicate, entities := range byPredicate {
+		for _, entityID := range entities {
+			require.NoError(t, comp.UpdatePredicateIndex(ctx, entityID, predicate))
+		}
+	}
+}
+
+// TestListAllPredicates_NoCrossContamination is the regression test for
+// the bug this ADR exists to fix: a raw dot-prefix design would let
+// "agent.run" silently absorb "agent.run.phase"'s members. The
+// hash-keyed design must keep them fully separate.
+func TestListAllPredicates_NoCrossContamination(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	seedPredicates(t, comp, map[string][]string{
+		"agent.run":       {"c360.a.b.c.d.e1", "c360.a.b.c.d.e2"},
+		"agent.run.phase": {"c360.a.b.c.d.e3"},
+	})
+
+	predicates, err := comp.listAllPredicates(context.Background())
+	require.NoError(t, err)
+
+	byName := make(map[string]int)
+	for _, p := range predicates {
+		byName[p.Predicate] = p.EntityCount
+	}
+
+	assert.Equal(t, 2, byName["agent.run"], "agent.run must report exactly its own 2 entities, not agent.run.phase's too")
+	assert.Equal(t, 1, byName["agent.run.phase"], "agent.run.phase must report exactly its own 1 entity")
+}
+
+func TestListAllPredicates_EmptyCatalog(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+
+	predicates, err := comp.listAllPredicates(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, predicates)
+}
+
+// TestListPredicatesByNamespace_TrailingDotNormalization is the
+// regression test for the blocking bug both reviewers found: a caller
+// that omits the trailing dot on Prefix must still get correct namespace
+// matches, not a silent empty result.
+func TestListPredicatesByNamespace_TrailingDotNormalization(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	seedPredicates(t, comp, map[string][]string{
+		"inferred.semantic.high":   {"c360.a.b.c.d.e1", "c360.a.b.c.d.e2"},
+		"inferred.semantic.medium": {"c360.a.b.c.d.e3"},
+		"inferred.structural.core": {"c360.a.b.c.d.e4"}, // different namespace, must not match
+	})
+
+	for _, prefix := range []string{"inferred.semantic.", "inferred.semantic"} {
+		t.Run("prefix="+prefix, func(t *testing.T) {
+			predicates, err := comp.listPredicatesByNamespace(context.Background(), prefix)
+			require.NoError(t, err)
+
+			byName := make(map[string]int)
+			for _, p := range predicates {
+				byName[p.Predicate] = p.EntityCount
+			}
+
+			assert.Len(t, predicates, 2, "should match exactly the two inferred.semantic.* predicates")
+			assert.Equal(t, 2, byName["inferred.semantic.high"])
+			assert.Equal(t, 1, byName["inferred.semantic.medium"])
+			assert.NotContains(t, byName, "inferred.structural.core", "different namespace must not match")
+		})
+	}
+}
+
+func TestListPredicatesByNamespace_NoMatches(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	seedPredicates(t, comp, map[string][]string{
+		"agent.run": {"c360.a.b.c.d.e1"},
+	})
+
+	predicates, err := comp.listPredicatesByNamespace(context.Background(), "inferred.semantic.")
+	require.NoError(t, err)
+	assert.Empty(t, predicates)
+}
+
+// TestHandleQueryPredicateListNATS_PrefixField exercises the full NATS
+// handler (request parsing + prefix routing), not just the internal
+// helpers, so a regression in the request-parsing glue would also be
+// caught here.
+func TestHandleQueryPredicateListNATS_PrefixField(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	seedPredicates(t, comp, map[string][]string{
+		"inferred.semantic.high": {"c360.a.b.c.d.e1"},
+		"agent.run":              {"c360.a.b.c.d.e2"},
+	})
+
+	reqJSON, err := json.Marshal(graph.PredicateListQuery{Prefix: "inferred.semantic"})
+	require.NoError(t, err)
+
+	respData, err := comp.handleQueryPredicateListNATS(context.Background(), reqJSON)
+	require.NoError(t, err)
+
+	var resp graph.PredicateListQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+
+	require.Len(t, resp.Data.Predicates, 1)
+	assert.Equal(t, "inferred.semantic.high", resp.Data.Predicates[0].Predicate)
+}
+
+func TestHandleQueryPredicateListNATS_EmptyBody_ListsAll(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	seedPredicates(t, comp, map[string][]string{
+		"agent.run":              {"c360.a.b.c.d.e1"},
+		"inferred.semantic.high": {"c360.a.b.c.d.e2"},
+	})
+
+	// Existing callers send an empty/absent body — must keep listing
+	// everything, not error or silently scope to nothing.
+	respData, err := comp.handleQueryPredicateListNATS(context.Background(), []byte("{}"))
+	require.NoError(t, err)
+
+	var resp graph.PredicateListQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+	assert.Len(t, resp.Data.Predicates, 2)
+}
+
+func TestHandleQueryPredicateStatsNATS_CompositeKeys(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	seedPredicates(t, comp, map[string][]string{
+		"robotics.status.armed": {
+			"c360.a.b.c.d.e1",
+			"c360.a.b.c.d.e2",
+			"c360.a.b.c.d.e3",
+		},
+	})
+
+	reqJSON, err := json.Marshal(map[string]any{"predicate": "robotics.status.armed", "sample_limit": 2})
+	require.NoError(t, err)
+
+	respData, err := comp.handleQueryPredicateStatsNATS(context.Background(), reqJSON)
+	require.NoError(t, err)
+
+	var resp graph.PredicateStatsQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &resp))
+
+	assert.Equal(t, 3, resp.Data.EntityCount, "count must reflect all members, not just the sample")
+	assert.Len(t, resp.Data.SampleEntities, 2, "sample must be capped at sample_limit")
+}
+
+func TestHandleQueryPredicateCompoundNATS_AndOr(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	seedPredicates(t, comp, map[string][]string{
+		"robotics.status.armed":    {"c360.a.b.c.d.e1", "c360.a.b.c.d.e2"},
+		"robotics.status.airborne": {"c360.a.b.c.d.e2", "c360.a.b.c.d.e3"},
+	})
+
+	andReq, err := json.Marshal(graph.CompoundPredicateQuery{
+		Predicates: []string{"robotics.status.armed", "robotics.status.airborne"},
+		Operator:   "AND",
+	})
+	require.NoError(t, err)
+	respData, err := comp.handleQueryPredicateCompoundNATS(context.Background(), andReq)
+	require.NoError(t, err)
+	var andResp graph.CompoundPredicateQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &andResp))
+	assert.ElementsMatch(t, []string{"c360.a.b.c.d.e2"}, andResp.Data.Entities, "AND must return only the shared entity")
+
+	orReq, err := json.Marshal(graph.CompoundPredicateQuery{
+		Predicates: []string{"robotics.status.armed", "robotics.status.airborne"},
+		Operator:   "OR",
+	})
+	require.NoError(t, err)
+	respData, err = comp.handleQueryPredicateCompoundNATS(context.Background(), orReq)
+	require.NoError(t, err)
+	var orResp graph.CompoundPredicateQueryResponse
+	require.NoError(t, json.Unmarshal(respData, &orResp))
+	assert.ElementsMatch(t, []string{"c360.a.b.c.d.e1", "c360.a.b.c.d.e2", "c360.a.b.c.d.e3"}, orResp.Data.Entities, "OR must return the union")
+}
+
+// TestNatsPrefixTokenMatch locks down the mock's own matching semantics
+// against the real NATS behavior both reviewers empirically verified
+// (KeysByPrefix hardcodes prefix+">" server-side) — if this test and the
+// production trailing-dot fix ever drift apart, this is what catches it.
+func TestNatsPrefixTokenMatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		filter string
+		want   bool
+	}{
+		{"well-formed prefix matches child", "agent.run.phase", "agent.run.>", true},
+		{"well-formed prefix does not match self", "agent.run", "agent.run.>", false},
+		{"well-formed prefix does not false-positive on longer token", "agent.runner.other", "agent.run.>", false},
+		{"missing trailing dot matches nothing", "agent.run.phase", "agent.run>", false},
+		{"unrelated namespace does not match", "inferred.structural.core", "inferred.semantic.>", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, natsPrefixTokenMatch(tt.key, tt.filter))
+		})
+	}
+}

--- a/processor/graph-index/query.go
+++ b/processor/graph-index/query.go
@@ -377,11 +377,19 @@ func (c *Component) listAllPredicates(ctx context.Context) ([]graph.PredicateSum
 	if err != nil {
 		return nil, err
 	}
+	// A pre-cutover blob-format key (bare predicate string, e.g.
+	// "code.artifact.type") almost always contains a "." too, so it does
+	// NOT reliably fail the Cut below — most real predicates are
+	// multi-token. What actually keeps it inert is the join step: its
+	// first token (e.g. "code") is never a genuine 64-hex-char hash, so
+	// countsByHash[that token] is written but never read by the
+	// predicateHashHex(name) lookup below — it's a dead map entry, not a
+	// skipped one.
 	countsByHash := make(map[string]int, len(names))
 	for _, key := range memberKeys {
 		hash, _, ok := strings.Cut(key, ".")
 		if !ok {
-			continue // pre-cutover blob-format key (bare predicate string, no ".") — inert, skip
+			continue // single-token key with no "." at all — can't be any predicate's composite key
 		}
 		countsByHash[hash]++
 	}
@@ -402,6 +410,16 @@ func (c *Component) listAllPredicates(ctx context.Context) ([]graph.PredicateSum
 // per-predicate KeysByPrefix fan-out against the membership bucket here
 // is fine — the namespace filter, not this loop, is what keeps it cheap.
 func (c *Component) listPredicatesByNamespace(ctx context.Context, prefix string) ([]graph.PredicateSummary, error) {
+	// KeysByPrefix appends NATS wildcard ">" directly onto prefix; ">" is
+	// only meaningful as its own token after a ".", so a prefix missing
+	// its trailing dot silently matches nothing instead of erroring —
+	// exactly the class of prefix-matching footgun this ADR exists to
+	// eliminate elsewhere. Normalize here rather than push the "must end
+	// in a dot" contract onto every future caller of predicateList.
+	if !strings.HasSuffix(prefix, ".") {
+		prefix += "."
+	}
+
 	names, err := c.predicateCatalogBucket.KeysByPrefix(ctx, prefix)
 	if err != nil {
 		return nil, err

--- a/processor/graph-index/query.go
+++ b/processor/graph-index/query.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
@@ -233,20 +235,15 @@ func (c *Component) handleQueryPredicateNATS(ctx context.Context, data []byte) (
 // handlers. It looks up the predicate index, optionally filters by value, and applies
 // the limit in a single place so both call sites stay consistent.
 func (c *Component) queryPredicateEntities(ctx context.Context, predicate string, value *string, limit int) ([]string, error) {
-	entry, err := c.predicateBucket.Get(ctx, predicate)
+	keys, err := c.predicateBucket.KeysByPrefix(ctx, predicateIndexPrefix(predicate))
 	if err != nil {
-		if natsclient.IsKVNotFoundError(err) {
-			return []string{}, nil
-		}
 		return nil, err
 	}
 
-	var indexEntry graph.PredicateIndexEntry
-	if err := json.Unmarshal(entry.Value, &indexEntry); err != nil {
-		return nil, err
+	entities := make([]string, 0, len(keys))
+	for _, key := range keys {
+		entities = append(entities, entityIDFromPredicateKey(key, predicate))
 	}
-
-	entities := indexEntry.Entities
 
 	if value != nil && c.entityStatesBucket != nil {
 		// filterEntitiesByPredicateValue handles limit internally so we avoid
@@ -324,45 +321,103 @@ func normalizeToString(v any) string {
 }
 
 // handleQueryPredicateListNATS handles predicate list query requests via NATS request/reply.
-// Returns all predicates with their entity counts.
-func (c *Component) handleQueryPredicateListNATS(ctx context.Context, _ []byte) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+// Returns predicates with their entity counts — every predicate, or, when
+// the request carries a Prefix, only those sharing that dotted namespace
+// (ADR-065: a deliberate, safe namespace query against PREDICATE_CATALOG's
+// unhashed keys — unlike a prefix query against PREDICATE_INDEX's hashed
+// membership keys, this can't corrupt which entities carry which
+// predicate, since the catalog carries no membership data).
+func (c *Component) handleQueryPredicateListNATS(ctx context.Context, data []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	// Get all predicate keys from the bucket
-	keys, err := c.predicateBucket.Keys(ctx)
+	var req graph.PredicateListQuery
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &req); err != nil {
+			return nil, errs.ClassifiedCode(errs.ErrorInvalid, graph.ErrorCodeInvalidRequest, errors.New("invalid request"))
+		}
+	}
+
+	var predicates []graph.PredicateSummary
+	var err error
+	if req.Prefix != "" {
+		predicates, err = c.listPredicatesByNamespace(ctx, req.Prefix)
+	} else {
+		predicates, err = c.listAllPredicates(ctx)
+	}
 	if err != nil {
 		return nil, errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("internal error"))
-	}
-	if len(keys) == 0 {
-		return json.Marshal(graph.NewQueryResponse(graph.PredicateListData{
-			Predicates: []graph.PredicateSummary{},
-			Total:      0,
-		}))
-	}
-
-	predicates := make([]graph.PredicateSummary, 0, len(keys))
-	for _, predicate := range keys {
-		entry, err := c.predicateBucket.Get(ctx, predicate)
-		if err != nil {
-			continue // Skip predicates we can't read
-		}
-
-		var indexEntry graph.PredicateIndexEntry
-		if err := json.Unmarshal(entry.Value, &indexEntry); err != nil {
-			continue // Skip malformed entries
-		}
-
-		predicates = append(predicates, graph.PredicateSummary{
-			Predicate:   predicate,
-			EntityCount: len(indexEntry.Entities),
-		})
 	}
 
 	return json.Marshal(graph.NewQueryResponse(graph.PredicateListData{
 		Predicates: predicates,
 		Total:      len(predicates),
 	}))
+}
+
+// listAllPredicates enumerates every predicate with its entity count via
+// ONE grouped scan of the membership bucket (not a per-predicate
+// KeysByPrefix fan-out, which would cost one bound ephemeral-consumer
+// round trip per catalog entry — see ADR-065). Membership keys are
+// hash(predicate).entityID; grouping on the first token before the first
+// "." buckets every key by its predicate hash without needing to know the
+// predicate strings up front. Catalog names are then forward-hashed to
+// join into that count map — catalog entries whose hash has no members
+// simply report a zero count.
+func (c *Component) listAllPredicates(ctx context.Context) ([]graph.PredicateSummary, error) {
+	names, err := c.predicateCatalogBucket.Keys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(names) == 0 {
+		return []graph.PredicateSummary{}, nil
+	}
+
+	memberKeys, err := c.predicateBucket.Keys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	countsByHash := make(map[string]int, len(names))
+	for _, key := range memberKeys {
+		hash, _, ok := strings.Cut(key, ".")
+		if !ok {
+			continue // pre-cutover blob-format key (bare predicate string, no ".") — inert, skip
+		}
+		countsByHash[hash]++
+	}
+
+	predicates := make([]graph.PredicateSummary, 0, len(names))
+	for _, name := range names {
+		predicates = append(predicates, graph.PredicateSummary{
+			Predicate:   name,
+			EntityCount: countsByHash[predicateHashHex(name)],
+		})
+	}
+	return predicates, nil
+}
+
+// listPredicatesByNamespace answers a namespace-scoped predicateList
+// request: PREDICATE_CATALOG.KeysByPrefix(prefix) bounds the candidate
+// predicate set server-side before any membership lookup, so a
+// per-predicate KeysByPrefix fan-out against the membership bucket here
+// is fine — the namespace filter, not this loop, is what keeps it cheap.
+func (c *Component) listPredicatesByNamespace(ctx context.Context, prefix string) ([]graph.PredicateSummary, error) {
+	names, err := c.predicateCatalogBucket.KeysByPrefix(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+	predicates := make([]graph.PredicateSummary, 0, len(names))
+	for _, name := range names {
+		keys, err := c.predicateBucket.KeysByPrefix(ctx, predicateIndexPrefix(name))
+		if err != nil {
+			return nil, err
+		}
+		predicates = append(predicates, graph.PredicateSummary{
+			Predicate:   name,
+			EntityCount: len(keys),
+		})
+	}
+	return predicates, nil
 }
 
 // handleQueryPredicateStatsNATS handles predicate stats query requests via NATS request/reply.
@@ -388,32 +443,25 @@ func (c *Component) handleQueryPredicateStatsNATS(ctx context.Context, data []by
 		req.SampleLimit = 10
 	}
 
-	entry, err := c.predicateBucket.Get(ctx, req.Predicate)
+	keys, err := c.predicateBucket.KeysByPrefix(ctx, predicateIndexPrefix(req.Predicate))
 	if err != nil {
-		if natsclient.IsKVNotFoundError(err) {
-			return json.Marshal(graph.NewQueryResponse(graph.PredicateStatsData{
-				Predicate:      req.Predicate,
-				EntityCount:    0,
-				SampleEntities: []string{},
-			}))
-		}
 		return nil, errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("internal error"))
 	}
 
-	var indexEntry graph.PredicateIndexEntry
-	if err := json.Unmarshal(entry.Value, &indexEntry); err != nil {
-		return nil, errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("internal error"))
+	entities := make([]string, 0, len(keys))
+	for _, key := range keys {
+		entities = append(entities, entityIDFromPredicateKey(key, req.Predicate))
 	}
+	sort.Strings(entities) // deterministic sample order
 
-	// Get sample entities
-	sampleEntities := indexEntry.Entities
+	sampleEntities := entities
 	if len(sampleEntities) > req.SampleLimit {
 		sampleEntities = sampleEntities[:req.SampleLimit]
 	}
 
 	return json.Marshal(graph.NewQueryResponse(graph.PredicateStatsData{
 		Predicate:      req.Predicate,
-		EntityCount:    len(indexEntry.Entities),
+		EntityCount:    len(entities),
 		SampleEntities: sampleEntities,
 	}))
 }
@@ -441,24 +489,14 @@ func (c *Component) handleQueryPredicateCompoundNATS(ctx context.Context, data [
 	// Collect entity sets for each predicate
 	entitySets := make([]map[string]struct{}, 0, len(req.Predicates))
 	for _, predicate := range req.Predicates {
-		entry, err := c.predicateBucket.Get(ctx, predicate)
+		keys, err := c.predicateBucket.KeysByPrefix(ctx, predicateIndexPrefix(predicate))
 		if err != nil {
-			if natsclient.IsKVNotFoundError(err) {
-				// Predicate not found - empty set
-				entitySets = append(entitySets, make(map[string]struct{}))
-				continue
-			}
 			return nil, errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("internal error"))
 		}
 
-		var indexEntry graph.PredicateIndexEntry
-		if err := json.Unmarshal(entry.Value, &indexEntry); err != nil {
-			return nil, errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("internal error"))
-		}
-
-		entitySet := make(map[string]struct{}, len(indexEntry.Entities))
-		for _, e := range indexEntry.Entities {
-			entitySet[e] = struct{}{}
+		entitySet := make(map[string]struct{}, len(keys))
+		for _, key := range keys {
+			entitySet[entityIDFromPredicateKey(key, predicate)] = struct{}{}
 		}
 		entitySets = append(entitySets, entitySet)
 	}

--- a/test/e2e/client/nats.go
+++ b/test/e2e/client/nats.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 
 	"github.com/c360studio/semstreams/agentic"
+	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/graph/clustering"
 	"github.com/c360studio/semstreams/natsclient"
 )
@@ -844,8 +845,19 @@ type VirtualEdgeCounts struct {
 	AutoApplied int            // Edges that were auto-applied
 }
 
-// CountVirtualEdges counts virtual edges (inferred relationships) by querying the PREDICATE_INDEX.
-// Virtual edges use predicates starting with "inferred." prefix.
+// CountVirtualEdges counts virtual edges (inferred relationships) via the
+// production query API (graph.index.query.predicateList), scoped to the
+// "inferred." namespace. Virtual edges use predicates starting with that
+// prefix.
+//
+// Routed through the query API rather than reading PREDICATE_INDEX
+// directly (ADR-065): the bucket's internal key format is hashed and
+// opaque, so a raw-bucket reader can no longer recover predicate names or
+// counts on its own. A genuine query failure or unparseable response is a
+// real error here — not swallowed to zero counts — so a caller can
+// distinguish "no virtual edges exist" from "couldn't find out." An empty
+// but successfully-parsed predicate list is a legitimate zero (e.g. no
+// semantic gaps met the auto-apply threshold), not an error.
 func (c *NATSValidationClient) CountVirtualEdges(ctx context.Context) (*VirtualEdgeCounts, error) {
 	c.mu.Lock()
 	if c.closed {
@@ -854,59 +866,32 @@ func (c *NATSValidationClient) CountVirtualEdges(ctx context.Context) (*VirtualE
 	}
 	c.mu.Unlock()
 
-	js, err := c.client.JetStream()
+	reqJSON, err := json.Marshal(graph.PredicateListQuery{Prefix: "inferred.semantic."})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get JetStream context: %w", err)
+		return nil, fmt.Errorf("failed to marshal predicateList request: %w", err)
 	}
 
-	bucket, err := js.KeyValue(ctx, "PREDICATE_INDEX")
+	respData, err := c.client.RequestClassified(ctx, "graph.index.query.predicateList", reqJSON, 5*time.Second)
 	if err != nil {
-		// Bucket doesn't exist - return zero counts
-		return &VirtualEdgeCounts{
-			ByBand: make(map[string]int),
-		}, nil
+		return nil, fmt.Errorf("predicateList query failed: %w", err)
 	}
 
-	keys, err := bucket.Keys(ctx)
-	if err != nil {
-		// No keys - return zero counts
-		return &VirtualEdgeCounts{
-			ByBand: make(map[string]int),
-		}, nil
+	var resp graph.PredicateListQueryResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal predicateList response: %w", err)
 	}
 
 	counts := &VirtualEdgeCounts{
 		ByBand: make(map[string]int),
 	}
-
-	// Count actual edges (entities) under each inferred.* predicate key
-	for _, key := range keys {
-		if !strings.HasPrefix(key, "inferred.") {
-			continue
-		}
-
-		// Get the predicate entry to count entities
-		entry, err := bucket.Get(ctx, key)
-		if err != nil {
-			continue
-		}
-
-		// Parse the predicate index entry
-		var predEntry struct {
-			Entities []string `json:"entities"`
-		}
-		if err := json.Unmarshal(entry.Value(), &predEntry); err != nil {
-			continue
-		}
-
-		edgeCount := len(predEntry.Entities)
-		counts.Total += edgeCount
+	for _, p := range resp.Data.Predicates {
+		counts.Total += p.EntityCount
 
 		// Parse the band from the predicate (e.g., "inferred.semantic.high" -> "high")
-		parts := strings.Split(key, ".")
+		parts := strings.Split(p.Predicate, ".")
 		if len(parts) >= 3 && parts[1] == "semantic" {
 			band := parts[2]
-			counts.ByBand[band] += edgeCount
+			counts.ByBand[band] += p.EntityCount
 		}
 	}
 

--- a/test/e2e/scenarios/tiered_semantic.go
+++ b/test/e2e/scenarios/tiered_semantic.go
@@ -539,12 +539,16 @@ func (s *TieredScenario) executeValidateVirtualEdges(ctx context.Context, result
 
 	fmt.Println("[VIRTUAL EDGES] Validating virtual edge creation from semantic gaps...")
 
-	// Get virtual edge counts from PREDICATE_INDEX
+	// Get virtual edge counts via the query API (ADR-065). A query/parse
+	// failure here is a hard failure, not a warning: CountVirtualEdges
+	// itself now distinguishes "legitimately zero" (nil error, zero count —
+	// handled below) from "couldn't determine the count" (non-nil error).
+	// Silently warning on the latter is exactly the failure class this
+	// stage used to have (a raw-bucket reader whose unmarshal errors were
+	// swallowed, quietly validating nothing while reporting green).
 	edgeCounts, err := s.natsClient.CountVirtualEdges(ctx)
 	if err != nil {
-		result.Warnings = append(result.Warnings, fmt.Sprintf("Failed to count virtual edges: %v", err))
-		result.Metrics["virtual_edges_total"] = 0
-		return nil
+		return fmt.Errorf("failed to count virtual edges: %w", err)
 	}
 
 	// Get auto-applied anomaly count from ANOMALY_INDEX


### PR DESCRIPTION
## Summary

Fixes #430. `UpdatePredicateIndex` was **O(N²)**: PREDICATE_INDEX stored one monolithic JSON blob per predicate, CAS read-modify-written on every entity write. A predicate carried by ~all entities (e.g. `code.artifact.type` on 21,265 code entities) grew that one key's blob to ~21k entries, so every one of the N writes re-parsed/re-serialized an O(N) blob. Found dogfooding semsource's MCP `code_context` tools against semstreams itself — indexing 22k entities took minutes, not seconds, and starved graph-embedding + byName readiness during ingest.

## Fix — composite-key membership, hashed predicate

Replaces the blob with **one KV key per (predicate, entity) pair**: `sha256(predicate) + "." + entityID`, written via unconditional `Put` (no CAS, no contention — no two entities ever write the same key). Reads enumerate via `KeysByPrefix`, the same server-side prefix-filtering idiom already used by every *other* multi-membership index in this codebase (`graph/inference`, `graph/structural`, `graph/clustering`, `graph-index-temporal`) — PREDICATE_INDEX was the one holdout still on the pattern the rest of the codebase already migrated away from.

**Why hashed, not the raw predicate string as the key prefix** (the first draft, rejected): NATS `KeysByPrefix` wildcarding matches on token *position*, not token *value* — a raw dotted prefix would let one predicate's query silently absorb another's members whenever one nests under the other (`agent.run` / `agent.run.phase`, both already shipping). Three independent adversarial reviews caught this before any code was written; `docs/adr/056-authoritative-semantic-state.md` already had this exact lesson on record ("predicate sets are EXACT-STRING enumeration only... no prefix/namespace/glob on predicates"). Hashing eliminates the collision structurally, mirroring `NAME_INDEX`'s existing `sha256(name)` scheme.

A new `PREDICATE_CATALOG` bucket (unhashed predicate names) recovers human-readable names and backs a new namespace-query capability (`predicateList`'s optional `prefix` field) — a deliberate, safe slice of the dotted-key "SQL-`LIKE`-prefix" pattern preserved on purpose, since prefix-matching predicate *names* (no membership data attached) can't reintroduce the collision the hashed membership keys were built to avoid.

The bucket **name** is unchanged (`PREDICATE_INDEX`) — a rename was considered and reversed after discovering ~9 deployment configs hardcode it as a literal port subject; old blob-format keys are left in place as inert residue (structurally can never match the new 64-hex-char key prefix).

Full design rationale, every rejected alternative, and the complete review trail are in `docs/adr/065-predicate-index-composite-key-sharding.md`.

## Migration

Bucket cutover, not a data migration: PREDICATE_INDEX is a derived index, rebuilt from ENTITY_STATES via the existing KV-watch replay on next boot — no custom migration code. The NATS query API is unchanged for every consumer (gateway, GraphQL, semsource); only two in-repo raw-bucket readers needed migrating, both in scope here: `test/e2e/client/nats.go`'s `CountVirtualEdges` (now routes through the query API) and two unit tests that read the old blob shape directly.

## Review

- **3-way adversarial design review** (architect, go-reviewer, semstreams-reviewer) before any code was written — found and fixed the raw-prefix collision bug above.
- **Architect gate-check** on the finished ADR — GO, refinements folded in.
- **go-reviewer + semstreams-reviewer** on the actual diff, post-implementation — both independently found and empirically verified against a live NATS container the same blocking bug: the new namespace-query `prefix` field didn't normalize a missing trailing dot, silently matching nothing instead of erroring. Fixed, plus a raw-`Request`-vs-`RequestClassified` test-consistency fix, a silent-failure severity bump on catalog-write errors, and real test coverage added for the read paths (none existed in the initial pass).

## Tests

- Unit: composite-key write/read paths, `agent.run`/`agent.run.phase` non-contamination regression test, trailing-dot normalization regression test, stats/compound handlers — all against a NATS-token-boundary-faithful mock (tightened from a naive `HasPrefix` approximation that couldn't have caught the trailing-dot bug).
- Integration (real NATS): full KV-watch-to-index flow, entity deletion, load test — 5,020 composite keys seeded in 123ms, unfiltered `predicateList` scanned them all in **12ms** (three orders of magnitude inside the 10s handler timeout), empirically confirming the O(1)-round-trip design.

## Gates

`go build`, `go vet` (default + integration), `task lint`, `go test -race` (unit + integration), `task schema:generate` (no drift), contract tests — all green. Breaking-change hard rule: `task e2e:structural` and `task e2e:semantic` both green (`validation_errors:0`), including the semantic tier's `validate-virtual-edges` step exercising the rewritten `CountVirtualEdges` end to end.

Adjacent finding — entity deletion never cleans up PREDICATE_INDEX/NAME_INDEX/ALIAS_INDEX/CONTEXT_INDEX — filed separately as #433, explicitly out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCuKoTBQ1cG2s3XQZsN5Qz