### PR TITLE
docs(openspec): scope configurable EntityID virtual edges in community detection (gh#461)

### DIFF
--- a/openspec/changes/graph-clustering-edge-config/.openspec.yaml
+++ b/openspec/changes/graph-clustering-edge-config/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/graph-clustering-edge-config/design.md
+++ b/openspec/changes/graph-clustering-edge-config/design.md
@@ -1,0 +1,86 @@
+# Design — Configurable EntityID virtual edges (gh#461)
+
+## The decision
+
+Expose the EntityID virtual-edge synthesis through the component config with a
+**tri-state shape** so that an *omitted* config reproduces today's behavior
+(heuristics ON) and an operator can *explicitly* disable siblings and/or
+system-peers. Wire the resolved config into `initProviderAndDetector` in place of
+the hardcoded `DefaultEntityIDProviderConfig()`.
+
+## The load-bearing invariant
+
+**Omitted config → current behavior (siblings + system-peers ON).** This is not a
+nicety — the current default is ON, and community detection over heterogeneous /
+sparse-explicit graphs relies on it. If the config shape makes "omitted" resolve
+to OFF, the change silently regresses every existing clustering deploy the moment
+the field exists. So the shape must distinguish three states for each toggle:
+*unset* (→ default), *explicit true*, *explicit false*.
+
+Go's `bool` zero value is `false`, so a plain value-typed `bool` cannot express
+*unset* vs *explicit false*. That is the entire design problem.
+
+## Options for the toggle shape
+
+1. **Pointer bools, positive framing (recommended).**
+   `IncludeSiblings *bool` / `IncludeSystemPeers *bool` on a nested config; `nil`
+   → default (on), `&true`/`&false` honored. Matches gh#461's suggested JSON
+   (`{"include_siblings": false}`) exactly and the library field names. Cost:
+   pointer bools need a JSON round-trip test covering absent / `true` / `false` /
+   `null` (house rule anyway).
+
+2. **Inverted value booleans.** `DisableSiblings bool` / `DisableSystemPeers bool`;
+   zero (`false`) → enabled = current behavior, `true` → off. No pointers, zero
+   value is safe by construction. Cost: double-negative field names; can't tune
+   the numeric weights via the same mechanism without more fields.
+
+3. **Presence-tracked nested block.** `EntityIDEdges *EntityIDEdgesConfig` where a
+   `nil` block → `DefaultEntityIDProviderConfig()`. Solves the *whole-block*
+   absent case, but a *present* block still can't tell an omitted `include_siblings`
+   from an explicit `false` — so the per-field toggles inside it collapse back to
+   Option 1 (pointer bools) or Option 2 (inverted).
+
+**Recommendation: Option 1** (pointer bools, positive framing) for the two
+toggles, on a nested optional block (`entity_id_edges`), with the numeric fields
+(`sibling_weight`, `max_siblings`, `system_peer_weight`, `max_system_peers`)
+value-typed and defaulted-when-zero (the library already does this at
+`entityid_provider.go:108-120`). Positive framing matches the operator mental
+model and the issue; pointers give the honest tri-state; numeric defaulting reuses
+the existing library behavior. If the reviewer prefers to avoid pointer bools,
+Option 2 is the fallback (safer zero value, uglier names).
+
+## Where the defaulting lives
+
+`Config.ApplyDefaults()` (`component.go:136`) is the existing defaulting seam.
+Resolve the operator config there into a concrete `clustering.EntityIDProviderConfig`
+(unset toggles → `true`; unset numerics → library defaults) and have
+`initProviderAndDetector` consume the resolved value instead of calling
+`DefaultEntityIDProviderConfig()` directly. Keeping resolution in `ApplyDefaults`
+(not scattered at the call site) makes the "omitted = on" invariant testable in
+one place.
+
+## JSON-tag note
+
+`clustering.EntityIDProviderConfig` has **no** JSON tags today. Do NOT marshal the
+bare library struct into operator config (it would expose Go field names and no
+tri-state). Define a component-owned, JSON-tagged config type (e.g.
+`EntityIDEdgesConfig`) and map it to the library struct in `ApplyDefaults` — no
+shadow struct that silently drops fields (house rule).
+
+## Tests
+
+- JSON round-trip for every operator-reachable field, asserting the tri-state:
+  absent block → resolves to defaults-on; `{"include_siblings": false}` → siblings
+  off, system-peers still on; explicit numerics honored.
+- A behavioral regression mirroring gh#461: two disjoint same-type cliques through
+  the component with `include_siblings:false, include_system_peers:false` yield 2
+  communities (not 1). (Can reuse the library-level `NewLPADetector` proof + the
+  component path; keep it deterministic, no wall-clock.)
+- A default-preservation test: omitted block → the provider is constructed with
+  the same values as `DefaultEntityIDProviderConfig()`.
+
+## Non-goals / follow-up
+
+- **Adaptive synthesis** (skip virtual edges when explicit degree ≥ k) — a better
+  default than a global switch, but a separate change; this one is the operator
+  escape hatch. Record it as the natural next step.

--- a/openspec/changes/graph-clustering-edge-config/proposal.md
+++ b/openspec/changes/graph-clustering-edge-config/proposal.md
@@ -1,0 +1,90 @@
+# Configurable EntityID virtual edges in community detection (gh#461)
+
+## Why
+
+`graph-clustering` runs community detection (LPA) over an edge set that is **not**
+just the explicit graph edges: `initProviderAndDetector`
+(`processor/graph-clustering/component.go:825`) wraps the KV adjacency provider in
+`clustering.NewEntityIDProvider(..., clustering.DefaultEntityIDProviderConfig(), ...)`
+with **hardcoded** defaults — sibling edges ON (`SiblingWeight 0.7`, `MaxSiblings
+10`) and system-peer edges ON (`SystemPeerWeight 0.3`, `MaxSystemPeers 15`). These
+synthesize *virtual* edges between every entity sharing the 5-part type prefix
+(`org.platform.domain.system.type`) or the same system.
+
+For a **homogeneous entity family whose explicit relationships already encode the
+topology** — flocks of same-type entities linked by `flock.neighbor`, sensor
+meshes, robot swarms — those virtual edges bridge everything and LPA collapses to
+**one community regardless of the explicit structure**. There is no way to turn
+them off.
+
+Verified (gh#461, against beta.133 and beta.135): two fully-connected 4-boid
+cliques with zero cross-cluster edges yield **2** level-0 communities when
+`clustering.NewLPADetector` is driven directly with the raw adjacency, but **1**
+community (all 8 members) through the full component — the only difference being
+the `EntityIDProvider` wrapper. The heuristic is valuable when explicit edges are
+sparse (entities still cluster near their family); it is destructive when explicit
+topology *is* the signal.
+
+The library already supports the off-switch: `NewEntityIDProvider`'s zero-value
+defaulting touches only the numeric fields, so `IncludeSiblings:false` /
+`IncludeSystemPeers:false` are honored verbatim
+(`graph/clustering/entityid_provider.go:126-127`). The gap is purely that the
+component never exposes them.
+
+## What Changes
+
+- **Expose EntityID virtual-edge synthesis through the graph-clustering component
+  config.** An operator can disable sibling and/or system-peer virtual edges (and
+  tune weights/caps), so community detection over a homogeneous family runs on the
+  explicit topology alone.
+- **Defaults preserve today's behavior (heuristics ON).** This is the load-bearing
+  invariant: an operator config that omits the new block MUST behave exactly as
+  today (`DefaultEntityIDProviderConfig`). A naive value-typed struct would make an
+  omitted block a zero-value struct → `IncludeSiblings:false` → silently disabling
+  the heuristics for every existing clustering deploy — a regression worse than the
+  bug. The config shape MUST be tri-state (omitted → on; explicit false → off); see
+  `design.md`.
+- **Schema regen + JSON round-trip tests** for every new operator-reachable field
+  (house rule: operator-configurable surface needs a JSON round-trip test; no
+  shadow structs).
+
+## Capabilities
+
+### New Capabilities
+- `graph-clustering` — seeded with the edge-set + configurable virtual-edge
+  synthesis facet this change touches (community detection runs over explicit +
+  optional EntityID-derived virtual edges; the synthesis is operator-configurable
+  with defaults preserving current behavior). Distilled from code, not backfilled.
+
+### Modified Capabilities
+- None (no existing spec covers graph-clustering yet).
+
+## Impact
+
+- `processor/graph-clustering/component.go`: new nested config field + wiring in
+  `initProviderAndDetector` (replace the hardcoded `DefaultEntityIDProviderConfig()`
+  with the operator-resolved config) + defaulting in `ApplyDefaults` (`:136`).
+- `graph/clustering/entityid_provider.go`: `EntityIDProviderConfig` currently has
+  no JSON tags — the component owns a JSON-tagged config shape (or tags are added)
+  rather than marshaling the bare library struct.
+- Schema: `task schema:generate` will add the new field to the component schema
+  (expected drift, committed).
+- **Consumers:** semboids (reported — flock coloring by LPA community over live
+  `flock.neighbor` edges); any homogeneous-family clustering use.
+
+## Non-goals
+
+- **Adaptive per-entity edge synthesis** (skip virtual edges when an entity's
+  explicit degree ≥ k) — a smarter default than a global toggle, floated in gh#461;
+  deferred as a follow-up refinement. The toggle unblocks the reported use now.
+- **Changing the defaults** — heuristics stay ON by default; this only adds the
+  ability to turn them off.
+- **Retiring EntityID virtual edges** — they remain valuable for sparse-explicit
+  graphs; this is about configurability, not removal.
+
+## Consumers
+
+`processor/graph-clustering` (framework component); semboids (reported consumer).
+The knob is generic — any homogeneous entity family where explicit relationships
+encode the real topology (sensor meshes, swarms, flocks) — so it belongs in the
+framework, not a product.

--- a/openspec/changes/graph-clustering-edge-config/specs/graph-clustering/spec.md
+++ b/openspec/changes/graph-clustering-edge-config/specs/graph-clustering/spec.md
@@ -1,0 +1,56 @@
+# Graph Clustering
+
+## ADDED Requirements
+
+### Requirement: Community detection runs over explicit plus EntityID-synthesized edges
+
+Community detection (LPA) MUST run over an edge set that combines the entity's
+explicit graph edges with optional *virtual* edges synthesized from the 6-part
+EntityID hierarchy: sibling edges between entities sharing the 5-part type prefix
+(`org.platform.domain.system.type`) and system-peer edges between entities sharing
+the same system. The synthesis augments explicit adjacency; it never removes an
+explicit edge.
+
+#### Scenario: explicit edges are always present in the detection input
+
+- **GIVEN** entities with explicit relationship triples
+- **WHEN** community detection runs
+- **THEN** the explicit edges are part of the adjacency the detector sees
+- **AND** any synthesized virtual edges are added on top, not substituted
+
+### Requirement: EntityID virtual-edge synthesis is operator-configurable
+
+The graph-clustering component MUST let an operator enable or disable sibling and
+system-peer virtual edges (and tune their weights and per-entity caps) through its
+configuration, so that community detection over a homogeneous entity family whose
+explicit relationships already encode the topology can run on the explicit edges
+alone.
+
+#### Scenario: an operator disables virtual edges for a homogeneous family
+
+- **GIVEN** a family of same-type entities whose explicit edges form two disjoint clusters
+- **AND** the component configured with sibling and system-peer synthesis disabled
+- **WHEN** community detection runs
+- **THEN** the two clusters are detected as distinct communities
+- **AND** the synthesized virtual edges do not bridge them into one
+
+### Requirement: Omitting the edge-synthesis config preserves the default behavior
+
+The virtual-edge configuration MUST be tri-state per toggle: unset resolves to the
+built-in default, and only an explicit value overrides it. A configuration that
+omits the edge-synthesis block MUST behave exactly as the built-in defaults
+(sibling and system-peer synthesis enabled), so introducing the field cannot
+silently disable synthesis for an existing deployment.
+
+#### Scenario: omitted config resolves to defaults-on
+
+- **GIVEN** a component configuration with no edge-synthesis block
+- **WHEN** the component initializes its community detector
+- **THEN** sibling and system-peer synthesis are enabled with the built-in default weights and caps
+
+#### Scenario: a partial config leaves unset toggles at their default
+
+- **GIVEN** a component configuration that disables only sibling edges
+- **WHEN** the component initializes its community detector
+- **THEN** sibling synthesis is disabled
+- **AND** system-peer synthesis remains at its default (enabled)

--- a/openspec/changes/graph-clustering-edge-config/tasks.md
+++ b/openspec/changes/graph-clustering-edge-config/tasks.md
@@ -1,0 +1,51 @@
+# Tasks — Configurable EntityID virtual edges (gh#461)
+
+> Scoping change (Proposed). Tasks unchecked; implementation follows approval.
+
+## 1. Component config shape
+
+- [ ] 1.1 Add a component-owned, JSON-tagged nested config type (e.g.
+      `EntityIDEdgesConfig`) with tri-state toggles `include_siblings *bool` /
+      `include_system_peers *bool` and value-typed numerics `sibling_weight`,
+      `max_siblings`, `system_peer_weight`, `max_system_peers`. Add the field to
+      `graph-clustering` `Config` with a `schema:"type:object,...,category:advanced"`
+      tag. Do NOT marshal the bare `clustering.EntityIDProviderConfig`.
+- [ ] 1.2 Confirm the final toggle shape with the reviewer (pointer bools vs
+      inverted booleans — design.md Option 1 vs 2).
+
+## 2. Defaulting + wiring (the load-bearing invariant)
+
+- [ ] 2.1 In `Config.ApplyDefaults()` (`component.go:136`), resolve the operator
+      config into a concrete `clustering.EntityIDProviderConfig`: unset toggles →
+      `true`; unset numerics → library defaults. An omitted block MUST resolve to
+      exactly `DefaultEntityIDProviderConfig()`.
+- [ ] 2.2 `initProviderAndDetector` (`component.go:825`) consumes the resolved
+      config instead of calling `clustering.DefaultEntityIDProviderConfig()`.
+
+## 3. Schema
+
+- [ ] 3.1 `task schema:generate`; commit the expected component-schema drift.
+
+## 4. Tests
+
+- [ ] 4.1 JSON round-trip per operator-reachable field with tri-state assertions:
+      absent block → defaults-on; `{"include_siblings": false}` → siblings off,
+      system-peers on; explicit numerics honored. (No shadow struct; assert
+      `reflect`-level shape where a wider destination type applies.)
+- [ ] 4.2 Default-preservation: omitted block → provider constructed with the same
+      values as `DefaultEntityIDProviderConfig()` (guards the regression the shape
+      could introduce).
+- [ ] 4.3 Behavioral regression (gh#461): two disjoint same-type cliques through
+      the component with siblings+system-peers OFF yield 2 level-0 communities, not
+      1. Deterministic; reuse the `NewLPADetector` proof + the component path.
+
+## 5. Spec + close
+
+- [ ] 5.1 `openspec validate --strict`; gates green (`go test -race`,
+      `-tags=integration` for `processor/graph-clustering`, `task lint`, schema
+      committed); semstreams-reviewer; archive → promote `graph-clustering` into
+      `openspec/specs/`.
+- [ ] 5.2 Confirm the diagnosis + fix back to semboids on gh#461; note the config
+      example (`{"entity_id_edges": {"include_siblings": false, "include_system_peers": false}}`).
+- [ ] 5.3 File the adaptive-synthesis follow-up (skip virtual edges when explicit
+      degree ≥ k) referencing this change.


### PR DESCRIPTION
## Summary

Scoping-only OpenSpec change (Proposed, **not implemented**) for gh#461. `graph-clustering` hardcodes `clustering.DefaultEntityIDProviderConfig()` (`component.go:825`) — sibling + system-peer virtual edges **ON** — and never exposes it. For a homogeneous entity family whose explicit relationships encode the topology (flocks, sensor meshes, swarms), those synthesized edges bridge everything and LPA collapses to **one** community regardless of explicit structure.

Verified in gh#461 (beta.133/beta.135): two disjoint 4-boid cliques → **1** community through the component, **2** via the raw `NewLPADetector` on the same adjacency. The library already honors the off-switch (`IncludeSiblings:false` passes through, `entityid_provider.go:126-127`); the component just never exposes it.

## Target state (proposal.md + design.md + spec delta)

- **Expose the virtual-edge synthesis** through the component config so operators can disable siblings/system-peers (and tune weights/caps) and run detection on explicit topology alone.
- **Load-bearing invariant** — omitted config → **current behavior (heuristics ON)**. The config shape must be **tri-state** (unset → default; explicit `false` → off); a naive value-typed bool would make an omitted block silently disable synthesis for every existing deploy — a regression worse than the bug. `design.md` recommends **pointer bools** (positive framing, matches the issue) with inverted-booleans as the fallback.
- Resolve in `Config.ApplyDefaults` (`component.go:136`); schema regen + JSON round-trip tests (house rule).

## Not in this PR

No code — proposal/design/tasks/spec-delta only. Seeds the `graph-clustering` capability spec (edge-synthesis facet). Non-goal: adaptive per-entity synthesis (skip when explicit degree ≥ k) — tracked as a follow-up. `openspec validate --strict` passes.

Refs #461