### PR TITLE
fix(rule): lifecycle Manager reaches hot-reloaded rules (gh#451) + correct rules-engine deprecation banner (gh#452)

### DIFF
--- a/docs/advanced/06-rules-engine.md
+++ b/docs/advanced/06-rules-engine.md
@@ -1,18 +1,16 @@
 # Rules Engine
 
-> **⚠️ DEPRECATED**
+> **Status: current.** The JSON rules engine (`processor/rule/`) is the blessed
+> orchestration path in SemStreams — *rules trigger, components execute*. See
+> [Orchestration Layers](../concepts/14-orchestration-layers.md) for the full
+> pattern catalog and the Rule Engine / Component boundary.
 >
-> The JSON-based rules engine is superseded by the **Reactive Workflow Engine**.
-> The reactive engine provides:
-> - Typed Go conditions (compile-time safety)
-> - Dual reactive primitives (KV watch + NATS subject consumers)
-> - Async callback correlation
-> - Combined message+state triggers
->
-> **For new development, use:**
-> - [Reactive Workflows Guide](./10-reactive-workflows.md) - Usage documentation
->
-> This documentation is retained for reference during migration.
+> An earlier revision of this page marked the rules engine DEPRECATED in favor of
+> a "Reactive Workflow Engine." That is backwards and has been corrected: the
+> `processor/reactive` engine was **retired** (2026-03-12) and *replaced by*
+> coordinated rules over lifecycle-managed graph entities
+> ([ADR-047](../adr/047-lifecycle-harness-substrate.md)). The
+> [Reactive Workflows](./10-reactive-workflows.md) page is a legacy reference only.
 
 ---
 

--- a/processor/rule/rule_loader.go
+++ b/processor/rule/rule_loader.go
@@ -177,17 +177,10 @@ func (rp *Processor) loadRules() error {
 
 		// ADR-047: propagate the Lifecycle harness Manager onto rule
 		// instances that opt into condition.Field resolution for
-		// `$entity.lifecycle.*` paths. Same setter pattern as
-		// ActionExecutor.SetLifecycleManager — type-assert so the
-		// rule.Rule interface stays narrow and only ExpressionRule (the
-		// implementation that owns the field) opts in.
-		if rp.lifecycleManager != nil {
-			if setter, ok := rule.(interface {
-				SetLifecycleManager(LifecycleManager)
-			}); ok {
-				setter.SetLifecycleManager(rp.lifecycleManager)
-			}
-		}
+		// `$entity.lifecycle.*` paths. Shared with the hot-reload reconcile
+		// path via attachLifecycleManager so no rule-construction path can
+		// silently drop it (gh#451).
+		rp.attachLifecycleManager(rule)
 
 		rp.rules[def.ID] = rule
 		rp.ruleDefinitions[def.ID] = def // Store definition for stateful evaluation

--- a/processor/rule/runtime_config.go
+++ b/processor/rule/runtime_config.go
@@ -174,6 +174,27 @@ func (rp *Processor) applyCronRuleChange(ruleID string, ruleMap map[string]any) 
 	return nil
 }
 
+// attachLifecycleManager offers the Lifecycle harness Manager (ADR-047) to a
+// freshly created rule instance. Only ExpressionRule implements the setter, so
+// the type-assert keeps the Rule interface narrow. EVERY path that constructs a
+// rule instance — the file/inline load (rule_loader.go) AND the hot-reload KV
+// reconcile (applyExpressionRuleChange) — must route through this, or the rule
+// keeps a nil manager and `$entity.lifecycle.*` conditions silently never
+// resolve (gh#451). It reads rp.lifecycleManager, which is set once at factory
+// time (factory.go, before Start) and never mutated after — so both callers
+// (init-time loadRules and the lock-held reconcile) read it race-free; the
+// helper takes no lock of its own.
+func (rp *Processor) attachLifecycleManager(rule Rule) {
+	if rp.lifecycleManager == nil {
+		return
+	}
+	if setter, ok := rule.(interface {
+		SetLifecycleManager(LifecycleManager)
+	}); ok {
+		setter.SetLifecycleManager(rp.lifecycleManager)
+	}
+}
+
 // applyExpressionRuleChange installs or replaces an expression-style rule.
 // Drops any previous CronRule under the same ID first to keep type swaps
 // symmetric with applyCronRuleChange.
@@ -184,6 +205,12 @@ func (rp *Processor) applyExpressionRuleChange(ruleID string, ruleMap map[string
 	if err != nil {
 		return fmt.Errorf("failed to create rule %s: %w", ruleID, err)
 	}
+
+	// gh#451: hot-reloaded rules must receive the Lifecycle Manager just like
+	// the file-load path (rule_loader.go). Without this, rules created via the
+	// KV-config reconcile have a nil manager and $entity.lifecycle.* conditions
+	// never fire.
+	rp.attachLifecycleManager(newRule)
 
 	if _, hadCron := rp.cronRules[ruleID]; hadCron {
 		if rp.cronScheduler != nil {

--- a/processor/rule/runtime_config_lifecycle_test.go
+++ b/processor/rule/runtime_config_lifecycle_test.go
@@ -1,0 +1,94 @@
+// Package rule — gh#451 regression.
+//
+// Rules installed via the hot-reload KV reconcile path (RuntimeConfigurable.
+// ApplyConfigUpdate → applyRuleChanges → applyExpressionRuleChange) must
+// receive the Lifecycle harness Manager, exactly like the file/inline-load
+// path (rule_loader.go). Before the fix, reconciled ExpressionRule instances
+// kept a nil manager, so `$entity.lifecycle.*` conditions silently never
+// resolved and the phase-gated rule never fired — defeating the documented
+// `(phase == X AND command == Y) -> transition` pattern.
+package rule
+
+import (
+	"log/slog"
+	"testing"
+
+	gtypes "github.com/c360studio/semstreams/graph"
+	"github.com/c360studio/semstreams/natsclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestApplyConfigUpdate_LifecycleManagerReachesReconciledRules drives the same
+// production wire the KV-config watcher's reconcile uses and proves a
+// phase-gated `$entity.lifecycle.phase` rule fires afterward. The bug lived in
+// applyExpressionRuleChange, which re-creates every rule on reconcile without
+// mirroring rule_loader.go's SetLifecycleManager call.
+func TestApplyConfigUpdate_LifecycleManagerReachesReconciledRules(t *testing.T) {
+	const (
+		workflow    = "quest"
+		postedEntry = "acme.ops.games.dragon.quest.001"
+		claimedEnt  = "acme.ops.games.dragon.quest.002"
+	)
+
+	// Fake Manager seeded with two lifecycle-managed entities in distinct
+	// phases so the assertion pair proves the phase field is genuinely
+	// resolved and compared — not vacuously matched.
+	mgr := newFakeManager()
+	mgr.seed(workflow, &fakeParticipant{EntityIDF: postedEntry, PhaseF: "posted"})
+	mgr.seed(workflow, &fakeParticipant{EntityIDF: claimedEnt, PhaseF: "claimed"})
+
+	cfg := DefaultConfig()
+	rp := &Processor{
+		natsClient:  &natsclient.Client{},
+		logger:      slog.Default(),
+		rules:       make(map[string]Rule),
+		ruleConfigs: make(map[string]map[string]any),
+		config:      &cfg,
+	}
+	// Wire the Manager the way the component factory does (factory.go:108).
+	rp.SetLifecycleManager(mgr)
+
+	// Install a phase-gated expression rule through the RuntimeConfigurable
+	// wire — the reconcile path, NOT rule_loader's file/inline load. "expression"
+	// (not "test_rule") is the type that yields an *ExpressionRule, the only rule
+	// type that resolves $entity.lifecycle.* and implements SetLifecycleManager.
+	const ruleID = "phase_gate"
+	changes := map[string]any{
+		"rules": map[string]any{
+			ruleID: map[string]any{
+				"type": "expression",
+				"name": "Phase-gated transition",
+				"conditions": []any{
+					map[string]any{
+						"field":    "$entity.lifecycle.phase",
+						"operator": "eq",
+						"value":    "posted",
+						"required": true,
+					},
+				},
+				"logic":   "and",
+				"enabled": true,
+			},
+		},
+	}
+	require.NoError(t, rp.ValidateConfigUpdate(changes))
+	require.NoError(t, rp.ApplyConfigUpdate(changes))
+
+	// The reconciled instance must be an ExpressionRule carrying the Manager.
+	rule, ok := rp.rules[ruleID]
+	require.True(t, ok, "rule not installed by reconcile")
+	er, ok := rule.(*ExpressionRule)
+	require.True(t, ok, "reconciled rule is not an *ExpressionRule")
+	require.NotNil(t, er.lifecycleManager,
+		"gh#451: reconciled rule kept a nil lifecycleManager — $entity.lifecycle.* would never resolve")
+
+	// Behavioural proof through the exact method the entity-watch path invokes
+	// (message_handler.go: entityEval.EvaluateEntityState). Positive: an entity
+	// in phase "posted" fires. Control: an entity in "claimed" does not — proves
+	// the phase is resolved and compared, not treated as always-true.
+	assert.True(t, er.EvaluateEntityState(&gtypes.EntityState{ID: postedEntry}),
+		"phase-gated rule should fire for an entity in phase 'posted'")
+	assert.False(t, er.EvaluateEntityState(&gtypes.EntityState{ID: claimedEnt}),
+		"phase-gated rule must not fire for an entity in phase 'claimed'")
+}


### PR DESCRIPTION
## Summary

Two rule-processor fixes from the freshly-reported cluster (both verified against `main`):

### gh#451 — `$entity.lifecycle.*` conditions silently never fire for hot-reloaded rules (functional, silent-failure)

Rules installed via the hot-reload KV reconcile path (`RuntimeConfigurable.ApplyConfigUpdate` → `applyRuleChanges` → `applyExpressionRuleChange`) were re-created **without** the Lifecycle harness Manager — unlike the file/inline-load path (`rule_loader.go:184-188`), which calls `SetLifecycleManager` on every created rule. Hot-reloaded `*ExpressionRule` instances kept a nil `lifecycleManager`, so `PopulateLifecycleStateFields` no-op'd, `$entity.lifecycle.phase` never resolved, and phase-gated rules silently never fired — defeating the documented `(phase==X AND command==Y) -> transition` pattern (bit a semdragons consumer building exactly that).

**Fix:** extract `Processor.attachLifecycleManager(Rule)` and route **both** construction paths through it, so no rule-construction path can silently drop the Manager again (this was a "third path forgot the setter" class bug). `CronRule` is correctly excluded — it doesn't implement `SetLifecycleManager` and is time-driven with no trigger entity to resolve `$entity.lifecycle.*` against.

**Regression test** (`runtime_config_lifecycle_test.go`) drives the production `ApplyConfigUpdate` wire and asserts through `EvaluateEntityState` (the exact method `message_handler.go` invokes on the entity-watch path): a phase-gated rule fires for an entity in `posted`, and — as a non-vacuous control — does **not** fire for one in `claimed`. Proven genuine: it fails on nil-manager without the fix, passes with it.

### gh#452 — rules-engine docs incorrectly marked DEPRECATED (docs)

`docs/advanced/06-rules-engine.md` carried a stale `⚠️ DEPRECATED` banner pointing new development at the **retired** `processor/reactive` engine — a circular deprecation (06 → "use reactive", 10 → "reactive is retired, use rules+lifecycle"). Removed the banner and replaced it with an accurate current-status note; the JSON rules engine is the current blessed orchestration path. Reported by the semboids team while scoping new work.

## Verification

- `task lint` (vet + fmt + revive + port-guard) — clean
- `processor/rule` unit (`-race`) + integration (`-race -tags=integration`, 46s) — pass
- Full repo unit suite (`-race ./...`) — 0 fail/panic/race
- `task schema:generate` + diff — no drift
- **semstreams-reviewer: APPROVE** — no blocking/high findings; verified fix correctness, completeness (only two `rp.rules[...]=` sites, both covered), test wire-fidelity + non-vacuous control, and docs accuracy.

## Out of scope (follow-ups)

- `docs/concepts/23-parallel-agents.md` and `docs/advanced/10-reactive-workflows.md` bodies are still written against the retired `processor/reactive` engine — a broader docs-drift problem tracked separately (docs audit).
- gh#455 (component config PUT no-op / reconfig-contract mismatch) is being scoped as an OpenSpec change.

Closes #451
Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)