### PR TITLE
feat(rule): first-class publish_agent filesystem_policy + scratch_paths fields (gh#445)

### DIFF
--- a/docs/adr/067-read-only-execution-policy.md
+++ b/docs/adr/067-read-only-execution-policy.md
@@ -300,6 +300,24 @@ From the issue's Non-Ask, plus the holes the review made explicit:
    tools hit GitHub/graph/KV, not the worktree). A future worktree-write tool
    reads the same policy key.
 
+## Rule-authoring surface (gh#445, beta.132)
+
+Rule packs stamp the policy via first-class `publish_agent` fields, NOT product
+`properties` (which skips reserved `agent.*` keys):
+
+```json
+{ "type": "publish_agent", "role": "planner",
+  "filesystem_policy": "read_only", "scratch_paths": [".probe/"] }
+```
+
+`rule.Action.{FilesystemPolicy,ScratchPaths}` stamp `MetadataKeyFilesystemPolicy`
+/ `MetadataKeyScratchPaths` through the same framework-owned path as
+`action_allowlist` / `related_loops` (`stampFilesystemPolicy`). The enum is
+validated at config-load time (`validateActionLists` → `IsKnownFilesystemPolicy`),
+so a typo fails load rather than deferring to the executor's dispatch-time
+fail-closed refusal. This is the rule-layer complement of Open Question #1 (it's
+the *authoring* surface, distinct from the `TaskMessage` transport question).
+
 ## Related decisions
 
 - ADR-052 (sandbox substrate, pre-ADR) — the OS-level backing this seam defers to.

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -234,11 +234,13 @@ type Action struct {
 	// framework-owned path as action_allowlist / related_loops, NOT product
 	// domain metadata (which `properties` skips for reserved agent.* keys).
 	//
-	// Valid values: "read_only" (enforce) | "workspace_write" (default,
-	// permissive). Validated at config-load time (validateActionLists); an
-	// unrecognized value fails load. Empty leaves the loop at workspace_write
-	// (back-compat). Per-task, NOT inherited by spawned sub-loops — re-declare on
-	// each spawned inspect child.
+	// Valid values (the framework filesystem enum, agentic.IsKnownFilesystemPolicy):
+	// "read_only" (enforce) | "workspace_write" (default, permissive) | "host_write"
+	// (also permissive here — an environment-level concern the sandbox substrate
+	// owns; no v1 enforcement effect at the rule layer). Validated at config-load
+	// time (validateActionLists); an unrecognized value fails load. Empty leaves
+	// the loop at workspace_write (back-compat). Per-task, NOT inherited by
+	// spawned sub-loops — re-declare on each spawned inspect child.
 	FilesystemPolicy string `json:"filesystem_policy,omitempty"`
 
 	// ScratchPaths are IN-WORKTREE paths exempt from the read_only proof (e.g.

--- a/processor/rule/actions.go
+++ b/processor/rule/actions.go
@@ -224,6 +224,32 @@ type Action struct {
 	// flows that don't opt in see no Metadata change).
 	RelatedLoops map[string]string `json:"related_loops,omitempty"`
 
+	// FilesystemPolicy is the spawned loop's task-scoped read-only execution
+	// policy (ADR-067, gh#443/gh#445). When non-empty, executePublishAgent
+	// stamps it onto TaskMessage.Metadata under MetadataKeyFilesystemPolicy;
+	// dispatch propagates it authoritatively onto every ToolCall.Metadata, and
+	// the bash executor enforces a pre+post git worktree-and-HEAD non-mutation
+	// proof (returning a typed violation) when the value is "read_only". This is
+	// the rule-authoring surface for the framework enforcement fact — the same
+	// framework-owned path as action_allowlist / related_loops, NOT product
+	// domain metadata (which `properties` skips for reserved agent.* keys).
+	//
+	// Valid values: "read_only" (enforce) | "workspace_write" (default,
+	// permissive). Validated at config-load time (validateActionLists); an
+	// unrecognized value fails load. Empty leaves the loop at workspace_write
+	// (back-compat). Per-task, NOT inherited by spawned sub-loops — re-declare on
+	// each spawned inspect child.
+	FilesystemPolicy string `json:"filesystem_policy,omitempty"`
+
+	// ScratchPaths are IN-WORKTREE paths exempt from the read_only proof (e.g.
+	// ".probe/"). Out-of-worktree paths (/tmp) are exempt automatically. When
+	// non-empty, executePublishAgent stamps them onto TaskMessage.Metadata under
+	// MetadataKeyScratchPaths (as []any for JSON-wire shape, like
+	// action_allowlist). Only meaningful with FilesystemPolicy "read_only".
+	// Static config paths — no variable substitution. Empty means only
+	// out-of-worktree paths are writable.
+	ScratchPaths []string `json:"scratch_paths,omitempty"`
+
 	// RunScope controls agent-run lifecycle management for publish_agent actions (ADR-053 D4).
 	// Three values:
 	//   - "new"     — mint a new AgentRun rooted at the FIRING loop. The spawned task carries
@@ -1255,6 +1281,33 @@ func (e *ActionExecutor) stampAuthorMetadata(task *agentic.TaskMessage, action A
 	}
 }
 
+// stampFilesystemPolicy threads the rule.Action's read-only execution policy
+// (ADR-067) onto the TaskMessage.Metadata under MetadataKeyFilesystemPolicy /
+// MetadataKeyScratchPaths. Mirrors the ActionAllowlist stamping pattern:
+// scratch paths are stored as []any so the JSON round-trip through
+// TaskMessage→agent.task→ToolCall.Metadata preserves shape (the bash executor's
+// FilesystemPolicyFromMetadata coerces back). Empty policy AND empty scratch is
+// a no-op (back-compat). The enum is validated at config-load time
+// (validateActionLists), so a bad value never reaches here.
+func stampFilesystemPolicy(task *agentic.TaskMessage, action Action) {
+	if action.FilesystemPolicy == "" && len(action.ScratchPaths) == 0 {
+		return
+	}
+	if task.Metadata == nil {
+		task.Metadata = map[string]any{}
+	}
+	if action.FilesystemPolicy != "" {
+		task.Metadata[agentic.MetadataKeyFilesystemPolicy] = action.FilesystemPolicy
+	}
+	if len(action.ScratchPaths) > 0 {
+		scratch := make([]any, 0, len(action.ScratchPaths))
+		for _, p := range action.ScratchPaths {
+			scratch = append(scratch, p)
+		}
+		task.Metadata[agentic.MetadataKeyScratchPaths] = scratch
+	}
+}
+
 // stampPerSpawnLLMKnobs threads the rule.Action's per-spawn LLM
 // constraints (ResponseFormat — ADR-034; ToolChoice — ADR-023) onto
 // the TaskMessage. The agentic-loop caches each on initial build and
@@ -1597,6 +1650,10 @@ func (e *ActionExecutor) publishAgentOnce(ctx context.Context, action Action, ec
 	// Per-spawn cross-arc loop-ID lineage. Mirrors the ActionAllowlist
 	// Metadata stamping pattern. See stampRelatedLoops for the why.
 	stampRelatedLoops(&task, action.RelatedLoops, ec, iterVarName, iterVarValue)
+
+	// Per-spawn read-only execution policy (ADR-067, gh#445). Same
+	// framework-owned Metadata path; dispatch propagates it authoritatively.
+	stampFilesystemPolicy(&task, action)
 
 	if e.logger != nil {
 		e.logger.Debug("Triggering agent task",

--- a/processor/rule/actions_test.go
+++ b/processor/rule/actions_test.go
@@ -3504,3 +3504,78 @@ func TestAction_PublishAgent_RunScopeNew_MintsRunSuccessfully(t *testing.T) {
 	_, created := mgr.entities["agent-run"][runEntityID]
 	assert.True(t, created, "Manager.Create must mint the AgentRun entity in 'dispatched' phase")
 }
+
+// TestAction_PublishAgent_FilesystemPolicy verifies that a publish_agent rule's
+// filesystem_policy + scratch_paths thread onto TaskMessage.Metadata under the
+// ADR-067 keys, in the JSON-wire shape the bash executor reads (gh#445). Drives
+// the production path (Execute → BaseMessage → decode) and round-trips through
+// agentic.FilesystemPolicyFromMetadata — the exact accessor the executor uses —
+// so the test proves the rule surface is actually consumable, not just present.
+func TestAction_PublishAgent_FilesystemPolicy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:             ActionTypePublishAgent,
+		Subject:          "agent.task.planner",
+		Role:             "planner",
+		Model:            "mock-model",
+		Prompt:           "inspect the repo",
+		FilesystemPolicy: "read_only",
+		ScratchPaths:     []string{".probe/", "build"},
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	require.NotNil(t, task.Metadata, "Metadata must be initialised when filesystem_policy is set")
+	assert.Equal(t, "read_only", task.Metadata[agentic.MetadataKeyFilesystemPolicy])
+	// scratch_paths survive the JSON round-trip as []any (each element a string).
+	rawScratch, ok := task.Metadata[agentic.MetadataKeyScratchPaths].([]any)
+	require.True(t, ok, "expected []any after JSON round-trip; got %T", task.Metadata[agentic.MetadataKeyScratchPaths])
+	assert.Equal(t, []any{".probe/", "build"}, rawScratch)
+
+	// The load-bearing assertion: the executor's own accessor reads it back.
+	policy, scratch := agentic.FilesystemPolicyFromMetadata(task.Metadata)
+	assert.True(t, agentic.IsReadOnlyPolicy(policy), "policy must resolve to read_only through the executor accessor")
+	assert.Equal(t, []string{".probe/", "build"}, scratch)
+}
+
+// TestAction_PublishAgent_NoFilesystemPolicy confirms back-compat: a
+// publish_agent with no policy stamps neither ADR-067 key.
+func TestAction_PublishAgent_NoFilesystemPolicy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockPublisher{}
+	executor := NewActionExecutorFull(nil, nil, mock)
+
+	action := Action{
+		Type:    ActionTypePublishAgent,
+		Subject: "agent.task.worker",
+		Role:    "worker",
+		Model:   "mock-model",
+		Prompt:  "do work",
+	}
+
+	require.NoError(t, executor.Execute(ctx, action, &ExecutionContext{EntityID: "e.1"}))
+	require.Len(t, mock.published, 1)
+
+	baseMsg, err := newActionsTestDecoder(t).Decode(mock.published[0].data)
+	require.NoError(t, err)
+	task, ok := baseMsg.Payload().(*agentic.TaskMessage)
+	require.True(t, ok)
+
+	if task.Metadata != nil {
+		_, hasPolicy := task.Metadata[agentic.MetadataKeyFilesystemPolicy]
+		_, hasScratch := task.Metadata[agentic.MetadataKeyScratchPaths]
+		assert.False(t, hasPolicy, "no filesystem_policy must be stamped when unset")
+		assert.False(t, hasScratch, "no scratch_paths must be stamped when unset")
+	}
+}

--- a/processor/rule/config_validation.go
+++ b/processor/rule/config_validation.go
@@ -319,7 +319,7 @@ func validateActionLists(def Definition) error {
 			// the field.
 			if a.Type == ActionTypePublishAgent && !agentic.IsKnownFilesystemPolicy(a.FilesystemPolicy) {
 				return errs.WrapInvalid(
-					fmt.Errorf("rule %s %s[%d] filesystem_policy %q is invalid; valid values: read_only, workspace_write (or omit for workspace_write default)",
+					fmt.Errorf("rule %s %s[%d] filesystem_policy %q is invalid; valid values: read_only, workspace_write, host_write (or omit for workspace_write default)",
 						def.ID, label, i, a.FilesystemPolicy),
 					"RuleProcessor", "ValidateDefinition", "validate action filesystem_policy")
 			}

--- a/processor/rule/config_validation.go
+++ b/processor/rule/config_validation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/c360studio/semstreams/agentic"
 	"github.com/c360studio/semstreams/pkg/errs"
 	"github.com/c360studio/semstreams/processor/rule/expression"
 	"github.com/c360studio/semstreams/vocabulary"
@@ -310,6 +311,17 @@ func validateActionLists(def Definition) error {
 					fmt.Errorf("rule %s %s[%d] run_scope %q is invalid; valid values: new, inherit, none (or omit for inherit default)",
 						def.ID, label, i, a.RunScope),
 					"RuleProcessor", "ValidateDefinition", "validate action run_scope")
+			}
+			// Validate filesystem_policy for publish_agent actions (ADR-067,
+			// gh#445). Fail load on an unrecognized enum so a typo surfaces at
+			// config time, not as a silent (fail-closed) refusal at dispatch.
+			// Empty is valid (default workspace_write); other action types ignore
+			// the field.
+			if a.Type == ActionTypePublishAgent && !agentic.IsKnownFilesystemPolicy(a.FilesystemPolicy) {
+				return errs.WrapInvalid(
+					fmt.Errorf("rule %s %s[%d] filesystem_policy %q is invalid; valid values: read_only, workspace_write (or omit for workspace_write default)",
+						def.ID, label, i, a.FilesystemPolicy),
+					"RuleProcessor", "ValidateDefinition", "validate action filesystem_policy")
 			}
 		}
 		return nil

--- a/processor/rule/config_validation_test.go
+++ b/processor/rule/config_validation_test.go
@@ -321,3 +321,60 @@ func TestValidateActionLists_RunScopeOnlyCheckedForPublishAgent(t *testing.T) {
 		t.Errorf("run_scope on non-publish_agent action must not be validated, got: %v", err)
 	}
 }
+
+// TestValidateActionLists_FilesystemPolicyValid verifies that valid
+// filesystem_policy values pass ValidateDefinition (ADR-067 / gh#445).
+func TestValidateActionLists_FilesystemPolicyValid(t *testing.T) {
+	t.Parallel()
+	for _, policy := range []string{"read_only", "workspace_write", ""} {
+		policy := policy
+		t.Run("policy_"+policy, func(t *testing.T) {
+			t.Parallel()
+			def := Definition{
+				ID:   "fs-policy-valid",
+				Type: "expression",
+				Actions: []Action{
+					{
+						Type:             ActionTypePublishAgent,
+						Subject:          "agent.task.test",
+						FilesystemPolicy: policy,
+					},
+				},
+			}
+			if err := ValidateDefinition(def); err != nil {
+				t.Errorf("filesystem_policy=%q must be accepted, got: %v", policy, err)
+			}
+		})
+	}
+}
+
+// TestValidateActionLists_FilesystemPolicyInvalidRejects verifies an
+// unrecognized filesystem_policy (a typo) fails config load, so the misconfig
+// surfaces at load time rather than as a silent fail-closed refusal at dispatch.
+func TestValidateActionLists_FilesystemPolicyInvalidRejects(t *testing.T) {
+	t.Parallel()
+	for _, policy := range []string{"readonly", "read-only", "ro", "foo"} {
+		policy := policy
+		t.Run("policy_"+policy, func(t *testing.T) {
+			t.Parallel()
+			def := Definition{
+				ID:   "fs-policy-invalid",
+				Type: "expression",
+				Actions: []Action{
+					{
+						Type:             ActionTypePublishAgent,
+						Subject:          "agent.task.test",
+						FilesystemPolicy: policy,
+					},
+				},
+			}
+			err := ValidateDefinition(def)
+			if err == nil {
+				t.Fatalf("filesystem_policy=%q must be rejected, got nil", policy)
+			}
+			if !strings.Contains(err.Error(), "filesystem_policy") {
+				t.Errorf("error for %q must mention 'filesystem_policy', got: %v", policy, err)
+			}
+		})
+	}
+}

--- a/processor/rule/config_validation_test.go
+++ b/processor/rule/config_validation_test.go
@@ -326,7 +326,7 @@ func TestValidateActionLists_RunScopeOnlyCheckedForPublishAgent(t *testing.T) {
 // filesystem_policy values pass ValidateDefinition (ADR-067 / gh#445).
 func TestValidateActionLists_FilesystemPolicyValid(t *testing.T) {
 	t.Parallel()
-	for _, policy := range []string{"read_only", "workspace_write", ""} {
+	for _, policy := range []string{"read_only", "workspace_write", "host_write", ""} {
 		policy := policy
 		t.Run("policy_"+policy, func(t *testing.T) {
 			t.Parallel()

--- a/schemas/rule-processor.v1.json
+++ b/schemas/rule-processor.v1.json
@@ -65,6 +65,10 @@
                   "type": "string",
                   "description": "bucket"
                 },
+                "filesystem_policy": {
+                  "type": "string",
+                  "description": "filesystem_policy"
+                },
                 "for_each": {
                   "type": "string",
                   "description": "for_each"
@@ -154,6 +158,13 @@
                 "run_scope": {
                   "type": "string",
                   "description": "run_scope"
+                },
+                "scratch_paths": {
+                  "type": "array",
+                  "description": "scratch_paths",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "set": {
                   "type": "object",
@@ -335,6 +346,10 @@
                   "type": "string",
                   "description": "bucket"
                 },
+                "filesystem_policy": {
+                  "type": "string",
+                  "description": "filesystem_policy"
+                },
                 "for_each": {
                   "type": "string",
                   "description": "for_each"
@@ -424,6 +439,13 @@
                 "run_scope": {
                   "type": "string",
                   "description": "run_scope"
+                },
+                "scratch_paths": {
+                  "type": "array",
+                  "description": "scratch_paths",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "set": {
                   "type": "object",
@@ -523,6 +545,10 @@
                   "type": "string",
                   "description": "bucket"
                 },
+                "filesystem_policy": {
+                  "type": "string",
+                  "description": "filesystem_policy"
+                },
                 "for_each": {
                   "type": "string",
                   "description": "for_each"
@@ -612,6 +638,13 @@
                 "run_scope": {
                   "type": "string",
                   "description": "run_scope"
+                },
+                "scratch_paths": {
+                  "type": "array",
+                  "description": "scratch_paths",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "set": {
                   "type": "object",
@@ -711,6 +744,10 @@
                   "type": "string",
                   "description": "bucket"
                 },
+                "filesystem_policy": {
+                  "type": "string",
+                  "description": "filesystem_policy"
+                },
                 "for_each": {
                   "type": "string",
                   "description": "for_each"
@@ -800,6 +837,13 @@
                 "run_scope": {
                   "type": "string",
                   "description": "run_scope"
+                },
+                "scratch_paths": {
+                  "type": "array",
+                  "description": "scratch_paths",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "set": {
                   "type": "object",
@@ -918,6 +962,10 @@
                   "type": "string",
                   "description": "bucket"
                 },
+                "filesystem_policy": {
+                  "type": "string",
+                  "description": "filesystem_policy"
+                },
                 "for_each": {
                   "type": "string",
                   "description": "for_each"
@@ -1007,6 +1055,13 @@
                 "run_scope": {
                   "type": "string",
                   "description": "run_scope"
+                },
+                "scratch_paths": {
+                  "type": "array",
+                  "description": "scratch_paths",
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "set": {
                   "type": "object",


### PR DESCRIPTION
## Summary

Closes #445 — the rule-authoring follow-on to ADR-067 (gh#443, beta.131). ADR-067 added the read-only execution policy, but JSON rule packs had no way to stamp it: `Action.Properties` is domain-metadata-only and `stampAuthorMetadata` skips reserved `agent.*` keys, so a rule adding `"agent.exec.filesystem_policy"` would warn and silently do nothing.

## What this adds

First-class `publish_agent` fields:

```json
{ "type": "publish_agent", "role": "planner",
  "filesystem_policy": "read_only", "scratch_paths": [".probe/"] }
```

- `rule.Action.{FilesystemPolicy,ScratchPaths}` stamp `MetadataKeyFilesystemPolicy` / `MetadataKeyScratchPaths` onto `TaskMessage.Metadata` via `stampFilesystemPolicy` — the **same framework-owned path** as `action_allowlist` / `related_loops` (scratch stored as `[]any` for JSON-wire shape, like the allowlist; the bash executor's `FilesystemPolicyFromMetadata` coerces back).
- Enum validated at **config-load time** (`validateActionLists` → `agentic.IsKnownFilesystemPolicy`): a typo fails load rather than deferring to the executor's dispatch-time fail-closed refusal.
- Schema regenerated (`schemas/rule-processor.v1.json`).

## Testing

- Stamping test drives the **production wire** (`Execute` → BaseMessage decode → `Metadata`) and round-trips through the executor's own `FilesystemPolicyFromMetadata` accessor — proving the surface is consumable, not just present.
- Load-time validation accept (`read_only`/`workspace_write`/empty) + reject (`readonly`/`read-only`/`ro`/`foo`) mirroring the `run_scope` validator tests.
- Back-compat (no policy → neither key stamped).
- `go build`, `go vet`, `gofmt`, `task lint`, `go test -race ./...`, contract tests — all green. Schema committed, no residual drift.

## Non-goals (from the issue)

No product-local `agent.*` passthrough in rule `properties`; no change to ADR-067's dispatch enforcement seam; no SemSpec-specific scheduler.

Closes #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)