### PR TITLE
fix(agentic-tools): ENTITY_STATES bucket TTL must be 0, not 24h (gh#484)

### DIFF
--- a/processor/agentic-tools/executors/register_graph_query.go
+++ b/processor/agentic-tools/executors/register_graph_query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 
@@ -19,14 +18,21 @@ import (
 const entityStatesBucket = "ENTITY_STATES"
 
 // entityStatesBucketConfig mirrors graph/query/client.go defaults
-// (History=3, TTL=24h). Tool registration races with the graph component's
+// (History=3, TTL=0). Tool registration races with the graph component's
 // ensureBuckets — CreateKeyValueBucket is idempotent Create-or-Get, so
 // whichever side lands first creates with these values and the other gets
 // the existing handle. Config must match the graph component's intent.
+//
+// TTL MUST be 0 on the live graph (ADR-068 D1): age-eviction is
+// reachability-blind and would silently expire entities with live inbound
+// edges. graph-ingest fail-closes at boot if it finds ENTITY_STATES carrying a
+// TTL, so a non-zero value here (a stale 24h mirror of the OLD graph/query
+// default, gh#484) makes this registration win the race and dead-lock
+// graph-ingest. Keep it 0, matching graph/query/client.go:DefaultConfig.
 var entityStatesBucketConfig = jetstream.KeyValueConfig{
 	Bucket:  entityStatesBucket,
 	History: 3,
-	TTL:     24 * time.Hour,
+	TTL:     0,
 }
 
 // registerGraphQuery wires GraphQueryExecutor against ENTITY_STATES.

--- a/processor/agentic-tools/executors/register_graph_query_ttl_test.go
+++ b/processor/agentic-tools/executors/register_graph_query_ttl_test.go
@@ -1,0 +1,18 @@
+package executors
+
+import "testing"
+
+// TestEntityStatesBucketConfig_NoTTL locks in the gh#484 fix: the agentic
+// graph-query tool creates ENTITY_STATES via get-or-create, so if it wins the
+// race with graph-ingest it stamps this config. ENTITY_STATES MUST have no
+// lifecycle retention (ADR-068 D1) — graph-ingest fail-closes at boot if it
+// finds a TTL, so a non-zero value here silently dead-locks the whole ingest
+// path. A stale 24h mirror of the OLD graph/query default caused exactly that.
+func TestEntityStatesBucketConfig_NoTTL(t *testing.T) {
+	if entityStatesBucketConfig.Bucket != entityStatesBucket {
+		t.Fatalf("bucket = %q, want %q", entityStatesBucketConfig.Bucket, entityStatesBucket)
+	}
+	if entityStatesBucketConfig.TTL != 0 {
+		t.Errorf("ENTITY_STATES TTL = %v, want 0 (ADR-068 D1: no lifecycle retention on the live graph; a non-zero TTL trips graph-ingest's boot guardrail)", entityStatesBucketConfig.TTL)
+	}
+}


### PR DESCRIPTION
Closes #484.

## Problem

On agentic/semantic stacks, **graph-ingest fails to start** and **zero entities ingest** — the whole ingest → entity → graph → query path is dead:

```
ERROR "Component failed to start" name=graph-ingest
  error: "graph retention guardrail failed: live graph bucket has lifecycle retention
          (ADR-068 D1: forbidden): bucket \"ENTITY_STATES\" has TTL/MaxAge 24h0m0s"
```

## Root cause

`register_graph_query.go` creates `ENTITY_STATES` with `TTL: 24 * time.Hour` — a **stale mirror** of the OLD `graph/query/client.go` default. That default was corrected to `TTL: 0` for **ADR-068 D1** (no lifecycle retention on the live graph — age-eviction is reachability-blind and would silently expire entities with live inbound edges), but this copy was never swept. `CreateKeyValueBucket` is get-or-create, so when this tool registration wins the race against graph-ingest's `ensureBuckets` it stamps the 24h TTL, and **#449's ADR-068 D1 boot guardrail then fail-closes graph-ingest**. #449's guardrail comment even *predicted* this race but didn't grep every `ENTITY_STATES` creator.

## Fix

`TTL: 24 * time.Hour` → `TTL: 0`, matching the corrected sibling default and the ADR-068 D1 decision. A sweep confirmed this was the **only** `ENTITY_STATES` creator with a non-zero TTL (oasf-generator creates with TTL 0; agentic-memory is a kv-watch reader). Adds a regression guard (`register_graph_query_ttl_test.go`) asserting the config TTL stays 0.

## Verification

`task e2e:semantic` after the fix: graph-ingest starts, entities ingest fully (`actual_count=142/189, missing_count=0, data_loss_percent=0` vs **0** before), semantic search returns correct known-answer results (`known_answer_tests_passed=7`), scenario `success=True`. (Pre-fix it was red at `wait-for-entity-stabilization` with 0 entities.)

## Process note

No e2e tier ran on #449 (a graph-ingest write-path change) — this collision would have been caught. See the E2E-required-for-breaking-changes rule in CLAUDE.md. Also surfaced a latent e2e-harness quirk: the semantic variant's SSE watch endpoint uses `:38080` instead of `--base-url :38180` (falls back to polling) — filed separately as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)