### PR TITLE
docs: ADR-071 (Accepted) + scope domain-scoped NL retrieval for a fusion lens (gh#463)

### DIFF
--- a/docs/adr/071-fusion-domain-scoped-nl-retrieval.md
+++ b/docs/adr/071-fusion-domain-scoped-nl-retrieval.md
@@ -2,16 +2,17 @@
 
 ## Status
 
-**Proposed — Option 1 selected (2026-07-05); pending pre-Accept adversarial review
-and open-question resolution.** The mechanism decision is made: **Option 1** — a
-`Scope` on `fusion.Request` plumbed to the embedding search. It is recorded as an ADR
-because it changes a **cross-component NATS RPC contract** (`graph.query.semantic` +
-`graph.embedding.query.search`), the class of decision an ADR exists to hold. Before
-Accept, the four open questions below are resolved and the mechanism gets a
+**Proposed — Option 1 selected; pre-Accept adversarial review folded (2026-07-05);
+awaiting user sign-off to Accept.** The mechanism is decided: **Option 1** — a
+`Scope []string` on `fusion.Request` plumbed to the embedding search — recorded as an
+ADR because it changes a **cross-component NATS RPC contract**
+(`graph.embedding.query.search`), the class of decision an ADR exists to hold. A
 code-grounded adversarial review (framework-ADR discipline —
-`feedback_adversarial_review_framework_adr`); then the mechanics move into an openspec
-change against the `fusion` + `graph-embedding` capability specs and implementation
-follows.
+`feedback_adversarial_review_framework_adr`) found a **BLOCKING** shape defect (a
+warm-cache no-op) and two HIGHs (scope must be a list; a cross-repo compile break),
+all folded into the Decision/Consequences/Resolved-decisions below. On Accept, the
+mechanics move into an openspec change against the `fusion` + `graph-embedding`
+capability specs and implementation follows.
 
 Scopes gh#463 / semsource upstream-asks #16.
 
@@ -54,24 +55,52 @@ retained below as the considered-and-rejected alternatives (Option 2 may still s
 
 ### Option 1 — `Scope` on `fusion.Request`, plumbed to the embedding search *(SELECTED)*
 
-Add an optional scope (an entity-ID glob/prefix, e.g. `*.web.*.doc.*`, matching the
-6-part federated entity ID) to `fusion.Request`, threaded to the vector scan so a
-lens instance constrains seeds to its domain at the source.
+Add an optional **`Scope []string`** (a list of dot-delimited entity-ID **prefixes**,
+OR-matched; empty/nil = no filter) to `fusion.Request`, threaded to the vector scan so
+a lens instance constrains seeds to its domain **at the candidate source**.
 
+- **Why a list, not a scalar (pre-Accept review, HIGH):** the code-vs-docs
+  discriminator lives in the ID's domain/system segments (positions 3–4 of
+  `org.platform.domain.system.type.instance`), and each side spans **multiple**
+  prefixes — semsource "all code" = `golang`/`python`/`ts`/`svelte`, "all docs" =
+  `source.doc` + `source.chunk`. A single glob/prefix cannot express either side. (The
+  earlier draft's `*.web.*.doc.*` example was fictional — no real ID has both `web` and
+  `doc` segments.) Prefix, not glob: `strings.HasPrefix(id, p+".")` is cheapest and
+  avoids `path.Match`'s dotted-delimiter ambiguity (`*` would span `.`).
 - **Correctness:** filters at the candidate source, so the small domain is never
   crowded out of the ranked window — the only option that reliably fixes *severe*
   dilution (the httpx case, where docs fell entirely below `resolveLimit = 40`).
-- **Cost — the reason this is an ADR:** the scope must be threaded through every hop,
-  two of which are **cross-component NATS RPC contracts** consumed by semsource:
-  1. `fusion.Request` (`contract.go:36`) — add `Scope`
-  2. `RetrievalClient.Resolve` signature (`retrieval.go:22`) — ripples to all impls + fakes
-  3. `fusionnats.Client.resolveSemantic` body (`client.go:131`)
-  4. `graph.query.semantic` handler passthrough (`processor/graph-query/query.go:562`)
-  5. **`SearchRequest`** (`processor/graph-embedding/query.go:65`) — add scope field **(RPC contract change)**
-  6. `findSimilarEntities` scan loop (`query.go:248`) — apply the filter
+- **Cost — the reason this is an ADR:** the scope is threaded through these hops (one
+  of the six the earlier draft listed is a free passthrough — LOW):
+  1. `fusion.Request` (`contract.go:36`) — add `Scope []string`
+  2. `RetrievalClient.Resolve` (`retrieval.go:22`) — **use a struct param**
+     (`Resolve(ctx, ResolveQuery{Query, Mode, Scope, Limit})`) rather than a positional
+     add: `Resolve` is shared across symbol/prefix/nl, scope is NL-only, and a
+     positional arg forces every mode's callers (incl. the cross-repo fake) to pass an
+     ignored value and re-breaks on the next dimension.
+  3. `fusionnats.Client.resolveSemantic` body (`client.go:131`) — insert `"scope"`
+     **only when non-empty** (byte-parity for the unscoped case).
+  4. `graph.query.semantic` handler — **no code change**: `handleQuerySemantic`
+     (`processor/graph-query/query.go:569`) forwards raw `[]byte` via
+     `RequestClassified`, so a new JSON field rides through untouched.
+  5. **`SearchRequest`** (`processor/graph-embedding/query.go:65`) — add `Scope []string`
+     **(the cross-component RPC contract change)**.
+  6. Apply the filter in **both** `findSimilarEntities` paths (see BLOCKING below).
 - **Backward-compat:** the field is optional; empty = no filter = today's behavior.
-  Additive to the RPC contract, but it is still a shared wire-shape change — hence
-  this ADR.
+  graph-embedding uses plain `json.Unmarshal` (no `DisallowUnknownFields`), so an
+  un-migrated server silently ignores `scope` (graceful degrade to unscoped), and every
+  other caller of the subject sends none. Additive, but a shared wire-shape change —
+  hence this ADR.
+
+> **BLOCKING (pre-Accept review) — the filter must live in the WARM path, not only the
+> scan fallback.** `findSimilarEntities` (`processor/graph-embedding/query.go:221`)
+> serves from an in-memory cache via `FindSimilarFromCache` (`graph/embedding/storage.go:439`,
+> loop `:451`) **first**, and only hits the KV-scan loop (`query.go:248`) when the cache
+> is cold. Applying the filter only at `query.go:248` (as the earlier draft said) makes
+> it a **silent no-op for essentially every real query** in warm production. The scope
+> filter MUST be applied in **both** paths via one shared helper, filtering **before**
+> `CosineSimilarity` (cache) / before the per-candidate `GetEmbedding` KV round-trip
+> (scan) — on the httpx case a docs scope turns ~1334 KV round-trips into ~30.
 
 ### Option 2 — `Lens.SeedFilter(entity) bool` + engine over-fetch *(self-contained, cheaper, weaker)*
 
@@ -92,35 +121,71 @@ deferred unless Options 1/2 prove insufficient.
 
 ### Recommendation
 
-**Option 1**, with the scope as an optional entity-ID glob/prefix applied in
-`findSimilarEntities` (`query.go:248`), because it is the only option that fixes the
-severe-dilution case semsource actually hit, and it keeps engine ownership intact
-(the product supplies the scope per lens). Option 2 could ship *additionally* as a
-cheap in-engine convenience, but is not sufficient on its own.
+**Option 1**, with `Scope []string` (OR-matched ID prefixes) applied at the candidate
+source in **both** `findSimilarEntities` paths, because it is the only option that
+fixes the severe-dilution case semsource actually hit, and it keeps engine ownership
+intact (the product supplies the scope per lens). Option 2 is **not** shipped alongside
+(see resolved question c).
 
 ## Consequences
 
-- The `graph.embedding.query.search` (and passthrough `graph.query.semantic`) RPC
-  request gains an optional scope field — additive and backward-compatible, but a
-  cross-component contract shape semsource depends on (the reason for this ADR).
-- `RetrievalClient.Resolve` signature changes; all impls and test fakes (`engine_lens_test.go`
-  `fakeGraph.Resolve`, `fusionnats.Client`) update.
-- Mechanics (field names, glob semantics, scan-loop filter, over-fetch interplay) are
-  specified in the `fusion` + `graph-embedding` capability specs via the follow-on
-  openspec change — NOT in this ADR.
+- The `graph.embedding.query.search` (`SearchRequest`) — and the raw-passthrough
+  `graph.query.semantic` — request gains an optional `Scope []string` — additive,
+  backward-compatible (unknown-field-tolerant decode), but a cross-component contract
+  shape semsource depends on (the reason for this ADR).
+- **`RetrievalClient.Resolve` change is a cross-repo compile break — full blast radius:**
+  the sole production impl `fusionnats.Client`; the in-repo fake `engine_lens_test.go`
+  `fakeGraph.Resolve` + 7 call sites (`client_test.go` L119/145/166/180,
+  `client_integration_test.go` L87/93/99); and — omitted from the earlier draft —
+  the **cross-repo** `../semsource/source/fusion/fusiontest/memgraph.go:73`
+  `MemGraph.Resolve`. (`engine_test.go`'s `fakeGraphQuery` implements the *different*
+  `GraphQueryClient` interface — unaffected.) The struct-param shape (question a)
+  contains this: adding a field to `ResolveQuery` later won't re-break these.
+- **Convergence decision (review MEDIUM):** an Option-2-shaped post-filter already
+  exists — `graph-query/graphrag.go` `handleStrategySemantic` calls
+  `filterEntityIDsByType` (`graphrag.go:907/1237`) **after** the embedding search. The
+  follow-on openspec change MUST decide to converge on one scope filter (reuse its
+  `[]string` + empty=no-op convention, and extract a shared
+  `graph.MatchesAnyIDPrefix(id, []string)` helper) rather than ship a second overlapping
+  filter on the same semantic path — "name the responsibility once."
+- **Coverage gap (review):** no e2e tier exercises `pkg/fusion` / the semantic NL path;
+  the openspec change adds a production-decoder round-trip test (`SearchRequest`-with-scope
+  → graph-embedding decode → filter applied) and ideally an integration test through
+  `fusionnats.Client → graph-query → graph-embedding`.
+- The `did_you_mean` path (`e.miss` → `Names` → `graph.query.byName`) stays **unscoped**
+  (LOW): a scoped docs-lens miss can suggest code names. Decide in the openspec change
+  whether to scope `Names` too or document the cross-domain suggestion.
+- Mechanics (field names, prefix semantics, both-path helper, decode tests) are specified
+  in the `fusion` + `graph-embedding` capability specs via the follow-on openspec
+  change — NOT in this ADR.
 - Product half (choosing/wiring the scope per lens) is semsource's, once the hook lands.
 
-## Open questions (resolve before Accept)
+## Resolved decisions (pre-Accept adversarial review, 2026-07-05)
 
-1. **Scope shape:** entity-ID glob (`*.web.*.doc.*`) vs bare prefix vs an
-   entity-type/domain enum? The 6-part ID favors a glob/prefix; confirm the scan-loop
-   match is cheap at index scale.
-2. **Reuse the deterministic prefix path?** `ResolveModePrefix` → `graph.query.prefix`
-   already carries a `Prefix`. Should NL scope reuse that field name/semantics for
-   consistency, or is a distinct `Scope` clearer (NL scope filters *candidates*, the
-   prefix mode *is* the query)?
-3. **Ship Option 2 alongside** as a cheap in-engine `SeedFilter` for mild dilution,
-   or Option 1 only?
-4. **Pre-Accept adversarial review** (framework-ADR discipline): verify the scan-loop
-   filter cost, that empty-scope is a true no-op on every hop, and that no other
-   `Resolve` caller breaks on the signature change.
+An architect adversarial review verified every line citation, confirmed Option 1's
+mechanism is sound, and resolved the four open questions (defects folded above):
+
+a. **Scope shape → `Scope []string` of dot-delimited ID *prefixes*, OR-matched, empty =
+   no filter.** Prefix (not glob — cheapest, no `path.Match` dotted-delimiter ambiguity);
+   list (not scalar — code/docs each span multiple prefixes, HIGH-2); match on the
+   domain/system-segment prefix (not the type segment — the discriminator isn't there).
+   Reuse the `graph.PrefixQueryRequest` dot-prefix convention + `filterEntityIDsByType`'s
+   `[]string`/empty=no-op convention via a shared matcher helper.
+b. **Reuse the prefix path? → Reuse the prefix *matching semantics*, but as a DISTINCT
+   `Scope` field, not the `Prefix` field.** `ResolveModePrefix`'s `Prefix` *is* a
+   deterministic query; NL `Scope` is a *filter on embedding candidates* (types differ:
+   list vs scalar). Overloading one field conflates "what I search for" with "the subset
+   I search within." Share only the matcher.
+c. **Ship Option 2 alongside? → No, Option 1 only.** Once Option 1 filters at the source,
+   a `Lens.SeedFilter` + over-fetch is a strictly-weaker duplicate, and two filter
+   surfaces is a silent-weak-scoping footgun. Option 2's shape already exists
+   (`graphrag.filterEntityIDsByType`, post-retrieval) and is precisely what fails severe
+   dilution. Add a non-prefix filter later only if a real need arises (e.g. on a triple
+   value), scoped to that need.
+d. **Also folded:** the BLOCKING warm-cache path, the `[]string` requirement, the
+   cross-repo `MemGraph.Resolve` blast radius, the struct-param `Resolve` shape, the
+   graphrag convergence decision, unscoped `did_you_mean`, and the e2e coverage gap.
+
+**Remaining to Accept:** user sign-off on this folded shape; then the follow-on openspec
+change against the `fusion` + `graph-embedding` specs pins the mechanics and
+implementation follows.

--- a/docs/adr/071-fusion-domain-scoped-nl-retrieval.md
+++ b/docs/adr/071-fusion-domain-scoped-nl-retrieval.md
@@ -2,15 +2,16 @@
 
 ## Status
 
-**Proposed — DRAFT, decision pending.** This ADR records a decision that is not yet
-made: **which mechanism** gives a `pkg/fusion` Lens a per-domain scope over NL
-retrieval (Option 1 vs Option 2 below), and — if Option 1 — the exact shape of the
-scope field added to the embedding-search RPC contract. It is stubbed here because
-the semsource-preferred fix (Option 1) changes a **cross-component NATS RPC
-contract** (`graph.query.semantic` + `graph.embedding.query.search`), which is
-exactly the class of decision an ADR exists to record. Once the option is chosen and
-adversarially reviewed (per the framework-ADR review discipline), the mechanics move
-into an openspec change against the `fusion` + `graph-embedding` capability specs.
+**Proposed — Option 1 selected (2026-07-05); pending pre-Accept adversarial review
+and open-question resolution.** The mechanism decision is made: **Option 1** — a
+`Scope` on `fusion.Request` plumbed to the embedding search. It is recorded as an ADR
+because it changes a **cross-component NATS RPC contract** (`graph.query.semantic` +
+`graph.embedding.query.search`), the class of decision an ADR exists to hold. Before
+Accept, the four open questions below are resolved and the mechanism gets a
+code-grounded adversarial review (framework-ADR discipline —
+`feedback_adversarial_review_framework_adr`); then the mechanics move into an openspec
+change against the `fusion` + `graph-embedding` capability specs and implementation
+follows.
 
 Scopes gh#463 / semsource upstream-asks #16.
 
@@ -44,12 +45,14 @@ hydration. Not MVP-blocking (a broad `code_search` retrieves docs well; `doc_con
 is accurate when domains are balanced), but it blocks accurate small-domain NL
 retrieval on mixed corpora.
 
-## Decision — TO BE MADE
+## Decision
 
-The engine keeps ownership of resolve/rank/budget; the product supplies the scope per
-lens. Three mechanisms were proposed (gh#463); the choice is the open decision.
+**Option 1 is selected** (2026-07-05). The engine keeps ownership of
+resolve/rank/budget; the product supplies the scope per lens. Options 2 and 3 are
+retained below as the considered-and-rejected alternatives (Option 2 may still ship
+*alongside* as a cheap in-engine convenience — open question #3).
 
-### Option 1 — `Scope` on `fusion.Request`, plumbed to the embedding search *(recommended, semsource-preferred)*
+### Option 1 — `Scope` on `fusion.Request`, plumbed to the embedding search *(SELECTED)*
 
 Add an optional scope (an entity-ID glob/prefix, e.g. `*.web.*.doc.*`, matching the
 6-part federated entity ID) to `fusion.Request`, threaded to the vector scan so a

--- a/docs/adr/071-fusion-domain-scoped-nl-retrieval.md
+++ b/docs/adr/071-fusion-domain-scoped-nl-retrieval.md
@@ -2,17 +2,18 @@
 
 ## Status
 
-**Proposed — Option 1 selected; pre-Accept adversarial review folded (2026-07-05);
-awaiting user sign-off to Accept.** The mechanism is decided: **Option 1** — a
-`Scope []string` on `fusion.Request` plumbed to the embedding search — recorded as an
-ADR because it changes a **cross-component NATS RPC contract**
-(`graph.embedding.query.search`), the class of decision an ADR exists to hold. A
-code-grounded adversarial review (framework-ADR discipline —
-`feedback_adversarial_review_framework_adr`) found a **BLOCKING** shape defect (a
-warm-cache no-op) and two HIGHs (scope must be a list; a cross-repo compile break),
-all folded into the Decision/Consequences/Resolved-decisions below. On Accept, the
-mechanics move into an openspec change against the `fusion` + `graph-embedding`
-capability specs and implementation follows.
+**Accepted — 2026-07-05.** Mechanism: **Option 1** — a `Scope []string` on
+`fusion.Request` plumbed to the embedding search — recorded as an ADR because it
+changes a **cross-component NATS RPC contract** (`graph.embedding.query.search`), the
+class of decision an ADR exists to hold. A code-grounded adversarial review
+(framework-ADR discipline — `feedback_adversarial_review_framework_adr`) found a
+**BLOCKING** shape defect (a warm-cache no-op) and two HIGHs (scope must be a list; a
+cross-repo compile break), all folded into the Decision/Consequences/Resolved-decisions
+below before Accept. **Convergence decided:** the follow-on change unifies the existing
+`graphrag.filterEntityIDsByType` post-filter with the new scope onto one shared
+`graph.MatchesAnyIDPrefix` helper (question c / MEDIUM). The mechanics now move into an
+openspec change against the `fusion` + `graph-embedding` + `graph-query` capability
+specs; implementation follows.
 
 Scopes gh#463 / semsource upstream-asks #16.
 

--- a/docs/adr/071-fusion-domain-scoped-nl-retrieval.md
+++ b/docs/adr/071-fusion-domain-scoped-nl-retrieval.md
@@ -1,0 +1,123 @@
+# ADR-071: Domain-scoped NL retrieval for a fusion Lens (gh#463)
+
+## Status
+
+**Proposed — DRAFT, decision pending.** This ADR records a decision that is not yet
+made: **which mechanism** gives a `pkg/fusion` Lens a per-domain scope over NL
+retrieval (Option 1 vs Option 2 below), and — if Option 1 — the exact shape of the
+scope field added to the embedding-search RPC contract. It is stubbed here because
+the semsource-preferred fix (Option 1) changes a **cross-component NATS RPC
+contract** (`graph.query.semantic` + `graph.embedding.query.search`), which is
+exactly the class of decision an ADR exists to record. Once the option is chosen and
+adversarially reviewed (per the framework-ADR review discipline), the mechanics move
+into an openspec change against the `fusion` + `graph-embedding` capability specs.
+
+Scopes gh#463 / semsource upstream-asks #16.
+
+## Context
+
+`pkg/fusion`'s `Engine.Fuse` resolves NL seeds over the **whole shared embedding
+index** with no per-lens or per-request domain filter:
+
+- `Engine.Fuse` calls `e.graph.Resolve(ctx, query, mode, resolveLimit)`
+  (`engine_lens.go:88`) with `mode ∈ {symbol, prefix, nl}`.
+- The `Lens` interface exposes no scope hook (`Name`/`ResolveMode`/`Edges`/`Label`/
+  `Kind`/`Location`/`Hydrate`).
+- `fusion.Request` carries only `Query`, `Want`, `Budget` (`contract.go:36`).
+- The production NL path is `fusionnats.Client.resolveSemantic` (`client.go:130`) →
+  `graph.query.semantic` → `graph.embedding.query.search` → `findSimilarEntities`
+  (`processor/graph-embedding/query.go:221`), which scans **all** generated entity
+  IDs, scores cosine, and truncates. **No scope/type/prefix filter exists at any hop**
+  — `SearchRequest` is `{Query, Limit}` only (`query.go:65`).
+
+Consequence for a product running multiple lens instances over one embedding index:
+NL retrieval for the smaller domain is **diluted by the larger one**. semsource runs
+a `code` lens and a `docs` lens over one index; measured on httpx (1304 Python code
+entities + 30 markdown docs):
+
+- `doc_context "what exceptions can be raised on a failed request"` → returned Python
+  **test functions** ranked above `docs/exceptions.md`.
+- The same query on a docs-dominant index → **100% documents, top-1 correct**.
+
+The doc content is embedded and retrievable — it is a **scope/ranking** problem, not
+hydration. Not MVP-blocking (a broad `code_search` retrieves docs well; `doc_context`
+is accurate when domains are balanced), but it blocks accurate small-domain NL
+retrieval on mixed corpora.
+
+## Decision — TO BE MADE
+
+The engine keeps ownership of resolve/rank/budget; the product supplies the scope per
+lens. Three mechanisms were proposed (gh#463); the choice is the open decision.
+
+### Option 1 — `Scope` on `fusion.Request`, plumbed to the embedding search *(recommended, semsource-preferred)*
+
+Add an optional scope (an entity-ID glob/prefix, e.g. `*.web.*.doc.*`, matching the
+6-part federated entity ID) to `fusion.Request`, threaded to the vector scan so a
+lens instance constrains seeds to its domain at the source.
+
+- **Correctness:** filters at the candidate source, so the small domain is never
+  crowded out of the ranked window — the only option that reliably fixes *severe*
+  dilution (the httpx case, where docs fell entirely below `resolveLimit = 40`).
+- **Cost — the reason this is an ADR:** the scope must be threaded through every hop,
+  two of which are **cross-component NATS RPC contracts** consumed by semsource:
+  1. `fusion.Request` (`contract.go:36`) — add `Scope`
+  2. `RetrievalClient.Resolve` signature (`retrieval.go:22`) — ripples to all impls + fakes
+  3. `fusionnats.Client.resolveSemantic` body (`client.go:131`)
+  4. `graph.query.semantic` handler passthrough (`processor/graph-query/query.go:562`)
+  5. **`SearchRequest`** (`processor/graph-embedding/query.go:65`) — add scope field **(RPC contract change)**
+  6. `findSimilarEntities` scan loop (`query.go:248`) — apply the filter
+- **Backward-compat:** the field is optional; empty = no filter = today's behavior.
+  Additive to the RPC contract, but it is still a shared wire-shape change — hence
+  this ADR.
+
+### Option 2 — `Lens.SeedFilter(entity) bool` + engine over-fetch *(self-contained, cheaper, weaker)*
+
+Add an optional post-retrieval predicate the engine applies over an over-fetched
+candidate set (resolve `N × limit`, filter, trim).
+
+- **Cost:** self-contained in `pkg/fusion` — **no RPC contract change, no ADR** if
+  chosen alone.
+- **Weakness:** post-filtering cannot recover a domain that falls *entirely* below
+  the over-fetch window. In the httpx case the docs were out-ranked at limit 40; a
+  post-filter would need a large, wasteful over-fetch and still risks returning too
+  few. Directionally helpful for mild dilution, unreliable for severe.
+
+### Option 3 — per-lens embedding namespace *(deferred)*
+
+A separate searchable embedding space per domain. Heaviest (index/topology change);
+deferred unless Options 1/2 prove insufficient.
+
+### Recommendation
+
+**Option 1**, with the scope as an optional entity-ID glob/prefix applied in
+`findSimilarEntities` (`query.go:248`), because it is the only option that fixes the
+severe-dilution case semsource actually hit, and it keeps engine ownership intact
+(the product supplies the scope per lens). Option 2 could ship *additionally* as a
+cheap in-engine convenience, but is not sufficient on its own.
+
+## Consequences
+
+- The `graph.embedding.query.search` (and passthrough `graph.query.semantic`) RPC
+  request gains an optional scope field — additive and backward-compatible, but a
+  cross-component contract shape semsource depends on (the reason for this ADR).
+- `RetrievalClient.Resolve` signature changes; all impls and test fakes (`engine_lens_test.go`
+  `fakeGraph.Resolve`, `fusionnats.Client`) update.
+- Mechanics (field names, glob semantics, scan-loop filter, over-fetch interplay) are
+  specified in the `fusion` + `graph-embedding` capability specs via the follow-on
+  openspec change — NOT in this ADR.
+- Product half (choosing/wiring the scope per lens) is semsource's, once the hook lands.
+
+## Open questions (resolve before Accept)
+
+1. **Scope shape:** entity-ID glob (`*.web.*.doc.*`) vs bare prefix vs an
+   entity-type/domain enum? The 6-part ID favors a glob/prefix; confirm the scan-loop
+   match is cheap at index scale.
+2. **Reuse the deterministic prefix path?** `ResolveModePrefix` → `graph.query.prefix`
+   already carries a `Prefix`. Should NL scope reuse that field name/semantics for
+   consistency, or is a distinct `Scope` clearer (NL scope filters *candidates*, the
+   prefix mode *is* the query)?
+3. **Ship Option 2 alongside** as a cheap in-engine `SeedFilter` for mild dilution,
+   or Option 1 only?
+4. **Pre-Accept adversarial review** (framework-ADR discipline): verify the scan-loop
+   filter cost, that empty-scope is a true no-op on every hop, and that no other
+   `Resolve` caller breaks on the signature change.

--- a/openspec/changes/fusion-nl-scope/.openspec.yaml
+++ b/openspec/changes/fusion-nl-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/fusion-nl-scope/proposal.md
+++ b/openspec/changes/fusion-nl-scope/proposal.md
@@ -1,0 +1,92 @@
+# Domain-scoped NL retrieval for a fusion Lens (gh#463, ADR-071)
+
+## Why
+
+`pkg/fusion`'s `Engine.Fuse` resolves NL seeds over the **whole shared embedding
+index** with no per-lens domain filter (`engine_lens.go:88` →
+`RetrievalClient.Resolve`). When multiple lens instances share one index (semsource's
+`code` + `docs` lenses, ADR-0004), NL retrieval for the smaller domain is **diluted**:
+on httpx (1304 Python code entities + 30 docs), `doc_context "what exceptions can be
+raised"` returns Python test functions above `docs/exceptions.md`; the same query with
+docs not drowned returns 100% docs, top-1 correct. It is a scope/ranking problem, not
+hydration.
+
+ADR-071 (Accepted) records the decision: **Option 1** — an optional `Scope []string`
+on `fusion.Request` plumbed to the embedding search, filtering candidates **at the
+source** so the small domain is never crowded out of the ranked window. This is the
+only option that fixes *severe* dilution (docs fell entirely below `resolveLimit = 40`).
+Scope is a cross-component NATS RPC contract change (`graph.embedding.query.search`),
+hence the ADR.
+
+The pre-Accept adversarial review reshaped the implementation (all folded into ADR-071):
+a **BLOCKING** warm-cache no-op, a `[]string` requirement, a cross-repo compile break,
+and a convergence decision with an existing overlapping filter.
+
+## What Changes
+
+- **`Scope []string` on `fusion.Request`** — a list of dot-delimited entity-ID
+  **prefixes**, OR-matched; empty/nil = no filter (backward-compatible). Prefix, not
+  glob (cheapest match, no `path.Match` dotted-delimiter ambiguity); list, not scalar
+  (semsource "all code" spans `golang`/`python`/`ts`/`svelte`, "all docs" spans
+  `source.doc` + `source.chunk` — one prefix cannot express either).
+
+- **Thread scope via a struct param, not a positional add.** `RetrievalClient.Resolve`
+  becomes `Resolve(ctx, ResolveQuery{Query, Mode, Scope, Limit})`. Scope is NL-only, but
+  `Resolve` is shared across symbol/prefix/nl; a struct param contains the cross-repo
+  blast radius (the sole prod impl `fusionnats.Client`, the in-repo fake + 7 call sites,
+  and the **cross-repo** `../semsource/.../fusiontest/memgraph.go MemGraph.Resolve`) and
+  won't re-break on the next dimension.
+
+- **Add `Scope []string` to `graph-embedding`'s `SearchRequest`** (the cross-component
+  RPC contract) and apply it in **BOTH** `findSimilarEntities` paths — the warm
+  `FindSimilarFromCache` (steady-state) and the cold KV-scan fallback — via one shared
+  helper, filtering **before** `CosineSimilarity` / before the per-candidate
+  `GetEmbedding` KV round-trip. Applying it only to the cold path (as the ADR's first
+  draft did) would be a **silent no-op for essentially every warm-production query** —
+  the single must-not-miss. `graph.query.semantic`'s handler forwards raw bytes, so it
+  needs no code change.
+
+- **Extract a shared `graph.MatchesAnyIDPrefix(id string, prefixes []string) bool`
+  helper** (dot-prefix, trailing-dot boundary, empty = match-all) and route the new
+  scope filter through it. Reuse the `[]string` + empty=no-op convention already proven
+  in `graphrag.filterEntityIDsByType` and the dot-prefix convention on
+  `graph.PrefixQueryRequest`.
+
+- **Converge the existing overlapping filter (`graph-query`).**
+  `graphrag.handleStrategySemantic` already post-filters the semantic path via
+  `filterEntityIDsByType` (an Option-2-shaped weak post-filter — exactly what fails
+  severe dilution). This change routes graph-query's semantic path through the
+  source-level `Scope` so there is **one** ID-scoping responsibility, not two drifting
+  ones. Note the axis wrinkle to resolve in implementation: graphrag filters by the
+  **type segment** (mid-ID, position 5) while `Scope` matches a **leading prefix**
+  (domain/system, positions 3–4) — so `MatchesAnyIDPrefix` covers the scope axis, and
+  the type-segment filter is either re-expressed against the shared helper or kept as a
+  documented-distinct axis layered on top. The invariant: no second post-retrieval ID
+  filter that silently duplicates source-level scope.
+
+- **Keep `Scope` distinct from the prefix-mode field.** `ResolveModePrefix`'s `Prefix`
+  *is* a deterministic query; NL `Scope` is a *filter on embedding candidates*. Share
+  the matcher helper, not the field.
+
+## Impact
+
+- **Affected specs:** `fusion` (ADDED: Scope on Request + resolve threading — the
+  capability seeded by gh#475), `graph-embedding` (seeded: SearchRequest scope + the
+  both-path filter contract), `graph-query` (seeded: the single-scope-responsibility
+  convergence).
+- **Affected code:** `pkg/fusion/contract.go` (`Scope`), `pkg/fusion/retrieval.go`
+  (`ResolveQuery` struct param), `pkg/fusion/engine_lens.go` (pass scope),
+  `pkg/fusion/fusionnats/client.go` (`resolveSemantic` body, conditional insert),
+  `processor/graph-embedding/query.go` (`SearchRequest.Scope`, both-path filter),
+  `graph/embedding/storage.go` (`FindSimilarFromCache` filter), a new
+  `graph.MatchesAnyIDPrefix` helper, and `processor/graph-query/graphrag.go`
+  (convergence). Cross-repo: `../semsource/.../fusiontest/memgraph.go` `MemGraph.Resolve`
+  updates to the struct param (coordinated on tag).
+- **Cross-repo contract:** additive `Scope []string` on `graph.embedding.query.search`;
+  unknown-field-tolerant decode means an un-migrated server degrades to unscoped.
+- **Coverage gap (flagged):** no e2e tier exercises `pkg/fusion` / the semantic NL path
+  — the change adds a production-decoder round-trip test (SearchRequest-with-scope →
+  graph-embedding decode → filter applied) and ideally an integration test through
+  `fusionnats.Client → graph-query → graph-embedding`.
+- **No `did_you_mean` scope** in this change: `e.miss` → `Names` stays unscoped (a
+  scoped docs-lens miss can suggest code names) — documented, deferred.

--- a/openspec/changes/fusion-nl-scope/specs/fusion/spec.md
+++ b/openspec/changes/fusion-nl-scope/specs/fusion/spec.md
@@ -1,0 +1,35 @@
+# Fusion
+
+> Delta for gh#463 (ADR-071). ADDs the NL-scope contract to the `fusion` capability
+> seeded by gh#475. Verified against `pkg/fusion` code.
+
+## ADDED Requirements
+
+### Requirement: A request MAY scope NL retrieval to entity-ID prefixes
+
+`fusion.Request` MUST support an optional `Scope` — a list of dot-delimited entity-ID
+prefixes. When non-empty, the engine MUST constrain NL seed resolution to entities
+whose ID matches at least one prefix (OR-matched), so a lens instance over a shared
+embedding index retrieves only its domain and is not diluted by a larger co-resident
+domain. An empty/absent `Scope` MUST behave exactly as today (no filter). Matching is
+by leading prefix on a dot boundary, not glob, and the scope MUST be applied at the
+candidate source (before ranking), not as a post-retrieval trim, so a small domain
+is never crowded out of the ranked window.
+
+The scope MUST be threaded to the retrieval client via a struct parameter
+(`ResolveQuery{Query, Mode, Scope, Limit}`) rather than a positional argument, so the
+NL-only scope does not force symbol/prefix callers to pass an ignored value.
+
+#### Scenario: a scoped NL query retrieves only the in-scope domain
+
+- **GIVEN** a shared embedding index holding a large `code` domain and a small `docs`
+      domain
+- **WHEN** `Fuse` runs an NL request whose `Scope` names the docs ID prefix
+- **THEN** the resolved seeds are docs entities only
+- **AND** the small domain is not out-ranked by the larger one
+
+#### Scenario: an empty scope is a no-op
+
+- **GIVEN** an NL request with an empty/absent `Scope`
+- **WHEN** `Fuse` resolves it
+- **THEN** retrieval is identical to the unscoped behavior (byte-identical request)

--- a/openspec/changes/fusion-nl-scope/specs/graph-embedding/spec.md
+++ b/openspec/changes/fusion-nl-scope/specs/graph-embedding/spec.md
@@ -1,0 +1,47 @@
+# Graph Embedding
+
+The `graph.embedding.query.search` semantic-search RPC and its similarity scan.
+
+> Seeded lazily by gh#463 (ADR-071). Scope is the **scoped semantic search** contract;
+> other graph-embedding behavior is seeded when a change first touches it. Distilled
+> from `processor/graph-embedding/query.go` + `graph/embedding/storage.go`, verified
+> against code.
+
+## ADDED Requirements
+
+### Requirement: Semantic search MAY be scoped to entity-ID prefixes, applied at the source
+
+The `graph.embedding.query.search` request (`SearchRequest`) MUST support an optional
+`Scope` — a list of entity-ID prefixes. When non-empty, the search MUST return only
+candidates whose entity ID matches at least one prefix (via the shared
+`graph.MatchesAnyIDPrefix` matcher), and MUST apply that filter **at the candidate
+source in every similarity path** — both the warm in-memory cache path
+(`FindSimilarFromCache`) and the cold KV-scan fallback — filtering **before** the
+expensive per-candidate operation (cosine similarity / the embedding KV fetch). An
+empty/absent `Scope` MUST behave exactly as today. The request MUST decode with
+unknown-field tolerance, so a producer sending `Scope` to an un-migrated server
+degrades gracefully to an unscoped search rather than erroring.
+
+Applying the filter to only one similarity path (e.g. the cold fallback) is
+non-conformant: the warm cache is the steady-state path, so a cache-path omission
+makes the scope a silent no-op in production.
+
+#### Scenario: a scoped search returns only in-scope candidates (warm and cold)
+
+- **GIVEN** an index holding entities under two ID prefixes
+- **WHEN** `graph.embedding.query.search` runs with `Scope` naming one prefix
+- **THEN** only entities under that prefix are returned
+- **AND** this holds whether the similarity is served from the warm cache or the cold
+      KV scan
+
+#### Scenario: an unscoped search is unchanged
+
+- **GIVEN** a `SearchRequest` with an empty/absent `Scope`
+- **WHEN** it runs
+- **THEN** results are identical to the pre-scope behavior
+
+#### Scenario: an un-migrated server ignores an unknown scope
+
+- **GIVEN** a server that predates the `Scope` field
+- **WHEN** it receives a `SearchRequest` carrying `Scope`
+- **THEN** it decodes successfully and runs an unscoped search (graceful degrade)

--- a/openspec/changes/fusion-nl-scope/specs/graph-query/spec.md
+++ b/openspec/changes/fusion-nl-scope/specs/graph-query/spec.md
@@ -1,0 +1,32 @@
+# Graph Query
+
+The semantic (embedding-backed) query strategy in `processor/graph-query`.
+
+> Seeded lazily by gh#463 (ADR-071). Scope is the **single ID-scoping responsibility**
+> on the semantic path; other graph-query strategies are seeded when touched. Distilled
+> from `processor/graph-query/graphrag.go`, verified against code.
+
+## ADDED Requirements
+
+### Requirement: The semantic path has a single, source-level ID-scoping responsibility
+
+The semantic query strategy MUST NOT carry a post-retrieval ID filter that duplicates
+the source-level `Scope` on `graph.embedding.query.search`. Where the semantic path
+constrains results by entity ID, it MUST pass that constraint to the embedding search
+as `Scope` (applied at the candidate source) rather than filtering the returned IDs
+after the fact — so a small domain is not first out-ranked and then filtered from an
+already-truncated window. Any ID-matching MUST go through the shared
+`graph.MatchesAnyIDPrefix` matcher so the prefix semantics cannot drift between the
+scope filter and the prefix query.
+
+A distinct filtering axis that is genuinely not expressible as an ID prefix (e.g. the
+type segment matched by the prior `filterEntityIDsByType`) MAY remain, but MUST be
+documented as a separate, intentional axis layered atop scope — never a second,
+silently-overlapping ID-prefix filter.
+
+#### Scenario: an ID constraint on the semantic path is applied at the source
+
+- **GIVEN** a semantic query that constrains results to an entity-ID prefix
+- **WHEN** it runs
+- **THEN** the constraint is passed to the embedding search as `Scope`
+- **AND** there is no redundant post-retrieval ID-prefix filter on the returned set

--- a/openspec/changes/fusion-nl-scope/tasks.md
+++ b/openspec/changes/fusion-nl-scope/tasks.md
@@ -1,0 +1,94 @@
+# Tasks — domain-scoped NL retrieval for a fusion Lens (gh#463, ADR-071)
+
+> Scoping change (Proposed). Tasks unchecked; implementation follows scope approval
+> (`/opsx:apply` on a `feat/` branch). Ordering note: land AFTER gh#475 (which seeds
+> the `fusion` capability spec) so this change's `fusion` delta ADDs cleanly.
+
+## 1. Shared prefix matcher
+
+- [ ] 1.1 Add `graph.MatchesAnyIDPrefix(id string, prefixes []string) bool`: empty/nil
+      prefixes → true (no filter); else true iff `id == p` or `strings.HasPrefix(id, p+".")`
+      for some `p` (dot-boundary so `c360.semspec.source.doc` doesn't match
+      `c360.semspec.source.docker...`). Table tests incl. empty, exact, boundary,
+      multi-prefix OR.
+- [ ] 1.2 Confirm the `graph.PrefixQueryRequest` dot-prefix convention
+      (`graph/query_prefix_types.go`) and reuse/align, so the prefix query and scope
+      filter share one matcher.
+
+## 2. fusion contract + resolve threading
+
+- [ ] 2.1 Add `Scope []string` to `fusion.Request` (`contract.go:36`), `json:"scope,omitempty"`.
+- [ ] 2.2 Change `RetrievalClient.Resolve` to a struct param:
+      `Resolve(ctx, ResolveQuery{Query string, Mode ResolveMode, Scope []string, Limit int}) ([]string, error)`.
+      Update `Engine.Fuse` (`engine_lens.go:88`) to pass `req.Scope`.
+- [ ] 2.3 Update ALL implementers/fakes/call sites (compile break — enumerate up front,
+      do NOT whack-a-mole): prod `fusionnats.Client.Resolve`; in-repo fake
+      `engine_lens_test.go fakeGraph.Resolve` + call sites `client_test.go`
+      L119/145/166/180, `client_integration_test.go` L87/93/99; **cross-repo**
+      `../semsource/source/fusion/fusiontest/memgraph.go:73 MemGraph.Resolve` (coordinate
+      on the framework tag — this is why it is a struct param, not positional).
+
+## 3. fusionnats — carry scope on the NL request
+
+- [ ] 3.1 `resolveSemantic` (`fusionnats/client.go:130`): insert `"scope"` into the
+      request body **only when non-empty** (byte-parity for the unscoped case). Symbol
+      and prefix resolve paths carry NO scope (NL-only).
+
+## 4. graph-embedding — the source filter (BOTH paths)
+
+- [ ] 4.1 Add `Scope []string` to `SearchRequest` (`processor/graph-embedding/query.go:65`),
+      `json:"scope,omitempty"`; decode stays `json.Unmarshal` (unknown-field-tolerant →
+      un-migrated server degrades to unscoped).
+- [ ] 4.2 **BLOCKING correctness:** apply the scope in BOTH `findSimilarEntities` paths
+      — `FindSimilarFromCache` (`graph/embedding/storage.go:451`, filter before
+      `CosineSimilarity`) AND the KV-scan fallback (`query.go:248`, filter the candidate
+      ID set before the per-candidate `GetEmbedding`). One shared code path calling
+      `graph.MatchesAnyIDPrefix`. A cache-path miss = silent warm-production no-op.
+- [ ] 4.3 Perf check: scope filter runs before the expensive op on both paths (cosine /
+      KV round-trip); on the httpx case a docs scope turns ~1334 KV reads into ~30.
+
+## 5. graph-query — converge the overlapping filter
+
+- [ ] 5.1 Route `graphrag.handleStrategySemantic`'s semantic path through the source-level
+      `Scope` (pass to `SearchRequest.Scope`) instead of / in addition to the
+      post-retrieval `filterEntityIDsByType`. Resolve the axis wrinkle: `Scope` =
+      leading-prefix (domain/system), `filterEntityIDsByType` = type segment (position 5).
+      Either re-express the type filter via the shared helper or keep it as a documented,
+      layered-distinct axis — but eliminate any second post-retrieval ID filter that
+      silently duplicates source-level scope. Reviewer confirms "one responsibility."
+
+## 6. Tests
+
+- [ ] 6.1 Unit: `MatchesAnyIDPrefix` table (task 1.1).
+- [ ] 6.2 Production-decoder round-trip: a `SearchRequest` with `Scope` JSON-decodes in
+      graph-embedding and the filter is applied (close the warning-not-fail gap;
+      `feedback_production_decoder_round_trip_required`).
+- [ ] 6.3 Both-path coverage: a scoped search over a mixed corpus returns only in-scope
+      entities via BOTH the warm cache and the cold KV-scan (drive each path explicitly;
+      warm-cache omission is the BLOCKING regression to guard).
+- [ ] 6.4 fusion engine: `Fuse` with `req.Scope` set threads scope to `Resolve`; empty
+      scope is a byte-identical no-op (assert the unscoped request body is unchanged).
+- [ ] 6.5 Integration (if feasible): `fusionnats.Client → graph-query → graph-embedding`
+      with a scoped NL query over a code+docs corpus reproduces the httpx fix (docs no
+      longer drowned). Closes the flagged `pkg/fusion` e2e coverage gap.
+- [ ] 6.6 Backward-compat: every existing caller of `graph.embedding.query.search` /
+      `RetrievalClient.Resolve` with no scope behaves identically.
+
+## 7. Spec + gates + close
+
+- [ ] 7.1 `openspec validate --strict`.
+- [ ] 7.2 Gates: `go test -race` (fusion, graph-embedding, graph-query), `task lint`,
+      schema no-drift (SearchRequest is an RPC type — confirm no generated-schema drift),
+      `go vet -tags=integration`.
+- [ ] 7.3 semstreams-reviewer pre-merge (RPC error-contract on the scoped search; the
+      BOTH-paths filter; the cross-repo `Resolve` blast radius incl. semsource; the
+      convergence really is one responsibility; empty-scope byte-parity).
+- [ ] 7.4 Archive → promote `graph-embedding` + `graph-query` into `openspec/specs/`;
+      ADD to `fusion`.
+- [ ] 7.5 Breaking-change check: `RetrievalClient.Resolve` signature change is a
+      cross-repo break (semsource `MemGraph.Resolve`) — coordinate the semsource bump on
+      the framework tag (see [[feedback_e2e_required_for_breaking_changes]] /
+      [[feedback_greenfield_cross_product_break_now]]). PR; CI; merge; tag.
+- [ ] 7.6 Confirm back to semsource on gh#463 / upstream-asks #16 (code + docs lenses
+      set their `Scope` prefixes; docs no longer diluted). File the semsource
+      `MemGraph.Resolve` bump.


### PR DESCRIPTION
**ADR + scope PR** (decision record + openspec proposal/tasks/spec-deltas). Implementation follows on a `feat/` branch via `/opsx:apply` after scope approval.

## Problem (gh#463 / semsource upstream-asks #16)

`pkg/fusion`'s `Engine.Fuse` resolves NL seeds over the **whole shared embedding index** with no domain filter. semsource's `code` + `docs` lenses share one index, so a small doc set is diluted by a large code set (httpx: 1304 code vs 30 docs → `doc_context "what exceptions…"` returns Python test funcs above `docs/exceptions.md`).

## ADR-071 (Accepted)

**Option 1** — an optional `Scope []string` on `fusion.Request` plumbed to the embedding search, filtering candidates **at the source**. Recorded as an ADR because it changes the `graph.embedding.query.search` RPC contract.

A pre-Accept **adversarial review** (architect) reshaped the implementation — all folded into the ADR before Accept:
- **BLOCKING** — the filter must live in the **warm in-memory cache path**, not only the cold KV-scan fallback the first draft cited; otherwise it's a **silent no-op for essentially every warm-production query**.
- **HIGH** — `Scope` must be `[]string` (code spans `golang`/`python`/`ts`/`svelte`, docs span `doc`+`chunk`; one prefix can't express either). The draft's `*.web.*.doc.*` example was fictional.
- **HIGH** — a cross-repo compile break (semsource `MemGraph.Resolve`) → use a **struct param** (`ResolveQuery`).
- **Converge** (your call) — unify the existing `graphrag.filterEntityIDsByType` post-filter onto a shared `graph.MatchesAnyIDPrefix` helper so there's **one** ID-scoping responsibility.

## Scope (openspec `fusion-nl-scope`)

Spec deltas for `fusion` (Scope on Request + struct-param Resolve), `graph-embedding` (`SearchRequest.Scope` applied in **both** similarity paths), and `graph-query` (single source-level scoping responsibility). Tasks carry the folded review including the cross-repo blast radius, both-path BLOCKING correctness, and the flagged `pkg/fusion` e2e coverage gap.

`openspec validate --strict` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)