### PR TITLE
fix(graph-ingest): re-stamp referential stubs on create_with_triples without reject noise (gh#435)

### DIFF
--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -47,6 +47,9 @@ var (
 	mutationRejectionsOnce sync.Once
 	mutationRejectionsVec  *prometheus.CounterVec
 
+	stubRestampsOnce    sync.Once
+	stubRestampsCounter prometheus.Counter
+
 	foreignEdgeUnclaimedOnce sync.Once
 	foreignEdgeUnclaimedVec  *prometheus.CounterVec
 
@@ -130,6 +133,27 @@ func getMutationRejectionsMetric(registry *metric.MetricsRegistry) *prometheus.C
 		}
 	})
 	return mutationRejectionsVec
+}
+
+// getStubRestampsMetric returns the process-wide stub-restamp counter (gh#435):
+// referential stubs re-stamped as a real birth on create_with_triples instead of
+// rejected as entity_already_exists. A DISTINCT, positive signal so a paid-run
+// monitor can tell a healthy stub→real path from a true graph-write reject.
+func getStubRestampsMetric(registry *metric.MetricsRegistry) prometheus.Counter {
+	stubRestampsOnce.Do(func() {
+		stubRestampsCounter = prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "graph_ingest",
+			Name:      "stub_restamps_total",
+			Help:      "Referential-integrity stubs re-stamped as a real birth on create_with_triples (gh#435) — a healthy stub→real path, NOT a rejection.",
+		})
+		if registry != nil {
+			_ = registry.RegisterCounter("graph-ingest", "stub_restamps_total", stubRestampsCounter)
+		} else {
+			_ = prometheus.DefaultRegisterer.Register(stubRestampsCounter)
+		}
+	})
+	return stubRestampsCounter
 }
 
 // getForeignEdgeUnclaimedMetric returns the process-wide counter for the
@@ -396,6 +420,7 @@ type Component struct {
 	entitiesUpdated        prometheus.Counter
 	indexingProfileDefault *prometheus.CounterVec
 	mutationRejections     *prometheus.CounterVec
+	stubRestamps           prometheus.Counter
 	foreignEdgeUnclaimed   *prometheus.CounterVec
 	foreignEdgeDropped     *prometheus.CounterVec
 	ownerLeaseMismatch     *prometheus.CounterVec // ADR-056 PR-3 observe-only lease-mismatch counter
@@ -445,6 +470,7 @@ func CreateGraphIngest(rawConfig json.RawMessage, deps component.Dependencies) (
 		entitiesUpdated:        getEntitiesUpdatedMetric(deps.MetricsRegistry),
 		indexingProfileDefault: getIndexingProfileDefaultMetric(deps.MetricsRegistry),
 		mutationRejections:     getMutationRejectionsMetric(deps.MetricsRegistry),
+		stubRestamps:           getStubRestampsMetric(deps.MetricsRegistry),
 		foreignEdgeUnclaimed:   getForeignEdgeUnclaimedMetric(deps.MetricsRegistry),
 		foreignEdgeDropped:     getForeignEdgeDroppedMetric(deps.MetricsRegistry),
 		ownerLeaseMismatch:     getOwnerLeaseMismatchMetric(deps.MetricsRegistry),

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -389,6 +389,39 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 // component.go:createEntity. Callers reasoning about provenance
 // should compare req.Triples against stored.Triples explicitly rather
 // than treating TriplesAdded as authoritative.
+// restampStubOnCreate resolves a create_with_triples ID collision (gh#435). If
+// the existing entity is a bare referential-integrity stub (graph.StubMessageType)
+// and the incoming entity carries a real, non-stub envelope, it merges the
+// incoming entity over the stub — the stub's true birth — via the same
+// update-lane MergeEntity the downstream would otherwise fall back to, returning
+// restamped=true with a Debug (no reject WARN) and a distinct stub_restamps_total
+// counter tick. A non-stub collision (a real entity), or an incoming stub
+// envelope, is a genuine conflict: restamped=false, and the caller rejects as
+// before. A transient read/merge failure returns a classified error.
+func (c *Component) restampStubOnCreate(ctx context.Context, entity *graph.EntityState) (bool, error) {
+	existing, _, err := c.fetchEntityState(ctx, entity.ID)
+	if err != nil {
+		return false, rejectInternal(fmt.Errorf("stub-restamp read-back for %s: %w", entity.ID, err))
+	}
+	if existing == nil || !existing.IsStub() || entity.MessageType.Equal(graph.StubMessageType) {
+		// A real entity already occupies the ID, or the incoming write is itself a
+		// stub — a true conflict, not a stub birth.
+		return false, nil
+	}
+	if merr := c.MergeEntity(ctx, entity); merr != nil {
+		return false, rejectInternal(merr)
+	}
+	if c.stubRestamps != nil {
+		c.stubRestamps.Inc()
+	}
+	if c.logger != nil {
+		c.logger.Debug("referential stub re-stamped as real birth on create_with_triples (gh#435)",
+			slog.String("entity_id", entity.ID),
+			slog.String("subject", SubjectEntityCreateWithTriples))
+	}
+	return true, nil
+}
+
 func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.CreateEntityWithTriplesRequest
 	if err := json.Unmarshal(data, &req); err != nil {
@@ -429,12 +462,26 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 	stampExplicitIndexingProfile(req.Entity, req.IndexingProfile)
 
 	if err := c.CreateEntityStrict(ctx, req.Entity); err != nil {
-		if errors.Is(err, natsclient.ErrKVKeyExists) {
+		if !errors.Is(err, natsclient.ErrKVKeyExists) {
+			return nil, rejectInternal(err)
+		}
+		// gh#435: the ID may exist only as a referential-integrity stub — a
+		// placeholder minted when something referenced it before its real birth.
+		// A create_with_triples carrying a real (non-stub) envelope IS that birth,
+		// so re-stamp the stub via merge instead of rejecting: a healthy stub→real
+		// path must not surface as a graph-write reject to paid-run monitors. A
+		// non-stub collision is a genuine conflict and still rejects.
+		restamped, rerr := c.restampStubOnCreate(ctx, req.Entity)
+		if rerr != nil {
+			return nil, rerr
+		}
+		if !restamped {
 			return nil, rejectInvalidDetail(graph.ErrorCodeEntityExists,
 				map[string]any{"entity": req.Entity.ID},
 				fmt.Errorf("entity already exists: %s", req.Entity.ID))
 		}
-		return nil, rejectInternal(err)
+		// Re-stamped: the stub is now born. Fall through to the shared success
+		// path (foreign-edge routing + read-back + response), same as a fresh create.
 	}
 
 	// Primary committed — route foreign edges onto their own subjects (after the

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -374,38 +374,36 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 	})
 }
 
-// handleEntityCreateWithTriples is handleEntityCreate that also accepts
-// a Triples slice in the request envelope. When Triples is non-empty
-// it REPLACES Entity.Triples before the write (the canonical set is
-// the request's Triples; Entity carries provenance metadata). When
-// Triples is nil/empty, Entity.Triples is written as-is.
-//
-// Atomicity matches handleEntityCreate: CreateEntityStrict is used
-// for atomic create-or-fail (returns ErrKVKeyExists on duplicate ID).
-//
-// TriplesAdded in the response is the count on the *stored* entity
-// after the write, which may exceed len(req.Triples) when the
-// framework injects hierarchy / referential-integrity triples per
-// component.go:createEntity. Callers reasoning about provenance
-// should compare req.Triples against stored.Triples explicitly rather
-// than treating TriplesAdded as authoritative.
 // restampStubOnCreate resolves a create_with_triples ID collision (gh#435). If
 // the existing entity is a bare referential-integrity stub (graph.StubMessageType)
-// and the incoming entity carries a real, non-stub envelope, it merges the
+// and the incoming entity carries a real, VALID, non-stub envelope, it merges the
 // incoming entity over the stub — the stub's true birth — via the same
 // update-lane MergeEntity the downstream would otherwise fall back to, returning
 // restamped=true with a Debug (no reject WARN) and a distinct stub_restamps_total
-// counter tick. A non-stub collision (a real entity), or an incoming stub
-// envelope, is a genuine conflict: restamped=false, and the caller rejects as
-// before. A transient read/merge failure returns a classified error.
+// counter tick. A non-stub collision (a real entity), or an incoming stub / zero /
+// invalid envelope, is NOT a stub birth: restamped=false, and the caller rejects
+// as before — which PRESERVES the stub. (A zero/invalid envelope must not reach
+// MergeEntity: that path overwrites MessageType unconditionally, so it would
+// demote the stub to a typeless non-stub entity — re-creating the gh#429
+// dispatchable-non-real class — and would violate graph.StubMessageType's
+// preserve-when-zero contract.) A transient read/merge failure returns a
+// classified error.
+//
+// Under a genuine double-birth race (two real create_with_triples on the same
+// stub) both callers may read the stub and both MergeEntity: convergent
+// (CAS-merged, last-writer-wins on MessageType), ticking the counter twice for one
+// entity — accepted over reject-one, and ill-defined for a well-formed graph.
 func (c *Component) restampStubOnCreate(ctx context.Context, entity *graph.EntityState) (bool, error) {
 	existing, _, err := c.fetchEntityState(ctx, entity.ID)
 	if err != nil {
 		return false, rejectInternal(fmt.Errorf("stub-restamp read-back for %s: %w", entity.ID, err))
 	}
-	if existing == nil || !existing.IsStub() || entity.MessageType.Equal(graph.StubMessageType) {
-		// A real entity already occupies the ID, or the incoming write is itself a
-		// stub — a true conflict, not a stub birth.
+	// Restamp ONLY for a real, valid, non-stub incoming envelope. !IsValid() rejects
+	// a zero/partial type (MergeEntity would overwrite the stub envelope to typeless
+	// — the gh#429 class); Equal(StubMessageType) rejects a validly-typed-as-stub
+	// incoming. Either falls through to the caller's reject, leaving the stub intact.
+	if existing == nil || !existing.IsStub() ||
+		!entity.MessageType.IsValid() || entity.MessageType.Equal(graph.StubMessageType) {
 		return false, nil
 	}
 	if merr := c.MergeEntity(ctx, entity); merr != nil {
@@ -422,6 +420,21 @@ func (c *Component) restampStubOnCreate(ctx context.Context, entity *graph.Entit
 	return true, nil
 }
 
+// handleEntityCreateWithTriples is handleEntityCreate that also accepts
+// a Triples slice in the request envelope. When Triples is non-empty
+// it REPLACES Entity.Triples before the write (the canonical set is
+// the request's Triples; Entity carries provenance metadata). When
+// Triples is nil/empty, Entity.Triples is written as-is.
+//
+// Atomicity matches handleEntityCreate: CreateEntityStrict is used
+// for atomic create-or-fail (returns ErrKVKeyExists on duplicate ID).
+//
+// TriplesAdded in the response is the count on the *stored* entity
+// after the write, which may exceed len(req.Triples) when the
+// framework injects hierarchy / referential-integrity triples per
+// component.go:createEntity. Callers reasoning about provenance
+// should compare req.Triples against stored.Triples explicitly rather
+// than treating TriplesAdded as authoritative.
 func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.CreateEntityWithTriplesRequest
 	if err := json.Unmarshal(data, &req); err != nil {

--- a/processor/graph-ingest/stub_restamp_test.go
+++ b/processor/graph-ingest/stub_restamp_test.go
@@ -56,6 +56,40 @@ func TestCreateWithTriples_ReStampsStub(t *testing.T) {
 		"a re-stamp ticks the distinct stub_restamps_total counter — a positive signal, not a rejection")
 }
 
+// gh#435 guard: a create_with_triples carrying a ZERO/invalid MessageType must
+// NOT re-stamp a stub — MergeEntity overwrites MessageType unconditionally, so a
+// zero-typed merge would demote the stub to a typeless non-stub entity (the gh#429
+// dispatchable-non-real class). It must reject and leave the stub intact.
+func TestCreateWithTriples_ZeroTypedDoesNotRestampStub(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+	const target = "c360.platform.test.sys.unit.003"
+
+	require.NoError(t, comp.ensureReferencedEntityExists(ctx, target, "c360.platform.test.sys.parent.001",
+		message.Type{Domain: "test", Category: "fixture", Version: "v1"}))
+	require.True(t, storedEntity(t, comp, target).IsStub(), "precondition: target is a stub")
+
+	before := testutil.ToFloat64(comp.stubRestamps)
+
+	// create_with_triples with a ZERO MessageType (no real envelope).
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity:  &graph.EntityState{ID: target}, // zero MessageType
+		Triples: []message.Triple{{Subject: target, Predicate: "real.label", Object: "x", Timestamp: time.Now(), Confidence: 1.0}},
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	_, err = comp.handleEntityCreateWithTriples(ctx, data)
+	require.Error(t, err, "a zero-typed create on a stub must reject, not demote the stub")
+	var ce *errs.ClassifiedError
+	require.True(t, errors.As(err, &ce), "reject must be classified")
+	assert.Equal(t, graph.ErrorCodeEntityExists, ce.Code)
+
+	still := storedEntity(t, comp, target)
+	assert.True(t, still.IsStub(), "the stub envelope must be PRESERVED (not overwritten to typeless)")
+	assert.Equal(t, before, testutil.ToFloat64(comp.stubRestamps), "a rejected zero-typed create must NOT tick the restamp counter")
+}
+
 // A create_with_triples collision with a REAL (non-stub) entity is a genuine
 // conflict and must still reject with entity_already_exists (the restamp counter
 // must NOT move).

--- a/processor/graph-ingest/stub_restamp_test.go
+++ b/processor/graph-ingest/stub_restamp_test.go
@@ -1,0 +1,90 @@
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// gh#435: a real create_with_triples for an ID that exists only as a referential
+// stub must RE-STAMP the stub (its true birth) and SUCCEED — not reject as
+// entity_already_exists, which meteredMutation logs as "graph mutation rejected"
+// (a false GRAPH_WRITE_REJECT that trips paid-run monitors). Success ⇒ no reject
+// ⇒ no WARN (the WARN is emitted by meteredMutation only on a non-nil err).
+func TestCreateWithTriples_ReStampsStub(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+	const target = "c360.platform.test.sys.unit.001"
+
+	// Materialize target as a bare referential stub.
+	require.NoError(t, comp.ensureReferencedEntityExists(ctx, target, "c360.platform.test.sys.parent.001",
+		message.Type{Domain: "test", Category: "fixture", Version: "v1"}))
+	require.True(t, storedEntity(t, comp, target).IsStub(), "precondition: target is a stub")
+
+	before := testutil.ToFloat64(comp.stubRestamps)
+
+	// Real producer births it via create_with_triples carrying a real envelope.
+	realType := message.Type{Domain: "workflow", Category: "task-unit", Version: "v1"}
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: target, MessageType: realType},
+		Triples: []message.Triple{
+			{Subject: target, Predicate: "real.label", Object: "Born", Timestamp: time.Now(), Confidence: 1.0},
+		},
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	resp, err := comp.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, err, "create_with_triples on a stub must SUCCEED (re-stamp), not reject")
+	require.NotNil(t, resp)
+
+	born := storedEntity(t, comp, target)
+	assert.False(t, born.IsStub(), "the stub envelope must be re-stamped to the real type")
+	assert.Equal(t, realType, born.MessageType)
+	assert.True(t, hasPredicate(born, "real.label"), "real triples merged onto the born entity")
+	assert.Equal(t, before+1, testutil.ToFloat64(comp.stubRestamps),
+		"a re-stamp ticks the distinct stub_restamps_total counter — a positive signal, not a rejection")
+}
+
+// A create_with_triples collision with a REAL (non-stub) entity is a genuine
+// conflict and must still reject with entity_already_exists (the restamp counter
+// must NOT move).
+func TestCreateWithTriples_RealCollisionStillRejects(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+	const target = "c360.platform.test.sys.unit.002"
+
+	realType := message.Type{Domain: "workflow", Category: "task-unit", Version: "v1"}
+	mk := func() []byte {
+		req := graph.CreateEntityWithTriplesRequest{
+			Entity:  &graph.EntityState{ID: target, MessageType: realType},
+			Triples: []message.Triple{{Subject: target, Predicate: "real.label", Object: "v", Timestamp: time.Now(), Confidence: 1.0}},
+		}
+		data, _ := json.Marshal(req)
+		return data
+	}
+
+	// First create succeeds (real birth, no stub involved).
+	_, err := comp.handleEntityCreateWithTriples(ctx, mk())
+	require.NoError(t, err)
+
+	before := testutil.ToFloat64(comp.stubRestamps)
+
+	// Second create on the now-real entity is a true conflict → reject.
+	_, err = comp.handleEntityCreateWithTriples(ctx, mk())
+	require.Error(t, err, "create on an existing REAL entity must still reject")
+	var ce *errs.ClassifiedError
+	require.True(t, errors.As(err, &ce), "reject must be classified")
+	assert.Equal(t, graph.ErrorCodeEntityExists, ce.Code, "a real collision keeps the entity_already_exists reject")
+	assert.Equal(t, before, testutil.ToFloat64(comp.stubRestamps), "a real conflict must NOT tick the restamp counter")
+}


### PR DESCRIPTION
## Summary

Fixes #435. A healthy referential stub → real-birth path was surfacing as a `graph mutation rejected` WARN that paid-run monitors read as `GRAPH_WRITE_REJECT`.

## Root cause

A real `create_with_triples` for an ID that already exists **only as a referential stub** (`graph.StubMessageType`, minted by referential integrity when something referenced it before its real birth) hit `CreateEntityStrict` → `ErrKVKeyExists` → `rejectInvalidDetail(entity_already_exists)`. `meteredMutation` logs every handler error as `graph mutation rejected`. The downstream safely fell back to `update_with_triples`, so it was semantically harmless — but the WARN made clean runs look suspect.

## Fix

On the create `ErrKVKeyExists` collision, if the existing entity `IsStub()` and the incoming write carries a real (non-stub) envelope, **merge it over the stub** — the stub's true birth, via the same update-lane `MergeEntity` the downstream would otherwise fall back to — and succeed. No reject, so no WARN (the WARN is emitted only on a non-nil handler error). A non-stub collision (a real entity) or an incoming stub envelope still rejects as `entity_already_exists`. Adds a distinct positive `graph_ingest_stub_restamps_total` counter so monitors can tell a healthy stub→real path from a true reject (the issue's "distinguishable classification" ask).

Composes directly with #429's shared `graph.StubMessageType` / `EntityState.IsStub()` — the **birth-side** sequel to #429's dispatch-side stub fix.

## Scope

Scoped to `create_with_triples` (the reported path). The plain `create` handler keeps its **deliberate strict-409-on-conflict contract** (semconnect CS API §7.6) — broadening the re-stamp there is a separate semconnect-coordinated decision.

## Tests

Unit (drives the real `handleEntityCreateWithTriples` with faithful mock KV): a `create_with_triples` on a stub re-stamps → success + envelope flipped + real triples merged + counter ticks; a collision with a real entity still rejects with `entity_already_exists` + counter unchanged.

## Bundle

Part of the **beta.128 "honest graph signals" QoL bundle** with #431 (readiness completeness). #435 = a healthy path no longer *over*-reports as failure; #431 = readiness no longer *under*-reports completeness.

Gates: full graph-ingest suite green · gofmt · revive · vet · no schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PcS2JwsPgB6xyLFjQtjQHQ