### PR TITLE
feat: gated-DAG durable dispatch — framework side (ADR-070, gh#385)

### DIFF
--- a/docs/adr/070-gated-dag-durable-dispatch.md
+++ b/docs/adr/070-gated-dag-durable-dispatch.md
@@ -2,8 +2,10 @@
 
 ## Status
 
-**Proposed — 2026-07-04.** Amends ADR-046 (parallel fan-out & gated-DAG
-dispatch). Scopes gh#385. Cross-repo contract decision: changes how the two
+**Accepted — 2026-07-04.** Amends ADR-046 (parallel fan-out & gated-DAG
+dispatch). Framework side implemented first (durable publish + `ConsumeDurable` +
+stall detector); the coordinated consumer migration (semspec, semdragon) follows
+on a framework tag. Scopes gh#385. Cross-repo contract decision: changes how the two
 gated-DAG dispatch consumers (semspec, semdragon — both ours) receive dispatches.
 Mechanics live in the `gated-dag-dispatch` spec
 (`openspec/changes/gated-dag-durable-dispatch/`); this ADR records the decision.

--- a/docs/adr/070-gated-dag-durable-dispatch.md
+++ b/docs/adr/070-gated-dag-durable-dispatch.md
@@ -8,6 +8,15 @@ gated-DAG dispatch consumers (semspec, semdragon — both ours) receive dispatch
 Mechanics live in the `gated-dag-dispatch` spec
 (`openspec/changes/gated-dag-durable-dispatch/`); this ADR records the decision.
 
+A pre-Accept adversarial review confirmed the core decision (transport is the
+root cause; the natsclient substrate exists; the lease rejection is defensible)
+and sharpened four points folded in below: (B1) the durable ack lets us roll the
+claim back on a *failed* publish — an auto-recovery core-NATS could not offer;
+(B2) the retained stall detector is a soft alert-only threshold, not the
+zero-tuning it was first framed as, and the stream — not the detector — now
+covers consumer-down; (B3) `heartbeat_interval < ack_wait` must be *enforced*;
+(B4) idempotency = terminal-marker short-circuit.
+
 ## Context
 
 The gated-DAG executor dispatches a unit by publishing a reference envelope via
@@ -45,8 +54,20 @@ Two observations make the fix clear:
    (ack-confirmed persisted) to a stream provisioned with `EnsureStream`,
    replacing core-NATS `nc.Publish`. A dispatch is durably queued and delivered
    whenever the consumer (re)subscribes; consumer crash mid-work is covered by
-   `AckWait` redelivery + the `InProgress` heartbeat. This is deterministic — no
-   claim lease / re-dispatch timer to tune.
+   `AckWait` redelivery + the `InProgress` heartbeat.
+
+   **Roll the claim back on a failed publish-ack (B1).** The claim is committed
+   before the publish (ADR-046 invariant #2). Under core-NATS, publish could not
+   fail-visibly, so the claim was left in place on error ("unit stranded until
+   reset", `executor.go:420`) — rolling back risked a double-run because you
+   could not know whether a consumer had already received it. With
+   `PublishToStreamWithAck`, a **failed** ack is proof the message was **not
+   persisted** and will **not** be delivered — so the executor MUST clear the
+   claim on publish error (mirroring the existing claim-failure rollback,
+   `executor.go:403-405`). This converts "publish failed → stranded until manual
+   reset" into "publish failed → auto-retried next eval." The durable ack is
+   exactly the information the fire-and-forget path lacked; using it is a
+   first-class part of this decision, not an afterthought.
 
 2. **The at-least-once consumer pattern is a framework primitive, not per-consumer
    glue.** natsclient gains a typed durable-consume wrapper —
@@ -56,17 +77,32 @@ Two observations make the fix clear:
    `jetstream.Msg`. The framework owns the ack/heartbeat/redelivery semantics
    once; both gated-DAG consumers use it.
 
-3. **The consumer contract is: ack after the terminal marker lands.** A dispatch
-   is complete only when the unit's terminal marker is durably written; the
-   consumer acks then. Crash before ack → JetStream redelivers. Consumers MUST be
-   idempotent for the (rare) redelivery of an in-flight unit — the heartbeat keeps
-   this rare (a genuinely-running unit is not redelivered).
+3. **The consumer contract is: ack after the terminal marker lands, and
+   short-circuit on redelivery (B4).** A dispatch is complete only when the unit's
+   terminal marker is durably written; the consumer acks then. Crash after
+   marker-write but before ack → JetStream redelivers an *already-terminal* unit.
+   Idempotency here is a **terminal-marker short-circuit**: on any delivery the
+   consumer FIRST checks whether the unit's terminal marker is already present and,
+   if so, **acks without re-running** — it does NOT re-run and rely on
+   replace-by-predicate (re-running an expensive agent unit for nothing is the cost
+   we are avoiding). The marker write uses the retrying mutation client
+   (`RequestWithRetryClassified`) so a dropped marker is rare.
 
-4. **A dropped terminal-marker write AFTER ack is a residual the stream cannot
-   fix** — the consumer must write the marker reliably (the mutation API is
-   already `RequestWithRetryClassified`), and a **stranded-unit stall detector**
-   (fix the `stallAfterInflight` blind spot) surfaces the residual + the
-   consumer-down case for operators. This is observability, not auto-re-dispatch.
+4. **After durable dispatch, the only residual strand is a marker dropped AFTER
+   ack** — consumer-down is now handled by the stream (the message waits until the
+   consumer returns), and publish-failure by Decision 1's rollback. A
+   **stranded-unit detector** (fix the `stallAfterInflight` blind spot, which today
+   reads any claimed non-terminal unit as healthy in-flight) surfaces that residual
+   plus any unknown wedge — as an **alert only**, never auto-re-dispatch. Honest
+   caveat (B2/B6): from KV state alone a *stranded* unit (claimed, no marker) is
+   indistinguishable from a *healthy long-running* one (claimed, no marker yet,
+   held alive by the consumer's `InProgress` heartbeat), so a wall-clock "claimed
+   too long" threshold is a **soft tuning knob** (set above max unit runtime) — not
+   the zero-tuning the lease-rejection first implied. The difference from the lease
+   is that a false positive is a spurious alert, not a double-run. A precise,
+   tuning-free alternative — cross-checking the JetStream consumer's per-unit
+   in-flight/pending state instead of a wall clock — is left to the spec/design
+   phase to evaluate.
 
 5. **Rejected: a claim lease / timer-based re-dispatch.** It is a band-aid over
    the lossy transport; the stream makes it unnecessary, it re-runs work
@@ -85,9 +121,18 @@ pass); its role narrows, no lease semantics. The `CAS-UPGRADE POINT`
 - Lost-dispatch strand is eliminated at the transport, deterministically.
 - gated-DAG dispatch becomes consistent with the framework's own durable-dispatch
   pattern (agentic-loop / `for_each`) rather than the lone core-NATS deviation.
-- The `ConsumeDurable` wrapper is reusable substrate for any durable at-least-once
-  consumer; both gated-DAG consumers drop their hand-rolled glue.
-- No lease-TTL tuning; long-running units held by the consumer's heartbeat.
+- Publish-failure and consumer-down become auto-recovering (Decision 1 rollback +
+  the stream holding the message), not reset-driven.
+- The `ConsumeDurable` wrapper owns the **ack/heartbeat/redelivery** pattern once
+  for any durable at-least-once consumer. It does NOT own **envelope decode**
+  (B5): natsclient deliberately does not import the payload registry (a layering
+  inversion), so the handler is `func(ctx, []byte) error` and the
+  `BaseMessage → DispatchMessage` unwrap stays above natsclient. To avoid each
+  consumer reinventing that unwrap, provide a small shared decode helper in the
+  gated-dag payload package that both consumers import.
+- No auto-re-dispatch timer (the lease). The stall detector's alert threshold is a
+  softer, alert-only knob (B2), not zero tuning; long-running units are held by
+  the consumer's `InProgress` heartbeat, not a guessed window.
 
 ### Negative / cost
 
@@ -100,10 +145,20 @@ pass); its role narrows, no lease semantics. The `CAS-UPGRADE POINT`
 
 ### Risks
 
-- **AckWait vs. long units** — mitigated by `ConsumeWithHeartbeat` (`InProgress`
-  extends the window while work runs); set `AckWait` above the heartbeat interval.
-- **Residual dropped-marker-after-ack** — surfaced by the stall detector, not
-  silently wedged; consumers use the retrying mutation client for marker writes.
+- **Misconfigured heartbeat vs. AckWait → double-dispatch of a live unit (B3).**
+  If `heartbeat_interval ≥ ack_wait`, the first `InProgress` lands *after* AckWait
+  has already expired, so JetStream redelivers a genuinely-running unit → duplicate
+  (expensive) work. The agentic-loop precedent DOCUMENTS this invariant
+  (`agentic-loop/config.go:169`) but its `Validate()` does NOT enforce it (checks
+  the two bounds independently). The gated-dag config MUST **cross-validate
+  `heartbeat_interval < ack_wait`** (with margin) at load time, not merely document
+  it. (File the same enforcement gap against agentic-loop's config as a sibling.)
+- **Residual dropped-marker-after-ack** — surfaced by the stranded-unit detector
+  (alert), not silently wedged; consumers use the retrying mutation client for
+  marker writes and the terminal-marker short-circuit on redelivery.
+- **Stall detector false-positive on a healthy long-running unit** — see Decision
+  4: alert-only, so the cost is a spurious alert; threshold set above max unit
+  runtime, or replaced by stream-state introspection in the design phase.
 
 ## Migration
 

--- a/docs/adr/070-gated-dag-durable-dispatch.md
+++ b/docs/adr/070-gated-dag-durable-dispatch.md
@@ -58,18 +58,30 @@ Two observations make the fix clear:
    whenever the consumer (re)subscribes; consumer crash mid-work is covered by
    `AckWait` redelivery + the `InProgress` heartbeat.
 
-   **Roll the claim back on a failed publish-ack (B1).** The claim is committed
-   before the publish (ADR-046 invariant #2). Under core-NATS, publish could not
-   fail-visibly, so the claim was left in place on error ("unit stranded until
-   reset", `executor.go:420`) — rolling back risked a double-run because you
-   could not know whether a consumer had already received it. With
-   `PublishToStreamWithAck`, a **failed** ack is proof the message was **not
-   persisted** and will **not** be delivered — so the executor MUST clear the
-   claim on publish error (mirroring the existing claim-failure rollback,
-   `executor.go:403-405`). This converts "publish failed → stranded until manual
-   reset" into "publish failed → auto-retried next eval." The durable ack is
-   exactly the information the fire-and-forget path lacked; using it is a
-   first-class part of this decision, not an afterthought.
+   **Publish idempotently (Nats-Msg-Id) so the claim rollback is dedup-safe (B1).**
+   The claim is committed before the publish (ADR-046 invariant #2). Under
+   core-NATS, publish could not fail-visibly, so the claim was left in place on
+   error ("unit stranded until reset"). We now dispatch via
+   `PublishToStreamWithMsgID` with **`Nats-Msg-Id = unitID`** and a stream
+   **`Duplicates` window ≥ `BackstopInterval`**, and roll the claim back (Unclaim
+   + clear the in-memory hint) on a publish error so the unit auto-retries next
+   eval instead of stranding until reset.
+
+   The msg-id is load-bearing, NOT the bare ack: a `PublishToStreamWithAck` can
+   return an error *after* the server already persisted the message (an ack-read
+   timeout), so "failed ack ⇒ not persisted" is **false** in that case — a bare
+   rollback + re-dispatch would store a **second** message (double delivery). With
+   msg-id dedup, the re-dispatch of the same unit within the window is collapsed to
+   a single stored message, so the rollback cannot double-deliver. (Config
+   `Validate` enforces `dispatch_dedupe_window ≥ backstop_interval` — a shorter
+   window would let a backstop-latency retry escape dedup.)
+
+   Honest edge: a *reset-driven* re-dispatch of the same unit within the dedup
+   window is deduped too, so it is delayed by ≤ the window; the dirtied unit is
+   re-selected every eval and the publish goes through once the window expires
+   (self-healing, bounded delay). Resets are operator-latency events far exceeding
+   the window in practice. Consumer idempotency (Decision 3) remains the
+   belt-and-suspenders for any residual duplicate.
 
 2. **The at-least-once consumer pattern is a framework primitive, not per-consumer
    glue.** natsclient gains a typed durable-consume wrapper —

--- a/docs/adr/070-gated-dag-durable-dispatch.md
+++ b/docs/adr/070-gated-dag-durable-dispatch.md
@@ -1,0 +1,124 @@
+# ADR-070: Gated-DAG dispatch is durable at-least-once (amends ADR-046)
+
+## Status
+
+**Proposed — 2026-07-04.** Amends ADR-046 (parallel fan-out & gated-DAG
+dispatch). Scopes gh#385. Cross-repo contract decision: changes how the two
+gated-DAG dispatch consumers (semspec, semdragon — both ours) receive dispatches.
+Mechanics live in the `gated-dag-dispatch` spec
+(`openspec/changes/gated-dag-durable-dispatch/`); this ADR records the decision.
+
+## Context
+
+The gated-DAG executor dispatches a unit by publishing a reference envelope via
+core-NATS `nc.Publish` (`processor/gated-dag/publisher.go`) — **fire-and-forget,
+the only dispatch path in the framework that is not durable**. A durable claim
+marker is written *before* the publish (ADR-046 invariant #2), and the eval-loop
+dedup then skips a claimed unit on every backstop pass unless it goes terminal or
+is reset.
+
+The failure (gh#385): a dispatch lost because the consumer was not subscribed
+(restarting, not-yet-started) leaves the unit claimed-but-never-terminal — its
+downstream subtree wedges **forever**, with no auto-recovery and (because
+`stallAfterInflight` treats any claimed non-terminal unit as healthy in-flight)
+no stall alert. The gh#373 "flake" was this in miniature.
+
+Two observations make the fix clear:
+
+1. **The transport is the root cause.** By the KV-or-stream heuristic a dispatch
+   is a *request to do something* → a resumable JetStream stream. ADR-046's own
+   `for_each` path (Phase 1) already dispatches into agentic-loop's **durable
+   JetStream consumer** ("operators set the cap on the JetStream consumer"). The
+   gated-DAG Phase-2 executor shipped a core-NATS shortcut that skipped
+   durability. Core-NATS is for loss-tolerant fan-out; a work-unit dispatch whose
+   loss wedges a subtree is not loss-tolerant.
+2. **The substrate already exists in `natsclient`** — `PublishToStreamWithAck`,
+   `EnsureStream`, `ConsumeStreamWithConfig`, and `ConsumeWithHeartbeat` (the
+   `InProgress` heartbeat that holds a long-running unit past `AckWait`). The fix
+   needs no raw `js.Publish`/`jetstream.*` in the component; the one gap is
+   consume ergonomics (see Decision 2).
+
+## Decision
+
+1. **Gated-DAG dispatch is durable at-least-once over a JetStream stream.** The
+   executor publishes each dispatch via `natsclient.PublishToStreamWithAck`
+   (ack-confirmed persisted) to a stream provisioned with `EnsureStream`,
+   replacing core-NATS `nc.Publish`. A dispatch is durably queued and delivered
+   whenever the consumer (re)subscribes; consumer crash mid-work is covered by
+   `AckWait` redelivery + the `InProgress` heartbeat. This is deterministic — no
+   claim lease / re-dispatch timer to tune.
+
+2. **The at-least-once consumer pattern is a framework primitive, not per-consumer
+   glue.** natsclient gains a typed durable-consume wrapper —
+   `ConsumeDurable(ctx, cfg, heartbeat, handler func(ctx, []byte) error)` —
+   composing `ConsumeStreamWithConfig` + `ConsumeWithHeartbeat` + ack/nak so a
+   consumer's handler is `func(ctx, payload) error` and never touches
+   `jetstream.Msg`. The framework owns the ack/heartbeat/redelivery semantics
+   once; both gated-DAG consumers use it.
+
+3. **The consumer contract is: ack after the terminal marker lands.** A dispatch
+   is complete only when the unit's terminal marker is durably written; the
+   consumer acks then. Crash before ack → JetStream redelivers. Consumers MUST be
+   idempotent for the (rare) redelivery of an in-flight unit — the heartbeat keeps
+   this rare (a genuinely-running unit is not redelivered).
+
+4. **A dropped terminal-marker write AFTER ack is a residual the stream cannot
+   fix** — the consumer must write the marker reliably (the mutation API is
+   already `RequestWithRetryClassified`), and a **stranded-unit stall detector**
+   (fix the `stallAfterInflight` blind spot) surfaces the residual + the
+   consumer-down case for operators. This is observability, not auto-re-dispatch.
+
+5. **Rejected: a claim lease / timer-based re-dispatch.** It is a band-aid over
+   the lossy transport; the stream makes it unnecessary, it re-runs work
+   (wasteful, idempotency-demanding), and it has strictly worse long-running-unit
+   semantics than the consumer-controlled `InProgress` heartbeat. Building it
+   would be churn — retired before it shipped.
+
+The claim marker stays (executor-side dedup — don't re-publish each backstop
+pass); its role narrows, no lease semantics. The `CAS-UPGRADE POINT`
+(`claim.go:46`, cross-instance exclusion) is untouched.
+
+## Consequences
+
+### Positive
+
+- Lost-dispatch strand is eliminated at the transport, deterministically.
+- gated-DAG dispatch becomes consistent with the framework's own durable-dispatch
+  pattern (agentic-loop / `for_each`) rather than the lone core-NATS deviation.
+- The `ConsumeDurable` wrapper is reusable substrate for any durable at-least-once
+  consumer; both gated-DAG consumers drop their hand-rolled glue.
+- No lease-TTL tuning; long-running units held by the consumer's heartbeat.
+
+### Negative / cost
+
+- **Breaking**: both consumers migrate from a core-NATS subject to the durable
+  consumer + ack-after-marker. Coordinated one-time change (we own both repos).
+- New stream + durable consumer to provision and observe (but the framework
+  already runs JetStream streams; `cmd/semstreams` provisions them via
+  `EnsureStreams`).
+- Consumers must be idempotent for redelivery (documented contract).
+
+### Risks
+
+- **AckWait vs. long units** — mitigated by `ConsumeWithHeartbeat` (`InProgress`
+  extends the window while work runs); set `AckWait` above the heartbeat interval.
+- **Residual dropped-marker-after-ack** — surfaced by the stall detector, not
+  silently wedged; consumers use the retrying mutation client for marker writes.
+
+## Migration
+
+Framework lands first (stream + `PublishToStreamWithAck` publisher +
+`ConsumeDurable` + stall detector), tag; then semspec and semdragon bump and
+switch their dispatch consumers to `ConsumeDurable` + ack-after-marker in a
+coordinated pass. The old core-NATS subject publish is removed only after both
+consumers migrate (or behind a brief transitional config if needed).
+
+## References
+
+- Amends ADR-046 (gated-DAG dispatch); gh#385 (the strand), gh#373 (the flake
+  that hid it).
+- `/kv-or-stream` heuristic (request → resumable stream);
+  `docs/concepts/03-streams-vs-kv-watches.md`.
+- natsclient: `PublishToStreamWithAck`, `EnsureStream`, `ConsumeStreamWithConfig`,
+  `ConsumeWithHeartbeat` (the substrate); `processor/gated-dag/publisher.go`
+  (the core-NATS deviation), `executor.go` `stallAfterInflight` (the blind spot).

--- a/natsclient/consume_durable.go
+++ b/natsclient/consume_durable.go
@@ -1,0 +1,76 @@
+package natsclient
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// defaultConsumerAckWait mirrors buildConsumerConfig's fallback (stream.go): a
+// zero AckWait resolves to 30s on the server, so heartbeat validation must use
+// the same effective value.
+const defaultConsumerAckWait = 30 * time.Second
+
+// ConsumeDurable runs a durable at-least-once consumer over a stream with a
+// plain handler: func(ctx, []byte) error — acked on nil, nak-with-delay on error,
+// and held past AckWait by an InProgress heartbeat while the handler runs (see
+// ConsumeWithHeartbeat). The consumer NEVER handles a raw jetstream.Msg for ack
+// semantics; the []byte is the raw message data and envelope decoding
+// (payload-registry BaseMessage, etc.) stays ABOVE natsclient — natsclient does
+// not depend on the message package.
+//
+// The framework owns the at-least-once ack/heartbeat/redelivery pattern here once,
+// so a durable consumer (e.g. gated-DAG dispatch — ADR-070) does not re-hand-roll
+// ConsumeStreamWithConfig + ConsumeWithHeartbeat + ack per call site.
+//
+// heartbeat MUST be safely below the effective AckWait: a heartbeat that first
+// fires only after AckWait has already expired lets the server redeliver a
+// still-running unit (duplicate work). ConsumeDurable ENFORCES this (heartbeat*2
+// <= effective AckWait) and returns an error on a violating config, rather than
+// merely documenting it (ADR-070 B3).
+func (c *Client) ConsumeDurable(
+	ctx context.Context,
+	cfg StreamConsumerConfig,
+	heartbeat time.Duration,
+	handler func(context.Context, []byte) error,
+) error {
+	if err := validateHeartbeatBelowAckWait(heartbeat, cfg.AckWait); err != nil {
+		return err
+	}
+	return c.ConsumeStreamWithConfig(ctx, cfg, func(mctx context.Context, msg jetstream.Msg) {
+		data := msg.Data()
+		// ConsumeWithHeartbeat owns Ack/Nak; a returned error is already handled
+		// (nak'd) — log for operator visibility only.
+		if err := ConsumeWithHeartbeat(mctx, msg, heartbeat, func(wctx context.Context) error {
+			return handler(wctx, data)
+		}); err != nil {
+			slog.Warn("ConsumeDurable handler error",
+				slog.String("stream", cfg.StreamName),
+				slog.String("consumer", cfg.ConsumerName),
+				slog.String("error", err.Error()))
+		}
+	})
+}
+
+// validateHeartbeatBelowAckWait enforces the ADR-070 B3 invariant: the heartbeat
+// must be able to fire (with margin) before AckWait expires, or a live unit gets
+// redelivered. A zero AckWait resolves to the 30s server default. Exported-shaped
+// as a package helper so config Validate() paths can reuse it.
+func validateHeartbeatBelowAckWait(heartbeat, ackWait time.Duration) error {
+	if heartbeat <= 0 {
+		return fmt.Errorf("heartbeat interval must be positive, got %s", heartbeat)
+	}
+	effAckWait := ackWait
+	if effAckWait <= 0 {
+		effAckWait = defaultConsumerAckWait
+	}
+	if heartbeat*2 > effAckWait {
+		return fmt.Errorf(
+			"heartbeat interval %s must be <= half of ack_wait %s (a heartbeat that first fires after ack_wait redelivers a live unit)",
+			heartbeat, effAckWait)
+	}
+	return nil
+}

--- a/natsclient/consume_durable.go
+++ b/natsclient/consume_durable.go
@@ -57,8 +57,9 @@ func (c *Client) ConsumeDurable(
 
 // validateHeartbeatBelowAckWait enforces the ADR-070 B3 invariant: the heartbeat
 // must be able to fire (with margin) before AckWait expires, or a live unit gets
-// redelivered. A zero AckWait resolves to the 30s server default. Exported-shaped
-// as a package helper so config Validate() paths can reuse it.
+// redelivered. A zero AckWait resolves to the 30s server default. Called by
+// ConsumeDurable so the check fails fast at consumer Start; kept unexported —
+// callers enforce it via ConsumeDurable, not by reaching in.
 func validateHeartbeatBelowAckWait(heartbeat, ackWait time.Duration) error {
 	if heartbeat <= 0 {
 		return fmt.Errorf("heartbeat interval must be positive, got %s", heartbeat)

--- a/natsclient/consume_durable_integration_test.go
+++ b/natsclient/consume_durable_integration_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+package natsclient
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_ConsumeDurable_ReceivesAndAcks drives the ASSEMBLED durable
+// consume path against a real server: publish via PublishToStreamWithMsgID, and
+// assert ConsumeDurable's func(ctx,[]byte)error handler receives the payload and
+// (returning nil) acks it — closing the "tests the pieces, not the system" gap.
+func TestIntegration_ConsumeDurable_ReceivesAndAcks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	natsContainer, natsURL := startTestNATSContainerWithJS(ctx, t)
+	defer natsContainer.Terminate(context.Background())
+
+	client, err := NewClient(natsURL, WithMaxReconnects(0))
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(context.Background())
+
+	const subject = "cd.test.recv"
+	_, err = client.EnsureStream(ctx, jetstream.StreamConfig{
+		Name: "CD_RECV", Subjects: []string{subject}, Duplicates: 2 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	got := make(chan []byte, 1)
+	err = client.ConsumeDurable(ctx, StreamConsumerConfig{
+		StreamName: "CD_RECV", ConsumerName: "cd-recv", FilterSubject: subject, AckWait: 2 * time.Second,
+	}, 500*time.Millisecond, func(_ context.Context, data []byte) error {
+		got <- data
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, client.PublishToStreamWithMsgID(ctx, subject, []byte("hello-durable"), "id1"))
+
+	select {
+	case data := <-got:
+		assert.Equal(t, []byte("hello-durable"), data)
+	case <-time.After(10 * time.Second):
+		t.Fatal("handler did not receive the published message within 10s")
+	}
+}
+
+// TestIntegration_ConsumeDurable_MsgIDDedup validates the ADR-070 B1 fix: two
+// publishes of the same Nats-Msg-Id within the stream's Duplicates window collapse
+// to ONE stored message, so the consumer sees the unit exactly once — this is what
+// makes the claim-rollback safe against an ack-timeout re-dispatch.
+func TestIntegration_ConsumeDurable_MsgIDDedup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	natsContainer, natsURL := startTestNATSContainerWithJS(ctx, t)
+	defer natsContainer.Terminate(context.Background())
+
+	client, err := NewClient(natsURL, WithMaxReconnects(0))
+	require.NoError(t, err)
+	require.NoError(t, client.Connect(ctx))
+	defer client.Close(context.Background())
+
+	const subject = "cd.test.dedup"
+	_, err = client.EnsureStream(ctx, jetstream.StreamConfig{
+		Name: "CD_DEDUP", Subjects: []string{subject}, Duplicates: 2 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	var deliveries int32
+	err = client.ConsumeDurable(ctx, StreamConsumerConfig{
+		StreamName: "CD_DEDUP", ConsumerName: "cd-dedup", FilterSubject: subject, AckWait: 2 * time.Second,
+	}, 500*time.Millisecond, func(_ context.Context, _ []byte) error {
+		atomic.AddInt32(&deliveries, 1)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Same msg-id twice (the ack-timeout re-dispatch shape).
+	require.NoError(t, client.PublishToStreamWithMsgID(ctx, subject, []byte("unit-a"), "unit-a"))
+	require.NoError(t, client.PublishToStreamWithMsgID(ctx, subject, []byte("unit-a"), "unit-a"))
+
+	// Wait past any delivery, then assert exactly one.
+	time.Sleep(2 * time.Second)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&deliveries), "same msg-id within the dedup window must deliver once")
+}

--- a/natsclient/consume_durable_test.go
+++ b/natsclient/consume_durable_test.go
@@ -1,0 +1,49 @@
+package natsclient
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestValidateHeartbeatBelowAckWait enforces the ADR-070 B3 invariant: a
+// heartbeat that can't fire (with margin) before AckWait expires would redeliver
+// a live unit — reject it. Zero AckWait resolves to the 30s server default.
+func TestValidateHeartbeatBelowAckWait(t *testing.T) {
+	tests := []struct {
+		name      string
+		heartbeat time.Duration
+		ackWait   time.Duration
+		wantErr   bool
+	}{
+		{"heartbeat well below ackwait", 5 * time.Second, 30 * time.Second, false},
+		{"heartbeat exactly half", 15 * time.Second, 30 * time.Second, false},
+		{"heartbeat above half (margin violation)", 20 * time.Second, 30 * time.Second, true},
+		{"heartbeat >= ackwait (the B3 bug)", 90 * time.Second, 30 * time.Second, true},
+		{"zero ackwait resolves to 30s default, ok", 10 * time.Second, 0, false},
+		{"zero ackwait default, heartbeat too big", 20 * time.Second, 0, true},
+		{"non-positive heartbeat rejected", 0, 30 * time.Second, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHeartbeatBelowAckWait(tt.heartbeat, tt.ackWait)
+			if tt.wantErr && err == nil {
+				t.Fatalf("want error for heartbeat=%s ackWait=%s, got nil", tt.heartbeat, tt.ackWait)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("want nil for heartbeat=%s ackWait=%s, got %v", tt.heartbeat, tt.ackWait, err)
+			}
+		})
+	}
+}
+
+// TestConsumeDurable_RejectsMisconfiguredHeartbeat proves the enforcement fires
+// at the public entry (before any server interaction).
+func TestConsumeDurable_RejectsMisconfiguredHeartbeat(t *testing.T) {
+	c := &Client{}
+	err := c.ConsumeDurable(nil, StreamConsumerConfig{StreamName: "S", ConsumerName: "C", AckWait: 30 * time.Second},
+		90*time.Second, func(_ context.Context, _ []byte) error { return nil })
+	if err == nil {
+		t.Fatal("ConsumeDurable must reject heartbeat >= ack_wait before touching the server")
+	}
+}

--- a/openspec/changes/gated-dag-durable-dispatch/.openspec.yaml
+++ b/openspec/changes/gated-dag-durable-dispatch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/gated-dag-durable-dispatch/design.md
+++ b/openspec/changes/gated-dag-durable-dispatch/design.md
@@ -1,0 +1,84 @@
+# Design — Gated-DAG durable dispatch
+
+The decision + rationale live in ADR-070; this captures the concrete mechanics
+and sequencing. **Framework side only** — the consumer migration (semspec,
+semdragon) is a follow-up on a framework tag.
+
+## Non-breaking by construction
+
+A JetStream `PublishToStreamWithAck` publishes to the *subject*; the stream
+captures a persisted copy AND core-NATS subscribers on that subject still receive
+the live message. So switching the executor from `nc.Publish` to
+`PublishToStreamWithAck` (with the dispatch stream provisioned) **does not break
+the existing core-NATS consumers** — they keep receiving dispatches while the
+stream begins persisting them. Consumers migrate to the durable consumer later,
+atomically (a consumer must not run both a core sub and a durable consumer, or it
+double-processes). This is why the framework side ships and tags independently.
+
+## natsclient — `ConsumeDurable`
+
+```go
+// ConsumeDurable runs a durable at-least-once consumer: it composes
+// ConsumeStreamWithConfig + ConsumeWithHeartbeat + ack/nak so the handler is a
+// plain func(ctx, []byte) error — ack on nil, nak-with-delay on error, InProgress
+// heartbeat holds a long-running unit past AckWait. The consumer never touches
+// jetstream.Msg. Envelope decode stays above natsclient (payload registry
+// layering); the []byte is the raw message data.
+func (c *Client) ConsumeDurable(ctx context.Context, cfg StreamConsumerConfig, heartbeat time.Duration, handler func(context.Context, []byte) error) error
+```
+
+Implemented as `ConsumeStreamWithConfig(ctx, cfg, func(mctx, msg) { _ =
+ConsumeWithHeartbeat(mctx, msg, heartbeat, func(wctx) error { return
+handler(wctx, msg.Data()) }) })`. AckPolicy explicit; the wrapper owns ack/nak.
+
+**Config cross-validation (B3):** `StreamConsumerConfig.Validate()` (or a
+ConsumeDurable-time check) MUST reject `heartbeat >= AckWait` — a heartbeat that
+first fires after AckWait already expired redelivers a live unit. Enforce
+`heartbeat <= AckWait/2` (margin for the first tick). File the same gap against
+`agentic-loop/config.go`'s `ConsumerConfig.Validate` as a sibling.
+
+## gated-dag executor — durable publish + claim rollback
+
+- **Provision the dispatch stream** at Start: `EnsureStream` on the dispatch
+  subject, with a bounded retention (`MaxAge`/`MaxMsgs`) so an unconsumed backlog
+  can't grow forever (a work stream, not the graph — ADR-068's no-TTL rule is
+  about ENTITY_STATES, not request streams).
+- **`natsPublisher.Dispatch`** switches `nc.Publish` → `PublishToStreamWithAck`,
+  returning the error on a non-ack.
+- **`claimThenDispatch` (executor.go:394-429)**: on a `Dispatch` error, **roll the
+  claim back** — the same path the claim-error branch already takes
+  (`executor.go:403-405`) — because a failed ack proves non-persistence, so the
+  unit is safe to re-select next eval. Remove the "stranded until reset" comment;
+  add a rollback + a `dispatch_publish_failures_total` metric tick.
+
+## gated-dag executor — stall detector (residual observability)
+
+`stallAfterInflight` (executor.go:435-448) currently returns nil the moment any
+claimed unit is non-terminal (treats it as healthy in-flight), suppressing the
+stall alert forever for a stranded unit. Change: a claimed, non-terminal,
+non-dirtied unit whose claim timestamp (`claim.go:60`) is older than a configured
+`stranded_after` threshold no longer suppresses the stall — it surfaces as a
+stall/alert (edge-triggered publish as today). **Alert-only, never re-dispatch.**
+Honest scope (ADR-070 B2): the threshold must be set above the max legitimate unit
+runtime (a healthy long-running unit held by the consumer's heartbeat is
+KV-indistinguishable from a stranded one); a false positive is a spurious alert,
+not a double-run. `stranded_after: 0` disables it (back-compat).
+
+## Shared decode helper (B5)
+
+Add `gateddagexec.DecodeDispatch(data []byte) (*DispatchMessage, error)` in the
+gated-dag payload package (BaseMessage → DispatchMessage). Both consumers import
+it so the envelope unwrap is not reinvented per repo. Framework-side deliverable
+even though the consumers live elsewhere.
+
+## Config knobs (config.go)
+
+`DispatchStream` (stream name), `DispatchDurable` (consumer name), `AckWait`,
+`MaxAckPending`, `HeartbeatInterval`, `StrandedAfter`, stream retention. Sensible
+defaults; `Validate()` enforces `HeartbeatInterval < AckWait` (B3) and
+non-negative durations.
+
+## Out of scope (this change)
+
+Consumer wiring in semspec/semdragon; the CAS-UPGRADE claim exclusion; removing
+the core-NATS publish path (kept until consumers migrate — non-breaking overlap).

--- a/openspec/changes/gated-dag-durable-dispatch/design.md
+++ b/openspec/changes/gated-dag-durable-dispatch/design.md
@@ -43,13 +43,18 @@ first fires after AckWait already expired redelivers a live unit. Enforce
   subject, with a bounded retention (`MaxAge`/`MaxMsgs`) so an unconsumed backlog
   can't grow forever (a work stream, not the graph — ADR-068's no-TTL rule is
   about ENTITY_STATES, not request streams).
-- **`natsPublisher.Dispatch`** switches `nc.Publish` → `PublishToStreamWithAck`,
-  returning the error on a non-ack.
-- **`claimThenDispatch` (executor.go:394-429)**: on a `Dispatch` error, **roll the
-  claim back** — the same path the claim-error branch already takes
-  (`executor.go:403-405`) — because a failed ack proves non-persistence, so the
-  unit is safe to re-select next eval. Remove the "stranded until reset" comment;
-  add a rollback + a `dispatch_publish_failures_total` metric tick.
+- **`natsPublisher.Dispatch`** switches to `PublishToStreamWithMsgID` with
+  `Nats-Msg-Id = unitID`, and the stream is provisioned with a `Duplicates` window
+  ≥ backstop (config `dispatch_dedupe_window`). This is what makes the rollback
+  safe (B1): a `PublishToStreamWithAck` can error after the server persisted (ack
+  timeout), so "failed ack ⇒ not persisted" is false; msg-id dedup collapses the
+  re-dispatch to one stored message.
+- **`claimThenDispatch`**: on a `Dispatch` error, **roll the claim back** (Unclaim
+  + clear the in-memory hint) — the unit re-selects next eval. Safe because of the
+  msg-id dedup above (a duplicate stored message cannot result). Unclaim runs
+  OUTSIDE evalMu, then the inflight delete under evalMu (the hint holds across
+  Unclaim so a concurrent reEvaluate does not re-select until the deliberate
+  delete).
 
 ## gated-dag executor — stall detector (residual observability)
 

--- a/openspec/changes/gated-dag-durable-dispatch/proposal.md
+++ b/openspec/changes/gated-dag-durable-dispatch/proposal.md
@@ -29,9 +29,18 @@ The substrate already exists in `natsclient`: `PublishToStreamWithAck`,
   `natsclient.PublishToStreamWithAck` (ack-confirmed persisted) to a
   JetStream stream provisioned with `EnsureStream`, replacing core-NATS
   `nc.Publish`. A dispatch is now durably queued and delivered whenever the
-  consumer (re)subscribes — fixing lost-dispatch deterministically, no lease TTL
-  to tune. Consumer crash mid-work is covered by `AckWait` redelivery +
-  `ConsumeWithHeartbeat`'s `InProgress` heartbeat.
+  consumer (re)subscribes — fixing lost-dispatch deterministically. Consumer crash
+  mid-work is covered by `AckWait` redelivery + `ConsumeWithHeartbeat`'s
+  `InProgress` heartbeat.
+- **Roll the claim back on a failed publish-ack (B1).** A failed
+  `PublishToStreamWithAck` proves the message was not persisted, so the executor
+  clears the claim (mirroring the existing claim-failure rollback) → auto-retry
+  next eval, instead of stranded-until-reset. The durable ack is the information
+  core-NATS lacked.
+- **Enforce `heartbeat_interval < ack_wait` at config-load (B3).** Not merely
+  documented (the agentic-loop precedent documents but doesn't validate it, so a
+  misconfig silently redelivers a live unit → duplicate paid work). File the same
+  gap against agentic-loop's config as a sibling.
 - **New natsclient primitive — a typed durable-consume wrapper.**
   `ConsumeDurable(ctx, cfg, heartbeat, handler func(ctx, []byte) error)` composes
   `ConsumeStreamWithConfig` + `ConsumeWithHeartbeat` + ack/nak so a consumer's
@@ -39,8 +48,13 @@ The substrate already exists in `natsclient`: `PublishToStreamWithAck`,
   framework owns the at-least-once pattern once; both gated-DAG consumers use it.
 - **BREAKING — consumer contract.** semspec and semdragon migrate from a
   core-NATS subject subscription to the durable consumer (`ConsumeDurable`),
-  **acking after the terminal marker lands**. We control both consumers, so the
-  break is coordinated and one-time.
+  **acking after the terminal marker lands**, and on redelivery
+  **short-circuiting** if the terminal marker is already present (ack without
+  re-running — B4). `ConsumeDurable` hands a `func(ctx, []byte) error`; the
+  `BaseMessage → DispatchMessage` unwrap stays above natsclient (layering), so a
+  **shared decode helper** in the gated-dag payload package (imported by both
+  consumers) owns it once rather than each repo reinventing it (B5). We control
+  both consumers, so the break is coordinated and one-time.
 - **Stall detector (the residual).** Fix the `stallAfterInflight` blind spot so a
   claimed-too-long non-terminal unit surfaces as a stall/alert — covering the one
   failure the stream cannot: a terminal-marker write dropped *after* the consumer

--- a/openspec/changes/gated-dag-durable-dispatch/proposal.md
+++ b/openspec/changes/gated-dag-durable-dispatch/proposal.md
@@ -1,0 +1,90 @@
+# Gated-DAG durable dispatch (gh#385)
+
+## Why
+
+A gated-DAG unit that is **claimed but never marked terminal** — because its
+dispatch was lost (fire-and-forget core-NATS, consumer not yet subscribed /
+restarting) — **wedges its entire downstream subtree forever, silently, with no
+auto-recovery and no stall alert**. `claimThenDispatch` already warns *"unit may
+be stranded until reset."*
+
+The **root cause** is the transport: gated-DAG dispatch is
+`processor/gated-dag/publisher.go` `nc.Publish` — **the only dispatch path in the
+framework that is not durable**. By the KV-or-stream heuristic a dispatch is a
+"request to do something" → a resumable JetStream stream; and the framework's own
+`for_each` path (ADR-046 Phase 1) already dispatches into agentic-loop's **durable
+JetStream consumer**. The gated-DAG Phase-2 executor shipped a core-NATS shortcut
+that skipped durability. A claim lease / timer-based re-dispatch would be a
+band-aid over the wrong transport (and re-running a unit to recover is wasteful +
+needs idempotency) — we fix the transport instead.
+
+The substrate already exists in `natsclient`: `PublishToStreamWithAck`,
+`EnsureStream`, `ConsumeStreamWithConfig`, and `ConsumeWithHeartbeat` (the
+`InProgress` heartbeat that holds a long-running unit past `AckWait`). No raw
+`js.Publish`/`jetstream.*` leaks into the gated-DAG component.
+
+## What Changes
+
+- **BREAKING — durable dispatch.** The executor publishes each dispatch via
+  `natsclient.PublishToStreamWithAck` (ack-confirmed persisted) to a
+  JetStream stream provisioned with `EnsureStream`, replacing core-NATS
+  `nc.Publish`. A dispatch is now durably queued and delivered whenever the
+  consumer (re)subscribes — fixing lost-dispatch deterministically, no lease TTL
+  to tune. Consumer crash mid-work is covered by `AckWait` redelivery +
+  `ConsumeWithHeartbeat`'s `InProgress` heartbeat.
+- **New natsclient primitive — a typed durable-consume wrapper.**
+  `ConsumeDurable(ctx, cfg, heartbeat, handler func(ctx, []byte) error)` composes
+  `ConsumeStreamWithConfig` + `ConsumeWithHeartbeat` + ack/nak so a consumer's
+  handler is `func(ctx, payload) error` and never touches `jetstream.Msg`. The
+  framework owns the at-least-once pattern once; both gated-DAG consumers use it.
+- **BREAKING — consumer contract.** semspec and semdragon migrate from a
+  core-NATS subject subscription to the durable consumer (`ConsumeDurable`),
+  **acking after the terminal marker lands**. We control both consumers, so the
+  break is coordinated and one-time.
+- **Stall detector (the residual).** Fix the `stallAfterInflight` blind spot so a
+  claimed-too-long non-terminal unit surfaces as a stall/alert — covering the one
+  failure the stream cannot: a terminal-marker write dropped *after* the consumer
+  acked (largely a consumer marker-write-reliability concern; the mutation API is
+  already `RequestWithRetryClassified`), and the consumer-down case.
+- **Retire the lease idea** entirely (not implemented). The **claim marker stays**
+  but narrows to executor-side dedup (don't re-publish each backstop pass); no
+  lease semantics.
+
+## Capabilities
+
+### New Capabilities
+- `gated-dag-dispatch` — the durable dispatch contract for the gated-DAG
+  executor: durable publish-with-ack, the durable-consumer + ack-after-marker
+  consumer contract, the heartbeat for long-running units, claim-based dedup, and
+  the stranded-unit stall signal.
+
+### Modified Capabilities
+- None (no existing spec covers gated-dag or natsclient streaming yet).
+
+## Impact
+
+- `natsclient`: new `ConsumeDurable` wrapper (composes existing primitives; small
+  surface add). No new raw-JS surface — publish/ack/heartbeat already exist.
+- `processor/gated-dag/`: `publisher.go` (`PublishToStreamWithAck` + stream
+  provisioning), `component.go` (stream/consumer wiring, config), `executor.go`
+  (`stallAfterInflight` fix), `config.go` (stream/consumer knobs — durable name,
+  `AckWait`, `MaxAckPending`, heartbeat interval), `metrics.go`.
+- **Consumers (semspec, semdragon — both ours):** migrate to
+  `natsclient.ConsumeDurable` + ack-after-marker. Cross-repo, coordinated.
+- **Decision recorded as an ADR amending ADR-046** (the dispatch-contract change).
+
+## Non-goals
+
+- **Claim lease / timer-based re-dispatch** — rejected as a band-aid over the
+  transport; the stream is the root fix.
+- **CAS-based cross-instance claim exclusion** (`claim.go:46` CAS-UPGRADE POINT) —
+  a separate concern (ADR-046 invariant #1), untouched.
+- **The reset-driven manual recovery path** stays as the operator escape hatch.
+- No change to the KV-watch-driven *input* side of the executor (unit markers);
+  only the *dispatch output* transport changes.
+
+## Consumers
+
+`processor/gated-dag` (framework); semspec + semdragon (the two dispatch
+consumers, both ours). The `ConsumeDurable` wrapper is generic natsclient
+substrate reusable by any durable at-least-once consumer.

--- a/openspec/changes/gated-dag-durable-dispatch/specs/gated-dag-dispatch/spec.md
+++ b/openspec/changes/gated-dag-durable-dispatch/specs/gated-dag-dispatch/spec.md
@@ -1,0 +1,98 @@
+# Gated-DAG Dispatch
+
+## ADDED Requirements
+
+### Requirement: Dispatch is durable at-least-once
+
+The gated-DAG executor MUST publish each unit dispatch to a JetStream stream via
+an ack-confirmed publish (`natsclient.PublishToStreamWithAck`), not a
+fire-and-forget core-NATS publish. A dispatch that is ack-confirmed is durably
+queued and delivered whenever a consumer (re)subscribes, so a lost dispatch
+(consumer not subscribed / restarting) can no longer strand a claimed unit.
+
+#### Scenario: dispatch is persisted before the executor considers it sent
+
+- **GIVEN** a dispatchable unit
+- **WHEN** the executor dispatches it
+- **THEN** it publishes via an ack-confirmed JetStream publish to the dispatch
+  stream
+- **AND** treats the dispatch as sent only after the publish ack returns
+
+#### Scenario: a consumer that subscribes later still receives the dispatch
+
+- **GIVEN** a unit was dispatched while no consumer was subscribed
+- **WHEN** a durable consumer subscribes afterward
+- **THEN** the persisted dispatch is delivered to it
+
+### Requirement: A failed publish rolls the claim back
+
+The executor MUST clear a unit's durable claim when its dispatch publish fails
+(the ack did not return), because a non-acked publish is proof the message was not
+persisted and will not be delivered. The unit is then re-selected on the next
+evaluation instead of being stranded until a manual reset.
+
+#### Scenario: publish-ack failure re-arms the unit
+
+- **GIVEN** the executor committed a unit's claim and then the dispatch publish
+  failed to ack
+- **WHEN** the next evaluation runs
+- **THEN** the unit's claim has been cleared
+- **AND** the unit is re-selected for dispatch (not skipped as claimed)
+
+### Requirement: The framework provides a typed durable-consume primitive
+
+natsclient MUST provide a durable at-least-once consume wrapper whose handler is
+`func(ctx, []byte) error` — acking on nil, nak-with-delay on error, and holding a
+long-running unit past `AckWait` via an `InProgress` heartbeat — so a consumer
+never handles a raw `jetstream.Msg` for ack semantics. Envelope decoding remains
+above natsclient.
+
+#### Scenario: handler success acks, error naks
+
+- **GIVEN** a durable consumer created via the wrapper
+- **WHEN** the handler returns nil for a message
+- **THEN** the message is acked
+- **AND WHEN** the handler returns an error
+- **THEN** the message is nak'd for redelivery
+
+#### Scenario: a long-running handler is not redelivered while alive
+
+- **GIVEN** a handler whose work runs longer than `AckWait`
+- **WHEN** it is processing
+- **THEN** `InProgress` heartbeats hold the message so it is not redelivered until
+  the work finishes or the process crashes
+
+### Requirement: Heartbeat interval is enforced below AckWait
+
+The durable-consume configuration MUST reject a `heartbeat_interval` that is not
+safely less than `ack_wait` at load/creation time, because a heartbeat that first
+fires after `AckWait` has expired redelivers a still-running unit and causes
+duplicate work. Documentation alone is insufficient.
+
+#### Scenario: misconfigured heartbeat fails fast
+
+- **GIVEN** a durable-consume config with `heartbeat_interval >= ack_wait`
+- **WHEN** the config is validated
+- **THEN** validation fails with an error naming both values
+
+### Requirement: A stranded unit surfaces as a stall alert
+
+The executor MUST surface a unit that is claimed, non-terminal, non-dirtied, and
+older than a configured `stranded_after` threshold as a stall alert rather than
+suppressing it (as it does today, where any claimed non-terminal unit reads as
+healthy in-flight). This is alert-only — never auto-re-dispatch. A zero threshold
+disables the check (back-compat).
+
+#### Scenario: a long-stranded unit is alerted, not hidden
+
+- **GIVEN** a unit claimed longer ago than `stranded_after`, with no terminal
+  marker and not dirtied
+- **WHEN** the executor evaluates stall
+- **THEN** the unit is reported as stalled (not suppressed as in-flight)
+
+#### Scenario: a fresh claimed unit is still treated as in-flight
+
+- **GIVEN** a claimed non-terminal unit whose claim is newer than `stranded_after`
+- **WHEN** the executor evaluates stall
+- **THEN** the unit does not trigger a stall (a healthy in-flight unit is not
+  falsely alerted)

--- a/openspec/changes/gated-dag-durable-dispatch/tasks.md
+++ b/openspec/changes/gated-dag-durable-dispatch/tasks.md
@@ -8,27 +8,27 @@
       ConsumeDurable time; reject with an error naming both + unit test
 - [x] 1.3 Test the wrapper acks on nil / naks on error (integration against a real
       server, tag integration)
-- [ ] 1.4 File the sibling enforcement gap against `agentic-loop/config.go`
+- [x] 1.4 File the sibling enforcement gap against `agentic-loop/config.go` (gh#453)
 
 ## 2. gated-dag config knobs
 
-- [ ] 2.1 `config.go`: `DispatchStream`, `DispatchDurable`, `AckWait`,
+- [x] 2.1 `config.go`: `DispatchStream`, `DispatchDurable`, `AckWait`,
       `MaxAckPending`, `HeartbeatInterval`, `StrandedAfter`, stream retention
-- [ ] 2.2 `Validate()`: `HeartbeatInterval < AckWait`, non-negative durations + test
+- [x] 2.2 `Validate()`: `HeartbeatInterval < AckWait`, non-negative durations + test
 
 ## 3. Durable publish + claim rollback
 
-- [ ] 3.1 Provision the dispatch stream (`EnsureStream`, bounded `MaxAge`/`MaxMsgs`)
+- [x] 3.1 Provision the dispatch stream (`EnsureStream`, bounded `MaxAge`/`MaxMsgs`)
       at Start
-- [ ] 3.2 `natsPublisher.Dispatch` → `PublishToStreamWithAck` (return error on
+- [x] 3.2 `natsPublisher.Dispatch` → `PublishToStreamWithAck` (return error on
       non-ack)
-- [ ] 3.3 `claimThenDispatch`: roll the claim back on a `Dispatch` error (mirror
+- [x] 3.3 `claimThenDispatch`: roll the claim back on a `Dispatch` error (mirror
       the claim-error rollback); `dispatch_publish_failures_total` metric; drop the
       "stranded until reset" comment + test (publish-fail re-arms the unit)
 
 ## 4. Stranded-unit stall detector
 
-- [ ] 4.1 `stallAfterInflight`: a claimed unit older than `StrandedAfter` (claim
+- [x] 4.1 `stallAfterInflight`: a claimed unit older than `StrandedAfter` (claim
       timestamp) no longer suppresses the stall; fresh claimed units still read as
       in-flight; `StrandedAfter==0` disables + test (stranded alerts, fresh does not)
 

--- a/openspec/changes/gated-dag-durable-dispatch/tasks.md
+++ b/openspec/changes/gated-dag-durable-dispatch/tasks.md
@@ -1,0 +1,44 @@
+# Tasks — Gated-DAG durable dispatch (framework side)
+
+## 1. natsclient `ConsumeDurable` + heartbeat/ackwait enforcement
+
+- [ ] 1.1 `Client.ConsumeDurable(ctx, cfg, heartbeat, handler func(ctx, []byte) error)`
+      composing `ConsumeStreamWithConfig` + `ConsumeWithHeartbeat` + ack/nak
+- [ ] 1.2 Enforce `heartbeat < AckWait` (with margin) at config-validate /
+      ConsumeDurable time; reject with an error naming both + unit test
+- [ ] 1.3 Test the wrapper acks on nil / naks on error (integration against a real
+      server, tag integration)
+- [ ] 1.4 File the sibling enforcement gap against `agentic-loop/config.go`
+
+## 2. gated-dag config knobs
+
+- [ ] 2.1 `config.go`: `DispatchStream`, `DispatchDurable`, `AckWait`,
+      `MaxAckPending`, `HeartbeatInterval`, `StrandedAfter`, stream retention
+- [ ] 2.2 `Validate()`: `HeartbeatInterval < AckWait`, non-negative durations + test
+
+## 3. Durable publish + claim rollback
+
+- [ ] 3.1 Provision the dispatch stream (`EnsureStream`, bounded `MaxAge`/`MaxMsgs`)
+      at Start
+- [ ] 3.2 `natsPublisher.Dispatch` → `PublishToStreamWithAck` (return error on
+      non-ack)
+- [ ] 3.3 `claimThenDispatch`: roll the claim back on a `Dispatch` error (mirror
+      the claim-error rollback); `dispatch_publish_failures_total` metric; drop the
+      "stranded until reset" comment + test (publish-fail re-arms the unit)
+
+## 4. Stranded-unit stall detector
+
+- [ ] 4.1 `stallAfterInflight`: a claimed unit older than `StrandedAfter` (claim
+      timestamp) no longer suppresses the stall; fresh claimed units still read as
+      in-flight; `StrandedAfter==0` disables + test (stranded alerts, fresh does not)
+
+## 5. Shared decode helper
+
+- [ ] 5.1 `gateddagexec.DecodeDispatch(data []byte) (*DispatchMessage, error)` +
+      test (framework-side; consumers import it)
+
+## 6. Spec + close
+
+- [ ] 6.1 `openspec validate`; gates green (`go test -race`, `task lint`, schema
+      no-drift); semstreams-reviewer; then archive → promote `gated-dag-dispatch`
+      into `openspec/specs/`

--- a/openspec/changes/gated-dag-durable-dispatch/tasks.md
+++ b/openspec/changes/gated-dag-durable-dispatch/tasks.md
@@ -39,6 +39,6 @@
 
 ## 6. Spec + close
 
-- [ ] 6.1 `openspec validate`; gates green (`go test -race`, `task lint`, schema
+- [x] 6.1 `openspec validate`; gates green (`go test -race`, `task lint`, schema
       no-drift); semstreams-reviewer; then archive → promote `gated-dag-dispatch`
       into `openspec/specs/`

--- a/openspec/changes/gated-dag-durable-dispatch/tasks.md
+++ b/openspec/changes/gated-dag-durable-dispatch/tasks.md
@@ -2,11 +2,11 @@
 
 ## 1. natsclient `ConsumeDurable` + heartbeat/ackwait enforcement
 
-- [ ] 1.1 `Client.ConsumeDurable(ctx, cfg, heartbeat, handler func(ctx, []byte) error)`
+- [x] 1.1 `Client.ConsumeDurable(ctx, cfg, heartbeat, handler func(ctx, []byte) error)`
       composing `ConsumeStreamWithConfig` + `ConsumeWithHeartbeat` + ack/nak
-- [ ] 1.2 Enforce `heartbeat < AckWait` (with margin) at config-validate /
+- [x] 1.2 Enforce `heartbeat < AckWait` (with margin) at config-validate /
       ConsumeDurable time; reject with an error naming both + unit test
-- [ ] 1.3 Test the wrapper acks on nil / naks on error (integration against a real
+- [x] 1.3 Test the wrapper acks on nil / naks on error (integration against a real
       server, tag integration)
 - [ ] 1.4 File the sibling enforcement gap against `agentic-loop/config.go`
 
@@ -34,7 +34,7 @@
 
 ## 5. Shared decode helper
 
-- [ ] 5.1 `gateddagexec.DecodeDispatch(data []byte) (*DispatchMessage, error)` +
+- [x] 5.1 `gateddagexec.DecodeDispatch(data []byte) (*DispatchMessage, error)` +
       test (framework-side; consumers import it)
 
 ## 6. Spec + close

--- a/processor/gated-dag/claim.go
+++ b/processor/gated-dag/claim.go
@@ -26,6 +26,11 @@ type claimer interface {
 	// Claim writes the claim marker on unitID. Returns an error if the write
 	// fails (the caller then does NOT publish — the unit is retried next eval).
 	Claim(ctx context.Context, unitID string) error
+	// Unclaim removes the claim marker on unitID. Called to roll a claim back
+	// when the dispatch publish fails after the claim committed (ADR-070 B1): a
+	// failed ack proves the dispatch was not persisted, so clearing the claim
+	// re-selects the unit next eval instead of stranding it until manual reset.
+	Unclaim(ctx context.Context, unitID string) error
 }
 
 // natsClaimer writes the claim via the atomic replace-by-predicate mutation
@@ -76,6 +81,25 @@ func (c *natsClaimer) Claim(ctx context.Context, unitID string) error {
 	var resp graph.UpdateEntityWithTriplesResponse
 	if err := json.Unmarshal(respData, &resp); err != nil {
 		return fmt.Errorf("unmarshal claim response for %s: %w", unitID, err)
+	}
+	return nil
+}
+
+// Unclaim removes the claim marker via the same atomic replace-by-predicate
+// mutation (RemoveTriples drops the claim, no AddTriples). Idempotent: removing
+// an already-absent predicate converges. Used only to roll back a claim after a
+// failed dispatch publish (ADR-070 B1).
+func (c *natsClaimer) Unclaim(ctx context.Context, unitID string) error {
+	req := graph.UpdateEntityWithTriplesRequest{
+		Entity:        &graph.EntityState{ID: unitID},
+		RemoveTriples: []string{c.predicate},
+	}
+	reqData, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal unclaim request: %w", err)
+	}
+	if _, err := c.nc.RequestWithRetryClassified(ctx, subjectUpdateWithTriples, reqData, claimMutationTimeout, natsclient.DefaultRetryConfig()); err != nil {
+		return fmt.Errorf("unclaim mutation failed for %s: %w", unitID, err)
 	}
 	return nil
 }

--- a/processor/gated-dag/component.go
+++ b/processor/gated-dag/component.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nats-io/nats.go/jetstream"
+
 	"github.com/c360studio/semstreams/component"
 	"github.com/c360studio/semstreams/metric"
 	"github.com/c360studio/semstreams/natsclient"
@@ -105,6 +107,25 @@ func (c *Component) Start(ctx context.Context) error {
 	qTimeout, err := c.cfg.queryTimeout()
 	if err != nil {
 		return err
+	}
+
+	// Provision the durable dispatch stream (ADR-070): it captures DispatchSubject,
+	// so a dispatch published via PublishToStreamWithAck is persisted and delivered
+	// whenever a consumer (re)subscribes — a lost dispatch can no longer strand a
+	// claimed unit. Idempotent (get-or-create). A bounded MaxAge keeps an
+	// unconsumed backlog from growing forever (a work stream, not the graph —
+	// ADR-068's no-TTL rule is about ENTITY_STATES).
+	streamMaxAge, err := c.cfg.dispatchStreamMaxAge()
+	if err != nil {
+		return err
+	}
+	if _, err := c.natsClient.EnsureStream(ctx, jetstream.StreamConfig{
+		Name:     c.cfg.DispatchStream,
+		Subjects: []string{c.cfg.DispatchSubject},
+		MaxAge:   streamMaxAge,
+	}); err != nil {
+		return fmt.Errorf("gated-dag: ensure dispatch stream %q for subject %q: %w",
+			c.cfg.DispatchStream, c.cfg.DispatchSubject, err)
 	}
 
 	var stall stallPublisher

--- a/processor/gated-dag/component.go
+++ b/processor/gated-dag/component.go
@@ -119,13 +119,29 @@ func (c *Component) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if _, err := c.natsClient.EnsureStream(ctx, jetstream.StreamConfig{
-		Name:     c.cfg.DispatchStream,
-		Subjects: []string{c.cfg.DispatchSubject},
-		MaxAge:   streamMaxAge,
-	}); err != nil {
+	dedupeWindow, err := c.cfg.dispatchDedupeWindow()
+	if err != nil {
+		return err
+	}
+	stream, err := c.natsClient.EnsureStream(ctx, jetstream.StreamConfig{
+		Name:       c.cfg.DispatchStream,
+		Subjects:   []string{c.cfg.DispatchSubject},
+		MaxAge:     streamMaxAge,
+		Duplicates: dedupeWindow, // server-side dedup on Nats-Msg-Id=unitID (ADR-070 B1)
+	})
+	if err != nil {
 		return fmt.Errorf("gated-dag: ensure dispatch stream %q for subject %q: %w",
 			c.cfg.DispatchStream, c.cfg.DispatchSubject, err)
+	}
+	// EnsureStream is get-or-create, NOT reconcile: a pre-existing stream of the
+	// same name (e.g. another gated-dag executor sharing the default
+	// DispatchStream while using a different DispatchSubject) is returned
+	// UNCHANGED. Fail loud at Start if it does not capture our subject — otherwise
+	// every publish hits "no stream matches subject" and loops claim/rollback
+	// (HIGH footgun). Give each distinct DispatchSubject a distinct DispatchStream.
+	if info := stream.CachedInfo(); info != nil && !subjectCovered(c.cfg.DispatchSubject, info.Config.Subjects) {
+		return fmt.Errorf("gated-dag: dispatch stream %q exists but does not capture subject %q (stream subjects: %v) — EnsureStream does not reconcile a pre-existing stream; set a distinct dispatch_stream per dispatch_subject",
+			c.cfg.DispatchStream, c.cfg.DispatchSubject, info.Config.Subjects)
 	}
 
 	var stall stallPublisher
@@ -193,6 +209,19 @@ func (c *Component) Start(ctx context.Context) error {
 		slog.Int("workers", c.cfg.Workers),
 		slog.String("backstop", c.cfg.BackstopInterval))
 	return nil
+}
+
+// subjectCovered reports whether want is captured by the stream's configured
+// subjects. gated-dag uses concrete (non-wildcard) dispatch subjects, so an exact
+// membership check suffices — a stream this executor created lists want exactly;
+// a name-collision with another executor's subject fails the check.
+func subjectCovered(want string, subjects []string) bool {
+	for _, s := range subjects {
+		if s == want {
+			return true
+		}
+	}
+	return false
 }
 
 // Stop gracefully stops the executor.

--- a/processor/gated-dag/config.go
+++ b/processor/gated-dag/config.go
@@ -21,7 +21,8 @@ const (
 	defaultMaxUnits             = 1000
 	defaultDispatchStream       = "GATEDDAG_DISPATCH"
 	defaultDispatchStreamMaxAge = "24h"
-	defaultStrandedAfter        = "0" // disabled by default (opt-in, back-compat)
+	defaultDispatchDedupeWindow = "2m" // >= default backstop (30s); bounds ack-timeout dedup + reset delay
+	defaultStrandedAfter        = "0"  // disabled by default (opt-in, back-compat)
 
 	// FailurePolicyContinueOthers keeps independent branches flowing when a unit
 	// fails (its dependents stay Blocked; everything else proceeds). Default.
@@ -67,6 +68,14 @@ type Config struct {
 	// not the graph — ADR-068's no-TTL rule is about ENTITY_STATES). An unconsumed
 	// dispatch older than this is dropped. Duration string; must be > 0.
 	DispatchStreamMaxAge string `json:"dispatch_stream_max_age,omitempty"`
+	// DispatchDedupeWindow is the stream's server-side duplicate-detection window
+	// (Nats-Msg-Id = unitID). It makes the B1 claim-rollback safe against an
+	// ack-timeout-after-persist: a re-dispatch of the same unit within the window
+	// is deduped to one stored message. MUST be >= BackstopInterval (the worst-case
+	// re-dispatch latency) or an ack-timeout retry could fall outside the window
+	// and double-deliver. A reset-driven re-dispatch within the window is delayed
+	// by <= the window. Duration string; must be > 0.
+	DispatchDedupeWindow string `json:"dispatch_dedupe_window,omitempty"`
 	// StrandedAfter is the age past which a claimed, non-terminal, non-dirtied unit
 	// stops being treated as healthy in-flight and instead surfaces as a stall
 	// alert (ADR-070; the stranded-unit detector). Duration string; "0" disables
@@ -128,6 +137,7 @@ func DefaultConfig() Config {
 		FailurePolicy:        FailurePolicyContinueOthers,
 		DispatchStream:       defaultDispatchStream,
 		DispatchStreamMaxAge: defaultDispatchStreamMaxAge,
+		DispatchDedupeWindow: defaultDispatchDedupeWindow,
 		StrandedAfter:        defaultStrandedAfter,
 	}
 }
@@ -177,6 +187,9 @@ func (c Config) withDefaults() Config {
 	if c.DispatchStreamMaxAge == "" {
 		c.DispatchStreamMaxAge = d.DispatchStreamMaxAge
 	}
+	if c.DispatchDedupeWindow == "" {
+		c.DispatchDedupeWindow = d.DispatchDedupeWindow
+	}
 	if c.StrandedAfter == "" {
 		c.StrandedAfter = d.StrandedAfter
 	}
@@ -223,6 +236,16 @@ func (c Config) Validate() error {
 	}
 	if _, err := c.dispatchStreamMaxAge(); err != nil {
 		return fmt.Errorf("dispatch_stream_max_age: %w", err)
+	}
+	dedupe, err := c.dispatchDedupeWindow()
+	if err != nil {
+		return fmt.Errorf("dispatch_dedupe_window: %w", err)
+	}
+	// The dedupe window must cover the worst-case re-dispatch latency (a
+	// backstop-driven re-eval) or an ack-timeout retry falls outside it and
+	// double-delivers (ADR-070 B1). backstop is already validated above.
+	if backstop, berr := c.backstopInterval(); berr == nil && dedupe < backstop {
+		return fmt.Errorf("dispatch_dedupe_window (%s) must be >= backstop_interval (%s): a shorter window lets an ack-timeout re-dispatch escape server dedup and double-deliver", dedupe, backstop)
 	}
 	if _, err := c.strandedAfter(); err != nil {
 		return fmt.Errorf("stranded_after: %w", err)
@@ -284,6 +307,18 @@ func (c Config) dispatchStreamMaxAge() (time.Duration, error) {
 	d, err := time.ParseDuration(c.DispatchStreamMaxAge)
 	if err != nil {
 		return 0, fmt.Errorf("invalid duration %q: %w", c.DispatchStreamMaxAge, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("must be > 0 (got %s)", d)
+	}
+	return d, nil
+}
+
+// dispatchDedupeWindow parses DispatchDedupeWindow; must be > 0.
+func (c Config) dispatchDedupeWindow() (time.Duration, error) {
+	d, err := time.ParseDuration(c.DispatchDedupeWindow)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", c.DispatchDedupeWindow, err)
 	}
 	if d <= 0 {
 		return 0, fmt.Errorf("must be > 0 (got %s)", d)

--- a/processor/gated-dag/config.go
+++ b/processor/gated-dag/config.go
@@ -14,11 +14,14 @@ const (
 	defaultDependsOnPredicate = "gateddag.depends_on"
 	defaultClaimPredicate     = "gateddag.claim"
 
-	defaultWorkers          = 4
-	defaultQueueSize        = 256
-	defaultBackstopInterval = "30s"
-	defaultQueryTimeout     = "30s"
-	defaultMaxUnits         = 1000
+	defaultWorkers              = 4
+	defaultQueueSize            = 256
+	defaultBackstopInterval     = "30s"
+	defaultQueryTimeout         = "30s"
+	defaultMaxUnits             = 1000
+	defaultDispatchStream       = "GATEDDAG_DISPATCH"
+	defaultDispatchStreamMaxAge = "24h"
+	defaultStrandedAfter        = "0" // disabled by default (opt-in, back-compat)
 
 	// FailurePolicyContinueOthers keeps independent branches flowing when a unit
 	// fails (its dependents stay Blocked; everything else proceeds). Default.
@@ -55,6 +58,22 @@ type Config struct {
 	DirtiedPredicate   string `json:"dirtied_predicate,omitempty"`
 	DependsOnPredicate string `json:"depends_on_predicate,omitempty"`
 	ClaimPredicate     string `json:"claim_predicate,omitempty"`
+
+	// DispatchStream is the JetStream stream the executor ensures at Start and
+	// publishes dispatches into (ADR-070). It captures DispatchSubject, so a
+	// dispatch is durably queued and delivered whenever a consumer (re)subscribes.
+	DispatchStream string `json:"dispatch_stream,omitempty"`
+	// DispatchStreamMaxAge bounds the dispatch stream's retention (a work stream,
+	// not the graph — ADR-068's no-TTL rule is about ENTITY_STATES). An unconsumed
+	// dispatch older than this is dropped. Duration string; must be > 0.
+	DispatchStreamMaxAge string `json:"dispatch_stream_max_age,omitempty"`
+	// StrandedAfter is the age past which a claimed, non-terminal, non-dirtied unit
+	// stops being treated as healthy in-flight and instead surfaces as a stall
+	// alert (ADR-070; the stranded-unit detector). Duration string; "0" disables
+	// the check (back-compat). Set it ABOVE the max legitimate unit runtime — a
+	// healthy long-running unit held by the consumer heartbeat is KV-
+	// indistinguishable from a stranded one, so this is a soft, alert-only knob.
+	StrandedAfter string `json:"stranded_after,omitempty"`
 
 	// Workers / QueueSize bound the dispatch concurrency leg (pkg/dispatch).
 	Workers   int `json:"workers,omitempty"`
@@ -95,18 +114,21 @@ type Config struct {
 // rejects a config that does not set them.
 func DefaultConfig() Config {
 	return Config{
-		FanOutWorkflow:     FanOutWorkflow,
-		CompletedPredicate: defaultCompletedPredicate,
-		FailedPredicate:    defaultFailedPredicate,
-		DirtiedPredicate:   defaultDirtiedPredicate,
-		DependsOnPredicate: defaultDependsOnPredicate,
-		ClaimPredicate:     defaultClaimPredicate,
-		Workers:            defaultWorkers,
-		QueueSize:          defaultQueueSize,
-		BackstopInterval:   defaultBackstopInterval,
-		QueryTimeout:       defaultQueryTimeout,
-		MaxUnits:           defaultMaxUnits,
-		FailurePolicy:      FailurePolicyContinueOthers,
+		FanOutWorkflow:       FanOutWorkflow,
+		CompletedPredicate:   defaultCompletedPredicate,
+		FailedPredicate:      defaultFailedPredicate,
+		DirtiedPredicate:     defaultDirtiedPredicate,
+		DependsOnPredicate:   defaultDependsOnPredicate,
+		ClaimPredicate:       defaultClaimPredicate,
+		Workers:              defaultWorkers,
+		QueueSize:            defaultQueueSize,
+		BackstopInterval:     defaultBackstopInterval,
+		QueryTimeout:         defaultQueryTimeout,
+		MaxUnits:             defaultMaxUnits,
+		FailurePolicy:        FailurePolicyContinueOthers,
+		DispatchStream:       defaultDispatchStream,
+		DispatchStreamMaxAge: defaultDispatchStreamMaxAge,
+		StrandedAfter:        defaultStrandedAfter,
 	}
 }
 
@@ -149,6 +171,15 @@ func (c Config) withDefaults() Config {
 	if c.FailurePolicy == "" {
 		c.FailurePolicy = d.FailurePolicy
 	}
+	if c.DispatchStream == "" {
+		c.DispatchStream = d.DispatchStream
+	}
+	if c.DispatchStreamMaxAge == "" {
+		c.DispatchStreamMaxAge = d.DispatchStreamMaxAge
+	}
+	if c.StrandedAfter == "" {
+		c.StrandedAfter = d.StrandedAfter
+	}
 	return c
 }
 
@@ -186,6 +217,15 @@ func (c Config) Validate() error {
 	}
 	if _, err := c.queryTimeout(); err != nil {
 		return fmt.Errorf("query_timeout: %w", err)
+	}
+	if c.DispatchStream == "" {
+		return fmt.Errorf("dispatch_stream is required (the durable stream dispatches are published into — ADR-070)")
+	}
+	if _, err := c.dispatchStreamMaxAge(); err != nil {
+		return fmt.Errorf("dispatch_stream_max_age: %w", err)
+	}
+	if _, err := c.strandedAfter(); err != nil {
+		return fmt.Errorf("stranded_after: %w", err)
 	}
 	switch c.FailurePolicy {
 	case FailurePolicyContinueOthers, FailurePolicyStopOnFirstFailure:
@@ -235,6 +275,30 @@ func (c Config) queryTimeout() (time.Duration, error) {
 	}
 	if d <= 0 {
 		return 0, fmt.Errorf("must be > 0 (got %s)", d)
+	}
+	return d, nil
+}
+
+// dispatchStreamMaxAge parses DispatchStreamMaxAge; must be > 0.
+func (c Config) dispatchStreamMaxAge() (time.Duration, error) {
+	d, err := time.ParseDuration(c.DispatchStreamMaxAge)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", c.DispatchStreamMaxAge, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("must be > 0 (got %s)", d)
+	}
+	return d, nil
+}
+
+// strandedAfter parses StrandedAfter; must be >= 0 (0 disables the detector).
+func (c Config) strandedAfter() (time.Duration, error) {
+	d, err := time.ParseDuration(c.StrandedAfter)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: %w", c.StrandedAfter, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("must be >= 0 (got %s)", d)
 	}
 	return d, nil
 }

--- a/processor/gated-dag/config_test.go
+++ b/processor/gated-dag/config_test.go
@@ -45,6 +45,11 @@ func TestConfig_Validate(t *testing.T) {
 		{"bad failure policy", func(c *Config) { c.FailurePolicy = "panic" }, "failure_policy"},
 		{"predicate collision", func(c *Config) { c.ClaimPredicate = c.CompletedPredicate }, "must be distinct"},
 		{"empty predicate", func(c *Config) { c.DirtiedPredicate = "" }, "must not be empty"},
+		{"missing dispatch stream", func(c *Config) { c.DispatchStream = "" }, "dispatch_stream is required"},
+		{"bad dispatch stream max age", func(c *Config) { c.DispatchStreamMaxAge = "nope" }, "dispatch_stream_max_age"},
+		{"nonpositive dispatch stream max age", func(c *Config) { c.DispatchStreamMaxAge = "0s" }, "dispatch_stream_max_age"},
+		{"bad stranded after", func(c *Config) { c.StrandedAfter = "nope" }, "stranded_after"},
+		{"negative stranded after", func(c *Config) { c.StrandedAfter = "-1s" }, "stranded_after"},
 		{"instance id with custom workflow", func(c *Config) {
 			c.FanOutInstanceID = "org.plat.gateddag.fanout.instance.x"
 			c.FanOutWorkflow = "custom-wf"
@@ -74,20 +79,23 @@ func TestConfig_ValidateHappy(t *testing.T) {
 // dropped field is caught by inequality rather than coinciding with a default.
 func TestConfig_JSONRoundTrip(t *testing.T) {
 	in := Config{
-		FanOutWorkflow:     "custom-fanout",
-		UnitEntityPrefix:   "acme.ops.plan.fanout.unit",
-		DispatchSubject:    "custom.dispatch",
-		CompletedPredicate: "x.done",
-		FailedPredicate:    "x.failed",
-		DirtiedPredicate:   "x.reset",
-		DependsOnPredicate: "x.needs",
-		ClaimPredicate:     "x.inflight",
-		Workers:            7,
-		QueueSize:          99,
-		BackstopInterval:   "12s",
-		QueryTimeout:       "8s",
-		MaxUnits:           250,
-		FailurePolicy:      FailurePolicyStopOnFirstFailure,
+		FanOutWorkflow:       "custom-fanout",
+		UnitEntityPrefix:     "acme.ops.plan.fanout.unit",
+		DispatchSubject:      "custom.dispatch",
+		CompletedPredicate:   "x.done",
+		FailedPredicate:      "x.failed",
+		DirtiedPredicate:     "x.reset",
+		DependsOnPredicate:   "x.needs",
+		ClaimPredicate:       "x.inflight",
+		Workers:              7,
+		QueueSize:            99,
+		BackstopInterval:     "12s",
+		QueryTimeout:         "8s",
+		MaxUnits:             250,
+		FailurePolicy:        FailurePolicyStopOnFirstFailure,
+		DispatchStream:       "CUSTOM_DISPATCH",
+		DispatchStreamMaxAge: "48h",
+		StrandedAfter:        "15m",
 	}
 	data, err := json.Marshal(in)
 	require.NoError(t, err)

--- a/processor/gated-dag/config_test.go
+++ b/processor/gated-dag/config_test.go
@@ -48,6 +48,8 @@ func TestConfig_Validate(t *testing.T) {
 		{"missing dispatch stream", func(c *Config) { c.DispatchStream = "" }, "dispatch_stream is required"},
 		{"bad dispatch stream max age", func(c *Config) { c.DispatchStreamMaxAge = "nope" }, "dispatch_stream_max_age"},
 		{"nonpositive dispatch stream max age", func(c *Config) { c.DispatchStreamMaxAge = "0s" }, "dispatch_stream_max_age"},
+		{"bad dedupe window", func(c *Config) { c.DispatchDedupeWindow = "nope" }, "dispatch_dedupe_window"},
+		{"dedupe window below backstop", func(c *Config) { c.DispatchDedupeWindow = "5s"; c.BackstopInterval = "30s" }, "must be >= backstop_interval"},
 		{"bad stranded after", func(c *Config) { c.StrandedAfter = "nope" }, "stranded_after"},
 		{"negative stranded after", func(c *Config) { c.StrandedAfter = "-1s" }, "stranded_after"},
 		{"instance id with custom workflow", func(c *Config) {
@@ -95,6 +97,7 @@ func TestConfig_JSONRoundTrip(t *testing.T) {
 		FailurePolicy:        FailurePolicyStopOnFirstFailure,
 		DispatchStream:       "CUSTOM_DISPATCH",
 		DispatchStreamMaxAge: "48h",
+		DispatchDedupeWindow: "3m",
 		StrandedAfter:        "15m",
 	}
 	data, err := json.Marshal(in)

--- a/processor/gated-dag/decode_dispatch_test.go
+++ b/processor/gated-dag/decode_dispatch_test.go
@@ -1,0 +1,37 @@
+package gateddagexec
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/c360studio/semstreams/message"
+)
+
+// TestDecodeDispatch_RoundTrip proves the shared helper (ADR-070 B5) decodes a
+// registry-wrapped dispatch envelope — the exact shape the durable stream
+// delivers — back to the typed payload, so consumers don't reinvent the unwrap.
+func TestDecodeDispatch_RoundTrip(t *testing.T) {
+	orig := &DispatchMessage{UnitEntityID: "acme.ops.plan.fanout.unit.a", FanOutWorkflow: "gateddag-fanout"}
+	data, err := json.Marshal(message.NewBaseMessage(orig.Schema(), orig, "gateddag-executor"))
+	if err != nil {
+		t.Fatalf("marshal base message: %v", err)
+	}
+
+	got, err := DecodeDispatch(data)
+	if err != nil {
+		t.Fatalf("DecodeDispatch: %v", err)
+	}
+	if got.UnitEntityID != orig.UnitEntityID {
+		t.Errorf("UnitEntityID = %q, want %q", got.UnitEntityID, orig.UnitEntityID)
+	}
+	if got.FanOutWorkflow != orig.FanOutWorkflow {
+		t.Errorf("FanOutWorkflow = %q, want %q", got.FanOutWorkflow, orig.FanOutWorkflow)
+	}
+}
+
+// TestDecodeDispatch_Garbage returns an error, not a panic, on non-envelope bytes.
+func TestDecodeDispatch_Garbage(t *testing.T) {
+	if _, err := DecodeDispatch([]byte("not a base message")); err == nil {
+		t.Fatal("want error on garbage input, got nil")
+	}
+}

--- a/processor/gated-dag/executor.go
+++ b/processor/gated-dag/executor.go
@@ -36,6 +36,9 @@ type executor struct {
 	metrics *metrics
 
 	backstop time.Duration
+	// strandedAfter is the parsed StrandedAfter: a claimed non-terminal unit older
+	// than this stops suppressing the stall (ADR-070). 0 disables the age-gate.
+	strandedAfter time.Duration
 
 	// lastStalled edge-triggers the stall event (#365.3): emit only on the
 	// 0→non-zero transition. Touched only inside reEvaluate (under evalMu).
@@ -81,6 +84,11 @@ func (e *executor) start(ctx context.Context) error {
 		return err
 	}
 	e.backstop = backstop
+	strandedAfter, err := e.cfg.strandedAfter()
+	if err != nil {
+		return err
+	}
+	e.strandedAfter = strandedAfter
 	e.trigger = make(chan struct{}, 1)
 
 	runCtx, cancel := context.WithCancel(ctx)
@@ -252,7 +260,7 @@ func (e *executor) reEvaluate(ctx context.Context, fromBackstop bool) {
 	// Stall surfacing (#8): pure observability, computed BEFORE dispatch so a
 	// stalled plan alerts even when nothing dispatches. Subtract in-flight
 	// (claimed, non-terminal) units so running work is not mistaken for a stall.
-	stalled := stallAfterInflight(gateddag.Stalled(view.unitIDs, view.dependsOn, view.markers), view)
+	stalled := stallAfterInflight(gateddag.Stalled(view.unitIDs, view.dependsOn, view.markers), view, e.strandedAfter, time.Now())
 	if e.metrics != nil {
 		e.metrics.stall.Set(float64(len(stalled)))
 	}
@@ -417,7 +425,22 @@ func (e *executor) claimThenDispatch(ctx context.Context, unitID string) error {
 		if e.metrics != nil {
 			e.metrics.dispatchErr.Inc()
 		}
-		e.log.Error("gated-dag: dispatch publish failed AFTER claim committed; unit may be stranded until reset",
+		// ADR-070 B1: an ack-confirmed publish that returns an error proves the
+		// dispatch was NOT persisted and will not be delivered, so roll the claim
+		// back — durable (Unclaim) and in-memory (inflight hint) — and the unit
+		// re-selects next eval instead of stranding until a manual reset. This was
+		// impossible under fire-and-forget core-NATS (no ack ⇒ you could not know
+		// it wasn't delivered, so rolling back risked a double-run). The Unclaim
+		// round-trip runs OUTSIDE evalMu (mirrors the claim-error path); if it
+		// fails the stranded-unit detector still surfaces the wedge.
+		if uerr := e.claimer.Unclaim(ctx, unitID); uerr != nil {
+			e.log.Warn("gated-dag: claim rollback after dispatch failure also failed; unit may be stranded until the stranded-unit detector alerts or a reset",
+				slog.String("unit", unitID), slog.String("error", uerr.Error()))
+		}
+		e.evalMu.Lock()
+		delete(e.inflight, unitID)
+		e.evalMu.Unlock()
+		e.log.Warn("gated-dag: dispatch publish failed after claim; claim rolled back, unit re-selected next eval (gh#385)",
 			slog.String("unit", unitID), slog.String("error", err.Error()))
 		return err
 	}
@@ -431,8 +454,15 @@ func (e *executor) claimThenDispatch(ctx context.Context, unitID string) error {
 // stallAfterInflight suppresses a stall alert while genuine work is in flight: a
 // unit that is claimed but not yet terminal (and not dirtied) is running, so the
 // plan is progressing even if the brain reports held-ready units (S1). Returns
-// the original stalled set only when nothing is in flight.
-func stallAfterInflight(stalled []string, view graphView) []string {
+// the original stalled set only when nothing genuine is in flight.
+//
+// Age-gate (ADR-070): a claimed non-terminal unit older than strandedAfter is
+// STRANDED (its dispatch was lost or its marker dropped after ack), not healthy
+// in-flight, so it no longer suppresses the stall — the wedge surfaces as an
+// alert. strandedAfter == 0 disables the age-gate (every claimed non-terminal
+// unit counts as in-flight — prior behavior, back-compat). Pure so it stays
+// table-testable: the caller passes the threshold and the clock.
+func stallAfterInflight(stalled []string, view graphView, strandedAfter time.Duration, now time.Time) []string {
 	if len(stalled) == 0 {
 		return nil
 	}
@@ -440,9 +470,16 @@ func stallAfterInflight(stalled []string, view graphView) []string {
 		if view.markers.Dirtied[id] {
 			continue // reset in progress, not in-flight
 		}
-		if !view.markers.Completed[id] && !view.markers.Failed[id] {
-			return nil // a claimed, non-terminal unit is running ⇒ not stalled
+		if view.markers.Completed[id] || view.markers.Failed[id] {
+			continue // terminal, not in-flight
 		}
+		// Claimed, non-terminal, non-dirtied: genuine in-flight OR stranded. A
+		// claim older than strandedAfter is treated as stranded and does NOT
+		// suppress the stall.
+		if strandedAfter > 0 && now.Sub(view.claimedAt[id]) >= strandedAfter {
+			continue
+		}
+		return nil // a FRESH claimed non-terminal unit is genuinely running ⇒ not stalled
 	}
 	return stalled
 }

--- a/processor/gated-dag/executor_integration_test.go
+++ b/processor/gated-dag/executor_integration_test.go
@@ -54,6 +54,9 @@ func startStack(t *testing.T, backstop string) (*graphingest.Component, *natscli
 		UnitEntityPrefix: itestPrefix,
 		DispatchSubject:  itestDispatchSubject,
 		BackstopInterval: backstop,
+		// dispatch_dedupe_window must be >= backstop (ADR-070 B1); these tests use
+		// artificial backstops (incl. a 10m sentinel), so match the window to it.
+		DispatchDedupeWindow: backstop,
 	}
 	cfgJSON, err := json.Marshal(cfg)
 	require.NoError(t, err)

--- a/processor/gated-dag/executor_test.go
+++ b/processor/gated-dag/executor_test.go
@@ -62,9 +62,10 @@ func (f *fakeReader) ReadUnitSet(_ context.Context) ([]graph.EntityState, error)
 }
 
 type fakeClaimer struct {
-	mu    sync.Mutex
-	calls []string
-	err   error
+	mu       sync.Mutex
+	calls    []string
+	unclaims []string
+	err      error
 }
 
 func (f *fakeClaimer) Claim(_ context.Context, unitID string) error {
@@ -75,6 +76,19 @@ func (f *fakeClaimer) Claim(_ context.Context, unitID string) error {
 	}
 	f.calls = append(f.calls, unitID)
 	return nil
+}
+
+func (f *fakeClaimer) Unclaim(_ context.Context, unitID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.unclaims = append(f.unclaims, unitID)
+	return nil
+}
+
+func (f *fakeClaimer) unclaimCalls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.unclaims...)
 }
 
 type fakePublisher struct {
@@ -159,12 +173,18 @@ func TestClaimThenDispatch_ClaimErrorSkipsPublish(t *testing.T) {
 	require.Empty(t, pub.calls, "publish must not run when claim fails")
 }
 
-func TestClaimThenDispatch_PublishErrorAfterClaimDoesNotRollBack(t *testing.T) {
+func TestClaimThenDispatch_PublishErrorRollsBackClaim(t *testing.T) {
+	// ADR-070 B1: an ack-confirmed publish that errors proves the dispatch was NOT
+	// persisted and will not be delivered, so the claim is rolled back (Unclaim)
+	// and the in-flight hint cleared — the unit re-selects next eval instead of
+	// stranding until a manual reset (the old, fire-and-forget behavior).
 	cl := &fakeClaimer{}
-	pub := &fakePublisher{err: errors.New("net down")}
-	e := &executor{cfg: validCfg(), log: discardLogger(), claimer: cl, pub: pub}
+	pub := &fakePublisher{err: errors.New("no ack")}
+	e := &executor{cfg: validCfg(), log: discardLogger(), claimer: cl, pub: pub, inflight: map[string]bool{"u1": true}}
 	require.Error(t, e.claimThenDispatch(context.Background(), "u1"))
-	require.Equal(t, []string{"u1"}, cl.calls, "claim stays committed (no rollback — avoids double-run window)")
+	require.Equal(t, []string{"u1"}, cl.calls, "claim was committed before publish")
+	require.Equal(t, []string{"u1"}, cl.unclaimCalls(), "publish failure rolls the claim back (B1)")
+	require.False(t, e.inflight["u1"], "in-flight hint cleared so the unit re-selects next eval")
 }
 
 func TestClaimThenDispatch_ClaimErrorClearsInflight(t *testing.T) {
@@ -319,33 +339,52 @@ func TestReEvaluate_StallSurfacedNothingDispatched(t *testing.T) {
 }
 
 func TestStallAfterInflight(t *testing.T) {
+	now := time.Now()
+	// mk builds a view; claimed units get a FRESH claim timestamp (now) unless
+	// overridden via claimAge.
 	mk := func(completed, failed, dirtied, claimed []string) graphView {
-		v := graphView{claimed: map[string]bool{}}
+		v := graphView{claimed: map[string]bool{}, claimedAt: map[string]time.Time{}}
 		for _, id := range claimed {
 			v.claimed[id] = true
+			v.claimedAt[id] = now
 		}
 		v.markers = gateddag.NewMarkerSet(completed, failed, dirtied)
 		return v
 	}
+	const off = time.Duration(0) // age-gate disabled (prior behavior)
 
 	t.Run("no stalled units → nil", func(t *testing.T) {
-		require.Nil(t, stallAfterInflight(nil, mk(nil, nil, nil, nil)))
+		require.Nil(t, stallAfterInflight(nil, mk(nil, nil, nil, nil), off, now))
 	})
 	t.Run("stalled and nothing in-flight → reported", func(t *testing.T) {
-		got := stallAfterInflight([]string{"a", "b"}, mk(nil, nil, nil, nil))
+		got := stallAfterInflight([]string{"a", "b"}, mk(nil, nil, nil, nil), off, now)
 		require.Equal(t, []string{"a", "b"}, got)
 	})
 	t.Run("stalled but a claimed non-terminal unit is in-flight → suppressed", func(t *testing.T) {
-		got := stallAfterInflight([]string{"a"}, mk(nil, nil, nil, []string{"c"}))
+		got := stallAfterInflight([]string{"a"}, mk(nil, nil, nil, []string{"c"}), off, now)
 		require.Nil(t, got, "running work is not a stall")
 	})
 	t.Run("claimed unit is terminal → not in-flight, stall reported", func(t *testing.T) {
-		got := stallAfterInflight([]string{"a"}, mk([]string{"c"}, nil, nil, []string{"c"}))
+		got := stallAfterInflight([]string{"a"}, mk([]string{"c"}, nil, nil, []string{"c"}), off, now)
 		require.Equal(t, []string{"a"}, got)
 	})
 	t.Run("claimed unit is dirtied → reset, not in-flight, stall reported", func(t *testing.T) {
-		got := stallAfterInflight([]string{"a"}, mk(nil, nil, []string{"c"}, []string{"c"}))
+		got := stallAfterInflight([]string{"a"}, mk(nil, nil, []string{"c"}, []string{"c"}), off, now)
 		require.Equal(t, []string{"a"}, got)
+	})
+
+	// Age-gate (ADR-070 / gh#385).
+	t.Run("STRANDED claim (older than threshold) → no longer suppresses, stall reported", func(t *testing.T) {
+		v := mk(nil, nil, nil, []string{"c"})
+		v.claimedAt["c"] = now.Add(-10 * time.Minute) // claimed 10m ago
+		got := stallAfterInflight([]string{"a"}, v, 5*time.Minute, now)
+		require.Equal(t, []string{"a"}, got, "a stranded claim must not hide its dependents' stall")
+	})
+	t.Run("FRESH claim with threshold set → still in-flight, not falsely alerted", func(t *testing.T) {
+		v := mk(nil, nil, nil, []string{"c"})
+		v.claimedAt["c"] = now.Add(-1 * time.Minute) // claimed 1m ago, threshold 5m
+		got := stallAfterInflight([]string{"a"}, v, 5*time.Minute, now)
+		require.Nil(t, got, "a healthy long-running unit under the threshold must not be alerted")
 	})
 }
 

--- a/processor/gated-dag/fullstack_integration_test.go
+++ b/processor/gated-dag/fullstack_integration_test.go
@@ -247,16 +247,20 @@ func setupFullStack(t *testing.T, opts fsOpts) *fullStack {
 
 	// Executor.
 	cfg := gateddagexec.Config{
-		UnitEntityPrefix:   prefix,
-		DispatchSubject:    subject,
-		BackstopInterval:   backstop,
-		CompletedPredicate: pCompleted,
-		FailedPredicate:    pFailed,
-		DirtiedPredicate:   pDirtied,
-		DependsOnPredicate: pDependsOn,
-		ClaimPredicate:     pClaim,
-		FanOutInstanceID:   opts.fanOutInstanceID,
-		StallSubject:       opts.stallSubject,
+		UnitEntityPrefix: prefix,
+		DispatchSubject:  subject,
+		BackstopInterval: backstop,
+		// dispatch_dedupe_window must be >= backstop (ADR-070 B1). These are
+		// artificial test backstops (incl. a 10m sentinel), so match the window to
+		// the backstop to keep the config valid.
+		DispatchDedupeWindow: backstop,
+		CompletedPredicate:   pCompleted,
+		FailedPredicate:      pFailed,
+		DirtiedPredicate:     pDirtied,
+		DependsOnPredicate:   pDependsOn,
+		ClaimPredicate:       pClaim,
+		FanOutInstanceID:     opts.fanOutInstanceID,
+		StallSubject:         opts.stallSubject,
 	}
 	cfgJSON, err := json.Marshal(cfg)
 	require.NoError(t, err)

--- a/processor/gated-dag/payload.go
+++ b/processor/gated-dag/payload.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/c360studio/semstreams/message"
 	"github.com/c360studio/semstreams/payloadregistry"
@@ -116,4 +117,46 @@ func RegisterPayloads(reg *payloadregistry.Registry) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// dispatchDecoder is the shared BaseMessage decoder for the dispatch envelope,
+// built once (RegisterPayloads is idempotent per registry but the registry+decoder
+// need only be constructed one time).
+var (
+	dispatchDecoderOnce sync.Once
+	dispatchDecoder     *message.Decoder
+	dispatchDecoderErr  error
+)
+
+func dispatchDecoderInstance() (*message.Decoder, error) {
+	dispatchDecoderOnce.Do(func() {
+		reg := payloadregistry.New()
+		if err := RegisterPayloads(reg); err != nil {
+			dispatchDecoderErr = fmt.Errorf("register gateddag payloads: %w", err)
+			return
+		}
+		dispatchDecoder = message.NewDecoder(reg)
+	})
+	return dispatchDecoder, dispatchDecoderErr
+}
+
+// DecodeDispatch decodes a raw dispatch message — a registry-wrapped BaseMessage
+// carrying a DispatchMessage, as delivered by the durable dispatch stream — into
+// the typed payload. Consumers of the stream import this so the BaseMessage →
+// DispatchMessage unwrap is owned once here (above natsclient, which hands the
+// raw []byte) rather than reinvented per consumer repo (ADR-070 B5).
+func DecodeDispatch(data []byte) (*DispatchMessage, error) {
+	dec, err := dispatchDecoderInstance()
+	if err != nil {
+		return nil, err
+	}
+	base, err := dec.Decode(data)
+	if err != nil {
+		return nil, fmt.Errorf("decode dispatch base message: %w", err)
+	}
+	msg, ok := base.Payload().(*DispatchMessage)
+	if !ok {
+		return nil, fmt.Errorf("decoded dispatch payload is %T, want *DispatchMessage", base.Payload())
+	}
+	return msg, nil
 }

--- a/processor/gated-dag/publisher.go
+++ b/processor/gated-dag/publisher.go
@@ -24,7 +24,10 @@ type natsPublisher struct {
 	fanOutWorkflow string
 }
 
-// Dispatch publishes the registry-wrapped DispatchMessage reference.
+// Dispatch publishes the registry-wrapped DispatchMessage reference to the
+// dispatch stream via an ack-confirmed JetStream publish (ADR-070). A returned
+// error means the ack did NOT come back — the message was not persisted and will
+// not be delivered — so the caller can safely roll the claim back (B1).
 func (p *natsPublisher) Dispatch(ctx context.Context, unitID string) error {
 	msg := &DispatchMessage{UnitEntityID: unitID, FanOutWorkflow: p.fanOutWorkflow}
 	base := message.NewBaseMessage(msg.Schema(), msg, "gateddag-executor")
@@ -32,7 +35,7 @@ func (p *natsPublisher) Dispatch(ctx context.Context, unitID string) error {
 	if err != nil {
 		return fmt.Errorf("marshal dispatch message for %s: %w", unitID, err)
 	}
-	if err := p.nc.Publish(ctx, p.subject, data); err != nil {
+	if _, err := p.nc.PublishToStreamWithAck(ctx, p.subject, data); err != nil {
 		return fmt.Errorf("publish dispatch for %s to %s: %w", unitID, p.subject, err)
 	}
 	return nil

--- a/processor/gated-dag/publisher.go
+++ b/processor/gated-dag/publisher.go
@@ -25,9 +25,15 @@ type natsPublisher struct {
 }
 
 // Dispatch publishes the registry-wrapped DispatchMessage reference to the
-// dispatch stream via an ack-confirmed JetStream publish (ADR-070). A returned
-// error means the ack did NOT come back — the message was not persisted and will
-// not be delivered — so the caller can safely roll the claim back (B1).
+// dispatch stream via an idempotent, ack-confirmed JetStream publish (ADR-070).
+// The Nats-Msg-Id is the unitID, so within the stream's Duplicates window the
+// server collapses re-publishes of the same unit to a single stored message.
+// This makes the B1 claim-rollback provably safe against the ack-timeout hole: a
+// PublishToStreamWithAck can error AFTER the server persisted (ack-read timeout),
+// and without dedup the rollback + re-dispatch would store a SECOND message
+// (double delivery); msg-id dedup collapses that to one. (Reset-driven
+// re-dispatch of the same unit within the window is delayed by ≤ the window and
+// self-heals via the dirtied re-selection — an acceptable bound, see ADR-070.)
 func (p *natsPublisher) Dispatch(ctx context.Context, unitID string) error {
 	msg := &DispatchMessage{UnitEntityID: unitID, FanOutWorkflow: p.fanOutWorkflow}
 	base := message.NewBaseMessage(msg.Schema(), msg, "gateddag-executor")
@@ -35,7 +41,7 @@ func (p *natsPublisher) Dispatch(ctx context.Context, unitID string) error {
 	if err != nil {
 		return fmt.Errorf("marshal dispatch message for %s: %w", unitID, err)
 	}
-	if _, err := p.nc.PublishToStreamWithAck(ctx, p.subject, data); err != nil {
+	if err := p.nc.PublishToStreamWithMsgID(ctx, p.subject, data, unitID); err != nil {
 		return fmt.Errorf("publish dispatch for %s to %s: %w", unitID, p.subject, err)
 	}
 	return nil

--- a/processor/gated-dag/reader.go
+++ b/processor/gated-dag/reader.go
@@ -118,6 +118,10 @@ type graphView struct {
 	dependsOn map[string][]string
 	markers   gateddag.MarkerSet
 	claimed   map[string]bool
+	// claimedAt records each claimed unit's claim-triple timestamp so the
+	// stranded-unit detector can age-gate a claim (ADR-070): a claimed unit older
+	// than StrandedAfter stops counting as healthy in-flight.
+	claimedAt map[string]time.Time
 	// stubsSkipped counts entities under the unit prefix that were referential
 	// stubs (graph.StubMessageType) and therefore excluded from the unit set
 	// this read (gh#429). A sustained nonzero value means a referenced unit's
@@ -148,6 +152,7 @@ func extractGraph(states []graph.EntityState, cfg Config) graphView {
 		unitIDs:   make([]string, 0, len(states)),
 		dependsOn: make(map[string][]string),
 		claimed:   make(map[string]bool),
+		claimedAt: make(map[string]time.Time),
 	}
 	var completed, failed, dirtied []string
 
@@ -171,6 +176,7 @@ func extractGraph(states []graph.EntityState, cfg Config) graphView {
 				dirtied = append(dirtied, s.ID)
 			case cfg.ClaimPredicate:
 				view.claimed[s.ID] = true
+				view.claimedAt[s.ID] = t.Timestamp
 			case cfg.DependsOnPredicate:
 				if dep, ok := objectAsEntityID(t.Object); ok {
 					view.dependsOn[s.ID] = append(view.dependsOn[s.ID], dep)

--- a/processor/gated-dag/schema.go
+++ b/processor/gated-dag/schema.go
@@ -100,6 +100,30 @@ func (c Config) Schema() component.ConfigSchema {
 				Description: "Optional subject for an edge-triggered StallEvent on the 0→non-zero stall transition (the gated_dag_stalled_units gauge + WARN log are always emitted).",
 				Category:    "advanced",
 			},
+			"dispatch_stream": {
+				Type:        "string",
+				Description: "JetStream stream the executor ensures at Start and publishes dispatches into (ADR-070). Use a distinct name per distinct dispatch_subject.",
+				Default:     defaultDispatchStream,
+				Category:    "advanced",
+			},
+			"dispatch_stream_max_age": {
+				Type:        "string",
+				Description: "Retention window for the dispatch stream; an unconsumed dispatch older than this is dropped.",
+				Default:     defaultDispatchStreamMaxAge,
+				Category:    "advanced",
+			},
+			"dispatch_dedupe_window": {
+				Type:        "string",
+				Description: "Server-side duplicate-detection window (Nats-Msg-Id=unitID). Must be >= backstop_interval; makes the claim-rollback safe against an ack-timeout-after-persist (ADR-070 B1).",
+				Default:     defaultDispatchDedupeWindow,
+				Category:    "advanced",
+			},
+			"stranded_after": {
+				Type:        "string",
+				Description: "Age past which a claimed non-terminal unit surfaces as a stall alert instead of counting as in-flight (ADR-070). Set above max unit runtime; '0' disables. Alert-only.",
+				Default:     defaultStrandedAfter,
+				Category:    "advanced",
+			},
 		},
 		Required: []string{"unit_entity_prefix", "dispatch_subject"},
 	}

--- a/schemas/gated-dag.v1.json
+++ b/schemas/gated-dag.v1.json
@@ -35,6 +35,24 @@
       "default": "gateddag.dirtied",
       "category": "advanced"
     },
+    "dispatch_dedupe_window": {
+      "type": "string",
+      "description": "Server-side duplicate-detection window (Nats-Msg-Id=unitID). Must be \u003e= backstop_interval; makes the claim-rollback safe against an ack-timeout-after-persist (ADR-070 B1).",
+      "default": "2m",
+      "category": "advanced"
+    },
+    "dispatch_stream": {
+      "type": "string",
+      "description": "JetStream stream the executor ensures at Start and publishes dispatches into (ADR-070). Use a distinct name per distinct dispatch_subject.",
+      "default": "GATEDDAG_DISPATCH",
+      "category": "advanced"
+    },
+    "dispatch_stream_max_age": {
+      "type": "string",
+      "description": "Retention window for the dispatch stream; an unconsumed dispatch older than this is dropped.",
+      "default": "24h",
+      "category": "advanced"
+    },
     "dispatch_subject": {
       "type": "string",
       "description": "Subject published with the unit entity ID reference when a unit is dispatchable. The consumer wires its handler here. Required.",
@@ -88,6 +106,12 @@
     "stall_subject": {
       "type": "string",
       "description": "Optional subject for an edge-triggered StallEvent on the 0→non-zero stall transition (the gated_dag_stalled_units gauge + WARN log are always emitted).",
+      "category": "advanced"
+    },
+    "stranded_after": {
+      "type": "string",
+      "description": "Age past which a claimed non-terminal unit surfaces as a stall alert instead of counting as in-flight (ADR-070). Set above max unit runtime; '0' disables. Alert-only.",
+      "default": "0",
       "category": "advanced"
     },
     "unit_entity_prefix": {


### PR DESCRIPTION
## Summary

Framework side of **ADR-070** (gh#385): makes gated-DAG dispatch **durable at-least-once over a JetStream stream** instead of fire-and-forget core-NATS, so a lost dispatch can no longer strand a claimed unit's subtree. Chosen over a claim-lease band-aid after a root-cause review (the transport *is* the bug, and the framework's own `for_each` path already dispatches durably).

## What's in it (framework only — consumer migration is a follow-up on a tag)

- **`natsclient.ConsumeDurable`** — a typed durable-consumer wrapper (`func(ctx,[]byte)error`, ack/heartbeat/redelivery owned by the framework; consumers never touch `jetstream.Msg`), enforcing `heartbeat < ack_wait` (B3; the agentic-loop precedent only documents it — filed gh#453).
- **Durable, idempotent publish** — `PublishToStreamWithMsgID` (`Nats-Msg-Id = unitID`) + a stream `Duplicates` window; the executor provisions the stream at Start.
- **Claim rollback on publish failure (B1)** — `claimThenDispatch` Unclaims + re-arms the unit. Made **dedup-safe**: a `PublishToStreamWithAck` can error *after* persisting (ack timeout), so the msg-id dedup collapses the ack-timeout re-dispatch to one stored message (config `Validate` enforces `dispatch_dedupe_window ≥ backstop`).
- **Stranded-unit detector** — `stallAfterInflight` age-gates on the claim timestamp so a claimed-too-long unit surfaces as a stall alert instead of hiding forever (alert-only; `stranded_after=0` disables).
- **Get-or-create guard** — fail loud at Start if a name-colliding stream doesn't capture our subject.
- `DecodeDispatch` shared helper; config knobs + Validate + schema.

## Non-breaking

`PublishToStreamWithMsgID` publishes on the subject, so existing core-NATS consumers still receive dispatches while the stream persists them — **proven by the fullstack integration test passing with a core-sub consumer**. semspec/semdragon migrate to `ConsumeDurable` + ack-after-marker on their own schedule.

## Review

semstreams-reviewer: **CHANGES-REQUESTED** on a real BLOCKING (the rollback's "failed ack ⇒ not persisted" was false on ack-timeout) — fixed exactly as prescribed (msg-id dedup), validated by a new integration test asserting same-id-twice delivers once. All HIGH/MEDIUM/NIT folded in.

## Testing

`go test -race ./...`, `task lint`, no schema drift, **fullstack + ConsumeDurable integration green**. Adversarial ADR review pre-Accept (B1–B5).

ADR-070 (amends ADR-046). Closes #385 (framework side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)