### PR TITLE
docs(openspec): scope predicate-level Graphable merge (gh#466)

### DIFF
--- a/openspec/changes/graphable-merge-semantics/.openspec.yaml
+++ b/openspec/changes/graphable-merge-semantics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/graphable-merge-semantics/design.md
+++ b/openspec/changes/graphable-merge-semantics/design.md
@@ -1,0 +1,77 @@
+# Design — Graphable merge is predicate-level (gh#466)
+
+## The decision
+
+Make the Graphable (JetStream) ingest lane merge triples with
+`graph.MergeTriples` — **replace per `(subject, predicate)`** — the same helper
+the mutation lane already uses. Pin that as the shared merge contract for
+graph-ingest, and correct the one place the documented contract lies.
+
+## Why MergeTriples is correct (satisfies gh#177 AND gh#466)
+
+`MergeTriples(existing, newer)` (`graph/helpers.go:101`):
+1. starts from `newer` (incoming wins),
+2. keeps each `existing` triple only if no `newer` triple shares its
+   `(subject, predicate)`.
+
+Consequences on a re-arrival of entity E carrying predicates {P1, P2}:
+- **gh#466 (duplication) fixed:** P1/P2 replace their prior values — no growth.
+- **gh#177 (clobber) still fixed:** a predicate P3 the arrival does NOT carry
+  (e.g. a lifecycle-managed or other-writer predicate) has no conflict, so it is
+  preserved. The append version preserved P3 too — but at the cost of duplicating
+  P1/P2. MergeTriples gets both right.
+
+This is why the fix is not "revert gh#177": gh#177 correctly stopped the
+full-replace clobber; it just used the wrong merge. Append and full-replace are
+the two wrong extremes; predicate-level merge is the intended middle.
+
+## The multi-valued-predicate contract (the real decision)
+
+`MergeTriples` conflicts on `(subject, predicate)` only — NOT on object. So a
+multi-valued predicate (a relationship like `flock.neighbor`, where one subject
+has several triples with the same predicate and different objects) is **full-set
+replaced**: if the incoming arrival contains any `flock.neighbor` triple, *all*
+prior `flock.neighbor` triples are dropped and replaced by the incoming set.
+
+- **Publish-the-full-set producers (semboids, sensor meshes): correct.** Each
+  arrival carries the complete current neighbor set; replace is exactly right.
+- **Publish-one-at-a-time producers: would lose the rest.** This lane does not
+  support incremental relationship append.
+
+**Decision:** the graph-ingest merge contract is *full-set-replace per
+`(subject, predicate)`*. Producers own publishing the complete object set for a
+predicate on each arrival. This matches the mutation lane and the KV-twofer model
+(the write IS the current state of that predicate group).
+
+The misleading `MergeTriples` doc comment ("For relationships, all unique
+relationships are preserved") MUST be corrected to state replace-per-predicate /
+full-set semantics — the comment currently describes behavior the code does not
+have, which is a latent trap for the next producer author.
+
+## Test reconciliation
+
+- `batch_integration_test.go` `base+5 / +3 / +2` assertions exercise **`AddTriples`**
+  (already `MergeTriples`-based) with distinct predicates over a bare-stub
+  pre-create, so `base=0` and no conflict → counts unaffected by this change.
+  Confirm during implementation; do not assume.
+- Find any test that drives **`MergeEntity`** with a repeated same-predicate
+  arrival and asserts growth — reconcile it to the replace contract.
+- **Add the regression:** publish the same entity (same `(subject, predicate)`
+  triples) N times via the Graphable lane → exactly one triple per
+  `(subject, predicate)`, not N. Mirror semboids' `TestSnapshotsLandAndReplace`
+  intent. Also assert a non-conflicting predicate written by a prior arrival
+  survives (the gh#177 half).
+
+## Risk
+
+- **A hidden producer relying on accumulation.** The only way append-semantics is
+  load-bearing is if some consumer reads the *history* of a predicate from the
+  duplicated triples in `ENTITY_STATES` (rather than from KV revision history or a
+  stream). That would be an anti-pattern (duplicated current-state triples are not
+  an event log), but the implementation MUST grep Graphable producers/consumers to
+  confirm none does before landing. If one does, it needs the explicit-opt-in path
+  (Non-goals), not the silent default.
+- **Ordering within a predicate group.** `MergeTriples` places `newer` first then
+  non-conflicting `existing`; downstream readers that assume triple order should be
+  spot-checked (predicate-keyed readers like `GetPropertyValue` are order-independent
+  for distinct predicates).

--- a/openspec/changes/graphable-merge-semantics/proposal.md
+++ b/openspec/changes/graphable-merge-semantics/proposal.md
@@ -1,0 +1,105 @@
+# Graphable merge is predicate-level, not raw append (gh#466)
+
+## Why
+
+The JetStream Graphable ingest lane merges a re-arriving entity's triples by **raw
+append**:
+
+```go
+// processor/graph-ingest/component.go:1802
+existing.Triples = append(existing.Triples, entity.Triples...)
+```
+
+So any producer that republishes the same entity **accumulates duplicate triples
+forever**. semboids reproduced it (`TestSnapshotsLandAndReplace`): a boid
+publishing position/velocity at 5 Hz has `flock.position.x` ×3 after three
+arrivals — growth is linear in arrivals × triples/payload. At load-dial rates
+(200 boids × up to 30 Hz × ~10 triples) that is ~60k new triples/second of KV
+growth; the slow version bites every Graphable producer (the `iot_sensor` example
+accumulates 6+ triples per reading on the same device entity). Downstream:
+unbounded KV entry size, index churn over duplicate relationships, and readers
+(`GetPropertyValue`, UI) seeing multi-valued properties where one value is meant.
+
+This is a **lane inconsistency**, not just a missing helper call:
+
+- The **mutation lane** (`graph.mutation.entity.*` → `AddTriples`) already uses
+  `graph.MergeTriples` — replace-by-`(subject, predicate)` (`mutations.go:794,
+  :905`, gh#244).
+- The **Graphable/JetStream lane** (`MergeEntity`) appends.
+
+The append is an over-correction from gh#177 ("jetstream consumer upserts
+(full-replace) … clobbers lifecycle-managed triples"), which fixed a Put-clobber
+by switching to "merge" but implemented merge as keep-everything. The correct
+middle — predicate-level merge — fixes **both** problems at once:
+`graph.MergeTriples(existing, newer)` lets `newer` win on a `(subject, predicate)`
+conflict while preserving non-conflicting existing triples (so lifecycle-managed
+or other-writer predicates are NOT clobbered — gh#177 — and re-arrivals do NOT
+duplicate — gh#466).
+
+## What Changes
+
+- **The Graphable merge lane replaces per `(subject, predicate)`.** `MergeEntity`'s
+  existing-entity branch uses `graph.MergeTriples(existing.Triples, entity.Triples)`
+  instead of `append`, making the two graph-write lanes consistent and matching the
+  documented merge intent.
+- **Pin the merge contract.** A predicate present in the incoming entity's triples
+  fully replaces that `(subject, predicate)`'s prior triples; a predicate absent
+  from the incoming set is preserved untouched. This is *full-set-replace per
+  predicate*, not accumulation.
+- **Resolve the multi-valued-predicate contract + fix the misleading comment.**
+  `MergeTriples`'s doc comment claims "for relationships, all unique relationships
+  are preserved," but the implementation replaces per `(subject, predicate)` — so
+  a multi-valued relationship predicate (e.g. `flock.neighbor`) is *full-set
+  replaced*: a producer MUST publish the complete object set for that predicate
+  each arrival; a partial publish drops the rest. This is the right behavior for
+  full-set publishers (semboids); document it and correct the comment so the
+  contract is not a trap.
+- **Reconcile tests + add a regression.** Confirm/adjust any test asserting
+  MergeEntity re-arrival growth (the `batch_integration_test.go` `base+N`
+  assertions test `AddTriples`, already MergeTriples-based, and use distinct
+  predicates — likely unaffected). Add a repeated-arrival regression: publishing
+  the same entity N times leaves one triple per `(subject, predicate)`, not N.
+
+## Capabilities
+
+### New Capabilities
+- `graph-ingest` — seeded with the entity-merge-semantics facet: how graph-ingest
+  merges a re-arriving entity's triples into existing state on both the Graphable
+  (JetStream) lane and the mutation (`AddTriples`) lane, and the
+  replace-per-`(subject, predicate)` contract they share. Distilled from code, not
+  backfilled.
+
+### Modified Capabilities
+- None (no existing spec covers graph-ingest yet).
+
+## Impact
+
+- `processor/graph-ingest/component.go`: one-line change in `MergeEntity`
+  (`append` → `graph.MergeTriples`), plus test reconciliation + regression.
+- `graph/helpers.go`: correct the `MergeTriples` doc comment (replace-per-predicate,
+  full-set semantics for multi-valued predicates).
+- **Behavior change on the highest-volume lane** — every Graphable producer stops
+  accumulating duplicates. Verify no producer relies on accumulation (see
+  Non-goals). Touches the graph-write-intent taxonomy (ADR-055/056) and the
+  single-writer invariant.
+- **Consumers:** semboids (reported — load-dial / fast-moving-graph profiling);
+  every Graphable producer (`iot_sensor` example, semsource, etc.).
+
+## Non-goals
+
+- **Time-series / accumulation semantics on the Graphable lane.** If a producer
+  genuinely wants to accumulate values over time, that is an explicit opt-in via a
+  different mechanism (append-only stream, distinct predicate per sample, or
+  ObjectStore) — not the silent default of the highest-volume state lane. Out of
+  scope here; file separately if a real need appears.
+- **Changing `AddTriples` / mutation-lane semantics** — already correct
+  (MergeTriples); this only aligns the Graphable lane to match.
+- **Per-object relationship diffing** (add one `flock.neighbor` without republishing
+  the set) — the contract is full-set-replace per predicate; per-object append is a
+  separate, larger design if ever needed.
+
+## Consumers
+
+`processor/graph-ingest` (framework, the single writer to `ENTITY_STATES`);
+semboids (reported); all Graphable producers across the `sem*` family. The merge
+contract is a cross-repo behavior, so it is pinned as a spec.

--- a/openspec/changes/graphable-merge-semantics/specs/graph-ingest/spec.md
+++ b/openspec/changes/graphable-merge-semantics/specs/graph-ingest/spec.md
@@ -1,0 +1,48 @@
+# Graph Ingest
+
+## ADDED Requirements
+
+### Requirement: A re-arriving entity's triples merge by predicate-level replacement
+
+graph-ingest MUST merge the incoming triples of a re-arriving (already-existing)
+entity by replacing per `(subject, predicate)`, not by appending, when the write
+comes through the Graphable (JetStream) ingest lane. A predicate carried by the
+incoming entity MUST replace that `(subject, predicate)`'s prior triples, so the
+entity does not accumulate duplicate triples across repeated arrivals. This matches
+the mutation (`AddTriples`) lane's merge semantics.
+
+#### Scenario: republishing the same entity does not accumulate duplicates
+
+- **GIVEN** an entity previously ingested with `flock.position.x = 1`
+- **WHEN** the same entity is ingested again with `flock.position.x = 2`
+- **THEN** the stored entity has exactly one `flock.position.x` triple
+- **AND** its value is `2`
+
+### Requirement: A predicate absent from an arrival is preserved
+
+Merging MUST preserve any existing triple whose `(subject, predicate)` is not
+present in the incoming arrival, so a Graphable arrival does not clobber
+predicates written by a different writer (e.g. lifecycle-managed triples).
+
+#### Scenario: a non-conflicting predicate survives a later arrival
+
+- **GIVEN** an entity carrying `lifecycle.phase = active` and `sensor.temp = 20`
+- **WHEN** a Graphable arrival for that entity carries only `sensor.temp = 21`
+- **THEN** the stored entity still has `lifecycle.phase = active`
+- **AND** `sensor.temp` is `21`
+
+### Requirement: A multi-valued predicate is full-set replaced
+
+On merge, a multi-valued relationship predicate MUST be full-set replaced.
+For a predicate a subject may hold several times (such as `flock.neighbor`), an
+arrival that carries that predicate replaces the entire prior set for that
+`(subject, predicate)` with the arrival's set. Producers therefore own publishing
+the complete object set for such a predicate on each arrival; this lane MUST NOT
+append individual relationship objects.
+
+#### Scenario: a new neighbor set replaces the prior set
+
+- **GIVEN** an entity whose stored `flock.neighbor` set is `{b, c}`
+- **WHEN** a Graphable arrival carries `flock.neighbor` = `{c, d}`
+- **THEN** the stored `flock.neighbor` set is exactly `{c, d}`
+- **AND** the prior-only member `b` is no longer present

--- a/openspec/changes/graphable-merge-semantics/tasks.md
+++ b/openspec/changes/graphable-merge-semantics/tasks.md
@@ -1,0 +1,50 @@
+# Tasks — Graphable merge is predicate-level (gh#466)
+
+> Scoping change (Proposed). Tasks unchecked; implementation follows approval.
+
+## 1. The fix
+
+- [ ] 1.1 `MergeEntity` existing-entity branch (`component.go:1802`): replace
+      `existing.Triples = append(existing.Triples, entity.Triples...)` with
+      `existing.Triples = graph.MergeTriples(existing.Triples, entity.Triples)`.
+- [ ] 1.2 Confirm the surrounding merge (MessageType refresh, StorageRef,
+      `reconcileIndexingProfile`, Version++, UpdatedAt) is unchanged and still
+      correct after the triple-merge swap.
+
+## 2. Contract + doc correction
+
+- [ ] 2.1 Correct the `graph.MergeTriples` doc comment (`graph/helpers.go:98-100`):
+      it replaces per `(subject, predicate)` (full-set semantics), NOT "all unique
+      relationships preserved". State the multi-valued-predicate behavior
+      explicitly so it is not a trap.
+
+## 3. Producer/consumer safety sweep
+
+- [ ] 3.1 Grep Graphable producers and `ENTITY_STATES` readers for any reliance on
+      accumulated/duplicated triples (reading a predicate's history from repeated
+      triples rather than KV revisions/streams). If found, it needs the
+      explicit-opt-in path, not this lane's default — surface before landing.
+
+## 4. Tests
+
+- [ ] 4.1 Reconcile existing tests: confirm `batch_integration_test.go` `base+N`
+      assertions (AddTriples, distinct predicates) are unaffected; find + fix any
+      test asserting `MergeEntity` re-arrival growth.
+- [ ] 4.2 Regression (gh#466): publish the same entity N times via the Graphable
+      lane → exactly one triple per `(subject, predicate)`, not N (mirror
+      semboids' `TestSnapshotsLandAndReplace`).
+- [ ] 4.3 gh#177 half: a non-conflicting predicate written by a prior arrival (or
+      other writer) survives a later Graphable arrival that does not carry it.
+- [ ] 4.4 Multi-valued predicate: an arrival with a full `flock.neighbor` set
+      replaces the prior set (not union); assert full-set-replace.
+
+## 5. Spec + close
+
+- [ ] 5.1 `openspec validate --strict`; gates green (`go test -race`,
+      `-tags=integration` for `processor/graph-ingest`, `task lint`, schema
+      no-drift); semstreams-reviewer; archive → promote `graph-ingest` into
+      `openspec/specs/`.
+- [ ] 5.2 Confirm the fix back to semboids on gh#466 (unskip
+      `TestSnapshotsLandAndReplace`); note the full-set-replace contract.
+- [ ] 5.3 If the safety sweep (3.1) finds an accumulation consumer, file the
+      explicit-opt-in follow-up referencing this change.


### PR DESCRIPTION
## Summary

Scoping-only OpenSpec change (Proposed, **not implemented**) for gh#466. The JetStream Graphable ingest lane merges a re-arriving entity's triples by **raw append** (`component.go:1802`), so any producer republishing the same entity accumulates duplicate triples forever — ~60k dup triples/sec at semboids' load-dial; every Graphable producer bleeds slower (`iot_sensor` accumulates 6+/reading).

**It's a lane inconsistency:** the *mutation* lane (`AddTriples`) already uses `graph.MergeTriples` — replace-by-`(subject, predicate)` (`mutations.go:794,905`, gh#244). The append is an over-correction from gh#177 (fixed a Put-clobber by switching to "merge" but implemented it as keep-everything). Predicate-level merge fixes **both**: `MergeTriples` lets incoming win on `(subject, predicate)` conflict while preserving non-conflicting existing triples — so re-arrivals don't duplicate (gh#466) **and** lifecycle-managed predicates aren't clobbered (gh#177).

## Target state (proposal.md + design.md + spec delta)

- **Graphable lane → `graph.MergeTriples`** (one-line at `component.go:1802`), consistent with the mutation lane.
- **Pin the contract:** full-set-replace per `(subject, predicate)`. Multi-valued predicates (e.g. `flock.neighbor`) are full-set replaced — producers publish the complete object set per arrival. **Correct the misleading `MergeTriples` doc comment** ("all unique relationships preserved" — the impl replaces per predicate; a latent trap).
- **Safety sweep** for any accumulation-reliant consumer; reconcile tests (note: `batch_integration_test.go` `base+N` tests `AddTriples`, already MergeTriples-based, distinct predicates → unaffected) + add a repeated-arrival regression.

## Not in this PR

No code — proposal/design/tasks/spec-delta only. Seeds the `graph-ingest` capability spec (merge-semantics facet). Non-goal: time-series accumulation on this lane (explicit opt-in if ever needed). `openspec validate --strict` passes.

Refs #466