### PR TITLE
docs(openspec): scope component runtime reconfiguration over HTTP (gh#455)

### DIFF
--- a/openspec/changes/component-runtime-reconfig-http/.openspec.yaml
+++ b/openspec/changes/component-runtime-reconfig-http/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/component-runtime-reconfig-http/design.md
+++ b/openspec/changes/component-runtime-reconfig-http/design.md
@@ -1,0 +1,92 @@
+# Design — Component runtime reconfiguration over HTTP (gh#455)
+
+## The decision
+
+**Bridge the two runtime-reconfig contracts at the HTTP seam now; do not unify
+the interfaces in this change.** Add an honest applied / restart-required
+response.
+
+## Context: two contracts for one responsibility
+
+The framework has two spellings of "apply a validated runtime config change to a
+running unit":
+
+| | Component-side | Service-side |
+|---|---|---|
+| Interface | anonymous `UpdateConfig(ctx, json.RawMessage) error` | named `service.RuntimeConfigurable` |
+| Methods | one | `ValidateConfigUpdate(map[string]any)`, `ApplyConfigUpdate(map[string]any)`, `GetRuntimeConfig()`, `ConfigSchema()` |
+| Payload | `json.RawMessage` | `map[string]any` |
+| Driver | ComponentManager PUT handler (`component_manager_http.go:701`) | service Manager (`service_manager.go` `applyServiceConfigChange`) |
+| Validation | inside `UpdateConfig` | explicit `ValidateConfigUpdate` step |
+
+`processor/rule` is a **component** that implements the **service** contract
+(because its hot-reload wire format is map-shaped and wants an explicit
+validate step). The PUT handler only knows the component spelling, so the rule
+processor's reconfig is unreachable over HTTP — the gh#455 defect.
+
+## Options considered
+
+1. **Bridge in the PUT handler (chosen).** After the `UpdateConfig` probe, also
+   probe `RuntimeConfigurable`: `json.Unmarshal(req.Config, &map)` →
+   `ValidateConfigUpdate` → `ApplyConfigUpdate`. Non-breaking, zero component
+   changes, generalizes to every `RuntimeConfigurable` component. Cost: the two
+   contracts still coexist (accepted — see below).
+2. **Implement `UpdateConfig` on `processor/rule`.** Narrow; fixes only this one
+   component and entrenches the split (the next `RuntimeConfigurable` component
+   hits the same wall). Rejected.
+3. **Unify into one `RuntimeReconfigurable` interface.** The clean end state, but
+   breaking: the service Manager path, `hasRuntimeConfigSupport`,
+   `GetServiceRuntimeConfig`, and every current implementer (`metrics`,
+   `message_logger`, `rule`) would move. Too large for the reported bug; deferred.
+4. **Honest response only (no bridge).** Fixes the lie but leaves the rule
+   processor un-reconfigurable — doesn't satisfy semboids. Insufficient alone;
+   adopted *together with* the bridge.
+
+## Why not unify now
+
+Unification is the right long-term shape (one named responsibility, one payload
+type), but it is a breaking cross-cutting refactor of the *service* reconfig path
+for no additional benefit to the reported use case. The bridge is the
+right-sized, non-breaking first step and it does not foreclose unification — a
+later change can collapse `UpdateConfig` into `RuntimeConfigurable` (or a shared
+`RuntimeReconfigurable`) and delete the bridge. Naming the seam here (rather than
+silently adding a second probe) is what keeps that follow-up honest.
+
+**Follow-up decision to record when unification is scoped:** pick one payload
+type (`map[string]any` vs `json.RawMessage`) and one interface name, migrate all
+three current implementers + both Manager drivers, and remove the HTTP-seam
+bridge. Track as a separate change; reference this one.
+
+## The honest response
+
+Currently the handler always returns `{"status":"success","message":"…updated…"}`.
+That conflates three outcomes: applied-live, stored-for-restart, and
+validation-rejected (the last already returns 400). The fix distinguishes the
+first two with **additive** fields so no current client breaks:
+
+```json
+{ "status": "success", "message": "...", "applied": true,  "restart_required": false }  // hot-applied
+{ "status": "success", "message": "...", "applied": false, "restart_required": true  }  // stored only
+```
+
+`applied` is true iff a reconfig contract (either spelling) accepted the change
+live. `restart_required` is its complement for a stored-but-not-applied update.
+
+## Ordering invariant
+
+Validate → apply-live → then treat as stored. A `ValidateConfigUpdate` failure
+returns the existing structured 400 and does **not** mutate the in-memory
+`componentConfigs` entry, so a rejected update can never be silently loaded on the
+next restart. (Today the handler stores *before* probing the hook; this change
+moves the store to after a successful apply, or explicitly marks it
+restart-pending when no hook exists.)
+
+## Risks
+
+- **Impedance (`json.RawMessage` → `map[string]any`).** The bridge unmarshals the
+  raw config to a map for `ValidateConfigUpdate`. Same shape the KV-config watcher
+  already feeds `ApplyConfigUpdate`, so no new decoding semantics — but the bridge
+  MUST reuse the component's own validate step, never a second parallel validator.
+- **A component implementing BOTH contracts.** Probe `UpdateConfig` first (current
+  behavior) and only fall through to `RuntimeConfigurable` if it's absent, so
+  existing `UpdateConfig` components are unaffected.

--- a/openspec/changes/component-runtime-reconfig-http/proposal.md
+++ b/openspec/changes/component-runtime-reconfig-http/proposal.md
@@ -1,0 +1,100 @@
+# Component runtime reconfiguration over HTTP (gh#455)
+
+## Why
+
+`PUT <prefix>config/<componentName>` on the ComponentManager validates the new
+config, stores it in memory, and then hot-applies **only** when the component
+implements the anonymous interface `UpdateConfig(ctx, json.RawMessage) error`
+(`service/component_manager_http.go:701`). Any component that instead implements
+the framework's *other* runtime-reconfig contract —
+`service.RuntimeConfigurable` (`ValidateConfigUpdate` / `ApplyConfigUpdate` /
+`GetRuntimeConfig`, `service/configurable.go:19`) — is **never hot-applied**,
+because the only driver of that interface is the **service** Manager
+(`service/service_manager.go` `applyServiceConfigChange`), not the component
+manager. Nothing bridges the two for component instances.
+
+`processor/rule` is exactly such a component: it implements `ApplyConfigUpdate` /
+`ValidateConfigUpdate` (its whole hot-reload wire format, the same path gh#451
+just fixed), yet the HTTP PUT can't reach it. Two concrete defects fall out:
+
+1. **The rule engine's hot-reload path is unreachable at runtime via HTTP.** The
+   carefully-built `applyRuleChanges` reconcile machinery has no HTTP caller for
+   component instances — only the KV-config watcher drives it.
+2. **PUT reports success without applying.** The handler returns
+   `200 {"status":"success","message":"Configuration updated successfully"}` even
+   when no hot-apply hook matched. The stored config changed but the running
+   component never saw it, and the client **cannot distinguish "applied live"
+   from "stored, will apply on restart"** — a silent-success lie.
+
+Reported by the **semboids** team building live rule toggles (flip `enabled` on a
+rule → flock behavior changes without restart): the natural path UI →
+`PUT /components/config/rule-processor` silently no-ops. They are shipping an
+app-side interim gate, per the "don't carve a parallel path — file the gap"
+discipline; this change closes the framework gap so that interim can be removed.
+
+## What Changes
+
+- **Bridge `RuntimeConfigurable` into the ComponentManager PUT handler.** After
+  the existing `UpdateConfig(ctx, json.RawMessage)` probe, also probe
+  `service.RuntimeConfigurable`: unmarshal `req.Config` to `map[string]any`, call
+  `ValidateConfigUpdate` then `ApplyConfigUpdate`. Any component implementing the
+  contract becomes live-reconfigurable with **zero changes to the component**.
+  Rule-processor is the first beneficiary.
+- **Make the PUT response honest.** The handler MUST report whether the config was
+  applied live or only stored. Add `applied: bool` and `restart_required: bool`
+  to the response (additive — `status`/`message` stay for compatibility). A
+  component with **no** reconfig hook returns `applied:false, restart_required:true`
+  instead of an unconditional `success` that implies a live apply.
+- **Validate-before-store ordering is preserved.** A `ValidateConfigUpdate`
+  failure returns the structured 400 already used for schema errors; the in-memory
+  config is only updated once a hot-apply path (either contract) has accepted it,
+  so a rejected update never leaves a stored-but-unapplied config that a restart
+  would then load.
+- **Name the two-contract split as a deliberate seam (not unify it here).** The
+  component-side `UpdateConfig(json.RawMessage)` and service-side
+  `RuntimeConfigurable(map[string]any)` are two spellings of one responsibility —
+  "apply a validated runtime config change to a running unit." Unifying them is a
+  breaking change across both reconfig paths; this change **bridges** at the HTTP
+  seam and records the convergence as a follow-up decision (see `design.md`),
+  rather than expanding scope.
+
+## Capabilities
+
+### New Capabilities
+- `component-runtime-config` — the contract for applying a runtime configuration
+  change to a running component over the ComponentManager HTTP API: which
+  reconfig interfaces are honored, the validate-before-apply ordering, and the
+  honest applied / restart-required response.
+
+### Modified Capabilities
+- None (no existing spec covers the ComponentManager config API yet).
+
+## Impact
+
+- `service/component_manager_http.go`: the PUT handler gains the
+  `RuntimeConfigurable` bridge and the honest response fields. A small shared
+  reconfig-dispatch helper may factor the "try each reconfig contract, report
+  which applied" logic so the component and service managers don't diverge.
+- **Response shape:** additive (`applied`, `restart_required`); existing
+  `status`/`message` unchanged → non-breaking for current clients.
+- No component changes required; `processor/rule` is reached as-is.
+- The two-contract convergence is deferred and recorded, not implemented.
+
+## Non-goals
+
+- **Unifying `UpdateConfig` and `RuntimeConfigurable` into one interface** — a
+  breaking change across the service reconfig path too; recorded as a follow-up
+  decision in `design.md`, not done here.
+- **Implementing `UpdateConfig(ctx, json.RawMessage)` on `processor/rule`** — the
+  bridge makes it unnecessary and would entrench the split.
+- **Persisting the config to KV / restart-time reload semantics** — unchanged;
+  this change only governs the live-apply path and the honesty of its response.
+- **A generic "which fields are runtime-mutable" schema surface** — orthogonal
+  (`PropertySchema.Runtime` already exists); not in scope.
+
+## Consumers
+
+`service` (framework — the ComponentManager HTTP API); semboids (reported
+consumer, live rule toggles). Any component implementing `RuntimeConfigurable`
+(today `processor/rule`) becomes HTTP-reconfigurable; any operator UI performing
+`PUT config/<component>` gets an honest applied/restart-required signal.

--- a/openspec/changes/component-runtime-reconfig-http/specs/component-runtime-config/spec.md
+++ b/openspec/changes/component-runtime-reconfig-http/specs/component-runtime-config/spec.md
@@ -1,0 +1,63 @@
+# Component Runtime Config
+
+## ADDED Requirements
+
+### Requirement: A runtime config change is applied via any supported reconfig contract
+
+The ComponentManager config API MUST hot-apply a `PUT config/<component>` update
+to a running component that implements EITHER runtime-reconfig contract: the
+component-side `UpdateConfig(ctx, json.RawMessage)` OR the service-side
+`RuntimeConfigurable` (`ValidateConfigUpdate` + `ApplyConfigUpdate`). A component
+implementing only `RuntimeConfigurable` (e.g. the rule processor) MUST be reached,
+not silently skipped. When a component implements both, `UpdateConfig` is used.
+
+#### Scenario: a RuntimeConfigurable component is hot-applied over HTTP
+
+- **GIVEN** a running component that implements `RuntimeConfigurable` but not `UpdateConfig`
+- **WHEN** a valid `PUT config/<component>` request is received
+- **THEN** the manager calls the component's `ValidateConfigUpdate` then `ApplyConfigUpdate`
+- **AND** the running component reflects the change without a restart
+
+#### Scenario: an UpdateConfig component keeps its existing path
+
+- **GIVEN** a running component that implements `UpdateConfig(ctx, json.RawMessage)`
+- **WHEN** a valid `PUT config/<component>` request is received
+- **THEN** the manager applies the change via `UpdateConfig`
+- **AND** does not additionally invoke the `RuntimeConfigurable` bridge
+
+### Requirement: The config-update response honestly reports whether it was applied
+
+A `PUT config/<component>` response MUST report whether the change was applied to
+the running component or only stored for the next restart. It carries `applied`
+(true only when a reconfig contract accepted the change live) and
+`restart_required` (its complement). A component with no runtime-reconfig hook
+MUST NOT return a response implying a live apply.
+
+#### Scenario: hot-applied change reports applied
+
+- **GIVEN** a component that supports runtime reconfiguration
+- **WHEN** a valid config update is hot-applied
+- **THEN** the response reports `applied: true` and `restart_required: false`
+
+#### Scenario: no-hook component reports restart required
+
+- **GIVEN** a component that implements no runtime-reconfig contract
+- **WHEN** a valid config update is accepted and stored
+- **THEN** the response reports `applied: false` and `restart_required: true`
+- **AND** does not report an unconditional success that implies a live apply
+
+### Requirement: A rejected update does not become a stored-but-unapplied config
+
+The manager MUST validate a config update before storing it, so a rejected update
+leaves the component's stored config unchanged and cannot be silently loaded on
+the next restart. A `ValidateConfigUpdate` (or schema) failure returns a
+structured error response and mutates neither the running component nor the stored
+config.
+
+#### Scenario: validation failure changes nothing
+
+- **GIVEN** a component that supports runtime reconfiguration
+- **WHEN** a `PUT config/<component>` request fails validation
+- **THEN** the response is a structured validation error
+- **AND** the running component is unchanged
+- **AND** the stored config is unchanged (a subsequent restart does not load it)

--- a/openspec/changes/component-runtime-reconfig-http/tasks.md
+++ b/openspec/changes/component-runtime-reconfig-http/tasks.md
@@ -1,0 +1,52 @@
+# Tasks — Component runtime reconfiguration over HTTP (gh#455)
+
+> Scoping change (Proposed). Tasks are unchecked; implementation follows approval.
+
+## 1. Bridge RuntimeConfigurable in the PUT handler
+
+- [ ] 1.1 In `service/component_manager_http.go` PUT handler, after the existing
+      `UpdateConfig(ctx, json.RawMessage)` probe, fall through to a
+      `service.RuntimeConfigurable` probe: `json.Unmarshal(req.Config, &map)` →
+      `ValidateConfigUpdate(map)` → `ApplyConfigUpdate(map)`.
+- [ ] 1.2 Probe order: `UpdateConfig` first, `RuntimeConfigurable` only if absent
+      (a component implementing both keeps current behavior).
+- [ ] 1.3 Factor the "try each reconfig contract, report which applied" logic into
+      a small shared helper so the component and service managers can't diverge.
+
+## 2. Honest applied / restart-required response
+
+- [ ] 2.1 Add `applied bool` + `restart_required bool` to the PUT response
+      (additive; keep `status`/`message`). `applied=true` iff a reconfig contract
+      accepted the change live.
+- [ ] 2.2 No-hook component returns `applied:false, restart_required:true` instead
+      of unconditional success.
+
+## 3. Validate-before-store ordering
+
+- [ ] 3.1 Move the in-memory `componentConfigs` update to AFTER a successful
+      live-apply (or explicitly mark restart-pending when no hook exists), so a
+      `ValidateConfigUpdate` rejection (structured 400) never leaves a
+      stored-but-unapplied config that a restart would load.
+
+## 4. Tests
+
+- [ ] 4.1 Integration: `PUT config/rule-processor` with a valid rule change hot-
+      applies via the bridge and returns `applied:true`; the running processor
+      reflects the change (assert through a reconfig-observable behavior, not just
+      the stored config).
+- [ ] 4.2 Integration: `PUT config/<component-with-no-hook>` returns
+      `applied:false, restart_required:true` and does not lie.
+- [ ] 4.3 Integration: a `ValidateConfigUpdate` rejection returns 400 and leaves
+      the stored config unchanged (no restart-time silent apply).
+- [ ] 4.4 A component implementing `UpdateConfig` still uses that path (regression
+      guard for probe order).
+
+## 5. Spec + close
+
+- [ ] 5.1 `openspec validate --strict`; gates green (`go test -race`,
+      `-tags=integration` for `service`, `task lint`, schema no-drift);
+      semstreams-reviewer; then archive → promote `component-runtime-config` into
+      `openspec/specs/`.
+- [ ] 5.2 Note in gh#455 that the semboids app-side interim gate can be removed.
+- [ ] 5.3 If/when unification is scoped, open the follow-up change (collapse the
+      two reconfig contracts, delete the HTTP-seam bridge) referencing this one.


### PR DESCRIPTION
## Summary

Scoping-only OpenSpec change (Proposed, **not implemented**) for gh#455: the
ComponentManager `PUT config/<component>` handler hot-applies **only** components
implementing the anonymous `UpdateConfig(ctx, json.RawMessage)` interface, so a
component implementing the service-flavored `RuntimeConfigurable` contract
(`ValidateConfigUpdate`/`ApplyConfigUpdate`, e.g. `processor/rule`) is never
applied — yet the PUT returns unconditional `{"status":"success"}`. Reported by
semboids building live rule toggles.

## Target state (see `proposal.md` + `design.md`)

- **Bridge** `RuntimeConfigurable` into the PUT handler — non-breaking, zero
  component changes; rule-processor becomes HTTP-reconfigurable.
- **Honest response** — additive `applied` / `restart_required` fields instead of
  a success that implies a live apply.
- **Validate-before-store** ordering so a rejected update can't be silently loaded
  on restart.
- **Name the two-contract split** (component `UpdateConfig` vs service
  `RuntimeConfigurable`) as a deliberate seam; unification is recorded as a
  follow-up decision, not done here (breaking cross-cutting refactor, no benefit
  to the reported use case).

New capability spec `component-runtime-config` with three requirements
(apply-via-either-contract, honest response, validate-before-store).
`openspec validate --strict` passes.

## Not in this PR

No code — this is the proposal/design/tasks/spec-delta. Implementation follows
approval (tasks.md, 0/13).

Refs #455