### PR TITLE
feat(graph-embedding): asymmetric query embedding — query-side prefix (gh#438)

### DIFF
--- a/graph/embedding/bm25_embedder.go
+++ b/graph/embedding/bm25_embedder.go
@@ -103,6 +103,15 @@ func NewBM25Embedder(cfg BM25Config) *BM25Embedder {
 	}
 }
 
+// GenerateQuery embeds query-side text. BM25 is a symmetric bag-of-words model —
+// there is no query/document asymmetry, so it is identical to Generate (gh#438).
+// Like Generate, it folds the text's terms into the corpus IDF statistics (the
+// pre-gh#438 query path already did this via the direct Generate call, so behavior
+// is unchanged); a read-only query vectorization would be a separate follow-up.
+func (b *BM25Embedder) GenerateQuery(ctx context.Context, texts []string) ([][]float32, error) {
+	return b.Generate(ctx, texts)
+}
+
 // Generate creates BM25-based embeddings for the given texts.
 //
 // This updates internal document statistics incrementally, so the embedder

--- a/graph/embedding/bm25_embedder_test.go
+++ b/graph/embedding/bm25_embedder_test.go
@@ -57,6 +57,31 @@ func TestBM25Embedder_Generate(t *testing.T) {
 	}
 }
 
+// TestBM25Embedder_GenerateQuerySymmetric: BM25 has no query/document asymmetry, so
+// GenerateQuery must produce the same vector as Generate for the same text (gh#438).
+func TestBM25Embedder_GenerateQuerySymmetric(t *testing.T) {
+	embedder := NewBM25Embedder(BM25Config{Dimensions: 384})
+	ctx := context.Background()
+	texts := []string{"retry with backoff on transient failure"}
+
+	doc, err := embedder.Generate(ctx, texts)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	qry, err := embedder.GenerateQuery(ctx, texts)
+	if err != nil {
+		t.Fatalf("GenerateQuery: %v", err)
+	}
+	if len(doc) != 1 || len(qry) != 1 || len(doc[0]) != len(qry[0]) {
+		t.Fatalf("shape mismatch: doc=%d qry=%d", len(doc), len(qry))
+	}
+	for i := range doc[0] {
+		if doc[0][i] != qry[0][i] {
+			t.Fatalf("BM25 GenerateQuery diverged from Generate at dim %d: %v vs %v", i, doc[0][i], qry[0][i])
+		}
+	}
+}
+
 func TestBM25Embedder_Dimensions(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/graph/embedding/embedder.go
+++ b/graph/embedding/embedder.go
@@ -12,12 +12,21 @@ import "context"
 // maintaining a consistent interface. All providers support batch operations
 // natively, following OpenAI API patterns.
 type Embedder interface {
-	// Generate creates embeddings for the given texts.
+	// Generate creates embeddings for the given texts (the DOCUMENT side — what is
+	// embedded at ingest).
 	//
 	// This is the primary method - batch operations are natural for all providers.
 	// For single text, pass a slice with one element.
 	// Returns a slice of float32 slices, where each inner slice is an embedding vector.
 	Generate(ctx context.Context, texts []string) ([][]float32, error)
+
+	// GenerateQuery creates embeddings for QUERY-side text (semantic search),
+	// as opposed to Generate which embeds documents at ingest. Asymmetric retrieval
+	// models (Snowflake arctic-embed, BGE, E5) are trained to embed a query with an
+	// instruction prefix while documents are embedded raw; omitting the query prefix
+	// is a measured retrieval-quality cliff, not a rounding error (gh#438). Symmetric
+	// embedders (BM25) implement this identically to Generate.
+	GenerateQuery(ctx context.Context, texts []string) ([][]float32, error)
 
 	// Dimensions returns the dimensionality of embeddings produced by this embedder.
 	//

--- a/graph/embedding/http_embedder.go
+++ b/graph/embedding/http_embedder.go
@@ -21,11 +21,12 @@ import (
 // Uses the standard OpenAI SDK for consistency and compatibility.
 // See Dockerfile.tei and docker-compose.services.yml for ready-to-use TEI setup.
 type HTTPEmbedder struct {
-	client     *openai.Client
-	model      string
-	dimensions int
-	cache      Cache
-	logger     *slog.Logger
+	client      *openai.Client
+	model       string
+	dimensions  int
+	cache       Cache
+	logger      *slog.Logger
+	queryPrefix string // prepended to query-side text only (gh#438)
 }
 
 // HTTPConfig configures the HTTP embedder.
@@ -48,6 +49,12 @@ type HTTPConfig struct {
 	// APIKey for authentication (optional for local services).
 	// Required for OpenAI, optional for TEI/LocalAI.
 	APIKey string
+
+	// QueryPrefix is prepended to query-side text only (GenerateQuery), never to
+	// documents. Set it to the model's query instruction for asymmetric retrieval
+	// models — e.g. "Represent this sentence for searching relevant passages: " for
+	// Snowflake arctic-embed / E5 (gh#438). Empty disables the prefix (symmetric use).
+	QueryPrefix string
 
 	// Timeout for HTTP requests (default: 30s).
 	Timeout time.Duration
@@ -110,19 +117,40 @@ func NewHTTPEmbedder(cfg HTTPConfig) (*HTTPEmbedder, error) {
 	}
 
 	return &HTTPEmbedder{
-		client:     client,
-		model:      cfg.Model,
-		dimensions: 384, // Will be detected on first call
-		cache:      cfg.Cache,
-		logger:     logger,
+		client:      client,
+		model:       cfg.Model,
+		dimensions:  384, // Will be detected on first call
+		cache:       cfg.Cache,
+		logger:      logger,
+		queryPrefix: cfg.QueryPrefix,
 	}, nil
 }
 
-// Generate creates embeddings by calling the external HTTP service.
+// Generate creates DOCUMENT-side embeddings by calling the external HTTP service.
 //
 // This method checks the cache first (if configured), then calls the
 // embedding API for any cache misses.
 func (h *HTTPEmbedder) Generate(ctx context.Context, texts []string) ([][]float32, error) {
+	return h.embed(ctx, texts)
+}
+
+// GenerateQuery creates QUERY-side embeddings, prepending the configured query
+// instruction prefix to each text (asymmetric retrieval models, gh#438). With no
+// prefix configured it is identical to Generate. The cache keys on the prefixed
+// text, so query and document embeddings of the same string never collide.
+func (h *HTTPEmbedder) GenerateQuery(ctx context.Context, texts []string) ([][]float32, error) {
+	if h.queryPrefix == "" {
+		return h.embed(ctx, texts)
+	}
+	prefixed := make([]string, len(texts))
+	for i, t := range texts {
+		prefixed[i] = h.queryPrefix + t
+	}
+	return h.embed(ctx, prefixed)
+}
+
+// embed is the shared cache-then-API path used by both Generate and GenerateQuery.
+func (h *HTTPEmbedder) embed(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return [][]float32{}, nil
 	}

--- a/graph/embedding/http_embedder_test.go
+++ b/graph/embedding/http_embedder_test.go
@@ -1,0 +1,89 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newCapturingEmbedServer returns an httptest server that records the `input` texts
+// of the last embeddings request and replies with one unit vector per input.
+func newCapturingEmbedServer(t *testing.T, captured *[]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Input []string `json:"input"`
+			Model string   `json:"model"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode embed request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		*captured = req.Input
+
+		type embObj struct {
+			Object    string    `json:"object"`
+			Index     int       `json:"index"`
+			Embedding []float32 `json:"embedding"`
+		}
+		data := make([]embObj, len(req.Input))
+		for i := range req.Input {
+			data[i] = embObj{Object: "embedding", Index: i, Embedding: []float32{1, 0, 0}}
+		}
+		resp := map[string]any{"object": "list", "model": req.Model, "data": data}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
+// TestHTTPEmbedder_GenerateQuery_PrependsPrefix is the gh#438 guard: the query side
+// must carry the model's query instruction prefix, the document side must not.
+func TestHTTPEmbedder_GenerateQuery_PrependsPrefix(t *testing.T) {
+	var captured []string
+	srv := newCapturingEmbedServer(t, &captured)
+	defer srv.Close()
+
+	const prefix = "Represent this sentence for searching relevant passages: "
+	emb, err := NewHTTPEmbedder(HTTPConfig{BaseURL: srv.URL, Model: "arctic-embed-s", QueryPrefix: prefix})
+	if err != nil {
+		t.Fatalf("NewHTTPEmbedder: %v", err)
+	}
+
+	// Query side → prefixed.
+	if _, err := emb.GenerateQuery(context.Background(), []string{"retry with backoff"}); err != nil {
+		t.Fatalf("GenerateQuery: %v", err)
+	}
+	if len(captured) != 1 || captured[0] != prefix+"retry with backoff" {
+		t.Fatalf("query input = %q, want prefixed %q", captured, prefix+"retry with backoff")
+	}
+
+	// Document side → raw (never prefixed).
+	if _, err := emb.Generate(context.Background(), []string{"retry with backoff"}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(captured) != 1 || captured[0] != "retry with backoff" {
+		t.Fatalf("document input = %q, want unprefixed", captured)
+	}
+}
+
+// TestHTTPEmbedder_GenerateQuery_NoPrefixConfigured: with no prefix, the query side
+// is identical to the document side (symmetric use / non-asymmetric model).
+func TestHTTPEmbedder_GenerateQuery_NoPrefixConfigured(t *testing.T) {
+	var captured []string
+	srv := newCapturingEmbedServer(t, &captured)
+	defer srv.Close()
+
+	emb, err := NewHTTPEmbedder(HTTPConfig{BaseURL: srv.URL, Model: "all-MiniLM-L6-v2"})
+	if err != nil {
+		t.Fatalf("NewHTTPEmbedder: %v", err)
+	}
+	if _, err := emb.GenerateQuery(context.Background(), []string{"hello"}); err != nil {
+		t.Fatalf("GenerateQuery: %v", err)
+	}
+	if len(captured) != 1 || captured[0] != "hello" {
+		t.Fatalf("no-prefix query input = %q, want unprefixed", captured)
+	}
+}

--- a/model/registry.go
+++ b/model/registry.go
@@ -209,6 +209,12 @@ type EndpointConfig struct {
 	URL string `json:"url,omitempty"`
 	// Model is the model identifier sent to the provider.
 	Model string `json:"model"`
+	// QueryPrefix is used ONLY by the embedding capability (gh#438): the query
+	// instruction prepended to query-side text for asymmetric retrieval models
+	// (arctic-embed, BGE, E5) — e.g. "Represent this sentence for searching relevant
+	// passages: ". Documents are embedded raw. Ignored by non-embedding capabilities
+	// and by symmetric embedders. Empty = no prefix.
+	QueryPrefix string `json:"query_prefix,omitempty"`
 	// MaxTokens is the context window size in tokens.
 	//
 	// For provider="ollama", this value is NOT forwarded to the server —

--- a/model/registry_test.go
+++ b/model/registry_test.go
@@ -1059,6 +1059,7 @@ func TestResolveEndpointWithConfig_KeepalivePlumbing(t *testing.T) {
 				DisableKeepAlives:     true,
 				IdleConnTimeout:       "10s",
 				ResponseHeaderTimeout: "30s",
+				QueryPrefix:           "Represent this sentence for searching relevant passages: ",
 				MaxTokens:             32000,
 			},
 		},
@@ -1093,6 +1094,11 @@ func TestResolveEndpointWithConfig_KeepalivePlumbing(t *testing.T) {
 	}
 	if ep.ResponseHeaderTimeout != "30s" {
 		t.Errorf("ResponseHeaderTimeout = %q, want 30s", ep.ResponseHeaderTimeout)
+	}
+	// query_prefix rides the identical resolve seam (gh#438); guard it against the
+	// same silent-strip regression class the keepalive fields hit (smoke-#10).
+	if ep.QueryPrefix != "Represent this sentence for searching relevant passages: " {
+		t.Errorf("QueryPrefix = %q, want the arctic query prefix (gh#438 plumbing)", ep.QueryPrefix)
 	}
 }
 

--- a/processor/graph-embedding/component.go
+++ b/processor/graph-embedding/component.go
@@ -693,6 +693,7 @@ func (c *Component) createEmbedder() error {
 			httpCfg.IdleConnTimeout = epCfg.IdleConnTimeout
 			httpCfg.ResponseHeaderTimeout = epCfg.ResponseHeaderTimeout
 			httpCfg.DisableKeepAlives = epCfg.DisableKeepAlives
+			httpCfg.QueryPrefix = epCfg.QueryPrefix // asymmetric query embedding (gh#438)
 		}
 		httpEmbedder, err := embedding.NewHTTPEmbedder(httpCfg)
 		if err != nil {

--- a/processor/graph-embedding/query.go
+++ b/processor/graph-embedding/query.go
@@ -176,8 +176,9 @@ func (c *Component) handleQuerySearchNATS(_ context.Context, data []byte) ([]byt
 		return nil, errs.WrapFatal(errs.ErrInvalidConfig, "handleQuerySearchNATS", "handler", "embedder not initialized")
 	}
 
-	// Generate embedding for query text
-	vectors, err := c.embedder.Generate(ctx, []string{req.Query})
+	// Generate embedding for query text via the QUERY-side path so asymmetric models
+	// get their query instruction prefix (gh#438); symmetric embedders (BM25) no-op it.
+	vectors, err := c.embedder.GenerateQuery(ctx, []string{req.Query})
 	if err != nil {
 		return nil, errs.Wrap(err, "handleQuerySearchNATS", "handler", "generate query embedding")
 	}


### PR DESCRIPTION
## Summary

Closes #438. Adds **asymmetric query/document embedding** — a query-side instruction prefix for retrieval models (Snowflake **arctic-embed**, **BGE**, **E5**) that are trained to prefix the *query* while embedding *documents* raw.

Omitting the query prefix is a **measured** quality cliff, not a rounding error: on a real 21k-entity corpus the arctic prefix ~doubles the relevant-vs-noise cosine margin (**+0.090 → +0.158, +76%**), and without it tier-1 semantic search ranked *below* tier-0 BM25. semembed's default model (`snowflake-arctic-embed-s`) is in this family, so HTTP-embedder retrieval quality was capped regardless of corpus/model. **This unblocks semsource's BM25-vs-semembed A/B** — currently it compares against a handicapped semembed.

## What changed

The asymmetry lives **in the embedder**, not scattered across callers:

- **`GenerateQuery(ctx, texts)` on the `Embedder` interface.** HTTP prepends a configured `QueryPrefix` (reusing the shared cache+API path); **BM25 is symmetric → `GenerateQuery = Generate`** (no-op).
- **Config:** `query_prefix` on `model.EndpointConfig` → `HTTPConfig`, threaded in `createEmbedder`.
- **Wire:** the semantic-search handler (`graph.embedding.query.search`) calls `GenerateQuery`; **ingest stays `Generate`**. The cache keys on the prefixed text, so a query and a document of the same string never collide.

**Explicit config only** — no fuzzy model-name auto-prefix table (a wrong prefix on the wrong model is a silent quality regression). Operators opt in per model:

```json
"embedding": { "provider": "openai", "url": "http://semembed:8080",
  "model": "Snowflake/snowflake-arctic-embed-s",
  "query_prefix": "Represent this sentence for searching relevant passages: " }
```

**Scope:** the classifier and similar-entity paths are deliberately left `Generate` (query-against-query / document-against-document — asymmetry only matters for query→document retrieval; confirmed in review).

## Testing

- httptest server proves the prefix reaches the wire on the **query** side and **not** the document side (+ the no-prefix symmetric case); BM25 `GenerateQuery==Generate`; a registry-seam assertion guards `query_prefix` against the silent-strip regression class (the keepalive-plumbing precedent).
- `semstreams-reviewer`: **APPROVE**, no blocking/high (verified cache-keying, interface completeness, config threading, byte-identical `embed` refactor, scope). One MEDIUM (the registry-seam test) addressed.
- Local gates: touched packages green under `-race`, lint clean, **no schema drift**. (Two unrelated load-induced integration flakes in `processor/rule` + `processor/graph-ingest` — packages this PR doesn't touch — pass in isolation.)

## Follow-up (optional, out of scope)

Read-only BM25 query vectorization — today `GenerateQuery` folds query terms into corpus IDF stats (unchanged from before this PR, since the old path already called `Generate` on the query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
