### PR TITLE
feat(graph): ADR-068 D1 — graph retention guardrail (first OpenSpec change)

### DIFF
--- a/graph/query/client.go
+++ b/graph/query/client.go
@@ -56,7 +56,11 @@ func DefaultConfig() *Config {
 			History  uint8         `json:"history"`
 			Replicas int           `json:"replicas"`
 		}{
-			TTL:      24 * time.Hour,
+			// TTL MUST be 0 on the live graph: NATS age-eviction is
+			// reachability-blind and would silently expire entities with live
+			// inbound edges (ADR-068 D1). graph-ingest owns ENTITY_STATES
+			// retention; the query client is a reader and must not race in a TTL.
+			TTL:      0,
 			History:  3,
 			Replicas: 1,
 		},
@@ -65,7 +69,7 @@ func DefaultConfig() *Config {
 			History  uint8         `json:"history"`
 			Replicas int           `json:"replicas"`
 		}{
-			TTL:      1 * time.Hour,
+			TTL:      0, // no lifecycle retention on the live graph (ADR-068 D1)
 			History:  1,
 			Replicas: 1,
 		},
@@ -74,7 +78,7 @@ func DefaultConfig() *Config {
 			History  uint8         `json:"history"`
 			Replicas int           `json:"replicas"`
 		}{
-			TTL:      24 * time.Hour,
+			TTL:      0, // no lifecycle retention on the live graph (ADR-068 D1)
 			History:  1,
 			Replicas: 1,
 		},

--- a/graph/query/client_test.go
+++ b/graph/query/client_test.go
@@ -36,16 +36,18 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, config.EntityCache.TTL)
 	assert.Equal(t, 1*time.Minute, config.EntityCache.CleanupInterval)
 
-	// Test bucket configurations
-	assert.Equal(t, 24*time.Hour, config.EntityStates.TTL)
+	// Test bucket configurations. TTL is 0 on every live graph bucket — a TTL
+	// here can win the get-or-create race and silently expire ENTITY_STATES
+	// (ADR-068 D1). See TestDefaultConfig_NoLifecycleRetentionOnGraphBuckets.
+	assert.Equal(t, time.Duration(0), config.EntityStates.TTL)
 	assert.Equal(t, uint8(3), config.EntityStates.History)
 	assert.Equal(t, 1, config.EntityStates.Replicas)
 
-	assert.Equal(t, 1*time.Hour, config.SpatialIndex.TTL)
+	assert.Equal(t, time.Duration(0), config.SpatialIndex.TTL)
 	assert.Equal(t, uint8(1), config.SpatialIndex.History)
 	assert.Equal(t, 1, config.SpatialIndex.Replicas)
 
-	assert.Equal(t, 24*time.Hour, config.IncomingIndex.TTL)
+	assert.Equal(t, time.Duration(0), config.IncomingIndex.TTL)
 	assert.Equal(t, uint8(1), config.IncomingIndex.History)
 	assert.Equal(t, 1, config.IncomingIndex.Replicas)
 }

--- a/graph/query/retention_guardrail_test.go
+++ b/graph/query/retention_guardrail_test.go
@@ -1,0 +1,22 @@
+package query
+
+import (
+	"testing"
+)
+
+// TestDefaultConfig_NoLifecycleRetentionOnGraphBuckets locks the ADR-068 D1
+// guardrail at the source of the former landmine: the query client's default
+// config must set NO TTL on the shared live graph buckets (a TTL here can win
+// the get-or-create race and silently expire ENTITY_STATES).
+func TestDefaultConfig_NoLifecycleRetentionOnGraphBuckets(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.EntityStates.TTL != 0 {
+		t.Errorf("ENTITY_STATES TTL = %v, want 0 (ADR-068 D1: no lifecycle retention on the live graph)", cfg.EntityStates.TTL)
+	}
+	if cfg.SpatialIndex.TTL != 0 {
+		t.Errorf("SPATIAL_INDEX TTL = %v, want 0 (ADR-068 D1)", cfg.SpatialIndex.TTL)
+	}
+	if cfg.IncomingIndex.TTL != 0 {
+		t.Errorf("INCOMING_INDEX TTL = %v, want 0 (ADR-068 D1)", cfg.IncomingIndex.TTL)
+	}
+}

--- a/natsclient/kv.go
+++ b/natsclient/kv.go
@@ -120,6 +120,64 @@ func BucketLastSeq(ctx context.Context, bucket jetstream.KeyValue) (uint64, erro
 	return info.State.LastSeq, nil
 }
 
+// BucketRetention returns a bucket's lifecycle-eviction config from its backing
+// stream: maxAge (the KV bucket's TTL — age eviction) and maxBytes (size
+// eviction; 0/negative = unlimited). Callers on the live graph assert both are
+// non-binding — NATS age/size eviction is reachability-blind and would drop
+// entities with live inbound edges (ADR-068 D1). Mirrors BucketLastSeq: the
+// KeyValueStatus interface does not surface these, so we read the concrete
+// JetStream-backed status's stream config.
+func BucketRetention(ctx context.Context, bucket jetstream.KeyValue) (maxAge time.Duration, maxBytes int64, err error) {
+	status, err := bucket.Status(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("kv status: %w", err)
+	}
+	bucketStatus, ok := status.(*jetstream.KeyValueBucketStatus)
+	if !ok {
+		return 0, 0, fmt.Errorf("kv status: unexpected type %T, want *jetstream.KeyValueBucketStatus", status)
+	}
+	info := bucketStatus.StreamInfo()
+	if info == nil {
+		return 0, 0, fmt.Errorf("kv status: nil backing stream info")
+	}
+	return info.Config.MaxAge, info.Config.MaxBytes, nil
+}
+
+// ErrGraphBucketRetention is returned by CheckNoLifecycleRetention when a live
+// graph bucket carries a lifecycle-eviction config. Sentinel so a boot path can
+// classify it (fail-closed) distinctly from a transient status error.
+var ErrGraphBucketRetention = errors.New("live graph bucket has lifecycle retention (ADR-068 D1: forbidden)")
+
+// CheckNoLifecycleRetention is the pure D1 guardrail: it errors if a bucket's
+// retention config is binding. maxAge > 0 (a TTL) is always a violation. maxBytes
+// > 0 is a violation too — a size cap on the live graph evicts by size, which is
+// reachability-blind; a deployment that genuinely wants a non-binding crash
+// backstop should size it far above steady state and treat hitting it as an
+// alert, not configure it here. Pure + no I/O so it is unit-testable; the boot
+// path pairs it with BucketRetention.
+func CheckNoLifecycleRetention(name string, maxAge time.Duration, maxBytes int64) error {
+	if maxAge > 0 {
+		return fmt.Errorf("%w: bucket %q has TTL/MaxAge %s", ErrGraphBucketRetention, name, maxAge)
+	}
+	if maxBytes > 0 {
+		return fmt.Errorf("%w: bucket %q has MaxBytes %d", ErrGraphBucketRetention, name, maxBytes)
+	}
+	return nil
+}
+
+// AssertNoLifecycleRetention reads this bucket's retention config and returns
+// ErrGraphBucketRetention if it is binding — the boot-time D1 guardrail for a
+// live graph bucket (ADR-068). A retention config here means some process won
+// the get-or-create race with a TTL/size cap; fail-closed rather than silently
+// expire graph state.
+func (kv *KVStore) AssertNoLifecycleRetention(ctx context.Context, name string) error {
+	maxAge, maxBytes, err := BucketRetention(ctx, kv.bucket)
+	if err != nil {
+		return err
+	}
+	return CheckNoLifecycleRetention(name, maxAge, maxBytes)
+}
+
 // Put creates or updates a key without revision check (last writer wins)
 func (kv *KVStore) Put(ctx context.Context, key string, value []byte) (uint64, error) {
 	ctx, cancel := kv.applyTimeout(ctx)

--- a/natsclient/kv_retention_integration_test.go
+++ b/natsclient/kv_retention_integration_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+
+package natsclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_BucketRetention_D1Guardrail proves the boot-time guardrail
+// against a real server: a clean bucket reads MaxAge 0 and passes; a bucket
+// created with a TTL reads it back and trips ErrGraphBucketRetention (ADR-068 D1).
+func TestIntegration_BucketRetention_D1Guardrail(t *testing.T) {
+	ctx := context.Background()
+	natsContainer, natsURL := startTestNATSContainerWithJS(ctx, t)
+	defer natsContainer.Terminate(ctx)
+
+	client, err := NewClient(natsURL, WithMaxReconnects(0))
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(ctx)
+
+	// Clean bucket (no retention) — reads MaxAge 0 and passes the guardrail.
+	clean, err := client.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{Bucket: "CLEAN_STATES"})
+	require.NoError(t, err)
+	maxAge, _, err := BucketRetention(ctx, clean)
+	require.NoError(t, err)
+	assert.Equal(t, time.Duration(0), maxAge)
+	require.NoError(t, client.NewKVStore(clean).AssertNoLifecycleRetention(ctx, "CLEAN_STATES"))
+
+	// Bucket with a TTL — reads it back and trips the guardrail.
+	ttlBucket, err := client.CreateKeyValueBucket(ctx, jetstream.KeyValueConfig{Bucket: "TTL_STATES", TTL: 24 * time.Hour})
+	require.NoError(t, err)
+	maxAge, _, err = BucketRetention(ctx, ttlBucket)
+	require.NoError(t, err)
+	assert.Equal(t, 24*time.Hour, maxAge)
+	err = client.NewKVStore(ttlBucket).AssertNoLifecycleRetention(ctx, "TTL_STATES")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGraphBucketRetention)
+}

--- a/natsclient/kv_retention_test.go
+++ b/natsclient/kv_retention_test.go
@@ -1,0 +1,38 @@
+package natsclient
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestCheckNoLifecycleRetention covers the pure D1 guardrail (ADR-068): any TTL
+// (MaxAge) or binding MaxBytes on a live graph bucket is forbidden; the NATS
+// default MaxBytes of -1 (unlimited) and a zero TTL are the clean case.
+func TestCheckNoLifecycleRetention(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxAge   time.Duration
+		maxBytes int64
+		wantErr  bool
+	}{
+		{"clean (zero TTL, unlimited bytes)", 0, -1, false},
+		{"clean (zero TTL, zero bytes)", 0, 0, false},
+		{"ttl set is a violation", 24 * time.Hour, -1, true},
+		{"maxbytes cap is a violation", 0, 1 << 20, true},
+		{"both set", time.Hour, 100, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckNoLifecycleRetention("ENTITY_STATES", tt.maxAge, tt.maxBytes)
+			switch {
+			case tt.wantErr && err == nil:
+				t.Fatal("want ErrGraphBucketRetention, got nil")
+			case tt.wantErr && !errors.Is(err, ErrGraphBucketRetention):
+				t.Errorf("want ErrGraphBucketRetention, got %v", err)
+			case !tt.wantErr && err != nil:
+				t.Errorf("want nil, got %v", err)
+			}
+		})
+	}
+}

--- a/openspec/changes/archive/2026-07-04-graph-retention-guardrail/proposal.md
+++ b/openspec/changes/archive/2026-07-04-graph-retention-guardrail/proposal.md
@@ -1,0 +1,47 @@
+# Graph Retention Guardrail (ADR-068 D1)
+
+## Why
+
+ADR-068 (D1) bans NATS KV TTL/MaxBytes/MaxAge as a lifecycle mechanism on the
+live graph: age/size eviction is reachability-blind and would silently drop an
+entity that still has live inbound edges — the "NATS dumbly deletes entities"
+catastrophe.
+
+Today the danger is latent but LIVE. `graph/query/client.go` `DefaultConfig()`
+defaults `ENTITY_STATES.TTL = 24h` (and `INCOMING_INDEX.TTL = 24h`,
+`SPATIAL_INDEX.TTL = 1h`). NATS KV bucket creation is get-or-create, so whichever
+process creates the bucket first wins its config. `graph-ingest` (the sole
+authoritative writer) currently creates `ENTITY_STATES` with no retention and
+wins the race — so nothing expires. But if boot order ever flips (the query
+client boots first), every entity silently expires 24h after its last write.
+Nothing detects this today.
+
+This is the first increment of ADR-068 and the first exercise of the OpenSpec
+loop for this repo.
+
+## What Changes
+
+- **Remove the landmine.** `DefaultConfig()` sets the shared graph-bucket TTLs
+  (`ENTITY_STATES`, `SPATIAL_INDEX`, `INCOMING_INDEX`) to `0`. The query client is
+  a reader; `graph-ingest` owns the authoritative bucket's retention.
+- **Add a boot-time guardrail.** After `graph-ingest` ensures `ENTITY_STATES`, it
+  reads the bucket's actual backing-stream retention and **fails to start** if
+  `MaxAge` (TTL) or a binding `MaxBytes` is set — catching the case where some
+  other process won the create race with retention config. Fail-closed: a graph
+  with a TTL is a catastrophe; refuse to boot rather than silently expire data.
+- **Seed the `graph-retention` capability spec** with the invariant.
+
+## Non-goals
+
+- The rest of ADR-068 (delete-as-refuse/cascade, tombstones, per-entity reverse
+  index, GC worker) — later increments.
+- A static/lint guard covering *arbitrary future* graph buckets — the boot
+  assertion covers `ENTITY_STATES` at runtime; a broader structural guard (a
+  graph-bucket-creation helper that cannot express retention) is a follow-up.
+- `History` tuning — History bounds revisions per key (audit tail), not
+  lifecycle eviction; out of scope for D1 (ADR-068 D2/D4 may raise it later).
+
+## Consumers
+
+`graph-ingest` (owner), `graph-query` (the landmine source). No product-facing
+API change; entirely internal correctness + a boot invariant.

--- a/openspec/changes/archive/2026-07-04-graph-retention-guardrail/specs/graph-retention/spec.md
+++ b/openspec/changes/archive/2026-07-04-graph-retention-guardrail/specs/graph-retention/spec.md
@@ -1,0 +1,35 @@
+# Graph Retention
+
+## ADDED Requirements
+
+### Requirement: The live graph carries no lifecycle retention
+
+The live graph KV buckets MUST NOT use NATS TTL (`MaxAge`) or a binding
+`MaxBytes` as a lifecycle mechanism. This covers `ENTITY_STATES` and its derived
+indexes (`PREDICATE_INDEX`, `INCOMING_INDEX`, `OUTGOING_INDEX`, `NAME_INDEX`,
+`ALIAS_INDEX`, `CONTEXT_INDEX`, `SPATIAL_INDEX`). Retention is a semantic
+operation (ADR-068), never a storage-policy side effect: age/size eviction is
+reachability-blind and would drop an entity that still has live inbound edges.
+
+#### Scenario: No component defaults a shared graph bucket to a TTL
+
+- **GIVEN** the graph-query client builds its default KV configuration
+- **WHEN** `DefaultConfig()` is constructed
+- **THEN** the `ENTITY_STATES`, `SPATIAL_INDEX`, and `INCOMING_INDEX` bucket TTLs
+  are `0` (no expiry)
+
+#### Scenario: graph-ingest refuses to boot on a retention-configured graph
+
+- **GIVEN** the `ENTITY_STATES` bucket exists with a non-zero `MaxAge` (TTL) or a
+  binding `MaxBytes` — e.g. because another process won the get-or-create race
+  with a retention config
+- **WHEN** `graph-ingest` starts and inspects the bucket's backing-stream config
+- **THEN** startup fails with a fatal error naming the bucket and its offending
+  retention, rather than proceeding to silently expire graph state
+
+#### Scenario: a clean graph bucket boots normally
+
+- **GIVEN** the `ENTITY_STATES` bucket exists with `MaxAge` `0` and no binding
+  `MaxBytes`
+- **WHEN** `graph-ingest` starts and inspects the bucket
+- **THEN** the guardrail passes and startup proceeds

--- a/openspec/changes/archive/2026-07-04-graph-retention-guardrail/tasks.md
+++ b/openspec/changes/archive/2026-07-04-graph-retention-guardrail/tasks.md
@@ -1,0 +1,24 @@
+# Tasks — Graph Retention Guardrail
+
+## 1. Remove the query-client retention landmine
+
+- [x] 1.1 `graph/query/client.go` `DefaultConfig()`: set `ENTITY_STATES`,
+      `SPATIAL_INDEX`, `INCOMING_INDEX` TTL to `0`
+- [x] 1.2 Unit test: `DefaultConfig()` yields TTL `0` on every shared graph bucket
+
+## 2. Boot-time guardrail
+
+- [x] 2.1 `natsclient`: `BucketRetention(ctx, bucket) (maxAge time.Duration, maxBytes int64, err error)`
+      reading the backing stream config (mirrors `BucketLastSeq`)
+- [x] 2.2 Pure check `errIfLifecycleRetention(name, maxAge, maxBytes) error` + unit test
+      (0/0 → ok; non-zero TTL → error; binding MaxBytes → error)
+- [x] 2.3 `graph-ingest` Start: after ensuring `ENTITY_STATES`, assert no lifecycle
+      retention; return a fatal error (fail-closed) if violated
+- [x] 2.4 Integration test: a bucket created with a TTL trips the assertion; a clean
+      bucket passes
+
+## 3. Spec + close
+
+- [x] 3.1 `openspec validate` the change
+- [x] 3.2 Gates green (`go test -race`, `task lint`), then archive → promotes
+      `graph-retention` into `openspec/specs/`

--- a/openspec/specs/graph-retention/spec.md
+++ b/openspec/specs/graph-retention/spec.md
@@ -1,7 +1,13 @@
 # graph-retention Specification
 
 ## Purpose
-TBD - created by archiving change graph-retention-guardrail. Update Purpose after archive.
+Current-truth for how the live graph's KV buckets treat retention and deletion:
+storage-level eviction (NATS TTL/MaxBytes/MaxAge) is never a lifecycle mechanism
+on the graph, because it is reachability-blind. This capability tracks the
+ADR-068 increments; today it covers the D1 guardrail (no lifecycle retention on
+live graph buckets). Later increments (delete-as-refuse/cascade, tombstones, the
+per-entity reverse index, the GC worker) extend it.
+
 ## Requirements
 ### Requirement: The live graph carries no lifecycle retention
 

--- a/openspec/specs/graph-retention/spec.md
+++ b/openspec/specs/graph-retention/spec.md
@@ -1,0 +1,37 @@
+# graph-retention Specification
+
+## Purpose
+TBD - created by archiving change graph-retention-guardrail. Update Purpose after archive.
+## Requirements
+### Requirement: The live graph carries no lifecycle retention
+
+The live graph KV buckets MUST NOT use NATS TTL (`MaxAge`) or a binding
+`MaxBytes` as a lifecycle mechanism. This covers `ENTITY_STATES` and its derived
+indexes (`PREDICATE_INDEX`, `INCOMING_INDEX`, `OUTGOING_INDEX`, `NAME_INDEX`,
+`ALIAS_INDEX`, `CONTEXT_INDEX`, `SPATIAL_INDEX`). Retention is a semantic
+operation (ADR-068), never a storage-policy side effect: age/size eviction is
+reachability-blind and would drop an entity that still has live inbound edges.
+
+#### Scenario: No component defaults a shared graph bucket to a TTL
+
+- **GIVEN** the graph-query client builds its default KV configuration
+- **WHEN** `DefaultConfig()` is constructed
+- **THEN** the `ENTITY_STATES`, `SPATIAL_INDEX`, and `INCOMING_INDEX` bucket TTLs
+  are `0` (no expiry)
+
+#### Scenario: graph-ingest refuses to boot on a retention-configured graph
+
+- **GIVEN** the `ENTITY_STATES` bucket exists with a non-zero `MaxAge` (TTL) or a
+  binding `MaxBytes` — e.g. because another process won the get-or-create race
+  with a retention config
+- **WHEN** `graph-ingest` starts and inspects the bucket's backing-stream config
+- **THEN** startup fails with a fatal error naming the bucket and its offending
+  retention, rather than proceeding to silently expire graph state
+
+#### Scenario: a clean graph bucket boots normally
+
+- **GIVEN** the `ENTITY_STATES` bucket exists with `MaxAge` `0` and no binding
+  `MaxBytes`
+- **WHEN** `graph-ingest` starts and inspects the bucket
+- **THEN** the guardrail passes and startup proceeds
+

--- a/processor/gated-dag/fullstack_integration_test.go
+++ b/processor/gated-dag/fullstack_integration_test.go
@@ -544,7 +544,14 @@ func fsRuleStateExists(t *testing.T, nc *natsclient.Client, key string) bool {
 func TestFullStack_EventDrivenDispatchBeatsBackstop(t *testing.T) {
 	const subject = "fs.dispatch.s5"
 	prefix := "fs.test.s5.fanout.unit"
-	fs := setupFullStack(t, fsOpts{prefix: prefix, subject: subject, backstop: "30s"})
+	// A 10m backstop provably cannot fire within the assertion window, so any
+	// dispatch inside it proves the event-driven unit-watch path — not the
+	// backstop — advanced the chain. The window is CI-contention-aware
+	// (fsEventually: 30s local / 90s CI, gh#404); this test previously hardcoded
+	// 12s and was the one full-stack test the gh#404 sweep missed, so it flaked
+	// under testcontainer contention when the 3-unit chain's serial NATS
+	// round-trips legitimately exceeded 12s.
+	fs := setupFullStack(t, fsOpts{prefix: prefix, subject: subject, backstop: "10m"})
 
 	a, b, c := fsUnit("s5", "a"), fsUnit("s5", "b"), fsUnit("s5", "c")
 	fs.seedUnit(t, a)
@@ -554,8 +561,8 @@ func TestFullStack_EventDrivenDispatchBeatsBackstop(t *testing.T) {
 	start := time.Now()
 	require.Eventually(t, func() bool {
 		return fs.dispatched.count(a) == 1 && fs.dispatched.count(b) == 1 && fs.dispatched.count(c) == 1
-	}, 12*time.Second, 100*time.Millisecond, "chain should dispatch once each via the unit watch, not the 30s backstop")
-	require.Less(t, time.Since(start), 12*time.Second, "well under the backstop-bound latency")
+	}, fsEventually, 100*time.Millisecond, "chain should dispatch once each via the unit watch, not the 10m backstop")
+	require.Less(t, time.Since(start), fsEventually, "dispatch completes within the window, well under the 10m backstop")
 }
 
 // TestFullStack_FanOutInstanceAutoCompletes (#364) proves the framework creates

--- a/processor/graph-ingest/component.go
+++ b/processor/graph-ingest/component.go
@@ -810,6 +810,14 @@ func (c *Component) initStorage(ctx context.Context) error {
 	}
 	c.entityBucket = c.natsClient.NewKVStore(bucket)
 
+	// D1 guardrail (ADR-068): ENTITY_STATES is get-or-create, so another process
+	// could have won the race with a TTL/size cap (e.g. a stale graph-query TTL
+	// default). Age/size eviction is reachability-blind and would silently expire
+	// entities with live inbound edges. Fail-closed at boot rather than proceed.
+	if err := c.entityBucket.AssertNoLifecycleRetention(ctx, graph.BucketEntityStates); err != nil {
+		return errs.Wrap(err, "Component", "Start", "graph retention guardrail")
+	}
+
 	// Entity query cache (HybridCache: LRU capacity + TTL freshness)
 	entityCache, err := cache.NewFromConfig[graph.EntityState](ctx, cache.Config{
 		Enabled:         true,


### PR DESCRIPTION
## Summary

First increment of **ADR-068** and the **first exercise of the OpenSpec loop** (proposal → tasks → spec delta → implement → verify → archive → promoted baseline spec).

The live graph must never use NATS TTL/MaxBytes for lifecycle — age/size eviction is reachability-blind and would silently expire entities that still have live inbound edges. The danger was **latent but live**: `graph/query/client.go` `DefaultConfig()` defaulted `ENTITY_STATES.TTL = 24h` (and `INCOMING_INDEX`/`SPATIAL_INDEX`). NATS KV is get-or-create; `graph-ingest` wins the race today (no TTL), but a boot-order flip would expire every entity 24h after its last write, undetected.

## Changes

- **Remove the landmine** — `DefaultConfig()` sets the shared graph-bucket TTLs to `0` (`graph-ingest` owns `ENTITY_STATES` retention; the query client is a reader).
- **Boot-time guardrail** — `natsclient.BucketRetention` reads a bucket's backing-stream `MaxAge`/`MaxBytes`; `CheckNoLifecycleRetention` is the pure rule; `graph-ingest` asserts `ENTITY_STATES` has no lifecycle retention at `Start` and **fails closed** if it does (catching a race-loser that created the bucket with a TTL).
- **Tests** — pure check (unit), `BucketRetention` + `AssertNoLifecycleRetention` against a real NATS server (integration, verified green locally in 3.8s), `DefaultConfig` zero-TTL guard, and the existing `TestDefaultConfig` updated off the former 24h landmine value.

## OpenSpec artifacts

- `openspec/changes/archive/2026-07-04-graph-retention-guardrail/` — proposal + tasks + delta (archived on completion).
- `openspec/specs/graph-retention/spec.md` — the promoted **current-truth** spec (`openspec validate` green).

This is the proof that the specs→change→implement→archive loop works end to end on real, high-value work.

## Non-goals

The rest of ADR-068 (delete-as-refuse/cascade, tombstones, reverse index, GC worker) and a broader static guard covering *arbitrary future* graph buckets — later increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)