### PR TITLE
feat(agentic): read-only execution policy — provable worktree non-mutation for inspect roles (gh#443)

### DIFF
--- a/agentic/exec_policy.go
+++ b/agentic/exec_policy.go
@@ -44,7 +44,22 @@ const MetadataKeyScratchPaths = "agent.exec.scratch_paths"
 const (
 	FilesystemPolicyReadOnly       = "read_only"
 	FilesystemPolicyWorkspaceWrite = "workspace_write"
+	FilesystemPolicyHostWrite      = "host_write" // valid enum; permissive, no v1 enforcement meaning (substrate concern)
 )
+
+// IsKnownFilesystemPolicy reports whether policy is a recognized filesystem
+// enum value. An UNRECOGNIZED non-empty value (a product typo like "readonly")
+// must NOT silently degrade to permissive — for a security control that is a
+// fail-open. Callers fail closed (refuse) + log on an unknown value; the empty
+// string is the back-compat default (workspace_write) and IS known.
+func IsKnownFilesystemPolicy(policy string) bool {
+	switch policy {
+	case "", FilesystemPolicyReadOnly, FilesystemPolicyWorkspaceWrite, FilesystemPolicyHostWrite:
+		return true
+	default:
+		return false
+	}
+}
 
 // DispatchEnforcedMetadataKeys is the set of task-scoped enforcement keys that
 // dispatchToolCall stamps AUTHORITATIVELY (overwrite) from the loop's cached

--- a/agentic/exec_policy.go
+++ b/agentic/exec_policy.go
@@ -1,0 +1,119 @@
+package agentic
+
+// Read-only execution policy (ADR-067, gh#443). A task-scoped filesystem
+// write-scope that flows to write-capable tool executors (v1: bash) via
+// ToolCall.Metadata and is enforced framework-side on every call. The model
+// produces only tool Arguments, never Metadata, and dispatch stamps these keys
+// authoritatively at the shared dispatchToolCall seam — so an inspect role
+// (planner, plan-reviewer) cannot create, modify, or delete product-worktree
+// files even though it has bash for inspection and probes.
+
+// MetadataKeyFilesystemPolicy is the TaskMessage.Metadata / ToolCall.Metadata
+// key under which a task's filesystem write-scope flows to write-capable tool
+// executors (v1: bash). Values are the sandbox-substrate filesystem enum
+// (ADR-052 vocabulary): FilesystemPolicyReadOnly | FilesystemPolicyWorkspaceWrite.
+// Absent/empty == workspace_write (unchanged, back-compat).
+//
+// Under read_only the bash executor enforces a pre+post git worktree-and-HEAD
+// non-mutation proof and returns a typed violation on mutation. The value is
+// model-uncontrollable: stamped by dispatchToolCall as an authoritative
+// overwrite (a framework enforcement fact), never read from tool Arguments.
+//
+// Set by the product's role→policy mapping when spawning an inspect-role loop
+// (role→policy is product-layer; the framework owns the enforcement floor).
+// Per-task, NOT inherited by spawned sub-loops — a product must re-assert it on
+// each spawned inspect child (see ADR-067 §5).
+const MetadataKeyFilesystemPolicy = "agent.exec.filesystem_policy"
+
+// MetadataKeyScratchPaths is the TaskMessage.Metadata / ToolCall.Metadata key
+// under which IN-WORKTREE paths exempt from the read_only proof flow (e.g. a
+// declared ".scratch/" build dir). Out-of-worktree paths (the common case:
+// /tmp) are exempt automatically — git in the worktree never reports them, so
+// probes there are invisible to the proof by construction.
+//
+// []string. Comes back from BaseMessage decode as []any (each element still a
+// Go string); readers coerce on access, like MetadataKeyDecideActionAllowlist.
+// Empty == only out-of-worktree paths are writable.
+const MetadataKeyScratchPaths = "agent.exec.scratch_paths"
+
+// Filesystem policy values. Deliberately match the sandbox-substrate filesystem
+// enum (ADR-052 vocabulary/sandbox: filesystem.read_only / filesystem.workspace_write)
+// so there is ONE filesystem-policy model across the framework and the future
+// substrate. host_write has no v1 meaning here (an environment-level concern the
+// substrate owns).
+const (
+	FilesystemPolicyReadOnly       = "read_only"
+	FilesystemPolicyWorkspaceWrite = "workspace_write"
+)
+
+// DispatchEnforcedMetadataKeys is the set of task-scoped enforcement keys that
+// dispatchToolCall stamps AUTHORITATIVELY (overwrite) from the loop's cached
+// task metadata onto every tool call — so they reach every dispatch path (main,
+// approval re-dispatch, queue dequeue), not just the main-path merge. These are
+// framework enforcement facts; a fill-only merge would let a stray pre-existing
+// value defeat the control. Absent keys stay absent (back-compat).
+//
+// MetadataKeyDecideActionAllowlist is included because it had the identical
+// approval-redispatch gap (an approved decide call silently lost its closed
+// vocabulary) — fixed at the same seam (ADR-067 §2).
+var DispatchEnforcedMetadataKeys = []string{
+	MetadataKeyFilesystemPolicy,
+	MetadataKeyScratchPaths,
+	MetadataKeyDecideActionAllowlist,
+}
+
+// FilesystemPolicyFromMetadata resolves the read-only execution policy from a
+// tool call's metadata. It returns the policy string (FilesystemPolicyReadOnly
+// or "" for the default workspace_write) and the in-worktree scratch-path
+// exemptions. Nil/absent metadata yields ("", nil) — the back-compat default.
+//
+// scratch values arrive from BaseMessage JSON decode as []any (each element a
+// Go string); this coerces them, dropping non-string / empty entries.
+func FilesystemPolicyFromMetadata(m map[string]any) (policy string, scratch []string) {
+	if m == nil {
+		return "", nil
+	}
+	if p, ok := m[MetadataKeyFilesystemPolicy].(string); ok {
+		policy = p
+	}
+	scratch = coerceStringSlice(m[MetadataKeyScratchPaths])
+	return policy, scratch
+}
+
+// IsReadOnlyPolicy reports whether a resolved policy string means read_only.
+func IsReadOnlyPolicy(policy string) bool {
+	return policy == FilesystemPolicyReadOnly
+}
+
+// coerceStringSlice coerces a metadata value into []string. JSON decode lands a
+// list as []any (with string elements); a native []string is also accepted (the
+// in-process spawn path that never round-trips through JSON). Anything else, or
+// a nil, yields nil. Non-string and empty elements are dropped.
+func coerceStringSlice(raw any) []string {
+	switch v := raw.(type) {
+	case []string:
+		out := make([]string, 0, len(v))
+		for _, s := range v {
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, e := range v {
+			if s, ok := e.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		if len(out) == 0 {
+			return nil
+		}
+		return out
+	default:
+		return nil
+	}
+}

--- a/agentic/exec_policy_test.go
+++ b/agentic/exec_policy_test.go
@@ -1,0 +1,122 @@
+package agentic
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestFilesystemPolicyFromMetadata_Coercion covers the accessor's coercion of
+// the scratch list — which arrives as []any after a BaseMessage JSON round-trip
+// but may be a native []string on the in-process spawn path — plus the
+// absent/default cases.
+func TestFilesystemPolicyFromMetadata_Coercion(t *testing.T) {
+	tests := []struct {
+		name        string
+		meta        map[string]any
+		wantPolicy  string
+		wantScratch []string
+	}{
+		{name: "nil metadata", meta: nil, wantPolicy: "", wantScratch: nil},
+		{name: "absent keys", meta: map[string]any{"loop_id": "x"}, wantPolicy: "", wantScratch: nil},
+		{
+			name:       "read_only, no scratch",
+			meta:       map[string]any{MetadataKeyFilesystemPolicy: FilesystemPolicyReadOnly},
+			wantPolicy: FilesystemPolicyReadOnly, wantScratch: nil,
+		},
+		{
+			name: "scratch as []any (post-JSON-decode shape)",
+			meta: map[string]any{
+				MetadataKeyFilesystemPolicy: FilesystemPolicyReadOnly,
+				MetadataKeyScratchPaths:     []any{".scratch", "build/"},
+			},
+			wantPolicy: FilesystemPolicyReadOnly, wantScratch: []string{".scratch", "build/"},
+		},
+		{
+			name: "scratch as native []string (in-process spawn)",
+			meta: map[string]any{
+				MetadataKeyFilesystemPolicy: FilesystemPolicyReadOnly,
+				MetadataKeyScratchPaths:     []string{".scratch"},
+			},
+			wantPolicy: FilesystemPolicyReadOnly, wantScratch: []string{".scratch"},
+		},
+		{
+			name: "scratch drops non-string and empty entries",
+			meta: map[string]any{
+				MetadataKeyScratchPaths: []any{".scratch", "", 42, nil, "ok"},
+			},
+			wantPolicy: "", wantScratch: []string{".scratch", "ok"},
+		},
+		{
+			name:       "workspace_write is not read_only",
+			meta:       map[string]any{MetadataKeyFilesystemPolicy: FilesystemPolicyWorkspaceWrite},
+			wantPolicy: FilesystemPolicyWorkspaceWrite, wantScratch: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPolicy, gotScratch := FilesystemPolicyFromMetadata(tt.meta)
+			if gotPolicy != tt.wantPolicy {
+				t.Errorf("policy = %q, want %q", gotPolicy, tt.wantPolicy)
+			}
+			if !reflect.DeepEqual(gotScratch, tt.wantScratch) {
+				t.Errorf("scratch = %#v, want %#v", gotScratch, tt.wantScratch)
+			}
+			if IsReadOnlyPolicy(gotPolicy) != (tt.wantPolicy == FilesystemPolicyReadOnly) {
+				t.Errorf("IsReadOnlyPolicy(%q) mismatch", gotPolicy)
+			}
+		})
+	}
+}
+
+// TestFilesystemPolicyFromMetadata_JSONRoundTrip proves the accessor reads the
+// policy back correctly after the exact BaseMessage-style JSON round-trip a
+// task's Metadata takes on the wire — the shape ([]any for the scratch list) is
+// what actually reaches a tool executor, not the native []string a test literal
+// might use.
+func TestFilesystemPolicyFromMetadata_JSONRoundTrip(t *testing.T) {
+	orig := map[string]any{
+		MetadataKeyFilesystemPolicy: FilesystemPolicyReadOnly,
+		MetadataKeyScratchPaths:     []string{".scratch", "tmp-build"},
+	}
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Sanity: after decode the slice is []any, not []string — the shape the
+	// accessor must tolerate.
+	if _, ok := decoded[MetadataKeyScratchPaths].([]any); !ok {
+		t.Fatalf("expected []any after JSON decode, got %T", decoded[MetadataKeyScratchPaths])
+	}
+
+	policy, scratch := FilesystemPolicyFromMetadata(decoded)
+	if policy != FilesystemPolicyReadOnly {
+		t.Errorf("policy = %q, want read_only", policy)
+	}
+	if !reflect.DeepEqual(scratch, []string{".scratch", "tmp-build"}) {
+		t.Errorf("scratch = %#v, want [.scratch tmp-build]", scratch)
+	}
+}
+
+// TestDispatchEnforcedMetadataKeys_Membership locks the set that dispatch stamps
+// path-universally: the read-only policy keys AND the decide allowlist (whose
+// approval-redispatch gap is fixed at the same seam, ADR-067 §2).
+func TestDispatchEnforcedMetadataKeys_Membership(t *testing.T) {
+	want := map[string]bool{
+		MetadataKeyFilesystemPolicy:      true,
+		MetadataKeyScratchPaths:          true,
+		MetadataKeyDecideActionAllowlist: true,
+	}
+	if len(DispatchEnforcedMetadataKeys) != len(want) {
+		t.Fatalf("DispatchEnforcedMetadataKeys = %v, want keys %v", DispatchEnforcedMetadataKeys, want)
+	}
+	for _, k := range DispatchEnforcedMetadataKeys {
+		if !want[k] {
+			t.Errorf("unexpected key %q in DispatchEnforcedMetadataKeys", k)
+		}
+	}
+}

--- a/agentic/exec_policy_test.go
+++ b/agentic/exec_policy_test.go
@@ -120,3 +120,18 @@ func TestDispatchEnforcedMetadataKeys_Membership(t *testing.T) {
 		}
 	}
 }
+
+// TestIsKnownFilesystemPolicy locks the recognized enum set — an unknown value
+// must be reported so callers can fail closed instead of silently degrading.
+func TestIsKnownFilesystemPolicy(t *testing.T) {
+	for _, p := range []string{"", FilesystemPolicyReadOnly, FilesystemPolicyWorkspaceWrite, FilesystemPolicyHostWrite} {
+		if !IsKnownFilesystemPolicy(p) {
+			t.Errorf("IsKnownFilesystemPolicy(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"readonly", "read-only", "ro", "workspace", "nonsense"} {
+		if IsKnownFilesystemPolicy(p) {
+			t.Errorf("IsKnownFilesystemPolicy(%q) = true, want false (unrecognized must fail closed)", p)
+		}
+	}
+}

--- a/docs/adr/067-read-only-execution-policy.md
+++ b/docs/adr/067-read-only-execution-policy.md
@@ -1,0 +1,321 @@
+# ADR-067: Read-only execution policy — provable worktree non-mutation for inspect roles
+
+## Status
+
+**Accepted — 2026-07-03.** Scopes gh#443 (SemSpec dogfooding ask: role-scoped
+read-only tool execution). Defines the **framework enforcement seam**; the
+OS-level containment guarantee is explicitly **deferred to the sandbox
+substrate** (ADR-052, still pre-ADR — `docs/proposals/sandbox-substrate.md`).
+v1 is shippable now and does not depend on the gated substrate.
+
+**A pre-Accept adversarial code review revised this ADR:** it refuted the
+original enforcement seam (the main-path metadata merge is NOT universal — the
+approval re-dispatch path dropped the policy) and surfaced three further holes
+(git-state laundering, fill-vs-overwrite direction, spawn non-inheritance). The
+design below is the corrected version; the crux moved to the shared
+`dispatchToolCall` seam. See §Design and §Risks.
+
+## Decision
+
+Add a framework-owned, **task-scoped read-only execution policy**: a well-known
+metadata key (`agent.exec.filesystem_policy = read_only`) plus optional
+in-worktree scratch-path exemptions, **stamped authoritatively onto every tool
+call at the shared `dispatchToolCall` seam** (the same seam that makes `loop_id`
+and the run anchor path-universal) and enforced by the `bash` executor as a
+**pre + post git worktree-and-HEAD non-mutation proof** returning a typed
+violation. The policy rides `Metadata` (never tool `Arguments`) and is stamped by
+the framework, so the **model cannot set or unset it**. A product maps its
+inspect roles (planner, plan-reviewer) → `read_only` when it spawns those loops.
+
+The policy uses the sandbox substrate's own `filesystem.{read_only,
+workspace_write, host_write}` vocabulary and is the **enforcement seam ADR-052's
+substrate later backs with OS-level read-only mounts**. v1 proves *net worktree
+and HEAD non-mutation* via git — honestly scoped below OS-level containment (see
+Non-goals; it is a guard against ordinary and git-state mutation, not against a
+determined agent writing outside the worktree or through a laundering primitive
+the git proof can't observe). It extends the `bash` executor's existing
+`verify_clean` pre-check with the symmetric post-check that gh#443 identifies as
+missing — not a new parallel path.
+
+## Context
+
+### The gap (verified against code)
+
+The framework has **two unconnected notions of "read-only," and SemSpec's need
+sits between them:**
+
+| Model | "Read-only" means | State (verified) |
+|---|---|---|
+| Tool categories (`categories.go` `ReadOnlyCategories()`) | which *tools* — excludes `CategoryInspect`, i.e. no `bash` at all | defined but **unwired** (only its own test references it, `categories.go:98`); all-or-nothing |
+| Sandbox substrate (ADR-052) | FS write-scope on the *environment* (`filesystem.read_only` IRI + admission pre-check) | **pre-ADR, gated, ~5 weeks stale**; no write-prevention, no worktree proof; runner convergence explicitly out of v1 |
+
+gh#443 needs `bash` **on** (planner/reviewer must inspect the repo, `/sources`,
+contracts, and run probes) but its *worktree writes* to be a **typed violation**.
+Neither model expresses that.
+
+The closest real primitive is the `bash` executor's `verify_clean` /
+`read_only_paths` (`executors/bash.go:145-330`): it runs `git status -z
+--porcelain --untracked-files=all` **before** the command and refuses if a dirty
+path matches, returning a typed violation via `formatVerifyCleanViolation`. But —
+exactly as the issue states — it is **pre-command only**: it proves the tree was
+clean *before*, never that the command *left it* unchanged. The missing
+**post-condition** is the heart of #443.
+
+### The enforcement seam — and the trap the review caught
+
+Enforcement must be a property of the *task/role*, resolved framework-side on
+every call, that the model cannot disable. The vehicle is `ToolCall.Metadata`
+("Domain context, propagated from task", `agentic/tools.go:77`) — the model
+produces only `Name`/`Arguments`/`ID` (verified across every model→ToolCall
+decode site in `processor/agentic-model/`; none writes `Metadata`).
+
+**The trap:** the obvious merge — `TaskMessage.Metadata` → each approved call at
+`handlers.go:1096-1110` — is **bound to the main path only** (`GetCachedMetadata`
+has exactly one non-test caller). The **approval re-dispatch** path rebuilds a
+*bare* `ToolCall{ID, Name, Arguments}` (`approval_response_handler.go:114-124`)
+and calls `dispatchToolCall`, which stamps **only** `loop_id`
+(`handlers.go:1338`) and the run anchor (`:1351-1356`) — it never re-merges task
+metadata. So an **approval-gated** `bash` call loses `filesystem_policy` entirely.
+That is reachable and dangerous: the more cautious the operator (bash in the
+approval set, `approval_filter.go:40-46`), the bigger the hole.
+
+The same defect is latent today in `MetadataKeyDecideActionAllowlist`: `decide`
+resolves its allowlist from `call.Metadata` (`decide.go:295`), so an approved
+`decide` call also loses its closed vocabulary. The fix below closes both.
+
+**The correct seam** is `dispatchToolCall` — the comment at `handlers.go:1089-1094`
+literally states `loop_id` was centralized there "so every dispatch path (this
+main path, approval re-dispatch, and queue dequeue) gets it consistently."
+`filesystem_policy` must be stamped at the same seam, and — being a framework
+security fact, not domain context — as an **authoritative overwrite**, exactly
+like the run anchor (`:1351-1356`), not the fill-only merge (a fill-only merge
+would let any pre-existing `Metadata[filesystem_policy]` survive and defeat the
+control).
+
+## Why this shape (and why not the alternatives)
+
+- **Not a per-call tool argument** (today's `verify_clean` boolean). Enforcement
+  the model can omit is not enforcement.
+- **Not the tool-category model.** `ReadOnlyCategories` removes `bash` entirely;
+  #443 needs `bash` present but write-scoped. Orthogonal axis — left untouched.
+- **Not "wait for the sandbox substrate."** ADR-052 is gated, does only
+  *admission* pre-checks, and pushes FS containment onto renderers; it would not
+  unblock SemSpec, who pause local work until this path is accepted.
+- **Reuse the git proof, extend it pre→post.** The typed-violation machinery
+  (`-z` porcelain parse surviving quoted paths, R/C rename-row handling) already
+  exists and is tested. v1 adds the symmetric post-check + HEAD pinning.
+
+## Design
+
+### 1. Policy vocabulary (`agentic` package)
+
+Well-known metadata keys, documented in the `MetadataKey*` house style
+(`Set by / read by / round-trip note / empty = back-compat`):
+
+```go
+// MetadataKeyFilesystemPolicy — a task's filesystem write-scope, flowed to
+// write-capable tool executors (v1: bash). Values are the sandbox-substrate
+// filesystem enum (ADR-052): "read_only" | "workspace_write". Absent/empty ==
+// workspace_write (unchanged, back-compat). Under "read_only" the executor
+// enforces a pre+post git worktree-and-HEAD proof and returns a typed violation
+// on mutation. Model-uncontrollable: stamped by dispatchToolCall (authoritative
+// overwrite), never read from tool Arguments. Set by the product's role→policy
+// mapping when spawning an inspect-role loop.
+const MetadataKeyFilesystemPolicy = "agent.exec.filesystem_policy"
+
+// MetadataKeyScratchPaths — in-worktree paths EXEMPT from the read_only proof
+// (e.g. a declared ".scratch/" build dir). Out-of-worktree paths are exempt
+// automatically (git in the worktree never reports them). []string; comes back
+// from BaseMessage decode as []any (coerce on access, like the decide
+// allowlist). Empty == only out-of-worktree paths are writable.
+const MetadataKeyScratchPaths = "agent.exec.scratch_paths"
+
+const (
+	FilesystemPolicyReadOnly       = "read_only"       // == vocabulary/sandbox filesystem.read_only
+	FilesystemPolicyWorkspaceWrite = "workspace_write" // == filesystem.workspace_write (default)
+)
+```
+
+Values deliberately match the substrate's enum so there is **one**
+filesystem-policy model, not two. `host_write` has no v1 meaning here (an
+environment-level concern the substrate owns).
+
+### 2. The enforcement seam (`dispatchToolCall`)
+
+`dispatchToolCall` resolves `filesystem_policy` + `scratch_paths` from
+`GetCachedMetadata(loopID)` and stamps them onto `tc.Metadata` as an
+**authoritative overwrite**, alongside the existing `loop_id` / run-anchor
+stamps. This makes the policy reach **every** dispatch path — main, approval
+re-dispatch, queue dequeue — and makes it model-proof. The main-path merge at
+`handlers.go:1096-1110` stays for the rest of the domain metadata; the security
+keys are additionally pinned here so they cannot be lost or overridden.
+
+**Bundled fix:** stamp `MetadataKeyDecideActionAllowlist` at the same seam — it
+has the identical approval-redispatch gap today (an approved `decide` call
+silently loses its closed vocabulary). One seam fix, both controls made
+path-universal. (Per the "footgun fix surfaces latent bugs" discipline: the
+surfaced `decide` gap is fixed in the same PR, not deferred.)
+
+### 3. The read_only invariant (`bash` executor)
+
+Under `filesystem_policy = read_only`, the protected worktree must be **clean
+modulo scratch, and on the same HEAD, before AND after** each command:
+
+1. **Pre-capture:** `git status -z --porcelain --untracked-files=all` (dirty set)
+   + `git rev-parse HEAD` (and `@{u}` upstream if present). If any dirty path is
+   **not** under a scratch exemption, **refuse** (an inspect role starts clean; a
+   dirty protected tree at entry is itself an anomaly).
+2. Run the command.
+3. **Post-capture:** same. **Violation** if HEAD moved OR any dirty path is not
+   under a scratch exemption — the command created, modified, formatted,
+   generated, deleted, or committed/reset a protected worktree file.
+
+HEAD pinning catches the common git-state mutations a formatter/generator or an
+over-eager agent might trigger (`git commit`, `git reset --hard`, `git checkout
+<ref>`) that leave the *worktree* clean. It does **not** catch every laundering
+primitive — see Non-goals.
+
+**Violation logic is the COMPLEMENT of `formatVerifyCleanViolation`, not a
+reuse of it.** That function treats its path list as *protected* (match ⇒
+violation; empty ⇒ every dirty path violates). read_only needs the inverse: a
+dirty path violates *unless* it is under scratch (`!pathMatchesAny(path,
+scratchPaths)`). The `pathMatchesAny` *matcher* is reused; a new
+`formatReadOnlyViolation` supplies the inverted logic and names the violating
+paths (auditable facts) with a stable error prefix.
+
+Scratch exemption = `MetadataKeyScratchPaths` (in-worktree) ∪ all out-of-worktree
+paths. The correct invariant is **out-of-worktree**, not "/tmp": `git status` in
+the worktree never reports paths outside it, so probes there are invisible to the
+proof by construction. /tmp is the common case, but a deploy that roots the
+worktree *under* /tmp (test worktrees, `t.TempDir()` → `/private/tmp` on macOS)
+would see writes under `workDir` reported — so the policy documents "out-of-
+worktree," and a product's scratch dirs are declared explicitly.
+
+### 4. Local and remote paths
+
+Both dispatch paths enforce. `verifyCleanLocal` / `verifyCleanRemote` already
+implement the pre-check against the local workdir and the remote runner's
+container; v1 adds their post-check + HEAD-pin twins. **Implementation note:** the
+local `Execute` path today reads `call.Metadata` only inside the `if e.runner !=
+nil` branch (`bash.go:176`); v1 must read the policy on **both** branches (the
+`call.Metadata` map is present on both). Honest scope: the local executor runs on
+the host (only the *worktree* is proven, not the whole host FS; sensitive env is
+already stripped by `filterEnv`); the remote runner runs in the sandbox
+container. True host/OS containment is the substrate.
+
+### 5. Spawn is not inheritance
+
+`filesystem_policy` is **per-task** and does **not** propagate to spawned
+sub-loops (mirroring `decide`'s per-spawn allowlist threading, `decide.go:212`).
+So: (a) a product that spawns inspect sub-loops MUST re-assert `read_only` on each
+child `TaskMessage`; (b) a `read_only` role SHOULD NOT carry child-minting
+orchestration tools (`spawn_agent`, `CategoryOrchestration`) that could mint an
+unpoliced child — otherwise the model routes a write through an unguarded
+grandchild. This is a product-policy constraint the ADR names explicitly; the
+framework cannot infer intended child scope.
+
+## Relationship to existing primitives
+
+- **`ReadOnlyCategories` / `CategoryInspect`** — untouched. That axis is *which
+  tools*; this is *how `bash` writes*. They compose (a role can have `bash`
+  enabled **and** `read_only`). We do not wire/retire the unwired
+  `ReadOnlyCategories` here.
+- **`verify_clean` / `read_only_paths`** — subsumed as the pre-check half; the
+  per-call boolean stays for ad-hoc callers (back-compat).
+- **Sandbox substrate (ADR-052)** — this policy is the enforcement seam it backs.
+  When the substrate ships, `read_only` resolves to an OS-level read-only mount /
+  overlay (which closes the git-laundering and out-of-worktree holes); the git
+  proof remains as defense-in-depth and the local / no-substrate fallback. Same
+  vocabulary; no fork.
+
+## Non-goals (honest scope of the git proof)
+
+From the issue's Non-Ask, plus the holes the review made explicit:
+
+- No SemSpec-specific scheduler, lifecycle, or readiness state machine; no
+  framework ownership of product labels; no gated-DAG change.
+- **No OS-level write *prevention*.** v1 *detects* net mutation and returns a
+  typed violation; it does not stop the write mid-command. Prevention
+  (read-only mounts / overlays / seccomp) is the substrate's job.
+- **git-state laundering is only partially covered.** HEAD pinning catches
+  commit / reset-to-different-ref / checkout-to-different-ref. It does NOT catch:
+  `git clean -fdx` deleting untracked files (incl. scratch), a reset/checkout
+  that lands back on the *same* HEAD with a clean tree, or a mid-command write
+  the command itself deletes before returning. These leave HEAD and the dirty
+  set unchanged; only OS-level observation (the substrate) sees them. An LLM
+  inspect role is unlikely to launder deliberately, but the guarantee is stated
+  honestly, not overstated.
+- **No host-filesystem proof.** A command writing *outside* the worktree on the
+  local host is not caught (the remote runner's container bounds this; the
+  substrate bounds it generally).
+- **No remote-mutation proof.** A `read_only` role that also holds `github_write`
+  or runs `bash git push` can mutate remote state; that is a tool-availability
+  decision (don't give inspect roles remote-write tools), not this policy's scope.
+- **No auto-revert.** v1 reports; it does not undo (surprising side effects; the
+  loop/product decides).
+
+## Consequences
+
+### Positive
+
+- Unblocks SemSpec's planner/reviewer isolation now, without the gated substrate.
+- One filesystem-policy vocabulary across framework and future substrate.
+- Enforcement is structural, model-proof, and **path-universal** (stamped at the
+  shared dispatch seam), and it hardens the `decide` allowlist as a bonus.
+- Extends a tested primitive rather than forking a third read-only model.
+
+### Negative / cost
+
+- The git proof is a *net worktree+HEAD* proof, not write-prevention, with the
+  laundering caveats above. Documented; the substrate closes the gap.
+- Two extra `git status` + two `git rev-parse` per read_only `bash` call. Cheap
+  vs. command runtime; only on read_only tasks.
+
+## Risks
+
+- **Approval-gated bash (the BLOCKING case).** Closed by stamping at
+  `dispatchToolCall`; a regression test must dispatch an *approved* read_only
+  bash call and assert the policy still enforces.
+- **Fill vs. overwrite.** The policy key is stamped as an overwrite; stale
+  comments in `processor/agentic-model/client_wire.go:495,526-529` still assert a
+  carrier lifts into `ToolCall.Metadata` — false today (ADR-051 moved it to
+  `ReasoningRecords`), but a fill-only merge + that regression would be a
+  model-controlled bypass. Update those stale comments in the same PR.
+- **Spawn escape.** Named in §5; the product must re-assert on children and keep
+  child-minting tools off read_only roles.
+- **Scratch over-exemption.** Product-declared; logged in the violation scope
+  string so it is auditable.
+
+## Open questions
+
+1. **Typed `TaskMessage.ExecPolicy` field vs. metadata key.** v1 uses the metadata
+   key (consistent with `loop_id` / `decide` allowlist, zero new propagation
+   wiring). A typed field is a possible future hardening if the policy grows
+   structure.
+2. **Beyond `bash`.** `bash` is the only *local-worktree* write vector today
+   (verified: no `os.WriteFile`/`Create`/`Remove` in `executors/`; other write
+   tools hit GitHub/graph/KV, not the worktree). A future worktree-write tool
+   reads the same policy key.
+
+## Related decisions
+
+- ADR-052 (sandbox substrate, pre-ADR) — the OS-level backing this seam defers to.
+- ADR-051 (reasoning records off Metadata) — why the model cannot reach
+  `ToolCall.Metadata` today; the stale comments to fix.
+- ADR-036 (agent-private observable state) — `write_todos` opacity is per-loop;
+  this is per-task filesystem scope. Different axis.
+- `MetadataKeyDecideActionAllowlist` — the model-uncontrollable-metadata pattern
+  this mirrors, and whose approval-redispatch gap this fixes.
+
+## References
+
+- gh#443 (this ask); SemSpec `docs/upstream/semstreams-asks.md`.
+- `processor/agentic-tools/executors/bash.go` (`verify_clean`,
+  `formatVerifyCleanViolation`, `pathMatchesAny`);
+  `processor/agentic-tools/categories.go` (`ReadOnlyCategories`);
+  `processor/agentic-loop/handlers.go:1323-1367` (`dispatchToolCall` seam),
+  `:1096-1110` (main-path merge); `processor/agentic-loop/approval_response_handler.go:114-124`
+  (bare re-dispatch); `processor/agentic-tools/decide.go:295,522`.
+- `docs/proposals/sandbox-substrate.md` + `-design-exercise.md`
+  (`filesystem.{read_only, workspace_write, host_write}` vocabulary, two-layer
+  admission model).

--- a/docs/adr/067-read-only-execution-policy.md
+++ b/docs/adr/067-read-only-execution-policy.md
@@ -162,9 +162,11 @@ Under `filesystem_policy = read_only`, the protected worktree must be **clean
 modulo scratch, and on the same HEAD, before AND after** each command:
 
 1. **Pre-capture:** `git status -z --porcelain --untracked-files=all` (dirty set)
-   + `git rev-parse HEAD` (and `@{u}` upstream if present). If any dirty path is
-   **not** under a scratch exemption, **refuse** (an inspect role starts clean; a
-   dirty protected tree at entry is itself an anomaly).
+   + `git rev-parse HEAD`. If any dirty path is **not** under a scratch exemption,
+   **refuse** (an inspect role starts clean; a dirty protected tree at entry is
+   itself an anomaly). (The proof pins the worktree and HEAD only; remote-tracking
+   refs like `@{u}` are out of scope — moving one via `git fetch` is a documented
+   no-remote-mutation non-goal below.)
 2. Run the command.
 3. **Post-capture:** same. **Violation** if HEAD moved OR any dirty path is not
    under a scratch exemption — the command created, modified, formatted,
@@ -240,11 +242,12 @@ From the issue's Non-Ask, plus the holes the review made explicit:
 - **git-state laundering is only partially covered.** HEAD pinning catches
   commit / reset-to-different-ref / checkout-to-different-ref. It does NOT catch:
   `git clean -fdx` deleting untracked files (incl. scratch), a reset/checkout
-  that lands back on the *same* HEAD with a clean tree, or a mid-command write
-  the command itself deletes before returning. These leave HEAD and the dirty
-  set unchanged; only OS-level observation (the substrate) sees them. An LLM
-  inspect role is unlikely to launder deliberately, but the guarantee is stated
-  honestly, not overstated.
+  that lands back on the *same* HEAD with a clean tree, a mid-command write the
+  command itself deletes before returning, or a **backgrounded/detached** write
+  (`(sleep 1; echo x > f) &`) that lands after the post-capture. These leave HEAD
+  and the dirty set unchanged at capture time; only OS-level observation (the
+  substrate) sees them. An LLM inspect role is unlikely to launder deliberately,
+  but the guarantee is stated honestly, not overstated.
 - **No host-filesystem proof.** A command writing *outside* the worktree on the
   local host is not caught (the remote runner's container bounds this; the
   substrate bounds it generally).

--- a/processor/agentic-loop/exec_policy_dispatch_test.go
+++ b/processor/agentic-loop/exec_policy_dispatch_test.go
@@ -1,0 +1,161 @@
+package agenticloop_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/c360studio/semstreams/agentic"
+	agenticloop "github.com/c360studio/semstreams/processor/agentic-loop"
+)
+
+// gateCallWithMetadata drives a loop carrying task Metadata to
+// awaiting_approval on a tool call, so an approval-response test can prove what
+// the RE-DISPATCH (bare-ToolCall) path stamps. Mirrors gateLoopAtCall but seeds
+// TaskMessage.Metadata (cached at loop start) — the enforcement policy lives there.
+func gateCallWithMetadata(t *testing.T, handler *agenticloop.MessageHandler, callID, toolName string, args, meta map[string]any) string {
+	t.Helper()
+	ctx := context.Background()
+
+	taskResult, err := handler.HandleTask(ctx, agenticloop.TaskMessage{
+		TaskID:   "task-" + callID,
+		Role:     "planner",
+		Model:    "qwen-32b",
+		Prompt:   "inspect the repo",
+		Metadata: meta,
+	})
+	if err != nil {
+		t.Fatalf("HandleTask: %v", err)
+	}
+	loopID := taskResult.LoopID
+
+	if _, err = handler.HandleModelResponse(ctx, loopID, agentic.AgentResponse{
+		RequestID: "req-" + callID,
+		Status:    "tool_call",
+		Message: agentic.ChatMessage{
+			Role: "assistant",
+			ToolCalls: []agentic.ToolCall{
+				{ID: callID, Name: toolName, Arguments: args},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("HandleModelResponse: %v", err)
+	}
+
+	gateRes, err := handler.HandleToolResult(ctx, loopID, agentic.ToolResult{
+		CallID: callID,
+		Name:   toolName,
+		Error:  agentic.ApprovalRequiredPrefix + "needs human review",
+	})
+	if err != nil {
+		t.Fatalf("HandleToolResult (gate): %v", err)
+	}
+	if gateRes.State != agentic.LoopStateAwaitingApproval {
+		t.Fatalf("loop state = %s, want awaiting_approval", gateRes.State)
+	}
+	return loopID
+}
+
+// TestApprovedBashCall_CarriesFilesystemPolicy is the ADR-067 BLOCKING
+// regression guard: an APPROVED (re-dispatched) bash call must still carry the
+// read-only policy. The approval path rebuilds a bare ToolCall with no Metadata
+// and dispatches via dispatchToolCall — before ADR-067 that path dropped
+// filesystem_policy, silently disabling read-only enforcement exactly when the
+// operator was most cautious (bash in the approval set). The fix stamps the
+// policy at the shared dispatchToolCall seam, so it survives re-dispatch.
+func TestApprovedBashCall_CarriesFilesystemPolicy(t *testing.T) {
+	handler := agenticloop.NewMessageHandler(createTestConfig())
+	loopID := gateCallWithMetadata(t, handler, "call-ro", "bash", map[string]any{"command": "ls"}, map[string]any{
+		agentic.MetadataKeyFilesystemPolicy: agentic.FilesystemPolicyReadOnly,
+		agentic.MetadataKeyScratchPaths:     []string{".probe"},
+	})
+
+	result, err := handler.HandleApprovalResponse(context.Background(), agentic.ApprovalResponse{
+		LoopID:     loopID,
+		CallID:     "call-ro",
+		Decision:   agentic.ApprovalDecisionApprove,
+		ApprovedBy: "alice@example.com",
+		DecidedAt:  time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("HandleApprovalResponse: %v", err)
+	}
+
+	var dispatched string
+	for _, msg := range result.PublishedMessages {
+		if strings.HasPrefix(msg.Subject, "tool.execute.") {
+			dispatched = string(msg.Data)
+		}
+	}
+	if dispatched == "" {
+		t.Fatalf("approve path published no tool.execute message")
+	}
+	if !strings.Contains(dispatched, `"agent.exec.filesystem_policy":"read_only"`) {
+		t.Errorf("re-dispatched bash call LOST filesystem_policy (ADR-067 BLOCKING regression): %s", dispatched)
+	}
+	if !strings.Contains(dispatched, `".probe"`) {
+		t.Errorf("re-dispatched bash call lost scratch_paths: %s", dispatched)
+	}
+}
+
+// TestApprovedCall_NoPolicyStampsNothing confirms back-compat: a loop with no
+// read-only policy re-dispatches an approved call with no filesystem_policy key
+// (the stamp is opt-in; absent keys stay absent).
+func TestApprovedCall_NoPolicyStampsNothing(t *testing.T) {
+	handler := agenticloop.NewMessageHandler(createTestConfig())
+	loopID := gateCallWithMetadata(t, handler, "call-plain", "bash", map[string]any{"command": "ls"}, nil)
+
+	result, err := handler.HandleApprovalResponse(context.Background(), agentic.ApprovalResponse{
+		LoopID:     loopID,
+		CallID:     "call-plain",
+		Decision:   agentic.ApprovalDecisionApprove,
+		ApprovedBy: "bob@example.com",
+		DecidedAt:  time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("HandleApprovalResponse: %v", err)
+	}
+
+	for _, msg := range result.PublishedMessages {
+		if strings.HasPrefix(msg.Subject, "tool.execute.") && strings.Contains(string(msg.Data), "filesystem_policy") {
+			t.Errorf("no-policy loop must not stamp filesystem_policy: %s", msg.Data)
+		}
+	}
+}
+
+// TestApprovedDecideCall_CarriesActionAllowlist guards the latent bug ADR-067
+// fixes as a bonus (same seam): before the fix, an APPROVED decide call lost its
+// action_allowlist on re-dispatch, silently reopening the closed action
+// vocabulary the allowlist exists to enforce. The dispatchToolCall stamp closes
+// it for the whole DispatchEnforcedMetadataKeys set, decide included.
+func TestApprovedDecideCall_CarriesActionAllowlist(t *testing.T) {
+	handler := agenticloop.NewMessageHandler(createTestConfig())
+	loopID := gateCallWithMetadata(t, handler, "call-dec", "decide",
+		map[string]any{"action": "handoff"},
+		map[string]any{agentic.MetadataKeyDecideActionAllowlist: []string{"handoff", "escalate"}})
+
+	result, err := handler.HandleApprovalResponse(context.Background(), agentic.ApprovalResponse{
+		LoopID:     loopID,
+		CallID:     "call-dec",
+		Decision:   agentic.ApprovalDecisionApprove,
+		ApprovedBy: "carol@example.com",
+		DecidedAt:  time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("HandleApprovalResponse: %v", err)
+	}
+
+	var dispatched string
+	for _, msg := range result.PublishedMessages {
+		if strings.HasPrefix(msg.Subject, "tool.execute.") {
+			dispatched = string(msg.Data)
+		}
+	}
+	if dispatched == "" {
+		t.Fatalf("approve path published no tool.execute message")
+	}
+	if !strings.Contains(dispatched, agentic.MetadataKeyDecideActionAllowlist) {
+		t.Errorf("re-dispatched decide call LOST action_allowlist (latent gap ADR-067 fixes): %s", dispatched)
+	}
+}

--- a/processor/agentic-loop/handlers.go
+++ b/processor/agentic-loop/handlers.go
@@ -1355,6 +1355,22 @@ func (h *MessageHandler) dispatchToolCall(result *HandlerResult, loopID string, 
 		}
 	}
 
+	// Stamp task-scoped ENFORCEMENT metadata (ADR-067) authoritatively from the
+	// loop's cached task metadata, so it reaches EVERY dispatch path — this main
+	// path, approval re-dispatch (which rebuilds a bare ToolCall,
+	// approval_response_handler.go), and queue dequeue — not just the fill-only
+	// merge in handleToolCallResponse. These are framework enforcement facts (the
+	// read-only execution policy; the decide action allowlist), so dispatch
+	// OVERWRITES rather than yielding: a fill-only merge would let a stray
+	// pre-existing value defeat the control. Absent keys stay absent (back-compat).
+	if cached := h.loopManager.GetCachedMetadata(loopID); len(cached) > 0 {
+		for _, key := range agentic.DispatchEnforcedMetadataKeys {
+			if v, ok := cached[key]; ok {
+				tc.Metadata[key] = v
+			}
+		}
+	}
+
 	toolMsg := message.NewBaseMessage(tc.Schema(), &tc, "agentic-loop")
 	toolData, err := json.Marshal(toolMsg)
 	if err != nil {

--- a/processor/agentic-model/client_wire.go
+++ b/processor/agentic-model/client_wire.go
@@ -492,7 +492,10 @@ func isRateLimitedAny(err error) bool {
 // readC360ThoughtSignature reads the framework-internal carrier key
 // from a wire.ToolCall.Extras. Returns "" if absent or non-string.
 // Called by convertWireResponse to lift the signature into
-// agentic.ToolCall.Metadata for cross-turn propagation.
+// Message.ReasoningRecords (ADR-051) for cross-turn propagation — NOT
+// ToolCall.Metadata. The model must never reach ToolCall.Metadata; it
+// carries framework enforcement facts (e.g. the read-only exec policy,
+// ADR-067) that dispatch stamps authoritatively.
 func readC360ThoughtSignature(tc wire.ToolCall) string {
 	raw, ok := tc.Extras[wireKeyC360ThoughtSignature]
 	if !ok {
@@ -523,10 +526,10 @@ func stripC360KeysFromRequest(req *wire.ChatCompletionRequest) {
 
 // stripC360KeysFromResponse removes the framework-internal carrier key
 // from a wire response after convertWireResponse has lifted its values
-// into agentic.Metadata. Keeps the response object clean for downstream
-// trace exports / debug logs — the canonical representation of a
-// processed Gemini response is "no extra_content, no carrier; signature
-// lives only in agentic.ToolCall.Metadata."
+// into Message.ReasoningRecords (ADR-051). Keeps the response object clean
+// for downstream trace exports / debug logs — the canonical representation
+// of a processed Gemini response is "no extra_content, no carrier; signature
+// lives only in Message.ReasoningRecords."
 func stripC360KeysFromResponse(resp *wire.ChatCompletionResponse) {
 	if resp == nil {
 		return

--- a/processor/agentic-tools/executors/bash.go
+++ b/processor/agentic-tools/executors/bash.go
@@ -171,21 +171,28 @@ func (e *BashExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agen
 	readOnlyPaths := stringSliceArg(call.Arguments["read_only_paths"])
 	verifyClean, _ := call.Arguments["verify_clean"].(bool)
 
+	// ADR-067 read-only execution policy: a task-scoped, model-uncontrollable
+	// filesystem write-scope stamped onto call.Metadata by dispatch. Under
+	// read_only the command must leave the worktree AND git HEAD unchanged
+	// (modulo declared scratch paths); a mutation is a typed violation. Distinct
+	// from the per-call verify_clean argument (which the model sets and which is
+	// pre-only) — this rides Metadata and is pre+post.
+	roPolicy, scratch := agentic.FilesystemPolicyFromMetadata(call.Metadata)
+	readOnly := agentic.IsReadOnlyPolicy(roPolicy)
+	taskID := bashTaskID(call)
+
 	if e.runner != nil {
-		taskID := "default"
-		if m := call.Metadata; m != nil {
-			if tid, ok := m["task_id"].(string); ok && tid != "" {
-				taskID = tid
-			} else if lid, ok := m["loop_id"].(string); ok && lid != "" {
-				taskID = lid
-			}
-		}
 		if verifyClean {
 			if violation, err := e.verifyCleanRemote(ctx, taskID, readOnlyPaths); err != nil {
 				return agentic.ToolResult{CallID: call.ID, Error: fmt.Sprintf("verify_clean precondition failed: %v", err)}, nil
 			} else if violation != "" {
 				return agentic.ToolResult{CallID: call.ID, Error: violation}, nil
 			}
+		}
+		if readOnly {
+			return e.execReadOnly(call.ID,
+				func() (worktreeSnapshot, error) { return e.captureRemote(ctx, taskID, scratch) },
+				func() (agentic.ToolResult, error) { return e.execRemote(ctx, call.ID, command, taskID) })
 		}
 		return e.execRemote(ctx, call.ID, command, taskID)
 	}
@@ -197,7 +204,26 @@ func (e *BashExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agen
 			return agentic.ToolResult{CallID: call.ID, Error: violation}, nil
 		}
 	}
+	if readOnly {
+		return e.execReadOnly(call.ID,
+			func() (worktreeSnapshot, error) { return e.captureLocal(ctx, scratch) },
+			func() (agentic.ToolResult, error) { return e.execLocal(ctx, call.ID, command) })
+	}
 	return e.execLocal(ctx, call.ID, command)
+}
+
+// bashTaskID resolves the sandbox worktree key from a call's metadata:
+// task_id, then loop_id, else "default". Stamped by dispatch, not the model.
+func bashTaskID(call agentic.ToolCall) string {
+	taskID := "default"
+	if m := call.Metadata; m != nil {
+		if tid, ok := m["task_id"].(string); ok && tid != "" {
+			taskID = tid
+		} else if lid, ok := m["loop_id"].(string); ok && lid != "" {
+			taskID = lid
+		}
+	}
+	return taskID
 }
 
 // stringSliceArg coerces a tool-call argument into []string. Tool arguments
@@ -284,28 +310,7 @@ func (e *BashExecutor) verifyCleanLocal(ctx context.Context, readOnlyPaths []str
 // source record by tracking pending.
 func formatVerifyCleanViolation(porcelainZ string, readOnlyPaths []string) string {
 	var dirty []string
-	skipNext := false
-	for record := range strings.SplitSeq(porcelainZ, "\x00") {
-		if skipNext {
-			skipNext = false
-			continue
-		}
-		// `XY <path>` — minimum 4 chars (status + space + at least one
-		// path char). Empty trailing record from the final NUL is dropped
-		// by the length check.
-		if len(record) < 4 {
-			continue
-		}
-		path := record[3:]
-		if path == "" {
-			continue
-		}
-		// R/C in either stage byte means a source-record follows. Skip
-		// it; we only score the destination (the path the next command
-		// would touch).
-		if record[0] == 'R' || record[0] == 'C' || record[1] == 'R' || record[1] == 'C' {
-			skipNext = true
-		}
+	for _, path := range parsePorcelainZ(porcelainZ) {
 		if pathMatchesAny(path, readOnlyPaths) {
 			dirty = append(dirty, path)
 		}
@@ -319,6 +324,187 @@ func formatVerifyCleanViolation(porcelainZ string, readOnlyPaths []string) strin
 	}
 	return fmt.Sprintf("verify_clean: tree has uncommitted changes in %s — refusing to run command. Dirty paths: %s",
 		scope, strings.Join(dirty, ", "))
+}
+
+// parsePorcelainZ extracts the destination paths from `git status -z --porcelain
+// --untracked-files=all` output — the paths the next command would touch.
+//
+// `-z` format is NUL-terminated `XY <path>\x00` records with NO quoting
+// regardless of git's core.quotePath setting, so paths with spaces, quotes,
+// backslashes, or non-ASCII survive intact (default porcelain-v1 would QUOTE
+// them, and a naive parser would then mis-match the quote-included string). Using
+// `-z` is the cleanest defence; we never have to know which quoting is in effect.
+//
+// Rename/copy rows (`R`/`C` in either stage byte) emit TWO records: destination
+// first, then source. We take the destination (what the command touched) and skip
+// the trailing source via the pending flag.
+func parsePorcelainZ(porcelainZ string) []string {
+	var paths []string
+	skipNext := false
+	for record := range strings.SplitSeq(porcelainZ, "\x00") {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		// `XY <path>` — minimum 4 chars (status + space + ≥1 path char). The
+		// empty trailing record from the final NUL is dropped by this check.
+		if len(record) < 4 {
+			continue
+		}
+		path := record[3:]
+		if path == "" {
+			continue
+		}
+		if record[0] == 'R' || record[0] == 'C' || record[1] == 'R' || record[1] == 'C' {
+			skipNext = true
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+// worktreeSnapshot is the read_only proof state (ADR-067): the current git HEAD
+// sha plus the dirty paths NOT under a scratch exemption. Two snapshots taken
+// before and after a command, both with an empty dirtyPaths and an equal head,
+// prove net worktree-and-HEAD non-mutation.
+type worktreeSnapshot struct {
+	head       string   // `git rev-parse HEAD`
+	dirtyPaths []string // dirty destination paths not exempted by scratch
+}
+
+// execReadOnly runs a command under the read_only policy: capture pre-state,
+// refuse if the protected tree is already dirty, run, capture post-state, and
+// return a typed violation if HEAD moved or any protected path was mutated.
+// capture is the local- or remote-specific state reader; run executes the
+// command. Fail-closed: a capture error (can't prove non-mutation) is an error
+// result, not a pass.
+func (e *BashExecutor) execReadOnly(callID string, capture func() (worktreeSnapshot, error), run func() (agentic.ToolResult, error)) (agentic.ToolResult, error) {
+	pre, err := capture()
+	if err != nil {
+		return agentic.ToolResult{CallID: callID, Error: fmt.Sprintf("read_only precondition check failed: %v", err)}, nil
+	}
+	if len(pre.dirtyPaths) > 0 {
+		return agentic.ToolResult{CallID: callID, Error: fmt.Sprintf(
+			"read_only: protected worktree is not clean before the command (modulo scratch) — refusing. Dirty paths: %s",
+			strings.Join(pre.dirtyPaths, ", "))}, nil
+	}
+	res, err := run()
+	if err != nil {
+		return res, err
+	}
+	post, perr := capture()
+	if perr != nil {
+		return agentic.ToolResult{CallID: callID, Error: fmt.Sprintf("read_only post-condition check failed: %v", perr)}, nil
+	}
+	if violation := readOnlyViolation(pre, post); violation != "" {
+		return agentic.ToolResult{CallID: callID, Error: violation}, nil
+	}
+	return res, nil
+}
+
+// readOnlyViolation compares pre/post snapshots and returns a typed violation
+// message (or "" when the command left the worktree and HEAD unchanged). HEAD
+// pinning catches git-state mutations (commit / reset / checkout to a different
+// ref) that leave the worktree clean; the dirty-path check catches direct
+// create/modify/delete of protected files.
+func readOnlyViolation(pre, post worktreeSnapshot) string {
+	if pre.head != post.head {
+		return fmt.Sprintf("read_only: command moved git HEAD (%s → %s) — worktree state mutated via git", pre.head, post.head)
+	}
+	if len(post.dirtyPaths) > 0 {
+		return fmt.Sprintf("read_only: command mutated protected worktree paths: %s", strings.Join(post.dirtyPaths, ", "))
+	}
+	return ""
+}
+
+// dirtyNonScratch returns the dirty destination paths NOT exempted by scratch.
+// Unlike verify_clean's pathMatchesAny (empty list ⇒ matches everything), an
+// empty scratch list here exempts NOTHING, so every dirty path is a violation —
+// scratch is an opt-in write allowance, not a default-open one.
+func dirtyNonScratch(porcelainZ string, scratch []string) []string {
+	var dirty []string
+	for _, path := range parsePorcelainZ(porcelainZ) {
+		if !pathUnderScratch(path, scratch) {
+			dirty = append(dirty, path)
+		}
+	}
+	return dirty
+}
+
+// pathUnderScratch reports whether path is equal to or under one of the scratch
+// patterns (trailing-slash tolerant). Empty scratch matches nothing.
+func pathUnderScratch(path string, scratch []string) bool {
+	for _, pat := range scratch {
+		pat = strings.TrimRight(pat, "/")
+		if pat == "" {
+			continue
+		}
+		if path == pat || strings.HasPrefix(path, pat+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// captureLocal reads the read_only proof state from the local workdir.
+func (e *BashExecutor) captureLocal(ctx context.Context, scratch []string) (worktreeSnapshot, error) {
+	status, err := e.gitLocal(ctx, "status", "-z", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return worktreeSnapshot{}, err
+	}
+	head, err := e.gitLocal(ctx, "rev-parse", "HEAD")
+	if err != nil {
+		return worktreeSnapshot{}, err
+	}
+	return worktreeSnapshot{head: strings.TrimSpace(head), dirtyPaths: dirtyNonScratch(status, scratch)}, nil
+}
+
+// gitLocal runs a git subcommand in the workdir with sensitive env stripped and
+// returns stdout. A non-zero exit is surfaced with git's stderr.
+func (e *BashExecutor) gitLocal(ctx context.Context, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, e.effectiveTimeout())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = e.workDir
+	cmd.Env = filterEnv()
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return "", fmt.Errorf("git %s exited %d: %s", strings.Join(args, " "), exitErr.ExitCode(), strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return string(out), nil
+}
+
+// captureRemote reads the read_only proof state from the runner's container.
+func (e *BashExecutor) captureRemote(ctx context.Context, taskID string, scratch []string) (worktreeSnapshot, error) {
+	status, err := e.gitRemote(ctx, taskID, "git status -z --porcelain --untracked-files=all")
+	if err != nil {
+		return worktreeSnapshot{}, err
+	}
+	head, err := e.gitRemote(ctx, taskID, "git rev-parse HEAD")
+	if err != nil {
+		return worktreeSnapshot{}, err
+	}
+	return worktreeSnapshot{head: strings.TrimSpace(head), dirtyPaths: dirtyNonScratch(status, scratch)}, nil
+}
+
+// gitRemote runs a git command inside the runner's taskID worktree and returns
+// stdout, surfacing timeout and non-zero exit as errors (fail-closed).
+func (e *BashExecutor) gitRemote(ctx context.Context, taskID, command string) (string, error) {
+	res, err := e.runner.Exec(ctx, taskID, command, int(e.effectiveTimeout().Milliseconds()))
+	if err != nil {
+		return "", err
+	}
+	if res.TimedOut {
+		return "", fmt.Errorf("%s timed out", command)
+	}
+	if res.ExitCode != 0 {
+		return "", fmt.Errorf("%s exited %d: %s", command, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return res.Stdout, nil
 }
 
 // pathMatchesAny returns true when path equals one of patterns or sits

--- a/processor/agentic-tools/executors/bash.go
+++ b/processor/agentic-tools/executors/bash.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"strings"
@@ -178,6 +179,18 @@ func (e *BashExecutor) Execute(ctx context.Context, call agentic.ToolCall) (agen
 	// from the per-call verify_clean argument (which the model sets and which is
 	// pre-only) — this rides Metadata and is pre+post.
 	roPolicy, scratch := agentic.FilesystemPolicyFromMetadata(call.Metadata)
+	// Fail CLOSED on an unrecognized policy value: a product typo (e.g.
+	// "readonly") must not silently degrade to permissive execution — for a
+	// security control that is a fail-open, the exact class this guard exists to
+	// prevent. Loud (Warn + typed refusal naming the bad value) so the misconfig
+	// surfaces instead of a role silently running unsandboxed. Known-but-permissive
+	// values (workspace_write, host_write) fall through to normal execution.
+	if !agentic.IsKnownFilesystemPolicy(roPolicy) {
+		slog.Warn("bash: unrecognized filesystem_policy — refusing (fail-closed)", "policy", roPolicy)
+		return agentic.ToolResult{CallID: call.ID, Error: fmt.Sprintf(
+			"filesystem_policy %q is not recognized — refusing (fail-closed). Expected %q or %q.",
+			roPolicy, agentic.FilesystemPolicyReadOnly, agentic.FilesystemPolicyWorkspaceWrite)}, nil
+	}
 	readOnly := agentic.IsReadOnlyPolicy(roPolicy)
 	taskID := bashTaskID(call)
 
@@ -388,6 +401,11 @@ func (e *BashExecutor) execReadOnly(callID string, capture func() (worktreeSnaps
 			"read_only: protected worktree is not clean before the command (modulo scratch) — refusing. Dirty paths: %s",
 			strings.Join(pre.dirtyPaths, ", "))}, nil
 	}
+	// run must never return a non-nil error AFTER a possibly-mutating command:
+	// execLocal/execRemote encode command failure in ToolResult.Error and always
+	// return a nil error, so the post-check below always runs (even on a non-zero
+	// exit that mutated). A future run closure that could return a non-nil error
+	// after a partial mutation would skip the proof — keep that invariant.
 	res, err := run()
 	if err != nil {
 		return res, err

--- a/processor/agentic-tools/executors/bash_test.go
+++ b/processor/agentic-tools/executors/bash_test.go
@@ -776,3 +776,40 @@ func TestBashExecutor_ReadOnly_RemoteWriteViolation(t *testing.T) {
 	assert.Contains(t, res.Error, "mutated protected worktree paths")
 	assert.Contains(t, res.Error, "out.txt")
 }
+
+// TestBashExecutor_ReadOnly_UnrecognizedPolicyFailsClosed: an unrecognized
+// filesystem_policy value (a product typo) must REFUSE, not silently run
+// unsandboxed — fail-closed on a security control (semstreams-reviewer MEDIUM).
+func TestBashExecutor_ReadOnly_UnrecognizedPolicyFailsClosed(t *testing.T) {
+	dir := initTempGitRepo(t)
+	e := NewBashExecutor(dir, "")
+	sentinel := filepath.Join(dir, "ran")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "ro-typo", Name: "bash",
+		Arguments: map[string]any{"command": "touch " + sentinel},
+		Metadata:  map[string]any{agentic.MetadataKeyFilesystemPolicy: "readonly"}, // typo
+	})
+	require.NoError(t, err)
+	assert.Contains(t, res.Error, "not recognized")
+	assert.Contains(t, res.Error, "readonly")
+	if _, statErr := os.Stat(sentinel); !os.IsNotExist(statErr) {
+		t.Errorf("command must NOT run under an unrecognized policy; sentinel exists: %v", statErr)
+	}
+}
+
+// TestBashExecutor_HostWritePolicyRuns: host_write is a KNOWN (permissive) enum
+// value — it must not be refused as unrecognized, and does not guard writes.
+func TestBashExecutor_HostWritePolicyRuns(t *testing.T) {
+	dir := initTempGitRepo(t)
+	e := NewBashExecutor(dir, "")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "hw", Name: "bash",
+		Arguments: map[string]any{"command": "echo x > wrote.go && echo done"},
+		Metadata:  map[string]any{agentic.MetadataKeyFilesystemPolicy: agentic.FilesystemPolicyHostWrite},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, res.Error, "host_write is permissive; must not refuse or guard")
+	assert.Contains(t, res.Content, "done")
+}

--- a/processor/agentic-tools/executors/bash_test.go
+++ b/processor/agentic-tools/executors/bash_test.go
@@ -583,3 +583,196 @@ func TestBashExecutor_VerifyClean_SandboxAllowsClean(t *testing.T) {
 	assert.Contains(t, (*calls)[0].command, "git status")
 	assert.Equal(t, "echo ran", (*calls)[1].command)
 }
+
+// --- ADR-067 read-only execution policy (gh#443) -------------------------------
+
+// readOnlyMeta builds the task-scoped metadata that dispatch stamps for a
+// read_only inspect role: the policy plus optional in-worktree scratch
+// exemptions. The model never sets these — they ride Metadata, not Arguments.
+func readOnlyMeta(scratch ...string) map[string]any {
+	m := map[string]any{agentic.MetadataKeyFilesystemPolicy: agentic.FilesystemPolicyReadOnly}
+	if len(scratch) > 0 {
+		m[agentic.MetadataKeyScratchPaths] = scratch
+	}
+	return m
+}
+
+// TestBashExecutor_ReadOnly_CleanCommandPasses: an inspection command that
+// leaves the worktree and HEAD unchanged runs normally under read_only.
+func TestBashExecutor_ReadOnly_CleanCommandPasses(t *testing.T) {
+	dir := initTempGitRepo(t)
+	e := NewBashExecutor(dir, "")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "ro-clean", Name: "bash",
+		Arguments: map[string]any{"command": "cat seed.txt && echo inspected"},
+		Metadata:  readOnlyMeta(),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, res.Error, "read-only inspection must pass")
+	assert.Contains(t, res.Content, "inspected")
+}
+
+// TestBashExecutor_ReadOnly_WorktreeWriteViolation: creating a product-worktree
+// file is a typed violation naming the path — the core gh#443 guarantee the
+// pre-only verify_clean could not provide.
+func TestBashExecutor_ReadOnly_WorktreeWriteViolation(t *testing.T) {
+	dir := initTempGitRepo(t)
+	e := NewBashExecutor(dir, "")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "ro-write", Name: "bash",
+		Arguments: map[string]any{"command": "echo generated > product.go"},
+		Metadata:  readOnlyMeta(),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, res.Error, "mutated protected worktree paths")
+	assert.Contains(t, res.Error, "product.go")
+}
+
+// TestBashExecutor_ReadOnly_DeleteTrackedViolation: deleting a tracked file is
+// caught (git reports ` D path`).
+func TestBashExecutor_ReadOnly_DeleteTrackedViolation(t *testing.T) {
+	dir := initTempGitRepo(t)
+	e := NewBashExecutor(dir, "")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "ro-del", Name: "bash",
+		Arguments: map[string]any{"command": "rm seed.txt"},
+		Metadata:  readOnlyMeta(),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, res.Error, "mutated protected worktree paths")
+	assert.Contains(t, res.Error, "seed.txt")
+}
+
+// TestBashExecutor_ReadOnly_ScratchWriteAllowed: a write UNDER a declared
+// in-worktree scratch path is exempt; the command passes.
+func TestBashExecutor_ReadOnly_ScratchWriteAllowed(t *testing.T) {
+	dir := initTempGitRepo(t)
+	e := NewBashExecutor(dir, "")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "ro-scratch", Name: "bash",
+		Arguments: map[string]any{"command": "mkdir -p .probe && echo x > .probe/out.txt && echo done"},
+		Metadata:  readOnlyMeta(".probe"),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, res.Error, "write under declared scratch must be allowed; got %q", res.Error)
+	assert.Contains(t, res.Content, "done")
+}
+
+// TestBashExecutor_ReadOnly_TmpProbeAllowed: a write to /tmp (out-of-worktree)
+// is invisible to the worktree proof — probes there are always allowed, with no
+// scratch declaration needed.
+func TestBashExecutor_ReadOnly_TmpProbeAllowed(t *testing.T) {
+	dir := initTempGitRepo(t)
+	e := NewBashExecutor(dir, "")
+	probe := filepath.Join(t.TempDir(), "probe.txt") // outside the worktree
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "ro-tmp", Name: "bash",
+		Arguments: map[string]any{"command": "echo probing > " + probe + " && echo probed"},
+		Metadata:  readOnlyMeta(),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, res.Error, "out-of-worktree probe must be allowed; got %q", res.Error)
+	assert.Contains(t, res.Content, "probed")
+}
+
+// TestBashExecutor_ReadOnly_HeadMoveViolation: a git-state mutation that leaves
+// the worktree clean (a commit) is caught by HEAD pinning — the hole a
+// status-only proof would miss.
+func TestBashExecutor_ReadOnly_HeadMoveViolation(t *testing.T) {
+	dir := initTempGitRepo(t)
+	e := NewBashExecutor(dir, "")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "ro-head", Name: "bash",
+		Arguments: map[string]any{
+			"command": "git -c user.name=t -c user.email=t@e commit -q --allow-empty -m sneak",
+		},
+		Metadata: readOnlyMeta(),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, res.Error, "moved git HEAD")
+}
+
+// TestBashExecutor_ReadOnly_PreDirtyRefuses: an already-dirty protected tree is
+// refused before the command runs (an inspect role must start clean).
+func TestBashExecutor_ReadOnly_PreDirtyRefuses(t *testing.T) {
+	dir := initTempGitRepo(t, "already/dirty.go")
+	e := NewBashExecutor(dir, "")
+	sentinel := filepath.Join(dir, "command-ran")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "ro-predirty", Name: "bash",
+		Arguments: map[string]any{"command": "touch " + sentinel},
+		Metadata:  readOnlyMeta(),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, res.Error, "not clean before")
+	assert.Contains(t, res.Error, "already/dirty.go")
+	if _, statErr := os.Stat(sentinel); !os.IsNotExist(statErr) {
+		t.Errorf("command must NOT run on a pre-dirty tree; sentinel exists or stat errored: %v", statErr)
+	}
+}
+
+// TestBashExecutor_ReadOnly_DefaultPolicyUnchanged: with no policy (or
+// workspace_write), a worktree write is NOT a violation — back-compat for every
+// non-inspect role.
+func TestBashExecutor_ReadOnly_DefaultPolicyUnchanged(t *testing.T) {
+	dir := initTempGitRepo(t)
+	e := NewBashExecutor(dir, "")
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "rw-write", Name: "bash",
+		Arguments: map[string]any{"command": "echo ok > wrote.go && echo done"},
+		// No filesystem_policy metadata → default workspace_write.
+	})
+	require.NoError(t, err)
+	assert.Empty(t, res.Error, "default policy must not guard worktree writes")
+	assert.Contains(t, res.Content, "done")
+}
+
+// scriptedRunner routes each Exec to a command→result function, letting a test
+// drive the remote read_only path (pre/post captures + the command) without a
+// server. The mutated flag flips the post-command git status to dirty.
+type scriptedRunner struct {
+	fn func(command string) *runner.ExecResult
+}
+
+func (r scriptedRunner) Exec(_ context.Context, _ string, command string, _ int) (*runner.ExecResult, error) {
+	return r.fn(command), nil
+}
+
+// TestBashExecutor_ReadOnly_RemoteWriteViolation: the remote (runner) path
+// enforces read_only too — a post-command dirty status yields the typed
+// violation.
+func TestBashExecutor_ReadOnly_RemoteWriteViolation(t *testing.T) {
+	mutated := false
+	run := scriptedRunner{fn: func(cmd string) *runner.ExecResult {
+		switch {
+		case strings.Contains(cmd, "git status"):
+			if mutated {
+				return &runner.ExecResult{Stdout: "?? out.txt\x00"} // post: dirty
+			}
+			return &runner.ExecResult{Stdout: ""} // pre: clean
+		case strings.Contains(cmd, "git rev-parse"):
+			return &runner.ExecResult{Stdout: "abc123\n"} // HEAD stable
+		default:
+			mutated = true
+			return &runner.ExecResult{Stdout: "did work"}
+		}
+	}}
+	e := NewBashExecutor("", "", WithRunner(run))
+
+	res, err := e.Execute(context.Background(), agentic.ToolCall{
+		ID: "ro-remote", Name: "bash",
+		Arguments: map[string]any{"command": "echo x > out.txt"},
+		Metadata:  readOnlyMeta(),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, res.Error, "mutated protected worktree paths")
+	assert.Contains(t, res.Error, "out.txt")
+}


### PR DESCRIPTION
## Summary

Closes #443 (SemSpec dogfooding ask). SemSpec's planner / plan-reviewer roles must **inspect** the product repo and run probes but must **not mutate** the worktree before an `emit_change` package is accepted. The framework had two unconnected "read-only" models and neither fit:

- **Tool categories** (`ReadOnlyCategories`) — remove `bash` entirely (all-or-nothing; unwired anyway).
- **Sandbox substrate** (ADR-052) — pre-ADR, gated, admission-pre-check-only.

The one close primitive, `bash`'s `verify_clean`, is **pre-command only** — it never proves the command *left* the worktree unchanged. That missing post-condition is the heart of #443.

## What this adds (ADR-067)

A task-scoped, **model-uncontrollable** read-only execution policy:

- `agent.exec.filesystem_policy = read_only` on `TaskMessage.Metadata` + optional in-worktree `scratch_paths`. Values match the sandbox-substrate `filesystem.{read_only,workspace_write}` enum — **one** vocabulary, and this is the enforcement seam the substrate later backs with OS-level mounts.
- **Stamped authoritatively at the shared `dispatchToolCall` seam** (like `loop_id` / the run anchor) so it reaches **every** dispatch path — main, approval re-dispatch, queue dequeue. The model produces only `Arguments`, never `Metadata`, so it cannot disable the policy.
- The `bash` executor enforces a **pre+post git worktree-AND-HEAD** non-mutation proof (HEAD pinning catches `commit`/`reset`/`checkout` that leave the tree clean), returning a typed violation naming the mutated paths. `/tmp` and declared scratch stay writable. Local + remote (runner) paths.

## Bundled fix (same seam, same latent defect)

Approved `decide` calls also **lost their `action_allowlist` on re-dispatch** — the closed action vocabulary silently reopened. `dispatchToolCall` now stamps the whole `DispatchEnforcedMetadataKeys` set. Also fixes stale `client_wire.go` comments claiming a carrier lifts into `ToolCall.Metadata` (ADR-051 moved it to `ReasoningRecords`; the model must never reach `Metadata` now that it carries enforcement facts).

## Adversarial review found & fixed a BLOCKING defect pre-Accept

The first design rested on the main-path metadata merge, which is **not** universal — the **approval re-dispatch** path rebuilds a bare `ToolCall` and dropped the policy, silently disabling read-only enforcement exactly when `bash` is approval-gated (the cautious deployment). Moving the stamp to `dispatchToolCall` closes it. The review also surfaced git-state laundering, fill-vs-overwrite direction, and spawn non-inheritance — all addressed in the ADR + Non-goals. The BLOCKING regression test is **empirically load-bearing** (verified: fails without the `dispatchToolCall` stamp, metadata comes through as `{loop_id}` only).

## Honest scope (deferred to the substrate)

No OS-level write *prevention* (v1 detects net mutation, doesn't block mid-command); `git clean` / same-HEAD laundering and out-of-worktree host writes are not caught; per-task policy is **not inherited** by spawned sub-loops (product re-asserts; keep child-minting tools off read_only roles).

## Files

- `agentic/exec_policy.go` (+test) — vocabulary, typed accessor, `DispatchEnforcedMetadataKeys`
- `processor/agentic-loop/handlers.go` — `dispatchToolCall` authoritative stamp (the crux)
- `processor/agentic-tools/executors/bash.go` (+test) — pre/post HEAD+worktree proof, complement violation logic
- `processor/agentic-loop/exec_policy_dispatch_test.go` — BLOCKING regression + decide guard + back-compat
- `processor/agentic-model/client_wire.go` — stale-comment fix
- `docs/adr/067-read-only-execution-policy.md`

## Testing

- `go build`, `go vet`, `gofmt`, `task lint` — clean
- `go test -race ./...` (full unit suite) — green
- No schema drift (metadata-key + accessor, no new payloads)
- ADR adversarially reviewed pre-Accept; BLOCKING regression test proven load-bearing via stash-revert

Closes #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)