### PR TITLE
feat(graph): honest revision-lag readiness — caught-up watermark (gh#431)

### DIFF
--- a/docs/adr/066-honest-graph-index-readiness.md
+++ b/docs/adr/066-honest-graph-index-readiness.md
@@ -1,0 +1,284 @@
+# ADR-066: Honest graph-index readiness — revision-lag "caught-up" signal
+
+## Status
+
+**Proposed** (2026-07-03, GH #431). Design-first; cross-repo (semstreams owns the
+index/embedding signals, semsource owns the `graph.query.status` aggregate). No
+code lands with this document. Part of the beta.128 "honest graph signals" QoL set
+(with GH #435).
+
+**Adversarially reviewed (2026-07-03).** The review confirmed **revision-lag is the
+right signal** but caught that the first-draft concrete invariants recreated the
+exact false-ready bug (and a worse never-ready deadlock) under the configs
+semstreams actually ships. This revision folds in the three required corrections:
+a **contiguous** high-water mark (not a monotonic max), a **query-time `LastSeq`**
+Target (not idle-gated), and a **distinct embedding definition** over eligible
+entities. Those corrections — not a redesign — are the substance below.
+
+## Decision
+
+Replace the sticky "indexing started = ready" signal with a **revision-lag /
+caught-up** signal on `graph.index.query.status`:
+
+- **`IndexedRevision`** — the **contiguous high-water mark**: the highest
+  ENTITY_STATES revision `R` such that *every* revision `≤ R` has been fully
+  applied to the indexes, advanced across **both** processing paths (the worker
+  pool AND the inline delete handler). NOT "the highest revision a worker
+  finished" — that is wrong under multi-worker pools and deletes.
+- **`TargetRevision`** — the stream's current `LastSeq`, read **at query time,
+  always** (not derived from the last `Delta()==0` watch entry, which is stale
+  exactly when writes are committed-but-not-yet-delivered).
+- **`Lag = TargetRevision − IndexedRevision`**; **`Ready = TargetRevision > 0 &&
+  IndexedRevision >= TargetRevision`** (no lossy `max(0,…)` clamp — a stale or
+  uninitialized Target must not read as caught-up).
+- optional **`Phase`** = `ingesting | indexing | ready` — the friendly projection.
+
+The mechanism is **(a) revision-lag**; the phase vocabulary is **(d)**, its
+projection. **Embeddings do NOT share this exact definition** (see Design) — a
+naive shared Target is a permanent deadlock. Add a **new
+`graph.embedding.query.status`** handler with an embedding-specific
+terminal-outcome watermark, and **no consumer gates on `embedding.ready` until
+that definition lands**.
+
+## Context
+
+### The bug (verified)
+
+`processor/graph-index/name_index.go` `nameIndexIsReady` flips a **sticky**
+`nameIndexReady` atomic to `true` the instant the NAME_INDEX bucket has ≥1 key,
+and `handleQueryStatusNATS` reports `Ready:true, State:"ready"` from it — "indexing
+started," not "caught up." `Revision` and `LastSynced` exist on
+`IndexStatusResponse` (`graph/index_status.go:18-19`) but are **never populated**.
+There is **no** `graph.embedding.query.status` handler, so embeddings are absent
+from every readiness signal.
+
+### The impact (GH #431 dogfooding, ~21k Go entities)
+
+`phase: ready` fired at ~30s; byName resolution of provably-existing symbols
+climbed 2/15 → ~9–10/15 over minutes and plateaued with symbols still missing at
+6–8 min; `total_entities` kept climbing after `ready`; embeddings were ~empty
+throughout. A consumer that correctly waits for `ready` then queries gets **false
+negatives**, unable to distinguish "absent" from "still indexing."
+
+### Relationship to GH #430 (shipped, beta.127)
+
+#430 fixed the O(N²) predicate-index path — indexes build *faster*, the lag window
+shrinks. The readiness *contract* is separate: even a fast index must honestly say
+"queryable," and #430 does not touch embeddings.
+
+### The architecture (why this shape, and why the invariants are subtle)
+
+graph-index is write-driven, lagging, async: a `kv-watch` over ENTITY_STATES
+(`component.go:700-761`) feeds a **worker pool** (`pkg/worker/pool.go` — a single
+buffered channel drained by N goroutines, **no completion ordering**), with an
+optional coalescer that re-`Get`s the *latest* revision per key. **Reference
+configs run `workers: 2–4`** (`configs/hello-world.json`, `e2e-structural.json`,
+`statistical.json`). **Deletes are handled inline in the watcher**
+(`component.go:740-746`), NOT through the pool. Every watch entry carries
+`Revision()` (stream seq) and `Delta()` (distance from latest). graph-embedding
+uses the same watch→pool pattern **plus a second async hop** (`pending` →
+`generated`, default **5 workers**), and only *text-bearing* entities enter it.
+
+These three facts — no ordering, inline deletes, text-only embeddings — are why the
+naive "monotonic max over pool completions, Target from `Delta()==0`, same block
+for embeddings" is wrong.
+
+## Why revision-lag (a), and why not the alternatives
+
+**Caught-up = `IndexedRevision >= TargetRevision`** is the only option the
+architecture supports cheaply and honestly. It distinguishes cold-start
+(`Indexed==0, Target>0` → not ready), mid-build (`Indexed < Target` → exact numeric
+lag), and caught-up — the exact confusion #431 is about. Refuted:
+
+- **(b) coverage-%** — no cheap "indexable" denominator (telemetry-only entities
+  never index; NAME_INDEX keys are shared name-hashes, so key-count ≠ entity-count).
+- **(c) pending-queue-depth** — reads `0` both when caught-up **and** when nothing
+  has started; re-creates the cold-start ambiguity. Secondary velocity gauge only.
+- **(d) phase-split** is the projection of (a)'s numbers, adopted as the vocabulary,
+  not a competing mechanism.
+
+## Design
+
+### 1. graph-index: contiguous high-water mark (the corrected invariant)
+
+`IndexedRevision` is a **commit-offset / contiguous watermark**, not a max. The
+pool completes revisions out of order (N>1) and deletes commit inline, so the
+signal must answer "all revisions ≤ R applied," which requires tracking gaps:
+
+- Maintain `{pending set of in-flight revisions}` and `IndexedRevision`. On the
+  watch delivery of revision `r`, add `r` to pending. On **completion** of `r` —
+  whether by a **pool worker** finishing `processEntityUpdateFromData` OR by the
+  **inline delete handler** finishing a delete — remove `r` from pending and, if
+  `r == IndexedRevision + 1`, advance `IndexedRevision` past every now-contiguous
+  completed revision. This advances the watermark only past the *lowest incomplete*
+  revision, so a fast late worker cannot report a gap as done, and a delete's
+  sequence participates rather than leaving a permanent hole.
+- The coalescer (which re-`Get`s the latest per key) must still register each
+  ENTITY_STATES revision it collapses as completed, or contiguity stalls even at
+  `workers:1`.
+- Complexity is bounded: pending is small (≤ in-flight window), advance is
+  amortized O(1). This is the standard out-of-order-ack commit-offset problem.
+
+### 2. graph-index: Target = query-time `LastSeq` (always)
+
+`TargetRevision` is read from the ENTITY_STATES stream's current `LastSeq` **on
+every status call**, not cached from the last `Delta()==0` watch entry. The stale
+window (writes acked to the stream but not yet delivered to the watch) is precisely
+when a cached Target lies. `entry.Revision()` and stream `LastSeq` share the stream
+sequence number space, so `LastSeq` reflects every *committed* write; the only
+residual window is an unacked in-flight write, which is not a durable fact and which
+no consumer has been told about — the correct place to stop. This needs a
+**net-new `natsclient` helper** to read a KV/stream `LastSeq` (none exists today);
+status is polled (not hot), so one stream-info round-trip per call is acceptable.
+
+### 3. graph-embedding: a DISTINCT terminal-outcome watermark (not the same block)
+
+Reusing graph-index's Target for embeddings is a **permanent deadlock**: only
+text-bearing entities reach `SaveGenerated`; telemetry-only entities never enter
+the pipeline, empty-text records are deleted without generating, failures go to
+`SaveFailed`. So a Target = "latest ENTITY_STATES revision" leaves permanent gaps
+and `Lag` never reaches 0. Instead:
+
+- `IndexedRevision` (embedding) advances on **every TERMINAL outcome of an eligible
+  entity** — `generated` OR deliberately-skipped-no-text OR `failed` — contiguously,
+  not only on `generated`. "Processed to a terminal state," not "embedded."
+- Thread the **ENTITY_STATES revision** through both hops: capture `entry.Revision()`
+  at ingest → store on the pending `Record` (which has no revision field today,
+  `storage.go:37-53`) → read it back at the terminal transition. `SaveGenerated`
+  today takes no revision (`storage.go:164`) — this plumbing is required, not
+  optional.
+- Target is the same query-time `LastSeq`, but `Ready` means "every eligible
+  revision ≤ Indexed reached a terminal state." Until this is implemented and
+  tested, **no consumer (mcp-gateway, fusion) gates on `embedding.ready`**.
+
+### 4. Degraded overrides (was punted; the review made it load-bearing)
+
+If the backend faults mid-build, `IndexedRevision` **stalls** while query-time
+Target keeps climbing → `Lag` grows unbounded. That must NOT read as "still
+building normally." `State: degraded` **overrides** ready/building. Distinguish
+"lag increasing because ingest is fast" (healthy, `building`) from "indexer stuck"
+(`degraded`): flip to `degraded` when `IndexedRevision` is unchanged across `> K`
+status intervals while Target advances (a stuck-watermark detector), in addition to
+the existing backend-fault degraded triggers.
+
+### 5. Wire shape
+
+Enrich `IndexStatusResponse` (`graph/index_status.go`) and mirror
+`pkg/fusion.IndexStatus` (`pkg/fusion/contract.go`) — field-identical, decoded
+directly by the fusion `RetrievalClient`, so they change together:
+
+```go
+type IndexStatusResponse struct {
+    Ready           bool   `json:"ready"`            // Target>0 && Indexed>=Target
+    State           string `json:"state"`            // building | ready | degraded
+    IndexedRevision uint64 `json:"indexed_revision,omitempty"` // contiguous watermark
+    TargetRevision  uint64 `json:"target_revision,omitempty"`  // query-time LastSeq
+    Lag             uint64 `json:"lag,omitempty"`    // Target - Indexed; 0 == caught up
+    Phase           string `json:"phase,omitempty"`  // ingesting | indexing | ready
+    Revision        string `json:"revision,omitempty"`     // now populated (string IndexedRevision)
+    LastSynced      string `json:"last_synced,omitempty"`  // now populated
+}
+```
+
+## semsource coordination (cross-repo)
+
+1. **`mcp-gateway/tools.go` `source_status`** already fans out to
+   `graph.query.status` + `graph.index.query.status` and carries a `readinessNote`
+   that *explicitly names semstreams#431* ("poll until `index.ready` AND
+   `total_entities` stopped climbing"). Once `index.ready` is honest: add a third
+   fan-out to `graph.embedding.query.status` (surfaced but **not** gated on until §3
+   lands), and **retire** the "stopped climbing" clause.
+2. **`source-manifest` `graph.query.status phase=ready`** is a *separate*
+   false-positive (fires when all *sources* reported, not when the graph is
+   queryable). Whether it should itself gate on the caught-up signal is a
+   **semsource ADR call**; this ADR only commits to exposing the honest signal.
+3. **Version note:** `Revision`/`LastSynced` already ship (unused) → additive; the
+   semantic change is `Ready`. Coordinate the tag — semsource pins semstreams.
+
+## Consequences
+
+### Positive
+
+- `ready` finally means **queryable** — correctly-gating consumers stop getting
+  false negatives. Exact numeric `Lag`/`IndexedRevision` also enable a **finer
+  contract**: a consumer that knows its target revision can gate on
+  `IndexedRevision >= myRev` instead of the global bool.
+- Embeddings enter a readiness signal for the first time (safely, once §3 lands).
+- The mcp-gateway "stopped climbing" workaround retires; dead wire fields filled.
+
+### Negative / cost
+
+- The contiguous watermark is **more than "one atomic"**: a small pending-set +
+  advance logic, wired into two completion paths (pool + inline delete) per
+  component. This is the bulk of the implementation.
+- A query-time `LastSeq` read per status call (new natsclient helper).
+- Embedding revision-threading through both hops + the pending `Record` gains a
+  revision field.
+- **`Ready` semantic change:** `pkg/fusion.Engine.Fuse` gates once per request on
+  `Ready` (`engine_lens.go:82-85`) and returns empty when not ready (no spin — the
+  eager→later flip is *safe*, callers fall back). But post-fix, `Fuse` returns empty
+  for the **entire multi-minute build window even for already-indexed symbols** — a
+  coarse global gate. That is correct per the honesty contract; the numeric fields
+  are the intended escape (gate on `IndexedRevision >= myRev`), and the interim cost
+  must be documented so it is not mistaken for a regression.
+
+### Risks
+
+- **Contiguity across two paths** — the delete handler and the pool must both
+  register completions into the same watermark, or a delete/late-worker leaves a
+  gap (false-not-ready) or is skipped (false-ready). Unit-test out-of-order
+  completion AND a trailing-delete-only tail.
+- **Embedding never-ready** — if Target isn't scoped to eligible-terminal outcomes,
+  `embedding.ready` deadlocks. Gate consumers off it until §3 is proven.
+- **Bootstrap replay** — WatchAll replays keys in ascending revision to the nil
+  marker; the contiguous watermark rebuilds from 0 correctly (transient high lag /
+  not-ready during replay is *correct*). Query-time Target avoids the Target=0
+  false-ready the idle-gated draft had.
+
+## Migration path
+
+1. `natsclient`: a `LastSeq` (stream/KV) helper.
+2. graph-index: contiguous watermark across pool completion + inline delete +
+   coalescer; query-time Target; honest `Ready`/`Lag`/`State` on
+   `IndexStatusResponse` (fill `Revision`/`LastSynced`); degraded stuck-detector.
+   Unit-test cold-start / mid-build / caught-up / out-of-order completion /
+   trailing-delete / stuck-watermark.
+3. Mirror on `pkg/fusion.IndexStatus`.
+4. graph-embedding: revision-threading (both hops + `Record` field) + new
+   `graph.embedding.query.status` with the terminal-outcome watermark.
+5. semsource: mcp-gateway third fan-out (surfaced, not gated) + retire the workaround
+   note; decide source-manifest gating (their ADR).
+6. Tag beta.128 (bundled with GH #435); coordinate the semsource pin.
+
+## Open questions
+
+- **Phase field now or later?** `Lag == 0` is load-bearing; `Phase` is sugar. Ship
+  the numbers first.
+- **source-manifest gating** — semstreams exposes the honest signal; whether
+  semsource's `phase=ready` composes it is semsource's decision.
+- **Embedding-ready consumer gating** — deferred until §3 is proven; the third
+  fan-out is surfaced-only meanwhile.
+
+## Related decisions
+
+- **GH #430 / ADR-065** — predicate-index O(N²) fix (shrinks the lag window).
+- **GH #397 / ADR-062** — the index-status honesty envelope this enriches.
+- **GH #420 / beta.125** — readiness-gated *reads* ("responder up," not "index
+  caught up") — do not conflate.
+- **GH #435** — the QoL-bundle sibling (a healthy path no longer over-reports as a
+  reject).
+
+## References
+
+- `processor/graph-index/name_index.go` (sticky bug, handler); `component.go`
+  (watch/pool `700-812`; inline delete `740-746`; coalescer re-Get `984-1010`;
+  worker completion `833-980`).
+- `pkg/worker/pool.go` (single-channel N-worker pool, no ordering).
+- `graph/index_status.go` + `pkg/fusion/contract.go` (wire shapes); `engine_lens.go:82-85`
+  (single-shot Ready gate).
+- `processor/graph-embedding/component.go` (revision dropped at watch `921`; no-text
+  skip `1019-1022`; 5-worker default); `graph/embedding/storage.go` (`SaveGenerated`
+  no revision `164`; `Record` no revision field `37-53`); `worker.go` (second hop,
+  no-text delete `310-317`, `markFailed` `496`).
+- `configs/hello-world.json`, `e2e-structural.json`, `statistical.json` (`workers` 2/4).
+- `semsource/processor/source-manifest/status.go`; `semsource/processor/mcp-gateway/tools.go`.

--- a/docs/adr/066-honest-graph-index-readiness.md
+++ b/docs/adr/066-honest-graph-index-readiness.md
@@ -2,29 +2,39 @@
 
 ## Status
 
-**Proposed** (2026-07-03, GH #431). Design-first; cross-repo (semstreams owns the
-index/embedding signals, semsource owns the `graph.query.status` aggregate). No
-code lands with this document. Part of the beta.128 "honest graph signals" QoL set
-(with GH #435).
+**Accepted** (2026-07-03, GH #431). Cross-repo (semstreams owns the
+index/embedding signals, semsource owns the `graph.query.status` aggregate).
+Implementation follows the Migration path below on
+`fix/gh431-honest-index-readiness`. Part of the beta.128 "honest graph signals"
+QoL set (with GH #435).
 
-**Adversarially reviewed (2026-07-03).** The review confirmed **revision-lag is the
-right signal** but caught that the first-draft concrete invariants recreated the
-exact false-ready bug (and a worse never-ready deadlock) under the configs
-semstreams actually ships. This revision folds in the three required corrections:
-a **contiguous** high-water mark (not a monotonic max), a **query-time `LastSeq`**
-Target (not idle-gated), and a **distinct embedding definition** over eligible
-entities. Those corrections — not a redesign — are the substance below.
+**Adversarially reviewed (2026-07-03), twice.** The first (design) review confirmed
+**revision-lag is the right signal** but caught that the first-draft concrete
+invariants recreated the exact false-ready bug (and a worse never-ready deadlock)
+under the configs semstreams actually ships: it folded in a **query-time `LastSeq`**
+Target (not idle-gated) and a **distinct embedding definition** over eligible
+entities. A second **code-grounded** review (against `nats.go` v1.48.0 and the
+nats-server storage layer) then corrected the watermark *algorithm* itself: the
+"contiguous, advance-from `IndexedRevision+1`" formulation **stalls permanently**
+because ENTITY_STATES runs at **History=1** and `WatchAll` delivers a **sparse**
+latest-per-key revision set (§1). The corrected watermark is **low-water-of-pending**
+with a **single key-scoped completion rule**, sound precisely because `OrderedConsumer`
+guarantees monotonic-ascending delivery. That review also fixed the completion wiring
+(coalescer-collapse + delete-orphan) and pinned two honest-scope boundaries (§1
+*Scope boundary*). Those corrections — not a redesign — are the substance below.
 
 ## Decision
 
 Replace the sticky "indexing started = ready" signal with a **revision-lag /
 caught-up** signal on `graph.index.query.status`:
 
-- **`IndexedRevision`** — the **contiguous high-water mark**: the highest
-  ENTITY_STATES revision `R` such that *every* revision `≤ R` has been fully
-  applied to the indexes, advanced across **both** processing paths (the worker
-  pool AND the inline delete handler). NOT "the highest revision a worker
-  finished" — that is wrong under multi-worker pools and deletes.
+- **`IndexedRevision`** — the **low-water-of-pending watermark**: the highest
+  revision `R` such that every *delivered* ENTITY_STATES revision `≤ R` has been
+  applied and nothing `≤ R` is still in flight, advanced across **both** processing
+  paths (the worker pool AND the inline delete handler). Concretely
+  `pending.empty() ? observedHigh : (minPending − 1)` — NOT "the highest revision a
+  worker finished" (wrong under multi-worker pools / deletes) and NOT absolute
+  revision contiguity (which stalls forever under History=1 sparse delivery — see §1).
 - **`TargetRevision`** — the stream's current `LastSeq`, read **at query time,
   always** (not derived from the last `Delta()==0` watch entry, which is stale
   exactly when writes are committed-but-not-yet-delivered).
@@ -99,25 +109,89 @@ lag), and caught-up — the exact confusion #431 is about. Refuted:
 
 ## Design
 
-### 1. graph-index: contiguous high-water mark (the corrected invariant)
+### 1. graph-index: low-water-of-pending watermark (the corrected invariant)
 
-`IndexedRevision` is a **commit-offset / contiguous watermark**, not a max. The
-pool completes revisions out of order (N>1) and deletes commit inline, so the
-signal must answer "all revisions ≤ R applied," which requires tracking gaps:
+`IndexedRevision` answers "every committed ENTITY_STATES revision ≤ R has been
+dispatched through and returned from the indexer." The naive "advance from
+`IndexedRevision+1` past every now-contiguous completed revision" **is wrong here
+and stalls forever**: ENTITY_STATES is created with **no `History`** override →
+NATS KV default **History=1** (`graph-ingest/component.go:804`), and `WatchAll`
+binds an **`OrderedConsumer` + `DeliverLastPerSubject`** (`nats.go` `jetstream/kv.go:1273`).
+Bootstrap therefore delivers only the *latest surviving revision per key* — a
+**sparse** revision set (superseded revisions are purged, never delivered). Waiting
+for revision `1, 2, …` that will never arrive pins the watermark at 0 permanently —
+a false-*not*-ready worse than the false-ready this ADR fixes.
 
-- Maintain `{pending set of in-flight revisions}` and `IndexedRevision`. On the
-  watch delivery of revision `r`, add `r` to pending. On **completion** of `r` —
-  whether by a **pool worker** finishing `processEntityUpdateFromData` OR by the
-  **inline delete handler** finishing a delete — remove `r` from pending and, if
-  `r == IndexedRevision + 1`, advance `IndexedRevision` past every now-contiguous
-  completed revision. This advances the watermark only past the *lowest incomplete*
-  revision, so a fast late worker cannot report a gap as done, and a delete's
-  sequence participates rather than leaving a permanent hole.
-- The coalescer (which re-`Get`s the latest per key) must still register each
-  ENTITY_STATES revision it collapses as completed, or contiguity stalls even at
-  `workers:1`.
-- Complexity is bounded: pending is small (≤ in-flight window), advance is
-  amortized O(1). This is the standard out-of-order-ack commit-offset problem.
+The correct watermark tracks quantities defined **entirely over delivered
+revisions**, so purged gaps are never in play:
+
+- **`observedHigh`** — the highest revision ever *delivered to the watcher*.
+  Monotonic; updated on **every** watch entry, update AND delete.
+- **`pending`** — per key, the set of delivered-but-not-yet-completed revisions.
+- **`IndexedRevision = pending.empty() ? observedHigh : (minPending − 1)`**, where
+  `minPending` is the smallest still-pending revision across all keys.
+
+**One completion rule, every path — key-scoped, not exact-revision.**
+`complete(key, rev)` removes from `pending[key]` **every** revision ≤ `rev`. Called
+from (a) a **pool worker** on return, with the entry it processed
+(`complete(entry.Key(), entry.Revision())`), and (b) the **inline delete handler**,
+with the delete entry's own revision. Key-scoped-≤ (not exact) is load-bearing:
+
+- The **coalescer** collapses several observed revisions of a key into one re-`Get`
+  at the latest surviving revision `rg`; `complete(key, rg)` drains the collapsed
+  lower revisions no worker will ever see individually. (Exact-revision completion
+  strands them → permanent not-ready. This is why the first draft was wrong even
+  ignoring History=1.)
+- A **delete** of a key with an earlier still-pending update drains that update —
+  its sequence is superseded by the tombstone — closing the delete-orphan hole.
+- On the direct path it is a no-op beyond the exact revision unless two updates to
+  the *same key* are in-flight, where the later-completing higher revision
+  optimistically drains the lower — honest, because ENTITY_STATES stores full-state
+  snapshots (the newer write already subsumes the older). See the *Scope boundary*.
+
+**Why it is correct.** It rests on one property, which `OrderedConsumer` guarantees
+at the nats-server storage layer for **both** the `DeliverLastPerSubject` bootstrap
+replay and live updates: **delivery is monotonic ascending in `Revision()`** (the
+skip-list of last-per-subject seqs is sorted server-side; the ordered-consumer reset
+path only ever re-delivers `> lastGood`). Because delivery is ascending, every
+revision ≤ `observedHigh` that will *ever* be delivered already has been; any
+un-observed revision below `observedHigh` is purged and correctly skipped. This
+yields three structural guarantees:
+
+- `IndexedRevision ≤ TargetRevision` **always** (pending empty → `observedHigh ≤
+  LastSeq`; else → `minPending−1 < observedHigh ≤ LastSeq`), so `Lag ≥ 0`
+  structurally — the no-`max(0,…)` clamp is *safe*, not stylistic.
+- `IndexedRevision` is monotonic non-decreasing (a newly observed revision exceeds
+  `observedHigh`, so `minPending` never drops below a value already reported ready).
+- `Ready` (`Indexed ≥ Target`) is reachable only when `pending` is empty AND
+  `observedHigh` has climbed to `Target` — exactly "caught up."
+
+`observedHigh`/`pending` are guarded by one mutex (touched by the watch goroutine,
+N pool workers, the coalescer callback, and the query handler); `observe`
+happens-before `complete` on every path (channel send precedes worker receive;
+delete is single-goroutine), so there is no `complete`-before-`observe` underflow.
+Complexity is bounded: `pending` ≤ the in-flight window; a per-key sorted structure
++ maintained minimum keeps observe/complete O(log n) and the query-time read O(1).
+
+**Scope boundary — what `Ready` does and does NOT promise.** `Ready` means
+**revision coverage**, not last-writer-wins **freshness** or per-index write
+**success**. Two pre-existing pipeline adjacencies are out of this ADR's scope and
+must not be silently inherited as stronger promises:
+
+- *Multi-worker stale overwrite* (live under the shipped `workers: 2–4`): the pool
+  has no completion ordering (`pkg/worker/pool.go`), so two rapid updates to the
+  *same key* can land the older revision's index writes last, leaving stale data
+  while the watermark honestly reports the revision *covered*. It does **not** fire
+  on the one-shot bulk ingest #431 is about (distinct entities, one write each); it
+  needs same-key churn. A per-key last-applied-revision guard that drops superseded
+  entries is a **companion follow-up**, not bundled here.
+- *Swallowed per-index write failures*: `processEntityUpdateFromData` logs sub-index
+  write failures at Debug and returns (after CAS-retry); completion fires on worker
+  **return**, so a persistently-failing sub-write still counts as covered. Making
+  those loud (Warn + counter) is a **companion follow-up**.
+
+A consumer that needs freshness (not just coverage) gates on the companions; this
+ADR does not claim more than coverage.
 
 ### 2. graph-index: Target = query-time `LastSeq` (always)
 
@@ -208,9 +282,10 @@ type IndexStatusResponse struct {
 
 ### Negative / cost
 
-- The contiguous watermark is **more than "one atomic"**: a small pending-set +
-  advance logic, wired into two completion paths (pool + inline delete) per
-  component. This is the bulk of the implementation.
+- The low-water-of-pending watermark is **more than "one atomic"**: a per-key
+  pending structure + `observedHigh`, wired into the single key-scoped completion
+  rule on both paths (pool return + inline delete) per component. This is the bulk
+  of the implementation.
 - A query-time `LastSeq` read per status call (new natsclient helper).
 - Embedding revision-threading through both hops + the pending `Record` gains a
   revision field.
@@ -224,25 +299,38 @@ type IndexStatusResponse struct {
 
 ### Risks
 
-- **Contiguity across two paths** — the delete handler and the pool must both
-  register completions into the same watermark, or a delete/late-worker leaves a
-  gap (false-not-ready) or is skipped (false-ready). Unit-test out-of-order
-  completion AND a trailing-delete-only tail.
+- **Completion wiring across paths** — the delete handler and the pool workers must
+  both call the *same* key-scoped `complete(key, rev)`, or a coalescer-collapsed
+  lower revision / a delete-superseded pending update strands forever (permanent
+  not-ready, which the §4 stuck-detector then reports as `degraded`). Unit-test:
+  out-of-order pool completion, a coalescer collapse (several revisions of one key →
+  one re-Get), a delete that supersedes a still-pending update, and a
+  trailing-delete-only tail.
+- **Sparse-delivery stall** — the reason the naive contiguous-from-`IndexedRevision+1`
+  algorithm is rejected (§1): History=1 + `DeliverLastPerSubject` means most
+  revisions ≤ `LastSeq` are purged and never delivered. Any watermark that waits on
+  absolute revision contiguity deadlocks. The unit tests must feed a **sparse**
+  ascending revision stream (e.g. `{50, 72, 100}`), not a dense `1..N`.
 - **Embedding never-ready** — if Target isn't scoped to eligible-terminal outcomes,
   `embedding.ready` deadlocks. Gate consumers off it until §3 is proven.
-- **Bootstrap replay** — WatchAll replays keys in ascending revision to the nil
-  marker; the contiguous watermark rebuilds from 0 correctly (transient high lag /
-  not-ready during replay is *correct*). Query-time Target avoids the Target=0
-  false-ready the idle-gated draft had.
+- **Bootstrap replay** — `WatchAll` replays last-per-key in ascending revision to the
+  nil marker; `observedHigh` climbs and `pending` drains as replay proceeds, so the
+  watermark rebuilds correctly from a cold start (transient high lag / not-ready
+  during replay is *correct*). Query-time Target avoids the Target=0 false-ready the
+  idle-gated draft had. An **empty** ENTITY_STATES (`LastSeq==0`) reports not-ready
+  until the first write — deliberate (`Target>0` guard), but a genuinely-empty
+  deployment gating on `Ready` waits indefinitely.
 
 ## Migration path
 
 1. `natsclient`: a `LastSeq` (stream/KV) helper.
-2. graph-index: contiguous watermark across pool completion + inline delete +
-   coalescer; query-time Target; honest `Ready`/`Lag`/`State` on
-   `IndexStatusResponse` (fill `Revision`/`LastSynced`); degraded stuck-detector.
-   Unit-test cold-start / mid-build / caught-up / out-of-order completion /
-   trailing-delete / stuck-watermark.
+2. graph-index: low-water-of-pending watermark (`observedHigh` + per-key `pending`)
+   with the single key-scoped `complete(key, rev)` on pool return + inline delete;
+   query-time Target; honest `Ready`/`Lag`/`State` on `IndexStatusResponse` (fill
+   `Revision`/`LastSynced`); degraded stuck-detector. Unit-test with a **sparse**
+   ascending revision stream: cold-start / mid-build / caught-up / out-of-order
+   completion / coalescer-collapse / delete-supersedes-pending / trailing-delete /
+   stuck-watermark.
 3. Mirror on `pkg/fusion.IndexStatus`.
 4. graph-embedding: revision-threading (both hops + `Record` field) + new
    `graph.embedding.query.status` with the terminal-outcome watermark.
@@ -268,17 +356,39 @@ type IndexStatusResponse struct {
 - **GH #435** — the QoL-bundle sibling (a healthy path no longer over-reports as a
   reject).
 
+### Companion follow-ups (surfaced by the code-grounded review, NOT bundled here)
+
+- **Multi-worker stale overwrite** — the pool has no completion ordering, so under
+  same-key churn an older revision's index writes can land last. `Ready` stays honest
+  about *coverage*; a per-key last-applied-revision drop-guard would make it honest
+  about *freshness*. To file. Does not affect the #431 bulk-ingest path.
+- **Silent per-index write failures** — `processEntityUpdateFromData` swallows
+  sub-index write errors at Debug; readiness trusts worker-return. Elevate to
+  Warn + counter so `Ready` cannot over-report on persistent write failure. To file.
+
 ## References
 
 - `processor/graph-index/name_index.go` (sticky bug, handler); `component.go`
-  (watch/pool `700-812`; inline delete `740-746`; coalescer re-Get `984-1010`;
-  worker completion `833-980`).
-- `pkg/worker/pool.go` (single-channel N-worker pool, no ordering).
-- `graph/index_status.go` + `pkg/fusion/contract.go` (wire shapes); `engine_lens.go:82-85`
-  (single-shot Ready gate).
-- `processor/graph-embedding/component.go` (revision dropped at watch `921`; no-text
-  skip `1019-1022`; 5-worker default); `graph/embedding/storage.go` (`SaveGenerated`
-  no revision `164`; `Record` no revision field `37-53`); `worker.go` (second hop,
-  no-text delete `310-317`, `markFailed` `496`).
-- `configs/hello-world.json`, `e2e-structural.json`, `statistical.json` (`workers` 2/4).
+  (watch/pool dispatch `722-761`; inline delete `740-746`; coalescer create
+  `522-527` + re-Get `984-1010`; worker completion `820-980`; `Workers` floors to 1
+  at `96`).
+- `pkg/worker/pool.go` (single-channel N-worker pool, no completion ordering
+  `301-338`).
+- `pkg/cache/coalescing_set.go` (batches by KEY only, drops revisions; `Remove` on
+  delete `60-64`).
+- `graph/index_status.go` + `pkg/fusion/contract.go` (wire shapes); `engine_lens.go:83-85`
+  (single-shot Ready gate); `pkg/fusion/retrieval.go:20` (`Status` decode site).
+- `processor/graph-ingest/component.go:804` (ENTITY_STATES created with no `History`
+  → default 1); `natsclient/client.go:970` (`CreateKeyValueBucket`, no history
+  injection).
+- `nats.go` v1.48.0 `jetstream/kv.go` (`WatchAll` = `OrderedConsumer` +
+  `DeliverLastPerSubject` `1273-1275`; `*KeyValueBucketStatus.StreamInfo().State.LastSeq`
+  `820`); ascending last-per-subject delivery guaranteed at the nats-server storage
+  layer (skip-list sorted; ordered-consumer reset re-delivers `> lastGood`).
+- `processor/graph-embedding/component.go` (embedding second hop, `SaveGenerated` /
+  `SaveFailed` / no-text-skip, `WatchAll` at `874` — all in this one file, **not** a
+  `worker.go`); `graph/embedding/storage.go` (`SaveGenerated` no revision `164`;
+  `Record` no revision field `37-53`; terminal states `generated`/`failed`).
+- `configs/hello-world.json`, `e2e-structural.json`, `statistical.json` (`workers` 2/4;
+  none set `coalesce_ms` → coalescer dormant in shipped configs).
 - `semsource/processor/source-manifest/status.go`; `semsource/processor/mcp-gateway/tools.go`.

--- a/docs/adr/066-honest-graph-index-readiness.md
+++ b/docs/adr/066-honest-graph-index-readiness.md
@@ -207,23 +207,57 @@ status is polled (not hot), so one stream-info round-trip per call is acceptable
 
 ### 3. graph-embedding: a DISTINCT terminal-outcome watermark (not the same block)
 
-Reusing graph-index's Target for embeddings is a **permanent deadlock**: only
-text-bearing entities reach `SaveGenerated`; telemetry-only entities never enter
-the pipeline, empty-text records are deleted without generating, failures go to
-`SaveFailed`. So a Target = "latest ENTITY_STATES revision" leaves permanent gaps
-and `Lag` never reaches 0. Instead:
+**Implemented** (reuses `pkg/revlag.Watermark` + `graph.ComputeIndexStatus`; new
+`graph.embedding.query.status`). Reusing graph-index's semantics naively is a
+**permanent deadlock**: only text-bearing entities reach `SaveGenerated`;
+telemetry-only entities carry no text, so a Target = "latest ENTITY_STATES revision"
+would leave their revisions permanently un-terminal and `Lag` never reaches 0. The
+resolution — verified by a code-grounded adversarial review against the **real
+two-hop / two-bucket** pipeline (the ADR's first draft cited a `worker.go` layout
+that does not exist):
 
-- `IndexedRevision` (embedding) advances on **every TERMINAL outcome of an eligible
-  entity** — `generated` OR deliberately-skipped-no-text OR `failed` — contiguously,
-  not only on `generated`. "Processed to a terminal state," not "embedded."
-- Thread the **ENTITY_STATES revision** through both hops: capture `entry.Revision()`
-  at ingest → store on the pending `Record` (which has no revision field today,
-  `storage.go:37-53`) → read it back at the terminal transition. `SaveGenerated`
-  today takes no revision (`storage.go:164`) — this plumbing is required, not
-  optional.
-- Target is the same query-time `LastSeq`, but `Ready` means "every eligible
-  revision ≤ Indexed reached a terminal state." Until this is implemented and
-  tested, **no consumer (mcp-gateway, fusion) gates on `embedding.ready`**.
+- The pipeline is **hop 1** (`processor/graph-embedding/component.go` watches
+  ENTITY_STATES → `queueEntityForEmbedding`) and **hop 2** (`graph/embedding/worker.go`
+  watches the *EMBEDDING_INDEX* bucket for pending `Record`s → generate).
+- `IndexedRevision` advances on **every TERMINAL outcome** — `generated` OR
+  deliberately-skipped-no-text OR `ineligible-skip` OR `failed` OR `delete` — not only
+  `generated`. Because every observed ENTITY_STATES revision reaches exactly one
+  terminal across the two hops, `Ready = Indexed >= Target(LastSeq)` **is** reachable
+  even though only text-bearing entities embed. That is the deadlock-avoidance.
+- Thread the **ENTITY_STATES revision** through both hops: `entry.Revision()` at hop-1
+  → new `Record.SourceRevision` field → `SavePending(…, sourceRevision)` → hop-2 reads
+  it and fires a single `WithOnTerminal(entityID, sourceRevision)` callback (a `defer`
+  placed **after** the not-pending skip, so a re-delivered generated/failed record does
+  not double-complete) → `watermark.Complete`. `SaveGenerated` rebuilds the record and
+  drops `SourceRevision` — fine, those records only ever hit the not-pending skip.
+- **Completion-wiring hazards the review caught (all fixed):** (D1) a `SavePending`
+  **network Put** failure must `Complete(key, rev)` — unlike graph-index's shutdown-only
+  `SubmitBlocking`, this fails transiently mid-run and would strand the bulk-ingest path
+  permanently; (D2) `offloaded-excluded` is **NOT** a terminal — it falls through to the
+  inline-text path, so completing there is a false-ready; (D3) a corrupt hop-2 record
+  (`worker.go` unmarshal-fail) cannot yield its revision → **max-rev drain** (`^uint64(0)`)
+  + loud Warn, so one poison record cannot wedge the whole signal.
+- **`SourceRevision==0` (a legacy pending record) → no-op** (`Complete(key,0)` is a
+  natural no-op; KV seqs start at 1). NOT a max-rev drain: hop-1's own bootstrap
+  re-observe re-queues the entity with the real revision, so the genuine completion is
+  guaranteed — a max-rev drain would instead cause a transient false-ready mid-replay.
+- **Stuck detector is COMPLETIONS-based**, not IndexedRevision-based, with a longer
+  threshold (embeddings add a slow external-LLM hop): a single slow call that pins
+  `Indexed` while other workers finish out of order is healthy, not degraded; only a
+  window with zero terminal completions (while lagging) is degraded.
+- **Scope boundary:** like graph-index, `Ready` means terminal *coverage*, not embedding
+  *success* — a backend outage that mass-`SaveFailed`s reads as caught-up (every
+  revision terminal). Counter/failure-ratio degraded signal is a companion follow-up.
+  Also: under **same-key churn + an ordered-consumer reset** (K written twice, the older
+  pending superseded by a `generated` record that drops `SourceRevision`, and the newer
+  pending's delivery lost to a reset), that revision can strand — read as `building`, not
+  `degraded`, since other entities keep the completions detector healthy. It does NOT
+  affect the gh#431 bulk-ingest path (distinct entities, one write each) and **self-heals
+  on the key's next write** (`Complete(K, newRev)` drains it as `≤`); noted so it is not
+  mistaken for a regression.
+- Target is the same query-time `LastSeq`. **No consumer (mcp-gateway, fusion) gates on
+  `embedding.ready`** until this is proven in the field; the handler is surfaced for
+  observability only.
 
 ### 4. Degraded overrides (was punted; the review made it load-bearing)
 
@@ -323,19 +357,21 @@ type IndexStatusResponse struct {
 
 ## Migration path
 
-1. `natsclient`: a `LastSeq` (stream/KV) helper.
-2. graph-index: low-water-of-pending watermark (`observedHigh` + per-key `pending`)
-   with the single key-scoped `complete(key, rev)` on pool return + inline delete;
-   query-time Target; honest `Ready`/`Lag`/`State` on `IndexStatusResponse` (fill
-   `Revision`/`LastSynced`); degraded stuck-detector. Unit-test with a **sparse**
-   ascending revision stream: cold-start / mid-build / caught-up / out-of-order
-   completion / coalescer-collapse / delete-supersedes-pending / trailing-delete /
-   stuck-watermark.
-3. Mirror on `pkg/fusion.IndexStatus`.
-4. graph-embedding: revision-threading (both hops + `Record` field) + new
-   `graph.embedding.query.status` with the terminal-outcome watermark.
-5. semsource: mcp-gateway third fan-out (surfaced, not gated) + retire the workaround
-   note; decide source-manifest gating (their ADR).
+1. ✅ `natsclient.BucketLastSeq` (query-time Target).
+2. ✅ graph-index: low-water-of-pending watermark (`pkg/revlag.Watermark`) with the
+   single key-scoped `Complete(key, rev)` on pool return + inline delete; query-time
+   Target; honest `Ready`/`Lag`/`State`; degraded stuck-detector. Sparse-stream unit
+   tests + a wired integration test. (commit `2ccffba3`)
+3. ✅ Mirror on `pkg/fusion.IndexStatus` + fix the fusionnats client to decode all
+   fields (was dropping the revision-lag fields).
+4. ✅ graph-embedding: `Record.SourceRevision` threaded through both hops; terminal
+   completion on every outcome (generated / failed / no-text / ineligible / delete);
+   `WithOnTerminal` callback; new `graph.embedding.query.status`; completions-based
+   stuck detector. Deadlock-avoidance integration test (text + telemetry-only both
+   catch up). Watermark mechanism extracted to `pkg/revlag`, projection to
+   `graph.ComputeIndexStatus`.
+5. semsource (cross-repo, NOT in this repo): mcp-gateway third fan-out (surfaced, not
+   gated) + retire the workaround note; decide source-manifest gating (their ADR).
 6. Tag beta.128 (bundled with GH #435); coordinate the semsource pin.
 
 ## Open questions
@@ -344,8 +380,9 @@ type IndexStatusResponse struct {
   the numbers first.
 - **source-manifest gating** — semstreams exposes the honest signal; whether
   semsource's `phase=ready` composes it is semsource's decision.
-- **Embedding-ready consumer gating** — deferred until §3 is proven; the third
-  fan-out is surfaced-only meanwhile.
+- **Embedding-ready consumer gating** — `graph.embedding.query.status` now ships
+  (§3 implemented), but **no consumer gates on it** until it is proven in the field;
+  the mcp-gateway third fan-out is surfaced-only meanwhile.
 
 ## Related decisions
 
@@ -365,6 +402,11 @@ type IndexStatusResponse struct {
 - **Silent per-index write failures** — `processEntityUpdateFromData` swallows
   sub-index write errors at Debug; readiness trusts worker-return. Elevate to
   Warn + counter so `Ready` cannot over-report on persistent write failure. To file.
+- **Embedding mass-failure reads as caught-up** — a backend outage that
+  mass-`SaveFailed`s advances the watermark (every revision terminal) → `embedding.ready`
+  true with embeddings missing. Add a failed-terminal counter / failure-ratio degraded
+  signal. Sharper than the graph-index analog because it silently degrades search
+  relevance. To file.
 
 ## References
 
@@ -385,10 +427,13 @@ type IndexStatusResponse struct {
   `DeliverLastPerSubject` `1273-1275`; `*KeyValueBucketStatus.StreamInfo().State.LastSeq`
   `820`); ascending last-per-subject delivery guaranteed at the nats-server storage
   layer (skip-list sorted; ordered-consumer reset re-delivers `> lastGood`).
-- `processor/graph-embedding/component.go` (embedding second hop, `SaveGenerated` /
-  `SaveFailed` / no-text-skip, `WatchAll` at `874` — all in this one file, **not** a
-  `worker.go`); `graph/embedding/storage.go` (`SaveGenerated` no revision `164`;
-  `Record` no revision field `37-53`; terminal states `generated`/`failed`).
+- graph-embedding is **two hops over two buckets**: hop-1
+  `processor/graph-embedding/component.go` (`watchEntityStates`, `queueEntityForEmbedding`
+  terminal-skips, `processEntityBatch` coalescer re-Get, `readiness.go` projection +
+  completions-based stuck detector); hop-2 `graph/embedding/worker.go` (`handleKVEntry`
+  watches EMBEDDING_INDEX, `SaveGenerated`/`markFailed`/no-text `DeleteEmbedding`,
+  `WithOnTerminal` callback). `graph/embedding/storage.go` (`Record.SourceRevision`;
+  `SavePending`/`SavePendingWithStorageRef` take the source revision).
 - `configs/hello-world.json`, `e2e-structural.json`, `statistical.json` (`workers` 2/4;
   none set `coalesce_ms` → coalescer dormant in shipped configs).
 - `semsource/processor/source-manifest/status.go`; `semsource/processor/mcp-gateway/tools.go`.

--- a/graph/embedding/doc.go
+++ b/graph/embedding/doc.go
@@ -122,6 +122,7 @@
 //	        message.ContentRoleAbstract: "abstract",
 //	        message.ContentRoleTitle:    "title",
 //	    },
+//	    sourceRevision, // ENTITY_STATES revision for the readiness watermark (0 if unknown)
 //	)
 //
 // # Vector Operations

--- a/graph/embedding/storage.go
+++ b/graph/embedding/storage.go
@@ -45,6 +45,15 @@ type Record struct {
 	Status      Status    `json:"status"`
 	ErrorMsg    string    `json:"error_msg,omitempty"` // If status=failed
 
+	// SourceRevision is the ENTITY_STATES stream revision that produced this pending
+	// record. It is threaded from the hop-1 watcher so hop-2 can complete the
+	// embedding readiness watermark at the terminal transition (ADR-066 §3). Only
+	// meaningful on pending records; SaveGenerated/SaveFailed rebuild the record and
+	// drop it (those records only ever hit hop-2's not-pending skip). 0 means
+	// "unknown" (a legacy record written before this field existed) — the watermark
+	// completion treats 0 as a no-op.
+	SourceRevision uint64 `json:"source_revision,omitempty"`
+
 	// ContentStorable support (Feature 008)
 	// When StorageRef is set, Worker fetches content from ObjectStore
 	// and uses ContentFields to extract text for embedding.
@@ -100,16 +109,19 @@ func NewStorage(indexBucket, dedupBucket jetstream.KeyValue) *Storage {
 }
 
 // SavePending saves a pending embedding request with source text (legacy mode).
-func (s *Storage) SavePending(ctx context.Context, entityID, contentHash, sourceText string) error {
+// sourceRevision is the ENTITY_STATES revision that produced this record (ADR-066
+// §3 readiness watermark); pass 0 when unknown.
+func (s *Storage) SavePending(ctx context.Context, entityID, contentHash, sourceText string, sourceRevision uint64) error {
 	if entityID == "" {
 		return errs.WrapInvalid(errs.ErrMissingConfig, "Storage", "SavePending", "entity_id is empty")
 	}
 
 	record := &Record{
-		EntityID:    entityID,
-		ContentHash: contentHash,
-		SourceText:  sourceText,
-		Status:      StatusPending,
+		EntityID:       entityID,
+		ContentHash:    contentHash,
+		SourceText:     sourceText,
+		Status:         StatusPending,
+		SourceRevision: sourceRevision,
 	}
 
 	data, err := json.Marshal(record)
@@ -132,6 +144,7 @@ func (s *Storage) SavePendingWithStorageRef(
 	entityID, contentHash string,
 	storageRef *StorageRef,
 	contentFields map[string]string,
+	sourceRevision uint64,
 ) error {
 	if entityID == "" {
 		return errs.WrapInvalid(errs.ErrMissingConfig, "Storage", "SavePendingWithStorageRef", "entity_id is empty")
@@ -141,11 +154,12 @@ func (s *Storage) SavePendingWithStorageRef(
 	}
 
 	record := &Record{
-		EntityID:      entityID,
-		ContentHash:   contentHash,
-		StorageRef:    storageRef,
-		ContentFields: contentFields,
-		Status:        StatusPending,
+		EntityID:       entityID,
+		ContentHash:    contentHash,
+		StorageRef:     storageRef,
+		ContentFields:  contentFields,
+		Status:         StatusPending,
+		SourceRevision: sourceRevision,
 	}
 
 	data, err := json.Marshal(record)

--- a/graph/embedding/worker.go
+++ b/graph/embedding/worker.go
@@ -42,6 +42,15 @@ func isExpectedShutdownError(err error) bool {
 // The callback receives the entity ID and the generated embedding vector.
 type GeneratedCallback func(entityID string, embedding []float32)
 
+// TerminalCallback is called when a pending embedding reaches ANY terminal outcome
+// — generated, failed, or deliberately skipped (no text) — carrying the entity ID
+// and the ENTITY_STATES SourceRevision that produced the record. It exists so the
+// hop-1 readiness watermark can be completed at the true end of the two-hop pipeline
+// (ADR-066 §3). sourceRevision==0 means "unknown" (a legacy record) and the
+// completion is a no-op; ^uint64(0) is the max-rev drain used for an unreadable
+// (corrupt) record whose revision cannot be recovered.
+type TerminalCallback func(entityID string, sourceRevision uint64)
+
 // WorkerMetrics provides metrics callbacks for embedding worker operations.
 // This allows the worker to report metrics without direct dependency on prometheus.
 type WorkerMetrics interface {
@@ -96,6 +105,7 @@ type Worker struct {
 
 	// Callbacks
 	onGenerated GeneratedCallback // Called when embedding is generated
+	onTerminal  TerminalCallback  // Called at ANY terminal outcome (ADR-066 §3)
 
 	// Metrics
 	metrics WorkerMetrics // Optional metrics reporter
@@ -171,6 +181,14 @@ func (w *Worker) WithMaxSourceTextLen(n int) *Worker {
 // Use this to populate caches or trigger downstream processing.
 func (w *Worker) WithOnGenerated(cb GeneratedCallback) *Worker {
 	w.onGenerated = cb
+	return w
+}
+
+// WithOnTerminal sets a callback invoked when a pending embedding reaches any
+// terminal outcome (generated, failed, or no-text skip). Used to complete the
+// hop-1 readiness watermark (ADR-066 §3).
+func (w *Worker) WithOnTerminal(cb TerminalCallback) *Worker {
+	w.onTerminal = cb
 	return w
 }
 
@@ -287,16 +305,39 @@ func (w *Worker) handleKVEntry(entry jetstream.KeyValueEntry, workerID int) {
 	// Parse the record to check status
 	var record Record
 	if err := json.Unmarshal(entry.Value(), &record); err != nil {
-		w.logger.Warn("Failed to unmarshal embedding record", "key", entry.Key(), "error", err)
+		// A corrupt record cannot yield its SourceRevision, so its hop-1 pending
+		// entry can never be completed with an exact revision — and unlike a
+		// deleted entity, no re-observation is guaranteed. Max-rev-drain the key so
+		// one poison record cannot wedge the whole embedding.ready signal into
+		// permanent degraded (ADR-066 §3 D3); loud, because it is not expected.
+		w.logger.Warn("Failed to unmarshal embedding record; draining readiness watermark for key",
+			"key", entry.Key(), "error", err)
+		if w.onTerminal != nil {
+			w.onTerminal(entry.Key(), ^uint64(0))
+		}
 		return
 	}
 
-	// Only process pending records
+	// Only process pending records. A re-delivered generated/failed record (from our
+	// own hop-2 writes) lands here and must NOT fire the terminal callback — it was
+	// already completed when it first transitioned. So the defer below is registered
+	// AFTER this skip, never before it (ADR-066 §3).
 	if record.Status != StatusPending {
 		return
 	}
 
 	entityID := entry.Key()
+
+	// Every path past this point is genuinely terminal — the pipeline never retries;
+	// every error is a hard SaveFailed, no-text is a delete, success is SaveGenerated.
+	// One deferred completion covers them all uniformly, closing the "missed a
+	// terminal site" risk. sourceRevision==0 (legacy record) makes it a no-op.
+	defer func() {
+		if w.onTerminal != nil {
+			w.onTerminal(entityID, record.SourceRevision)
+		}
+	}()
+
 	w.logger.Debug("Processing pending embedding", "worker_id", workerID, "entity_id", entityID)
 
 	// Get source text - either from record or from ObjectStore via StorageRef

--- a/graph/index_status.go
+++ b/graph/index_status.go
@@ -1,5 +1,7 @@
 package graph
 
+import "strconv"
+
 // IndexStatusResponse is the wire shape of graph.index.query.status (gh#397,
 // enriched by ADR-066): the deterministic-fusion honesty envelope's readiness
 // signal.
@@ -42,3 +44,40 @@ const (
 	IndexStateReady    = "ready"
 	IndexStateDegraded = "degraded"
 )
+
+// ComputeIndexStatus builds the honest revision-lag readiness envelope (ADR-066)
+// from an indexed watermark, the query-time target (a stream LastSeq), a stuck flag
+// (the caller's stuck-watermark detector), and a last-synced timestamp. It is the
+// shared PROJECTION over pkg/revlag.Watermark used by every revision-lag consumer
+// (graph-index, graph-embedding); the watermark mechanism and the per-consumer
+// stuck-detector live elsewhere.
+//
+//   - Ready = target > 0 && indexed >= target (no max(0,…) clamp — indexed <= target
+//     is structural in the watermark, so Lag cannot underflow).
+//   - State = ready ? "ready" : (stuck ? "degraded" : "building"); ready wins.
+func ComputeIndexStatus(indexed, target uint64, stuck bool, lastSynced string) IndexStatusResponse {
+	ready := target > 0 && indexed >= target
+	var lag uint64
+	if target > indexed {
+		lag = target - indexed
+	}
+	state := IndexStateBuilding
+	switch {
+	case ready:
+		state = IndexStateReady
+	case stuck:
+		state = IndexStateDegraded
+	}
+	resp := IndexStatusResponse{
+		Ready:           ready,
+		State:           state,
+		IndexedRevision: indexed,
+		TargetRevision:  target,
+		Lag:             lag,
+		LastSynced:      lastSynced,
+	}
+	if indexed > 0 {
+		resp.Revision = strconv.FormatUint(indexed, 10)
+	}
+	return resp
+}

--- a/graph/index_status.go
+++ b/graph/index_status.go
@@ -1,22 +1,39 @@
 package graph
 
-// IndexStatusResponse is the wire shape of graph.index.query.status (gh#397):
-// the deterministic-fusion honesty envelope's readiness signal.
+// IndexStatusResponse is the wire shape of graph.index.query.status (gh#397,
+// enriched by ADR-066): the deterministic-fusion honesty envelope's readiness
+// signal.
 //
 // Ready is load-bearing — only Ready permits a caller to treat an empty result
 // as an authoritative not-found; when not Ready the caller must fall back (e.g.
-// to grep) rather than conclude absence. Today Ready means the NAME_INDEX (the
-// index deterministic symbol/prefix resolution depends on) has been populated
-// (non-empty); a not-yet-populated index can't distinguish "absent" from
-// "not-yet-indexed", so it reports not-ready (ADR-062 / gh#397).
+// to grep) rather than conclude absence. Ready now means the index is CAUGHT UP:
+// every committed ENTITY_STATES revision <= the query-time target has been
+// applied (revision-lag, ADR-066), not merely "indexing started" (the old sticky
+// NAME_INDEX-non-empty signal that fired minutes before the index was populated,
+// gh#431). Ready guarantees revision COVERAGE, not last-writer-wins freshness
+// under same-key churn (ADR-066 §1 Scope boundary).
 //
 // The JSON field names match pkg/fusion.IndexStatus so the fusion
-// RetrievalClient decodes this response directly into its honesty envelope.
+// RetrievalClient decodes this response directly into its honesty envelope; the
+// two structs change together.
 type IndexStatusResponse struct {
-	Ready      bool   `json:"ready"`
-	State      string `json:"state"` // "building" | "ready" | "degraded"
-	Revision   string `json:"revision,omitempty"`
-	LastSynced string `json:"last_synced,omitempty"`
+	Ready bool   `json:"ready"` // target>0 && indexed_revision>=target_revision
+	State string `json:"state"` // "building" | "ready" | "degraded"
+	// IndexedRevision is the low-water-of-pending watermark: every delivered
+	// ENTITY_STATES revision <= this has been applied and nothing <= it is still
+	// in flight. A consumer that knows its own target revision can gate on
+	// IndexedRevision >= myRev instead of the coarse global Ready bool.
+	IndexedRevision uint64 `json:"indexed_revision,omitempty"`
+	// TargetRevision is the ENTITY_STATES stream LastSeq read at query time — the
+	// latest committed write the index must catch up to.
+	TargetRevision uint64 `json:"target_revision,omitempty"`
+	// Lag is TargetRevision - IndexedRevision; 0 means caught up.
+	Lag uint64 `json:"lag,omitempty"`
+	// Phase is the optional friendly projection (ingesting | indexing | ready);
+	// deferred — the numeric fields are load-bearing (ADR-066 open question).
+	Phase      string `json:"phase,omitempty"`
+	Revision   string `json:"revision,omitempty"`    // string IndexedRevision (now populated)
+	LastSynced string `json:"last_synced,omitempty"` // last watermark advance (now populated)
 }
 
 // Index readiness states. Mirrors pkg/fusion.IndexState string values.

--- a/natsclient/kv.go
+++ b/natsclient/kv.go
@@ -91,6 +91,35 @@ func (kv *KVStore) Get(ctx context.Context, key string) (*KVEntry, error) {
 	}, nil
 }
 
+// BucketLastSeq returns the backing stream's LastSeq for a KV bucket — the highest
+// sequence ever assigned to the bucket, read fresh from the server on every call.
+//
+// It is the query-time "target" for revision-lag readiness (ADR-066): every
+// committed write to the bucket has a Revision() <= LastSeq, and LastSeq is
+// monotonic even under History=1 — a purge raises FirstSeq but never lowers
+// LastSeq. LastSeq shares the same sequence space as KeyValueEntry.Revision()
+// (both are stream sequence numbers), so a caller can compare an indexed-revision
+// watermark directly against it. Prefer this over the last watch entry's
+// Delta()==0: that cache is stale exactly in the committed-but-not-yet-delivered
+// window this target must see through.
+func BucketLastSeq(ctx context.Context, bucket jetstream.KeyValue) (uint64, error) {
+	status, err := bucket.Status(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("kv status: %w", err)
+	}
+	// The concrete JetStream-backed status exposes the backing stream info; the
+	// KeyValueStatus interface itself does not surface LastSeq.
+	bucketStatus, ok := status.(*jetstream.KeyValueBucketStatus)
+	if !ok {
+		return 0, fmt.Errorf("kv status: unexpected type %T, want *jetstream.KeyValueBucketStatus", status)
+	}
+	info := bucketStatus.StreamInfo()
+	if info == nil {
+		return 0, fmt.Errorf("kv status: nil backing stream info")
+	}
+	return info.State.LastSeq, nil
+}
+
 // Put creates or updates a key without revision check (last writer wins)
 func (kv *KVStore) Put(ctx context.Context, key string, value []byte) (uint64, error) {
 	ctx, cancel := kv.applyTimeout(ctx)

--- a/pkg/fusion/contract.go
+++ b/pkg/fusion/contract.go
@@ -61,11 +61,21 @@ const (
 
 // IndexStatus is attached to every response. Ready is load-bearing: when false
 // the caller must fall back (e.g. to grep) rather than treat empty as not-found.
+// Ready now means the index is CAUGHT UP (revision-lag), not merely started
+// (ADR-066). Field-identical to graph.IndexStatusResponse — the RetrievalClient
+// decodes graph.index.query.status directly into this; the two change together.
 type IndexStatus struct {
-	Ready      bool       `json:"ready"`
-	State      IndexState `json:"state"`
-	Revision   string     `json:"revision,omitempty"`
-	LastSynced string     `json:"last_synced,omitempty"`
+	Ready bool       `json:"ready"`
+	State IndexState `json:"state"`
+	// IndexedRevision / TargetRevision / Lag expose the exact revision-lag so a
+	// caller that knows its own target revision can gate on IndexedRevision >=
+	// myRev rather than the coarse global Ready bool (ADR-066).
+	IndexedRevision uint64 `json:"indexed_revision,omitempty"`
+	TargetRevision  uint64 `json:"target_revision,omitempty"`
+	Lag             uint64 `json:"lag,omitempty"`
+	Phase           string `json:"phase,omitempty"`
+	Revision        string `json:"revision,omitempty"`
+	LastSynced      string `json:"last_synced,omitempty"`
 }
 
 // Ref points to a node by what a human reads — never the entity ID.

--- a/pkg/fusion/fusionnats/client.go
+++ b/pkg/fusion/fusionnats/client.go
@@ -66,16 +66,16 @@ func (c *Client) Status(ctx context.Context) (fusion.IndexStatus, error) {
 	if err != nil {
 		return fusion.IndexStatus{}, err
 	}
-	var resp graph.IndexStatusResponse
+	// Decode straight into the target: graph.IndexStatusResponse and
+	// fusion.IndexStatus are field-identical by contract (ADR-066 §5), so a direct
+	// unmarshal keeps them changing together — a hand-copied remap silently drops
+	// any field added to the wire (as it did for IndexedRevision/Lag before the
+	// round-trip test below), which reads as a false-caught-up (Lag==0) downstream.
+	var resp fusion.IndexStatus
 	if err := json.Unmarshal(raw, &resp); err != nil {
 		return fusion.IndexStatus{}, fmt.Errorf("fusionnats: decode status: %w", err)
 	}
-	return fusion.IndexStatus{
-		Ready:      resp.Ready,
-		State:      fusion.IndexState(resp.State),
-		Revision:   resp.Revision,
-		LastSynced: resp.LastSynced,
-	}, nil
+	return resp, nil
 }
 
 // Resolve maps a query to seed entity IDs by mode, most relevant first. The mode

--- a/pkg/fusion/fusionnats/client_test.go
+++ b/pkg/fusion/fusionnats/client_test.go
@@ -42,8 +42,14 @@ func mustJSON(t *testing.T, v any) []byte {
 }
 
 func TestStatus_MapsResponse(t *testing.T) {
+	// Round-trip guard (ADR-066 §5): every field of graph.IndexStatusResponse must
+	// survive the client decode into fusion.IndexStatus. The revision-lag fields
+	// (IndexedRevision/TargetRevision/Lag/Phase) were silently dropped by an earlier
+	// hand-copied remap — Lag==0 downstream reads as false-caught-up mid-build.
 	fake := &fakeRequester{resp: mustJSON(t, graph.IndexStatusResponse{
-		Ready: true, State: graph.IndexStateReady, Revision: "42", LastSynced: "now",
+		Ready: true, State: graph.IndexStateReady,
+		IndexedRevision: 100, TargetRevision: 100, Lag: 0, Phase: "ready",
+		Revision: "100", LastSynced: "now",
 	})}
 	c := New(fake, time.Second)
 
@@ -54,9 +60,36 @@ func TestStatus_MapsResponse(t *testing.T) {
 	if fake.lastSubject != subjectStatus {
 		t.Errorf("subject = %q, want %q", fake.lastSubject, subjectStatus)
 	}
-	want := fusion.IndexStatus{Ready: true, State: fusion.StateReady, Revision: "42", LastSynced: "now"}
+	want := fusion.IndexStatus{
+		Ready: true, State: fusion.StateReady,
+		IndexedRevision: 100, TargetRevision: 100, Lag: 0, Phase: "ready",
+		Revision: "100", LastSynced: "now",
+	}
 	if got != want {
 		t.Errorf("status = %+v, want %+v", got, want)
+	}
+}
+
+// TestStatus_RevisionLagFieldsSurvive is the explicit guard that a mid-build
+// envelope (not caught up) round-trips its numeric fields — a consumer gating on
+// Lag must see the real lag, not a dropped-to-zero false-ready.
+func TestStatus_RevisionLagFieldsSurvive(t *testing.T) {
+	fake := &fakeRequester{resp: mustJSON(t, graph.IndexStatusResponse{
+		Ready: false, State: graph.IndexStateBuilding,
+		IndexedRevision: 40, TargetRevision: 100, Lag: 60, Revision: "40",
+	})}
+	c := New(fake, time.Second)
+
+	got, err := c.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if got.Lag != 60 || got.IndexedRevision != 40 || got.TargetRevision != 100 {
+		t.Errorf("revision-lag fields dropped: got Lag=%d Indexed=%d Target=%d, want 60/40/100",
+			got.Lag, got.IndexedRevision, got.TargetRevision)
+	}
+	if got.Ready {
+		t.Error("mid-build must not read ready")
 	}
 }
 

--- a/pkg/revlag/watermark.go
+++ b/pkg/revlag/watermark.go
@@ -1,0 +1,94 @@
+// Package revlag provides a revision-lag "caught up" watermark for async,
+// write-driven, lagging pipelines fed by a NATS KV watch (ADR-066).
+//
+// A component that watches a KV bucket and processes each entry through a pool
+// (with optional coalescing and inline deletes) needs to answer "have I caught up
+// to the latest committed write?" honestly — not "have I started?". The Watermark
+// tracks that as revision lag: Observe every delivered revision, Complete it when
+// its processing reaches a terminal outcome, and read Indexed() — the highest
+// revision such that every delivered revision <= it is done and nothing <= it is
+// still in flight.
+package revlag
+
+import "sync"
+
+// Watermark is the low-water-of-pending "caught up" tracker. It answers "every
+// DELIVERED revision <= Indexed() has completed and nothing <= it is still in
+// flight." It is deliberately defined only over DELIVERED revisions, so it is
+// correct even when the delivered revision set is SPARSE — as it is for a NATS KV
+// bucket at History=1, where WatchAll delivers via OrderedConsumer +
+// DeliverLastPerSubject and superseded revisions are purged and never delivered.
+// The rejected "advance from Indexed+1 past every contiguous completion" would
+// stall forever on the first purged gap.
+//
+// Correctness rests on ONE property, which OrderedConsumer guarantees at the
+// nats-server storage layer for both the bootstrap replay and live updates:
+// delivery is monotonic ascending in the revision passed to Observe. Any
+// un-observed revision below observedHigh is therefore purged (permanently absent)
+// and correctly skipped.
+//
+// All methods are safe for concurrent use: the watch goroutine Observes; N pool
+// workers, a coalescer callback, and/or an inline delete handler Complete; a status
+// handler reads Indexed().
+type Watermark struct {
+	mu           sync.Mutex
+	observedHigh uint64            // highest revision ever delivered
+	pending      map[uint64]string // in-flight revision -> its key
+}
+
+// New returns an empty Watermark (Indexed() == 0 until the first Observe).
+func New() *Watermark {
+	return &Watermark{pending: make(map[uint64]string)}
+}
+
+// Observe records revision r (for key) as delivered-and-in-flight. Call it from the
+// watch goroutine for EVERY delivered entry — updates AND deletes — before dispatch.
+// observedHigh is monotonic; ascending delivery means r exceeds any prior, but max()
+// is kept for defensiveness. Revision 0 ("no revision") is ignored — KV stream
+// sequences start at 1.
+func (w *Watermark) Observe(r uint64, key string) {
+	if r == 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if r > w.observedHigh {
+		w.observedHigh = r
+	}
+	w.pending[r] = key
+}
+
+// Complete drains every in-flight revision for key with revision <= rev — the single
+// key-scoped completion rule. A pool worker calls it with the entry it processed,
+// which drains any coalescer-collapsed lower revisions of that key that no worker
+// sees individually; an inline delete handler calls it with the tombstone's
+// revision, which drains an earlier pending update the delete supersedes. Key-scoped
+// (never global-<=-rev) so one key's completion cannot drop a different key's pending
+// revision.
+func (w *Watermark) Complete(key string, rev uint64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for r, k := range w.pending {
+		if k == key && r <= rev {
+			delete(w.pending, r)
+		}
+	}
+}
+
+// Indexed returns the low-water-of-pending watermark: observedHigh when nothing is in
+// flight, else minPending-1. Every delivered revision <= the result is complete and
+// nothing <= it is still pending.
+func (w *Watermark) Indexed() uint64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.pending) == 0 {
+		return w.observedHigh
+	}
+	minRev := ^uint64(0)
+	for r := range w.pending {
+		if r < minRev {
+			minRev = r
+		}
+	}
+	return minRev - 1
+}

--- a/pkg/revlag/watermark_test.go
+++ b/pkg/revlag/watermark_test.go
@@ -1,0 +1,169 @@
+package revlag
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// The watermark's whole reason to exist is honesty under SPARSE, out-of-order,
+// multi-path completion. These tests feed sparse ascending revision streams (e.g.
+// {50, 72, 100}) — NOT dense 1..N — because History=1 + DeliverLastPerSubject never
+// delivers a dense set, and the rejected "advance-from-Indexed+1" algorithm would
+// stall on the very first gap.
+
+func TestWatermark_ColdStart(t *testing.T) {
+	w := New()
+	if got := w.Indexed(); got != 0 {
+		t.Fatalf("cold start Indexed = %d, want 0", got)
+	}
+}
+
+func TestWatermark_SparseMidBuild_LowWaterOfPending(t *testing.T) {
+	w := New()
+	// Sparse ascending delivery: distinct keys at purged-gap revisions.
+	w.Observe(50, "A")
+	w.Observe(72, "B")
+	w.Observe(100, "C")
+
+	// Nothing completed: Indexed is minPending-1, NOT stuck at 0 waiting for rev 1.
+	if got := w.Indexed(); got != 49 {
+		t.Fatalf("all pending: Indexed = %d, want 49 (minPending-1)", got)
+	}
+
+	// Out-of-order completion: a fast LATE worker (rev 72) cannot report the gap done.
+	w.Complete("B", 72)
+	if got := w.Indexed(); got != 49 {
+		t.Fatalf("after completing 72 (50 still pending): Indexed = %d, want 49", got)
+	}
+
+	// Complete the low revision: watermark advances past it to the next gap.
+	w.Complete("A", 50)
+	if got := w.Indexed(); got != 99 {
+		t.Fatalf("after completing 50 (100 still pending): Indexed = %d, want 99", got)
+	}
+
+	// Complete the last: pending empties → Indexed jumps to observedHigh (=100),
+	// honestly skipping the purged 51..71, 73..99 that were never delivered.
+	w.Complete("C", 100)
+	if got := w.Indexed(); got != 100 {
+		t.Fatalf("caught up: Indexed = %d, want 100 (observedHigh)", got)
+	}
+}
+
+func TestWatermark_CoalescerCollapse_KeyScopedDrainsLowerRevisions(t *testing.T) {
+	w := New()
+	// One key delivered three times (the coalescer will re-Get only the latest, 30).
+	w.Observe(10, "K")
+	w.Observe(20, "K")
+	w.Observe(30, "K")
+	if got := w.Indexed(); got != 9 {
+		t.Fatalf("three pending revs of K: Indexed = %d, want 9", got)
+	}
+
+	// The single completion at the re-Got latest revision drains ALL collapsed lower
+	// revisions of K that no worker ever sees individually. Exact-revision completion
+	// would strand 10 and 20 forever.
+	w.Complete("K", 30)
+	if got := w.Indexed(); got != 30 {
+		t.Fatalf("after key-scoped Complete(K,30): Indexed = %d, want 30", got)
+	}
+}
+
+func TestWatermark_DeleteSupersedesPendingUpdate(t *testing.T) {
+	w := New()
+	// Update K@10 is delivered and in flight...
+	w.Observe(10, "K")
+	// ...then a delete K@11 arrives. The delete's key-scoped completion drains the
+	// tombstone AND the earlier still-pending update it supersedes.
+	w.Observe(11, "K")
+	w.Complete("K", 11)
+	if got := w.Indexed(); got != 11 {
+		t.Fatalf("after delete supersedes pending update: Indexed = %d, want 11", got)
+	}
+}
+
+func TestWatermark_CompletionIsKeyScoped(t *testing.T) {
+	w := New()
+	w.Observe(10, "A")
+	w.Observe(11, "B") // a delete of a DIFFERENT key
+	// Completing B must NOT drain A's pending revision even though 10 <= 11.
+	w.Complete("B", 11)
+	if got := w.Indexed(); got != 9 {
+		t.Fatalf("key-scoped: completing B left A@10 pending, Indexed = %d, want 9", got)
+	}
+	w.Complete("A", 10)
+	if got := w.Indexed(); got != 11 {
+		t.Fatalf("after A completes too: Indexed = %d, want 11 (observedHigh)", got)
+	}
+}
+
+func TestWatermark_TrailingDeleteOnlyTail(t *testing.T) {
+	w := New()
+	w.Observe(10, "A")
+	w.Complete("A", 10)
+	if got := w.Indexed(); got != 10 {
+		t.Fatalf("after A: Indexed = %d, want 10", got)
+	}
+	// A tail of pure deletes must still advance the watermark — their sequences
+	// participate, or lag wedges forever.
+	w.Observe(11, "B")
+	w.Complete("B", 11)
+	if got := w.Indexed(); got != 11 {
+		t.Fatalf("trailing delete: Indexed = %d, want 11", got)
+	}
+}
+
+func TestWatermark_RevisionZeroIgnored(t *testing.T) {
+	w := New()
+	w.Observe(0, "X") // "no revision" — stream sequences start at 1
+	if got := w.Indexed(); got != 0 {
+		t.Fatalf("Observe(0) should be a no-op, Indexed = %d, want 0", got)
+	}
+	w.Observe(5, "A")
+	if got := w.Indexed(); got != 4 {
+		t.Fatalf("after Observe(5): Indexed = %d, want 4", got)
+	}
+}
+
+func TestWatermark_CompleteUnobservedRevisionDrainsLower(t *testing.T) {
+	// A coalescer re-Get can return a revision NEWER than any yet delivered to the
+	// watch (a write between snapshot and Get). Completing at that not-yet-observed
+	// revision must still drain the key's lower pending, and must NOT advance
+	// observedHigh (only Observe does that).
+	w := New()
+	w.Observe(10, "K")
+	w.Complete("K", 40) // 40 never observed
+	if got := w.Indexed(); got != 10 {
+		t.Fatalf("Indexed = %d, want 10 (observedHigh unchanged; 10 drained)", got)
+	}
+}
+
+// TestWatermark_Concurrent runs Observe/Complete across many goroutines to prove the
+// mutex holds and that draining every observed revision leaves Indexed at
+// observedHigh (run under -race). Mirrors the real wiring: the watch goroutine
+// Observes ascending; N workers Complete out of order.
+func TestWatermark_Concurrent(t *testing.T) {
+	w := New()
+	const n = 2000
+
+	keys := make([]string, n)
+	for i := 0; i < n; i++ {
+		keys[i] = string(rune('a'+i%26)) + "-" + time.Duration(i).String()
+		w.Observe(uint64(i+1), keys[i])
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(rev int) {
+			defer wg.Done()
+			w.Complete(keys[rev], uint64(rev+1))
+		}(i)
+	}
+	wg.Wait()
+
+	if got := w.Indexed(); got != uint64(n) {
+		t.Fatalf("after draining all: Indexed = %d, want %d", got, n)
+	}
+}

--- a/processor/graph-embedding/component.go
+++ b/processor/graph-embedding/component.go
@@ -21,6 +21,7 @@ import (
 	"github.com/c360studio/semstreams/pkg/cache"
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/pkg/resource"
+	"github.com/c360studio/semstreams/pkg/revlag"
 	"github.com/c360studio/semstreams/storage/objectstore"
 	"github.com/c360studio/semstreams/storage/storeregistry"
 	"github.com/c360studio/semstreams/vocabulary"
@@ -240,6 +241,22 @@ type Component struct {
 
 	// Query subscriptions (for cleanup)
 	querySubscriptions []*natsclient.Subscription
+
+	// watermark is the ADR-066 §3 low-water-of-pending "caught up" tracker for the
+	// two-hop embedding pipeline. hop-1 (this component's ENTITY_STATES watcher)
+	// Observes every delivered revision; the terminal is Completed from hop-1
+	// immediate skips (delete / no-text / ineligible / SavePending failure) AND the
+	// hop-2 worker's onTerminal callback. Non-nil once Start wires the watcher.
+	watermark            *revlag.Watermark
+	embeddingCompletions atomic.Uint64 // total terminal completions (stuck-detector)
+
+	// Readiness stuck-detector state (ADR-066 §3), guarded by statusMu. Keyed off
+	// COMPLETIONS, not IndexedRevision: a slow single external-LLM call can pin
+	// Indexed for minutes while other workers complete higher revisions, which is
+	// healthy, not stuck. Only a window with zero terminal completions is degraded.
+	statusMu            sync.Mutex
+	lastCompletionsSeen uint64
+	lastProgressAt      time.Time
 }
 
 // CreateGraphEmbedding is the factory function for creating graph-embedding components
@@ -525,6 +542,10 @@ func (c *Component) Start(ctx context.Context) error {
 	// Initialize lifecycle reporter
 	c.initLifecycleReporter(ctx)
 
+	// Readiness watermark (ADR-066 §3): must exist before the worker (whose
+	// onTerminal completes it) and the watcher (which observes into it).
+	c.watermark = revlag.New()
+
 	// Create storage and worker
 	if err := c.initStorageAndWorker(ctx, embeddingIndexBucket, embeddingDedupBucket); err != nil {
 		cancel()
@@ -763,6 +784,11 @@ func (c *Component) initStorageAndWorker(ctx context.Context, indexBucket, dedup
 				c.metrics.recordEmbeddingGenerated()
 			}
 			c.logger.Debug("embedding generated", "entity_id", entityID)
+		}).
+		WithOnTerminal(func(entityID string, sourceRevision uint64) {
+			// hop-2 reached a terminal (generated / failed / no-text skip). Complete
+			// the hop-1 readiness watermark for this entity (ADR-066 §3).
+			c.completeEmbedding(entityID, sourceRevision)
 		})
 
 	// Wire the shared store resolver (ADR-063) as the PRIMARY content-fetch path:
@@ -908,17 +934,28 @@ func (c *Component) watchEntityStates(ctx context.Context, bucket jetstream.KeyV
 				continue
 			}
 
+			// Record every delivered revision (update AND delete) as in-flight for
+			// the readiness watermark before dispatch (ADR-066 §3). observedHigh
+			// advances here; completion fires at the terminal (hop-1 skip or hop-2).
+			if c.watermark != nil {
+				c.watermark.Observe(entry.Revision(), entry.Key())
+			}
+
 			if entry.Operation() == jetstream.KeyValueDelete {
 				if c.entityCoalescer != nil {
 					c.entityCoalescer.Remove(entry.Key())
 				}
+				// A delete is terminal for embedding — nothing to generate. Its
+				// key-scoped completion also drains an earlier still-pending update
+				// the delete supersedes (ADR-066 §3).
+				c.completeEmbedding(entry.Key(), entry.Revision())
 				continue
 			}
 
 			if c.entityCoalescer != nil {
 				c.entityCoalescer.Add(entry.Key())
 			} else {
-				c.queueEntityForEmbedding(ctx, entry.Key(), entry.Value())
+				c.queueEntityForEmbedding(ctx, entry.Key(), entry.Revision(), entry.Value())
 			}
 		}
 	}
@@ -939,10 +976,15 @@ func (c *Component) processEntityBatch(ctx context.Context, entityIDs []string) 
 			c.logger.Debug("entity not found during batch processing",
 				slog.String("entity", entityID),
 				slog.Any("error", err))
+			// The coalescer discarded the source revision(s), so there is no exact
+			// revision to complete. Max-rev-drain the key rather than strand it:
+			// a transient Get failure would otherwise pin the watermark forever
+			// (ADR-066 §3). Fails toward caught-up; the next update re-observes it.
+			c.completeEmbedding(entityID, ^uint64(0))
 			continue
 		}
 
-		c.queueEntityForEmbedding(ctx, entry.Key(), entry.Value())
+		c.queueEntityForEmbedding(ctx, entry.Key(), entry.Revision(), entry.Value())
 	}
 }
 
@@ -971,7 +1013,13 @@ func (c *Component) indexingEligible(es *graph.EntityState) bool {
 	return true
 }
 
-func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string, data []byte) {
+// queueEntityForEmbedding is hop 1 of the two-hop embedding pipeline: parse the
+// entity, decide eligibility, and either terminate immediately (no text to embed) or
+// SavePending a record for hop 2. sourceRevision is the ENTITY_STATES revision that
+// produced this entry (ADR-066 §3); every IMMEDIATE terminal here completes the
+// readiness watermark, and SavePending threads the revision so hop 2 completes it at
+// the true terminal.
+func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string, sourceRevision uint64, data []byte) {
 	// Report embedding stage (throttled to avoid KV spam)
 	if err := c.lifecycleReporter.ReportStage(ctx, "embedding"); err != nil {
 		c.logger.Debug("failed to report lifecycle stage", slog.String("stage", "embedding"), slog.Any("error", err))
@@ -983,6 +1031,7 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 		c.logger.Warn("failed to unmarshal entity state",
 			slog.String("entity", entityID),
 			slog.Any("error", err))
+		c.completeEmbedding(entityID, sourceRevision) // terminal: nothing to embed
 		return
 	}
 
@@ -991,6 +1040,7 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 	// preconditions. indexingEligible always returns true here, so this is a
 	// provable no-op (zero behavior change); it is the seam Phase 3 turns live.
 	if !c.indexingEligible(&entityState) {
+		c.completeEmbedding(entityID, sourceRevision) // terminal: deliberately skipped
 		return
 	}
 
@@ -1007,9 +1057,12 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 	// the entity's content triples instead of failing. Configs WITH a content
 	// store keep the offloaded-content fetch path unchanged.
 	if c.shouldFetchViaStorageRef(&entityState) {
-		c.queueEmbeddingWithStorageRef(ctx, entityID, &entityState)
+		c.queueEmbeddingWithStorageRef(ctx, entityID, sourceRevision, &entityState)
 		return
 	}
+	// NOT a terminal: reporting the excluded offload falls THROUGH to the inline-text
+	// path below, whose no-text return / SavePending owns the true terminal. Completing
+	// here would drain the watermark before hop 2 finishes (false-ready — ADR-066 §3 D2).
 	if entityState.StorageRef != nil {
 		c.reportOffloadedContentExcluded(entityID, entityState.StorageRef.StorageInstance)
 	}
@@ -1018,17 +1071,26 @@ func (c *Component) queueEntityForEmbedding(ctx context.Context, entityID string
 	text := c.extractTextForEmbedding(&entityState)
 	if text == "" {
 		c.logger.Debug("no text content found, skipping embedding", slog.String("entity", entityID))
+		// Terminal: telemetry-only / no-text entities never reach hop 2. Completing
+		// here is what makes Target=LastSeq reachable (else embedding.ready deadlocks
+		// on every text-less entity — ADR-066 §3).
+		c.completeEmbedding(entityID, sourceRevision)
 		return
 	}
 
 	// Calculate content hash for deduplication
 	contentHash := embedding.ContentHash(text)
 
-	// Queue for embedding generation
-	if err := c.storage.SavePending(ctx, entityID, contentHash, text); err != nil {
+	// Queue for embedding generation. On failure this is a network KV Put that can
+	// fail transiently WHILE the component runs — complete the watermark or the
+	// revision strands forever (permanent not-ready on the bulk-ingest path this ADR
+	// targets — ADR-066 §3 D1). Fails toward covered; the entity re-embeds on its
+	// next write.
+	if err := c.storage.SavePending(ctx, entityID, contentHash, text, sourceRevision); err != nil {
 		c.logger.Error("failed to queue embedding",
 			slog.String("entity", entityID),
 			slog.Any("error", err))
+		c.completeEmbedding(entityID, sourceRevision)
 		return
 	}
 
@@ -1083,8 +1145,9 @@ func (c *Component) reportOffloadedContentExcluded(entityID, storageInstance str
 		slog.String("entity", entityID))
 }
 
-// queueEmbeddingWithStorageRef queues an embedding using ContentStorable pattern
-func (c *Component) queueEmbeddingWithStorageRef(ctx context.Context, entityID string, state *graph.EntityState) {
+// queueEmbeddingWithStorageRef queues an embedding using ContentStorable pattern.
+// sourceRevision threads through to hop 2 for the readiness watermark (ADR-066 §3).
+func (c *Component) queueEmbeddingWithStorageRef(ctx context.Context, entityID string, sourceRevision uint64, state *graph.EntityState) {
 	// Create StorageRef for embedding record
 	storageRef := &embedding.StorageRef{
 		StorageInstance: state.StorageRef.StorageInstance,
@@ -1094,11 +1157,14 @@ func (c *Component) queueEmbeddingWithStorageRef(ctx context.Context, entityID s
 	// Calculate content hash from storage key (for deduplication)
 	contentHash := embedding.ContentHash(state.StorageRef.Key)
 
-	// Queue for embedding generation with storage reference
-	if err := c.storage.SavePendingWithStorageRef(ctx, entityID, contentHash, storageRef, nil); err != nil {
+	// Queue for embedding generation with storage reference. On failure, complete the
+	// watermark (network Put can fail transiently mid-run — same D1 strand as the
+	// legacy path; ADR-066 §3).
+	if err := c.storage.SavePendingWithStorageRef(ctx, entityID, contentHash, storageRef, nil, sourceRevision); err != nil {
 		c.logger.Error("failed to queue embedding with storage ref",
 			slog.String("entity", entityID),
 			slog.Any("error", err))
+		c.completeEmbedding(entityID, sourceRevision)
 		return
 	}
 

--- a/processor/graph-embedding/integration_test.go
+++ b/processor/graph-embedding/integration_test.go
@@ -5,6 +5,7 @@ package graphembedding
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -140,6 +141,105 @@ func TestIntegration_EmbeddingFlow(t *testing.T) {
 
 	t.Logf("Generated embedding for %s: model=%s, dimensions=%d, content_hash=%s",
 		entityID, record.Model, record.Dimensions, record.ContentHash)
+}
+
+// TestIntegration_EmbeddingReadiness_DeadlockAvoidance proves the ADR-066 §3
+// terminal-outcome watermark end to end: a MIX of text-bearing entities (which reach
+// the hop-2 SaveGenerated terminal) and telemetry-only entities (which terminate at
+// the hop-1 no-text skip) BOTH advance the readiness watermark, so
+// graph.embedding.query.status catches up to Ready. The deadlock the ADR warns about
+// — only text-bearing entities embed, so Target=LastSeq is never reached — does NOT
+// occur precisely because the no-text terminal completes the watermark too.
+func TestIntegration_EmbeddingReadiness_DeadlockAvoidance(t *testing.T) {
+	testClient := natsclient.NewTestClient(t, natsclient.WithKV())
+	nc := testClient.Client
+
+	config := DefaultConfig()
+	configJSON, err := json.Marshal(config)
+	require.NoError(t, err)
+
+	comp, err := CreateGraphEmbedding(configJSON, component.Dependencies{NATSClient: nc})
+	require.NoError(t, err)
+	embeddingComp := comp.(*Component)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, embeddingComp.Initialize())
+
+	js, err := nc.JetStream()
+	require.NoError(t, err)
+	entityBucket, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{
+		Bucket: graph.BucketEntityStates, Description: "Test entity states",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, embeddingComp.Start(ctx))
+	defer embeddingComp.Stop(5 * time.Second)
+
+	conn := nc.GetConnection()
+	// Raw Request is fine here — the status handler's only error path is an
+	// unreachable scalar-marshal failure. A production consumer that gates on this
+	// signal must use RequestClassified (ADR-066 §3) to distinguish a classified
+	// error body from a zero-value success status.
+	statusNow := func() graph.IndexStatusResponse {
+		msg, reqErr := conn.Request("graph.embedding.query.status", []byte(`{}`), 2*time.Second)
+		require.NoError(t, reqErr)
+		var st graph.IndexStatusResponse
+		require.NoError(t, json.Unmarshal(msg.Data, &st))
+		return st
+	}
+
+	// Empty ENTITY_STATES → not ready, zero target.
+	st := statusNow()
+	assert.False(t, st.Ready, "empty bucket must not read ready")
+	assert.Zero(t, st.TargetRevision)
+
+	now := time.Now().UTC()
+	writeEntity := func(id string, triples []message.Triple) {
+		state := graph.EntityState{
+			ID: id, Triples: triples,
+			MessageType: message.Type{Domain: "test", Category: "entity", Version: "v1"},
+			Version:     1, UpdatedAt: now,
+		}
+		data, mErr := json.Marshal(state)
+		require.NoError(t, mErr)
+		_, pErr := entityBucket.Put(ctx, id, data)
+		require.NoError(t, pErr)
+	}
+
+	// Text-bearing entities → hop-2 SaveGenerated terminal.
+	const textN = 4
+	for i := 0; i < textN; i++ {
+		id := fmt.Sprintf("c360.p.d.s.drone.%03d", i)
+		writeEntity(id, []message.Triple{
+			{Subject: id, Predicate: "dc.terms.title", Object: fmt.Sprintf("Drone %d", i), Source: "test", Timestamp: now},
+		})
+	}
+	// Telemetry-only entities (no text predicate) → hop-1 no-text terminal. If these
+	// did NOT complete the watermark, Ready would deadlock forever (the ADR's warning).
+	const teleN = 3
+	for i := 0; i < teleN; i++ {
+		id := fmt.Sprintf("c360.p.d.s.sensor.%03d", i)
+		writeEntity(id, []message.Triple{
+			{Subject: id, Predicate: "robotics.status.armed", Object: true, Source: "test", Timestamp: now},
+		})
+	}
+
+	// Poll until caught up. If any telemetry-only revision stranded, this never fires.
+	var final graph.IndexStatusResponse
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		final = statusNow()
+		if final.Ready {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.True(t, final.Ready, "embedding readiness must catch up — text AND telemetry-only both terminal")
+	assert.Equal(t, graph.IndexStateReady, final.State)
+	assert.Zero(t, final.Lag, "caught up means zero lag")
+	assert.GreaterOrEqual(t, final.IndexedRevision, uint64(textN+teleN), "indexed reflects every write")
+	assert.Equal(t, final.TargetRevision, final.IndexedRevision, "indexed == target when caught up")
 }
 
 // TestIntegration_EmbeddingDeduplication verifies deduplication works

--- a/processor/graph-embedding/query.go
+++ b/processor/graph-embedding/query.go
@@ -28,8 +28,16 @@ func (c *Component) setupQueryHandlers(ctx context.Context) error {
 	}
 	c.querySubscriptions = append(c.querySubscriptions, sub)
 
+	// Subscribe to the honest embedding-readiness signal (ADR-066 §3). No consumer
+	// gates on embedding.ready until it is proven; this exposes it for observability.
+	sub, err = c.natsClient.SubscribeForRequests(ctx, "graph.embedding.query.status", c.handleEmbeddingStatusNATS)
+	if err != nil {
+		return errs.WrapTransient(err, "Component", "setupQueryHandlers", "subscribe status query")
+	}
+	c.querySubscriptions = append(c.querySubscriptions, sub)
+
 	c.logger.Info("query handlers registered",
-		"subjects", []string{"graph.embedding.query.similar", "graph.embedding.query.search"})
+		"subjects", []string{"graph.embedding.query.similar", "graph.embedding.query.search", "graph.embedding.query.status"})
 
 	return nil
 }

--- a/processor/graph-embedding/readiness.go
+++ b/processor/graph-embedding/readiness.go
@@ -1,0 +1,112 @@
+package graphembedding
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// The low-water-of-pending watermark mechanism lives in pkg/revlag (shared with
+// graph-index); the readiness projection lives in graph.ComputeIndexStatus. This file
+// holds graph-embedding's glue: the terminal-completion counter, the query-time
+// target read, and the COMPLETIONS-based stuck detector (ADR-066 §3).
+
+// embeddingDegradedAfter is how long the pipeline may go with ZERO terminal
+// completions (while not caught up) before the status flips to "degraded". It is
+// generous relative to graph-index's because embeddings add a slow external-LLM hop;
+// and the detector keys off completions, not IndexedRevision, so a single slow call
+// pinning Indexed while other workers finish is correctly NOT degraded.
+const embeddingDegradedAfter = 120 * time.Second
+
+// completeEmbedding drains the readiness watermark for a terminal outcome and counts
+// the completion (feeds the stuck detector). Called from every hop-1 immediate
+// terminal AND the hop-2 onTerminal callback. sourceRevision==0 (a legacy record with
+// no revision) makes Complete a no-op — hop-1's own bootstrap re-observe carries the
+// real revision, so there is nothing to strand; ^uint64(0) is the max-rev drain for
+// an unrecoverable (corrupt) record.
+func (c *Component) completeEmbedding(entityID string, sourceRevision uint64) {
+	if c.watermark == nil {
+		return
+	}
+	c.watermark.Complete(entityID, sourceRevision)
+	// A liveness counter for the stuck detector, not an exact terminal count: a
+	// delete-branch completion whose revision hop-2 later re-completes (a no-op
+	// Complete) bumps it twice. Harmless — it only ever over-reports progress, which
+	// fails toward "healthy", never toward a false-degraded.
+	c.embeddingCompletions.Add(1)
+}
+
+// handleEmbeddingStatusNATS serves graph.embedding.query.status (ADR-066 §3): the
+// honest revision-lag readiness of the embedding pipeline. Ready means every eligible
+// ENTITY_STATES revision <= the query-time target reached a TERMINAL embedding outcome
+// (generated / failed / deliberately-skipped), not merely "embedding started". Takes
+// no request body; the response JSON shape matches graph.IndexStatusResponse.
+func (c *Component) handleEmbeddingStatusNATS(ctx context.Context, _ []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	data, err := json.Marshal(c.computeEmbeddingStatus(ctx))
+	if err != nil {
+		// Unreachable (all-scalar struct), but classify like the sibling handlers so
+		// a caller cannot mistake an error body for a zero-value success status.
+		return nil, errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("internal error"))
+	}
+	return data, nil
+}
+
+// computeEmbeddingStatus builds the embedding readiness envelope (ADR-066 §3):
+// IndexedRevision from the low-water-of-pending watermark (advanced on every terminal
+// outcome, so telemetry-only/no-text entities do not deadlock it), TargetRevision
+// from the ENTITY_STATES stream LastSeq at query time, and the completions-based stuck
+// detector for the degraded state.
+func (c *Component) computeEmbeddingStatus(ctx context.Context) graph.IndexStatusResponse {
+	// A status call before Start wired the watcher (early boot / unit tests) reports
+	// building rather than panicking. Unreachable in production: setupQueryHandlers
+	// runs after both watermark and entityStatesBucket are set in Start.
+	if c.watermark == nil || c.entityStatesBucket == nil {
+		return graph.IndexStatusResponse{Ready: false, State: graph.IndexStateBuilding}
+	}
+
+	indexed := c.watermark.Indexed()
+
+	target, err := natsclient.BucketLastSeq(ctx, c.entityStatesBucket)
+	if err != nil {
+		c.logger.Warn("embedding status: failed to read ENTITY_STATES LastSeq target",
+			slog.Any("error", err))
+		return graph.IndexStatusResponse{
+			Ready:           false,
+			State:           graph.IndexStateDegraded,
+			IndexedRevision: indexed,
+		}
+	}
+
+	stuck, lastSynced := c.trackEmbeddingProgress(indexed, target)
+	return graph.ComputeIndexStatus(indexed, target, stuck, lastSynced)
+}
+
+// trackEmbeddingProgress is the COMPLETIONS-based stuck detector (ADR-066 §3). Unlike
+// graph-index's IndexedRevision-based detector, it flips degraded only when NO
+// terminal completion has fired for embeddingDegradedAfter while not caught up — so a
+// slow single LLM call that pins IndexedRevision (its low revision runs while higher
+// revisions finish out of order) is correctly healthy, not degraded. Returns the
+// stuck flag and the last-completion timestamp for LastSynced.
+func (c *Component) trackEmbeddingProgress(indexed, target uint64) (stuck bool, lastSynced string) {
+	now := time.Now()
+	completions := c.embeddingCompletions.Load()
+	c.statusMu.Lock()
+	defer c.statusMu.Unlock()
+	if completions > c.lastCompletionsSeen || c.lastProgressAt.IsZero() {
+		c.lastCompletionsSeen = completions
+		c.lastProgressAt = now
+	}
+	caughtUp := target > 0 && indexed >= target
+	stuck = !caughtUp && now.Sub(c.lastProgressAt) > embeddingDegradedAfter
+	lastSynced = c.lastProgressAt.UTC().Format(time.RFC3339)
+	return stuck, lastSynced
+}

--- a/processor/graph-embedding/readiness_test.go
+++ b/processor/graph-embedding/readiness_test.go
@@ -1,0 +1,48 @@
+package graphembedding
+
+import (
+	"testing"
+	"time"
+)
+
+// TestTrackEmbeddingProgress_CompletionsBasedStuckDetector pins the key difference
+// from graph-index's detector (ADR-066 §3): stuck is keyed off terminal COMPLETIONS,
+// not IndexedRevision, so a slow single LLM call that pins Indexed while other workers
+// finish out of order is healthy, not degraded.
+func TestTrackEmbeddingProgress_CompletionsBasedStuckDetector(t *testing.T) {
+	c := &Component{}
+
+	// First call initializes progress; never stuck.
+	if stuck, _ := c.trackEmbeddingProgress(5, 100); stuck {
+		t.Fatal("first call must not be stuck")
+	}
+
+	// A terminal completion in the window clears stuck even though IndexedRevision is
+	// unchanged — the slow-single-call case: other workers completing keeps it alive.
+	c.lastProgressAt = time.Now().Add(-embeddingDegradedAfter - time.Second)
+	c.embeddingCompletions.Add(1)
+	if stuck, _ := c.trackEmbeddingProgress(5, 100); stuck {
+		t.Fatal("a terminal completion in the window must clear stuck (pinned Indexed is healthy)")
+	}
+
+	// Zero completions for the whole window while lagging → stuck (degraded).
+	c.lastProgressAt = time.Now().Add(-embeddingDegradedAfter - time.Second)
+	if stuck, _ := c.trackEmbeddingProgress(5, 100); !stuck {
+		t.Fatal("zero completions while lagging must be stuck")
+	}
+
+	// Caught up is never stuck, even with an old timestamp.
+	c.lastProgressAt = time.Now().Add(-embeddingDegradedAfter - time.Second)
+	if stuck, _ := c.trackEmbeddingProgress(100, 100); stuck {
+		t.Fatal("caught-up must never be degraded")
+	}
+}
+
+// TestCompleteEmbedding_NilWatermarkSafe guards the pre-Start / test path.
+func TestCompleteEmbedding_NilWatermarkSafe(t *testing.T) {
+	c := &Component{} // no watermark wired
+	c.completeEmbedding("entity", 5)
+	if got := c.embeddingCompletions.Load(); got != 0 {
+		t.Fatalf("nil-watermark completion must be a no-op, counter = %d, want 0", got)
+	}
+}

--- a/processor/graph-index/component.go
+++ b/processor/graph-index/component.go
@@ -230,7 +230,23 @@ type Component struct {
 	// (gh#397). Set once the NAME_INDEX is known non-empty; an index does not
 	// un-build, so once true it stays true (O(1) steady state). Restart-safe: a
 	// not-yet-true status read does a one-time bucket check (handleQueryStatus).
+	//
+	// DEPRECATED by ADR-066: readiness is now the revision-lag watermark below,
+	// which means "caught up," not "indexing started." Retained only for the
+	// nameIndexIsReady fallback used by the byName query path.
 	nameIndexReady atomic.Bool
+
+	// watermark is the ADR-066 low-water-of-pending "caught up" tracker feeding the
+	// honest graph.index.query.status. Non-nil once Start wires the watcher.
+	watermark *revisionWatermark
+
+	// Readiness stuck-detector state (ADR-066 §4), guarded by statusMu; touched only
+	// by the polled status handler. lastProgressAt is the wall-clock of the last
+	// observed IndexedRevision advance; a stall past degradedStuckAfter while not
+	// caught-up flips State to degraded.
+	statusMu        sync.Mutex
+	lastIndexedSeen uint64
+	lastProgressAt  time.Time
 
 	// Prometheus metrics
 	metrics *indexMetrics
@@ -497,6 +513,10 @@ func (c *Component) Start(ctx context.Context) error {
 		return err
 	}
 
+	// Readiness watermark (ADR-066): must exist before the pool or the watcher so
+	// the first completion/observation has somewhere to land.
+	c.watermark = newRevisionWatermark()
+
 	// Create and start the entity index worker pool
 	if err := c.startIndexPool(ctx); err != nil {
 		cancel()
@@ -737,11 +757,24 @@ func (c *Component) watchEntityStates(ctx context.Context, bucket jetstream.KeyV
 				continue
 			}
 
+			// Record every delivered revision (update AND delete) as in-flight for
+			// the readiness watermark before dispatch (ADR-066 §1). observedHigh
+			// advances here; complete() drains on processing return / after delete.
+			if c.watermark != nil {
+				c.watermark.observe(entry.Revision(), entry.Key())
+			}
+
 			if entry.Operation() == jetstream.KeyValueDelete {
 				if c.entityCoalescer != nil {
 					c.entityCoalescer.Remove(entry.Key())
 				}
 				c.handleEntityDelete(ctx, entry.Key())
+				// Key-scoped completion: the tombstone's revision drains the delete
+				// itself AND any earlier still-pending update for this key that the
+				// delete supersedes (ADR-066 §1).
+				if c.watermark != nil {
+					c.watermark.complete(entry.Key(), entry.Revision())
+				}
 				continue
 			}
 
@@ -823,9 +856,20 @@ func (c *Component) processEntityUpdateWorker(ctx context.Context, entry jetstre
 }
 
 // processEntityUpdate indexes an entity's relationships from its triples.
-// It is a thin wrapper around processEntityUpdateFromData for use with KV watcher entries.
+// It is a thin wrapper around processEntityUpdateFromData for use with KV watcher
+// entries. It is the single funnel for every update-completion path — the pool
+// worker, the direct branch, and the coalescer batch all route through here — so it
+// is the one place the readiness watermark's completion fires (ADR-066 §1).
 func (c *Component) processEntityUpdate(ctx context.Context, entry jetstream.KeyValueEntry) {
 	c.processEntityUpdateFromData(ctx, entry.Key(), entry.Value())
+	// Completion fires on RETURN, not on indexing success: a malformed entry that
+	// early-returns inside processEntityUpdateFromData must still complete or its
+	// revision strands the watermark forever (ADR-066 §1 Scope boundary — Ready
+	// means revision coverage, not per-index write success). Key-scoped <=rev drains
+	// coalescer-collapsed lower revisions of this key that no worker sees alone.
+	if c.watermark != nil {
+		c.watermark.complete(entry.Key(), entry.Revision())
+	}
 }
 
 // processEntityUpdateFromData indexes an entity's relationships from its triples using raw data.
@@ -994,6 +1038,15 @@ func (c *Component) processEntityBatch(ctx context.Context, entityIDs []string) 
 			c.logger.Debug("entity not found during batch processing",
 				slog.String("entity", entityID),
 				slog.Any("error", err))
+			// The coalescer discarded the source revision(s), so there is no exact
+			// revision to complete here. Drain the key's pending (complete at max
+			// revision) rather than strand it: a transient Get failure would
+			// otherwise pin the watermark and flip the whole index to degraded
+			// forever (ADR-066 §1). Draining fails toward caught-up (within the
+			// Scope boundary) — the next update to this key re-observes it.
+			if c.watermark != nil {
+				c.watermark.complete(entityID, ^uint64(0))
+			}
 			continue
 		}
 

--- a/processor/graph-index/component.go
+++ b/processor/graph-index/component.go
@@ -20,6 +20,7 @@ import (
 	"github.com/c360studio/semstreams/pkg/cache"
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/pkg/resource"
+	"github.com/c360studio/semstreams/pkg/revlag"
 	"github.com/c360studio/semstreams/pkg/worker"
 	"github.com/c360studio/semstreams/vocabulary"
 	"github.com/nats-io/nats.go/jetstream"
@@ -238,7 +239,7 @@ type Component struct {
 
 	// watermark is the ADR-066 low-water-of-pending "caught up" tracker feeding the
 	// honest graph.index.query.status. Non-nil once Start wires the watcher.
-	watermark *revisionWatermark
+	watermark *revlag.Watermark
 
 	// Readiness stuck-detector state (ADR-066 §4), guarded by statusMu; touched only
 	// by the polled status handler. lastProgressAt is the wall-clock of the last
@@ -515,7 +516,7 @@ func (c *Component) Start(ctx context.Context) error {
 
 	// Readiness watermark (ADR-066): must exist before the pool or the watcher so
 	// the first completion/observation has somewhere to land.
-	c.watermark = newRevisionWatermark()
+	c.watermark = revlag.New()
 
 	// Create and start the entity index worker pool
 	if err := c.startIndexPool(ctx); err != nil {
@@ -761,7 +762,7 @@ func (c *Component) watchEntityStates(ctx context.Context, bucket jetstream.KeyV
 			// the readiness watermark before dispatch (ADR-066 §1). observedHigh
 			// advances here; complete() drains on processing return / after delete.
 			if c.watermark != nil {
-				c.watermark.observe(entry.Revision(), entry.Key())
+				c.watermark.Observe(entry.Revision(), entry.Key())
 			}
 
 			if entry.Operation() == jetstream.KeyValueDelete {
@@ -773,7 +774,7 @@ func (c *Component) watchEntityStates(ctx context.Context, bucket jetstream.KeyV
 				// itself AND any earlier still-pending update for this key that the
 				// delete supersedes (ADR-066 §1).
 				if c.watermark != nil {
-					c.watermark.complete(entry.Key(), entry.Revision())
+					c.watermark.Complete(entry.Key(), entry.Revision())
 				}
 				continue
 			}
@@ -868,7 +869,7 @@ func (c *Component) processEntityUpdate(ctx context.Context, entry jetstream.Key
 	// means revision coverage, not per-index write success). Key-scoped <=rev drains
 	// coalescer-collapsed lower revisions of this key that no worker sees alone.
 	if c.watermark != nil {
-		c.watermark.complete(entry.Key(), entry.Revision())
+		c.watermark.Complete(entry.Key(), entry.Revision())
 	}
 }
 
@@ -1045,7 +1046,7 @@ func (c *Component) processEntityBatch(ctx context.Context, entityIDs []string) 
 			// forever (ADR-066 §1). Draining fails toward caught-up (within the
 			// Scope boundary) — the next update to this key re-observes it.
 			if c.watermark != nil {
-				c.watermark.complete(entityID, ^uint64(0))
+				c.watermark.Complete(entityID, ^uint64(0))
 			}
 			continue
 		}

--- a/processor/graph-index/name_index.go
+++ b/processor/graph-index/name_index.go
@@ -113,22 +113,22 @@ func (c *Component) nameIndexIsReady(ctx context.Context) bool {
 	return true
 }
 
-// handleQueryStatusNATS serves graph.index.query.status (gh#397): the
-// deterministic-fusion honesty-envelope readiness signal. Ready means the
-// NAME_INDEX is populated (see nameIndexIsReady). Takes no request body; the
-// response JSON shape matches pkg/fusion.IndexStatus.
+// handleQueryStatusNATS serves graph.index.query.status (gh#397, enriched by
+// ADR-066): the deterministic-fusion honesty-envelope readiness signal. Ready now
+// means the index is CAUGHT UP (revision-lag: IndexedRevision >= query-time
+// TargetRevision), not merely "indexing started" (the old sticky NAME_INDEX signal
+// that fired minutes early, gh#431). Takes no request body; the response JSON shape
+// matches pkg/fusion.IndexStatus.
 func (c *Component) handleQueryStatusNATS(ctx context.Context, _ []byte) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	ready := c.nameIndexIsReady(ctx)
-	state := graph.IndexStateBuilding
-	if ready {
-		state = graph.IndexStateReady
-	}
-	data, err := json.Marshal(graph.IndexStatusResponse{Ready: ready, State: state})
+	data, err := json.Marshal(c.computeIndexStatus(ctx))
 	if err != nil {
-		return nil, errs.Wrap(err, "Component", "handleQueryStatusNATS", "marshal status")
+		// Unreachable (an all-scalar struct never fails to marshal), but classify it
+		// like every sibling handler so a caller decoding the reply cannot mistake an
+		// error body for a zero-value success status.
+		return nil, errs.ClassifiedCode(errs.ErrorTransient, graph.ErrorCodeInternal, errors.New("internal error"))
 	}
 	return data, nil
 }

--- a/processor/graph-index/query_integration_test.go
+++ b/processor/graph-index/query_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -534,4 +535,74 @@ func TestQueryInvalidRequest_Integration(t *testing.T) {
 				"invalid request must carry the invalid_request code")
 		})
 	}
+}
+
+// TestQueryStatus_RevisionLag_Integration drives the full production wire (real
+// WatchAll delivery, real entry.Revision(), real BucketLastSeq against the KV
+// backing stream) to prove the ADR-066 caught-up contract end to end: an empty
+// bucket is not-ready with a zero target, and after the writes settle the status
+// catches up to Lag==0 with the numeric revision fields populated (not the old
+// sticky NAME_INDEX-non-empty false-ready).
+func TestQueryStatus_RevisionLag_Integration(t *testing.T) {
+	_, natsClient, cleanup := setupIntegrationTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	nc := natsClient.GetConnection()
+
+	statusNow := func(t *testing.T) graph.IndexStatusResponse {
+		t.Helper()
+		msg, err := nc.Request("graph.index.query.status", []byte(`{}`), 2*time.Second)
+		require.NoError(t, err)
+		var st graph.IndexStatusResponse
+		require.NoError(t, json.Unmarshal(msg.Data, &st))
+		return st
+	}
+
+	// Empty ENTITY_STATES: LastSeq==0 → not ready, building. The old sticky signal
+	// would also say building here, but for the wrong reason (NAME_INDEX empty);
+	// this asserts the honest target-based path.
+	st := statusNow(t)
+	assert.False(t, st.Ready, "empty bucket must not read ready")
+	assert.Equal(t, graph.IndexStateBuilding, st.State)
+	assert.Zero(t, st.TargetRevision, "empty bucket target should be 0")
+
+	// Write several entities — each Put advances ENTITY_STATES LastSeq (the target).
+	js, err := natsClient.JetStream()
+	require.NoError(t, err)
+	entityBucket, err := js.KeyValue(ctx, graph.BucketEntityStates)
+	require.NoError(t, err)
+
+	const n = 8
+	for i := 0; i < n; i++ {
+		id := fmt.Sprintf("c360.platform.robotics.mav1.drone.%03d", i)
+		state := graph.EntityState{
+			ID:      id,
+			Triples: []message.Triple{{Subject: id, Predicate: "dc.terms.title", Object: fmt.Sprintf("Drone %d", i)}},
+		}
+		stateJSON, err := json.Marshal(state)
+		require.NoError(t, err)
+		_, err = entityBucket.Put(ctx, id, stateJSON)
+		require.NoError(t, err)
+	}
+
+	// Poll until caught up: Ready flips only when IndexedRevision >= TargetRevision.
+	// (statusNow runs in THIS goroutine — require.Eventually would run it in another,
+	// where testify's FailNow is illegal.)
+	var final graph.IndexStatusResponse
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		final = statusNow(t)
+		if final.Ready {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	require.True(t, final.Ready, "index must catch up to the writes within timeout")
+	assert.Equal(t, graph.IndexStateReady, final.State)
+	assert.Zero(t, final.Lag, "caught up means zero lag")
+	assert.GreaterOrEqual(t, final.IndexedRevision, uint64(n), "indexed revision reflects the writes")
+	assert.Equal(t, final.TargetRevision, final.IndexedRevision, "indexed == target when caught up")
+	assert.NotEmpty(t, final.Revision, "the string Revision field is now populated")
 }

--- a/processor/graph-index/watermark.go
+++ b/processor/graph-index/watermark.go
@@ -3,137 +3,20 @@ package graphindex
 import (
 	"context"
 	"log/slog"
-	"strconv"
-	"sync"
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
 	"github.com/c360studio/semstreams/natsclient"
 )
 
+// The low-water-of-pending watermark mechanism lives in pkg/revlag (shared with
+// graph-embedding); the readiness projection lives in graph.ComputeIndexStatus. This
+// file holds graph-index's glue: the query-time target read and the §4 stuck detector.
+
 // degradedStuckAfter is how long IndexedRevision may stall while the index is not
 // caught up before the status flips to "degraded" — the §4 stuck-watermark detector.
 // Wall-clock based, so it is independent of how often a consumer polls status.
 const degradedStuckAfter = 30 * time.Second
-
-// revisionWatermark is the low-water-of-pending "caught up" tracker for the async,
-// write-driven, lagging index pipeline (ADR-066 §1): a kv-watch over ENTITY_STATES
-// feeds an unordered N-worker pool (plus an optional coalescer and an inline delete
-// path). It answers "every DELIVERED ENTITY_STATES revision <= R has been applied
-// and nothing <= R is still in flight."
-//
-// Why not "advance from indexed+1 past every contiguous completion": ENTITY_STATES
-// runs at NATS KV default History=1 and WatchAll delivers via OrderedConsumer +
-// DeliverLastPerSubject, so the delivered revision set is SPARSE (superseded
-// revisions are purged, never delivered). Absolute-contiguity would wait forever on
-// a purged revision. This tracker is defined only over delivered revisions:
-//
-//   - observedHigh: the highest revision ever delivered (monotonic).
-//   - pending:      delivered-but-not-yet-completed revisions, keyed by revision.
-//   - indexed():    pending.empty() ? observedHigh : (minPending - 1).
-//
-// Its correctness rests on delivery being monotonic ascending in Revision() — which
-// OrderedConsumer guarantees at the nats-server storage layer for both the bootstrap
-// replay and live updates — so any un-observed revision below observedHigh is purged
-// and correctly skipped. All methods are safe for concurrent use (the watch
-// goroutine observes; N pool workers, the coalescer callback, and the inline delete
-// handler complete; the status handler reads).
-type revisionWatermark struct {
-	mu           sync.Mutex
-	observedHigh uint64            // highest revision ever delivered to the watcher
-	pending      map[uint64]string // in-flight revision -> its key
-}
-
-func newRevisionWatermark() *revisionWatermark {
-	return &revisionWatermark{pending: make(map[uint64]string)}
-}
-
-// observe records revision r (for key) as delivered-and-in-flight. Called from the
-// watch goroutine for EVERY delivered entry — updates AND deletes — before dispatch.
-// observedHigh is monotonic; delivery is ascending so r exceeds any prior, but max()
-// is kept for defensiveness. Revision 0 ("no revision") is ignored — stream
-// sequences start at 1.
-func (w *revisionWatermark) observe(r uint64, key string) {
-	if r == 0 {
-		return
-	}
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if r > w.observedHigh {
-		w.observedHigh = r
-	}
-	w.pending[r] = key
-}
-
-// complete drains every in-flight revision for key with revision <= rev — the single
-// key-scoped completion rule (ADR-066 §1). A pool worker calls it with the entry it
-// processed, which drains the coalescer-collapsed lower revisions of that key that no
-// worker sees individually; the inline delete handler calls it with the tombstone's
-// revision, which drains an earlier pending update the delete supersedes. Key-scoped
-// (never global-<=-rev) so one key's completion cannot drop a different key's pending
-// revision.
-func (w *revisionWatermark) complete(key string, rev uint64) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	for r, k := range w.pending {
-		if k == key && r <= rev {
-			delete(w.pending, r)
-		}
-	}
-}
-
-// indexed returns the low-water-of-pending watermark: observedHigh when nothing is in
-// flight, else minPending-1. Every delivered revision <= the result is applied and
-// nothing <= it is still pending.
-func (w *revisionWatermark) indexed() uint64 {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if len(w.pending) == 0 {
-		return w.observedHigh
-	}
-	minRev := ^uint64(0)
-	for r := range w.pending {
-		if r < minRev {
-			minRev = r
-		}
-	}
-	return minRev - 1
-}
-
-// indexReadiness computes the honest readiness envelope (ADR-066) from the indexed
-// watermark, the query-time target (ENTITY_STATES LastSeq), a stuck flag (the §4
-// stuck-watermark detector), and the last-synced timestamp. It is pure so the subtle
-// Ready/Lag/State logic is unit-testable without a live NATS.
-//
-//   - Ready  = target > 0 && indexed >= target (no max(0,…) clamp — indexed <= target
-//     is structural, so Lag cannot underflow).
-//   - State  = ready ? "ready" : (stuck ? "degraded" : "building"); ready wins.
-func indexReadiness(indexed, target uint64, stuck bool, lastSynced string) graph.IndexStatusResponse {
-	ready := target > 0 && indexed >= target
-	var lag uint64
-	if target > indexed {
-		lag = target - indexed
-	}
-	state := graph.IndexStateBuilding
-	switch {
-	case ready:
-		state = graph.IndexStateReady
-	case stuck:
-		state = graph.IndexStateDegraded
-	}
-	resp := graph.IndexStatusResponse{
-		Ready:           ready,
-		State:           state,
-		IndexedRevision: indexed,
-		TargetRevision:  target,
-		Lag:             lag,
-		LastSynced:      lastSynced,
-	}
-	if indexed > 0 {
-		resp.Revision = strconv.FormatUint(indexed, 10)
-	}
-	return resp
-}
 
 // computeIndexStatus builds the honest revision-lag readiness envelope (ADR-066):
 // IndexedRevision from the low-water-of-pending watermark, TargetRevision from the
@@ -155,7 +38,7 @@ func (c *Component) computeIndexStatus(ctx context.Context) graph.IndexStatusRes
 		return graph.IndexStatusResponse{Ready: ready, State: state}
 	}
 
-	indexed := c.watermark.indexed()
+	indexed := c.watermark.Indexed()
 
 	target, err := natsclient.BucketLastSeq(ctx, c.entityStatesBucket)
 	if err != nil {
@@ -171,7 +54,7 @@ func (c *Component) computeIndexStatus(ctx context.Context) graph.IndexStatusRes
 	}
 
 	stuck, lastSynced := c.trackReadinessProgress(indexed, target)
-	return indexReadiness(indexed, target, stuck, lastSynced)
+	return graph.ComputeIndexStatus(indexed, target, stuck, lastSynced)
 }
 
 // trackReadinessProgress updates the wall-clock stuck-watermark detector and returns

--- a/processor/graph-index/watermark.go
+++ b/processor/graph-index/watermark.go
@@ -1,0 +1,193 @@
+package graphindex
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
+)
+
+// degradedStuckAfter is how long IndexedRevision may stall while the index is not
+// caught up before the status flips to "degraded" — the §4 stuck-watermark detector.
+// Wall-clock based, so it is independent of how often a consumer polls status.
+const degradedStuckAfter = 30 * time.Second
+
+// revisionWatermark is the low-water-of-pending "caught up" tracker for the async,
+// write-driven, lagging index pipeline (ADR-066 §1): a kv-watch over ENTITY_STATES
+// feeds an unordered N-worker pool (plus an optional coalescer and an inline delete
+// path). It answers "every DELIVERED ENTITY_STATES revision <= R has been applied
+// and nothing <= R is still in flight."
+//
+// Why not "advance from indexed+1 past every contiguous completion": ENTITY_STATES
+// runs at NATS KV default History=1 and WatchAll delivers via OrderedConsumer +
+// DeliverLastPerSubject, so the delivered revision set is SPARSE (superseded
+// revisions are purged, never delivered). Absolute-contiguity would wait forever on
+// a purged revision. This tracker is defined only over delivered revisions:
+//
+//   - observedHigh: the highest revision ever delivered (monotonic).
+//   - pending:      delivered-but-not-yet-completed revisions, keyed by revision.
+//   - indexed():    pending.empty() ? observedHigh : (minPending - 1).
+//
+// Its correctness rests on delivery being monotonic ascending in Revision() — which
+// OrderedConsumer guarantees at the nats-server storage layer for both the bootstrap
+// replay and live updates — so any un-observed revision below observedHigh is purged
+// and correctly skipped. All methods are safe for concurrent use (the watch
+// goroutine observes; N pool workers, the coalescer callback, and the inline delete
+// handler complete; the status handler reads).
+type revisionWatermark struct {
+	mu           sync.Mutex
+	observedHigh uint64            // highest revision ever delivered to the watcher
+	pending      map[uint64]string // in-flight revision -> its key
+}
+
+func newRevisionWatermark() *revisionWatermark {
+	return &revisionWatermark{pending: make(map[uint64]string)}
+}
+
+// observe records revision r (for key) as delivered-and-in-flight. Called from the
+// watch goroutine for EVERY delivered entry — updates AND deletes — before dispatch.
+// observedHigh is monotonic; delivery is ascending so r exceeds any prior, but max()
+// is kept for defensiveness. Revision 0 ("no revision") is ignored — stream
+// sequences start at 1.
+func (w *revisionWatermark) observe(r uint64, key string) {
+	if r == 0 {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if r > w.observedHigh {
+		w.observedHigh = r
+	}
+	w.pending[r] = key
+}
+
+// complete drains every in-flight revision for key with revision <= rev — the single
+// key-scoped completion rule (ADR-066 §1). A pool worker calls it with the entry it
+// processed, which drains the coalescer-collapsed lower revisions of that key that no
+// worker sees individually; the inline delete handler calls it with the tombstone's
+// revision, which drains an earlier pending update the delete supersedes. Key-scoped
+// (never global-<=-rev) so one key's completion cannot drop a different key's pending
+// revision.
+func (w *revisionWatermark) complete(key string, rev uint64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for r, k := range w.pending {
+		if k == key && r <= rev {
+			delete(w.pending, r)
+		}
+	}
+}
+
+// indexed returns the low-water-of-pending watermark: observedHigh when nothing is in
+// flight, else minPending-1. Every delivered revision <= the result is applied and
+// nothing <= it is still pending.
+func (w *revisionWatermark) indexed() uint64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.pending) == 0 {
+		return w.observedHigh
+	}
+	minRev := ^uint64(0)
+	for r := range w.pending {
+		if r < minRev {
+			minRev = r
+		}
+	}
+	return minRev - 1
+}
+
+// indexReadiness computes the honest readiness envelope (ADR-066) from the indexed
+// watermark, the query-time target (ENTITY_STATES LastSeq), a stuck flag (the §4
+// stuck-watermark detector), and the last-synced timestamp. It is pure so the subtle
+// Ready/Lag/State logic is unit-testable without a live NATS.
+//
+//   - Ready  = target > 0 && indexed >= target (no max(0,…) clamp — indexed <= target
+//     is structural, so Lag cannot underflow).
+//   - State  = ready ? "ready" : (stuck ? "degraded" : "building"); ready wins.
+func indexReadiness(indexed, target uint64, stuck bool, lastSynced string) graph.IndexStatusResponse {
+	ready := target > 0 && indexed >= target
+	var lag uint64
+	if target > indexed {
+		lag = target - indexed
+	}
+	state := graph.IndexStateBuilding
+	switch {
+	case ready:
+		state = graph.IndexStateReady
+	case stuck:
+		state = graph.IndexStateDegraded
+	}
+	resp := graph.IndexStatusResponse{
+		Ready:           ready,
+		State:           state,
+		IndexedRevision: indexed,
+		TargetRevision:  target,
+		Lag:             lag,
+		LastSynced:      lastSynced,
+	}
+	if indexed > 0 {
+		resp.Revision = strconv.FormatUint(indexed, 10)
+	}
+	return resp
+}
+
+// computeIndexStatus builds the honest revision-lag readiness envelope (ADR-066):
+// IndexedRevision from the low-water-of-pending watermark, TargetRevision from the
+// ENTITY_STATES stream LastSeq read at query time, and the §4 stuck-watermark
+// detector for the degraded state.
+func (c *Component) computeIndexStatus(ctx context.Context) graph.IndexStatusResponse {
+	// A status call before Start wired the watcher (early boot / unit tests that do
+	// not start it) falls back to the legacy sticky signal rather than panicking.
+	// This MUST NOT become reachable in production: setupQueryHandlers (which
+	// subscribes this handler) runs after both watermark and entityStatesBucket are
+	// set in Start, so a live request always takes the honest revision-lag path. The
+	// fallback returns the exact false-ready signal ADR-066 retires — keep it caged.
+	if c.watermark == nil || c.entityStatesBucket == nil {
+		ready := c.nameIndexIsReady(ctx)
+		state := graph.IndexStateBuilding
+		if ready {
+			state = graph.IndexStateReady
+		}
+		return graph.IndexStatusResponse{Ready: ready, State: state}
+	}
+
+	indexed := c.watermark.indexed()
+
+	target, err := natsclient.BucketLastSeq(ctx, c.entityStatesBucket)
+	if err != nil {
+		// Can't read the target → can't honestly confirm caught-up. A backend fault
+		// is a degraded signal, not "building" (ADR-066 §4).
+		c.logger.Warn("index status: failed to read ENTITY_STATES LastSeq target",
+			slog.Any("error", err))
+		return graph.IndexStatusResponse{
+			Ready:           false,
+			State:           graph.IndexStateDegraded,
+			IndexedRevision: indexed,
+		}
+	}
+
+	stuck, lastSynced := c.trackReadinessProgress(indexed, target)
+	return indexReadiness(indexed, target, stuck, lastSynced)
+}
+
+// trackReadinessProgress updates the wall-clock stuck-watermark detector and returns
+// whether IndexedRevision has stalled while not caught-up (→ degraded), plus the
+// last-advance timestamp for LastSynced. Wall-clock based so it is independent of how
+// often a consumer polls status (ADR-066 §4).
+func (c *Component) trackReadinessProgress(indexed, target uint64) (stuck bool, lastSynced string) {
+	now := time.Now()
+	c.statusMu.Lock()
+	defer c.statusMu.Unlock()
+	if indexed > c.lastIndexedSeen || c.lastProgressAt.IsZero() {
+		c.lastIndexedSeen = indexed
+		c.lastProgressAt = now
+	}
+	caughtUp := target > 0 && indexed >= target
+	stuck = !caughtUp && now.Sub(c.lastProgressAt) > degradedStuckAfter
+	lastSynced = c.lastProgressAt.UTC().Format(time.RFC3339)
+	return stuck, lastSynced
+}

--- a/processor/graph-index/watermark_test.go
+++ b/processor/graph-index/watermark_test.go
@@ -1,145 +1,15 @@
 package graphindex
 
 import (
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/c360studio/semstreams/graph"
 )
 
-// The watermark's whole reason to exist is honesty under SPARSE, out-of-order,
-// multi-path completion (ADR-066 §1). These tests feed sparse ascending revision
-// streams (e.g. {50, 72, 100}) — NOT dense 1..N — because History=1 +
-// DeliverLastPerSubject never delivers a dense set, and the rejected
-// "advance-from-indexed+1" algorithm would stall on the very first gap.
-
-func TestRevisionWatermark_ColdStart(t *testing.T) {
-	w := newRevisionWatermark()
-	if got := w.indexed(); got != 0 {
-		t.Fatalf("cold start indexed = %d, want 0", got)
-	}
-}
-
-func TestRevisionWatermark_SparseMidBuild_LowWaterOfPending(t *testing.T) {
-	w := newRevisionWatermark()
-	// Sparse ascending delivery: distinct keys at purged-gap revisions.
-	w.observe(50, "A")
-	w.observe(72, "B")
-	w.observe(100, "C")
-
-	// Nothing completed: indexed is minPending-1, NOT stuck at 0 waiting for rev 1.
-	if got := w.indexed(); got != 49 {
-		t.Fatalf("all pending: indexed = %d, want 49 (minPending-1)", got)
-	}
-
-	// Out-of-order completion: a fast LATE worker (rev 72) cannot report the gap done.
-	w.complete("B", 72)
-	if got := w.indexed(); got != 49 {
-		t.Fatalf("after completing 72 (50 still pending): indexed = %d, want 49", got)
-	}
-
-	// Complete the low revision: watermark advances past it to the next gap.
-	w.complete("A", 50)
-	if got := w.indexed(); got != 99 {
-		t.Fatalf("after completing 50 (100 still pending): indexed = %d, want 99", got)
-	}
-
-	// Complete the last: pending empties → indexed jumps to observedHigh (=100),
-	// honestly skipping the purged 51..71, 73..99 that were never delivered.
-	w.complete("C", 100)
-	if got := w.indexed(); got != 100 {
-		t.Fatalf("caught up: indexed = %d, want 100 (observedHigh)", got)
-	}
-}
-
-func TestRevisionWatermark_CoalescerCollapse_KeyScopedDrainsLowerRevisions(t *testing.T) {
-	w := newRevisionWatermark()
-	// One key delivered three times (the coalescer will re-Get only the latest, 30).
-	w.observe(10, "K")
-	w.observe(20, "K")
-	w.observe(30, "K")
-	if got := w.indexed(); got != 9 {
-		t.Fatalf("three pending revs of K: indexed = %d, want 9", got)
-	}
-
-	// The single completion at the re-Got latest revision drains ALL collapsed lower
-	// revisions of K that no worker ever sees individually. Exact-revision completion
-	// would strand 10 and 20 forever.
-	w.complete("K", 30)
-	if got := w.indexed(); got != 30 {
-		t.Fatalf("after key-scoped complete(K,30): indexed = %d, want 30", got)
-	}
-}
-
-func TestRevisionWatermark_DeleteSupersedesPendingUpdate(t *testing.T) {
-	w := newRevisionWatermark()
-	// Update K@10 is delivered and in flight...
-	w.observe(10, "K")
-	// ...then a delete K@11 arrives. The delete's key-scoped completion drains the
-	// tombstone AND the earlier still-pending update it supersedes (Defect #1 fix).
-	w.observe(11, "K")
-	w.complete("K", 11)
-	if got := w.indexed(); got != 11 {
-		t.Fatalf("after delete supersedes pending update: indexed = %d, want 11", got)
-	}
-}
-
-func TestRevisionWatermark_CompletionIsKeyScoped(t *testing.T) {
-	w := newRevisionWatermark()
-	w.observe(10, "A")
-	w.observe(11, "B") // a delete of a DIFFERENT key
-	// Completing B must NOT drain A's pending revision even though 10 <= 11.
-	w.complete("B", 11)
-	if got := w.indexed(); got != 9 {
-		t.Fatalf("key-scoped: completing B left A@10 pending, indexed = %d, want 9", got)
-	}
-	w.complete("A", 10)
-	if got := w.indexed(); got != 11 {
-		t.Fatalf("after A completes too: indexed = %d, want 11 (observedHigh)", got)
-	}
-}
-
-func TestRevisionWatermark_TrailingDeleteOnlyTail(t *testing.T) {
-	w := newRevisionWatermark()
-	w.observe(10, "A")
-	w.complete("A", 10)
-	if got := w.indexed(); got != 10 {
-		t.Fatalf("after A: indexed = %d, want 10", got)
-	}
-	// A tail of pure deletes must still advance the watermark — their sequences
-	// participate, or lag wedges forever.
-	w.observe(11, "B")
-	w.complete("B", 11)
-	if got := w.indexed(); got != 11 {
-		t.Fatalf("trailing delete: indexed = %d, want 11", got)
-	}
-}
-
-func TestRevisionWatermark_RevisionZeroIgnored(t *testing.T) {
-	w := newRevisionWatermark()
-	w.observe(0, "X") // "no revision" — stream sequences start at 1
-	if got := w.indexed(); got != 0 {
-		t.Fatalf("observe(0) should be a no-op, indexed = %d, want 0", got)
-	}
-	w.observe(5, "A")
-	if got := w.indexed(); got != 4 {
-		t.Fatalf("after observe(5): indexed = %d, want 4", got)
-	}
-}
-
-func TestRevisionWatermark_CompleteUnobservedRevisionDrainsLower(t *testing.T) {
-	// The coalescer re-Get can return a revision NEWER than any yet delivered to the
-	// watch (a write between snapshot and Get). Completing at that not-yet-observed
-	// revision must still drain the key's lower pending, and must NOT advance
-	// observedHigh (only the watch does that).
-	w := newRevisionWatermark()
-	w.observe(10, "K")
-	w.complete("K", 40) // 40 never observed via watch
-	if got := w.indexed(); got != 10 {
-		t.Fatalf("indexed = %d, want 10 (observedHigh unchanged; 10 drained)", got)
-	}
-}
+// The low-water-of-pending watermark mechanism is tested in pkg/revlag and the
+// Ready/Lag/State projection in graph.ComputeIndexStatus's own package. This test
+// pins graph-index's use of the projection plus the §4 wall-clock stuck detector.
 
 func TestIndexReadiness(t *testing.T) {
 	tests := []struct {
@@ -161,7 +31,7 @@ func TestIndexReadiness(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := indexReadiness(tt.indexed, tt.target, tt.stuck, "ts")
+			got := graph.ComputeIndexStatus(tt.indexed, tt.target, tt.stuck, "ts")
 			if got.Ready != tt.wantReady {
 				t.Errorf("Ready = %v, want %v", got.Ready, tt.wantReady)
 			}
@@ -204,35 +74,5 @@ func TestTrackReadinessProgress_StuckDetector(t *testing.T) {
 	c.lastProgressAt = time.Now().Add(-degradedStuckAfter - time.Second)
 	if stuck, _ := c.trackReadinessProgress(100, 100); stuck {
 		t.Fatal("caught-up index must never be degraded")
-	}
-}
-
-// TestRevisionWatermark_Concurrent runs observe/complete across many goroutines to
-// prove the mutex holds and that draining every observed revision leaves indexed at
-// observedHigh (run under -race). Mirrors the real wiring: the watch goroutine
-// observes ascending; N workers complete out of order.
-func TestRevisionWatermark_Concurrent(t *testing.T) {
-	w := newRevisionWatermark()
-	const n = 2000
-
-	// Observe ascending (as OrderedConsumer delivery guarantees), one key each.
-	keys := make([]string, n)
-	for i := 0; i < n; i++ {
-		keys[i] = string(rune('a'+i%26)) + "-" + time.Duration(i).String()
-		w.observe(uint64(i+1), keys[i])
-	}
-
-	var wg sync.WaitGroup
-	for i := 0; i < n; i++ {
-		wg.Add(1)
-		go func(rev int) {
-			defer wg.Done()
-			w.complete(keys[rev], uint64(rev+1))
-		}(i)
-	}
-	wg.Wait()
-
-	if got := w.indexed(); got != uint64(n) {
-		t.Fatalf("after draining all: indexed = %d, want %d", got, n)
 	}
 }

--- a/processor/graph-index/watermark_test.go
+++ b/processor/graph-index/watermark_test.go
@@ -1,0 +1,238 @@
+package graphindex
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/graph"
+)
+
+// The watermark's whole reason to exist is honesty under SPARSE, out-of-order,
+// multi-path completion (ADR-066 §1). These tests feed sparse ascending revision
+// streams (e.g. {50, 72, 100}) — NOT dense 1..N — because History=1 +
+// DeliverLastPerSubject never delivers a dense set, and the rejected
+// "advance-from-indexed+1" algorithm would stall on the very first gap.
+
+func TestRevisionWatermark_ColdStart(t *testing.T) {
+	w := newRevisionWatermark()
+	if got := w.indexed(); got != 0 {
+		t.Fatalf("cold start indexed = %d, want 0", got)
+	}
+}
+
+func TestRevisionWatermark_SparseMidBuild_LowWaterOfPending(t *testing.T) {
+	w := newRevisionWatermark()
+	// Sparse ascending delivery: distinct keys at purged-gap revisions.
+	w.observe(50, "A")
+	w.observe(72, "B")
+	w.observe(100, "C")
+
+	// Nothing completed: indexed is minPending-1, NOT stuck at 0 waiting for rev 1.
+	if got := w.indexed(); got != 49 {
+		t.Fatalf("all pending: indexed = %d, want 49 (minPending-1)", got)
+	}
+
+	// Out-of-order completion: a fast LATE worker (rev 72) cannot report the gap done.
+	w.complete("B", 72)
+	if got := w.indexed(); got != 49 {
+		t.Fatalf("after completing 72 (50 still pending): indexed = %d, want 49", got)
+	}
+
+	// Complete the low revision: watermark advances past it to the next gap.
+	w.complete("A", 50)
+	if got := w.indexed(); got != 99 {
+		t.Fatalf("after completing 50 (100 still pending): indexed = %d, want 99", got)
+	}
+
+	// Complete the last: pending empties → indexed jumps to observedHigh (=100),
+	// honestly skipping the purged 51..71, 73..99 that were never delivered.
+	w.complete("C", 100)
+	if got := w.indexed(); got != 100 {
+		t.Fatalf("caught up: indexed = %d, want 100 (observedHigh)", got)
+	}
+}
+
+func TestRevisionWatermark_CoalescerCollapse_KeyScopedDrainsLowerRevisions(t *testing.T) {
+	w := newRevisionWatermark()
+	// One key delivered three times (the coalescer will re-Get only the latest, 30).
+	w.observe(10, "K")
+	w.observe(20, "K")
+	w.observe(30, "K")
+	if got := w.indexed(); got != 9 {
+		t.Fatalf("three pending revs of K: indexed = %d, want 9", got)
+	}
+
+	// The single completion at the re-Got latest revision drains ALL collapsed lower
+	// revisions of K that no worker ever sees individually. Exact-revision completion
+	// would strand 10 and 20 forever.
+	w.complete("K", 30)
+	if got := w.indexed(); got != 30 {
+		t.Fatalf("after key-scoped complete(K,30): indexed = %d, want 30", got)
+	}
+}
+
+func TestRevisionWatermark_DeleteSupersedesPendingUpdate(t *testing.T) {
+	w := newRevisionWatermark()
+	// Update K@10 is delivered and in flight...
+	w.observe(10, "K")
+	// ...then a delete K@11 arrives. The delete's key-scoped completion drains the
+	// tombstone AND the earlier still-pending update it supersedes (Defect #1 fix).
+	w.observe(11, "K")
+	w.complete("K", 11)
+	if got := w.indexed(); got != 11 {
+		t.Fatalf("after delete supersedes pending update: indexed = %d, want 11", got)
+	}
+}
+
+func TestRevisionWatermark_CompletionIsKeyScoped(t *testing.T) {
+	w := newRevisionWatermark()
+	w.observe(10, "A")
+	w.observe(11, "B") // a delete of a DIFFERENT key
+	// Completing B must NOT drain A's pending revision even though 10 <= 11.
+	w.complete("B", 11)
+	if got := w.indexed(); got != 9 {
+		t.Fatalf("key-scoped: completing B left A@10 pending, indexed = %d, want 9", got)
+	}
+	w.complete("A", 10)
+	if got := w.indexed(); got != 11 {
+		t.Fatalf("after A completes too: indexed = %d, want 11 (observedHigh)", got)
+	}
+}
+
+func TestRevisionWatermark_TrailingDeleteOnlyTail(t *testing.T) {
+	w := newRevisionWatermark()
+	w.observe(10, "A")
+	w.complete("A", 10)
+	if got := w.indexed(); got != 10 {
+		t.Fatalf("after A: indexed = %d, want 10", got)
+	}
+	// A tail of pure deletes must still advance the watermark — their sequences
+	// participate, or lag wedges forever.
+	w.observe(11, "B")
+	w.complete("B", 11)
+	if got := w.indexed(); got != 11 {
+		t.Fatalf("trailing delete: indexed = %d, want 11", got)
+	}
+}
+
+func TestRevisionWatermark_RevisionZeroIgnored(t *testing.T) {
+	w := newRevisionWatermark()
+	w.observe(0, "X") // "no revision" — stream sequences start at 1
+	if got := w.indexed(); got != 0 {
+		t.Fatalf("observe(0) should be a no-op, indexed = %d, want 0", got)
+	}
+	w.observe(5, "A")
+	if got := w.indexed(); got != 4 {
+		t.Fatalf("after observe(5): indexed = %d, want 4", got)
+	}
+}
+
+func TestRevisionWatermark_CompleteUnobservedRevisionDrainsLower(t *testing.T) {
+	// The coalescer re-Get can return a revision NEWER than any yet delivered to the
+	// watch (a write between snapshot and Get). Completing at that not-yet-observed
+	// revision must still drain the key's lower pending, and must NOT advance
+	// observedHigh (only the watch does that).
+	w := newRevisionWatermark()
+	w.observe(10, "K")
+	w.complete("K", 40) // 40 never observed via watch
+	if got := w.indexed(); got != 10 {
+		t.Fatalf("indexed = %d, want 10 (observedHigh unchanged; 10 drained)", got)
+	}
+}
+
+func TestIndexReadiness(t *testing.T) {
+	tests := []struct {
+		name             string
+		indexed, target  uint64
+		stuck            bool
+		wantReady        bool
+		wantState        string
+		wantLag          uint64
+		wantRevisionText string
+	}{
+		{"cold start", 0, 100, false, false, graph.IndexStateBuilding, 100, ""},
+		{"mid build", 50, 100, false, false, graph.IndexStateBuilding, 50, "50"},
+		{"caught up", 100, 100, false, true, graph.IndexStateReady, 0, "100"},
+		{"caught up past", 105, 100, false, true, graph.IndexStateReady, 0, "105"},
+		{"stuck while lagging", 50, 100, true, false, graph.IndexStateDegraded, 50, "50"},
+		{"ready overrides stuck", 100, 100, true, true, graph.IndexStateReady, 0, "100"},
+		{"empty stream not ready", 0, 0, false, false, graph.IndexStateBuilding, 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := indexReadiness(tt.indexed, tt.target, tt.stuck, "ts")
+			if got.Ready != tt.wantReady {
+				t.Errorf("Ready = %v, want %v", got.Ready, tt.wantReady)
+			}
+			if got.State != tt.wantState {
+				t.Errorf("State = %q, want %q", got.State, tt.wantState)
+			}
+			if got.Lag != tt.wantLag {
+				t.Errorf("Lag = %d, want %d", got.Lag, tt.wantLag)
+			}
+			if got.IndexedRevision != tt.indexed || got.TargetRevision != tt.target {
+				t.Errorf("revisions = (%d,%d), want (%d,%d)", got.IndexedRevision, got.TargetRevision, tt.indexed, tt.target)
+			}
+			if got.Revision != tt.wantRevisionText {
+				t.Errorf("Revision text = %q, want %q", got.Revision, tt.wantRevisionText)
+			}
+		})
+	}
+}
+
+func TestTrackReadinessProgress_StuckDetector(t *testing.T) {
+	c := &Component{}
+
+	// First observation initializes progress; never stuck on the first call.
+	if stuck, _ := c.trackReadinessProgress(10, 100); stuck {
+		t.Fatal("first call must not be stuck")
+	}
+
+	// Simulate a stall: no advance and the last progress was long ago.
+	c.lastProgressAt = time.Now().Add(-degradedStuckAfter - time.Second)
+	if stuck, _ := c.trackReadinessProgress(10, 100); !stuck {
+		t.Fatal("stalled watermark while lagging must be stuck (degraded)")
+	}
+
+	// A real advance clears the stall.
+	if stuck, _ := c.trackReadinessProgress(20, 100); stuck {
+		t.Fatal("advancing watermark must not be stuck")
+	}
+
+	// Caught up is never stuck, even if the timestamp is old.
+	c.lastProgressAt = time.Now().Add(-degradedStuckAfter - time.Second)
+	if stuck, _ := c.trackReadinessProgress(100, 100); stuck {
+		t.Fatal("caught-up index must never be degraded")
+	}
+}
+
+// TestRevisionWatermark_Concurrent runs observe/complete across many goroutines to
+// prove the mutex holds and that draining every observed revision leaves indexed at
+// observedHigh (run under -race). Mirrors the real wiring: the watch goroutine
+// observes ascending; N workers complete out of order.
+func TestRevisionWatermark_Concurrent(t *testing.T) {
+	w := newRevisionWatermark()
+	const n = 2000
+
+	// Observe ascending (as OrderedConsumer delivery guarantees), one key each.
+	keys := make([]string, n)
+	for i := 0; i < n; i++ {
+		keys[i] = string(rune('a'+i%26)) + "-" + time.Duration(i).String()
+		w.observe(uint64(i+1), keys[i])
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(rev int) {
+			defer wg.Done()
+			w.complete(keys[rev], uint64(rev+1))
+		}(i)
+	}
+	wg.Wait()
+
+	if got := w.indexed(); got != uint64(n) {
+		t.Fatalf("after draining all: indexed = %d, want %d", got, n)
+	}
+}

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -47,6 +47,9 @@ var (
 	mutationRejectionsOnce sync.Once
 	mutationRejectionsVec  *prometheus.CounterVec
 
+	stubRestampsOnce    sync.Once
+	stubRestampsCounter prometheus.Counter
+
 	foreignEdgeUnclaimedOnce sync.Once
 	foreignEdgeUnclaimedVec  *prometheus.CounterVec
 
@@ -130,6 +133,27 @@ func getMutationRejectionsMetric(registry *metric.MetricsRegistry) *prometheus.C
 		}
 	})
 	return mutationRejectionsVec
+}
+
+// getStubRestampsMetric returns the process-wide stub-restamp counter (gh#435):
+// referential stubs re-stamped as a real birth on create_with_triples instead of
+// rejected as entity_already_exists. A DISTINCT, positive signal so a paid-run
+// monitor can tell a healthy stub→real path from a true graph-write reject.
+func getStubRestampsMetric(registry *metric.MetricsRegistry) prometheus.Counter {
+	stubRestampsOnce.Do(func() {
+		stubRestampsCounter = prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "semstreams",
+			Subsystem: "graph_ingest",
+			Name:      "stub_restamps_total",
+			Help:      "Referential-integrity stubs re-stamped as a real birth on create_with_triples (gh#435) — a healthy stub→real path, NOT a rejection.",
+		})
+		if registry != nil {
+			_ = registry.RegisterCounter("graph-ingest", "stub_restamps_total", stubRestampsCounter)
+		} else {
+			_ = prometheus.DefaultRegisterer.Register(stubRestampsCounter)
+		}
+	})
+	return stubRestampsCounter
 }
 
 // getForeignEdgeUnclaimedMetric returns the process-wide counter for the
@@ -396,6 +420,7 @@ type Component struct {
 	entitiesUpdated        prometheus.Counter
 	indexingProfileDefault *prometheus.CounterVec
 	mutationRejections     *prometheus.CounterVec
+	stubRestamps           prometheus.Counter
 	foreignEdgeUnclaimed   *prometheus.CounterVec
 	foreignEdgeDropped     *prometheus.CounterVec
 	ownerLeaseMismatch     *prometheus.CounterVec // ADR-056 PR-3 observe-only lease-mismatch counter
@@ -445,6 +470,7 @@ func CreateGraphIngest(rawConfig json.RawMessage, deps component.Dependencies) (
 		entitiesUpdated:        getEntitiesUpdatedMetric(deps.MetricsRegistry),
 		indexingProfileDefault: getIndexingProfileDefaultMetric(deps.MetricsRegistry),
 		mutationRejections:     getMutationRejectionsMetric(deps.MetricsRegistry),
+		stubRestamps:           getStubRestampsMetric(deps.MetricsRegistry),
 		foreignEdgeUnclaimed:   getForeignEdgeUnclaimedMetric(deps.MetricsRegistry),
 		foreignEdgeDropped:     getForeignEdgeDroppedMetric(deps.MetricsRegistry),
 		ownerLeaseMismatch:     getOwnerLeaseMismatchMetric(deps.MetricsRegistry),

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -389,6 +389,39 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 // component.go:createEntity. Callers reasoning about provenance
 // should compare req.Triples against stored.Triples explicitly rather
 // than treating TriplesAdded as authoritative.
+// restampStubOnCreate resolves a create_with_triples ID collision (gh#435). If
+// the existing entity is a bare referential-integrity stub (graph.StubMessageType)
+// and the incoming entity carries a real, non-stub envelope, it merges the
+// incoming entity over the stub — the stub's true birth — via the same
+// update-lane MergeEntity the downstream would otherwise fall back to, returning
+// restamped=true with a Debug (no reject WARN) and a distinct stub_restamps_total
+// counter tick. A non-stub collision (a real entity), or an incoming stub
+// envelope, is a genuine conflict: restamped=false, and the caller rejects as
+// before. A transient read/merge failure returns a classified error.
+func (c *Component) restampStubOnCreate(ctx context.Context, entity *graph.EntityState) (bool, error) {
+	existing, _, err := c.fetchEntityState(ctx, entity.ID)
+	if err != nil {
+		return false, rejectInternal(fmt.Errorf("stub-restamp read-back for %s: %w", entity.ID, err))
+	}
+	if existing == nil || !existing.IsStub() || entity.MessageType.Equal(graph.StubMessageType) {
+		// A real entity already occupies the ID, or the incoming write is itself a
+		// stub — a true conflict, not a stub birth.
+		return false, nil
+	}
+	if merr := c.MergeEntity(ctx, entity); merr != nil {
+		return false, rejectInternal(merr)
+	}
+	if c.stubRestamps != nil {
+		c.stubRestamps.Inc()
+	}
+	if c.logger != nil {
+		c.logger.Debug("referential stub re-stamped as real birth on create_with_triples (gh#435)",
+			slog.String("entity_id", entity.ID),
+			slog.String("subject", SubjectEntityCreateWithTriples))
+	}
+	return true, nil
+}
+
 func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.CreateEntityWithTriplesRequest
 	if err := json.Unmarshal(data, &req); err != nil {
@@ -429,12 +462,26 @@ func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []by
 	stampExplicitIndexingProfile(req.Entity, req.IndexingProfile)
 
 	if err := c.CreateEntityStrict(ctx, req.Entity); err != nil {
-		if errors.Is(err, natsclient.ErrKVKeyExists) {
+		if !errors.Is(err, natsclient.ErrKVKeyExists) {
+			return nil, rejectInternal(err)
+		}
+		// gh#435: the ID may exist only as a referential-integrity stub — a
+		// placeholder minted when something referenced it before its real birth.
+		// A create_with_triples carrying a real (non-stub) envelope IS that birth,
+		// so re-stamp the stub via merge instead of rejecting: a healthy stub→real
+		// path must not surface as a graph-write reject to paid-run monitors. A
+		// non-stub collision is a genuine conflict and still rejects.
+		restamped, rerr := c.restampStubOnCreate(ctx, req.Entity)
+		if rerr != nil {
+			return nil, rerr
+		}
+		if !restamped {
 			return nil, rejectInvalidDetail(graph.ErrorCodeEntityExists,
 				map[string]any{"entity": req.Entity.ID},
 				fmt.Errorf("entity already exists: %s", req.Entity.ID))
 		}
-		return nil, rejectInternal(err)
+		// Re-stamped: the stub is now born. Fall through to the shared success
+		// path (foreign-edge routing + read-back + response), same as a fresh create.
 	}
 
 	// Primary committed — route foreign edges onto their own subjects (after the

--- a/processor/graph-ingest/mutations.go
+++ b/processor/graph-ingest/mutations.go
@@ -374,38 +374,36 @@ func (c *Component) handleEntityCreate(ctx context.Context, data []byte) ([]byte
 	})
 }
 
-// handleEntityCreateWithTriples is handleEntityCreate that also accepts
-// a Triples slice in the request envelope. When Triples is non-empty
-// it REPLACES Entity.Triples before the write (the canonical set is
-// the request's Triples; Entity carries provenance metadata). When
-// Triples is nil/empty, Entity.Triples is written as-is.
-//
-// Atomicity matches handleEntityCreate: CreateEntityStrict is used
-// for atomic create-or-fail (returns ErrKVKeyExists on duplicate ID).
-//
-// TriplesAdded in the response is the count on the *stored* entity
-// after the write, which may exceed len(req.Triples) when the
-// framework injects hierarchy / referential-integrity triples per
-// component.go:createEntity. Callers reasoning about provenance
-// should compare req.Triples against stored.Triples explicitly rather
-// than treating TriplesAdded as authoritative.
 // restampStubOnCreate resolves a create_with_triples ID collision (gh#435). If
 // the existing entity is a bare referential-integrity stub (graph.StubMessageType)
-// and the incoming entity carries a real, non-stub envelope, it merges the
+// and the incoming entity carries a real, VALID, non-stub envelope, it merges the
 // incoming entity over the stub — the stub's true birth — via the same
 // update-lane MergeEntity the downstream would otherwise fall back to, returning
 // restamped=true with a Debug (no reject WARN) and a distinct stub_restamps_total
-// counter tick. A non-stub collision (a real entity), or an incoming stub
-// envelope, is a genuine conflict: restamped=false, and the caller rejects as
-// before. A transient read/merge failure returns a classified error.
+// counter tick. A non-stub collision (a real entity), or an incoming stub / zero /
+// invalid envelope, is NOT a stub birth: restamped=false, and the caller rejects
+// as before — which PRESERVES the stub. (A zero/invalid envelope must not reach
+// MergeEntity: that path overwrites MessageType unconditionally, so it would
+// demote the stub to a typeless non-stub entity — re-creating the gh#429
+// dispatchable-non-real class — and would violate graph.StubMessageType's
+// preserve-when-zero contract.) A transient read/merge failure returns a
+// classified error.
+//
+// Under a genuine double-birth race (two real create_with_triples on the same
+// stub) both callers may read the stub and both MergeEntity: convergent
+// (CAS-merged, last-writer-wins on MessageType), ticking the counter twice for one
+// entity — accepted over reject-one, and ill-defined for a well-formed graph.
 func (c *Component) restampStubOnCreate(ctx context.Context, entity *graph.EntityState) (bool, error) {
 	existing, _, err := c.fetchEntityState(ctx, entity.ID)
 	if err != nil {
 		return false, rejectInternal(fmt.Errorf("stub-restamp read-back for %s: %w", entity.ID, err))
 	}
-	if existing == nil || !existing.IsStub() || entity.MessageType.Equal(graph.StubMessageType) {
-		// A real entity already occupies the ID, or the incoming write is itself a
-		// stub — a true conflict, not a stub birth.
+	// Restamp ONLY for a real, valid, non-stub incoming envelope. !IsValid() rejects
+	// a zero/partial type (MergeEntity would overwrite the stub envelope to typeless
+	// — the gh#429 class); Equal(StubMessageType) rejects a validly-typed-as-stub
+	// incoming. Either falls through to the caller's reject, leaving the stub intact.
+	if existing == nil || !existing.IsStub() ||
+		!entity.MessageType.IsValid() || entity.MessageType.Equal(graph.StubMessageType) {
 		return false, nil
 	}
 	if merr := c.MergeEntity(ctx, entity); merr != nil {
@@ -422,6 +420,21 @@ func (c *Component) restampStubOnCreate(ctx context.Context, entity *graph.Entit
 	return true, nil
 }
 
+// handleEntityCreateWithTriples is handleEntityCreate that also accepts
+// a Triples slice in the request envelope. When Triples is non-empty
+// it REPLACES Entity.Triples before the write (the canonical set is
+// the request's Triples; Entity carries provenance metadata). When
+// Triples is nil/empty, Entity.Triples is written as-is.
+//
+// Atomicity matches handleEntityCreate: CreateEntityStrict is used
+// for atomic create-or-fail (returns ErrKVKeyExists on duplicate ID).
+//
+// TriplesAdded in the response is the count on the *stored* entity
+// after the write, which may exceed len(req.Triples) when the
+// framework injects hierarchy / referential-integrity triples per
+// component.go:createEntity. Callers reasoning about provenance
+// should compare req.Triples against stored.Triples explicitly rather
+// than treating TriplesAdded as authoritative.
 func (c *Component) handleEntityCreateWithTriples(ctx context.Context, data []byte) ([]byte, error) {
 	var req graph.CreateEntityWithTriplesRequest
 	if err := json.Unmarshal(data, &req); err != nil {

--- a/processor/graph-ingest/stub_restamp_test.go
+++ b/processor/graph-ingest/stub_restamp_test.go
@@ -56,6 +56,40 @@ func TestCreateWithTriples_ReStampsStub(t *testing.T) {
 		"a re-stamp ticks the distinct stub_restamps_total counter — a positive signal, not a rejection")
 }
 
+// gh#435 guard: a create_with_triples carrying a ZERO/invalid MessageType must
+// NOT re-stamp a stub — MergeEntity overwrites MessageType unconditionally, so a
+// zero-typed merge would demote the stub to a typeless non-stub entity (the gh#429
+// dispatchable-non-real class). It must reject and leave the stub intact.
+func TestCreateWithTriples_ZeroTypedDoesNotRestampStub(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+	const target = "c360.platform.test.sys.unit.003"
+
+	require.NoError(t, comp.ensureReferencedEntityExists(ctx, target, "c360.platform.test.sys.parent.001",
+		message.Type{Domain: "test", Category: "fixture", Version: "v1"}))
+	require.True(t, storedEntity(t, comp, target).IsStub(), "precondition: target is a stub")
+
+	before := testutil.ToFloat64(comp.stubRestamps)
+
+	// create_with_triples with a ZERO MessageType (no real envelope).
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity:  &graph.EntityState{ID: target}, // zero MessageType
+		Triples: []message.Triple{{Subject: target, Predicate: "real.label", Object: "x", Timestamp: time.Now(), Confidence: 1.0}},
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	_, err = comp.handleEntityCreateWithTriples(ctx, data)
+	require.Error(t, err, "a zero-typed create on a stub must reject, not demote the stub")
+	var ce *errs.ClassifiedError
+	require.True(t, errors.As(err, &ce), "reject must be classified")
+	assert.Equal(t, graph.ErrorCodeEntityExists, ce.Code)
+
+	still := storedEntity(t, comp, target)
+	assert.True(t, still.IsStub(), "the stub envelope must be PRESERVED (not overwritten to typeless)")
+	assert.Equal(t, before, testutil.ToFloat64(comp.stubRestamps), "a rejected zero-typed create must NOT tick the restamp counter")
+}
+
 // A create_with_triples collision with a REAL (non-stub) entity is a genuine
 // conflict and must still reject with entity_already_exists (the restamp counter
 // must NOT move).

--- a/processor/graph-ingest/stub_restamp_test.go
+++ b/processor/graph-ingest/stub_restamp_test.go
@@ -1,0 +1,90 @@
+package graphingest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/message"
+	"github.com/c360studio/semstreams/pkg/errs"
+)
+
+// gh#435: a real create_with_triples for an ID that exists only as a referential
+// stub must RE-STAMP the stub (its true birth) and SUCCEED — not reject as
+// entity_already_exists, which meteredMutation logs as "graph mutation rejected"
+// (a false GRAPH_WRITE_REJECT that trips paid-run monitors). Success ⇒ no reject
+// ⇒ no WARN (the WARN is emitted by meteredMutation only on a non-nil err).
+func TestCreateWithTriples_ReStampsStub(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+	const target = "c360.platform.test.sys.unit.001"
+
+	// Materialize target as a bare referential stub.
+	require.NoError(t, comp.ensureReferencedEntityExists(ctx, target, "c360.platform.test.sys.parent.001",
+		message.Type{Domain: "test", Category: "fixture", Version: "v1"}))
+	require.True(t, storedEntity(t, comp, target).IsStub(), "precondition: target is a stub")
+
+	before := testutil.ToFloat64(comp.stubRestamps)
+
+	// Real producer births it via create_with_triples carrying a real envelope.
+	realType := message.Type{Domain: "workflow", Category: "task-unit", Version: "v1"}
+	req := graph.CreateEntityWithTriplesRequest{
+		Entity: &graph.EntityState{ID: target, MessageType: realType},
+		Triples: []message.Triple{
+			{Subject: target, Predicate: "real.label", Object: "Born", Timestamp: time.Now(), Confidence: 1.0},
+		},
+	}
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	resp, err := comp.handleEntityCreateWithTriples(ctx, data)
+	require.NoError(t, err, "create_with_triples on a stub must SUCCEED (re-stamp), not reject")
+	require.NotNil(t, resp)
+
+	born := storedEntity(t, comp, target)
+	assert.False(t, born.IsStub(), "the stub envelope must be re-stamped to the real type")
+	assert.Equal(t, realType, born.MessageType)
+	assert.True(t, hasPredicate(born, "real.label"), "real triples merged onto the born entity")
+	assert.Equal(t, before+1, testutil.ToFloat64(comp.stubRestamps),
+		"a re-stamp ticks the distinct stub_restamps_total counter — a positive signal, not a rejection")
+}
+
+// A create_with_triples collision with a REAL (non-stub) entity is a genuine
+// conflict and must still reject with entity_already_exists (the restamp counter
+// must NOT move).
+func TestCreateWithTriples_RealCollisionStillRejects(t *testing.T) {
+	comp := createTestComponentWithMockKV(t)
+	ctx := context.Background()
+	const target = "c360.platform.test.sys.unit.002"
+
+	realType := message.Type{Domain: "workflow", Category: "task-unit", Version: "v1"}
+	mk := func() []byte {
+		req := graph.CreateEntityWithTriplesRequest{
+			Entity:  &graph.EntityState{ID: target, MessageType: realType},
+			Triples: []message.Triple{{Subject: target, Predicate: "real.label", Object: "v", Timestamp: time.Now(), Confidence: 1.0}},
+		}
+		data, _ := json.Marshal(req)
+		return data
+	}
+
+	// First create succeeds (real birth, no stub involved).
+	_, err := comp.handleEntityCreateWithTriples(ctx, mk())
+	require.NoError(t, err)
+
+	before := testutil.ToFloat64(comp.stubRestamps)
+
+	// Second create on the now-real entity is a true conflict → reject.
+	_, err = comp.handleEntityCreateWithTriples(ctx, mk())
+	require.Error(t, err, "create on an existing REAL entity must still reject")
+	var ce *errs.ClassifiedError
+	require.True(t, errors.As(err, &ce), "reject must be classified")
+	assert.Equal(t, graph.ErrorCodeEntityExists, ce.Code, "a real collision keeps the entity_already_exists reject")
+	assert.Equal(t, before, testutil.ToFloat64(comp.stubRestamps), "a real conflict must NOT tick the restamp counter")
+}


### PR DESCRIPTION
## Summary

Makes graph readiness **honest** (gh#431): `ready` now means the index is **caught up** to the latest committed write, not merely "indexing started". Implements ADR-066 across graph-index and graph-embedding, plus the gh#435 QoL sibling. Part of the beta.128 "honest graph signals" set.

The old signal flipped `ready` the instant `NAME_INDEX` had one key — minutes before the index was populated — so a consumer that correctly waited for `ready` still got false negatives (found dogfooding semstreams beta.124 against itself, ~21k entities).

## What changed

- **`natsclient.BucketLastSeq`** — query-time Target (the backing-stream `LastSeq`).
- **`pkg/revlag.Watermark`** — a shared low-water-of-pending "caught up" tracker: `Indexed = pending.empty() ? observedHigh : minPending−1`, with a single **key-scoped `Complete(key, rev)`**. It is **sparse-delivery correct**: ENTITY_STATES runs at History=1 and `WatchAll` delivers via `OrderedConsumer + DeliverLastPerSubject`, so superseded revisions are purged/never delivered — absolute-revision contiguity would stall forever. Correctness rests on `OrderedConsumer`'s monotonic-ascending delivery.
- **graph-index** — honest `Ready`/`Lag`/`State` on `graph.index.query.status`, the dead `Revision`/`LastSynced` fields filled, a wall-clock stuck→`degraded` detector. `pkg/fusion.IndexStatus` mirrored; the fusionnats client now decodes **all** fields (it was dropping the revision-lag fields → false-caught-up downstream).
- **graph-embedding** — a distinct **terminal-outcome** watermark on a new `graph.embedding.query.status`. Only text-bearing entities embed, so a naive watermark would deadlock; `Indexed` advances on **every** terminal (generated / failed / no-text-skip / ineligible / delete), so `Ready` is reachable. The ENTITY_STATES revision threads through both hops (`Record.SourceRevision` → `WithOnTerminal`). Completions-based stuck detector (a slow LLM call is healthy, not degraded). **Ungated**: no consumer gates on `embedding.ready` until proven.

`Ready` means revision **coverage**, not last-writer-wins **freshness** — two adjacencies documented as companion follow-ups (multi-worker stale-overwrite; embedding mass-failure).

## Reviews (subtle change — reviewed at each critical point)

- **Architect, pre-code (×2):** caught that the ADR's first-draft algorithm was *permanently broken* under History=1 sparse delivery, and the embedding half had a deadlock + 3 completion-wiring hazards (D1/D2/D3). All folded into the design before any code.
- **semstreams-reviewer, pre-merge (×2):** graph-index — fixed a fusionnats field-drop + a coalescer `Get`-strand. graph-embedding — **APPROVE**, exactly-once terminal completion verified on every hop-1/hop-2 path.

## Testing

- `pkg/revlag` mechanism units (sparse / coalescer-collapse / delete-supersedes / key-scoped / concurrent under `-race`), fusionnats round-trip guard, completions-stuck units.
- Wired integration tests: graph-index revision-lag (real `WatchAll` + `BucketLastSeq`); **graph-embedding deadlock-avoidance** (text + telemetry-only entities both catch up to `Ready`).
- Full `task check:push` gauntlet green; **`task e2e:statistical` green** (breaking-change gate — 41/41 stages, `validation_errors:0`, embedding queue drained `generated=352 failed=0 pending=0`, indexes 8/8); no schema drift.

## Breaking

The `Ready` **semantic** changed (caught-up vs started); `fusion.Fuse` gates on it and now returns empty for the whole build window (safe — callers fall back; the numeric fields are the escape: gate on `IndexedRevision >= myRev`). e2e:statistical validates the full ingest→index→embed→query path.

## Follow-ups (not in this PR)

- semsource: mcp-gateway third fan-out to `graph.embedding.query.status` (surfaced, not gated) + retire the "stopped climbing" workaround note.
- Companion issues: graph-index multi-worker stale-overwrite; embedding mass-failure-reads-as-covered.

Closes #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
