### PR TITLE
feat(fusion): signed predicate salience — down-rank noise, not just boost (gh#441)

### DIFF
--- a/docs/adr/062-deterministic-graph-fusion.md
+++ b/docs/adr/062-deterministic-graph-fusion.md
@@ -165,6 +165,16 @@ Carried on every response (from semsource's validated shape):
    helper) and #2 (predicate salience: `WithRole`/`WithWeight` on `vocabulary.Register`).
 6. **Convergence** — semsource ports `source/fusion` onto `pkg/fusion`; contributes the code + docs
    lenses (rule-of-three inputs) + ontology ranking.
+7. **Signed salience (down-rank)** — gh#441. `WithWeight` accepts NEGATIVE weights; the ranker folds an
+   entity's strongest boost (max positive) and strongest demotion (min negative) predicate weights
+   together (`entitySalience`), so a consumer can push structurally-identifiable noise — tests
+   (`*_test.go`), generated code (`*.pb.go`), mocks — BELOW the real thing even when it carries the
+   SAME salient predicates (a test's doc-comment has the same salience as its impl's). Presence-predicate
+   based (emit e.g. `code.artifact.test` and weight it negative); no new SPI surface (the existing signed
+   `PredicateSalience` starts meaning what its sign says). Demotion is `max`+`min` over predicates, NOT a
+   sum — fact count still cannot inflate rank — and stays a bounded secondary reordering, never an
+   exclusion. All-positive configs (every config before this) are unchanged (min-negative stays 0 → old
+   `max`).
 
 ## Division of labor
 
@@ -207,3 +217,4 @@ Carried on every response (from semsource's validated shape):
 - ADR-055/056 (ContentStorable / authoritative state), gh#264 (StorageRef lift at ingest).
 - #380 (`graph.query.byName`, increment 1); #381 (index value-growth follow-up).
 - gh#376 sub-asks: #1 (BFO/CCO subclass helper), #2 (predicate salience), #5 (name→ranked-IDs, shipped).
+- gh#441 (signed salience — down-rank tests/generated/mocks; semsource ask #14), increment 7.

--- a/pkg/fusion/engine_lens.go
+++ b/pkg/fusion/engine_lens.go
@@ -37,7 +37,7 @@ const (
 	lexContains   = 8.0
 	resolveScale  = 4.0 // base score per resolve-rank position
 	ontologyScale = 1.5 // per ontology-depth level (class specificity)
-	salienceScale = 3.0 // per unit of an entity's max predicate salience
+	salienceScale = 3.0 // per unit of an entity's net predicate salience (signed: boost − demotion, gh#441)
 )
 
 // ontologyClassPredicate is the stamped BFO/CCO class triple (semsource ADR-0005).
@@ -281,18 +281,35 @@ func (e *Engine) rankEntities(entities []*Entity, names []string, query string) 
 	return out
 }
 
-// entitySalience is an entity's ranking salience: the maximum stored weight over
-// its predicates (the single most salient fact it carries). Max, not sum, so a
-// densely-annotated entity does not outrank a sharply-identified one purely on
-// fact count.
+// entitySalience is an entity's ranking salience: the entity's single most
+// salient (max positive) weight PLUS its single strongest demotion (min
+// negative) weight over its predicates — one presence-based boost and one
+// presence-based penalty, summed (gh#441). Extremes, not a sum over all
+// predicates, so a densely-annotated entity does not outrank a sharply-
+// identified one purely on fact count; and the two extremes come from different
+// predicates (a predicate's weight is one sign), so a boost and a demotion
+// compose without either masking the other.
+//
+// Signed weights are what let a ranker DEMOTE, not just boost: structurally-
+// identifiable noise (tests, generated code, mocks) that carries the SAME
+// salient predicates as the real thing — a *_test.go with the same doc-comment
+// salience as its impl — also carries a negatively-weighted presence predicate
+// (e.g. code.artifact.test → WithWeight(-1.5)), so it sinks below the impl the
+// additive-only ranker could never separate it from. With no negative weights
+// (every config before gh#441) min-negative stays 0 and this is exactly the old
+// max — backward-compatible.
 func entitySalience(ent *Entity, sig RankSignals) float64 {
-	var best float64
+	var maxPos, minNeg float64 // strongest boost (≥0), strongest demotion (≤0)
 	for i := range ent.Triples {
-		if w := sig.PredicateSalience(ent.Triples[i].Predicate); w > best {
-			best = w
+		w := sig.PredicateSalience(ent.Triples[i].Predicate)
+		if w > maxPos {
+			maxPos = w
+		}
+		if w < minNeg {
+			minNeg = w
 		}
 	}
-	return best
+	return maxPos + minNeg
 }
 
 // lexicalScore scores a name against a lowercased query.

--- a/pkg/fusion/engine_lens_test.go
+++ b/pkg/fusion/engine_lens_test.go
@@ -372,3 +372,108 @@ func TestEngine_Signals_TooSmallToReorder(t *testing.T) {
 		t.Errorf("top = %q, want Apple (sub-gap signal must not override resolve order)", got)
 	}
 }
+
+// TestEngine_Signals_NegativeSalienceDemotes: A (resolved first) carries a
+// negatively-weighted predicate — the tests/generated/mocks case (gh#441). The
+// demotion overcomes A's resolve-order lead, so B reorders ahead. Additive-only
+// salience could never do this: a max over non-negative weights can only boost.
+func TestEngine_Signals_NegativeSalienceDemotes(t *testing.T) {
+	// A carries the demotion predicate; B is clean. Both same class (no ontology
+	// signal). A leads by resolveScale (4.0); demotion on A = salienceScale*1.5 =
+	// 4.5 > 4.0, so B wins.
+	a := entity("acme.ops.code.repo.symbol.Apple", "Apple", "a_test.go",
+		message.Triple{Predicate: "entity.ontology.class", Object: "http://x/Same"},
+		message.Triple{Predicate: "code.artifact.test", Object: "true"})
+	b := entity("acme.ops.code.repo.symbol.Banana", "Banana", "b.go",
+		message.Triple{Predicate: "entity.ontology.class", Object: "http://x/Same"})
+	g := &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"zzz": {a.ID, b.ID}},
+		entities: map[string]*fusion.Entity{a.ID: a, b.ID: b},
+	}
+	sig := fakeSignals{salience: map[string]float64{"code.artifact.test": -1.5}}
+	eng := fusion.NewEngine(g, nil).WithSignals(sig)
+	if got := topName(t, eng); got != "Banana" {
+		t.Errorf("top = %q, want Banana (negatively-weighted predicate demotes A below B)", got)
+	}
+}
+
+// TestEngine_Signals_BoostAndDemotionCompose: the issue's core case (gh#441) —
+// impl and test carry the SAME salient (doc-comment) predicate, so additive
+// salience alone cannot separate them; the test ALSO carries a demotion
+// predicate, and boost+demotion compose so the impl sorts ahead of its test.
+func TestEngine_Signals_BoostAndDemotionCompose(t *testing.T) {
+	// Impl (A) resolves first; both carry the same +1.0 doc-comment salience.
+	// Test (B) additionally carries a -1.5 demotion. Net: A salience = +1.0,
+	// B salience = 1.0 - 1.5 = -0.5. Salience gap = salienceScale*(1.0-(-0.5)) =
+	// 3.0*1.5 = 4.5 > resolve gap 4.0, so the impl stays ahead of the test even
+	// though the test resolved... second here, so also assert order explicitly.
+	impl := entity("acme.ops.code.repo.symbol.retry", "retry", "retry.go",
+		message.Triple{Predicate: "entity.ontology.class", Object: "http://x/Same"},
+		message.Triple{Predicate: "code.symbol.doc", Object: "retries the op"})
+	test := entity("acme.ops.code.repo.symbol.retryTest", "retry", "retry_test.go",
+		message.Triple{Predicate: "entity.ontology.class", Object: "http://x/Same"},
+		message.Triple{Predicate: "code.symbol.doc", Object: "tests retry"},
+		message.Triple{Predicate: "code.artifact.test", Object: "true"})
+	// Resolve the TEST first (adversarial: it has the resolve-order lead), so the
+	// demotion must overcome resolve order to put the impl on top.
+	g := &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"zzz": {test.ID, impl.ID}},
+		entities: map[string]*fusion.Entity{test.ID: test, impl.ID: impl},
+	}
+	sig := fakeSignals{salience: map[string]float64{
+		"code.symbol.doc":    1.0,
+		"code.artifact.test": -1.5,
+	}}
+	eng := fusion.NewEngine(g, nil).WithSignals(sig)
+	resp, err := eng.Fuse(context.Background(), fusion.Request{Query: "zzz"}, refLens{})
+	if err != nil {
+		t.Fatalf("Fuse: %v", err)
+	}
+	if len(resp.Nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(resp.Nodes))
+	}
+	if resp.Nodes[0].Path != "retry.go" || resp.Nodes[1].Path != "retry_test.go" {
+		t.Errorf("order = [%s, %s], want [retry.go, retry_test.go] (impl ahead of its test)",
+			resp.Nodes[0].Path, resp.Nodes[1].Path)
+	}
+}
+
+// TestEngine_Signals_MaxNotSum_NoFactCountInflation: the anti-inflation
+// property the signed aggregation must preserve — a densely-annotated entity
+// must NOT outrank a sharply-identified one purely on fact count (the reason
+// entitySalience takes the positive EXTREME, not a sum). This is also the
+// backward-compat guard for every all-positive config from before gh#441.
+func TestEngine_Signals_MaxNotSum_NoFactCountInflation(t *testing.T) {
+	// A (resolved first, sharp): one +2.0 predicate → salience 2.0 either way.
+	// B (resolved second, dense): four +1.0 predicates → max 1.0, sum 4.0.
+	// Under the correct max/extreme aggregation, A's resolve lead (4.0) holds and
+	// A stays on top. Under a (wrong) sum aggregation, B's salience 4.0 vs A's 2.0
+	// gives salienceScale*(4-2)=6 > 4 and B would flip ahead. Assert A wins.
+	a := entity("acme.ops.code.repo.symbol.Apple", "Apple", "a.go",
+		message.Triple{Predicate: "entity.ontology.class", Object: "http://x/Same"},
+		message.Triple{Predicate: "acme.identity.serial", Object: "SN-1"})
+	b := entity("acme.ops.code.repo.symbol.Banana", "Banana", "b.go",
+		message.Triple{Predicate: "entity.ontology.class", Object: "http://x/Same"},
+		message.Triple{Predicate: "acme.label.one", Object: "1"},
+		message.Triple{Predicate: "acme.label.two", Object: "2"},
+		message.Triple{Predicate: "acme.label.three", Object: "3"},
+		message.Triple{Predicate: "acme.label.four", Object: "4"})
+	g := &fakeGraph{
+		status:   readyStatus(),
+		seeds:    map[string][]string{"zzz": {a.ID, b.ID}},
+		entities: map[string]*fusion.Entity{a.ID: a, b.ID: b},
+	}
+	sig := fakeSignals{salience: map[string]float64{
+		"acme.identity.serial": 2.0,
+		"acme.label.one":       1.0,
+		"acme.label.two":       1.0,
+		"acme.label.three":     1.0,
+		"acme.label.four":      1.0,
+	}}
+	eng := fusion.NewEngine(g, nil).WithSignals(sig)
+	if got := topName(t, eng); got != "Apple" {
+		t.Errorf("top = %q, want Apple (sharp entity holds; dense fact count must not inflate via sum)", got)
+	}
+}

--- a/pkg/fusion/fusionvocab/signals.go
+++ b/pkg/fusion/fusionvocab/signals.go
@@ -41,7 +41,8 @@ func (Signals) ClassSpecificity(classIRI string) float64 {
 }
 
 // PredicateSalience returns a predicate's stored salience weight from the
-// vocabulary registry (0 when unregistered or unweighted).
+// vocabulary registry (0 when unregistered or unweighted). Signed: a negative
+// weight down-ranks (gh#441) — a faithful pass-through of PredicateMetadata.Weight.
 func (Signals) PredicateSalience(predicate string) float64 {
 	if meta := vocabulary.GetPredicateMetadata(predicate); meta != nil {
 		return meta.Weight

--- a/pkg/fusion/rank_signals.go
+++ b/pkg/fusion/rank_signals.go
@@ -6,7 +6,10 @@ package fusion
 // interface so pkg/fusion stays a leaf (no vocabulary / bfo / cco imports);
 // production wires the vocabulary registry + BFO/CCO subclass helper (see
 // pkg/fusion/fusionvocab). A nil RankSignals leaves ranking at resolve-order +
-// lexical — the increments 1–4 behavior — so the signals are strictly additive.
+// lexical — the increments 1–4 behavior — so attaching signals is purely
+// additive to the pipeline (nil → unchanged). The salience signal itself is
+// DIRECTIONAL: a predicate's weight is signed, so it can down-rank as well as
+// boost (gh#441).
 type RankSignals interface {
 	// ClassSpecificity scores how specific an ontology class IRI is: more
 	// specific (deeper in the BFO/CCO subclass tree) = higher; 0 for an
@@ -15,8 +18,14 @@ type RankSignals interface {
 	// vaguely-typed peer.
 	ClassSpecificity(classIRI string) float64
 
-	// PredicateSalience returns a predicate's stored salience weight (0 =
-	// neutral). Production reads vocabulary PredicateMetadata.Weight so an
-	// entity carrying more salient facts reorders ahead of a sparse peer.
+	// PredicateSalience returns a predicate's stored salience weight, SIGNED:
+	// positive boosts (an entity carrying the fact reorders ahead), negative
+	// demotes (it reorders behind), 0 is neutral. Production reads vocabulary
+	// PredicateMetadata.Weight. A negative weight is how a consumer down-ranks
+	// structurally-identifiable noise (tests, generated code, mocks) that carries
+	// the same boosted predicates as the real thing — additive boosting alone
+	// cannot separate them (gh#441). The engine folds an entity's strongest boost
+	// and strongest demotion together (see entitySalience), so a demotion is a
+	// bounded secondary reordering, never an exclusion.
 	PredicateSalience(predicate string) float64
 }

--- a/vocabulary/predicates.go
+++ b/vocabulary/predicates.go
@@ -422,9 +422,12 @@ type PredicateMetadata struct {
 	// semstreams ranking annotation, not an ontology assertion.
 	Role PredicateRole
 
-	// Weight is the predicate's salience weight for ranking (higher = more
-	// salient). 0 means unweighted (neutral). Lets a ranker prefer entities
-	// carrying more salient facts without hard-coding a per-product table.
+	// Weight is the predicate's salience weight for ranking, SIGNED: positive =
+	// more salient (boost), 0 = unweighted (neutral), negative = down-rank
+	// (demote, gh#441). Lets a ranker prefer entities carrying salient facts, or
+	// push down structurally-identifiable noise (tests, generated code, mocks)
+	// that carries the same boosted predicates as the real thing, without
+	// hard-coding a per-product table.
 	Weight float64
 }
 

--- a/vocabulary/registry.go
+++ b/vocabulary/registry.go
@@ -236,9 +236,19 @@ func WithRole(role PredicateRole) Option {
 	}
 }
 
-// WithWeight declares the predicate's salience weight (higher = more salient;
-// 0 = neutral). Lets a ranker prefer entities carrying more salient facts
-// without a per-product weight table (ADR-062 increment 5, semsource ask #2).
+// WithWeight declares the predicate's salience weight, SIGNED: positive = more
+// salient (boost), 0 = neutral, NEGATIVE = down-rank (demote). Lets a ranker
+// prefer entities carrying salient facts — or push down structurally-
+// identifiable noise (tests, generated code, mocks) that carries the same
+// boosted predicates as the real thing — without a per-product weight table
+// (ADR-062 increment 5, semsource ask #2; negative weights gh#441). The fusion
+// ranker folds an entity's strongest boost and strongest demotion together, so
+// a negative weight is a bounded reordering, never an exclusion.
+//
+// Example (demote tests below their impl, both carrying the same doc-comment
+// salience):
+//
+//	Register("code.artifact.test", WithWeight(-1.5))
 func WithWeight(weight float64) Option {
 	return func(m *PredicateMetadata) {
 		m.Weight = weight


### PR DESCRIPTION
## Summary

`fusion.RankSignals.PredicateSalience` was **additive-only**: `entitySalience` took `max` over an entity's predicate weights and the engine added `salienceScale × maxWeight`. Non-negative only, so a consumer could **boost** high-value entities but never **demote** structurally-identifiable noise (tests / generated code / mocks) that carries the *same* salient predicates as the real thing — a `*_test.go` has the same doc-comment salience as its impl, so additive salience can't push the test *below* the impl. (gh#441; semsource ask #14.)

## Fix

Make salience **signed**. `entitySalience` now folds an entity's **strongest boost** (max positive) and **strongest demotion** (min negative) predicate weights and returns their sum (`boost − demotion`). A consumer emits a presence predicate and weights it negative:

```go
vocabulary.Register("code.artifact.test", vocabulary.WithWeight(-1.5))
```

Worked example — impl & test both carry the same `+1.0` doc-comment salience; the test also carries `code.artifact.test` (`-1.5`): impl salience `= +1.0`, test salience `= 1.0 − 1.5 = −0.5`. The gap flips an adjacent impl/test pair → *"the impl, then its tests."*

## Why this shape (vs. the issue's other two directions)

- **No new SPI surface.** semsource already implements `PredicateSalience` and calls `WithWeight` — they just pass a negative. A separate `PredicateDemotion` method would be a *breaking* interface change forcing every implementer to add a method; value-conditioned `PredicateSalience(pred, value)` needs per-value weight storage in the registry, and the tests/generated/mocks case is presence-identifiable so value-conditioning isn't needed.
- **Backward-compatible.** Extremes, not `sum`: all-positive configs (every config today — grepped, zero negatives exist) collapse to the exact old `max` (min-negative stays `0`).
- **Anti-inflation preserved.** `max`/`min` over predicates (not a sum) → dense fact count still can't inflate rank. The reason `entitySalience` used `max` in the first place.
- **Bounded.** Demotion is a secondary reordering via `sort`, never an exclusion.

## Changes

- `pkg/fusion/engine_lens.go` — `entitySalience` signed aggregation (core)
- `pkg/fusion/rank_signals.go` — interface doc: "strictly additive" disambiguated (pipeline-additive vs. directional/signed value)
- `vocabulary/registry.go`, `vocabulary/predicates.go` — `WithWeight` / `Weight` docs: negative = down-rank
- `pkg/fusion/fusionvocab/signals.go` — doc parity note (unchanged pass-through)
- `pkg/fusion/engine_lens_test.go` — 3 new tests: `NegativeSalienceDemotes`, `BoostAndDemotionCompose`, `MaxNotSum_NoFactCountInflation` (empirically load-bearing — fails under a `sum` aggregation)
- `docs/adr/062-deterministic-graph-fusion.md` — increment 7 + reference

## Testing

- `go build ./...`, `go vet`, `gofmt`, `task lint` — clean
- `go test -race ./...` (full unit suite) — green
- Schema drift (`task schema:generate` + `git diff schemas/ specs/`) — none (vocabulary edits are doc-comment only)
- **semstreams-reviewer: APPROVE** — backward-compat held under adversarial checking; anti-inflation guard confirmed load-bearing (temporarily swapped to `sum`, `MaxNotSum` failed as predicted); demotion confirmed bounded/non-excluding

Closes #441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)