### PR TITLE
docs(openspec): scope pkg/fusion per-facet edge selection (gh#475)

### DIFF
--- a/openspec/changes/fusion-per-facet-edges/.openspec.yaml
+++ b/openspec/changes/fusion-per-facet-edges/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/fusion-per-facet-edges/proposal.md
+++ b/openspec/changes/fusion-per-facet-edges/proposal.md
@@ -1,0 +1,75 @@
+# pkg/fusion: per-facet edge selection for a Lens (gh#475)
+
+## Why
+
+`fusion.Lens.Edges()` returns **one** `[]EdgeSpec` list that the engine uses for
+**three** distinct facets:
+
+- `computeImpact` — incoming (reverse) BFS over the edge predicates
+  (`engine_facets.go:47`)
+- `computePaths` — outgoing DFS over the edge predicates (`engine_facets.go:100`)
+- the `relations` map on each result node (`engine_lens.go:176`)
+
+All three derive their predicate set from the same undifferentiated `[]EdgeSpec`
+via a single flattener, `edgePredicates` (`engine_lens.go:219`). A lens therefore
+**cannot** say *"walk this edge for `relations` but not for `impact`."* Every
+declared edge participates in all three facets.
+
+That is a real fidelity problem for any lens with a **containment** edge. semsource's
+code lens (ADR-0004) must declare `CodeContains` (file→symbol) so `code_context` can
+show a symbol's container and contents in `relations` — but that same predicate then
+pollutes `code_impact`, whose incoming-`contains` walk pulls every dependent's
+`file → folder → repo` into the blast radius. The impact **count** then mixes
+structural containment ancestry with real reverse-dependents. Measured on httpx:
+
+```
+code_impact("BaseClient") = {nodes: 5} = 2 real subclasses + 3 structural containers
+```
+
+The containment ancestry dominates a small dependency set, so the count reads as
+noisier / larger than the true reverse-dependency closure. This is a **framework
+SPI expressiveness gap** — the engine owns resolve/rank/budget/walk; the lens should
+be able to annotate which facets each edge feeds.
+
+## What Changes
+
+- **Add an optional per-`EdgeSpec` facet mask.** A new `Facets []Facet` field on
+  `EdgeSpec` (`pkg/fusion/lens.go`), where `Facet` names the three edge-walk facets
+  — `relations`, `paths`, `impact` (the same three the caller already requests via
+  the existing `Want` vocabulary). A spec lists the facets it should feed.
+
+- **Empty `Facets` means all three — fully backward-compatible.** Every existing
+  lens (and the `refLens` fixture) declares `EdgeSpec`s with no `Facets` field; the
+  zero value (`nil`) MUST mean "participate in every facet," so current behavior is
+  byte-for-byte unchanged. The field is a *restriction*, opted into only when a lens
+  wants an edge to skip a walk.
+
+- **Make the single choke point facet-aware.** `edgePredicates`
+  (`engine_lens.go:219`) gains a facet-filtered variant; the three callers each pass
+  their own facet — `relations` (needs the forward+reverse role maps), `computePaths`
+  and `computeImpact` (predicates only). An `EdgeSpec` is included for a facet iff
+  its `Facets` is empty or contains that facet.
+
+- **No change to `Want`, `Request`, `Budget`, or the resolve/rank/hydrate path.**
+  This is a narrow SPI addition on the edge-walk side only.
+
+The product half is semsource's: once the mask exists, the code lens sets
+`CodeContains.Facets = {relations}` (and `{relations, paths}` for any containment
+edge it also wants in outgoing paths), so containment feeds `relations`/`code_context`
+but no longer inflates `code_impact`.
+
+## Impact
+
+- **Affected specs:** new capability `fusion` (seeded lazily by this change — the
+  Lens SPI edge model + this per-facet contract, distilled from `pkg/fusion` and
+  verified against code). Scope is the **edge-walk / facet** contract; resolve, rank,
+  budget, and hydration are separate concerns, seeded when a change first touches them.
+- **Affected code:** `pkg/fusion/lens.go` (`EdgeSpec` field + `Facet` type),
+  `pkg/fusion/engine_lens.go` (`edgePredicates` facet filter + `relations` caller),
+  `pkg/fusion/engine_facets.go` (`computeImpact` / `computePaths` callers), and the
+  `lens_test.go` / `engine_facets_test.go` fixtures.
+- **No breaking change, no ADR.** `EdgeSpec` is an in-process SPI struct constructed
+  by each product's Lens, not a cross-repo wire contract; the addition is a
+  backward-compatible field (empty = all). No NATS/RPC contract is touched. (Contrast
+  gh#463, whose `Scope`-on-embedding-search fix *does* change a cross-component RPC
+  contract and therefore carries an ADR.)

--- a/openspec/changes/fusion-per-facet-edges/specs/fusion/spec.md
+++ b/openspec/changes/fusion-per-facet-edges/specs/fusion/spec.md
@@ -1,0 +1,54 @@
+# Fusion
+
+Deterministic graph fusion (`pkg/fusion`, ADR-062): a `Lens` describes how to
+resolve a query into seed entities and how to walk their relationships; the `Engine`
+owns resolve, rank, budget, and the facet walks. This spec covers the **edge-walk /
+facet** contract — how a Lens's declared edges feed the three graph facets.
+
+> Seeded lazily by the gh#475 per-facet-edge change. Requirements distilled from
+> `pkg/fusion` (`lens.go`, `engine_lens.go`, `engine_facets.go`) and verified against
+> code. Scope is the edge model only; resolve mode, ranking, budgeting, and hydration
+> are separate concerns, seeded when a change first touches them.
+
+## ADDED Requirements
+
+### Requirement: A Lens declares its relationship edges as EdgeSpecs
+
+A `Lens` MUST declare the relationship predicates it walks via `Edges() []EdgeSpec`.
+Each `EdgeSpec` names a `Predicate` and the role labels for its forward
+(`OutgoingRole`) and optional reverse (`IncomingRole`) directions; an empty
+`IncomingRole` skips the reverse direction. The engine consumes these specs for
+three facets: the per-node `relations` map (forward + reverse roles), the outgoing
+`paths` walk, and the incoming `impact` walk.
+
+#### Scenario: a declared edge feeds the relations map
+
+- **GIVEN** a Lens whose `Edges()` includes an `EdgeSpec` with a forward and reverse role
+- **WHEN** the engine builds the `relations` map for a result node
+- **THEN** neighbors reachable over that predicate appear under the declared roles
+
+### Requirement: An EdgeSpec participates only in its selected facets
+
+`EdgeSpec` MUST support an optional `Facets` selector naming the facets the edge
+feeds — `relations`, `paths`, and/or `impact`. An `EdgeSpec` whose `Facets` is
+empty MUST participate in **all three** facets (the backward-compatible default, so
+a lens that declares no selector is unchanged). A non-empty `Facets` MUST restrict
+the edge to exactly the named facets: the engine includes the edge's predicate in a
+facet's walk iff the edge's `Facets` is empty or contains that facet.
+
+This lets a lens declare a containment edge (e.g. file→symbol) that populates the
+`relations` map without polluting the `impact` walk, whose incoming traversal would
+otherwise pull structural containment ancestry into the reverse-dependency closure.
+
+#### Scenario: an edge excluded from impact still populates relations
+
+- **GIVEN** a Lens with an `EdgeSpec` whose `Facets` is `{relations}`
+- **WHEN** the engine builds a result node's `relations` map AND computes `impact`
+- **THEN** the edge's neighbors appear in the `relations` map
+- **AND** the edge is NOT traversed by the `impact` walk
+
+#### Scenario: an edge with no facet selector participates everywhere
+
+- **GIVEN** a Lens with an `EdgeSpec` whose `Facets` is empty
+- **WHEN** the engine computes `relations`, `paths`, and `impact`
+- **THEN** the edge's predicate is walked for all three facets

--- a/openspec/changes/fusion-per-facet-edges/tasks.md
+++ b/openspec/changes/fusion-per-facet-edges/tasks.md
@@ -1,0 +1,58 @@
+# Tasks — pkg/fusion per-facet edge selection (gh#475)
+
+> Scoping change (Proposed). Tasks unchecked; implementation follows scope approval
+> (`/opsx:apply` on a `feat/` branch).
+
+## 1. SPI: the facet mask
+
+- [ ] 1.1 Add a `Facet` type (`pkg/fusion/lens.go`) with constants `FacetRelations`,
+      `FacetPaths`, `FacetImpact` whose string values match the existing `Want`
+      values (`relations`/`paths`/`impact`), so lens authors and callers share one
+      vocabulary. Do NOT reuse `Want` directly (it also has `WantBody`, which is not
+      an edge-walk facet — a distinct type keeps `EdgeSpec.Facets` type-safe).
+- [ ] 1.2 Add `Facets []Facet` to `EdgeSpec` (`lens.go:98`). Document the invariant:
+      **empty/nil = participates in all three facets** (backward-compatible zero
+      value); a non-empty list restricts participation to the named facets.
+
+## 2. Engine: facet-aware predicate selection
+
+- [ ] 2.1 Add a facet filter at the single choke point `edgePredicates`
+      (`engine_lens.go:219`): a spec is included for facet `f` iff
+      `len(spec.Facets) == 0 || slices.Contains(spec.Facets, f)`. Prefer a new
+      `edgePredicatesFor(specs, f)` variant over mutating the existing signature, so
+      the change is additive.
+- [ ] 2.2 `relations` (`engine_lens.go:176`) passes `FacetRelations` and keeps using
+      the forward + reverse role maps.
+- [ ] 2.3 `computePaths` (`engine_facets.go:100`) passes `FacetPaths` (predicates only).
+- [ ] 2.4 `computeImpact` (`engine_facets.go:47`) passes `FacetImpact` (predicates only).
+- [ ] 2.5 Confirm no other caller of `edgePredicates` exists (grep); if any, route it
+      through the appropriate facet.
+
+## 3. Tests
+
+- [ ] 3.1 Backward-compat: an `EdgeSpec` with no `Facets` participates in all three
+      facets (extend the `refLens` fixture assertions — existing behavior unchanged).
+- [ ] 3.2 Impact-excluded edge: a spec with `Facets: {relations}` populates the
+      `relations` map but is NOT walked by `computeImpact` — mirror the semsource
+      containment case (a `contains`-style edge feeds relations; impact returns only
+      the real reverse-dependents, not the containment ancestry).
+- [ ] 3.3 Paths selectivity: a spec limited to `{relations, impact}` is excluded from
+      `computePaths`.
+- [ ] 3.4 Multi-facet: a spec with `{relations, paths, impact}` behaves identically to
+      an empty (all) spec.
+- [ ] 3.5 Extend `engine_facets_test.go` (`facetGraph`/`fuseFacet` builders) and the
+      `lens_test.go` `refLens` `Edges()` fixture.
+
+## 4. Spec + gates + close
+
+- [ ] 4.1 `openspec validate --strict`.
+- [ ] 4.2 Gates: `go test -race ./pkg/fusion/...`, `task lint`, schema no-drift
+      (pkg/fusion has no generated schema — confirm), `go vet -tags=integration`.
+- [ ] 4.3 semstreams-reviewer pre-merge (backward-compat of empty=all verified across
+      ALL `edgePredicates` callers; no facet dropped; the `refLens`/production lenses
+      still walk every facet by default).
+- [ ] 4.4 Archive → promote `fusion` into `openspec/specs/`.
+- [ ] 4.5 PR; CI green; merge; tag. (No e2e tier directly covers `pkg/fusion` — it is
+      consumed by semsource, not the semstreams e2e stack; note the coverage gap.)
+- [ ] 4.6 Confirm back to semsource on gh#475 / upstream-asks #17 (code lens sets
+      `CodeContains.Facets = {relations}` so containment stops inflating `code_impact`).


### PR DESCRIPTION
**Scope-only PR** (proposal + tasks + `fusion` spec delta). Implementation follows on a `feat/` branch via `/opsx:apply` after scope approval, per the fusion/semsource cadence.

## Problem (gh#475 / semsource upstream-asks #17)

`fusion.Lens.Edges()` returns one `[]EdgeSpec` that the engine uses for **three** facets — `computeImpact` (incoming BFS), `computePaths` (outgoing DFS), and the `relations` map — all via the single `edgePredicates` flattener (`engine_lens.go:219`). A lens can't say "walk this edge for `relations` but not `impact`."

semsource's code lens must declare `CodeContains` (file→symbol) for `code_context`'s `relations`, but that edge then pollutes `code_impact`: the incoming-`contains` walk pulls every dependent's `file→folder→repo` into the blast radius. Measured (httpx): `code_impact("BaseClient") = {nodes: 5}` = 2 real subclasses + 3 structural containers.

## Proposed fix (Option 1 — per-`EdgeSpec` facet mask)

- Optional `Facets []Facet` on `EdgeSpec` (`relations`/`paths`/`impact`, matching the existing `Want` vocabulary).
- **Empty = all three** → fully backward-compatible; every current lens/fixture is unchanged. The field is an opt-in *restriction*.
- `edgePredicates` becomes facet-aware; the three callers each pass their facet. An edge is included for a facet iff its `Facets` is empty or contains that facet.

**No ADR:** `EdgeSpec` is an in-process SPI struct constructed by each product's Lens — not a cross-repo wire contract. (Contrast gh#463, whose embedding-search `Scope` fix changes a NATS RPC contract → ADR-071.)

Seeds the `fusion` capability spec (edge-walk contract). `openspec validate --strict` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)